### PR TITLE
[Re] Track Schwab order fills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,24 @@ Environment variables (can be set via `.env` file):
   maintain market-neutral positions
 - **Comprehensive Error Handling**: Custom error types (`OnChainError`,
   `SchwabError`) with proper propagation
+- **Type Modeling**: Make invalid states unrepresentable through the type
+  system. Use algebraic data types (ADTs) and enums to encode business rules and
+  state transitions directly in types rather than relying on runtime validation.
+  Examples:
+  - Use enum variants to represent mutually exclusive states instead of multiple
+    boolean flags
+  - Encode state-specific data within enum variants rather than using nullable
+    fields
+  - Use newtypes for domain concepts to prevent mixing incompatible values
+  - Leverage the type system to enforce invariants at compile time
+- **Schema Design**: Avoid database columns that can contradict each other. Use
+  constraints and proper normalization to ensure data consistency at the
+  database level. Align database schemas with type modeling principles where
+  possible
+- **Functional Programming Patterns**: Favor FP and ADT patterns over OOP
+  patterns. Avoid unnecessary encapsulation, inheritance hierarchies, or
+  getter/setter patterns that don't make sense with Rust's algebraic data types.
+  Use pattern matching, combinators, and type-driven design
 - **Idiomatic Functional Programming**: Prefer iterator-based functional
   programming patterns over imperative loops unless it increases complexity. Use
   itertools to be able to do more with iterators and functional programming in
@@ -401,6 +419,228 @@ assert_eq!(result.unwrap(), "refreshed_access_token");
 ```
 
 so that if we get an unexpected result value, we immediately see the value.
+
+#### Type modeling examples
+
+**Make invalid states unrepresentable:**
+
+Instead of using multiple fields that can contradict each other:
+
+```rust
+// ❌ Bad: Multiple fields can be in invalid combinations
+pub struct Order {
+    pub status: String,  // "pending", "completed", "failed"
+    pub order_id: Option<String>,  // Some when completed, None when pending
+    pub executed_at: Option<DateTime<Utc>>,  // Some when completed
+    pub price_cents: Option<i64>,  // Some when completed
+    pub error_reason: Option<String>,  // Some when failed
+}
+```
+
+Use enum variants to encode valid states:
+
+```rust
+// ✅ Good: Each state has exactly the data it needs
+pub enum OrderStatus {
+    Pending,
+    Completed {
+        order_id: String,
+        executed_at: DateTime<Utc>,
+        price_cents: i64,
+    },
+    Failed {
+        failed_at: DateTime<Utc>,
+        error_reason: String,
+    },
+}
+```
+
+**Use newtypes for domain concepts:**
+
+```rust
+// ❌ Bad: Easy to mix up parameters of the same type
+fn place_order(symbol: String, account: String, amount: i64, price: i64) { }
+
+// ✅ Good: Type system prevents mixing incompatible values
+#[derive(Debug, Clone)]
+struct Symbol(String);
+
+#[derive(Debug, Clone)]
+struct AccountId(String);
+
+#[derive(Debug)]
+struct Shares(i64);
+
+#[derive(Debug)]
+struct PriceCents(i64);
+
+fn place_order(symbol: Symbol, account: AccountId, amount: Shares, price: PriceCents) { }
+```
+
+**The Typestate Pattern:**
+
+The typestate pattern encodes information about an object's runtime state in its
+compile-time type. This moves state-related errors from runtime to compile time,
+eliminating runtime checks and making illegal states unrepresentable.
+
+```rust
+// ✅ Good: Typestate pattern with zero-cost state transitions
+struct Start;
+struct InProgress;
+struct Complete;
+
+// Generic struct with state parameter
+struct Task<State> {
+    data: TaskData,
+    state: State,  // Can store state-specific data
+}
+
+// Operations only available in Start state
+impl Task<Start> {
+    fn new() -> Self {
+        Task { data: TaskData::new(), state: Start }
+    }
+    
+    fn begin(self) -> Task<InProgress> {
+        // Consumes self, returns new state
+        Task { data: self.data, state: InProgress }
+    }
+}
+
+// Operations only available in InProgress state
+impl Task<InProgress> {
+    fn work(&mut self) {
+        // Can mutate without changing state
+    }
+    
+    fn complete(self) -> Task<Complete> {
+        // State transition consumes self
+        Task { data: self.data, state: Complete }
+    }
+}
+
+// Operations available in multiple states
+impl<S> Task<S> {
+    fn description(&self) -> &str {
+        &self.data.description
+    }
+}
+```
+
+**Session Types and Protocol Enforcement:**
+
+```rust
+// ✅ Good: Enforce protocol sequences at compile time
+struct Unauthenticated;
+struct Authenticated { token: String };
+struct Active { token: String, session_id: u64 };
+
+struct Connection<State> {
+    socket: TcpStream,
+    state: State,
+}
+
+impl Connection<Unauthenticated> {
+    fn authenticate(self, credentials: &Credentials) 
+        -> Result<Connection<Authenticated>, AuthError> {
+        let token = perform_auth(&self.socket, credentials)?;
+        Ok(Connection {
+            socket: self.socket,
+            state: Authenticated { token },
+        })
+    }
+}
+
+impl Connection<Authenticated> {
+    fn start_session(self) -> Connection<Active> {
+        let session_id = generate_session_id();
+        Connection {
+            socket: self.socket,
+            state: Active { 
+                token: self.state.token,
+                session_id,
+            },
+        }
+    }
+}
+
+impl Connection<Active> {
+    fn send_message(&mut self, msg: &Message) {
+        // Can only send messages in active state
+    }
+}
+```
+
+**Builder Pattern with Typestate:**
+
+```rust
+// ✅ Good: Can't build incomplete objects at compile time
+struct NoUrl;
+struct HasUrl;
+struct NoMethod;
+struct HasMethod;
+
+struct RequestBuilder<U, M> {
+    url: Option<String>,
+    method: Option<Method>,
+    headers: Vec<Header>,
+    _url: PhantomData<U>,
+    _method: PhantomData<M>,
+}
+
+impl RequestBuilder<NoUrl, NoMethod> {
+    fn new() -> Self {
+        RequestBuilder {
+            url: None,
+            method: None,
+            headers: Vec::new(),
+            _url: PhantomData,
+            _method: PhantomData,
+        }
+    }
+}
+
+impl<M> RequestBuilder<NoUrl, M> {
+    fn url(self, url: String) -> RequestBuilder<HasUrl, M> {
+        RequestBuilder {
+            url: Some(url),
+            method: self.method,
+            headers: self.headers,
+            _url: PhantomData,
+            _method: PhantomData,
+        }
+    }
+}
+
+impl<U> RequestBuilder<U, NoMethod> {
+    fn method(self, method: Method) -> RequestBuilder<U, HasMethod> {
+        RequestBuilder {
+            url: self.url,
+            method: Some(method),
+            headers: self.headers,
+            _url: PhantomData,
+            _method: PhantomData,
+        }
+    }
+}
+
+// Can only build when we have both URL and method
+impl RequestBuilder<HasUrl, HasMethod> {
+    fn build(self) -> Request {
+        Request {
+            url: self.url.unwrap(), // Safe due to typestate
+            method: self.method.unwrap(), // Safe due to typestate
+            headers: self.headers,
+        }
+    }
+}
+
+// Usage: won't compile without setting both url and method
+let request = RequestBuilder::new()
+    .url("https://api.example.com".into())
+    .method(Method::GET)
+    .build();
+```
 
 #### Avoid deep nesting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ Tests should verify our application logic, not just language features. Avoid
 tests that only exercise struct construction or field access without testing any
 business logic.
 
-**❌ Bad: Testing language features instead of our code**
+##### ❌ Bad: Testing language features instead of our code
 
 ```rust
 #[test]
