### PR TITLE
chore: upgrade httpmock to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ base64 = "0.22"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.40", features = ["derive", "env"] }
 flate2 = "1.0"
-httpmock = "0.7.0"
+httpmock = "0.8"
 rain-math-float = { path = "lib/rain.orderbook/lib/rain.orderbook.interface/lib/rain.interpreter.interface/lib/rain.math.float/crates/float" }
 reqwest = { version = "0.12.4", features = [
   "json",

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -755,7 +755,7 @@ mod tests {
         };
 
         fetch_attestation.retry(backoff).await.unwrap();
-        assert_eq!(mock.hits(), 1, "Expected exactly 1 API call");
+        assert_eq!(mock.calls(), 1, "Expected exactly 1 API call");
     }
 
     #[tokio::test]
@@ -815,7 +815,7 @@ mod tests {
             "Expected AttestationError::NotYetAvailable with status 404"
         );
         assert!(
-            mock.hits() == 4,
+            mock.calls() == 4,
             "Expected exactly 4 attempts (1 initial + 3 retries)"
         );
     }
@@ -1345,7 +1345,7 @@ mod tests {
             let fee_mock_server = MockServer::start();
             // Mock fee endpoint for any domain pair - returns fast (1000) and standard (2000) fees
             fee_mock_server.mock(|when, then| {
-                when.method(GET).path_contains("/v2/burn/USDC/fees/");
+                when.method(GET).path_includes("/v2/burn/USDC/fees/");
                 then.status(200).json_body(serde_json::json!([
                     {"finalityThreshold": 1000, "minimumFee": 1},
                     {"finalityThreshold": 2000, "minimumFee": 0}

--- a/crates/evm/src/fireblocks.rs
+++ b/crates/evm/src/fireblocks.rs
@@ -803,7 +803,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert!(
@@ -860,7 +860,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert!(
@@ -932,7 +932,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert_eq!(result.transaction_hash, tx_hash);
@@ -1293,10 +1293,10 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            poll_mock.hits() >= 2,
+            poll_mock.calls() >= 2,
             "should have polled multiple times before timing out, \
              but only polled {} time(s)",
-            poll_mock.hits()
+            poll_mock.calls()
         );
         assert!(
             matches!(

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -394,7 +394,7 @@ mod tests {
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
         let mock = server.mock(|when, then| {
-            when.method(POST).path("/v1/journals").json_body_partial(
+            when.method(POST).path("/v1/journals").json_body_includes(
                 r#"{
                         "from_account":"904837e3-3b76-47ec-b432-046db621571b",
                         "to_account":"11111111-2222-3333-4444-555555555555",

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -568,7 +568,7 @@ mod tests {
 
         // Account endpoint is hit twice: once during try_from_ctx (verify_account)
         // and once during get_inventory (get_account_details for cash balance)
-        account_mock.assert_hits(2);
+        account_mock.assert_calls(2);
         positions_mock.assert();
         assert!(matches!(result, crate::InventoryResult::Fetched(_)));
     }
@@ -753,9 +753,9 @@ mod tests {
         executor.place_market_order(order2).await.unwrap();
 
         // Asset endpoint should only be called once
-        asset_mock.assert_hits(1);
+        asset_mock.assert_calls(1);
         // Order endpoint should be called twice
-        order_mock.assert_hits(2);
+        order_mock.assert_calls(2);
     }
 
     #[tokio::test]
@@ -825,7 +825,7 @@ mod tests {
         executor.place_market_order(order2).await.unwrap();
 
         // Asset endpoint should be called twice due to cache expiration
-        asset_mock.assert_hits(2);
-        order_mock.assert_hits(2);
+        asset_mock.assert_calls(2);
+        order_mock.assert_calls(2);
     }
 }

--- a/crates/execution/src/schwab/auth/oauth.rs
+++ b/crates/execution/src/schwab/auth/oauth.rs
@@ -345,9 +345,9 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=authorization_code")
-                .body_contains("code=test_code")
-                .body_contains("redirect_uri=https%3A%2F%2F127.0.0.1%2F");
+                .body_includes("grant_type=authorization_code")
+                .body_includes("code=test_code")
+                .body_includes("redirect_uri=https%3A%2F%2F127.0.0.1%2F");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -477,8 +477,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=old_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=old_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -734,7 +734,7 @@ mod tests {
 
         let error = ctx.get_tokens_from_code("test_code").await.unwrap_err();
 
-        assert_eq!(mock.hits(), 1);
+        assert_eq!(mock.calls(), 1);
         match error {
             SchwabError::RequestFailed { action, status, .. } => {
                 assert_eq!(action, "get tokens");

--- a/crates/execution/src/schwab/executor.rs
+++ b/crates/execution/src/schwab/executor.rs
@@ -327,8 +327,8 @@ mod tests {
             when.method(POST)
                 .path("/v1/oauth/token")
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/crates/execution/src/schwab/mod.rs
+++ b/crates/execution/src/schwab/mod.rs
@@ -188,8 +188,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=authorization_code")
-                .body_contains("code=invalid_code");
+                .body_includes("grant_type=authorization_code")
+                .body_includes("code=invalid_code");
             then.status(401)
                 .header("content-type", "application/json")
                 .json_body(json!({"error": "invalid_grant"}));

--- a/crates/execution/src/schwab/order.rs
+++ b/crates/execution/src/schwab/order.rs
@@ -674,7 +674,7 @@ mod tests {
 
         // At least one attempt should have been made
         assert!(
-            order_mock.hits() >= 1,
+            order_mock.calls() >= 1,
             "Expected at least one API call attempt"
         );
     }
@@ -1169,7 +1169,7 @@ mod tests {
         account_mock.assert();
 
         // Should have made at least one request (retry logic is handled by backon)
-        assert!(order_status_mock.hits() >= 1);
+        assert!(order_status_mock.calls() >= 1);
         assert!(matches!(
             error,
             SchwabError::RequestFailed { action, status, .. }

--- a/crates/execution/src/schwab/tokens.rs
+++ b/crates/execution/src/schwab/tokens.rs
@@ -518,8 +518,8 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -611,8 +611,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -708,8 +708,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -756,8 +756,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);

--- a/src/alpaca_wallet/status.rs
+++ b/src/alpaca_wallet/status.rs
@@ -424,7 +424,7 @@ mod tests {
 
         assert!(matches!(error, AlpacaWalletError::TransferTimeout { .. }));
 
-        assert!(status_mock.hits() >= 2);
+        assert!(status_mock.calls() >= 2);
     }
 
     #[tokio::test]
@@ -458,7 +458,7 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            error_mock.hits() >= 1,
+            error_mock.calls() >= 1,
             "Expected at least one retry attempt"
         );
         assert!(
@@ -514,7 +514,7 @@ mod tests {
             poll_transfer_status(&client_clone, &transfer_id_clone, &config).await
         });
 
-        while processing_mock.hits() < 1 {
+        while processing_mock.calls() < 1 {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
@@ -722,7 +722,7 @@ mod tests {
                 async move { poll_deposit_by_tx_hash(&client_clone, &tx_hash, &config).await },
             );
 
-        while empty_mock.hits() < 1 {
+        while empty_mock.calls() < 1 {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
@@ -793,7 +793,10 @@ mod tests {
             "Expected DepositTimeout error, got: {error:?}"
         );
 
-        assert!(empty_mock.hits() >= 1, "Expected at least one poll attempt");
+        assert!(
+            empty_mock.calls() >= 1,
+            "Expected at least one poll attempt"
+        );
     }
 
     #[tokio::test]

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -186,7 +186,7 @@ mod tests {
         let refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token");
+                .body_includes("grant_type=refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1015,8 +1015,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -1636,8 +1636,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_but_rejected_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_but_rejected_refresh_token");
             then.status(400)
                 .header("content-type", "application/json")
                 .json_body(
@@ -1687,8 +1687,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2153,8 +2153,8 @@ mod tests {
         assert!(stdout_str2.contains("Processing trade with TradeAccumulator"));
         assert!(stdout_str2.contains("Trade accumulated but did not trigger execution yet"));
 
-        account_mock.assert_hits(1);
-        order_mock.assert_hits(1);
+        account_mock.assert_calls(1);
+        order_mock.assert_calls(1);
     }
 
     #[test]

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -428,7 +428,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
     let mint_mock = server.mock(|when, then| {
         when.method(POST)
             .path(tokenization_mint_path())
-            .json_body_partial(r#"{"underlying_symbol":"AAPL","qty":"30.500000000","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
+            .json_body_includes(r#"{"underlying_symbol":"AAPL","qty":"30.500000000","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(sample_pending_response("mint_int_test"));

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -371,7 +371,7 @@ mod tests {
         let server = MockServer::start();
 
         let _account_mock = server.mock(|when, then| {
-            when.method(GET).path_contains("/trading/accounts/");
+            when.method(GET).path_includes("/trading/accounts/");
             then.status(401)
                 .header("content-type", "application/json")
                 .json_body(json!({"message": "Invalid API credentials"}));

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1969,7 +1969,7 @@ mod tests {
         let conversion_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body_partial(r#"{"symbol":"USDCUSD"}"#);
+                .json_body_includes(r#"{"symbol":"USDCUSD"}"#);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2002,7 +2002,7 @@ mod tests {
 
         // Conversion MUST be called before withdrawal
         assert!(
-            conversion_mock.hits() >= 1,
+            conversion_mock.calls() >= 1,
             "execute_alpaca_to_base MUST call USD-to-USDC conversion \
              before withdrawal"
         );
@@ -2039,7 +2039,7 @@ mod tests {
         let conversion_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body_partial(r#"{"symbol":"USDCUSD"}"#);
+                .json_body_includes(r#"{"symbol":"USDCUSD"}"#);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2072,7 +2072,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            conversion_mock.hits() >= 1,
+            conversion_mock.calls() >= 1,
             "execute_base_to_alpaca MUST call USDC-to-USD conversion \
              after deposit confirmation"
         );
@@ -2204,7 +2204,7 @@ mod tests {
 
         // Verify no order was placed - CQRS failure should prevent side effects
         assert_eq!(
-            order_mock.hits(),
+            order_mock.calls(),
             0,
             "Order API should not be called when InitiateConversion fails"
         );


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

<!-- Use the snippet below for chained PRs
> [!CAUTION]
> Chained to #PR
-->

## Motivation
The mocks of #316 needed to give a response based on the query. httpmock 0.7 didn't have this, hence we need to upgrade to 0.8.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Upgrade the cargo.toml declaration, and update some apis that changed to new names

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->

By submitting this for review, I'm confirming I've done the following:

- [ x] added comprehensive test coverage for any changes in logic
- [ x] made this PR as small as possible
- [ x] linked any relevant issues or PRs
- [ x] included screenshots (if this involves a change to the dashboard)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #316 
- <kbd>&nbsp;4&nbsp;</kbd> #317 
- <kbd>&nbsp;3&nbsp;</kbd> #318 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #319 
- <kbd>&nbsp;1&nbsp;</kbd> #320 
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped httpmock to 0.8.
  * Extended reqwest features to include TLS, gzip, and blocking support.

* **Tests**
  * Updated mock assertions and request-body/path matching across the test suite to align with the testing library's API changes (call counting, inclusion-based body/path matchers, and related polling assertions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->