### PR TITLE
feat: make things configurable

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -119,6 +119,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -549,6 +549,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -601,6 +603,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::AlpacaBrokerApi(AlpacaBrokerApiCtx {
                 api_key: "test-key".to_string(),
                 api_secret: "test-secret".to_string(),

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -137,6 +137,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(schwab_auth.clone()),
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -90,6 +90,9 @@ pub(super) async fn cctp_bridge_command<Registry: IntoErrorRegistry, Writer: Wri
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        circle_api_base: None,
+        token_messenger: None,
+        message_transmitter: None,
     })?;
 
     let direction = from.to_bridge_direction();
@@ -144,6 +147,9 @@ pub(super) async fn cctp_recover_command<Writer: Write>(
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        circle_api_base: None,
+        token_messenger: None,
+        message_transmitter: None,
     })?;
 
     // Use the V2 API which returns both message and attestation from tx hash
@@ -254,6 +260,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1279,6 +1279,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -194,6 +194,9 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        circle_api_base: None,
+        token_messenger: None,
+        message_transmitter: None,
     })?);
 
     let (_vault_store, vault_registry_projection) =
@@ -556,6 +559,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -528,6 +528,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -167,6 +167,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,8 @@ struct Config {
     operational_limits: OperationalLimits,
     order_polling_interval: Option<u64>,
     order_polling_max_jitter: Option<u64>,
+    position_check_interval: Option<u64>,
+    inventory_poll_interval: Option<u64>,
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetryConfig>,
     rebalancing: Option<RebalancingConfig>,
@@ -132,6 +134,8 @@ pub struct Ctx {
     pub(crate) evm: EvmCtx,
     pub(crate) order_polling_interval: u64,
     pub(crate) order_polling_max_jitter: u64,
+    pub(crate) position_check_interval: u64,
+    pub(crate) inventory_poll_interval: u64,
     pub(crate) broker: BrokerCtx,
     pub telemetry: Option<TelemetryCtx>,
     pub(crate) trading_mode: TradingMode,
@@ -278,6 +282,8 @@ impl std::fmt::Debug for Ctx {
             .field("evm", &self.evm)
             .field("order_polling_interval", &self.order_polling_interval)
             .field("order_polling_max_jitter", &self.order_polling_max_jitter)
+            .field("position_check_interval", &self.position_check_interval)
+            .field("inventory_poll_interval", &self.inventory_poll_interval)
             .field("broker", &self.broker)
             .field("telemetry", &self.telemetry)
             .field("trading_mode", &self.trading_mode)
@@ -417,6 +423,8 @@ impl Ctx {
             evm,
             order_polling_interval: config.order_polling_interval.unwrap_or(15),
             order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
+            position_check_interval: config.position_check_interval.unwrap_or(60),
+            inventory_poll_interval: config.inventory_poll_interval.unwrap_or(60),
             broker,
             telemetry,
             trading_mode,
@@ -553,6 +561,7 @@ pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePo
     // (single INSERT per trade) to avoid blocking the main bot.
     let options: SqliteConnectOptions = database_url
         .parse::<SqliteConnectOptions>()?
+        .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(std::time::Duration::from_secs(10));
 
@@ -593,6 +602,8 @@ pub(crate) mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_key".to_owned(),
                 app_secret: "test_secret".to_owned(),
@@ -771,6 +782,8 @@ pub(crate) mod tests {
         assert_eq!(ctx.server_port, 8080);
         assert_eq!(ctx.order_polling_interval, 15);
         assert_eq!(ctx.order_polling_max_jitter, 5);
+        assert_eq!(ctx.position_check_interval, 60);
+        assert_eq!(ctx.inventory_poll_interval, 60);
     }
 
     #[tokio::test]
@@ -871,11 +884,12 @@ pub(crate) mod tests {
             server_port = 9090
             order_polling_interval = 30
             order_polling_max_jitter = 10
-
-            [equities]
-
+            position_check_interval = 120
+            inventory_poll_interval = 90
             [operational_limits]
             mode = "disabled"
+
+            [equities]
 
             [evm]
             orderbook = "0x1111111111111111111111111111111111111111"
@@ -892,6 +906,8 @@ pub(crate) mod tests {
         assert_eq!(ctx.server_port, 9090);
         assert_eq!(ctx.order_polling_interval, 30);
         assert_eq!(ctx.order_polling_max_jitter, 10);
+        assert_eq!(ctx.position_check_interval, 120);
+        assert_eq!(ctx.inventory_poll_interval, 90);
     }
 
     #[tokio::test]

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -84,6 +84,9 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             usdc_base: USDC_BASE,
             ethereum_wallet,
             base_wallet: base_wallet.clone(),
+            circle_api_base: ctx.circle_api_base.clone(),
+            token_messenger: ctx.token_messenger,
+            message_transmitter: ctx.message_transmitter,
         })?);
 
         let wrapper = Arc::new(WrapperService::new(base_wallet, equities));
@@ -329,6 +332,9 @@ mod tests {
                 usdc_base: USDC_BASE,
                 ethereum_wallet,
                 base_wallet: base_wallet.clone(),
+                circle_api_base: None,
+                token_messenger: None,
+                message_transmitter: None,
             })
             .unwrap(),
         );

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -132,6 +132,13 @@ pub(crate) struct RebalancingCtx {
     base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
     /// Pre-built wallet for Ethereum mainnet.
     ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+    /// Override the Circle attestation/fee API base URL (for e2e tests
+    /// with locally deployed CCTP contracts).
+    pub(crate) circle_api_base: Option<String>,
+    /// Override the `TokenMessengerV2` contract address.
+    pub(crate) token_messenger: Option<Address>,
+    /// Override the `MessageTransmitterV2` contract address.
+    pub(crate) message_transmitter: Option<Address>,
 }
 
 impl RebalancingCtx {
@@ -177,6 +184,9 @@ impl RebalancingCtx {
             alpaca_broker_auth: broker_auth,
             base_wallet: Arc::new(base_wallet),
             ethereum_wallet: Arc::new(ethereum_wallet),
+            circle_api_base: None,
+            token_messenger: None,
+            message_transmitter: None,
         })
     }
 