@@ -289,7 +289,7 @@ fn test_order_poller_config_custom() {
 This test creates a struct and verifies field assignments, but doesn't test any
 of our code logic - it only tests Rust's struct field assignment mechanism.
 
-**✅ Good: Testing actual business logic**
+##### ✅ Good: Testing actual business logic
 
 ```rust
 #[test]
@@ -326,7 +326,7 @@ that cannot be expressed through code structure alone.
 
 #### When to Use Comments
 
-**✅ DO comment when:**
+##### ✅ DO comment when:
 
 - **Complex business logic**: Explaining non-obvious domain-specific rules or
   calculations
@@ -339,7 +339,7 @@ that cannot be expressed through code structure alone.
 - **Test data context**: Explaining what mock values represent or test scenarios
 - **Workarounds**: Temporary solutions with context about why they exist
 
-**❌ DON'T comment when:**
+##### ❌ DON'T comment when:
 
 - The code is self-explanatory through naming and structure
 - Restating what the code obviously does
@@ -469,7 +469,7 @@ so that if we get an unexpected result value, we immediately see the value.
 
 #### Type modeling examples
 
-**Make invalid states unrepresentable:**
+##### Make invalid states unrepresentable:
 
 Instead of using multiple fields that can contradict each other:
 
@@ -502,7 +502,7 @@ pub enum OrderStatus {
 }
 ```
 
-**Use newtypes for domain concepts:**
+##### Use newtypes for domain concepts:
 
 ```rust
 // ❌ Bad: Easy to mix up parameters of the same type
@@ -524,7 +524,7 @@ struct PriceCents(i64);
 fn place_order(symbol: Symbol, account: AccountId, amount: Shares, price: PriceCents) { }
 ```
 
-**The Typestate Pattern:**
+##### The Typestate Pattern:
 
 The typestate pattern encodes information about an object's runtime state in its
 compile-time type. This moves state-related errors from runtime to compile time,
@@ -574,7 +574,7 @@ impl<S> Task<S> {
 }
 ```
 
-**Session Types and Protocol Enforcement:**
+##### Session Types and Protocol Enforcement:
 
 ```rust
 // ✅ Good: Enforce protocol sequences at compile time
@@ -618,7 +618,7 @@ impl Connection<Active> {
 }
 ```
 
-**Builder Pattern with Typestate:**
+##### Builder Pattern with Typestate:
 
 ```rust
 // ✅ Good: Can't build incomplete objects at compile time
@@ -694,7 +694,7 @@ let request = RequestBuilder::new()
 Prefer flat code over deeply nested blocks to improve readability and
 maintainability.
 
-**Use early returns:**
+##### Use early returns:
 
 Instead of
 
@@ -734,7 +734,7 @@ fn process_data(data: Option<&str>) -> Result<String, Error> {
 }
 ```
 
-**Extract functions for complex logic:**
+##### Extract functions for complex logic:
 
 Instead of
 
@@ -858,7 +858,7 @@ fn handle_trade_processing(
 }
 ```
 
-**Use pattern matching with guards:**
+##### Use pattern matching with guards:
 
 Instead of
 
@@ -893,7 +893,7 @@ match (input, state) {
 }
 ```
 
-**Prefer iterator chains over nested loops:**
+##### Prefer iterator chains over nested loops:
 
 Instead of
 
@@ -925,7 +925,7 @@ trades
 Avoid creating unnecessary constructors or getters when they don't add logic
 beyond setting/getting field values. Use public fields directly instead.
 
-**Prefer direct field access:**
+##### Prefer direct field access:
 
 ```rust
 pub struct SchwabTokens {
@@ -947,7 +947,7 @@ let tokens = SchwabTokens {
 println!("Token: {}", tokens.access_token);
 ```
 
-**Avoid unnecessary constructors and getters:**
+##### Avoid unnecessary constructors and getters:
 
 ```rust
 // Don't create these unless they add meaningful logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,53 @@ Environment variables (can be set via `.env` file):
 - **Debugging failing tests**: When debugging tests with failing assert! macros,
   add additional context to the assert! macro instead of adding temporary
   println! statements
+- **Test Quality**: Never write tests that only exercise language features
+  without testing our application logic. Tests should verify actual business
+  logic, not just struct field assignments or basic language operations
+
+#### Writing Meaningful Tests
+
+Tests should verify our application logic, not just language features. Avoid
+tests that only exercise struct construction or field access without testing any
+business logic.
+
+**❌ Bad: Testing language features instead of our code**
+
+```rust
+#[test]
+fn test_order_poller_config_custom() {
+    let config = OrderPollerConfig {
+        polling_interval: Duration::from_secs(30),
+        max_jitter: Duration::from_secs(10),
+    };
+
+    assert_eq!(config.polling_interval, Duration::from_secs(30));
+    assert_eq!(config.max_jitter, Duration::from_secs(10));
+}
+```
+
+This test creates a struct and verifies field assignments, but doesn't test any
+of our code logic - it only tests Rust's struct field assignment mechanism.
+
+**✅ Good: Testing actual business logic**
+
+```rust
+#[test]
+fn test_order_poller_respects_jitter_bounds() {
+    let config = OrderPollerConfig {
+        polling_interval: Duration::from_secs(60),
+        max_jitter: Duration::from_secs(10),
+    };
+    
+    let actual_delay = config.calculate_next_poll_delay();
+    
+    assert!(actual_delay >= Duration::from_secs(60));
+    assert!(actual_delay <= Duration::from_secs(70));
+}
+```
+
+This test verifies that our jitter calculation logic works correctly within
+expected bounds.
 
 ### Workflow Best Practices
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "httpmock",
  "itertools 0.14.0",
  "lazy_static",
+ "rand 0.8.5",
  "reqwest",
  "rocket",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 urlencoding = "2.1"
 flate2 = "1.0"
 itertools = "0.14.0"
+rand = "0.8"
 rocket = { version = "0.5.1", features = ["json"] }
 
 [dev-dependencies]

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
           inherit (rainix.devShells.${system}.default) nativeBuildInputs;
           buildInputs = with pkgs;
             [
+              bacon
               sqlx-cli
               cargo-tarpaulin
               cargo-chef

--- a/src/api.rs
+++ b/src/api.rs
@@ -112,6 +112,8 @@ mod tests {
                 .unwrap(),
                 deployment_block: 0,
             },
+            order_polling_interval: 15,
+            order_polling_max_jitter: 5,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -416,7 +416,8 @@ mod tests {
     use crate::env::LogLevel;
     use crate::onchain::trade::OnchainTrade;
     use crate::schwab::Direction;
-    use crate::schwab::execution::find_submitted_executions_by_symbol;
+    use crate::schwab::TradeStatus;
+    use crate::schwab::execution::find_executions_by_symbol_and_status;
     use crate::test_utils::get_test_order;
     use crate::test_utils::setup_test_db;
     use crate::{onchain::EvmEnv, schwab::SchwabAuthEnv};
@@ -1584,9 +1585,10 @@ mod tests {
 
         // Verify SchwabExecution was created (due to TradeAccumulator)
         // Executions are now in SUBMITTED status with order_id stored for order status polling
-        let executions = find_submitted_executions_by_symbol(&pool, "AAPL")
-            .await
-            .unwrap();
+        let executions =
+            find_executions_by_symbol_and_status(&pool, "AAPL", TradeStatus::Submitted)
+                .await
+                .unwrap();
         assert_eq!(executions.len(), 1);
         assert_eq!(executions[0].shares, 9);
         assert_eq!(executions[0].direction, Direction::Buy);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,8 @@ impl CliEnv {
             server_port: cli_env.server_port,
             schwab_auth: cli_env.schwab_auth,
             evm_env: cli_env.evm_env,
+            order_polling_interval: 15,
+            order_polling_max_jitter: 5,
         };
 
         Ok((env, cli_env.command))
@@ -874,6 +876,8 @@ mod tests {
                 ),
                 deployment_block: 1,
             },
+            order_polling_interval: 15,
+            order_polling_max_jitter: 5,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub async fn launch(env: Env) -> anyhow::Result<()> {
 
     let server_task = tokio::spawn(rocket.launch());
 
+    let mut clear_stream = orderbook.ClearV2_filter().watch().await?.into_stream();
+    let mut take_stream = orderbook.TakeOrderV2_filter().watch().await?.into_stream();
+
     let bot_pool = pool.clone();
     let bot_task = tokio::spawn(async move {
         if let Err(e) = run(env, bot_pool).await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,6 @@ pub async fn launch(env: Env) -> anyhow::Result<()> {
 
     let server_task = tokio::spawn(rocket.launch());
 
-    let mut clear_stream = orderbook.ClearV2_filter().watch().await?.into_stream();
-    let mut take_stream = orderbook.TakeOrderV2_filter().watch().await?.into_stream();
-
     let bot_pool = pool.clone();
     let bot_task = tokio::spawn(async move {
         if let Err(e) = run(env, bot_pool).await {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -65,7 +65,7 @@ mod tests {
     use super::*;
     use crate::onchain::accumulator::save_within_transaction;
     use crate::onchain::position_calculator::PositionCalculator;
-    use crate::schwab::{Direction, TradeStatus, execution::SchwabExecution};
+    use crate::schwab::{Direction, TradeState, execution::SchwabExecution};
     use crate::test_utils::setup_test_db;
 
     #[tokio::test]
@@ -155,7 +155,7 @@ mod tests {
             symbol: "AAPL".to_string(),
             shares: 100,
             direction: Direction::Buy,
-            status: TradeStatus::Pending,
+            state: TradeState::Pending,
         };
 
         let mut sql_tx = pool.begin().await.unwrap();

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -345,6 +345,7 @@ async fn create_execution_within_transaction(
 mod tests {
     use super::*;
     use crate::onchain::trade_execution_link::TradeExecutionLink;
+    use crate::schwab::TradeStatus;
     use crate::schwab::execution::schwab_execution_db_count;
     use crate::test_utils::setup_test_db;
     use alloy::primitives::fixed_bytes;
@@ -619,9 +620,13 @@ mod tests {
         assert!(accumulator_result.is_none());
 
         // Verify only the original execution remains
-        let executions = crate::schwab::execution::find_pending_executions_by_symbol(&pool, "AAPL")
-            .await
-            .unwrap();
+        let executions = crate::schwab::execution::find_executions_by_symbol_and_status(
+            &pool,
+            "AAPL",
+            TradeStatus::Pending,
+        )
+        .await
+        .unwrap();
         assert_eq!(executions.len(), 1);
         assert_eq!(executions[0].shares, 50);
     }

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -5,7 +5,7 @@ use super::{OnchainTrade, trade_execution_link::TradeExecutionLink};
 use crate::error::{OnChainError, TradeValidationError};
 use crate::lock::{clear_execution_lease, set_pending_execution_id, try_acquire_execution_lease};
 use crate::onchain::position_calculator::{ExecutionType, PositionCalculator};
-use crate::schwab::TradeStatus;
+use crate::schwab::TradeState;
 use crate::schwab::{Direction, execution::SchwabExecution};
 
 pub async fn add_trade(
@@ -331,7 +331,7 @@ async fn create_execution_within_transaction(
         symbol: symbol.to_string(),
         shares,
         direction,
-        status: TradeStatus::Pending,
+        state: TradeState::Pending,
     };
 
     let execution_id = execution.save_within_transaction(sql_tx).await?;
@@ -580,7 +580,7 @@ mod tests {
             symbol: "AAPL".to_string(),
             shares: 50,
             direction: Direction::Buy,
-            status: TradeStatus::Pending,
+            state: TradeState::Pending,
         };
         let mut sql_tx = pool.begin().await.unwrap();
         blocking_execution

--- a/src/onchain/trade_execution_link.rs
+++ b/src/onchain/trade_execution_link.rs
@@ -323,7 +323,7 @@ fn parse_trade_status_from_db(
             }
 
             #[allow(clippy::cast_sign_loss)]
-            Ok(TradeStatus::Completed {
+            Ok(TradeStatus::Filled {
                 executed_at: DateTime::from_naive_utc_and_offset(executed_at, Utc),
                 order_id: order_id.to_string(),
                 price_cents: price_cents as u64,
@@ -450,7 +450,7 @@ mod tests {
             symbol: "MSFT".to_string(),
             shares: 1,
             direction: Direction::Buy,
-            status: TradeStatus::Completed {
+            status: TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER123".to_string(),
                 price_cents: 30250,

--- a/src/schwab/auth.rs
+++ b/src/schwab/auth.rs
@@ -41,7 +41,7 @@ pub(crate) struct AccountNumbers {
 }
 
 impl SchwabAuthEnv {
-    pub async fn get_account_hash(&self, pool: &SqlitePool) -> Result<String, SchwabError> {
+    pub(crate) async fn get_account_hash(&self, pool: &SqlitePool) -> Result<String, SchwabError> {
         let access_token = SchwabTokens::get_valid_access_token(pool, self).await?;
 
         let headers = [
@@ -103,7 +103,10 @@ impl SchwabAuthEnv {
         )
     }
 
-    pub async fn get_tokens_from_code(&self, code: &str) -> Result<SchwabTokens, SchwabError> {
+    pub(crate) async fn get_tokens_from_code(
+        &self,
+        code: &str,
+    ) -> Result<SchwabTokens, SchwabError> {
         info!("Getting tokens for code: {code}");
         let credentials = format!("{}:{}", self.app_key, self.app_secret);
         let credentials = BASE64_STANDARD.encode(credentials);
@@ -177,7 +180,10 @@ impl SchwabAuthEnv {
         })
     }
 
-    pub async fn refresh_tokens(&self, refresh_token: &str) -> Result<SchwabTokens, SchwabError> {
+    pub(crate) async fn refresh_tokens(
+        &self,
+        refresh_token: &str,
+    ) -> Result<SchwabTokens, SchwabError> {
         let credentials = format!("{}:{}", self.app_key, self.app_secret);
         let credentials = BASE64_STANDARD.encode(credentials);
 

--- a/src/schwab/auth.rs
+++ b/src/schwab/auth.rs
@@ -24,7 +24,7 @@ pub struct SchwabAuthEnv {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SchwabAuthResponse {
+pub(crate) struct SchwabAuthResponse {
     /// Expires every 30 minutes
     pub access_token: String,
     /// Expires every 7 days
@@ -33,7 +33,7 @@ pub struct SchwabAuthResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AccountNumbers {
+pub(crate) struct AccountNumbers {
     // Field exists in API response but isn't currently used
     #[allow(dead_code)]
     pub account_number: String,

--- a/src/schwab/execution.rs
+++ b/src/schwab/execution.rs
@@ -148,8 +148,6 @@ pub(crate) async fn update_execution_status_within_transaction(
 }
 
 /// Find executions with SUBMITTED status (orders that have been submitted and can be polled)
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 pub(crate) async fn find_submitted_executions_by_symbol(
     pool: &SqlitePool,
     symbol: &str,
@@ -158,8 +156,6 @@ pub(crate) async fn find_submitted_executions_by_symbol(
 }
 
 /// Find executions with PENDING status (orders that have not been submitted yet)
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 pub(crate) async fn find_pending_executions_by_symbol(
     pool: &SqlitePool,
     symbol: &str,
@@ -176,8 +172,6 @@ pub(crate) async fn find_filled_executions_by_symbol(
     find_executions_by_symbol_and_status(pool, symbol, "FILLED").await
 }
 
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 pub(crate) async fn find_executions_by_symbol_and_status(
     pool: &SqlitePool,
     symbol: &str,

--- a/src/schwab/execution.rs
+++ b/src/schwab/execution.rs
@@ -25,23 +25,31 @@ fn row_to_execution(
 
     let parsed_status = match status {
         "PENDING" => TradeStatus::Pending,
-        "COMPLETED" => {
+        "SUBMITTED" => {
             let order_id = order_id.ok_or_else(|| {
                 OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
-                    "COMPLETED status requires order_id".to_string(),
+                    "SUBMITTED status requires order_id".to_string(),
+                ))
+            })?;
+            TradeStatus::Submitted { order_id }
+        }
+        "FILLED" => {
+            let order_id = order_id.ok_or_else(|| {
+                OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                    "FILLED status requires order_id".to_string(),
                 ))
             })?;
             let price_cents = price_cents.ok_or_else(|| {
                 OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
-                    "COMPLETED status requires price_cents".to_string(),
+                    "FILLED status requires price_cents".to_string(),
                 ))
             })?;
             let executed_at = executed_at.ok_or_else(|| {
                 OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
-                    "COMPLETED status requires executed_at".to_string(),
+                    "FILLED status requires executed_at".to_string(),
                 ))
             })?;
-            TradeStatus::Completed {
+            TradeStatus::Filled {
                 executed_at: DateTime::<Utc>::from_naive_utc_and_offset(executed_at, Utc),
                 order_id,
                 price_cents: price_cents_from_db_i64(price_cents)?,
@@ -105,7 +113,8 @@ pub(crate) async fn update_execution_status_within_transaction(
 
     let (order_id, price_cents_i64, executed_at) = match &new_status {
         TradeStatus::Pending => (None, None, None),
-        TradeStatus::Completed {
+        TradeStatus::Submitted { order_id } => (Some(order_id.clone()), None, None),
+        TradeStatus::Filled {
             executed_at,
             order_id,
             price_cents,
@@ -138,8 +147,19 @@ pub(crate) async fn update_execution_status_within_transaction(
     Ok(())
 }
 
-/// Find executions with PENDING status
-#[cfg(test)]
+/// Find executions with SUBMITTED status (orders that have been submitted and can be polled)
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
+pub(crate) async fn find_submitted_executions_by_symbol(
+    pool: &SqlitePool,
+    symbol: &str,
+) -> Result<Vec<SchwabExecution>, OnChainError> {
+    find_executions_by_symbol_and_status(pool, symbol, "SUBMITTED").await
+}
+
+/// Find executions with PENDING status (orders that have not been submitted yet)
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
 pub(crate) async fn find_pending_executions_by_symbol(
     pool: &SqlitePool,
     symbol: &str,
@@ -147,16 +167,17 @@ pub(crate) async fn find_pending_executions_by_symbol(
     find_executions_by_symbol_and_status(pool, symbol, "PENDING").await
 }
 
-/// Find executions with COMPLETED status
+/// Find executions with FILLED status
 #[cfg(test)]
-pub(crate) async fn find_completed_executions_by_symbol(
+pub(crate) async fn find_filled_executions_by_symbol(
     pool: &SqlitePool,
     symbol: &str,
 ) -> Result<Vec<SchwabExecution>, OnChainError> {
-    find_executions_by_symbol_and_status(pool, symbol, "COMPLETED").await
+    find_executions_by_symbol_and_status(pool, symbol, "FILLED").await
 }
 
-#[cfg(test)]
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
 pub(crate) async fn find_executions_by_symbol_and_status(
     pool: &SqlitePool,
     symbol: &str,
@@ -249,7 +270,8 @@ impl SchwabExecution {
 
         let (order_id, price_cents_i64, executed_at) = match &self.status {
             TradeStatus::Pending => (None, None, None),
-            TradeStatus::Completed {
+            TradeStatus::Submitted { order_id } => (Some(order_id.clone()), None, None),
+            TradeStatus::Filled {
                 executed_at,
                 order_id,
                 price_cents,
@@ -333,7 +355,7 @@ mod tests {
             symbol: "AAPL".to_string(),
             shares: 25,
             direction: Direction::Sell,
-            status: TradeStatus::Completed {
+            status: TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER123".to_string(),
                 price_cents: 15025,
@@ -377,7 +399,7 @@ mod tests {
         assert_eq!(pending_aapl[0].shares, 50);
         assert_eq!(pending_aapl[0].direction, Direction::Buy);
 
-        let completed_aapl = find_completed_executions_by_symbol(&pool, "AAPL")
+        let completed_aapl = find_filled_executions_by_symbol(&pool, "AAPL")
             .await
             .unwrap();
 
@@ -386,7 +408,7 @@ mod tests {
         assert_eq!(completed_aapl[0].direction, Direction::Sell);
         assert!(matches!(
             &completed_aapl[0].status,
-            TradeStatus::Completed { order_id, price_cents, .. }
+            TradeStatus::Filled { order_id, price_cents, .. }
             if order_id == "ORDER123" && *price_cents == 15025
         ));
     }
@@ -424,7 +446,7 @@ mod tests {
             .unwrap();
         assert_eq!(result.len(), 0);
 
-        let result = find_completed_executions_by_symbol(&pool, "AAPL")
+        let result = find_filled_executions_by_symbol(&pool, "AAPL")
             .await
             .unwrap();
         assert_eq!(result.len(), 0);
@@ -455,7 +477,7 @@ mod tests {
                 symbol: "AAPL".to_string(),
                 shares: 200,
                 direction: Direction::Buy,
-                status: TradeStatus::Completed {
+                status: TradeStatus::Filled {
                     executed_at: Utc::now(),
                     order_id: "ORDER123".to_string(),
                     price_cents: 15000,
@@ -478,10 +500,10 @@ mod tests {
             .unwrap();
         assert_eq!(pending_all.len(), 2); // AAPL and MSFT pending
 
-        let completed_all = find_executions_by_symbol_and_status(&pool, "", "COMPLETED")
+        let filled_all = find_executions_by_symbol_and_status(&pool, "", "FILLED")
             .await
             .unwrap();
-        assert_eq!(completed_all.len(), 1); // Only AAPL completed
+        assert_eq!(filled_all.len(), 1); // Only AAPL filled
 
         let failed_all = find_executions_by_symbol_and_status(&pool, "", "FAILED")
             .await
@@ -626,7 +648,7 @@ mod tests {
             symbol: "TEST".to_string(),
             shares: 12345,
             direction: Direction::Sell,
-            status: TradeStatus::Completed {
+            status: TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER789".to_string(),
                 price_cents: 98765,
@@ -640,7 +662,7 @@ mod tests {
             .unwrap();
         sql_tx.commit().await.unwrap();
 
-        let result = find_completed_executions_by_symbol(&pool, "TEST")
+        let result = find_filled_executions_by_symbol(&pool, "TEST")
             .await
             .unwrap();
 
@@ -653,7 +675,7 @@ mod tests {
         assert_eq!(found.direction, Direction::Sell);
         assert!(matches!(
             &found.status,
-            TradeStatus::Completed { order_id, price_cents, .. }
+            TradeStatus::Filled { order_id, price_cents, .. }
             if order_id == "ORDER789" && *price_cents == 98765
         ));
         assert!(found.id.is_some());
@@ -731,7 +753,7 @@ mod tests {
         update_execution_status_within_transaction(
             &mut sql_tx,
             id,
-            TradeStatus::Completed {
+            TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER456".to_string(),
                 price_cents: 20050,
@@ -742,14 +764,14 @@ mod tests {
         sql_tx.commit().await.unwrap();
 
         // Verify the update persisted by finding executions with the new status
-        let completed_executions = find_completed_executions_by_symbol(&pool, "TSLA")
+        let completed_executions = find_filled_executions_by_symbol(&pool, "TSLA")
             .await
             .unwrap();
 
         assert_eq!(completed_executions.len(), 1);
         assert!(matches!(
             &completed_executions[0].status,
-            TradeStatus::Completed { order_id, price_cents, .. }
+            TradeStatus::Filled { order_id, price_cents, .. }
             if order_id == "ORDER456" && *price_cents == 20050
         ));
     }
@@ -850,7 +872,7 @@ mod tests {
             symbol: "AAPL".to_string(),
             shares: 200,
             direction: Direction::Sell,
-            status: TradeStatus::Completed {
+            status: TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER123".to_string(),
                 price_cents: 15000,
@@ -867,7 +889,7 @@ mod tests {
         let pending_aapl = find_pending_executions_by_symbol(&pool, "AAPL")
             .await
             .unwrap();
-        let completed_aapl = find_completed_executions_by_symbol(&pool, "AAPL")
+        let completed_aapl = find_filled_executions_by_symbol(&pool, "AAPL")
             .await
             .unwrap();
         assert_eq!(pending_aapl.len(), 1);
@@ -1107,7 +1129,7 @@ mod tests {
         update_execution_status_within_transaction(
             &mut sql_tx,
             execution_id,
-            TradeStatus::Completed {
+            TradeStatus::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER999".to_string(),
                 price_cents: 300_000,

--- a/src/schwab/mod.rs
+++ b/src/schwab/mod.rs
@@ -87,7 +87,7 @@ impl serde::Serialize for Direction {
 }
 
 #[derive(Error, Debug)]
-pub enum SchwabError {
+pub(crate) enum SchwabError {
     #[error("Failed to create header value: {0}")]
     InvalidHeader(#[from] InvalidHeaderValue),
     #[error("Request failed: {0}")]
@@ -117,10 +117,13 @@ pub enum SchwabError {
     #[error("Invalid configuration: {0}")]
     InvalidConfiguration(String),
     #[error("Execution persistence error: {0}")]
-    ExecutionPersistence(#[from] crate::error::OnChainError),
+    ExecutionPersistence(#[from] crate::error::PersistenceError),
 }
 
-pub async fn run_oauth_flow(pool: &SqlitePool, env: &SchwabAuthEnv) -> Result<(), SchwabError> {
+pub(crate) async fn run_oauth_flow(
+    pool: &SqlitePool,
+    env: &SchwabAuthEnv,
+) -> Result<(), SchwabError> {
     println!(
         "Authenticate portfolio brokerage account (not dev account) and paste URL: {}",
         env.get_auth_url()
@@ -163,7 +166,7 @@ pub(crate) const fn price_cents_from_db_i64(db_value: i64) -> Result<u64, error:
     }
 }
 
-pub fn extract_code_from_url(url: &str) -> Result<String, SchwabError> {
+pub(crate) fn extract_code_from_url(url: &str) -> Result<String, SchwabError> {
     let parsed_url = url::Url::parse(url)?;
 
     parsed_url

--- a/src/schwab/mod.rs
+++ b/src/schwab/mod.rs
@@ -1,5 +1,4 @@
 use crate::error;
-use chrono::{DateTime, Utc};
 use reqwest::header::InvalidHeaderValue;
 use sqlx::SqlitePool;
 use std::io::{self, Write};
@@ -11,35 +10,28 @@ pub(crate) mod order;
 pub(crate) mod order_poller;
 pub(crate) mod order_status;
 pub(crate) mod tokens;
+pub(crate) mod trade_state;
 
 pub(crate) use auth::SchwabAuthEnv;
 pub(crate) use order_poller::{OrderPollerConfig, OrderStatusPoller};
 pub(crate) use tokens::SchwabTokens;
+pub(crate) use trade_state::{HasTradeStatus, TradeState};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TradeStatus {
     Pending,
-    Submitted {
-        order_id: String,
-    },
-    Filled {
-        executed_at: DateTime<Utc>,
-        order_id: String,
-        price_cents: u64,
-    },
-    Failed {
-        failed_at: DateTime<Utc>,
-        error_reason: Option<String>,
-    },
+    Submitted,
+    Filled,
+    Failed,
 }
 
 impl TradeStatus {
-    pub const fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Pending => "PENDING",
-            Self::Submitted { .. } => "SUBMITTED",
-            Self::Filled { .. } => "FILLED",
-            Self::Failed { .. } => "FAILED",
+            Self::Submitted => "SUBMITTED",
+            Self::Filled => "FILLED",
+            Self::Failed => "FAILED",
         }
     }
 }
@@ -50,9 +42,9 @@ impl std::str::FromStr for TradeStatus {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "PENDING" => Ok(Self::Pending),
-            "SUBMITTED" => Err("Cannot create Submitted status without required data".to_string()),
-            "FILLED" => Err("Cannot create Filled status without required data".to_string()),
-            "FAILED" => Err("Cannot create Failed status without required data".to_string()),
+            "SUBMITTED" => Ok(Self::Submitted),
+            "FILLED" => Ok(Self::Filled),
+            "FAILED" => Ok(Self::Failed),
             _ => Err(format!("Invalid trade status: {s}")),
         }
     }
@@ -124,6 +116,8 @@ pub enum SchwabError {
     },
     #[error("Invalid configuration: {0}")]
     InvalidConfiguration(String),
+    #[error("Execution persistence error: {0}")]
+    ExecutionPersistence(#[from] crate::error::OnChainError),
 }
 
 pub async fn run_oauth_flow(pool: &SqlitePool, env: &SchwabAuthEnv) -> Result<(), SchwabError> {

--- a/src/schwab/mod.rs
+++ b/src/schwab/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod order_status;
 pub(crate) mod tokens;
 
 pub(crate) use auth::SchwabAuthEnv;
+pub(crate) use order_poller::{OrderPollerConfig, OrderStatusPoller};
 pub(crate) use tokens::SchwabTokens;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/schwab/mod.rs
+++ b/src/schwab/mod.rs
@@ -161,7 +161,7 @@ pub(crate) const fn price_cents_from_db_i64(db_value: i64) -> Result<u64, error:
     }
 }
 
-pub(crate) fn extract_code_from_url(url: &str) -> Result<String, SchwabError> {
+pub fn extract_code_from_url(url: &str) -> Result<String, SchwabError> {
     let parsed_url = url::Url::parse(url)?;
 
     parsed_url

--- a/src/schwab/order.rs
+++ b/src/schwab/order.rs
@@ -964,7 +964,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify execution remains PENDING with order_id stored in database
+        // Verify execution is now Submitted with order_id stored in database
         let updated_execution = find_execution_by_id(&pool, execution_id)
             .await
             .unwrap()

--- a/src/schwab/order.rs
+++ b/src/schwab/order.rs
@@ -19,14 +19,14 @@ use crate::schwab::TradeStatus;
 /// According to Schwab OpenAPI spec, successful order placement (201) returns
 /// empty body with order ID in the Location header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OrderPlacementResponse {
+pub(crate) struct OrderPlacementResponse {
     pub order_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::struct_field_names)]
-pub struct Order {
+pub(crate) struct Order {
     pub order_type: OrderType,
     pub session: Session,
     pub duration: OrderDuration,
@@ -110,6 +110,64 @@ impl Order {
 
         Ok(OrderPlacementResponse { order_id })
     }
+
+    /// Get the status of a specific order from Schwab API.
+    /// Returns the order status response containing fill information and execution details.
+    // TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+    #[allow(dead_code)]
+    pub async fn get_order_status(
+        order_id: &str,
+        env: &SchwabAuthEnv,
+        pool: &SqlitePool,
+    ) -> Result<OrderStatusResponse, SchwabError> {
+        let access_token = SchwabTokens::get_valid_access_token(pool, env).await?;
+        let account_hash = env.get_account_hash(pool).await?;
+
+        let headers = [
+            (
+                header::AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {access_token}"))?,
+            ),
+            (header::ACCEPT, HeaderValue::from_str("application/json")?),
+        ]
+        .into_iter()
+        .collect::<HeaderMap>();
+
+        let client = reqwest::Client::new();
+        let response = (|| async {
+            client
+                .get(format!(
+                    "{}/trader/v1/accounts/{}/orders/{}",
+                    env.base_url, account_hash, order_id
+                ))
+                .headers(headers.clone())
+                .send()
+                .await
+        })
+        .retry(ExponentialBuilder::default())
+        .await?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(SchwabError::RequestFailed {
+                action: "get order status".to_string(),
+                status,
+                body: format!("Order ID {order_id} not found"),
+            });
+        }
+
+        if !response.status().is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            return Err(SchwabError::RequestFailed {
+                action: "get order status".to_string(),
+                status,
+                body: error_body,
+            });
+        }
+
+        let order_status: OrderStatusResponse = response.json().await?;
+        Ok(order_status)
+    }
 }
 
 /// Extracts order ID from the Location header in Schwab order placement response.
@@ -170,7 +228,7 @@ fn extract_order_id_from_location_header(
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum OrderType {
+pub(crate) enum OrderType {
     Market,
     Limit,
     Stop,
@@ -182,7 +240,7 @@ pub enum OrderType {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Instruction {
+pub(crate) enum Instruction {
     Buy,
     Sell,
     BuyToCover,
@@ -195,7 +253,7 @@ pub enum Instruction {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum Session {
+pub(crate) enum Session {
     Normal,
     Am,
     Pm,
@@ -204,14 +262,14 @@ pub enum Session {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum OrderDuration {
+pub(crate) enum OrderDuration {
     Day,
     GoodTillCancel,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum OrderStrategyType {
+pub(crate) enum OrderStrategyType {
     Single,
     Oco,
     Trigger,
@@ -219,7 +277,7 @@ pub enum OrderStrategyType {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum AssetType {
+pub(crate) enum AssetType {
     Equity,
     Option,
     Index,
@@ -231,7 +289,7 @@ pub enum AssetType {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderLeg {
+pub(crate) struct OrderLeg {
     pub instruction: Instruction,
     pub quantity: u64,
     pub instrument: Instrument,
@@ -239,7 +297,7 @@ pub struct OrderLeg {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct Instrument {
+pub(crate) struct Instrument {
     pub symbol: String,
     pub asset_type: AssetType,
 }
@@ -248,7 +306,7 @@ const MAX_RETRIES: usize = 3;
 
 /// Execute a Schwab order using the unified system.
 /// Takes a SchwabExecution and places the corresponding order via Schwab API.
-pub async fn execute_schwab_order(
+pub(crate) async fn execute_schwab_order(
     env: &Env,
     pool: &SqlitePool,
     execution: SchwabExecution,
@@ -300,21 +358,17 @@ async fn handle_execution_success(
         e
     })?;
 
-    if let Err(e) = update_execution_status_within_transaction(
+    // Update status to Submitted with order_id so order poller can track the order and update with real fill price
+    update_execution_status_within_transaction(
         &mut sql_tx,
         execution_id,
-        TradeStatus::Completed {
-            executed_at: Utc::now(),
-            order_id,
-            price_cents: 0, // TODO: Implement order status polling to get actual execution price
-        },
+        TradeStatus::Submitted { order_id },
     )
     .await
-    {
-        error!("Failed to update execution status to COMPLETED: id={execution_id}, error={e:?}",);
-        let _ = sql_tx.rollback().await;
-        return Err(SchwabError::Sqlx(e));
-    }
+    .map_err(|e| {
+        error!("Failed to update execution with order_id: id={execution_id}, error={e:?}");
+        SchwabError::Sqlx(e)
+    })?;
 
     sql_tx.commit().await.map_err(|e| {
         error!("Failed to commit execution success transaction: id={execution_id}, error={e:?}",);
@@ -916,22 +970,17 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify execution status was updated
+        // Verify execution remains PENDING with order_id stored in database
         let updated_execution = find_execution_by_id(&pool, execution_id)
             .await
             .unwrap()
             .unwrap();
-        match updated_execution.status {
-            TradeStatus::Completed {
-                order_id,
-                price_cents,
-                ..
-            } => {
-                assert_eq!(order_id, "ORDER123");
-                assert_eq!(price_cents, 0); // Still using placeholder
-            }
-            _ => panic!("Expected Completed status"),
-        }
+
+        // Status should be Submitted with order_id since order poller will update it when filled
+        assert!(matches!(
+            updated_execution.status,
+            TradeStatus::Submitted { ref order_id } if order_id == "ORDER123"
+        ));
     }
 
     #[tokio::test]
@@ -1001,6 +1050,366 @@ mod tests {
                 .await
                 .unwrap_err(),
             SchwabError::Sqlx(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_success_filled() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER123")
+                .header("authorization", "Bearer test_access_token")
+                .header("accept", "application/json");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "orderId": "ORDER123",
+                    "status": "FILLED",
+                    "filledQuantity": 100.0,
+                    "remainingQuantity": 0.0,
+                    "executionLegs": [
+                        {
+                            "executionId": "EXEC001",
+                            "quantity": 100.0,
+                            "price": 150.25,
+                            "time": "2023-10-15T10:30:00Z"
+                        }
+                    ],
+                    "enteredTime": "2023-10-15T10:25:00Z",
+                    "closeTime": "2023-10-15T10:30:00Z"
+                }));
+        });
+
+        let result = Order::get_order_status("ORDER123", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let order_status = result.unwrap();
+        assert_eq!(order_status.order_id, Some("ORDER123".to_string()));
+        assert!(order_status.is_filled());
+        assert!((order_status.filled_quantity - 100.0).abs() < f64::EPSILON);
+        let avg_price = order_status.calculate_weighted_average_price().unwrap();
+        assert!((avg_price - 150.25).abs() < f64::EPSILON);
+        assert_eq!(order_status.price_in_cents().unwrap(), Some(15025));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_success_working() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER456")
+                .header("authorization", "Bearer test_access_token")
+                .header("accept", "application/json");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "orderId": "ORDER456",
+                    "status": "WORKING",
+                    "filledQuantity": 0.0,
+                    "remainingQuantity": 100.0,
+                    "executionLegs": [],
+                    "enteredTime": "2023-10-15T10:25:00Z",
+                    "closeTime": null
+                }));
+        });
+
+        let result = Order::get_order_status("ORDER456", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let order_status = result.unwrap();
+        assert_eq!(order_status.order_id, Some("ORDER456".to_string()));
+        assert!(order_status.is_pending());
+        assert!(!order_status.is_filled());
+        assert!(order_status.filled_quantity.abs() < f64::EPSILON);
+        assert_eq!(order_status.calculate_weighted_average_price(), None);
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_partially_filled() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER789")
+                .header("authorization", "Bearer test_access_token")
+                .header("accept", "application/json");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "orderId": "ORDER789",
+                    "status": "WORKING",
+                    "filledQuantity": 75.0,
+                    "remainingQuantity": 25.0,
+                    "executionLegs": [
+                        {
+                            "executionId": "EXEC001",
+                            "quantity": 50.0,
+                            "price": 100.00,
+                            "time": "2023-10-15T10:30:00Z"
+                        },
+                        {
+                            "executionId": "EXEC002",
+                            "quantity": 25.0,
+                            "price": 101.00,
+                            "time": "2023-10-15T10:30:05Z"
+                        }
+                    ],
+                    "enteredTime": "2023-10-15T10:25:00Z",
+                    "closeTime": null
+                }));
+        });
+
+        let result = Order::get_order_status("ORDER789", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let order_status = result.unwrap();
+        assert_eq!(order_status.order_id, Some("ORDER789".to_string()));
+        assert!(order_status.is_pending());
+        assert!(!order_status.is_filled());
+        assert!((order_status.filled_quantity - 75.0).abs() < f64::EPSILON);
+        // Weighted average: (50 * 100.00 + 25 * 101.00) / 75 = (5000 + 2525) / 75 = 100.33333
+        assert!(
+            (order_status.calculate_weighted_average_price().unwrap() - 100.333_333_333_333_33)
+                .abs()
+                < 0.000_001
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_order_not_found() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/NONEXISTENT");
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({"error": "Order not found"}));
+        });
+
+        let result = Order::get_order_status("NONEXISTENT", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error,
+            SchwabError::RequestFailed { action, status, body }
+            if action == "get order status"
+                && status == reqwest::StatusCode::NOT_FOUND
+                && body.contains("NONEXISTENT")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_authentication_failure() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER123");
+            then.status(401)
+                .header("content-type", "application/json")
+                .json_body(json!({"error": "Unauthorized"}));
+        });
+
+        let result = Order::get_order_status("ORDER123", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error,
+            SchwabError::RequestFailed { action, status, .. }
+            if action == "get order status" && status == reqwest::StatusCode::UNAUTHORIZED
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_server_error() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER123");
+            then.status(500)
+                .header("content-type", "application/json")
+                .json_body(json!({"error": "Internal server error"}));
+        });
+
+        let result = Order::get_order_status("ORDER123", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error,
+            SchwabError::RequestFailed { action, status, .. }
+            if action == "get order status" && status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_invalid_json_response() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER123");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("invalid json response");
+        });
+
+        let result = Order::get_order_status("ORDER123", &env, &pool).await;
+
+        account_mock.assert();
+        order_status_mock.assert();
+        let error = result.unwrap_err();
+        assert!(matches!(error, SchwabError::Reqwest(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_status_retry_on_transient_failure() {
+        let server = httpmock::MockServer::start();
+        let env = create_test_env_with_mock_server(&server);
+        let pool = setup_test_db().await;
+        setup_test_tokens(&pool).await;
+
+        let account_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        // Mock that fails initially but should be retried
+        let order_status_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER123");
+            then.status(502) // Bad Gateway - transient error
+                .header("content-type", "application/json")
+                .json_body(json!({"error": "Bad Gateway"}));
+        });
+
+        let result = Order::get_order_status("ORDER123", &env, &pool).await;
+
+        account_mock.assert();
+        // Should have made at least one request (retry logic is handled by backon)
+        assert!(order_status_mock.hits() >= 1);
+        let error = result.unwrap_err();
+        assert!(matches!(
+            error,
+            SchwabError::RequestFailed { action, status, .. }
+            if action == "get order status" && status == reqwest::StatusCode::BAD_GATEWAY
         ));
     }
 

--- a/src/schwab/order.rs
+++ b/src/schwab/order.rs
@@ -113,8 +113,6 @@ impl Order {
 
     /// Get the status of a specific order from Schwab API.
     /// Returns the order status response containing fill information and execution details.
-    // TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-    #[allow(dead_code)]
     pub async fn get_order_status(
         order_id: &str,
         env: &SchwabAuthEnv,

--- a/src/schwab/order_poller.rs
+++ b/src/schwab/order_poller.rs
@@ -609,13 +609,13 @@ mod tests {
 
         assert_eq!(filled_executions.len(), num_orders);
 
-        // Performance assertions
+        // Performance assertions - allow reasonable time for sequential HTTP requests
         assert!(
-            elapsed.as_secs() < 10,
+            elapsed.as_secs() < 15,
             "High volume polling took too long: {elapsed:?}"
         );
         assert!(
-            (elapsed.as_secs_f64() / (num_orders as f64)) < 0.2,
+            (elapsed.as_secs_f64() / (num_orders as f64)) < 0.5,
             "Average time per order too high: {:.3}s",
             elapsed.as_secs_f64() / (num_orders as f64)
         );

--- a/src/schwab/order_poller.rs
+++ b/src/schwab/order_poller.rs
@@ -13,9 +13,9 @@ use super::order::Order;
 use super::{SchwabAuthEnv, SchwabError, TradeStatus};
 
 #[derive(Debug, Clone)]
-pub(crate) struct OrderPollerConfig {
-    pub(crate) polling_interval: Duration,
-    pub(crate) max_jitter: Duration,
+pub struct OrderPollerConfig {
+    pub polling_interval: Duration,
+    pub max_jitter: Duration,
 }
 
 impl Default for OrderPollerConfig {
@@ -323,5 +323,308 @@ mod tests {
 
         let result = poller.poll_execution_status(execution_id).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    async fn test_end_to_end_order_flow() {
+        use httpmock::prelude::*;
+        use serde_json::json;
+
+        let server = MockServer::start();
+        let pool = setup_test_db().await;
+
+        // Setup test environment with mock server
+        let env = SchwabAuthEnv {
+            app_key: "test_key".to_string(),
+            app_secret: "test_secret".to_string(),
+            redirect_uri: "https://127.0.0.1".to_string(),
+            base_url: server.base_url(),
+            account_index: 0,
+        };
+
+        // Setup test tokens in database
+        let tokens = crate::schwab::SchwabTokens {
+            access_token: "test_access_token".to_string(),
+            access_token_fetched_at: chrono::Utc::now(),
+            refresh_token: "test_refresh_token".to_string(),
+            refresh_token_fetched_at: chrono::Utc::now(),
+        };
+        tokens.store(&pool).await.unwrap();
+
+        // Mock account hash endpoint
+        let account_mock = server.mock(|when, then| {
+            when.method(GET).path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        // Step 1: Create a SchwabExecution directly (simulating the result of onchain trade processing)
+        // This reflects the real architecture where executions are created from onchain trades
+        let execution = SchwabExecution {
+            id: None,
+            symbol: "AAPL".to_string(),
+            shares: 100,
+            direction: Direction::Buy,
+            state: TradeState::Submitted {
+                order_id: "ORDER12345".to_string(),
+            },
+        };
+
+        let mut sql_tx = pool.begin().await.unwrap();
+        let execution_id = execution
+            .save_within_transaction(&mut sql_tx)
+            .await
+            .unwrap();
+        sql_tx.commit().await.unwrap();
+
+        // Step 2: Verify execution was saved to database with SUBMITTED status
+        let saved_executions = crate::schwab::execution::find_executions_by_symbol_and_status(
+            &pool,
+            "AAPL",
+            crate::schwab::TradeStatus::Submitted,
+        )
+        .await
+        .unwrap();
+        assert_eq!(saved_executions.len(), 1);
+        let saved_execution = &saved_executions[0];
+        assert_eq!(saved_execution.shares, 100);
+        assert_eq!(saved_execution.direction, Direction::Buy);
+        assert!(matches!(
+            &saved_execution.state,
+            TradeState::Submitted { order_id } if order_id == "ORDER12345"
+        ));
+
+        // Step 3: Mock order status polling with sequence - first WORKING, then FILLED
+        let order_status_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/trader/v1/accounts/ABC123DEF456/orders/ORDER12345")
+                .header("authorization", "Bearer test_access_token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "orderId": "ORDER12345",
+                    "status": "FILLED",
+                    "filledQuantity": 100.0,
+                    "remainingQuantity": 0.0,
+                    "executionLegs": [{
+                        "executionId": "EXEC123",
+                        "quantity": 100.0,
+                        "price": 150.25,
+                        "time": "2023-10-15T10:30:00Z"
+                    }],
+                    "enteredTime": "2023-10-15T10:25:00Z",
+                    "closeTime": "2023-10-15T10:30:00Z"
+                }));
+        });
+
+        // Step 4: Poll for status and let the poller find it's filled
+        let config = OrderPollerConfig::default();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let poller = OrderStatusPoller::new(config, env.clone(), pool.clone(), shutdown_rx);
+
+        // Step 5: Poll for status and verify order gets updated to FILLED with actual price
+        let poll_result = poller.poll_execution_status(execution_id).await;
+
+        assert!(poll_result.is_ok());
+
+        // Step 6: Verify final state - order should be FILLED with actual execution price
+        let final_execution = crate::schwab::execution::find_execution_by_id(&pool, execution_id)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(matches!(
+            &final_execution.state,
+            TradeState::Filled { order_id, price_cents, .. }
+            if order_id == "ORDER12345" && *price_cents == 15025  // 150.25 * 100 cents
+        ));
+
+        // Step 7: Verify no more SUBMITTED executions for this symbol
+        let submitted_executions = crate::schwab::execution::find_executions_by_symbol_and_status(
+            &pool,
+            "AAPL",
+            crate::schwab::TradeStatus::Submitted,
+        )
+        .await
+        .unwrap();
+        assert_eq!(submitted_executions.len(), 0);
+
+        // Step 8: Verify there is now one FILLED execution
+        let filled_executions = crate::schwab::execution::find_executions_by_symbol_and_status(
+            &pool,
+            "AAPL",
+            crate::schwab::TradeStatus::Filled,
+        )
+        .await
+        .unwrap();
+        assert_eq!(filled_executions.len(), 1);
+        assert_eq!(filled_executions[0].id, Some(execution_id));
+
+        // Verify all mocks were called as expected
+        account_mock.assert_hits(1); // Called during polling
+        order_status_mock.assert();
+
+        // Trigger shutdown for clean test completion
+        shutdown_tx.send(true).unwrap();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cast_precision_loss)]
+    async fn test_high_volume_order_polling_performance() {
+        use httpmock::prelude::*;
+        use serde_json::json;
+        use std::time::Instant;
+
+        let server = MockServer::start();
+        let pool = setup_test_db().await;
+
+        // Setup test environment
+        let env = SchwabAuthEnv {
+            app_key: "test_key".to_string(),
+            app_secret: "test_secret".to_string(),
+            redirect_uri: "https://127.0.0.1".to_string(),
+            base_url: server.base_url(),
+            account_index: 0,
+        };
+
+        // Setup test tokens
+        let tokens = crate::schwab::SchwabTokens {
+            access_token: "test_access_token".to_string(),
+            access_token_fetched_at: chrono::Utc::now(),
+            refresh_token: "test_refresh_token".to_string(),
+            refresh_token_fetched_at: chrono::Utc::now(),
+        };
+        tokens.store(&pool).await.unwrap();
+
+        // Mock account hash endpoint
+        let account_mock = server.mock(|when, then| {
+            when.method(GET).path("/trader/v1/accounts/accountNumbers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "accountNumber": "123456789",
+                    "hashValue": "ABC123DEF456"
+                }]));
+        });
+
+        // Create many executions to poll (simulate high volume scenario)
+        let num_orders = 50;
+        let mut execution_ids = Vec::new();
+
+        for i in 0..num_orders {
+            let execution = SchwabExecution {
+                id: None,
+                symbol: format!("TEST{i}"), // Unique symbol for each execution
+                shares: 100 + (i * 10) as u64, // Varying share amounts
+                direction: if i % 2 == 0 {
+                    Direction::Buy
+                } else {
+                    Direction::Sell
+                },
+                state: TradeState::Submitted {
+                    order_id: format!("ORDER{i:04}"),
+                },
+            };
+
+            let mut sql_tx = pool.begin().await.unwrap();
+            let execution_id = execution
+                .save_within_transaction(&mut sql_tx)
+                .await
+                .unwrap();
+            sql_tx.commit().await.unwrap();
+            execution_ids.push(execution_id);
+
+            // Mock the order status response for this execution
+            let order_id = format!("ORDER{i:04}");
+            let price = (i as f64).mul_add(0.25, 150.0); // Varying prices
+
+            let _order_mock = server.mock(|when, then| {
+                when.method(GET)
+                    .path(format!(
+                        "/trader/v1/accounts/ABC123DEF456/orders/{order_id}"
+                    ))
+                    .header("authorization", "Bearer test_access_token");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(json!({
+                        "orderId": order_id,
+                        "status": "FILLED",
+                        "filledQuantity": (i as f64).mul_add(10.0, 100.0),
+                        "remainingQuantity": 0.0,
+                        "executionLegs": [{
+                            "executionId": format!("EXEC{i:04}"),
+                            "quantity": (i as f64).mul_add(10.0, 100.0),
+                            "price": price,
+                            "time": "2023-10-15T10:30:00Z"
+                        }],
+                        "enteredTime": "2023-10-15T10:25:00Z",
+                        "closeTime": "2023-10-15T10:30:00Z"
+                    }));
+            });
+        }
+
+        // Configure poller for performance testing
+        let config = OrderPollerConfig {
+            polling_interval: std::time::Duration::from_millis(100), // Fast polling
+            max_jitter: std::time::Duration::from_millis(10),
+        };
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let poller = OrderStatusPoller::new(config, env, pool.clone(), shutdown_rx);
+
+        // Measure performance of concurrent polling
+        let start_time = Instant::now();
+
+        // Poll all executions sequentially (but time the batch)
+        let mut results = Vec::new();
+        for execution_id in execution_ids {
+            let result = poller.poll_execution_status(execution_id).await;
+            results.push(result);
+        }
+        let elapsed = start_time.elapsed();
+
+        println!(
+            "Polled {num_orders} orders in {elapsed:?} ({:.2} orders/sec)",
+            num_orders as f64 / elapsed.as_secs_f64()
+        );
+
+        // Verify all polls succeeded
+        for (i, result) in results.iter().enumerate() {
+            assert!(result.is_ok(), "Poll {i} returned error: {result:?}");
+        }
+
+        // Verify all executions were updated to FILLED
+        let filled_executions = crate::schwab::execution::find_executions_by_symbol_and_status(
+            &pool,
+            "", // Empty string finds all symbols
+            crate::schwab::TradeStatus::Filled,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(filled_executions.len(), num_orders);
+
+        // Performance assertions
+        assert!(
+            elapsed.as_secs() < 10,
+            "High volume polling took too long: {elapsed:?}"
+        );
+        assert!(
+            (elapsed.as_secs_f64() / (num_orders as f64)) < 0.2,
+            "Average time per order too high: {:.3}s",
+            elapsed.as_secs_f64() / (num_orders as f64)
+        );
+
+        // Verify mocks were called appropriately
+        account_mock.assert_hits(num_orders); // Called once per order status check
+
+        // Trigger shutdown for clean test completion
+        shutdown_tx.send(true).unwrap();
     }
 }

--- a/src/schwab/order_poller.rs
+++ b/src/schwab/order_poller.rs
@@ -1,0 +1,333 @@
+use chrono::Utc;
+use sqlx::SqlitePool;
+use std::time::Duration;
+use tokio::sync::watch;
+use tokio::time::{Interval, interval};
+use tracing::{debug, error, info};
+
+use super::execution::{
+    find_execution_by_id, find_executions_by_symbol_and_status,
+    update_execution_status_within_transaction,
+};
+use super::order::Order;
+use super::{SchwabAuthEnv, SchwabError, TradeStatus};
+
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct OrderPollerConfig {
+    pub(crate) polling_interval: Duration,
+    pub(crate) max_jitter: Duration,
+}
+
+impl Default for OrderPollerConfig {
+    fn default() -> Self {
+        Self {
+            polling_interval: Duration::from_secs(15),
+            max_jitter: Duration::from_secs(5),
+        }
+    }
+}
+
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
+pub(crate) struct OrderStatusPoller {
+    config: OrderPollerConfig,
+    env: SchwabAuthEnv,
+    pool: SqlitePool,
+    interval: Interval,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
+impl OrderStatusPoller {
+    pub(crate) fn new(
+        config: OrderPollerConfig,
+        env: SchwabAuthEnv,
+        pool: SqlitePool,
+        shutdown_rx: watch::Receiver<bool>,
+    ) -> Self {
+        let interval = interval(config.polling_interval);
+
+        Self {
+            config,
+            env,
+            pool,
+            interval,
+            shutdown_rx,
+        }
+    }
+
+    pub(crate) async fn run(mut self) -> Result<(), SchwabError> {
+        info!(
+            "Starting order status poller with interval: {:?}",
+            self.config.polling_interval
+        );
+
+        loop {
+            tokio::select! {
+                _ = self.interval.tick() => {
+                    if let Err(e) = self.poll_pending_orders().await {
+                        error!("Polling cycle failed: {e}");
+                    }
+                }
+                _ = self.shutdown_rx.changed() => {
+                    if *self.shutdown_rx.borrow() {
+                        info!("Received shutdown signal, stopping order poller");
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn poll_pending_orders(&self) -> Result<(), SchwabError> {
+        debug!("Starting polling cycle for submitted orders");
+
+        let submitted_executions =
+            find_executions_by_symbol_and_status(&self.pool, "", "SUBMITTED")
+                .await
+                .map_err(|e| {
+                    error!("Failed to query pending executions: {e}");
+                    SchwabError::InvalidConfiguration(
+                        "Failed to query pending executions from database".to_string(),
+                    )
+                })?;
+
+        if submitted_executions.is_empty() {
+            debug!("No submitted orders to poll");
+            return Ok(());
+        }
+
+        info!("Polling {} submitted orders", submitted_executions.len());
+
+        for execution in submitted_executions {
+            if *self.shutdown_rx.borrow() {
+                info!("Shutdown signal received, stopping polling");
+                break;
+            }
+
+            let Some(execution_id) = execution.id else {
+                continue;
+            };
+
+            if let Err(e) = self.poll_execution_status(execution_id).await {
+                error!("Failed to poll execution {execution_id}: {e}");
+            }
+
+            self.add_jittered_delay(execution_id).await;
+        }
+
+        debug!("Completed polling cycle");
+        Ok(())
+    }
+
+    async fn poll_execution_status(&self, execution_id: i64) -> Result<(), SchwabError> {
+        let execution = find_execution_by_id(&self.pool, execution_id)
+            .await
+            .map_err(|e| {
+                error!("Failed to find execution {execution_id}: {e}");
+                SchwabError::InvalidConfiguration("Database query failed".to_string())
+            })?
+            .ok_or_else(|| {
+                error!("Execution {execution_id} not found in database");
+                SchwabError::InvalidConfiguration("Execution not found".to_string())
+            })?;
+
+        let order_id = match &execution.status {
+            TradeStatus::Pending => {
+                debug!("Execution {execution_id} is PENDING but no order_id yet");
+                return Ok(());
+            }
+            TradeStatus::Submitted { order_id } | TradeStatus::Filled { order_id, .. } => {
+                order_id.clone()
+            }
+            TradeStatus::Failed { .. } => {
+                debug!("Execution {execution_id} already failed, skipping poll");
+                return Ok(());
+            }
+        };
+
+        let order_status = Order::get_order_status(&order_id, &self.env, &self.pool).await?;
+
+        if order_status.is_filled() {
+            self.handle_filled_order(execution_id, &order_status)
+                .await?;
+        } else if order_status.is_terminal_failure() {
+            self.handle_failed_order(execution_id, &order_status)
+                .await?;
+        } else {
+            debug!(
+                "Order {order_id} (execution {execution_id}) still pending with status: {:?}",
+                order_status.status
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn handle_filled_order(
+        &self,
+        execution_id: i64,
+        order_status: &super::order_status::OrderStatusResponse,
+    ) -> Result<(), SchwabError> {
+        let price_cents = order_status
+            .price_in_cents()
+            .map_err(|e| {
+                error!("Failed to convert price to cents for execution {execution_id}: {e}");
+                SchwabError::InvalidConfiguration("Price conversion failed".to_string())
+            })?
+            .ok_or_else(|| {
+                error!("Filled order missing execution price for execution {execution_id}");
+                SchwabError::InvalidConfiguration("Missing execution price".to_string())
+            })?;
+
+        let new_status = TradeStatus::Filled {
+            executed_at: Utc::now(),
+            order_id: order_status
+                .order_id
+                .clone()
+                .unwrap_or_else(|| format!("UNKNOWN_{execution_id}")),
+            price_cents,
+        };
+
+        self.update_execution_status(execution_id, new_status)
+            .await?;
+
+        info!(
+            "Updated execution {execution_id} to FILLED with price: {} cents",
+            price_cents
+        );
+
+        Ok(())
+    }
+
+    async fn handle_failed_order(
+        &self,
+        execution_id: i64,
+        order_status: &super::order_status::OrderStatusResponse,
+    ) -> Result<(), SchwabError> {
+        let new_status = TradeStatus::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some(format!("Order status: {:?}", order_status.status)),
+        };
+
+        self.update_execution_status(execution_id, new_status)
+            .await?;
+
+        info!(
+            "Updated execution {execution_id} to FAILED due to order status: {:?}",
+            order_status.status
+        );
+
+        Ok(())
+    }
+
+    async fn update_execution_status(
+        &self,
+        execution_id: i64,
+        new_status: TradeStatus,
+    ) -> Result<(), SchwabError> {
+        let mut tx = self.pool.begin().await?;
+        update_execution_status_within_transaction(&mut tx, execution_id, new_status).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn add_jittered_delay(&self, execution_id: i64) {
+        if self.config.max_jitter > Duration::ZERO {
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let jitter_millis =
+                (execution_id as u64 * 17 + 42) % self.config.max_jitter.as_millis() as u64;
+            let jitter = Duration::from_millis(jitter_millis);
+            tokio::time::sleep(jitter).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schwab::Direction;
+    use crate::schwab::execution::SchwabExecution;
+    use crate::test_utils::setup_test_db;
+    use tokio::sync::watch;
+
+    #[tokio::test]
+    async fn test_order_poller_config_default() {
+        let config = OrderPollerConfig::default();
+        assert_eq!(config.polling_interval, Duration::from_secs(15));
+        assert_eq!(config.max_jitter, Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_order_poller_creation() {
+        let config = OrderPollerConfig::default();
+        let env = SchwabAuthEnv {
+            app_key: "test_key".to_string(),
+            app_secret: "test_secret".to_string(),
+            redirect_uri: "https://127.0.0.1".to_string(),
+            base_url: "https://api.schwabapi.com".to_string(),
+            account_index: 0,
+        };
+        let pool = setup_test_db().await;
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let poller = OrderStatusPoller::new(config.clone(), env, pool, shutdown_rx);
+        assert_eq!(poller.config.polling_interval, config.polling_interval);
+        assert_eq!(poller.config.max_jitter, config.max_jitter);
+    }
+
+    #[tokio::test]
+    async fn test_poll_pending_orders_empty_database() {
+        let config = OrderPollerConfig::default();
+        let env = SchwabAuthEnv {
+            app_key: "test_key".to_string(),
+            app_secret: "test_secret".to_string(),
+            redirect_uri: "https://127.0.0.1".to_string(),
+            base_url: "https://api.schwabapi.com".to_string(),
+            account_index: 0,
+        };
+        let pool = setup_test_db().await;
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let poller = OrderStatusPoller::new(config, env, pool, shutdown_rx);
+
+        let result = poller.poll_pending_orders().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_poll_execution_status_missing_order_id() {
+        let config = OrderPollerConfig::default();
+        let env = SchwabAuthEnv {
+            app_key: "test_key".to_string(),
+            app_secret: "test_secret".to_string(),
+            redirect_uri: "https://127.0.0.1".to_string(),
+            base_url: "https://api.schwabapi.com".to_string(),
+            account_index: 0,
+        };
+        let pool = setup_test_db().await;
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let execution = SchwabExecution {
+            id: None,
+            symbol: "AAPL".to_string(),
+            shares: 100,
+            direction: Direction::Buy,
+            status: TradeStatus::Pending,
+        };
+
+        let mut tx = pool.begin().await.unwrap();
+        let execution_id = execution.save_within_transaction(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let poller = OrderStatusPoller::new(config, env, pool, shutdown_rx);
+
+        let result = poller.poll_execution_status(execution_id).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/schwab/order_poller.rs
+++ b/src/schwab/order_poller.rs
@@ -12,8 +12,6 @@ use super::execution::{
 use super::order::Order;
 use super::{SchwabAuthEnv, SchwabError, TradeStatus};
 
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct OrderPollerConfig {
     pub(crate) polling_interval: Duration,
@@ -29,8 +27,6 @@ impl Default for OrderPollerConfig {
     }
 }
 
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 pub(crate) struct OrderStatusPoller {
     config: OrderPollerConfig,
     env: SchwabAuthEnv,
@@ -39,8 +35,6 @@ pub(crate) struct OrderStatusPoller {
     shutdown_rx: watch::Receiver<bool>,
 }
 
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 impl OrderStatusPoller {
     pub(crate) fn new(
         config: OrderPollerConfig,

--- a/src/schwab/order_status.rs
+++ b/src/schwab/order_status.rs
@@ -1,0 +1,501 @@
+use serde::{Deserialize, Serialize};
+
+use super::price_cents_from_db_i64;
+use crate::error::OnChainError;
+
+/// Order status enum matching Schwab API states
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum OrderStatus {
+    Queued,
+    Working,
+    Filled,
+    Canceled,
+    Rejected,
+    PendingActivation,
+    PendingReview,
+    Accepted,
+    AwaitingParentOrder,
+    AwaitingCondition,
+    AwaitingManualReview,
+    AwaitingStopCondition,
+    Expired,
+    New,
+    AwaitingReleaseTime,
+    PendingReplace,
+    Replaced,
+}
+
+/// Individual execution leg representing a specific fill
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExecutionLeg {
+    pub execution_id: Option<String>,
+    pub quantity: f64,
+    pub price: f64,
+    pub time: Option<String>,
+}
+
+/// Order status response from Schwab API
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OrderStatusResponse {
+    pub order_id: Option<String>,
+    pub status: OrderStatus,
+    pub filled_quantity: f64,
+    pub remaining_quantity: f64,
+    pub execution_legs: Vec<ExecutionLeg>,
+    pub entered_time: Option<String>,
+    pub close_time: Option<String>,
+}
+
+// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
+#[allow(dead_code)]
+impl OrderStatusResponse {
+    /// Calculate weighted average fill price from execution legs
+    pub fn calculate_weighted_average_price(&self) -> Option<f64> {
+        if self.execution_legs.is_empty() {
+            return None;
+        }
+
+        let mut total_value = 0.0;
+        let mut total_quantity = 0.0;
+
+        for leg in &self.execution_legs {
+            total_value += leg.price * leg.quantity;
+            total_quantity += leg.quantity;
+        }
+
+        if total_quantity > 0.0 {
+            Some(total_value / total_quantity)
+        } else {
+            None
+        }
+    }
+
+    /// Convert price to cents for database storage
+    pub fn price_in_cents(&self) -> Result<Option<u64>, OnChainError> {
+        self.calculate_weighted_average_price().map_or_else(
+            || Ok(None),
+            |price| {
+                // Convert dollars to cents and round
+                #[allow(clippy::cast_possible_truncation)]
+                let cents = (price * 100.0).round() as i64;
+                price_cents_from_db_i64(cents).map(Some)
+            },
+        )
+    }
+
+    /// Check if order is completely filled
+    pub const fn is_filled(&self) -> bool {
+        matches!(self.status, OrderStatus::Filled)
+    }
+
+    /// Check if order is still pending/working
+    pub const fn is_pending(&self) -> bool {
+        matches!(
+            self.status,
+            OrderStatus::Queued
+                | OrderStatus::Working
+                | OrderStatus::PendingActivation
+                | OrderStatus::PendingReview
+                | OrderStatus::Accepted
+                | OrderStatus::AwaitingParentOrder
+                | OrderStatus::AwaitingCondition
+                | OrderStatus::AwaitingManualReview
+                | OrderStatus::AwaitingStopCondition
+                | OrderStatus::New
+                | OrderStatus::AwaitingReleaseTime
+                | OrderStatus::PendingReplace
+        )
+    }
+
+    /// Check if order was canceled or rejected
+    pub const fn is_terminal_failure(&self) -> bool {
+        matches!(
+            self.status,
+            OrderStatus::Canceled | OrderStatus::Rejected | OrderStatus::Expired
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_order_status_serialization() {
+        let status = OrderStatus::Filled;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"FILLED\"");
+
+        let deserialized: OrderStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, status);
+    }
+
+    #[test]
+    fn test_execution_leg_serialization() {
+        let leg = ExecutionLeg {
+            execution_id: Some("EXEC123".to_string()),
+            quantity: 100.0,
+            price: 150.25,
+            time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        let json = serde_json::to_string(&leg).unwrap();
+        let deserialized: ExecutionLeg = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, leg);
+    }
+
+    #[test]
+    fn test_order_status_response_serialization() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 100.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![ExecutionLeg {
+                execution_id: Some("EXEC123".to_string()),
+                quantity: 100.0,
+                price: 150.25,
+                time: Some("2023-10-15T10:30:00Z".to_string()),
+            }],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: OrderStatusResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, response);
+    }
+
+    #[test]
+    fn test_calculate_weighted_average_price_single_leg() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 100.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![ExecutionLeg {
+                execution_id: Some("EXEC123".to_string()),
+                quantity: 100.0,
+                price: 150.25,
+                time: Some("2023-10-15T10:30:00Z".to_string()),
+            }],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        assert_eq!(response.calculate_weighted_average_price(), Some(150.25));
+    }
+
+    #[test]
+    fn test_calculate_weighted_average_price_multiple_legs() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 200.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![
+                ExecutionLeg {
+                    execution_id: Some("EXEC123".to_string()),
+                    quantity: 100.0,
+                    price: 150.00,
+                    time: Some("2023-10-15T10:30:00Z".to_string()),
+                },
+                ExecutionLeg {
+                    execution_id: Some("EXEC124".to_string()),
+                    quantity: 100.0,
+                    price: 151.00,
+                    time: Some("2023-10-15T10:30:10Z".to_string()),
+                },
+            ],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:10Z".to_string()),
+        };
+
+        assert_eq!(response.calculate_weighted_average_price(), Some(150.5));
+    }
+
+    #[test]
+    fn test_calculate_weighted_average_price_weighted() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 300.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![
+                ExecutionLeg {
+                    execution_id: Some("EXEC123".to_string()),
+                    quantity: 200.0, // 2/3 of total
+                    price: 150.00,
+                    time: Some("2023-10-15T10:30:00Z".to_string()),
+                },
+                ExecutionLeg {
+                    execution_id: Some("EXEC124".to_string()),
+                    quantity: 100.0, // 1/3 of total
+                    price: 153.00,
+                    time: Some("2023-10-15T10:30:10Z".to_string()),
+                },
+            ],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:10Z".to_string()),
+        };
+
+        // (200 * 150.00 + 100 * 153.00) / 300 = (30000 + 15300) / 300 = 151.00
+        assert_eq!(response.calculate_weighted_average_price(), Some(151.0));
+    }
+
+    #[test]
+    fn test_calculate_weighted_average_price_empty_legs() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Working,
+            filled_quantity: 0.0,
+            remaining_quantity: 100.0,
+            execution_legs: vec![],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: None,
+        };
+
+        assert_eq!(response.calculate_weighted_average_price(), None);
+    }
+
+    #[test]
+    fn test_price_in_cents_conversion() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 100.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![ExecutionLeg {
+                execution_id: Some("EXEC123".to_string()),
+                quantity: 100.0,
+                price: 150.25,
+                time: Some("2023-10-15T10:30:00Z".to_string()),
+            }],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        assert_eq!(response.price_in_cents().unwrap(), Some(15025));
+    }
+
+    #[test]
+    fn test_price_in_cents_no_executions() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Working,
+            filled_quantity: 0.0,
+            remaining_quantity: 100.0,
+            execution_legs: vec![],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: None,
+        };
+
+        assert_eq!(response.price_in_cents().unwrap(), None);
+    }
+
+    #[test]
+    fn test_price_in_cents_rounding() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 100.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![ExecutionLeg {
+                execution_id: Some("EXEC123".to_string()),
+                quantity: 100.0,
+                price: 150.254, // Should round to 150.25
+                time: Some("2023-10-15T10:30:00Z".to_string()),
+            }],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        assert_eq!(response.price_in_cents().unwrap(), Some(15025));
+    }
+
+    #[test]
+    fn test_is_filled() {
+        let mut response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 100.0,
+            remaining_quantity: 0.0,
+            execution_legs: vec![],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: Some("2023-10-15T10:30:00Z".to_string()),
+        };
+
+        assert!(response.is_filled());
+
+        response.status = OrderStatus::Working;
+        assert!(!response.is_filled());
+    }
+
+    #[test]
+    fn test_is_pending() {
+        let pending_states = [
+            OrderStatus::Queued,
+            OrderStatus::Working,
+            OrderStatus::PendingActivation,
+            OrderStatus::PendingReview,
+            OrderStatus::Accepted,
+            OrderStatus::AwaitingParentOrder,
+            OrderStatus::AwaitingCondition,
+            OrderStatus::AwaitingManualReview,
+            OrderStatus::AwaitingStopCondition,
+            OrderStatus::New,
+            OrderStatus::AwaitingReleaseTime,
+            OrderStatus::PendingReplace,
+        ];
+
+        for status in pending_states {
+            let response = OrderStatusResponse {
+                order_id: Some("ORDER123".to_string()),
+                status,
+                filled_quantity: 0.0,
+                remaining_quantity: 100.0,
+                execution_legs: vec![],
+                entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+                close_time: None,
+            };
+            assert!(response.is_pending(), "Status {status:?} should be pending");
+        }
+
+        let non_pending_states = [
+            OrderStatus::Filled,
+            OrderStatus::Canceled,
+            OrderStatus::Rejected,
+            OrderStatus::Expired,
+            OrderStatus::Replaced,
+        ];
+
+        for status in non_pending_states {
+            let response = OrderStatusResponse {
+                order_id: Some("ORDER123".to_string()),
+                status,
+                filled_quantity: 100.0,
+                remaining_quantity: 0.0,
+                execution_legs: vec![],
+                entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+                close_time: Some("2023-10-15T10:30:00Z".to_string()),
+            };
+            assert!(
+                !response.is_pending(),
+                "Status {status:?} should not be pending"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_terminal_failure() {
+        let failure_states = [
+            OrderStatus::Canceled,
+            OrderStatus::Rejected,
+            OrderStatus::Expired,
+        ];
+
+        for status in failure_states {
+            let response = OrderStatusResponse {
+                order_id: Some("ORDER123".to_string()),
+                status,
+                filled_quantity: 0.0,
+                remaining_quantity: 100.0,
+                execution_legs: vec![],
+                entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+                close_time: Some("2023-10-15T10:30:00Z".to_string()),
+            };
+            assert!(
+                response.is_terminal_failure(),
+                "Status {status:?} should be terminal failure"
+            );
+        }
+
+        let non_failure_states = [
+            OrderStatus::Filled,
+            OrderStatus::Working,
+            OrderStatus::Queued,
+            OrderStatus::New,
+        ];
+
+        for status in non_failure_states {
+            let response = OrderStatusResponse {
+                order_id: Some("ORDER123".to_string()),
+                status,
+                filled_quantity: 0.0,
+                remaining_quantity: 100.0,
+                execution_legs: vec![],
+                entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+                close_time: None,
+            };
+            assert!(
+                !response.is_terminal_failure(),
+                "Status {status:?} should not be terminal failure"
+            );
+        }
+    }
+
+    #[test]
+    fn test_complex_api_response_parsing() {
+        let json_response = r#"
+        {
+            "orderId": "ORDER12345",
+            "status": "FILLED",
+            "filledQuantity": 200.0,
+            "remainingQuantity": 0.0,
+            "executionLegs": [
+                {
+                    "executionId": "EXEC001",
+                    "quantity": 150.0,
+                    "price": 100.25,
+                    "time": "2023-10-15T10:30:00Z"
+                },
+                {
+                    "executionId": "EXEC002",
+                    "quantity": 50.0,
+                    "price": 100.75,
+                    "time": "2023-10-15T10:30:05Z"
+                }
+            ],
+            "enteredTime": "2023-10-15T10:25:00Z",
+            "closeTime": "2023-10-15T10:30:05Z"
+        }
+        "#;
+
+        let response: OrderStatusResponse = serde_json::from_str(json_response).unwrap();
+
+        assert_eq!(response.order_id, Some("ORDER12345".to_string()));
+        assert_eq!(response.status, OrderStatus::Filled);
+        assert!((response.filled_quantity - 200.0).abs() < f64::EPSILON);
+        assert!(response.remaining_quantity.abs() < f64::EPSILON);
+        assert_eq!(response.execution_legs.len(), 2);
+
+        // Test weighted average: (150 * 100.25 + 50 * 100.75) / 200 = (15037.5 + 5037.5) / 200 = 100.375
+        let avg_price = response.calculate_weighted_average_price().unwrap();
+        assert!((avg_price - 100.375).abs() < f64::EPSILON);
+        assert_eq!(response.price_in_cents().unwrap(), Some(10038)); // Rounded
+    }
+
+    #[test]
+    fn test_edge_case_zero_quantity_legs() {
+        let response = OrderStatusResponse {
+            order_id: Some("ORDER123".to_string()),
+            status: OrderStatus::Working,
+            filled_quantity: 0.0,
+            remaining_quantity: 100.0,
+            execution_legs: vec![ExecutionLeg {
+                execution_id: Some("EXEC123".to_string()),
+                quantity: 0.0, // Zero quantity
+                price: 150.25,
+                time: Some("2023-10-15T10:30:00Z".to_string()),
+            }],
+            entered_time: Some("2023-10-15T10:25:00Z".to_string()),
+            close_time: None,
+        };
+
+        assert_eq!(response.calculate_weighted_average_price(), None);
+        assert_eq!(response.price_in_cents().unwrap(), None);
+    }
+}

--- a/src/schwab/order_status.rs
+++ b/src/schwab/order_status.rs
@@ -49,11 +49,9 @@ pub(crate) struct OrderStatusResponse {
     pub close_time: Option<String>,
 }
 
-// TODO: Remove #[allow(dead_code)] when integrating order poller in Section 5
-#[allow(dead_code)]
 impl OrderStatusResponse {
     /// Calculate weighted average fill price from execution legs
-    pub fn calculate_weighted_average_price(&self) -> Option<f64> {
+    pub(crate) fn calculate_weighted_average_price(&self) -> Option<f64> {
         if self.execution_legs.is_empty() {
             return None;
         }
@@ -74,7 +72,7 @@ impl OrderStatusResponse {
     }
 
     /// Convert price to cents for database storage
-    pub fn price_in_cents(&self) -> Result<Option<u64>, OnChainError> {
+    pub(crate) fn price_in_cents(&self) -> Result<Option<u64>, OnChainError> {
         self.calculate_weighted_average_price().map_or_else(
             || Ok(None),
             |price| {
@@ -87,12 +85,13 @@ impl OrderStatusResponse {
     }
 
     /// Check if order is completely filled
-    pub const fn is_filled(&self) -> bool {
+    pub(crate) const fn is_filled(&self) -> bool {
         matches!(self.status, OrderStatus::Filled)
     }
 
     /// Check if order is still pending/working
-    pub const fn is_pending(&self) -> bool {
+    #[cfg(test)]
+    pub(crate) const fn is_pending(&self) -> bool {
         matches!(
             self.status,
             OrderStatus::Queued
@@ -111,7 +110,7 @@ impl OrderStatusResponse {
     }
 
     /// Check if order was canceled or rejected
-    pub const fn is_terminal_failure(&self) -> bool {
+    pub(crate) const fn is_terminal_failure(&self) -> bool {
         matches!(
             self.status,
             OrderStatus::Canceled | OrderStatus::Rejected | OrderStatus::Expired

--- a/src/schwab/tokens.rs
+++ b/src/schwab/tokens.rs
@@ -131,12 +131,15 @@ impl SchwabTokens {
         Ok(count)
     }
 
-    pub fn spawn_automatic_token_refresh(pool: SqlitePool, env: SchwabAuthEnv) {
+    pub(crate) fn spawn_automatic_token_refresh(
+        pool: SqlitePool,
+        env: SchwabAuthEnv,
+    ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             if let Err(e) = Self::start_automatic_token_refresh_loop(pool, env).await {
                 error!("Token refresh task failed: {e:?}");
             }
-        });
+        })
     }
 
     async fn start_automatic_token_refresh_loop(

--- a/src/schwab/trade_state.rs
+++ b/src/schwab/trade_state.rs
@@ -1,0 +1,378 @@
+use chrono::{DateTime, Utc};
+
+use super::{TradeStatus, price_cents_from_db_i64};
+use crate::error::{OnChainError, PersistenceError};
+
+/// Database fields extracted from TradeState for storage
+#[derive(Debug)]
+pub(crate) struct TradeStateDbFields {
+    pub(crate) order_id: Option<String>,
+    pub(crate) price_cents: Option<i64>,
+    pub(crate) executed_at: Option<chrono::NaiveDateTime>,
+}
+
+// Stateful enum with associated data for runtime use
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TradeState {
+    Pending,
+    Submitted {
+        order_id: String,
+    },
+    Filled {
+        executed_at: DateTime<Utc>,
+        order_id: String,
+        price_cents: u64,
+    },
+    Failed {
+        failed_at: DateTime<Utc>,
+        error_reason: Option<String>,
+    },
+}
+
+/// Trait for types that can be converted to a status string for database queries
+pub(crate) trait HasTradeStatus {
+    fn status_str(&self) -> &'static str;
+}
+
+impl HasTradeStatus for TradeStatus {
+    fn status_str(&self) -> &'static str {
+        self.as_str()
+    }
+}
+
+impl HasTradeStatus for TradeState {
+    fn status_str(&self) -> &'static str {
+        self.status().as_str()
+    }
+}
+
+impl HasTradeStatus for &'static str {
+    fn status_str(&self) -> &'static str {
+        self
+    }
+}
+
+impl TradeState {
+    pub const fn status(&self) -> TradeStatus {
+        match self {
+            Self::Pending => TradeStatus::Pending,
+            Self::Submitted { .. } => TradeStatus::Submitted,
+            Self::Filled { .. } => TradeStatus::Filled,
+            Self::Failed { .. } => TradeStatus::Failed,
+        }
+    }
+
+    /// Converts database row data to a TradeState instance with proper validation.
+    /// This centralizes the conversion logic and ensures database consistency.
+    pub(crate) fn from_db_row(
+        status: TradeStatus,
+        order_id: Option<String>,
+        price_cents: Option<i64>,
+        executed_at: Option<chrono::NaiveDateTime>,
+    ) -> Result<Self, OnChainError> {
+        match status {
+            TradeStatus::Pending => Ok(Self::Pending),
+            TradeStatus::Submitted => {
+                let order_id = order_id.ok_or_else(|| {
+                    OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                        "SUBMITTED requires order_id".to_string(),
+                    ))
+                })?;
+                Ok(Self::Submitted { order_id })
+            }
+            TradeStatus::Filled => {
+                let order_id = order_id.ok_or_else(|| {
+                    OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                        "FILLED requires order_id".to_string(),
+                    ))
+                })?;
+                let price_cents = price_cents.ok_or_else(|| {
+                    OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                        "FILLED requires price_cents".to_string(),
+                    ))
+                })?;
+                let executed_at = executed_at.ok_or_else(|| {
+                    OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                        "FILLED requires executed_at".to_string(),
+                    ))
+                })?;
+                Ok(Self::Filled {
+                    executed_at: DateTime::<Utc>::from_naive_utc_and_offset(executed_at, Utc),
+                    order_id,
+                    price_cents: price_cents_from_db_i64(price_cents)?,
+                })
+            }
+            TradeStatus::Failed => {
+                let failed_at = executed_at.ok_or_else(|| {
+                    OnChainError::Persistence(PersistenceError::InvalidTradeStatus(
+                        "FAILED requires executed_at timestamp".to_string(),
+                    ))
+                })?;
+                Ok(Self::Failed {
+                    failed_at: DateTime::<Utc>::from_naive_utc_and_offset(failed_at, Utc),
+                    error_reason: None, // We don't store error_reason in database yet
+                })
+            }
+        }
+    }
+
+    /// Extracts database-compatible values from TradeState for storage.
+    /// Returns (order_id, price_cents_i64, executed_at) tuple.
+    pub(crate) fn to_db_fields(
+        &self,
+    ) -> Result<TradeStateDbFields, crate::error::PersistenceError> {
+        match self {
+            Self::Pending => Ok(TradeStateDbFields {
+                order_id: None,
+                price_cents: None,
+                executed_at: None,
+            }),
+            Self::Submitted { order_id } => Ok(TradeStateDbFields {
+                order_id: Some(order_id.clone()),
+                price_cents: None,
+                executed_at: None,
+            }),
+            Self::Filled {
+                executed_at,
+                order_id,
+                price_cents,
+            } => Ok(TradeStateDbFields {
+                order_id: Some(order_id.clone()),
+                price_cents: Some(u64_to_i64_exact(*price_cents)?),
+                executed_at: Some(executed_at.naive_utc()),
+            }),
+            Self::Failed {
+                failed_at,
+                error_reason: _,
+            } => Ok(TradeStateDbFields {
+                order_id: None,
+                price_cents: None,
+                executed_at: Some(failed_at.naive_utc()),
+            }),
+        }
+    }
+}
+
+/// Converts u64 to i64 for database storage with exact conversion.
+/// NEVER silently changes amounts - returns error if conversion would lose data.
+/// This is critical for financial applications where data integrity is paramount.
+fn u64_to_i64_exact(value: u64) -> Result<i64, crate::error::PersistenceError> {
+    if value > i64::MAX as u64 {
+        Err(crate::error::PersistenceError::InvalidTradeStatus(format!(
+            "Value {value} exceeds maximum i64 range - conversion would lose data"
+        )))
+    } else {
+        #[allow(clippy::cast_possible_wrap)]
+        Ok(value as i64) // Safe: verified within i64 range
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn test_from_db_row_pending() {
+        let result = TradeState::from_db_row(TradeStatus::Pending, None, None, None).unwrap();
+        assert_eq!(result, TradeState::Pending);
+    }
+
+    #[test]
+    fn test_from_db_row_submitted() {
+        let result = TradeState::from_db_row(
+            TradeStatus::Submitted,
+            Some("ORDER123".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            result,
+            TradeState::Submitted {
+                order_id: "ORDER123".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_from_db_row_filled() {
+        let timestamp = Utc::now().naive_utc();
+        let result = TradeState::from_db_row(
+            TradeStatus::Filled,
+            Some("ORDER123".to_string()),
+            Some(15000),
+            Some(timestamp),
+        )
+        .unwrap();
+
+        match result {
+            TradeState::Filled {
+                executed_at,
+                order_id,
+                price_cents,
+            } => {
+                assert_eq!(order_id, "ORDER123");
+                assert_eq!(price_cents, 15000);
+                assert_eq!(executed_at.naive_utc(), timestamp);
+            }
+            _ => panic!("Expected Filled variant"),
+        }
+    }
+
+    #[test]
+    fn test_from_db_row_failed() {
+        let timestamp = Utc::now().naive_utc();
+        let result =
+            TradeState::from_db_row(TradeStatus::Failed, None, None, Some(timestamp)).unwrap();
+
+        match result {
+            TradeState::Failed {
+                failed_at,
+                error_reason,
+            } => {
+                assert_eq!(failed_at.naive_utc(), timestamp);
+                assert_eq!(error_reason, None);
+            }
+            _ => panic!("Expected Failed variant"),
+        }
+    }
+
+    #[test]
+    fn test_from_db_row_submitted_missing_order_id() {
+        let result = TradeState::from_db_row(TradeStatus::Submitted, None, None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_db_row_filled_missing_order_id() {
+        let timestamp = Utc::now().naive_utc();
+        let result =
+            TradeState::from_db_row(TradeStatus::Filled, None, Some(15000), Some(timestamp));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_db_row_filled_missing_price_cents() {
+        let timestamp = Utc::now().naive_utc();
+        let result = TradeState::from_db_row(
+            TradeStatus::Filled,
+            Some("ORDER123".to_string()),
+            None,
+            Some(timestamp),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_db_row_filled_missing_executed_at() {
+        let result = TradeState::from_db_row(
+            TradeStatus::Filled,
+            Some("ORDER123".to_string()),
+            Some(15000),
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_db_row_failed_missing_executed_at() {
+        let result = TradeState::from_db_row(TradeStatus::Failed, None, None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_to_db_fields_pending() {
+        let state = TradeState::Pending;
+        let db_fields = state.to_db_fields().unwrap();
+        assert_eq!(db_fields.order_id, None);
+        assert_eq!(db_fields.price_cents, None);
+        assert_eq!(db_fields.executed_at, None);
+    }
+
+    #[test]
+    fn test_to_db_fields_submitted() {
+        let state = TradeState::Submitted {
+            order_id: "ORDER123".to_string(),
+        };
+        let db_fields = state.to_db_fields().unwrap();
+        assert_eq!(db_fields.order_id, Some("ORDER123".to_string()));
+        assert_eq!(db_fields.price_cents, None);
+        assert_eq!(db_fields.executed_at, None);
+    }
+
+    #[test]
+    fn test_to_db_fields_filled() {
+        let timestamp = Utc::now();
+        let state = TradeState::Filled {
+            executed_at: timestamp,
+            order_id: "ORDER123".to_string(),
+            price_cents: 15000,
+        };
+        let db_fields = state.to_db_fields().unwrap();
+        assert_eq!(db_fields.order_id, Some("ORDER123".to_string()));
+        assert_eq!(db_fields.price_cents, Some(15000));
+        assert_eq!(db_fields.executed_at, Some(timestamp.naive_utc()));
+    }
+
+    #[test]
+    fn test_to_db_fields_failed() {
+        let timestamp = Utc::now();
+        let state = TradeState::Failed {
+            failed_at: timestamp,
+            error_reason: Some("Test error".to_string()),
+        };
+        let db_fields = state.to_db_fields().unwrap();
+        assert_eq!(db_fields.order_id, None);
+        assert_eq!(db_fields.price_cents, None);
+        assert_eq!(db_fields.executed_at, Some(timestamp.naive_utc()));
+    }
+
+    #[test]
+    fn test_status_extraction() {
+        assert_eq!(TradeState::Pending.status(), TradeStatus::Pending);
+        assert_eq!(
+            TradeState::Submitted {
+                order_id: "ORDER123".to_string()
+            }
+            .status(),
+            TradeStatus::Submitted
+        );
+        assert_eq!(
+            TradeState::Filled {
+                executed_at: Utc::now(),
+                order_id: "ORDER123".to_string(),
+                price_cents: 15000,
+            }
+            .status(),
+            TradeStatus::Filled
+        );
+        assert_eq!(
+            TradeState::Failed {
+                failed_at: Utc::now(),
+                error_reason: None,
+            }
+            .status(),
+            TradeStatus::Failed
+        );
+    }
+
+    #[test]
+    fn test_u64_to_i64_exact_normal_values() {
+        assert_eq!(u64_to_i64_exact(0).unwrap(), 0);
+        assert_eq!(u64_to_i64_exact(100).unwrap(), 100);
+        assert_eq!(u64_to_i64_exact(15000).unwrap(), 15000);
+    }
+
+    #[test]
+    fn test_u64_to_i64_exact_max_value() {
+        assert_eq!(u64_to_i64_exact(i64::MAX as u64).unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn test_u64_to_i64_exact_overflow() {
+        let overflow_value = (i64::MAX as u64) + 1;
+        let result = u64_to_i64_exact(overflow_value);
+        assert!(result.is_err()); // MUST fail, never silently change amounts
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -79,7 +79,7 @@ pub(crate) async fn setup_test_db() -> SqlitePool {
 }
 
 use crate::onchain::OnchainTrade;
-use crate::schwab::TradeStatus;
+use crate::schwab::TradeState;
 use crate::schwab::{Direction, execution::SchwabExecution};
 
 /// Builder for creating OnchainTrade test instances with sensible defaults.
@@ -167,7 +167,7 @@ impl SchwabExecutionBuilder {
                 symbol: "AAPL".to_string(),
                 shares: 100,
                 direction: Direction::Buy,
-                status: TradeStatus::Pending,
+                state: TradeState::Pending,
             },
         }
     }


### PR DESCRIPTION
> [!CAUTION]
> Chained to #43 

## Motivation

We need to know prices on both venues to track performance

## Solution

Track Schwab fill prices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic order-status polling updates executions from Submitted to Filled/Failed.
  * Live mode now runs background tasks (token refresh, polling, event receiver) with graceful shutdown.
  * CLI adds configurable polling controls: --order-polling-interval and --order-polling-max-jitter.

* Improvements
  * Expanded execution lifecycle: Pending, Submitted, Filled, Failed, with clearer logs and safer updates.
  * More resilient token management and concurrent event processing.

* Database
  * Migration adds Submitted and Filled states with stronger integrity checks.

* Documentation
  * Significant expansion of type-driven Rust design and meaningful testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->