### PR TITLE
fix: add projection to equity redemption

### DIFF
--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -92,7 +92,10 @@ impl QueryManifest {
             .build(services.clone())
             .await?;
 
+        let redemption_projection = Projection::<EquityRedemption>::sqlite(pool.clone())?;
+
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .with(Arc::new(redemption_projection))
             .with(rebalancing_trigger.clone())
             .with(event_broadcaster.clone())
             .build(services)


### PR DESCRIPTION
## Motivation
During e2e testing, checking the equity redemption resulted in an empty result. After closer inspection I saw that it was not being properly added to the manifest

## Solution
- Add projection to equity redemption store builder

## Checks

By submitting this for review, I'm confirming I've done the following:

This will come in the e2e tests
- [- ] added comprehensive test coverage for any changes in logic
- 
- [X ] made this PR as small as possible
- [X ] linked any relevant issues or PRs
- [X ] included screenshots (if this involves a change to a front-end/dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated a new projection into the equity redemption pipeline, improving how redemption data is processed and stored for more reliable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->