### PR TITLE
simplify permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,17 +70,12 @@ ARG BUILD_PROFILE=release
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd -m -u 1000 schwab
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 # Copy only the compiled binaries from builder stage (now with fixed interpreter paths)
 COPY --from=builder /app/target/${BUILD_PROFILE}/server ./
 COPY --from=builder /app/migrations ./migrations
-
-RUN chown -R schwab:schwab /app
-
-USER schwab
 
 ENTRYPOINT ["./server"]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

The bot couldn't write to SQLite due to restricted permissions

## Solution

Simplify Dockerfile permissions to get the deployment working

## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [ ] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a change to a front-end or a dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration: Removed user privilege management and explicit container startup instructions. The container now runs with default permissions instead of a dedicated non-root user account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->