@@ -241,6 +251,9 @@ impl RebalancingCtx {
             alpaca_broker_auth,
             base_wallet: wallet.clone(),
             ethereum_wallet: wallet,
+            circle_api_base: None,
+            token_messenger: None,
+            message_transmitter: None,
         }
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1043,6 +1043,9 @@ mod tests {
             usdc_base: USDC_ADDRESS,
             ethereum_wallet: wallet.clone(),
             base_wallet: wallet.clone(),
+            circle_api_base: None,
+            token_messenger: None,
+            message_transmitter: None,
         })
         .unwrap();
 


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

<!-- Use the snippet below for chained PRs
> [!CAUTION]
> Chained to #PR
-->

## Motivation
#316 is running the bot directly, but needed tighter loops to avoid tests running for too long. As well as some mocks exposing a different url than the hardcoded ones (cctp)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add more config fields to the bot ctx.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->

By submitting this for review, I'm confirming I've done the following:

- [x ] added comprehensive test coverage for any changes in logic
- [ x] made this PR as small as possible
- [ x] linked any relevant issues or PRs
- [ x] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable intervals for position checking and inventory polling (both default to 60 seconds).
  * Added optional configuration overrides for cross-chain transfer protocol settings to support testing and non-production environments.

* **Improvements**
  * SQLite database now automatically creates if missing on initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #316 
- <kbd>&nbsp;4&nbsp;</kbd> #317 
- <kbd>&nbsp;3&nbsp;</kbd> #318 
- <kbd>&nbsp;2&nbsp;</kbd> #319 
- <kbd>&nbsp;1&nbsp;</kbd> #320 👈 
<!-- GitButler Footer Boundary Bottom -->

