### PR TITLE
Add block timestamp field

### DIFF
--- a/migrations/20250924015332_add_block_timestamp_to_onchain_trades.sql
+++ b/migrations/20250924015332_add_block_timestamp_to_onchain_trades.sql
@@ -1,6 +1,6 @@
 -- Add block_timestamp column to onchain_trades table
-ALTER TABLE onchain_trades ADD COLUMN block_timestamp INTEGER;
+ALTER TABLE onchain_trades ADD COLUMN block_timestamp TIMESTAMP;
 
 -- Update existing records to use created_at timestamp as fallback
 -- This is not ideal but prevents losing historical data
-UPDATE onchain_trades SET block_timestamp = strftime('%s', created_at);
+UPDATE onchain_trades SET block_timestamp = created_at;

--- a/migrations/20250924015332_add_block_timestamp_to_onchain_trades.sql
+++ b/migrations/20250924015332_add_block_timestamp_to_onchain_trades.sql
@@ -1,0 +1,6 @@
+-- Add block_timestamp column to onchain_trades table
+ALTER TABLE onchain_trades ADD COLUMN block_timestamp INTEGER;
+
+-- Update existing records to use created_at timestamp as fallback
+-- This is not ideal but prevents losing historical data
+UPDATE onchain_trades SET block_timestamp = strftime('%s', created_at);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2028,6 +2028,7 @@ mod tests {
             amount: 2.5,
             direction: Direction::Buy,
             price_usdc: 20000.0,
+            block_timestamp: None,
             created_at: None,
         };
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -932,6 +932,7 @@ mod tests {
             amount: 5.0,
             direction: Direction::Sell,
             price_usdc: 20000.0,
+            block_timestamp: None,
             created_at: None,
         };
         let mut sql_tx = pool.begin().await.unwrap();

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -587,6 +587,7 @@ mod tests {
             amount: 0.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -616,6 +617,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 300.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -647,6 +649,7 @@ mod tests {
             amount: 0.3,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -663,6 +666,7 @@ mod tests {
             amount: 0.4,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -679,6 +683,7 @@ mod tests {
             amount: 0.4,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -711,6 +716,7 @@ mod tests {
             amount: 1.0,
             direction: Direction::Buy,
             price_usdc: 100.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -733,6 +739,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -757,6 +764,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Buy,
             price_usdc: 300.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -797,6 +805,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -845,6 +854,7 @@ mod tests {
             amount: 0.8,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -858,6 +868,7 @@ mod tests {
             amount: 0.3,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -910,6 +921,7 @@ mod tests {
             amount: 0.8,
             direction: Direction::Sell,
             price_usdc: 15000.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -923,6 +935,7 @@ mod tests {
             amount: 0.8,
             direction: Direction::Sell,
             price_usdc: 15000.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1027,6 +1040,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1064,6 +1078,7 @@ mod tests {
                 amount: 0.3,
                 direction: Direction::Buy,
                 price_usdc: 300.0,
+                block_timestamp: None,
                 created_at: None,
             },
             OnchainTrade {
@@ -1076,6 +1091,7 @@ mod tests {
                 amount: 0.4,
                 direction: Direction::Buy,
                 price_usdc: 305.0,
+                block_timestamp: None,
                 created_at: None,
             },
             OnchainTrade {
@@ -1088,6 +1104,7 @@ mod tests {
                 amount: 0.5,
                 direction: Direction::Buy,
                 price_usdc: 310.0,
+                block_timestamp: None,
                 created_at: None,
             },
         ];
@@ -1149,6 +1166,7 @@ mod tests {
                 amount: 0.4, // Below threshold
                 direction: Direction::Sell,
                 price_usdc: 150.0,
+                block_timestamp: None,
                 created_at: None,
             },
             OnchainTrade {
@@ -1161,6 +1179,7 @@ mod tests {
                 amount: 0.8, // Combined: 0.4 + 0.8 = 1.2, triggers execution of 1 share
                 direction: Direction::Sell,
                 price_usdc: 155.0,
+                block_timestamp: None,
                 created_at: None,
             },
         ];
@@ -1222,6 +1241,7 @@ mod tests {
             amount: 1.2,
             direction: Direction::Buy,
             price_usdc: 800.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1264,6 +1284,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Buy,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1277,6 +1298,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 155.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1363,6 +1385,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1570,6 +1593,7 @@ mod tests {
             amount: 0.8,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1670,6 +1694,7 @@ mod tests {
             amount: 0.6,
             direction: Direction::Sell,
             price_usdc: 120.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -1683,6 +1708,7 @@ mod tests {
             amount: 0.5,
             direction: Direction::Sell,
             price_usdc: 100.0,
+            block_timestamp: None,
             created_at: None,
         };
 

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -33,6 +33,7 @@ pub struct OnchainTrade {
     pub amount: f64,
     pub direction: Direction,
     pub price_usdc: f64,
+    pub block_timestamp: Option<u64>,
     pub created_at: Option<DateTime<Utc>>,
 }
 
@@ -47,17 +48,20 @@ impl OnchainTrade {
 
         let direction_str = self.direction.as_str();
         let symbol_str = self.symbol.to_string();
+        #[allow(clippy::cast_possible_wrap)]
+        let block_timestamp_i64 = self.block_timestamp.map(|ts| ts as i64);
         let result = sqlx::query!(
             r#"
-            INSERT INTO onchain_trades (tx_hash, log_index, symbol, amount, direction, price_usdc)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            INSERT INTO onchain_trades (tx_hash, log_index, symbol, amount, direction, price_usdc, block_timestamp)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             "#,
             tx_hash_str,
             log_index_i64,
             symbol_str,
             self.amount,
             direction_str,
-            self.price_usdc
+            self.price_usdc,
+            block_timestamp_i64
         )
         .execute(&mut **sql_tx)
         .await?;
@@ -75,7 +79,7 @@ impl OnchainTrade {
         #[allow(clippy::cast_possible_wrap)]
         let log_index_i64 = log_index as i64;
         let row = sqlx::query!(
-            "SELECT id, tx_hash, log_index, symbol, amount, direction, price_usdc, created_at FROM onchain_trades WHERE tx_hash = ?1 AND log_index = ?2",
+            "SELECT id, tx_hash, log_index, symbol, amount, direction, price_usdc, block_timestamp, created_at FROM onchain_trades WHERE tx_hash = ?1 AND log_index = ?2",
             tx_hash_str,
             log_index_i64
         )
@@ -105,6 +109,8 @@ impl OnchainTrade {
             amount: row.amount,
             direction,
             price_usdc: row.price_usdc,
+            #[allow(clippy::cast_sign_loss)]
+            block_timestamp: row.block_timestamp.map(|ts| ts as u64),
             created_at: row
                 .created_at
                 .map(|naive_dt| DateTime::from_naive_utc_and_offset(naive_dt, Utc)),
@@ -182,6 +188,7 @@ impl OnchainTrade {
             amount: trade_details.equity_amount().value(),
             direction: trade_details.direction(),
             price_usdc: price_per_share_usdc,
+            block_timestamp: log.block_timestamp,
             created_at: None,
         };
 
@@ -326,6 +333,7 @@ mod tests {
             amount: 10.0,
             direction: Direction::Sell,
             price_usdc: 150.25,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -408,6 +416,7 @@ mod tests {
             amount: 10.0,
             direction: Direction::Buy,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -442,6 +451,7 @@ mod tests {
             amount: 10.0,
             direction: Direction::Buy,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -554,6 +564,7 @@ mod tests {
                 amount: 10.0,
                 direction: Direction::Buy,
                 price_usdc: 150.0,
+                block_timestamp: None,
                 created_at: None,
             };
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -105,6 +105,7 @@ impl OnchainTradeBuilder {
                 amount: 1.0,
                 direction: Direction::Buy,
                 price_usdc: 150.0,
+                block_timestamp: None,
                 created_at: None,
             },
         }

--- a/src/trade_execution_link.rs
+++ b/src/trade_execution_link.rs
@@ -323,6 +323,7 @@ mod tests {
             amount: 1.5,
             direction: Direction::Sell,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 
@@ -381,6 +382,7 @@ mod tests {
                 amount: 0.5,
                 direction: Direction::Buy,
                 price_usdc: 300.0,
+                block_timestamp: None,
                 created_at: None,
             },
             OnchainTrade {
@@ -393,6 +395,7 @@ mod tests {
                 amount: 0.8,
                 direction: Direction::Buy,
                 price_usdc: 305.0,
+                block_timestamp: None,
                 created_at: None,
             },
         ];
@@ -469,6 +472,7 @@ mod tests {
                 amount,
                 direction: Direction::Sell,
                 price_usdc: 150.0,
+                block_timestamp: None,
                 created_at: None,
             };
             let trade_id = trade.save_within_transaction(&mut sql_tx).await.unwrap();
@@ -521,6 +525,7 @@ mod tests {
             amount: 1.0,
             direction: Direction::Buy,
             price_usdc: 150.0,
+            block_timestamp: None,
             created_at: None,
         };
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a block timestamp to on-chain trades, now stored and returned where available for more precise trade timing.
  * Historical trades are backfilled using their creation time to ensure consistent timestamp coverage.
  * Ingestion now captures and persists the block timestamp from blockchain logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->