### PR TITLE
fix: replace rust_decimal with ExactDecimal (Rain Float) to eliminate precision artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ the limit:
 - [docs/alloy.md](docs/alloy.md) - Alloy types, FixedBytes aliases,
   `::random()`, mocks, encoding, compile-time macros
 - [docs/cqrs.md](docs/cqrs.md) - Event sourcing with st0x-event-sorcery
-  (EventSourced trait, Store, Projection, testing, cqrs-es internals)
+- [docs/exact-decimal.md](docs/exact-decimal.md) - ExactDecimal type, Float
+  migration, precision-safe financial arithmetic (EventSourced trait, Store,
+  Projection, testing, cqrs-es internals)
 
 **Update at the end:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "sqlx",
  "st0x-event-sorcery",
  "st0x-evm",
+ "st0x-exact-decimal",
  "st0x-execution",
  "st0x-hedge",
  "tempfile",
@@ -6555,6 +6556,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "st0x-exact-decimal",
  "ts-rs",
 ]
 
@@ -6596,6 +6598,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "st0x-exact-decimal"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "proptest",
+ "rain-math-float",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "st0x-execution"
 version = "0.1.0"
 dependencies = [
@@ -6613,6 +6627,7 @@ dependencies = [
  "num-decimal",
  "num-traits",
  "proptest",
+ "rain-math-float",
  "rand 0.8.5",
  "reqwest 0.12.24",
  "rust_decimal",
@@ -6622,6 +6637,7 @@ dependencies = [
  "serial_test",
  "sqlite-es",
  "sqlx",
+ "st0x-exact-decimal",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6673,6 +6689,7 @@ dependencies = [
  "st0x-dto",
  "st0x-event-sorcery",
  "st0x-evm",
+ "st0x-exact-decimal",
  "st0x-execution",
  "st0x-hedge",
  "temp-env",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/dto",
   "crates/e2e-tests",
   "crates/event-sorcery",
+  "crates/exact-decimal",
   "crates/execution",
   "crates/bridge",
   "crates/evm",
@@ -83,6 +84,7 @@ tracing-opentelemetry = "0.31.0"
 proptest = "1.7.0"
 rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error" }
 rust_decimal = { version = "1.38.0", features = ["serde"] }
+st0x-exact-decimal = { path = "crates/exact-decimal" }
 st0x-evm = { path = "crates/evm" }
 num-decimal = { version = "0.2.5", default-features = false, features = [
   "num-v04",
@@ -146,6 +148,7 @@ toml = "0.9.11"
 rust_decimal_macros = "1.38.0"
 st0x-evm = { workspace = true, features = ["fireblocks"] }
 bon = { version = "3.9.0", optional = true }
+st0x-exact-decimal = { version = "0.1.0", path = "crates/exact-decimal" }
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,10 @@
   - PR:
     [#241 Wrapped Token Handling](https://github.com/ST0x-Technology/st0x.liquidity/pull/241)
 
+#### Precision & Numeric Types
+
+- [x] [#312 Decimal precision artifacts from Rain Float and U256 conversions cause production failures](https://github.com/ST0x-Technology/st0x.liquidity/issues/312)
+
 #### Alpaca Trading Improvements
 
 - [x] PR:

--- a/crates/dto/Cargo.toml
+++ b/crates/dto/Cargo.toml
@@ -10,6 +10,7 @@ chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive"] }
 rust_decimal = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
+st0x-exact-decimal = { version = "0.1.0", path = "../exact-decimal" }
 ts-rs = { version = "11.1.0", features = [
   "chrono",
   "chrono-impl",

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -31,6 +31,7 @@ st0x-evm = { workspace = true, features = ["local-signer"] }
 st0x-execution = { path = "../execution", features = ["mock", "test-support"] }
 st0x-hedge = { path = "../..", features = ["test-support"] }
 reqwest.workspace = true
+st0x-exact-decimal = { version = "0.1.0", path = "../exact-decimal" }
 
 [lints]
 workspace = true

--- a/crates/e2e-tests/src/services/alpaca_broker.rs
+++ b/crates/e2e-tests/src/services/alpaca_broker.rs
@@ -6,7 +6,6 @@
 //! state via the builder — no per-request mock setup needed.
 
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
@@ -17,8 +16,8 @@ use alloy::sol_types::SolEvent;
 use bon::bon;
 use chrono::Utc;
 use httpmock::prelude::*;
-use rust_decimal::Decimal;
 use serde_json::{Value, json};
+use st0x_exact_decimal::ExactDecimal;
 use st0x_execution::Symbol;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -26,6 +25,11 @@ use uuid::Uuid;
 sol! {
     #[sol(all_derives = true)]
     event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+/// Shorthand for parsing an `ExactDecimal` from a static literal in mock code.
+fn ed(value: &str) -> ExactDecimal {
+    ExactDecimal::parse(value).unwrap_or_else(|_| ExactDecimal::zero())
 }
 
 pub const TEST_ACCOUNT_ID: &str = "904837e3-3b76-47ec-b432-046db621571b";
@@ -48,13 +52,13 @@ pub enum MockMode {
 
 pub struct MockPosition {
     pub symbol: Symbol,
-    pub qty: Decimal,
-    pub market_value: Decimal,
+    pub qty: ExactDecimal,
+    pub market_value: ExactDecimal,
 }
 
 struct MockAccount {
-    cash: Decimal,
-    buying_power: Decimal,
+    cash: ExactDecimal,
+    buying_power: ExactDecimal,
     positions: HashMap<Symbol, MockPosition>,
 }
 
@@ -92,7 +96,7 @@ struct MockWalletTransfer {
 struct MockState {
     account: MockAccount,
     orders: HashMap<String, MockOrder>,
-    symbol_fill_prices: HashMap<Symbol, Decimal>,
+    symbol_fill_prices: HashMap<Symbol, ExactDecimal>,
     mode: MockMode,
     /// Per-symbol fill delays: number of polls before filling.
     /// Symbols without an entry fill immediately in `HappyPath` mode.
@@ -157,7 +161,7 @@ impl AlpacaBrokerMock {
     /// registered. Optionally configure per-symbol fill prices.
     #[builder]
     pub async fn start(
-        symbol_fill_prices: Vec<(Symbol, Decimal)>,
+        symbol_fill_prices: Vec<(Symbol, ExactDecimal)>,
         symbol_positions: Vec<MockPosition>,
     ) -> Self {
         let today = Utc::now().format("%Y-%m-%d").to_string();
@@ -176,8 +180,8 @@ impl AlpacaBrokerMock {
 
         let state = Arc::new(Mutex::new(MockState {
             account: MockAccount {
-                cash: Decimal::from(100_000),
-                buying_power: Decimal::from(100_000),
+                cash: ed("100000"),
+                buying_power: ed("100000"),
                 positions,
             },
             orders: HashMap::new(),
@@ -212,7 +216,7 @@ impl AlpacaBrokerMock {
     }
 
     /// Sets a fill price for a specific symbol.
-    pub fn set_symbol_fill_price(&self, symbol: Symbol, price: Decimal) {
+    pub fn set_symbol_fill_price(&self, symbol: Symbol, price: ExactDecimal) {
         lock(&self.state).symbol_fill_prices.insert(symbol, price);
     }
 
@@ -609,14 +613,23 @@ fn handle_crypto_order(
     qty: &str,
     side: &str,
 ) -> HttpMockResponse {
-    let Ok(qty_dec) = Decimal::from_str(qty) else {
+    let Ok(qty_dec) = ExactDecimal::parse(qty) else {
         return json_response(400, &json!({"message": format!("invalid qty: {qty}")}));
     };
 
-    if side == "buy" {
-        state.account.cash -= qty_dec;
+    let updated_cash = if side == "buy" {
+        state.account.cash - qty_dec
     } else {
-        state.account.cash += qty_dec;
+        state.account.cash + qty_dec
+    };
+    match updated_cash {
+        Ok(cash) => state.account.cash = cash,
+        Err(error) => {
+            return json_response(
+                500,
+                &json!({"message": format!("cash arithmetic error: {error}")}),
+            );
+        }
     }
 
     state.orders.insert(
@@ -692,7 +705,14 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                                 );
                             };
 
-                            apply_happy_path_fill(&mut state, &order_id, fill_price);
+                            if let Err(error) =
+                                apply_happy_path_fill(&mut state, &order_id, fill_price)
+                            {
+                                return json_response(
+                                    500,
+                                    &json!({"message": format!("fill arithmetic error: {error}")}),
+                                );
+                            }
                         }
                     }
                     MockMode::OrderRejected => {
@@ -719,7 +739,14 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
                                 );
                             };
 
-                            apply_happy_path_fill(&mut state, &order_id, fill_price);
+                            if let Err(error) =
+                                apply_happy_path_fill(&mut state, &order_id, fill_price)
+                            {
+                                return json_response(
+                                    500,
+                                    &json!({"message": format!("fill arithmetic error: {error}")}),
+                                );
+                            }
                         }
                     }
                     MockMode::PlacementFails => {
@@ -754,22 +781,27 @@ fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockSta
 }
 
 /// Transitions a "new" order to "filled" and updates account balances.
-fn apply_happy_path_fill(state: &mut MockState, order_id: &str, fill_price: Decimal) {
+fn apply_happy_path_fill(
+    state: &mut MockState,
+    order_id: &str,
+    fill_price: ExactDecimal,
+) -> Result<(), rain_math_float::FloatError> {
     let should_fill = state
         .orders
         .get(order_id)
         .is_some_and(|o| o.status == "new");
     if !should_fill {
-        return;
+        return Ok(());
     }
 
     let symbol = state.orders[order_id].symbol.clone();
     let qty_str = state.orders[order_id].qty.clone();
     let side = state.orders[order_id].side.clone();
 
-    let qty = Decimal::from_str(&qty_str)
+    let qty = ExactDecimal::parse(&qty_str)
         .unwrap_or_else(|_| panic!("order {order_id} has invalid qty '{qty_str}' in mock state"));
     let symbol_key = Symbol::force_new(symbol);
+    let cost = (qty * fill_price)?;
 
     if let Some(order) = state.orders.get_mut(order_id) {
         order.status = "filled".to_string();
@@ -777,32 +809,34 @@ fn apply_happy_path_fill(state: &mut MockState, order_id: &str, fill_price: Deci
     }
 
     if side == "buy" {
-        state.account.cash -= qty * fill_price;
+        state.account.cash = (state.account.cash - cost)?;
         let position = state
             .account
             .positions
             .entry(symbol_key.clone())
             .or_insert_with(|| MockPosition {
                 symbol: symbol_key,
-                qty: Decimal::ZERO,
-                market_value: Decimal::ZERO,
+                qty: ExactDecimal::zero(),
+                market_value: ExactDecimal::zero(),
             });
-        position.qty += qty;
-        position.market_value += qty * fill_price;
+        position.qty = (position.qty + qty)?;
+        position.market_value = (position.market_value + cost)?;
     } else {
-        state.account.cash += qty * fill_price;
+        state.account.cash = (state.account.cash + cost)?;
         let position = state
             .account
             .positions
             .entry(symbol_key.clone())
             .or_insert_with(|| MockPosition {
                 symbol: symbol_key,
-                qty: Decimal::ZERO,
-                market_value: Decimal::ZERO,
+                qty: ExactDecimal::zero(),
+                market_value: ExactDecimal::zero(),
             });
-        position.qty -= qty;
-        position.market_value -= qty * fill_price;
+        position.qty = (position.qty - qty)?;
+        position.market_value = (position.market_value - cost)?;
     }
+
+    Ok(())
 }
 
 fn register_whitelist_get_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>) {

--- a/crates/e2e-tests/src/services/base_chain.rs
+++ b/crates/e2e-tests/src/services/base_chain.rs
@@ -15,7 +15,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
 use alloy::sol_types::SolEvent as _;
 use rain_math_float::Float;
-use rust_decimal::Decimal;
+use st0x_exact_decimal::ExactDecimal;
 use std::collections::HashMap;
 use url::Url;
 
@@ -363,8 +363,8 @@ impl<P: Provider + Clone> BaseChain<P> {
     pub async fn setup_order(
         &self,
         symbol: &str,
-        amount: Decimal,
-        price: Decimal,
+        amount: ExactDecimal,
+        price: ExactDecimal,
         direction: TakeDirection,
         usdc_vault_id: Option<B256>,
         rain_expression_override: Option<String>,
@@ -379,9 +379,9 @@ impl<P: Provider + Clone> BaseChain<P> {
         let deployer_instance = Deployer::DeployerInstance::new(self.deployer_addr, &self.provider);
 
         let is_sell = matches!(direction, TakeDirection::SellEquity);
-        let usdc_total = amount * price;
-        let amount_str = format!("{amount:.6}");
-        let usdc_total_str = format!("{usdc_total:.6}");
+        let usdc_total = (amount * price)?;
+        let amount_str = amount.round_dp(6)?.to_string();
+        let usdc_total_str = usdc_total.round_dp(6)?.to_string();
 
         let (input_token, output_token) = if is_sell {
             (USDC_BASE, equity_vault_addr)
@@ -606,8 +606,8 @@ impl<P: Provider + Clone> BaseChain<P> {
     pub async fn take_order(
         &self,
         symbol: &str,
-        amount: Decimal,
-        price: Decimal,
+        amount: ExactDecimal,
+        price: ExactDecimal,
         direction: TakeDirection,
         rain_expression_override: Option<String>,
     ) -> anyhow::Result<TakeOrderResult> {
@@ -621,9 +621,9 @@ impl<P: Provider + Clone> BaseChain<P> {
         let deployer_instance = Deployer::DeployerInstance::new(self.deployer_addr, &self.provider);
 
         let is_sell = matches!(direction, TakeDirection::SellEquity);
-        let usdc_total = amount * price;
-        let amount_str = format!("{amount:.6}");
-        let usdc_total_str = format!("{usdc_total:.6}");
+        let usdc_total = (amount * price)?;
+        let amount_str = amount.round_dp(6)?.to_string();
+        let usdc_total_str = usdc_total.round_dp(6)?.to_string();
 
         // Order: input = what order receives, output = what order gives
         let (input_token, output_token) = if is_sell {

--- a/crates/e2e-tests/src/services/cctp/infra.rs
+++ b/crates/e2e-tests/src/services/cctp/infra.rs
@@ -11,7 +11,7 @@ use alloy::providers::Provider;
 use alloy::providers::ext::AnvilApi as _;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
-use rust_decimal_macros::dec;
+use st0x_exact_decimal::ExactDecimal;
 use st0x_execution::Symbol;
 use tokio::task::JoinHandle;
 
@@ -175,9 +175,10 @@ impl CctpInfra {
             .register_wallet_endpoints(infra.base_chain.owner);
 
         // USDC/USD conversion is a 1:1 stablecoin pair on Alpaca
-        infra
-            .broker_service
-            .set_symbol_fill_price(Symbol::force_new("USDCUSD".to_string()), dec!(1.0));
+        infra.broker_service.set_symbol_fill_price(
+            Symbol::force_new("USDCUSD".to_string()),
+            ExactDecimal::parse("1")?,
+        );
 
         let eth_watcher_provider = alloy::providers::ProviderBuilder::new()
             .connect(&ethereum_endpoint)

--- a/crates/e2e-tests/tests/hedging/utils.rs
+++ b/crates/e2e-tests/tests/hedging/utils.rs
@@ -14,12 +14,18 @@ use e2e_tests::services::alpaca_broker;
 use e2e_tests::services::alpaca_broker::AlpacaBrokerMock;
 use e2e_tests::services::base_chain::{self, TakeOrderResult};
 
-pub(crate) use std::str::FromStr;
 pub(crate) use std::time::Duration;
 
 pub(crate) use alloy::providers::Provider;
-pub(crate) use rust_decimal::Decimal;
-pub(crate) use rust_decimal_macros::dec;
+pub(crate) use st0x_exact_decimal::ExactDecimal;
+
+pub(crate) fn ed(value: &str) -> ExactDecimal {
+    match ExactDecimal::parse(value) {
+        Ok(val) => val,
+        Err(error) => panic!("ed({value:?}) failed: {error}"),
+    }
+}
+
 pub(crate) use st0x_event_sorcery::Projection;
 pub(crate) use st0x_execution::{FractionalShares, Positive, Symbol};
 pub(crate) use st0x_hedge::ExecutionThreshold;

--- a/crates/e2e-tests/tests/rebalancing/mod.rs
+++ b/crates/e2e-tests/tests/rebalancing/mod.rs
@@ -33,9 +33,9 @@ use self::utils::*;
 /// that direct decimal price literals do not block the mint pipeline.
 #[test_log::test(tokio::test)]
 async fn equity_mint_handles_direct_high_precision_sell_price() -> anyhow::Result<()> {
-    let onchain_price = Decimal::from_str("112.50000000000000000000000002")?;
-    let broker_fill_price = dec!(110);
-    let amount_per_trade = dec!(7.5);
+    let onchain_price = ed("112.50000000000000000000000002");
+    let broker_fill_price = ed("110");
+    let amount_per_trade = ed("7.5");
 
     let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
 
@@ -85,13 +85,13 @@ async fn equity_mint_handles_direct_high_precision_sell_price() -> anyhow::Resul
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
-        .amount(dec!(22.5))
+        .amount(ed("22.5"))
         .direction(TakeDirection::SellEquity)
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
-        .expected_accumulated_long(dec!(0))
-        .expected_accumulated_short(dec!(22.5))
-        .expected_net(dec!(0))
+        .expected_accumulated_long(ed("0"))
+        .expected_accumulated_short(ed("22.5"))
+        .expected_net(ed("0"))
         .build()];
 
     assert_equity_rebalancing_flow()
@@ -131,9 +131,9 @@ async fn equity_mint_handles_direct_high_precision_sell_price() -> anyhow::Resul
 /// ERC-4626 wrapping and Raindex vault deposit.
 #[test_log::test(tokio::test)]
 async fn equity_imbalance_triggers_mint() -> anyhow::Result<()> {
-    let onchain_price = dec!(150.00);
-    let broker_fill_price = dec!(148.00);
-    let amount_per_trade = dec!(7.5);
+    let onchain_price = ed("150.00");
+    let broker_fill_price = ed("148.00");
+    let amount_per_trade = ed("7.5");
 
     let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
 
@@ -188,13 +188,13 @@ async fn equity_imbalance_triggers_mint() -> anyhow::Result<()> {
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
-        .amount(dec!(22.5))
+        .amount(ed("22.5"))
         .direction(TakeDirection::SellEquity)
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
-        .expected_accumulated_long(dec!(0))
-        .expected_accumulated_short(dec!(22.5))
-        .expected_net(dec!(0))
+        .expected_accumulated_long(ed("0"))
+        .expected_accumulated_short(ed("22.5"))
+        .expected_net(ed("0"))
         .build()];
 
     assert_equity_rebalancing_flow()
@@ -232,12 +232,12 @@ async fn equity_imbalance_triggers_mint() -> anyhow::Result<()> {
 /// API mock endpoints for redemption detection/completion polling.
 #[test_log::test(tokio::test)]
 async fn equity_imbalance_triggers_redemption() -> anyhow::Result<()> {
-    let onchain_price = dec!(112.50);
-    let broker_fill_price = dec!(113.60);
-    let trade_amount = dec!(12.5);
+    let onchain_price = ed("112.50");
+    let broker_fill_price = ed("113.60");
+    let trade_amount = ed("12.5");
 
     let infra =
-        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", dec!(20))]).await?;
+        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", ed("20"))]).await?;
 
     // Set up order and deposit extra equity before bot starts.
     let prepared = infra
@@ -301,9 +301,9 @@ async fn equity_imbalance_triggers_redemption() -> anyhow::Result<()> {
         .direction(TakeDirection::BuyEquity)
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
-        .expected_accumulated_long(dec!(12.5))
-        .expected_accumulated_short(dec!(0))
-        .expected_net(dec!(0))
+        .expected_accumulated_long(ed("12.5"))
+        .expected_accumulated_short(ed("0"))
+        .expected_net(ed("0"))
         .build()];
 
     let redemption_wallet_balance_after =
@@ -347,12 +347,12 @@ async fn equity_imbalance_triggers_redemption() -> anyhow::Result<()> {
 #[ignore = "Diagnostic repro: run with --nocapture and inspect PrecisionLoss logs"]
 #[test_log::test(tokio::test)]
 async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::Result<()> {
-    let onchain_price = dec!(115);
-    let broker_fill_price = dec!(113.57);
-    let trade_amount = dec!(12.5);
+    let onchain_price = ed("115");
+    let broker_fill_price = ed("113.57");
+    let trade_amount = ed("12.5");
 
     let infra =
-        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", dec!(20))]).await?;
+        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", ed("20"))]).await?;
 
     let prepared = infra
         .base_chain
@@ -412,8 +412,8 @@ async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
         .expected_accumulated_long(trade_amount)
-        .expected_accumulated_short(dec!(0))
-        .expected_net(dec!(0))
+        .expected_accumulated_short(ed("0"))
+        .expected_net(ed("0"))
         .build()];
 
     let redemption_wallet_balance_after =
@@ -444,7 +444,7 @@ async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::
 }
 
 /// Diagnostic repro using the historical harness behavior: precompute the
-/// buy-side reciprocal in Rust `Decimal` and inject it as a Rainlang literal.
+/// buy-side reciprocal in `ExactDecimal` and inject it as a Rainlang literal.
 ///
 /// This uses the same rebalancing redemption setup as the `inv(price)` repro
 /// but replaces the generated Rainlang expression with a direct reciprocal
@@ -452,17 +452,17 @@ async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::
 #[ignore = "Diagnostic repro: run with --nocapture and inspect PrecisionLoss logs"]
 #[test_log::test(tokio::test)]
 async fn equity_redemption_buy_literal_reciprocal_regression() -> anyhow::Result<()> {
-    let onchain_price = dec!(112);
-    let broker_fill_price = dec!(113.57);
-    let trade_amount = dec!(12.5);
+    let onchain_price = ed("112");
+    let broker_fill_price = ed("113.57");
+    let trade_amount = ed("12.5");
 
-    let reciprocal_literal = (dec!(1.0) / onchain_price).to_string();
-    let usdc_total = trade_amount * onchain_price;
-    let max_amount_base: U256 = parse_units(&format!("{usdc_total:.6}"), 6)?.into();
+    let reciprocal_literal = (ed("1.0") / onchain_price).unwrap().to_string();
+    let usdc_total = (trade_amount * onchain_price).unwrap();
+    let max_amount_base: U256 = parse_units(&usdc_total.round_dp(6)?.to_string(), 6)?.into();
     let rain_expression_override = format!("_ _: {max_amount_base} {reciprocal_literal};:;");
 
     let infra =
-        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", dec!(20))]).await?;
+        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", ed("20"))]).await?;
 
     let prepared = infra
         .base_chain
@@ -523,8 +523,8 @@ async fn equity_redemption_buy_literal_reciprocal_regression() -> anyhow::Result
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
         .expected_accumulated_long(trade_amount)
-        .expected_accumulated_short(dec!(0))
-        .expected_net(dec!(0))
+        .expected_accumulated_short(ed("0"))
+        .expected_net(ed("0"))
         .build()];
 
     let redemption_wallet_balance_after =
@@ -572,9 +572,9 @@ async fn equity_redemption_buy_literal_reciprocal_regression() -> anyhow::Result
 /// for `MessageSent` events using a test attester key.
 #[test_log::test(tokio::test)]
 async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
-    let onchain_price = dec!(158.39);
-    let broker_fill_price = dec!(155.00);
-    let amount_per_trade = dec!(7.5);
+    let onchain_price = ed("158.39");
+    let broker_fill_price = ed("155.00");
+    let amount_per_trade = ed("7.5");
 
     let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
     let cctp = CctpInfra::start(&infra).await?;
@@ -660,13 +660,13 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
-        .amount(amount_per_trade * dec!(3))
+        .amount((amount_per_trade * ed("3")).unwrap())
         .direction(TakeDirection::BuyEquity)
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
-        .expected_accumulated_long(amount_per_trade * dec!(3))
-        .expected_accumulated_short(dec!(0))
-        .expected_net(dec!(0))
+        .expected_accumulated_long((amount_per_trade * ed("3")).unwrap())
+        .expected_accumulated_short(ed("0"))
+        .expected_net(ed("0"))
         .build()];
 
     assert_usdc_rebalancing_flow()
@@ -706,9 +706,9 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
 /// Raindex USDC vault is pre-funded so the bot can withdraw from it.
 #[test_log::test(tokio::test)]
 async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
-    let onchain_price = dec!(158.39);
-    let broker_fill_price = dec!(155.00);
-    let amount_per_trade = dec!(7.5);
+    let onchain_price = ed("158.39");
+    let broker_fill_price = ed("155.00");
+    let amount_per_trade = ed("7.5");
 
     let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
     let cctp = CctpInfra::start(&infra).await?;
@@ -817,13 +817,13 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
-        .amount(amount_per_trade * dec!(3))
+        .amount((amount_per_trade * ed("3")).unwrap())
         .direction(TakeDirection::SellEquity)
         .onchain_price(onchain_price)
         .broker_fill_price(broker_fill_price)
-        .expected_accumulated_long(dec!(0))
-        .expected_accumulated_short(amount_per_trade * dec!(3))
-        .expected_net(dec!(0))
+        .expected_accumulated_long(ed("0"))
+        .expected_accumulated_short((amount_per_trade * ed("3")).unwrap())
+        .expected_net(ed("0"))
         .build()];
 
     assert_usdc_rebalancing_flow()

--- a/crates/exact-decimal/Cargo.toml
+++ b/crates/exact-decimal/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "st0x-exact-decimal"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+alloy.workspace = true
+rain-math-float.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/exact-decimal/src/lib.rs
+++ b/crates/exact-decimal/src/lib.rs
@@ -1,0 +1,557 @@
+//! Exact decimal floating-point type backed by Rain's `Float`.
+//!
+//! `ExactDecimal` wraps `rain_math_float::Float` (224-bit coefficient + 32-bit
+//! exponent) and provides the standard Rust trait implementations that `Float`
+//! itself cannot offer because its operations are fallible EVM calls.
+//!
+//! Key properties:
+//! - **No precision loss** on values that originate from onchain `Float` data.
+//! - **Backward-compatible serde**: serializes as a decimal string (`"1.5"`),
+//!   deserializes from both decimal strings and hex B256 strings.
+//! - **`PartialEq`/`Eq`/`Ord`** via `Float`'s EVM-based comparison (panics
+//!   only on malformed B256 data that cannot occur through valid construction).
+
+use std::cmp::Ordering;
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+use std::str::FromStr;
+
+use alloy::primitives::{B256, U256};
+use rain_math_float::{Float, FloatError};
+use serde::{Deserialize, Serialize};
+
+/// Exact decimal floating-point value using Rain's Float
+/// (224-bit coefficient + 32-bit exponent).
+///
+/// Provides `PartialEq`/`Eq`/`Ord` via Float's EVM-based comparison and
+/// custom serde as decimal strings for backward compatibility with existing
+/// event payloads that stored `rust_decimal::Decimal` as `"1.5"`.
+#[derive(Clone, Copy)]
+pub struct ExactDecimal(Float);
+
+/// Unwraps a Float comparison result. Float comparisons fail only on malformed
+/// B256 values, which cannot occur through valid construction paths.
+fn unwrap_comparison(result: Result<bool, FloatError>) -> bool {
+    match result {
+        Ok(value) => value,
+        Err(error) => panic!("ExactDecimal comparison failed (corrupted Float data): {error}"),
+    }
+}
+
+impl ExactDecimal {
+    pub fn new(float: Float) -> Self {
+        Self(float)
+    }
+
+    /// Parse a decimal string into an `ExactDecimal`.
+    pub fn parse(value: &str) -> Result<Self, FloatError> {
+        Float::parse(value.to_string()).map(Self)
+    }
+
+    /// Convert from a fixed-point decimal representation.
+    ///
+    /// E.g., `from_fixed_decimal(U256::from(1_500_000), 6)` produces `1.5`.
+    pub fn from_fixed_decimal(value: U256, decimals: u8) -> Result<Self, FloatError> {
+        Float::from_fixed_decimal(value, decimals).map(Self)
+    }
+
+    /// Convert to a fixed-point decimal representation (lossless).
+    ///
+    /// E.g., for an `ExactDecimal` of `1.5`, `to_fixed_decimal(6)` returns
+    /// `U256::from(1_500_000)`.
+    ///
+    /// Returns an error if the conversion would lose precision. Use
+    /// [`to_fixed_decimal_lossy`](Self::to_fixed_decimal_lossy) when
+    /// truncation is acceptable.
+    pub fn to_fixed_decimal(self, decimals: u8) -> Result<U256, FloatError> {
+        self.0.to_fixed_decimal(decimals)
+    }
+
+    /// Convert to a fixed-point decimal representation, truncating any
+    /// digits beyond the requested precision.
+    ///
+    /// Returns `(value, lossless)` where `lossless` is `false` when
+    /// truncation occurred.
+    pub fn to_fixed_decimal_lossy(self, decimals: u8) -> Result<(U256, bool), FloatError> {
+        self.0.to_fixed_decimal_lossy(decimals)
+    }
+
+    /// Construct from a raw B256 (onchain Float representation).
+    pub fn from_raw(value: B256) -> Self {
+        Self(Float::from_raw(value))
+    }
+
+    /// Returns the zero value.
+    pub const fn zero() -> Self {
+        Self(Float::from_raw(B256::ZERO))
+    }
+
+    pub fn is_zero(self) -> Result<bool, FloatError> {
+        self.0.is_zero()
+    }
+
+    pub fn is_negative(self) -> Result<bool, FloatError> {
+        let zero = Float::zero()?;
+        self.0.lt(zero)
+    }
+
+    pub fn abs(self) -> Result<Self, FloatError> {
+        self.0.abs().map(Self)
+    }
+
+    /// Returns the integer part (truncation toward zero).
+    pub fn integer(self) -> Result<Self, FloatError> {
+        self.0.integer().map(Self)
+    }
+
+    /// Returns the fractional part.
+    pub fn frac(self) -> Result<Self, FloatError> {
+        self.0.frac().map(Self)
+    }
+
+    /// Truncate to `dp` decimal places (toward zero).
+    ///
+    /// Uses a fixed-decimal roundtrip: convert to fixed-point with `dp`
+    /// decimal digits (which truncates), then convert back.
+    pub fn round_dp(self, dp: u8) -> Result<Self, FloatError> {
+        let (fixed, _lossless) = self.0.to_fixed_decimal_lossy(dp)?;
+        Float::from_fixed_decimal(fixed, dp).map(Self)
+    }
+
+    /// Escape hatch for direct Float operations.
+    pub fn inner(self) -> Float {
+        self.0
+    }
+
+    /// Returns the raw B256 representation.
+    pub fn to_raw(self) -> B256 {
+        self.0.get_inner()
+    }
+
+    /// Format as a decimal string (never scientific notation).
+    pub fn format_decimal(self) -> Result<String, FloatError> {
+        self.0.format_with_scientific(false)
+    }
+}
+
+impl Debug for ExactDecimal {
+    fn fmt(&self, dest: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.format_with_scientific(false) {
+            Ok(text) => write!(dest, "ExactDecimal({text})"),
+            Err(error) => write!(dest, "ExactDecimal(<format error: {error}>)"),
+        }
+    }
+}
+
+impl Display for ExactDecimal {
+    fn fmt(&self, dest: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.format_with_scientific(false) {
+            Ok(text) => write!(dest, "{text}"),
+            Err(error) => write!(dest, "<format error: {error}>"),
+        }
+    }
+}
+
+impl FromStr for ExactDecimal {
+    type Err = FloatError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+impl Default for ExactDecimal {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl Hash for ExactDecimal {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialEq for ExactDecimal {
+    fn eq(&self, other: &Self) -> bool {
+        unwrap_comparison(self.0.eq(other.0))
+    }
+}
+
+impl Eq for ExactDecimal {}
+
+impl PartialOrd for ExactDecimal {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ExactDecimal {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if unwrap_comparison(self.0.lt(other.0)) {
+            Ordering::Less
+        } else if unwrap_comparison(self.0.eq(other.0)) {
+            Ordering::Equal
+        } else {
+            Ordering::Greater
+        }
+    }
+}
+
+impl Serialize for ExactDecimal {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let formatted = self
+            .0
+            .format_with_scientific(false)
+            .map_err(serde::ser::Error::custom)?;
+
+        serializer.serialize_str(&formatted)
+    }
+}
+
+impl<'de> Deserialize<'de> for ExactDecimal {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+
+        // Try decimal string first (backward compat with existing "1.5" format)
+        if let Ok(float) = Float::parse(value.clone()) {
+            return Ok(Self(float));
+        }
+
+        // Fall back to hex B256 string ("0xffff...")
+        Float::from_hex(&value)
+            .map(Self)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::ops::Add for ExactDecimal {
+    type Output = Result<Self, FloatError>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        (self.0 + rhs.0).map(Self)
+    }
+}
+
+impl std::ops::Sub for ExactDecimal {
+    type Output = Result<Self, FloatError>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        (self.0 - rhs.0).map(Self)
+    }
+}
+
+impl std::ops::Mul for ExactDecimal {
+    type Output = Result<Self, FloatError>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        (self.0 * rhs.0).map(Self)
+    }
+}
+
+impl std::ops::Div for ExactDecimal {
+    type Output = Result<Self, FloatError>;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        (self.0 / rhs.0).map(Self)
+    }
+}
+
+impl std::ops::Neg for ExactDecimal {
+    type Output = Result<Self, FloatError>;
+
+    fn neg(self) -> Self::Output {
+        (-self.0).map(Self)
+    }
+}
+
+impl From<Float> for ExactDecimal {
+    fn from(float: Float) -> Self {
+        Self(float)
+    }
+}
+
+impl From<ExactDecimal> for Float {
+    fn from(exact: ExactDecimal) -> Self {
+        exact.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+    use proptest::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn parse_and_display_roundtrip() {
+        let original = "1.5";
+        let exact = ExactDecimal::parse(original).unwrap();
+        assert_eq!(exact.to_string(), "1.5");
+    }
+
+    #[test]
+    fn parse_zero() {
+        let exact = ExactDecimal::parse("0").unwrap();
+        assert_eq!(exact.to_string(), "0");
+        assert!(exact.is_zero().unwrap());
+    }
+
+    #[test]
+    fn parse_negative() {
+        let exact = ExactDecimal::parse("-3.14").unwrap();
+        assert_eq!(exact.to_string(), "-3.14");
+        assert!(exact.is_negative().unwrap());
+    }
+
+    #[test]
+    fn parse_integer() {
+        let exact = ExactDecimal::parse("42").unwrap();
+        assert_eq!(exact.to_string(), "42");
+    }
+
+    #[test]
+    fn serde_roundtrip_decimal_string() {
+        let exact = ExactDecimal::parse("1.5").unwrap();
+        let json = serde_json::to_string(&exact).unwrap();
+        assert_eq!(json, "\"1.5\"");
+
+        let deserialized: ExactDecimal = serde_json::from_str(&json).unwrap();
+        assert_eq!(exact, deserialized);
+    }
+
+    #[test]
+    fn serde_roundtrip_zero() {
+        let exact = ExactDecimal::parse("0").unwrap();
+        let json = serde_json::to_string(&exact).unwrap();
+        assert_eq!(json, "\"0\"");
+
+        let deserialized: ExactDecimal = serde_json::from_str(&json).unwrap();
+        assert_eq!(exact, deserialized);
+    }
+
+    #[test]
+    fn serde_roundtrip_negative() {
+        let exact = ExactDecimal::parse("-3.14").unwrap();
+        let json = serde_json::to_string(&exact).unwrap();
+        assert_eq!(json, "\"-3.14\"");
+
+        let deserialized: ExactDecimal = serde_json::from_str(&json).unwrap();
+        assert_eq!(exact, deserialized);
+    }
+
+    #[test]
+    fn deserialize_backward_compat_decimal_strings() {
+        let test_cases = ["\"1.5\"", "\"0\"", "\"-3.14\"", "\"42\"", "\"0.000001\""];
+
+        for json in test_cases {
+            let result: Result<ExactDecimal, _> = serde_json::from_str(json);
+            assert!(
+                result.is_ok(),
+                "Failed to deserialize backward-compat string: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn deserialize_hex_b256_string() {
+        let original = ExactDecimal::parse("1.5").unwrap();
+        let hex = format!("\"{}\"", original.to_raw());
+
+        let deserialized: ExactDecimal = serde_json::from_str(&hex).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn equality_logically_equal_values() {
+        let value_a = ExactDecimal::parse("1.5").unwrap();
+        let value_b = ExactDecimal::parse("1.5").unwrap();
+        assert_eq!(value_a, value_b);
+    }
+
+    #[test]
+    fn equality_different_values() {
+        let value_a = ExactDecimal::parse("1.5").unwrap();
+        let value_b = ExactDecimal::parse("2.5").unwrap();
+        assert_ne!(value_a, value_b);
+    }
+
+    #[test]
+    fn ordering() {
+        let one = ExactDecimal::parse("1").unwrap();
+        let two = ExactDecimal::parse("2").unwrap();
+        let negative = ExactDecimal::parse("-1").unwrap();
+
+        assert!(negative < one);
+        assert!(one < two);
+        assert!(two > one);
+        assert!(one > negative);
+    }
+
+    #[test]
+    fn add_basic() {
+        let value_a = ExactDecimal::parse("1.5").unwrap();
+        let value_b = ExactDecimal::parse("2.5").unwrap();
+        let result = (value_a + value_b).unwrap();
+        assert_eq!(result.to_string(), "4");
+    }
+
+    #[test]
+    fn sub_basic() {
+        let value_a = ExactDecimal::parse("5").unwrap();
+        let value_b = ExactDecimal::parse("2").unwrap();
+        let result = (value_a - value_b).unwrap();
+        assert_eq!(result.to_string(), "3");
+    }
+
+    #[test]
+    fn mul_basic() {
+        let value_a = ExactDecimal::parse("2").unwrap();
+        let value_b = ExactDecimal::parse("3").unwrap();
+        let result = (value_a * value_b).unwrap();
+        assert_eq!(result.to_string(), "6");
+    }
+
+    #[test]
+    fn div_basic() {
+        let value_a = ExactDecimal::parse("6").unwrap();
+        let value_b = ExactDecimal::parse("2").unwrap();
+        let result = (value_a / value_b).unwrap();
+        assert_eq!(result.to_string(), "3");
+    }
+
+    #[test]
+    fn neg_basic() {
+        let value = ExactDecimal::parse("3.14").unwrap();
+        let negated = (-value).unwrap();
+        assert_eq!(negated.to_string(), "-3.14");
+    }
+
+    #[test]
+    fn abs_negative() {
+        let value = ExactDecimal::parse("-3.14").unwrap();
+        let absolute = value.abs().unwrap();
+        assert_eq!(absolute.to_string(), "3.14");
+    }
+
+    #[test]
+    fn abs_positive() {
+        let value = ExactDecimal::parse("3.14").unwrap();
+        let absolute = value.abs().unwrap();
+        assert_eq!(absolute.to_string(), "3.14");
+    }
+
+    #[test]
+    fn from_fixed_decimal_roundtrip() {
+        let original = U256::from(1_500_000_000_000_000_000u64);
+        let exact = ExactDecimal::from_fixed_decimal(original, 18).unwrap();
+        assert_eq!(exact.to_string(), "1.5");
+
+        let back = exact.to_fixed_decimal(18).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn from_fixed_decimal_usdc() {
+        let original = U256::from(1_500_000u64);
+        let exact = ExactDecimal::from_fixed_decimal(original, 6).unwrap();
+        assert_eq!(exact.to_string(), "1.5");
+
+        let back = exact.to_fixed_decimal(6).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn from_raw_preserves_value() {
+        let parsed = ExactDecimal::parse("7.5").unwrap();
+        let raw = parsed.to_raw();
+        let from_raw = ExactDecimal::from_raw(raw);
+        assert_eq!(parsed, from_raw);
+    }
+
+    #[test]
+    fn zero_is_zero() {
+        let zero = ExactDecimal::zero();
+        assert!(zero.is_zero().unwrap());
+        assert!(!zero.is_negative().unwrap());
+    }
+
+    #[test]
+    fn default_is_zero() {
+        let default = ExactDecimal::default();
+        let zero = ExactDecimal::zero();
+        assert_eq!(default.to_string(), zero.to_string());
+    }
+
+    #[test]
+    fn integer_and_frac_parts() {
+        let value = ExactDecimal::parse("3.75").unwrap();
+        let int_part = value.integer().unwrap();
+        let frac_part = value.frac().unwrap();
+
+        assert_eq!(int_part.to_string(), "3");
+        assert_eq!(frac_part.to_string(), "0.75");
+    }
+
+    #[test]
+    fn regression_7_5_shares_precision() {
+        let shares_u256 = U256::from(7_500_000_000_000_000_000u64);
+        let exact = ExactDecimal::from_fixed_decimal(shares_u256, 18).unwrap();
+
+        assert_eq!(
+            exact.to_string(),
+            "7.5",
+            "7.5 shares must not have precision artifacts"
+        );
+
+        let back = exact.to_fixed_decimal(18).unwrap();
+        assert_eq!(back, shares_u256, "Roundtrip must be lossless");
+    }
+
+    proptest! {
+        #[test]
+        fn parse_format_roundtrip(
+            integer in 0u64..1_000_000,
+            fractional in 0u64..1_000_000,
+        ) {
+            let value_str = format!("{integer}.{fractional:06}");
+            if let Ok(exact) = ExactDecimal::parse(&value_str) {
+                let formatted = exact.to_string();
+                if let Ok(reparsed) = ExactDecimal::parse(&formatted) {
+                    prop_assert_eq!(exact, reparsed);
+                }
+            }
+        }
+
+        #[test]
+        fn from_fixed_decimal_roundtrip_18(
+            raw_value in 0u64..1_000_000_000_000_000_000u64,
+        ) {
+            let value = U256::from(raw_value);
+            if let Ok(exact) = ExactDecimal::from_fixed_decimal(value, 18)
+                && let Ok(back) = exact.to_fixed_decimal(18)
+            {
+                prop_assert_eq!(value, back);
+            }
+        }
+
+        #[test]
+        fn from_fixed_decimal_roundtrip_6(
+            raw_value in 0u64..1_000_000_000_000u64,
+        ) {
+            let value = U256::from(raw_value);
+            if let Ok(exact) = ExactDecimal::from_fixed_decimal(value, 6)
+                && let Ok(back) = exact.to_fixed_decimal(6)
+            {
+                prop_assert_eq!(value, back);
+            }
+        }
+    }
+}

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -37,6 +37,8 @@ sqlite-es.workspace = true
 rust_decimal = { workspace = true, features = ["serde-with-float"] }
 num-decimal.workspace = true
 rust_decimal_macros = "1.40.0"
+st0x-exact-decimal = { version = "0.1.0", path = "../exact-decimal" }
+rain-math-float = { version = "0.1.0", path = "../../lib/rain.orderbook/lib/rain.orderbook.interface/lib/rain.interpreter.interface/lib/rain.math.float/crates/float" }
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -211,7 +211,7 @@ impl AlpacaBrokerApiClient {
 #[cfg(test)]
 mod tests {
     use httpmock::prelude::*;
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
     use uuid::uuid;
 
     use super::*;
@@ -421,7 +421,8 @@ mod tests {
 
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = Positive::new(FractionalShares::new(dec!(10.5))).unwrap();
+        let quantity =
+            Positive::new(FractionalShares::new(ExactDecimal::parse("10.5").unwrap())).unwrap();
         let response = client
             .create_journal(DESTINATION_ACCOUNT_ID, &symbol, quantity)
             .await
@@ -440,9 +441,9 @@ mod tests {
         assert_eq!(response.symbol, Symbol::new("AAPL").unwrap());
         assert_eq!(
             response.quantity,
-            Positive::new(FractionalShares::new(dec!(10.5))).unwrap()
+            Positive::new(FractionalShares::new(ExactDecimal::parse("10.5").unwrap())).unwrap()
         );
-        assert_eq!(response.price, Some(dec!(150.25)));
+        assert_eq!(response.price, Some(ExactDecimal::parse("150.25").unwrap()));
     }
 
     #[tokio::test]
@@ -462,7 +463,10 @@ mod tests {
 
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = Positive::new(FractionalShares::new(dec!(999999))).unwrap();
+        let quantity = Positive::new(FractionalShares::new(
+            ExactDecimal::parse("999999").unwrap(),
+        ))
+        .unwrap();
         let err = client
             .create_journal(DESTINATION_ACCOUNT_ID, &symbol, quantity)
             .await
@@ -491,7 +495,8 @@ mod tests {
 
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = Positive::new(FractionalShares::new(dec!(10))).unwrap();
+        let quantity =
+            Positive::new(FractionalShares::new(ExactDecimal::parse("10").unwrap())).unwrap();
         let err = client
             .create_journal(DESTINATION_ACCOUNT_ID, &symbol, quantity)
             .await

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -622,7 +622,8 @@ mod tests {
 
         let order = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(100))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(100)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
 
@@ -653,7 +654,8 @@ mod tests {
 
         let order = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(100))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(100)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
 
@@ -684,7 +686,8 @@ mod tests {
 
         let order = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(100))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(100)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
 
@@ -739,7 +742,8 @@ mod tests {
         // Place first order
         let order1 = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(100))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(100)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
         executor.place_market_order(order1).await.unwrap();
@@ -747,7 +751,8 @@ mod tests {
         // Place second order for same symbol - should use cached asset info
         let order2 = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(50))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(50)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
         executor.place_market_order(order2).await.unwrap();
@@ -808,7 +813,8 @@ mod tests {
         // Place first order
         let order1 = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(100))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(100)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
         executor.place_market_order(order1).await.unwrap();
@@ -819,7 +825,8 @@ mod tests {
         // Place second order - cache should be expired, so asset API called again
         let order2 = MarketOrder {
             symbol: Symbol::new("AAPL").unwrap(),
-            shares: Positive::new(FractionalShares::new(Decimal::from(50))).unwrap(),
+            shares: Positive::new(FractionalShares::from_decimal(Decimal::from(50)).unwrap())
+                .unwrap(),
             direction: Direction::Buy,
         };
         executor.place_market_order(order2).await.unwrap();

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -1,3 +1,4 @@
+use rain_math_float::FloatError;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::fmt;
@@ -139,4 +140,7 @@ pub enum AlpacaBrokerApiError {
 
     #[error("Invalid symbol in position: {0}")]
     InvalidSymbol(#[from] crate::EmptySymbolError),
+
+    #[error("Float conversion error: {0}")]
+    FloatConversion(#[from] FloatError),
 }

--- a/crates/execution/src/alpaca_trading_api/mod.rs
+++ b/crates/execution/src/alpaca_trading_api/mod.rs
@@ -1,3 +1,4 @@
+use rain_math_float::FloatError;
 use thiserror::Error;
 
 mod auth;
@@ -34,6 +35,8 @@ pub enum AlpacaTradingApiError {
     DecimalParse(#[from] rust_decimal::Error),
     #[error("Num parse error: {0}")]
     NumParse(#[from] num_decimal::ParseNumError),
+    #[error("Float conversion error: {0}")]
+    FloatConversion(#[from] FloatError),
     #[error("Notional orders not supported")]
     NotionalOrdersNotSupported,
     #[error("Filled order {order_id} is missing required field: {field}")]

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use chrono::{DateTime, Utc};
-use rust_decimal::Decimal;
+use st0x_exact_decimal::ExactDecimal;
 
 use crate::{Direction, FractionalShares, Positive, Symbol};
 
@@ -28,7 +28,7 @@ pub struct OrderUpdate<OrderId> {
     pub direction: Direction,
     pub status: OrderStatus,
     pub updated_at: DateTime<Utc>,
-    pub price: Option<Decimal>,
+    pub price: Option<ExactDecimal>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/execution/src/order/state.rs
+++ b/crates/execution/src/order/state.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rust_decimal::Decimal;
+use st0x_exact_decimal::ExactDecimal;
 
 use super::OrderStatus;
 
@@ -13,7 +13,7 @@ pub enum OrderState {
     Filled {
         executed_at: DateTime<Utc>,
         order_id: String,
-        price: Decimal,
+        price: ExactDecimal,
     },
     Failed {
         failed_at: DateTime<Utc>,
@@ -34,8 +34,6 @@ impl OrderState {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
-
     use super::*;
 
     #[test]
@@ -52,7 +50,7 @@ mod tests {
             OrderState::Filled {
                 executed_at: Utc::now(),
                 order_id: "ORDER123".to_string(),
-                price: dec!(150.00),
+                price: ExactDecimal::parse("150.00").unwrap(),
             }
             .status(),
             OrderStatus::Filled

--- a/docs/exact-decimal.md
+++ b/docs/exact-decimal.md
@@ -1,0 +1,149 @@
+# ExactDecimal: Precision-Safe Financial Arithmetic
+
+Reference for the `ExactDecimal` type and the migration away from
+`rust_decimal::Decimal`.
+
+## Problem
+
+`rust_decimal::Decimal` has a 96-bit mantissa (~28 significant digits). Rain's
+onchain `Float` type uses a 224-bit coefficient + 32-bit exponent. When
+converting Float or U256 values into Decimal, precision artifacts appear beyond
+the token's native precision. For example, `7.5` shares becomes
+`7.5000000000000000000000000375`. These artifacts cascade through position
+tracking, inventory checks, and rebalancing triggers, causing hard production
+failures.
+
+See [#312](https://github.com/ST0x-Technology/st0x.liquidity/issues/312) for the
+full incident description.
+
+## Solution: `ExactDecimal`
+
+`ExactDecimal` is a newtype wrapping `rain_math_float::Float` that provides
+standard Rust trait implementations (`PartialEq`, `Eq`, `Ord`, `Serialize`,
+`Deserialize`, arithmetic operators) that `Float` itself cannot offer because
+its operations are fallible EVM calls.
+
+```rust
+// crates/exact-decimal/src/lib.rs
+pub struct ExactDecimal(Float);
+```
+
+The type lives in its own crate (`st0x-exact-decimal`) so it can be used by both
+`st0x-execution` and `st0x-hedge` without circular dependencies.
+
+### Key Properties
+
+- **No precision loss** on values originating from onchain Float data.
+- **224-bit coefficient** means no truncation artifacts when converting from
+  U256 token amounts (18 decimals for ERC-20, 6 for USDC).
+- **Backward-compatible serde**: serializes as a decimal string (`"1.5"`),
+  deserializes from both decimal strings and hex B256 strings (`"0xffff..."`).
+- **Trailing zero stripping**: `ExactDecimal` formats without trailing zeros.
+  `"500.50"` becomes `"500.5"`, `"1.0"` becomes `"1"`. Code that compares
+  formatted output must account for this.
+
+## Usage Patterns
+
+### Construction
+
+```rust
+// From a decimal string
+let value = ExactDecimal::parse("7.5")?;
+
+// From a fixed-point U256 (e.g., ERC-20 amount with 18 decimals)
+let shares = ExactDecimal::from_fixed_decimal(u256_amount, 18)?;
+
+// From a raw onchain B256 (Float's wire format)
+let float_value = ExactDecimal::from_raw(b256_value);
+
+// Zero constant (const, no allocation)
+let zero = ExactDecimal::zero();
+```
+
+### Conversion to Fixed-Point
+
+Two methods exist for converting back to U256 fixed-point:
+
+```rust
+// Lossless: fails if precision would be lost
+let u256 = value.to_fixed_decimal(18)?;
+
+// Lossy: truncates excess precision, returns whether truncation occurred
+let (u256, lossless) = value.to_fixed_decimal_lossy(18)?;
+```
+
+**When to use which:**
+
+- Use `to_fixed_decimal` (strict) for values that should round-trip exactly
+  (e.g., parsing a U256 and converting back).
+- Use `to_fixed_decimal_lossy` when the source may have more precision than the
+  target (e.g., onchain Float values being written to an ERC-20 with 18
+  decimals, or USDC with 6 decimals). This is the common case for production
+  code paths.
+
+### Arithmetic
+
+All arithmetic operators return `Result<ExactDecimal, FloatError>`:
+
+```rust
+let sum = (a + b)?;
+let difference = (a - b)?;
+let product = (a * b)?;
+let quotient = (a / b)?;
+let negated = (-a)?;
+```
+
+### Comparisons
+
+`PartialEq`, `Eq`, `PartialOrd`, and `Ord` are implemented. They delegate to
+Float's EVM-based comparison and panic on malformed B256 data (which cannot
+occur through valid construction paths). This makes comparisons infallible in
+practice:
+
+```rust
+if amount > threshold {
+    // ...
+}
+```
+
+### Serde
+
+Serializes as a JSON string: `"1.5"`, `"0"`, `"-3.14"`. Deserialization accepts
+both decimal strings (backward compat with existing event payloads that used
+`rust_decimal::Decimal`) and hex B256 strings.
+
+## Where `ExactDecimal` Replaced `Decimal`
+
+| Domain type         | Before                      | After                            |
+| ------------------- | --------------------------- | -------------------------------- |
+| `FractionalShares`  | `FractionalShares(Decimal)` | `FractionalShares(ExactDecimal)` |
+| `Usdc` (threshold)  | `Usdc(Decimal)`             | `Usdc(ExactDecimal)`             |
+| `Usdc` (onchain/io) | `Usdc(Decimal)`             | `Usdc(ExactDecimal)`             |
+| `Dollars`           | `Dollars(Decimal)`          | `Dollars(ExactDecimal)`          |
+| Pyth prices         | `Decimal`                   | `ExactDecimal`                   |
+| Inventory balances  | `Decimal`                   | `ExactDecimal`                   |
+| Position events     | `Decimal`                   | `ExactDecimal`                   |
+| Dashboard DTOs      | `Decimal`                   | `ExactDecimal`                   |
+
+## Broker API Boundary
+
+`rust_decimal::Decimal` is still used at the Alpaca and Schwab API boundaries as
+a private implementation detail inside `st0x-execution`. The broker APIs expect
+`Decimal` values, so conversion happens at the edge:
+
+- `FractionalShares::to_decimal()` -- for outgoing broker requests
+- `FractionalShares::from_decimal()` -- for incoming broker responses
+
+These converters live in `st0x-execution` and are not part of the public API.
+`rust_decimal` remains as a private dependency of `st0x-execution` only.
+
+## Crate Structure
+
+```
+crates/exact-decimal/
+  Cargo.toml          # depends on rain-math-float, serde, alloy-primitives
+  src/lib.rs          # ExactDecimal type + all trait impls + tests
+```
+
+The crate is a workspace member and is imported as `st0x-exact-decimal` by
+`st0x-execution` and `st0x-hedge`.

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -202,13 +202,17 @@ impl AlpacaWalletService {
 mod tests {
     use alloy::primitives::address;
     use httpmock::prelude::*;
-    use rust_decimal_macros::dec;
     use serde_json::json;
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::AlpacaAccountId;
     use std::time::Duration;
     use uuid::uuid;
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
@@ -239,7 +243,7 @@ mod tests {
 
         let asset = TokenSymbol::new("USDC");
         let to_address = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let amount = Positive::new(Usdc(dec!(100))).unwrap();
+        let amount = Positive::new(Usdc(ed("100"))).unwrap();
 
         assert!(matches!(
             service
@@ -274,7 +278,7 @@ mod tests {
         });
 
         let asset = TokenSymbol::new("USDC");
-        let amount = Positive::new(Usdc(dec!(100))).unwrap();
+        let amount = Positive::new(Usdc(ed("100"))).unwrap();
 
         assert!(matches!(
             service
@@ -331,7 +335,7 @@ mod tests {
         });
 
         let asset = TokenSymbol::new("USDC");
-        let amount = Positive::new(Usdc(dec!(100))).unwrap();
+        let amount = Positive::new(Usdc(ed("100"))).unwrap();
 
         let result = service
             .initiate_withdrawal(amount, &asset, &to_address)

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -447,7 +447,7 @@ pub(super) async fn alpaca_convert_command<W: Write>(
         ConvertDirection::ToUsdc => ConversionDirection::UsdToUsdc,
     };
 
-    let amount_decimal: Decimal = amount.into();
+    let amount_decimal: Decimal = amount.to_string().parse()?;
 
     writeln!(stdout, "   Placing market order...")?;
 
@@ -518,8 +518,8 @@ pub(super) async fn alpaca_journal_command<W: Write>(
 mod tests {
     use alloy::primitives::{Address, B256, address};
     use httpmock::prelude::*;
-    use rust_decimal_macros::dec;
     use serde_json::json;
+    use st0x_exact_decimal::ExactDecimal;
     use std::collections::HashMap;
     use url::Url;
     use uuid::uuid;
@@ -535,6 +535,10 @@ mod tests {
     use crate::rebalancing::RebalancingCtx;
     use crate::rebalancing::trigger::UsdcRebalancing;
     use crate::threshold::ExecutionThreshold;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     fn create_ctx_without_alpaca() -> Ctx {
         Ctx {
@@ -618,8 +622,8 @@ mod tests {
             trading_mode: TradingMode::Rebalancing(Box::new(
                 RebalancingCtx::stub()
                     .equity(ImbalanceThreshold {
-                        target: dec!(0.5),
-                        deviation: dec!(0.1),
+                        target: ed("0.5"),
+                        deviation: ed("0.1"),
                     })
                     .usdc(UsdcRebalancing::Disabled)
                     .redemption_wallet(Address::ZERO)
@@ -641,7 +645,7 @@ mod tests {
     #[tokio::test]
     async fn test_alpaca_deposit_requires_rebalancing_ctx() {
         let ctx = create_alpaca_ctx_without_rebalancing();
-        let amount = Usdc(dec!(100));
+        let amount = Usdc(ed("100"));
 
         let mut stdout = Vec::new();
         let err_msg = alpaca_deposit_command::<NoOpErrorRegistry, _>(&mut stdout, amount, &ctx)
@@ -657,7 +661,7 @@ mod tests {
     #[tokio::test]
     async fn test_alpaca_deposit_writes_amount_to_stdout() {
         let ctx = create_full_alpaca_ctx();
-        let amount = Usdc(dec!(500.50));
+        let amount = Usdc(ed("500.5"));
 
         let mut stdout = Vec::new();
         alpaca_deposit_command::<NoOpErrorRegistry, _>(&mut stdout, amount, &ctx)
@@ -666,7 +670,7 @@ mod tests {
 
         let output = String::from_utf8(stdout).unwrap();
         assert!(
-            output.contains("500.50 USDC"),
+            output.contains("500.5 USDC"),
             "Expected amount in output, got: {output}"
         );
     }
@@ -674,7 +678,7 @@ mod tests {
     #[tokio::test]
     async fn test_alpaca_withdraw_requires_rebalancing_ctx() {
         let ctx = create_alpaca_ctx_without_rebalancing();
-        let amount = Usdc(dec!(100));
+        let amount = Usdc(ed("100"));
 
         let mut stdout = Vec::new();
         let err_msg =
@@ -706,7 +710,7 @@ mod tests {
     #[tokio::test]
     async fn test_alpaca_convert_writes_direction_to_stdout() {
         let ctx = create_alpaca_ctx_without_rebalancing();
-        let amount = Usdc(dec!(500.50));
+        let amount = Usdc(ed("500.5"));
 
         let mut stdout = Vec::new();
         alpaca_convert_command(&mut stdout, ConvertDirection::ToUsd, amount, &ctx)
@@ -719,7 +723,7 @@ mod tests {
             "Expected USDC to USD in output, got: {output}"
         );
         assert!(
-            output.contains("500.50 USDC"),
+            output.contains("500.5 USDC"),
             "Expected amount in output, got: {output}"
         );
     }
@@ -727,7 +731,7 @@ mod tests {
     #[tokio::test]
     async fn test_alpaca_convert_to_usdc_writes_direction_to_stdout() {
         let ctx = create_alpaca_ctx_without_rebalancing();
-        let amount = Usdc(dec!(250));
+        let amount = Usdc(ed("250"));
 
         let mut stdout = Vec::new();
         alpaca_convert_command(&mut stdout, ConvertDirection::ToUsdc, amount, &ctx)
@@ -746,7 +750,7 @@ mod tests {
         let ctx = create_ctx_without_alpaca();
         let destination = AlpacaAccountId::new(uuid!("11111111-2222-3333-4444-555555555555"));
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = Positive::new(FractionalShares::new(dec!(10))).unwrap();
+        let quantity = Positive::new(FractionalShares::new(ed("10"))).unwrap();
 
         let mut stdout = Vec::new();
         let err_msg = alpaca_journal_command(&mut stdout, destination, symbol, quantity, &ctx)
@@ -796,7 +800,7 @@ mod tests {
 
         let destination = AlpacaAccountId::new(uuid!("11111111-2222-3333-4444-555555555555"));
         let symbol = Symbol::new("TSLA").unwrap();
-        let quantity = Positive::new(FractionalShares::new(dec!(5.5))).unwrap();
+        let quantity = Positive::new(FractionalShares::new(ed("5.5"))).unwrap();
 
         let mut stdout = Vec::new();
         alpaca_journal_command(&mut stdout, destination, symbol, quantity, &ctx)

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -1,7 +1,6 @@
 //! CCTP bridge and recovery CLI commands.
 
 use alloy::primitives::{B256, U256};
-use rust_decimal::Decimal;
 use std::io::Write;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
@@ -77,7 +76,7 @@ pub(super) async fn cctp_bridge_command<Registry: IntoErrorRegistry, Writer: Wri
         CctpChain::Ethereum => CctpChain::Base,
         CctpChain::Base => CctpChain::Ethereum,
     };
-    let amount_display = Decimal::from(amount_u256.to::<u128>()) / Decimal::from(1_000_000u64);
+    let amount_display = st0x_exact_decimal::ExactDecimal::from_fixed_decimal(amount_u256, 6)?;
     writeln!(
         stdout,
         "CCTP Bridge: {from:?} -> {dest:?}, Amount: {amount_display} USDC"
@@ -235,9 +234,8 @@ pub(super) async fn reset_allowance_command<Registry: IntoErrorRegistry, Writer:
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address};
-    use rust_decimal::Decimal;
+    use st0x_exact_decimal::ExactDecimal;
     use std::collections::HashMap;
-    use std::str::FromStr;
     use url::Url;
 
     use st0x_evm::OpenChainErrorRegistry;
@@ -275,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn test_cctp_bridge_requires_rebalancing_ctx() {
         let ctx = create_ctx_without_rebalancing();
-        let amount = Some(Usdc(Decimal::from_str("100").unwrap()));
+        let amount = Some(Usdc(ExactDecimal::parse("100").unwrap()));
 
         let mut stdout = Vec::new();
         let error = cctp_bridge_command::<OpenChainErrorRegistry, _>(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,7 +10,6 @@ mod vault;
 use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::{ProviderBuilder, WsConnect};
 use clap::{Parser, Subcommand, ValueEnum};
-use rust_decimal::Decimal;
 use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
@@ -18,6 +17,7 @@ use thiserror::Error;
 use tracing::info;
 
 use st0x_evm::OpenChainErrorRegistry;
+use st0x_exact_decimal::ExactDecimal;
 use st0x_execution::{AlpacaAccountId, Direction, FractionalShares, Positive, Symbol, TimeInForce};
 
 use crate::config::{Ctx, Env};
@@ -205,7 +205,7 @@ pub enum Commands {
     VaultDeposit {
         /// Amount of tokens to deposit (human-readable, e.g., 100 for 100 tokens)
         #[arg(short = 'a', long = "amount")]
-        amount: Decimal,
+        amount: ExactDecimal,
 
         /// Token contract address
         #[arg(short = 't', long = "token")]
@@ -468,7 +468,7 @@ enum ProviderCommand {
         amount: Usdc,
     },
     VaultDeposit {
-        amount: Decimal,
+        amount: ExactDecimal,
         token: Address,
         vault_id: B256,
         decimals: u8,
@@ -797,9 +797,8 @@ mod tests {
     use clap::CommandFactory;
     use httpmock::MockServer;
     use rain_math_float::Float;
-    use rust_decimal::Decimal;
-    use rust_decimal_macros::dec;
     use serde_json::json;
+    use st0x_exact_decimal::ExactDecimal;
     use std::collections::HashMap;
     use std::str::FromStr;
     use url::Url;
@@ -2002,7 +2001,7 @@ mod tests {
         let (order_id, order) = &executions[0];
         assert_eq!(
             order.shares(),
-            Positive::new(FractionalShares::new(Decimal::from(9))).unwrap()
+            Positive::new(FractionalShares::new(ExactDecimal::parse("9").unwrap())).unwrap()
         );
         assert_eq!(order.direction(), Direction::Buy);
         assert!(
@@ -2102,7 +2101,7 @@ mod tests {
         let order = &executions[0].1;
         assert_eq!(
             order.shares(),
-            Positive::new(FractionalShares::new(dec!(5))).unwrap()
+            Positive::new(FractionalShares::new(ExactDecimal::parse("5").unwrap())).unwrap()
         );
 
         let stdout_str1 = String::from_utf8(stdout1).unwrap();

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -532,9 +532,8 @@ fn format_tokenization_request<Writer: Write>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address};
-    use rust_decimal::Decimal;
+    use st0x_exact_decimal::ExactDecimal;
     use std::collections::HashMap;
-    use std::str::FromStr;
     use url::Url;
     use uuid::uuid;
 
@@ -589,7 +588,7 @@ mod tests {
         let ctx = create_ctx_without_rebalancing();
         let pool = setup_test_db().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = FractionalShares::new(Decimal::from_str("10.5").unwrap());
+        let quantity = FractionalShares::new(ExactDecimal::parse("10.5").unwrap());
 
         let mut stdout = Vec::new();
         let result = transfer_equity_command(
@@ -614,7 +613,7 @@ mod tests {
         let ctx = create_alpaca_ctx_without_rebalancing();
         let pool = setup_test_db().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = FractionalShares::new(Decimal::from_str("10.5").unwrap());
+        let quantity = FractionalShares::new(ExactDecimal::parse("10.5").unwrap());
 
         let mut stdout = Vec::new();
         let result = transfer_equity_command(
@@ -638,7 +637,7 @@ mod tests {
     async fn test_transfer_usdc_requires_alpaca_broker() {
         let ctx = create_ctx_without_rebalancing();
         let pool = setup_test_db().await;
-        let amount = Usdc(Decimal::from_str("100").unwrap());
+        let amount = Usdc(ExactDecimal::parse("100").unwrap());
 
         let mut stdout = Vec::new();
         let result = transfer_usdc_command(
@@ -661,7 +660,7 @@ mod tests {
     async fn test_transfer_usdc_requires_rebalancing_ctx() {
         let ctx = create_alpaca_ctx_without_rebalancing();
         let pool = setup_test_db().await;
-        let amount = Usdc(Decimal::from_str("100").unwrap());
+        let amount = Usdc(ExactDecimal::parse("100").unwrap());
 
         let mut stdout = Vec::new();
         let result = transfer_usdc_command(
@@ -684,7 +683,7 @@ mod tests {
     async fn test_transfer_usdc_writes_direction_to_stdout() {
         let ctx = create_alpaca_ctx_without_rebalancing();
         let pool = setup_test_db().await;
-        let amount = Usdc(Decimal::from_str("100").unwrap());
+        let amount = Usdc(ExactDecimal::parse("100").unwrap());
 
         let mut stdout = Vec::new();
         transfer_usdc_command(

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -115,7 +115,7 @@ impl QueryManifest {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::Address;
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
     use std::collections::HashSet;
     use tokio::sync::{RwLock, broadcast, mpsc};
 
@@ -132,15 +132,19 @@ mod tests {
     use crate::tokenization::mock::MockTokenizer;
     use crate::wrapper::mock::MockWrapper;
 
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     fn test_trigger_config() -> RebalancingTriggerConfig {
         RebalancingTriggerConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             },
             usdc: UsdcRebalancing::Enabled {
-                target: dec!(0.6),
-                deviation: dec!(0.15),
+                target: ed("0.6"),
+                deviation: ed("0.15"),
             },
             limits: OperationalLimits::Disabled,
             disabled_assets: HashSet::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,13 +4,15 @@
 //! validates compatibility, and assembles the runtime [`Ctx`] that the rest
 //! of the application consumes.
 
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
 use alloy::primitives::{Address, FixedBytes};
 use clap::Parser;
-use rust_decimal::Decimal;
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
-use std::path::{Path, PathBuf};
+use st0x_exact_decimal::ExactDecimal;
 use std::collections::HashMap;
 use tracing::Level;
 use url::Url;
@@ -30,6 +32,21 @@ use crate::rebalancing::{
 use crate::telemetry::{TelemetryConfig, TelemetryCtx, TelemetrySecrets};
 use crate::threshold::{ExecutionThreshold, InvalidThresholdError, Usdc};
 use crate::wrapper::EquityTokenAddresses;
+
+/// Schwab minimum execution threshold: 1 share.
+static SCHWAB_MIN_SHARES: LazyLock<Positive<FractionalShares>> = LazyLock::new(|| {
+    Positive::new(FractionalShares::new(
+        ExactDecimal::parse("1").unwrap_or_else(|_| ExactDecimal::zero()),
+    ))
+    .unwrap_or_else(|_| {
+        // Positive::new only fails for zero/negative — "1" is always positive.
+        unreachable!()
+    })
+});
+
+/// Alpaca minimum execution threshold: $2.
+static ALPACA_MIN_DOLLARS: LazyLock<Usdc> =
+    LazyLock::new(|| Usdc(ExactDecimal::parse("2").unwrap_or_else(|_| ExactDecimal::zero())));
 
 #[derive(Parser, Debug)]
 pub struct Env {
@@ -164,11 +181,9 @@ impl BrokerCtx {
 
     pub fn execution_threshold(&self) -> Result<ExecutionThreshold, CtxError> {
         match self {
-            Self::Schwab(_) | Self::DryRun => Ok(ExecutionThreshold::shares(
-                Positive::<FractionalShares>::ONE,
-            )),
+            Self::Schwab(_) | Self::DryRun => Ok(ExecutionThreshold::shares(*SCHWAB_MIN_SHARES)),
             Self::AlpacaTradingApi(_) | Self::AlpacaBrokerApi(_) => {
-                Ok(ExecutionThreshold::dollar_value(Usdc(Decimal::TWO))?)
+                Ok(ExecutionThreshold::dollar_value(*ALPACA_MIN_DOLLARS)?)
             }
         }
     }
@@ -406,7 +421,7 @@ impl Ctx {
         if let OperationalLimits::Enabled { max_amount, .. } = &config.operational_limits
             && usdc_rebalancing_enabled
         {
-            let minimum = crate::rebalancing::trigger::ALPACA_MINIMUM_WITHDRAWAL;
+            let minimum = *crate::rebalancing::trigger::ALPACA_MINIMUM_WITHDRAWAL;
             if max_amount.inner() < minimum {
                 return Err(CtxError::OperationalLimitBelowMinimumWithdrawal {
                     configured: max_amount.inner(),
@@ -571,7 +586,6 @@ pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePo
 #[cfg(test)]
 pub(crate) mod tests {
     use alloy::primitives::{Address, FixedBytes, address};
-    use rust_decimal_macros::dec;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -580,6 +594,10 @@ pub(crate) mod tests {
     use super::*;
     use crate::onchain::EvmCtx;
     use crate::threshold::ExecutionThreshold;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     const TEST_ENCRYPTION_KEY: FixedBytes<32> = FixedBytes::ZERO;
 
@@ -817,8 +835,8 @@ pub(crate) mod tests {
         else {
             panic!("Expected Enabled, got {:?}", ctx.operational_limits);
         };
-        assert_eq!(max_amount.inner(), Usdc(dec!(100)));
-        assert_eq!(max_shares.inner(), FractionalShares::new(dec!(2)));
+        assert_eq!(max_amount.inner(), Usdc(ed("100")));
+        assert_eq!(max_shares.inner(), FractionalShares::new(ed("2")));
     }
 
     #[tokio::test]
@@ -872,7 +890,7 @@ pub(crate) mod tests {
         let OperationalLimits::Enabled { max_amount, .. } = ctx.operational_limits else {
             panic!("Expected Enabled");
         };
-        assert_eq!(max_amount.inner(), Usdc(dec!(50)));
+        assert_eq!(max_amount.inner(), Usdc(ed("50")));
     }
 
     #[tokio::test]
@@ -1233,7 +1251,7 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(
             ctx.execution_threshold,
-            ExecutionThreshold::shares(Positive::<FractionalShares>::ONE)
+            ExecutionThreshold::shares(Positive::new(FractionalShares::new(ed("1"))).unwrap())
         );
     }
 
@@ -1246,7 +1264,7 @@ pub(crate) mod tests {
             .unwrap();
         assert_eq!(
             ctx.execution_threshold,
-            ExecutionThreshold::shares(Positive::<FractionalShares>::ONE)
+            ExecutionThreshold::shares(Positive::new(FractionalShares::new(ed("1"))).unwrap())
         );
     }
 
@@ -1268,7 +1286,7 @@ pub(crate) mod tests {
         let ctx = Ctx::load_files(config.path(), secrets.path())
             .await
             .unwrap();
-        let expected = ExecutionThreshold::dollar_value(Usdc(Decimal::TWO)).unwrap();
+        let expected = ExecutionThreshold::dollar_value(Usdc(ed("2"))).unwrap();
         assert_eq!(ctx.execution_threshold, expected);
     }
 
@@ -1291,7 +1309,7 @@ pub(crate) mod tests {
         let ctx = Ctx::load_files(config.path(), secrets.path())
             .await
             .unwrap();
-        let expected = ExecutionThreshold::dollar_value(Usdc(Decimal::TWO)).unwrap();
+        let expected = ExecutionThreshold::dollar_value(Usdc(ed("2"))).unwrap();
         assert_eq!(ctx.execution_threshold, expected);
     }
 

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -84,6 +84,7 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_event_sorcery::ReactorHarness;
+    use st0x_exact_decimal::ExactDecimal;
 
     use super::*;
     use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
@@ -93,7 +94,7 @@ mod tests {
     fn make_mint_requested(symbol: &str, quantity: u64) -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::MintRequested {
             symbol: Symbol::new(symbol).unwrap(),
-            quantity: quantity.into(),
+            quantity: ExactDecimal::parse(&quantity.to_string()).unwrap(),
             wallet: Address::ZERO,
             requested_at: chrono::Utc::now(),
         }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -12,10 +12,9 @@ use alloy::signers::local::PrivateKeySigner;
 use chrono::Utc;
 use httpmock::Mock;
 use httpmock::prelude::*;
-use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use serde_json::json;
 use sqlx::SqlitePool;
+use st0x_exact_decimal::ExactDecimal;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::{RwLock, mpsc};
@@ -51,6 +50,10 @@ use crate::tokenization::alpaca::tests::{
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
 use crate::wrapper::mock::MockWrapper;
+
+fn ed(value: &str) -> ExactDecimal {
+    ExactDecimal::parse(value).unwrap()
+}
 
 const TEST_ORDERBOOK: Address = address!("0x0000000000000000000000000000000000000001");
 const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000000002");
@@ -108,12 +111,12 @@ async fn discover_deterministic_tx_hash(
 fn test_trigger_config() -> RebalancingTriggerConfig {
     RebalancingTriggerConfig {
         equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         usdc: UsdcRebalancing::Enabled {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         limits: OperationalLimits::Disabled,
         disabled_assets: HashSet::new(),
@@ -159,7 +162,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
                 FractionalShares::ZERO,
                 FractionalShares::ZERO,
             )
-            .with_usdc(Usdc(dec!(1000000)), Usdc(dec!(1000000))),
+            .with_usdc(Usdc(ed("1000000")), Usdc(ed("1000000"))),
     ));
     let (sender, receiver) = mpsc::channel(10);
 
@@ -270,8 +273,8 @@ enum Imbalance<'a> {
     Equity {
         position_cqrs: &'a Store<Position>,
         symbol: &'a Symbol,
-        onchain: Decimal,
-        offchain: Decimal,
+        onchain: ExactDecimal,
+        offchain: ExactDecimal,
     },
     Usdc {
         inventory: &'a Arc<RwLock<InventoryView>>,
@@ -300,7 +303,7 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
                         },
                         amount: FractionalShares::new(onchain),
                         direction: Direction::Buy,
-                        price_usdc: dec!(150.0),
+                        price_usdc: ed("150.0"),
                         block_timestamp: Utc::now(),
                     },
                 )
@@ -331,7 +334,7 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
                         shares_filled: Positive::new(FractionalShares::new(offchain)).unwrap(),
                         direction: Direction::Buy,
                         executor_order_id: ExecutorOrderId::new("ORD1"),
-                        price: Dollars(dec!(150)),
+                        price: Dollars(ed("150")),
                         broker_timestamp: Utc::now(),
                     },
                 )
@@ -404,8 +407,8 @@ async fn equity_offchain_imbalance_triggers_mint() {
     build_imbalanced_inventory(Imbalance::Equity {
         position_cqrs: &position_cqrs,
         symbol: &symbol,
-        onchain: dec!(20),
-        offchain: dec!(80),
+        onchain: ed("20"),
+        offchain: ed("80"),
     })
     .await;
 
@@ -428,7 +431,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
     let mint_mock = server.mock(|when, then| {
         when.method(POST)
             .path(tokenization_mint_path())
-            .json_body_includes(r#"{"underlying_symbol":"AAPL","qty":"30.500000000","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
+            .json_body_includes(r#"{"underlying_symbol":"AAPL","qty":"30.5","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(sample_pending_response("mint_int_test"));
@@ -464,9 +467,9 @@ async fn equity_offchain_imbalance_triggers_mint() {
                     tx_hash: TxHash::random(),
                     log_index: 2,
                 },
-                amount: FractionalShares::new(dec!(1)),
+                amount: FractionalShares::new(ed("1")),
                 direction: Direction::Sell,
-                price_usdc: dec!(150.0),
+                price_usdc: ed("150.0"),
                 block_timestamp: Utc::now(),
             },
         )
@@ -633,8 +636,8 @@ async fn equity_onchain_imbalance_triggers_redemption() {
     build_imbalanced_inventory(Imbalance::Equity {
         position_cqrs: &position_cqrs,
         symbol: &symbol,
-        onchain: dec!(79),
-        offchain: dec!(20),
+        onchain: ed("79"),
+        offchain: ed("20"),
     })
     .await;
     seed_vault_registry(&pool, &symbol, token_address).await;
@@ -659,9 +662,9 @@ async fn equity_onchain_imbalance_triggers_redemption() {
                     tx_hash: TxHash::random(),
                     log_index: 2,
                 },
-                amount: FractionalShares::new(dec!(1)),
+                amount: FractionalShares::new(ed("1")),
                 direction: Direction::Buy,
-                price_usdc: dec!(150.0),
+                price_usdc: ed("150.0"),
                 block_timestamp: Utc::now(),
             },
         )
@@ -804,8 +807,8 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
 
     build_imbalanced_inventory(Imbalance::Usdc {
         inventory: &inventory,
-        onchain: Usdc(dec!(100)),
-        offchain: Usdc(dec!(900)),
+        onchain: Usdc(ed("100")),
+        offchain: Usdc(ed("900")),
     })
     .await;
 
@@ -853,7 +856,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         .expect("Expected a captured call");
     assert_eq!(
         call.amount,
-        Usdc(dec!(400)),
+        Usdc(ed("400")),
         "Expected excess of $400 (target $500 - actual $100)"
     );
 
@@ -877,8 +880,8 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
 
     build_imbalanced_inventory(Imbalance::Usdc {
         inventory: &inventory,
-        onchain: Usdc(dec!(900)),
-        offchain: Usdc(dec!(100)),
+        onchain: Usdc(ed("900")),
+        offchain: Usdc(ed("100")),
     })
     .await;
 
@@ -925,7 +928,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         .expect("Expected a captured call");
     assert_eq!(
         call.amount,
-        Usdc(dec!(400)),
+        Usdc(ed("400")),
         "Expected excess of $400 (actual $900 - target $500)"
     );
 
@@ -955,8 +958,8 @@ async fn mint_api_failure_produces_rejected_event() {
     build_imbalanced_inventory(Imbalance::Equity {
         position_cqrs: &position_cqrs,
         symbol: &symbol,
-        onchain: dec!(20),
-        offchain: dec!(80),
+        onchain: ed("20"),
+        offchain: ed("80"),
     })
     .await;
 
@@ -999,9 +1002,9 @@ async fn mint_api_failure_produces_rejected_event() {
                     tx_hash: TxHash::random(),
                     log_index: 2,
                 },
-                amount: FractionalShares::new(dec!(1)),
+                amount: FractionalShares::new(ed("1")),
                 direction: Direction::Sell,
-                price_usdc: dec!(150.0),
+                price_usdc: ed("150.0"),
                 block_timestamp: Utc::now(),
             },
         )
@@ -1078,22 +1081,22 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     // 50 onchain, 950 offchain = 5% ratio -> TooMuchOffchain
     // Excess to reach 50% target = 500 - 50 = 450 USDC
     let inventory = Arc::new(RwLock::new(
-        InventoryView::default().with_usdc(Usdc(dec!(50)), Usdc(dec!(950))),
+        InventoryView::default().with_usdc(Usdc(ed("50")), Usdc(ed("950"))),
     ));
 
     let limits = OperationalLimits::Enabled {
-        max_shares: Positive::new(FractionalShares::new(dec!(50))).unwrap(),
-        max_amount: Positive::new(Usdc(dec!(100))).unwrap(),
+        max_shares: Positive::new(FractionalShares::new(ed("50"))).unwrap(),
+        max_amount: Positive::new(Usdc(ed("100"))).unwrap(),
     };
 
     let config = RebalancingTriggerConfig {
         equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         usdc: UsdcRebalancing::Enabled {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         limits,
         disabled_assets: HashSet::new(),
@@ -1118,7 +1121,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let op1 = receiver.try_recv().expect("First trigger should fire");
     match op1 {
         TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(amount, Usdc(dec!(100)), "First transfer capped to $100");
+            assert_eq!(amount, Usdc(ed("100")), "First transfer capped to $100");
         }
         _ => panic!("Expected UsdcAlpacaToBase, got {op1:?}"),
     }
@@ -1129,7 +1132,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc(dec!(150)), Usdc(dec!(850)));
+        *guard = taken.with_usdc(Usdc(ed("150")), Usdc(ed("850")));
     }
 
     // Cycle 2: excess = 350, capped to 100
@@ -1137,7 +1140,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let op2 = receiver.try_recv().expect("Second trigger should fire");
     match op2 {
         TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(amount, Usdc(dec!(100)), "Second transfer capped to $100");
+            assert_eq!(amount, Usdc(ed("100")), "Second transfer capped to $100");
         }
         _ => panic!("Expected UsdcAlpacaToBase, got {op2:?}"),
     }
@@ -1148,7 +1151,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc(dec!(250)), Usdc(dec!(750)));
+        *guard = taken.with_usdc(Usdc(ed("250")), Usdc(ed("750")));
     }
 
     // Cycle 3: excess = 250, capped to 100
@@ -1156,7 +1159,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let op3 = receiver.try_recv().expect("Third trigger should fire");
     match op3 {
         TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(amount, Usdc(dec!(100)), "Third transfer capped to $100");
+            assert_eq!(amount, Usdc(ed("100")), "Third transfer capped to $100");
         }
         _ => panic!("Expected UsdcAlpacaToBase, got {op3:?}"),
     }
@@ -1167,7 +1170,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc(dec!(350)), Usdc(dec!(650)));
+        *guard = taken.with_usdc(Usdc(ed("350")), Usdc(ed("650")));
     }
 
     trigger.check_and_trigger_usdc().await;
@@ -1190,21 +1193,21 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
 
     // Large imbalance: 100 onchain, 900 offchain
     let inventory = Arc::new(RwLock::new(
-        InventoryView::default().with_usdc(Usdc(dec!(100)), Usdc(dec!(900))),
+        InventoryView::default().with_usdc(Usdc(ed("100")), Usdc(ed("900"))),
     ));
 
     let limits = OperationalLimits::Enabled {
-        max_shares: Positive::new(FractionalShares::new(dec!(50))).unwrap(),
-        max_amount: Positive::new(Usdc(dec!(100))).unwrap(),
+        max_shares: Positive::new(FractionalShares::new(ed("50"))).unwrap(),
+        max_amount: Positive::new(Usdc(ed("100"))).unwrap(),
     };
     let config = RebalancingTriggerConfig {
         equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         usdc: UsdcRebalancing::Enabled {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+            target: ed("0.5"),
+            deviation: ed("0.2"),
         },
         limits,
         disabled_assets: HashSet::new(),
@@ -1231,7 +1234,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         .expect("First trigger should produce an operation");
     match op1 {
         TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(amount, Usdc(dec!(100)), "First transfer capped to $100");
+            assert_eq!(amount, Usdc(ed("100")), "First transfer capped to $100");
         }
         _ => panic!("Expected UsdcAlpacaToBase, got {op1:?}"),
     }
@@ -1258,7 +1261,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         TriggeredOperation::UsdcAlpacaToBase { amount } => {
             assert_eq!(
                 amount,
-                Usdc(dec!(100)),
+                Usdc(ed("100")),
                 "Retry transfer also capped to $100"
             );
         }
@@ -1284,20 +1287,20 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
         build_imbalanced_inventory(Imbalance::Usdc {
             inventory: &inventory,
-            onchain: Usdc(dec!(350)),
-            offchain: Usdc(dec!(650)),
+            onchain: Usdc(ed("350")),
+            offchain: Usdc(ed("650")),
         })
         .await;
 
         let (sender, mut receiver) = mpsc::channel(10);
         let wide_config = RebalancingTriggerConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.4),
+                target: ed("0.5"),
+                deviation: ed("0.4"),
             },
             usdc: UsdcRebalancing::Enabled {
-                target: dec!(0.5),
-                deviation: dec!(0.4),
+                target: ed("0.5"),
+                deviation: ed("0.4"),
             },
             limits: OperationalLimits::Disabled,
             disabled_assets: HashSet::new(),
@@ -1332,20 +1335,20 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
         build_imbalanced_inventory(Imbalance::Usdc {
             inventory: &inventory,
-            onchain: Usdc(dec!(350)),
-            offchain: Usdc(dec!(650)),
+            onchain: Usdc(ed("350")),
+            offchain: Usdc(ed("650")),
         })
         .await;
 
         let (sender, mut receiver) = mpsc::channel(10);
         let tight_config = RebalancingTriggerConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.1),
+                target: ed("0.5"),
+                deviation: ed("0.1"),
             },
             usdc: UsdcRebalancing::Enabled {
-                target: dec!(0.5),
-                deviation: dec!(0.1),
+                target: ed("0.5"),
+                deviation: ed("0.1"),
             },
             limits: OperationalLimits::Disabled,
             disabled_assets: HashSet::new(),
@@ -1374,7 +1377,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             TriggeredOperation::UsdcAlpacaToBase { amount } => {
                 assert_eq!(
                     amount,
-                    Usdc(dec!(150)),
+                    Usdc(ed("150")),
                     "Excess should be $150 (target $500 - actual $350)"
                 );
             }

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -247,9 +247,8 @@ mod tests {
     use alloy::primitives::{B256, TxHash, address, b256};
     use alloy::providers::mock::Asserter;
     use alloy::providers::{Provider, ProviderBuilder};
-    use rust_decimal::Decimal;
-    use rust_decimal_macros::dec;
     use sqlx::{Row, SqlitePool};
+    use st0x_exact_decimal::ExactDecimal;
 
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_evm::ReadOnlyEvm;
@@ -281,8 +280,12 @@ mod tests {
         Symbol::new(s).unwrap()
     }
 
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     fn test_shares(n: i64) -> FractionalShares {
-        FractionalShares::new(Decimal::from(n))
+        FractionalShares::new(ed(&n.to_string()))
     }
 
     async fn create_test_raindex_service(
@@ -315,12 +318,12 @@ mod tests {
                 EquityPosition {
                     symbol: test_symbol("AAPL"),
                     quantity: test_shares(100),
-                    market_value: Some(dec!(15000)),
+                    market_value: Some(ed("15000")),
                 },
                 EquityPosition {
                     symbol: test_symbol("MSFT"),
                     quantity: test_shares(50),
-                    market_value: Some(dec!(20000)),
+                    market_value: Some(ed("20000")),
                 },
             ],
             cash_balance_cents: 10_000_000,
@@ -499,7 +502,7 @@ mod tests {
             positions: vec![EquityPosition {
                 symbol: test_symbol("AAPL"),
                 quantity: test_shares(1000),
-                market_value: Some(dec!(150000)),
+                market_value: Some(ed("150000")),
             }],
             cash_balance_cents: -5_000_000, // -$50,000 (margin debt)
         };
@@ -541,12 +544,12 @@ mod tests {
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
         let (orderbook, order_owner) = test_addresses();
 
-        let fractional_qty = FractionalShares::new(dec!(12.345)); // 12.345 shares
+        let fractional_qty = FractionalShares::new(ed("12.345")); // 12.345 shares
         let inventory = Inventory {
             positions: vec![EquityPosition {
                 symbol: test_symbol("AAPL"),
                 quantity: fractional_qty,
-                market_value: Some(dec!(1851.75)),
+                market_value: Some(ed("1851.75")),
             }],
             cash_balance_cents: 1_000_000,
         };

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -250,7 +250,7 @@ impl DomainEvent for InventorySnapshotEvent {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal::Decimal;
+    use st0x_exact_decimal::ExactDecimal;
     use std::str::FromStr;
 
     use super::*;
@@ -301,7 +301,7 @@ mod tests {
     }
 
     fn test_shares(n: i64) -> FractionalShares {
-        FractionalShares::new(Decimal::from(n))
+        FractionalShares::new(ExactDecimal::parse(&n.to_string()).unwrap())
     }
 
     #[tokio::test]

--- a/src/offchain/order_poller.rs
+++ b/src/offchain/order_poller.rs
@@ -332,8 +332,7 @@ impl<E: Executor> OrderStatusPoller<E> {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use rust_decimal::Decimal;
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
 
     use st0x_execution::{
         Direction, FractionalShares, MockExecutor, Positive, SupportedExecutor, Symbol,
@@ -347,6 +346,10 @@ mod tests {
     use crate::position::TradeId;
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
     use crate::threshold::ExecutionThreshold;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     async fn create_test_frameworks(
         pool: &SqlitePool,
@@ -371,12 +374,12 @@ mod tests {
         position_store: &Store<Position>,
         symbol: &Symbol,
         tokenized_symbol: &str,
-        amount: Decimal,
+        amount: ExactDecimal,
     ) {
         let mut onchain_trade = OnchainTradeBuilder::new()
             .with_symbol(tokenized_symbol)
             .with_amount(amount)
-            .with_price(dec!(150.0))
+            .with_price(ed("150.0"))
             .build();
         onchain_trade.direction = Direction::Buy;
         onchain_trade.block_timestamp = Some(Utc::now());
@@ -455,9 +458,9 @@ mod tests {
         let ctx = OrderPollerCtx::default();
 
         let symbol = Symbol::new("AAPL").unwrap();
-        let shares = Positive::new(FractionalShares::new(Decimal::from(10))).unwrap();
+        let shares = Positive::new(FractionalShares::new(ed("10"))).unwrap();
 
-        setup_position_with_onchain_fill(&position_store, &symbol, "wtAAPL", dec!(10)).await;
+        setup_position_with_onchain_fill(&position_store, &symbol, "wtAAPL", ed("10")).await;
 
         let offchain_order_id = OffchainOrderId::new();
         setup_offchain_order_aggregate(
@@ -495,7 +498,7 @@ mod tests {
             .handle_filled_order(
                 offchain_order_id,
                 &order,
-                Dollars(dec!(150.25)),
+                Dollars(ed("150.25")),
                 &ExecutorOrderId::new("ORD123"),
                 Utc::now(),
             )
@@ -541,9 +544,9 @@ mod tests {
         let ctx = OrderPollerCtx::default();
 
         let symbol = Symbol::new("TSLA").unwrap();
-        let shares = Positive::new(FractionalShares::new(Decimal::from(5))).unwrap();
+        let shares = Positive::new(FractionalShares::new(ed("5"))).unwrap();
 
-        setup_position_with_onchain_fill(&position_store, &symbol, "wtTSLA", dec!(5)).await;
+        setup_position_with_onchain_fill(&position_store, &symbol, "wtTSLA", ed("5")).await;
 
         let offchain_order_id = OffchainOrderId::new();
         setup_offchain_order_aggregate(

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -145,10 +145,14 @@ pub(crate) async fn check_all_positions<E: Executor>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::TxHash;
-    use rust_decimal_macros::dec;
     use std::sync::Arc;
 
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     use sqlx::SqlitePool;
 
@@ -188,7 +192,7 @@ mod tests {
                     },
                     amount,
                     direction,
-                    price_usdc: dec!(150.0),
+                    price_usdc: ed("150.0"),
                     block_timestamp: chrono::Utc::now(),
                 },
             )
@@ -226,7 +230,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(0.5)),
+            FractionalShares::new(ed("0.5")),
             Direction::Buy,
         )
         .await;
@@ -255,7 +259,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(1.5)),
+            FractionalShares::new(ed("1.5")),
             Direction::Buy,
         )
         .await;
@@ -275,7 +279,7 @@ mod tests {
         assert_eq!(params.symbol, symbol);
         assert_eq!(
             params.shares,
-            Positive::new(FractionalShares::new(dec!(1.5))).unwrap(),
+            Positive::new(FractionalShares::new(ed("1.5"))).unwrap(),
             "DryRun supports fractional shares"
         );
         assert_eq!(
@@ -298,7 +302,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &aapl,
-            FractionalShares::new(dec!(0.3)),
+            FractionalShares::new(ed("0.3")),
             Direction::Buy,
         )
         .await;
@@ -307,7 +311,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &msft,
-            FractionalShares::new(dec!(2.0)),
+            FractionalShares::new(ed("2.0")),
             Direction::Sell,
         )
         .await;
@@ -326,7 +330,7 @@ mod tests {
         assert_eq!(ready[0].symbol, msft);
         assert_eq!(
             ready[0].shares,
-            Positive::new(FractionalShares::new(dec!(2))).unwrap()
+            Positive::new(FractionalShares::new(ed("2"))).unwrap()
         );
         assert_eq!(
             ready[0].direction,
@@ -345,7 +349,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(2.0)),
+            FractionalShares::new(ed("2.0")),
             Direction::Buy,
         )
         .await;
@@ -379,7 +383,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(2.0)),
+            FractionalShares::new(ed("2.0")),
             Direction::Buy,
         )
         .await;
@@ -401,7 +405,7 @@ mod tests {
         assert_eq!(params.symbol, symbol);
         assert_eq!(
             params.shares,
-            Positive::new(FractionalShares::new(dec!(2))).unwrap()
+            Positive::new(FractionalShares::new(ed("2"))).unwrap()
         );
     }
 
@@ -418,7 +422,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(0.5)),
+            FractionalShares::new(ed("0.5")),
             Direction::Buy,
         )
         .await;
@@ -446,9 +450,9 @@ mod tests {
                         tx_hash: TxHash::random(),
                         log_index: 2,
                     },
-                    amount: FractionalShares::new(dec!(1.0)),
+                    amount: FractionalShares::new(ed("1.0")),
                     direction: Direction::Buy,
-                    price_usdc: dec!(150.0),
+                    price_usdc: ed("150.0"),
                     block_timestamp: chrono::Utc::now(),
                 },
             )
@@ -488,7 +492,7 @@ mod tests {
         assert_eq!(params.symbol, symbol);
         assert_eq!(
             params.shares,
-            Positive::new(FractionalShares::new(dec!(1.5))).unwrap(),
+            Positive::new(FractionalShares::new(ed("1.5"))).unwrap(),
             "Should execute full accumulated amount"
         );
     }
@@ -503,14 +507,14 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(10.0)),
+            FractionalShares::new(ed("10.0")),
             Direction::Buy,
         )
         .await;
 
         let limits = OperationalLimits::Enabled {
-            max_shares: Positive::new(FractionalShares::new(dec!(3.0))).unwrap(),
-            max_amount: Positive::new(crate::threshold::Usdc(dec!(1000))).unwrap(),
+            max_shares: Positive::new(FractionalShares::new(ed("3.0"))).unwrap(),
+            max_amount: Positive::new(crate::threshold::Usdc(ed("1000"))).unwrap(),
         };
 
         let params = check_execution_readiness(
@@ -528,7 +532,7 @@ mod tests {
         assert_eq!(params.symbol, symbol);
         assert_eq!(
             params.shares,
-            Positive::new(FractionalShares::new(dec!(3.0))).unwrap(),
+            Positive::new(FractionalShares::new(ed("3.0"))).unwrap(),
             "Shares should be capped by operational limit"
         );
     }
@@ -543,7 +547,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &symbol,
-            FractionalShares::new(dec!(5.0)),
+            FractionalShares::new(ed("5.0")),
             Direction::Buy,
         )
         .await;
@@ -578,7 +582,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &aapl,
-            FractionalShares::new(dec!(2.0)),
+            FractionalShares::new(ed("2.0")),
             Direction::Buy,
         )
         .await;
@@ -586,7 +590,7 @@ mod tests {
         initialize_position_with_fill(
             &store,
             &msft,
-            FractionalShares::new(dec!(3.0)),
+            FractionalShares::new(ed("3.0")),
             Direction::Buy,
         )
         .await;

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -229,12 +229,16 @@ mod tests {
     use alloy::rpc::types::Log;
     use alloy::sol_types::SolCall;
     use rain_math_float::Float;
-    use rust_decimal_macros::dec;
     use serde_json::json;
     use url::Url;
 
     use st0x_evm::ReadOnlyEvm;
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::FractionalShares;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     use super::*;
     use crate::bindings::IERC20::{decimalsCall, symbolCall};
@@ -391,7 +395,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
         assert_eq!(trade.tx_hash, tx_hash);
         assert_eq!(trade.log_index, 1);
     }
@@ -475,7 +479,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
         assert_eq!(trade.tx_hash, tx_hash);
         assert_eq!(trade.log_index, 1);
     }
@@ -829,7 +833,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
         assert_eq!(trade.tx_hash, tx_hash);
         assert_eq!(trade.log_index, 1);
     }
@@ -983,7 +987,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
     }
 
     #[tokio::test]
@@ -1131,7 +1135,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
     }
 
     fn create_after_clear_log_data() -> (Vec<B256>, Bytes) {
@@ -1203,7 +1207,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
         assert_eq!(trade.tx_hash, tx_hash);
         assert_eq!(trade.log_index, 1);
     }
@@ -1281,7 +1285,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
     }
 
     #[tokio::test]
@@ -1568,6 +1572,6 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
     }
 }

--- a/src/onchain/io.rs
+++ b/src/onchain/io.rs
@@ -6,11 +6,11 @@
 //! trade direction (buy/sell), and validates amounts before
 //! further processing.
 
-use rust_decimal::Decimal;
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
 
+use st0x_exact_decimal::ExactDecimal;
 use st0x_execution::{Direction, FractionalShares, Symbol};
 
 use super::OnChainError;
@@ -37,17 +37,17 @@ macro_rules! symbol {
 
 /// Represents a validated USDC amount (non-negative)
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) struct Usdc(Decimal);
+pub(crate) struct Usdc(ExactDecimal);
 
 impl Usdc {
-    pub(crate) fn new(value: Decimal) -> Result<Self, TradeValidationError> {
-        if value < Decimal::ZERO {
+    pub(crate) fn new(value: ExactDecimal) -> Result<Self, TradeValidationError> {
+        if value.is_negative().map_err(TradeValidationError::Float)? {
             return Err(TradeValidationError::NegativeUsdc(value));
         }
         Ok(Self(value))
     }
 
-    pub(crate) fn value(self) -> Decimal {
+    pub(crate) fn value(self) -> ExactDecimal {
         self.0
     }
 }
@@ -160,9 +160,9 @@ impl TradeDetails {
     /// (wtTICKER), since Raindex orders always involve wrapped tokens.
     pub(crate) fn try_from_io(
         input_symbol: &str,
-        input_amount: Decimal,
+        input_amount: ExactDecimal,
         output_symbol: &str,
-        output_amount: Decimal,
+        output_amount: ExactDecimal,
     ) -> Result<Self, OnChainError> {
         let (ticker, direction) = determine_trade_details(input_symbol, output_symbol)?;
 
@@ -183,7 +183,10 @@ impl TradeDetails {
                 .into());
             };
 
-        if equity_amount_raw < Decimal::ZERO {
+        if equity_amount_raw
+            .is_negative()
+            .map_err(TradeValidationError::Float)?
+        {
             return Err(TradeValidationError::NegativeShares(equity_amount_raw).into());
         }
         let equity_amount = FractionalShares::new(equity_amount_raw);
@@ -229,9 +232,11 @@ fn determine_trade_details(
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
-
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     #[test]
     fn test_tokenized_equity_symbol_parse() {
@@ -353,13 +358,13 @@ mod tests {
 
     #[test]
     fn test_usdc_validation() {
-        let usdc = Usdc::new(dec!(1000.50)).unwrap();
-        assert_eq!(usdc.value(), dec!(1000.50));
+        let usdc = Usdc::new(ed("1000.50")).unwrap();
+        assert_eq!(usdc.value(), ed("1000.50"));
 
-        let usdc = Usdc::new(Decimal::ZERO).unwrap();
-        assert_eq!(usdc.value(), Decimal::ZERO);
+        let usdc = Usdc::new(ExactDecimal::zero()).unwrap();
+        assert_eq!(usdc.value(), ExactDecimal::zero());
 
-        let result = Usdc::new(dec!(-100));
+        let result = Usdc::new(ed("-100"));
         assert!(matches!(
             result.unwrap_err(),
             TradeValidationError::NegativeUsdc(_)
@@ -368,9 +373,9 @@ mod tests {
 
     #[test]
     fn test_usdc_equality() {
-        let usdc1 = Usdc::new(dec!(1000)).unwrap();
-        let usdc2 = Usdc::new(dec!(1000)).unwrap();
-        let usdc3 = Usdc::new(dec!(2000)).unwrap();
+        let usdc1 = Usdc::new(ed("1000")).unwrap();
+        let usdc2 = Usdc::new(ed("1000")).unwrap();
+        let usdc3 = Usdc::new(ed("2000")).unwrap();
 
         assert_eq!(usdc1, usdc2);
         assert_ne!(usdc1, usdc3);
@@ -450,52 +455,52 @@ mod tests {
 
     #[test]
     fn test_trade_details_try_from_io_usdc_to_wrapped() {
-        let details = TradeDetails::try_from_io("USDC", dec!(100), "wtAAPL", dec!(0.5)).unwrap();
+        let details = TradeDetails::try_from_io("USDC", ed("100"), "wtAAPL", ed("0.5")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("AAPL"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.5));
-        assert_eq!(details.usdc_amount().value(), dec!(100));
+        assert_eq!(details.equity_amount().inner(), ed("0.5"));
+        assert_eq!(details.usdc_amount().value(), ed("100"));
         assert_eq!(details.direction(), Direction::Sell);
     }
 
     #[test]
     fn test_trade_details_try_from_io_wrapped_to_usdc() {
-        let details = TradeDetails::try_from_io("wtAAPL", dec!(0.5), "USDC", dec!(100)).unwrap();
+        let details = TradeDetails::try_from_io("wtAAPL", ed("0.5"), "USDC", ed("100")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("AAPL"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.5));
-        assert_eq!(details.usdc_amount().value(), dec!(100));
+        assert_eq!(details.equity_amount().inner(), ed("0.5"));
+        assert_eq!(details.usdc_amount().value(), ed("100"));
         assert_eq!(details.direction(), Direction::Buy);
     }
 
     #[test]
     fn test_trade_details_try_from_io_nvda() {
         let details =
-            TradeDetails::try_from_io("USDC", dec!(64.17), "wtNVDA", dec!(0.374)).unwrap();
+            TradeDetails::try_from_io("USDC", ed("64.17"), "wtNVDA", ed("0.374")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.374));
-        assert_eq!(details.usdc_amount().value(), dec!(64.17));
+        assert_eq!(details.equity_amount().inner(), ed("0.374"));
+        assert_eq!(details.usdc_amount().value(), ed("64.17"));
         assert_eq!(details.direction(), Direction::Sell);
 
         let details =
-            TradeDetails::try_from_io("wtNVDA", dec!(0.374), "USDC", dec!(64.17)).unwrap();
+            TradeDetails::try_from_io("wtNVDA", ed("0.374"), "USDC", ed("64.17")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.374));
-        assert_eq!(details.usdc_amount().value(), dec!(64.17));
+        assert_eq!(details.equity_amount().inner(), ed("0.374"));
+        assert_eq!(details.usdc_amount().value(), ed("64.17"));
         assert_eq!(details.direction(), Direction::Buy);
     }
 
     #[test]
     fn test_trade_details_try_from_io_invalid_configurations() {
-        let result = TradeDetails::try_from_io("USDC", dec!(100), "USDC", dec!(100));
+        let result = TradeDetails::try_from_io("USDC", ed("100"), "USDC", ed("100"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
         ));
 
-        let result = TradeDetails::try_from_io("BTC", dec!(1), "ETH", dec!(3000));
+        let result = TradeDetails::try_from_io("BTC", ed("1"), "ETH", ed("3000"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
@@ -504,13 +509,13 @@ mod tests {
 
     #[test]
     fn test_trade_details_negative_amount_validation() {
-        let result = TradeDetails::try_from_io("USDC", dec!(100), "wtAAPL", dec!(-0.5));
+        let result = TradeDetails::try_from_io("USDC", ed("100"), "wtAAPL", ed("-0.5"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::NegativeShares(_))
         ));
 
-        let result = TradeDetails::try_from_io("USDC", dec!(-100), "wtAAPL", dec!(0.5));
+        let result = TradeDetails::try_from_io("USDC", ed("-100"), "wtAAPL", ed("0.5"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::NegativeUsdc(_))
@@ -550,84 +555,82 @@ mod tests {
         // Real transaction: 0.374 wtNVDA sold for 64.169234 USDC
         // Verifies equity vs USDC amounts are not swapped
         let details =
-            TradeDetails::try_from_io("USDC", dec!(64.169234), "wtNVDA", dec!(0.374)).unwrap();
+            TradeDetails::try_from_io("USDC", ed("64.169234"), "wtNVDA", ed("0.374")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.374));
-        assert_eq!(details.usdc_amount().value(), dec!(64.169234));
+        assert_eq!(details.equity_amount().inner(), ed("0.374"));
+        assert_eq!(details.usdc_amount().value(), ed("64.169234"));
         assert_eq!(details.direction(), Direction::Sell);
 
-        let price_per_share = dec!(64.169234) / dec!(0.374);
-        assert!((price_per_share - dec!(171.58)).abs() < dec!(0.01));
+        let price_per_share = (ed("64.169234") / ed("0.374")).unwrap();
+        let diff = (price_per_share - ed("171.58")).unwrap().abs().unwrap();
+        assert!(diff < ed("0.01"));
     }
 
     #[test]
     fn test_real_transaction_nvda_small_trade() {
         // Real transaction: 0.2 wtNVDA sold for 34.645024 USDC
         let details =
-            TradeDetails::try_from_io("USDC", dec!(34.645024), "wtNVDA", dec!(0.2)).unwrap();
+            TradeDetails::try_from_io("USDC", ed("34.645024"), "wtNVDA", ed("0.2")).unwrap();
 
         assert_eq!(details.ticker(), &symbol!("NVDA"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.2));
-        assert_eq!(details.usdc_amount().value(), dec!(34.645024));
+        assert_eq!(details.equity_amount().inner(), ed("0.2"));
+        assert_eq!(details.usdc_amount().value(), ed("34.645024"));
         assert_eq!(details.direction(), Direction::Sell);
 
-        let price_per_share = dec!(34.645024) / dec!(0.2);
-        assert!((price_per_share - dec!(173.23)).abs() < dec!(0.01));
+        let price_per_share = (ed("34.645024") / ed("0.2")).unwrap();
+        let diff = (price_per_share - ed("173.23")).unwrap().abs().unwrap();
+        assert!(diff < ed("0.01"));
     }
 
     #[test]
     #[ignore = "known precision dust bug — not yet patched"]
     fn test_trade_details_normalizes_spurious_precision_beyond_onchain_scales() {
-        let usdc_with_dust = Decimal::from_str("64.169234000001").unwrap();
-        let shares_with_dust = Decimal::from_str("0.374000000000000000001").unwrap();
+        let usdc_with_dust = ed("64.169234000001");
+        let shares_with_dust = ed("0.374000000000000000001");
 
         let details =
             TradeDetails::try_from_io("USDC", usdc_with_dust, "tNVDA", shares_with_dust).unwrap();
 
-        assert_eq!(details.usdc_amount().value(), dec!(64.169234));
-        assert_eq!(details.equity_amount().inner(), dec!(0.374));
+        assert_eq!(details.usdc_amount().value(), ed("64.169234"));
+        assert_eq!(details.equity_amount().inner(), ed("0.374"));
     }
 
     #[test]
     #[ignore = "known precision dust bug — not yet patched"]
     fn test_trade_details_regression_precision_dust_breaks_exact_equality_without_normalization() {
-        let shares_with_dust = Decimal::from_str("0.200000000000000000001").unwrap();
+        let shares_with_dust = ed("0.200000000000000000001");
         let pre_fix_shares = FractionalShares::new(shares_with_dust);
 
         assert_ne!(
             pre_fix_shares,
-            FractionalShares::new(dec!(0.2)),
+            FractionalShares::new(ed("0.2")),
             "Pre-fix behavior preserved dust and broke exact equality checks",
         );
 
-        let details = TradeDetails::try_from_io(
-            "USDC",
-            Decimal::from_str("34.645024000001").unwrap(),
-            "tNVDA",
-            shares_with_dust,
-        )
-        .unwrap();
+        let details =
+            TradeDetails::try_from_io("USDC", ed("34.645024000001"), "tNVDA", shares_with_dust)
+                .unwrap();
 
-        assert_eq!(details.equity_amount().inner(), dec!(0.2));
-        assert_eq!(details.usdc_amount().value(), dec!(34.645024));
+        assert_eq!(details.equity_amount().inner(), ed("0.2"));
+        assert_eq!(details.usdc_amount().value(), ed("34.645024"));
     }
 
     #[test]
     fn test_edge_case_validation_very_small_amounts() {
         let details =
-            TradeDetails::try_from_io("USDC", dec!(0.01), "wtAAPL", dec!(0.0001)).unwrap();
+            TradeDetails::try_from_io("USDC", ed("0.01"), "wtAAPL", ed("0.0001")).unwrap();
         assert_eq!(details.ticker(), &symbol!("AAPL"));
-        assert_eq!(details.equity_amount().inner(), dec!(0.0001));
-        assert_eq!(details.usdc_amount().value(), dec!(0.01));
+        assert_eq!(details.equity_amount().inner(), ed("0.0001"));
+        assert_eq!(details.usdc_amount().value(), ed("0.01"));
     }
 
     #[test]
     fn test_edge_case_validation_very_large_amounts() {
-        let details = TradeDetails::try_from_io("USDC", dec!(1000000), "wtBRK", dec!(100)).unwrap();
+        let details = TradeDetails::try_from_io("USDC", ed("1000000"), "wtBRK", ed("100")).unwrap();
         assert_eq!(details.ticker(), &symbol!("BRK"));
-        assert_eq!(details.equity_amount().inner(), dec!(100));
-        assert_eq!(details.usdc_amount().value(), dec!(1000000));
+        assert_eq!(details.equity_amount().inner(), ed("100"));
+        assert_eq!(details.usdc_amount().value(), ed("1000000"));
     }
 
     #[test]
@@ -657,13 +660,13 @@ mod tests {
 
     #[test]
     fn test_trade_details_rejects_unwrapped_prefix() {
-        let result = TradeDetails::try_from_io("USDC", dec!(100), "tAAPL", dec!(0.5));
+        let result = TradeDetails::try_from_io("USDC", ed("100"), "tAAPL", ed("0.5"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))
         ));
 
-        let result = TradeDetails::try_from_io("tAAPL", dec!(0.5), "USDC", dec!(100));
+        let result = TradeDetails::try_from_io("tAAPL", ed("0.5"), "USDC", ed("100"));
         assert!(matches!(
             result.unwrap_err(),
             OnChainError::Validation(TradeValidationError::InvalidSymbolConfiguration(_, _))

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -118,8 +118,6 @@ pub(crate) enum OnChainError {
     Position(#[from] PositionError),
     #[error("Shares conversion error: {0}")]
     SharesConversion(#[from] SharesConversionError),
-    #[error("Decimal parse error: {0}")]
-    DecimalParse(#[from] rust_decimal::Error),
     #[error("JSON serialization error: {0}")]
     Json(#[from] serde_json::Error),
     #[error("UUID parse error: {0}")]

--- a/src/onchain/take_order.rs
+++ b/src/onchain/take_order.rs
@@ -55,10 +55,13 @@ mod tests {
     use alloy::providers::{ProviderBuilder, mock::Asserter};
     use alloy::sol_types::SolCall;
     use rain_math_float::Float;
-    use rust_decimal_macros::dec;
-
     use st0x_evm::ReadOnlyEvm;
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::FractionalShares;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     use super::*;
     use crate::bindings::IERC20::{decimalsCall, symbolCall};
@@ -161,7 +164,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(9)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("9")));
         assert_eq!(
             trade.tx_hash,
             fixed_bytes!("0xbeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
@@ -267,7 +270,7 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(5)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("5")));
     }
 
     #[tokio::test]
@@ -338,9 +341,9 @@ mod tests {
             trade.symbol,
             tokenized_symbol!(WrappedTokenizedShares, "wtAAPL")
         );
-        assert_eq!(trade.amount, FractionalShares::new(dec!(15)));
+        assert_eq!(trade.amount, FractionalShares::new(ed("15")));
         // Price should be 200 USDC / 15 shares = 13.333... USDC per share
-        assert_eq!(trade.price.value(), dec!(200) / dec!(15));
+        assert_eq!(trade.price.value(), (ed("200") / ed("15")).unwrap());
     }
 
     #[tokio::test]

--- a/src/rebalancing/equity/mock.rs
+++ b/src/rebalancing/equity/mock.rs
@@ -98,9 +98,13 @@ impl CrossVenueTransfer<MarketMakingVenue, HedgingVenue> for MockCrossVenueEquit
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     #[test]
     fn new_mock_starts_with_zero_counts() {
@@ -124,7 +128,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(100)),
+                quantity: FractionalShares::new(ed("100")),
             },
         )
         .await
@@ -142,7 +146,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(50)),
+                quantity: FractionalShares::new(ed("50")),
             },
         )
         .await
@@ -160,7 +164,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(dec!(42.5)),
+                quantity: FractionalShares::new(ed("42.5")),
             },
         )
         .await
@@ -168,7 +172,7 @@ mod tests {
 
         let call = mock.last_mint_call().unwrap();
         assert_eq!(call.symbol, Symbol::new("TSLA").unwrap());
-        assert_eq!(call.quantity, FractionalShares::new(dec!(42.5)));
+        assert_eq!(call.quantity, FractionalShares::new(ed("42.5")));
     }
 
     #[tokio::test]
@@ -179,7 +183,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("GOOG").unwrap(),
-                quantity: FractionalShares::new(dec!(7.25)),
+                quantity: FractionalShares::new(ed("7.25")),
             },
         )
         .await
@@ -187,7 +191,7 @@ mod tests {
 
         let call = mock.last_redeem_call().unwrap();
         assert_eq!(call.symbol, Symbol::new("GOOG").unwrap());
-        assert_eq!(call.quantity, FractionalShares::new(dec!(7.25)));
+        assert_eq!(call.quantity, FractionalShares::new(ed("7.25")));
     }
 
     #[tokio::test]
@@ -198,7 +202,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(10)),
+                quantity: FractionalShares::new(ed("10")),
             },
         )
         .await
@@ -208,7 +212,7 @@ mod tests {
             &mock,
             Equity {
                 symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(dec!(20)),
+                quantity: FractionalShares::new(ed("20")),
             },
         )
         .await

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -433,14 +433,19 @@ impl CrossVenueTransfer<MarketMakingVenue, HedgingVenue> for CrossVenueEquityTra
 #[cfg(test)]
 mod tests {
     use alloy::primitives::Address;
-    use rust_decimal_macros::dec;
     use sqlx::SqlitePool;
+    use st0x_exact_decimal::ExactDecimal;
     use std::sync::Arc;
 
     use st0x_event_sorcery::test_store;
     use st0x_execution::{FractionalShares, Symbol};
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     use crate::onchain::mock::MockRaindex;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
     use crate::wrapper::mock::MockWrapper;
@@ -488,7 +493,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(100.0)),
+                quantity: FractionalShares::new(ed("100.0")),
             },
         )
         .await
@@ -513,7 +518,7 @@ mod tests {
                 &transfer,
                 Equity {
                     symbol: Symbol::new("TEST").unwrap(),
-                    quantity: FractionalShares::new(dec!(50)),
+                    quantity: FractionalShares::new(ed("50")),
                 },
             ),
         )
@@ -535,7 +540,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("TEST").unwrap(),
-                quantity: FractionalShares::new(dec!(50)),
+                quantity: FractionalShares::new(ed("50")),
             },
         )
         .await
@@ -560,7 +565,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("TEST").unwrap(),
-                quantity: FractionalShares::new(dec!(50)),
+                quantity: FractionalShares::new(ed("50")),
             },
         )
         .await
@@ -588,7 +593,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("TEST").unwrap(),
-                quantity: FractionalShares::new(dec!(50)),
+                quantity: FractionalShares::new(ed("50")),
             },
         )
         .await
@@ -616,7 +621,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("TEST").unwrap(),
-                quantity: FractionalShares::new(dec!(50)),
+                quantity: FractionalShares::new(ed("50")),
             },
         )
         .await
@@ -641,7 +646,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(100.0)),
+                quantity: FractionalShares::new(ed("100.0")),
             },
         )
         .await
@@ -666,7 +671,7 @@ mod tests {
             &transfer,
             Equity {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(100.0)),
+                quantity: FractionalShares::new(ed("100.0")),
             },
         )
         .await

--- a/src/rebalancing/rebalancer.rs
+++ b/src/rebalancing/rebalancer.rs
@@ -113,12 +113,17 @@ impl Rebalancer {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
     use std::sync::Arc;
 
     use st0x_execution::{FractionalShares, Symbol};
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
     use crate::rebalancing::usdc::mock::MockUsdcRebalance;
 
@@ -151,7 +156,7 @@ mod tests {
     async fn execute_mint_calls_equity_to_market_making() {
         let (equity, usdc) = execute(vec![TriggeredOperation::Mint {
             symbol: Symbol::new("AAPL").unwrap(),
-            quantity: FractionalShares::new(dec!(10)),
+            quantity: FractionalShares::new(ed("10")),
         }])
         .await;
 
@@ -165,7 +170,7 @@ mod tests {
     async fn execute_redemption_calls_equity_to_hedging() {
         let (equity, usdc) = execute(vec![TriggeredOperation::Redemption {
             symbol: Symbol::new("AAPL").unwrap(),
-            quantity: FractionalShares::new(dec!(50)),
+            quantity: FractionalShares::new(ed("50")),
             wrapped_token: address!("0x1234567890123456789012345678901234567890"),
             unwrapped_token: address!("0xabcdef0123456789abcdef0123456789abcdef01"),
         }])
@@ -180,7 +185,7 @@ mod tests {
     #[tokio::test]
     async fn execute_usdc_alpaca_to_base_calls_usdc_to_market_making() {
         let (equity, usdc) = execute(vec![TriggeredOperation::UsdcAlpacaToBase {
-            amount: Usdc(dec!(1000)),
+            amount: Usdc(ed("1000")),
         }])
         .await;
 
@@ -193,7 +198,7 @@ mod tests {
     #[tokio::test]
     async fn execute_usdc_base_to_alpaca_calls_usdc_to_hedging() {
         let (equity, usdc) = execute(vec![TriggeredOperation::UsdcBaseToAlpaca {
-            amount: Usdc(dec!(2000)),
+            amount: Usdc(ed("2000")),
         }])
         .await;
 
@@ -208,23 +213,23 @@ mod tests {
         let (equity, usdc) = execute(vec![
             TriggeredOperation::Mint {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(dec!(10)),
+                quantity: FractionalShares::new(ed("10")),
             },
             TriggeredOperation::Mint {
                 symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(dec!(20)),
+                quantity: FractionalShares::new(ed("20")),
             },
             TriggeredOperation::Redemption {
                 symbol: Symbol::new("GOOG").unwrap(),
-                quantity: FractionalShares::new(dec!(5)),
+                quantity: FractionalShares::new(ed("5")),
                 wrapped_token: address!("0x1234567890123456789012345678901234567890"),
                 unwrapped_token: address!("0xabcdef0123456789abcdef0123456789abcdef01"),
             },
             TriggeredOperation::UsdcAlpacaToBase {
-                amount: Usdc(dec!(500)),
+                amount: Usdc(ed("500")),
             },
             TriggeredOperation::UsdcBaseToAlpaca {
-                amount: Usdc(dec!(300)),
+                amount: Usdc(ed("300")),
             },
         ])
         .await;

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -158,8 +158,8 @@ mod tests {
     use alloy::providers::{Identity, ProviderBuilder, RootProvider};
     use httpmock::Method::GET;
     use httpmock::MockServer;
-    use rust_decimal_macros::dec;
     use serde_json::json;
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, FractionalShares, Symbol,
         TimeInForce,
@@ -183,6 +183,10 @@ mod tests {
     use crate::vault_registry::VaultRegistry;
     use crate::wrapper::mock::MockWrapper;
 
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     type BaseProvider = FillProvider<
         JoinFill<
             Identity,
@@ -197,12 +201,12 @@ mod tests {
     fn make_ctx() -> RebalancingCtx {
         RebalancingCtx::stub()
             .equity(ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             })
             .usdc(UsdcRebalancing::Enabled {
-                target: dec!(0.6),
-                deviation: dec!(0.15),
+                target: ed("0.6"),
+                deviation: ed("0.15"),
             })
             .redemption_wallet(address!("0x1234567890123456789012345678901234567890"))
             .usdc_vault_id(b256!(
@@ -244,8 +248,8 @@ mod tests {
             disabled_assets: HashSet::new(),
         };
 
-        assert_eq!(trigger_config.equity.target, dec!(0.5));
-        assert_eq!(trigger_config.equity.deviation, dec!(0.2));
+        assert_eq!(trigger_config.equity.target, ed("0.5"));
+        assert_eq!(trigger_config.equity.deviation, ed("0.2"));
     }
 
     #[test]
@@ -262,8 +266,8 @@ mod tests {
         let UsdcRebalancing::Enabled { target, deviation } = trigger_config.usdc else {
             panic!("expected enabled");
         };
-        assert_eq!(target, dec!(0.6));
-        assert_eq!(deviation, dec!(0.15));
+        assert_eq!(target, ed("0.6"));
+        assert_eq!(deviation, ed("0.15"));
     }
 
     async fn make_services_with_mock_wallet(
@@ -427,7 +431,7 @@ mod tests {
 
         tx.send(TriggeredOperation::Mint {
             symbol: Symbol::new("AAPL").unwrap(),
-            quantity: FractionalShares::new(dec!(10)),
+            quantity: FractionalShares::new(ed("10")),
         })
         .await
         .unwrap();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -9,8 +9,8 @@ use alloy::primitives::{Address, B256};
 use alloy::providers::{Provider, RootProvider};
 use async_trait::async_trait;
 use chrono::Utc;
-use rust_decimal::Decimal;
 use serde::Deserialize;
+use st0x_exact_decimal::ExactDecimal;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -51,8 +51,8 @@ pub(crate) enum RebalancingTriggerError {
     Inventory(#[from] InventoryViewError),
     #[error(transparent)]
     EquityTrigger(#[from] equity::EquityTriggerError),
-    #[error("USDC amount overflow computing price {price} * quantity {quantity}")]
-    UsdcAmountOverflow { price: Decimal, quantity: Decimal },
+    #[error("float arithmetic error: {0}")]
+    Float(#[from] rain_math_float::FloatError),
 }
 
 /// Why loading a token address from the vault registry failed.
@@ -83,7 +83,10 @@ pub enum RebalancingCtxError {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "mode", rename_all = "lowercase")]
 pub enum UsdcRebalancing {
-    Enabled { target: Decimal, deviation: Decimal },
+    Enabled {
+        target: ExactDecimal,
+        deviation: ExactDecimal,
+    },
     Disabled,
 }
 
@@ -409,6 +412,7 @@ impl RebalancingTrigger {
         event: InventorySnapshotEvent,
     ) -> Result<(), RebalancingTriggerError> {
         let now = Utc::now();
+        let fetched_at = event.timestamp();
         let mut inventory = self.inventory.write().await;
 
         use InventorySnapshotEvent::*;
@@ -419,14 +423,18 @@ impl RebalancingTrigger {
                     |view, (symbol, snapshot_balance)| {
                         view.update_equity(
                             symbol,
-                            Inventory::on_snapshot(Venue::MarketMaking, *snapshot_balance),
+                            Inventory::on_snapshot(
+                                Venue::MarketMaking,
+                                *snapshot_balance,
+                                fetched_at,
+                            ),
                             now,
                         )
                     },
                 ),
 
                 OnchainCash { usdc_balance, .. } => inventory.clone().update_usdc(
-                    Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance),
+                    Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
                     now,
                 ),
 
@@ -435,7 +443,7 @@ impl RebalancingTrigger {
                     |view, (symbol, snapshot_balance)| {
                         view.update_equity(
                             symbol,
-                            Inventory::on_snapshot(Venue::Hedging, *snapshot_balance),
+                            Inventory::on_snapshot(Venue::Hedging, *snapshot_balance, fetched_at),
                             now,
                         )
                     },
@@ -447,9 +455,10 @@ impl RebalancingTrigger {
                     let usdc = Usdc::from_cents(*cash_balance_cents).ok_or(
                         InventoryViewError::CashBalanceConversion(*cash_balance_cents),
                     )?;
-                    inventory
-                        .clone()
-                        .update_usdc(Inventory::on_snapshot(Venue::Hedging, usdc), now)
+                    inventory.clone().update_usdc(
+                        Inventory::on_snapshot(Venue::Hedging, usdc, fetched_at),
+                        now,
+                    )
                 }
             }?;
 
@@ -474,13 +483,16 @@ impl RebalancingTrigger {
         let inventory_error = match error {
             RebalancingTriggerError::Inventory(inventory_error) => inventory_error,
             other @ (RebalancingTriggerError::EquityTrigger(_)
-            | RebalancingTriggerError::UsdcAmountOverflow { .. }) => return Err(other),
+            | RebalancingTriggerError::Float(_)) => return Err(other),
         };
 
         warn!(
             ?inventory_error,
             "Resetting inventory and force-applying snapshot to recover"
         );
+
+        // Convert to string so it can be cloned across multiple force_on_snapshot calls
+        let recovery_reason = inventory_error.to_string();
 
         let now = Utc::now();
         let mut inventory = self.inventory.write().await;
@@ -497,7 +509,7 @@ impl RebalancingTrigger {
                             Inventory::force_on_snapshot(
                                 Venue::MarketMaking,
                                 *snapshot_balance,
-                                inventory_error.clone(),
+                                recovery_reason.clone(),
                             ),
                             now,
                         )
@@ -508,7 +520,7 @@ impl RebalancingTrigger {
                     Inventory::force_on_snapshot(
                         Venue::MarketMaking,
                         *usdc_balance,
-                        inventory_error.clone(),
+                        recovery_reason.clone(),
                     ),
                     now,
                 ),
@@ -521,7 +533,7 @@ impl RebalancingTrigger {
                             Inventory::force_on_snapshot(
                                 Venue::Hedging,
                                 *snapshot_balance,
-                                inventory_error.clone(),
+                                recovery_reason.clone(),
                             ),
                             now,
                         )
@@ -535,7 +547,7 @@ impl RebalancingTrigger {
                         InventoryViewError::CashBalanceConversion(*cash_balance_cents),
                     )?;
                     inventory.clone().update_usdc(
-                        Inventory::force_on_snapshot(Venue::Hedging, usdc, inventory_error),
+                        Inventory::force_on_snapshot(Venue::Hedging, usdc, recovery_reason),
                         now,
                     )
                 }
@@ -608,13 +620,8 @@ impl Reactor for RebalancingTrigger {
                         ..
                     } => {
                         let equity_op: Operator = (*direction).into();
-                        let quantity = Decimal::from(*amount);
-                        let usdc_value = price_usdc.checked_mul(quantity).ok_or(
-                            RebalancingTriggerError::UsdcAmountOverflow {
-                                price: *price_usdc,
-                                quantity,
-                            },
-                        )?;
+                        let quantity: ExactDecimal = (*amount).into();
+                        let usdc_value = (*price_usdc * quantity)?;
 
                         (
                             Inventory::available(Venue::MarketMaking, equity_op, *amount),
@@ -633,14 +640,9 @@ impl Reactor for RebalancingTrigger {
                         ..
                     } => {
                         let equity_op: Operator = (*direction).into();
-                        let quantity = Decimal::from(shares_filled.inner());
+                        let quantity: ExactDecimal = shares_filled.inner().into();
                         let Dollars(price_value) = price;
-                        let usdc_value = price_value.checked_mul(quantity).ok_or(
-                            RebalancingTriggerError::UsdcAmountOverflow {
-                                price: *price_value,
-                                quantity,
-                            },
-                        )?;
+                        let usdc_value = (*price_value * quantity)?;
 
                         (
                             Inventory::available(Venue::Hedging, equity_op, shares_filled.inner()),
@@ -848,11 +850,26 @@ impl RebalancingTrigger {
                 TransferOp::Cancel,
                 quantity,
             )),
-            TokensReceived { .. } => Some(Inventory::transfer(
-                Venue::Hedging,
-                TransferOp::Complete,
-                quantity,
-            )),
+            TokensReceived { received_at, .. } => {
+                // Compose TransferOp::Complete with with_last_rebalancing so that the
+                // staleness guard is active the instant inflight is cleared. Without this,
+                // a stale snapshot fetched before the mint could slip through between
+                // inflight clearing and DepositedIntoRaindex.
+                let received_at = *received_at;
+                let composed: Box<
+                    dyn FnOnce(
+                            Inventory<FractionalShares>,
+                        ) -> Result<Inventory<FractionalShares>, _>
+                        + Send,
+                > = Box::new(move |inventory| {
+                    let transferred =
+                        Inventory::transfer(Venue::Hedging, TransferOp::Complete, quantity)(
+                            inventory,
+                        )?;
+                    Inventory::with_last_rebalancing(received_at)(transferred)
+                });
+                Some(composed)
+            }
             DepositedIntoRaindex { deposited_at, .. } => {
                 Some(Inventory::with_last_rebalancing(*deposited_at))
             }
@@ -1044,10 +1061,9 @@ mod tests {
     use httpmock::MockServer;
     use rsa::RsaPrivateKey;
     use rsa::pkcs8::EncodePrivateKey;
-    use rust_decimal::Decimal;
-    use rust_decimal_macros::dec;
     use sqlx::SqlitePool;
     use st0x_event_sorcery::{EntityList, Never, ReactorHarness, TestStore, deps, test_store};
+    use st0x_exact_decimal::ExactDecimal;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiMode, Direction, ExecutorOrderId, Positive, TimeInForce,
     };
@@ -1081,15 +1097,19 @@ mod tests {
         pem.as_bytes().to_vec()
     });
 
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
+
     fn test_config() -> RebalancingTriggerConfig {
         RebalancingTriggerConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             },
             usdc: UsdcRebalancing::Enabled {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             },
             limits: OperationalLimits::Disabled,
             disabled_assets: HashSet::new(),
@@ -1268,7 +1288,7 @@ mod tests {
     }
 
     fn shares(n: i64) -> FractionalShares {
-        FractionalShares::new(Decimal::from(n))
+        FractionalShares::new(ed(&n.to_string()))
     }
 
     fn make_onchain_fill(amount: FractionalShares, direction: Direction) -> PositionEvent {
@@ -1279,7 +1299,7 @@ mod tests {
             },
             amount,
             direction,
-            price_usdc: dec!(150.0),
+            price_usdc: ed("150"),
             block_timestamp: Utc::now(),
             seen_at: Utc::now(),
         }
@@ -1291,7 +1311,7 @@ mod tests {
             shares_filled: Positive::new(shares_filled).unwrap(),
             direction,
             executor_order_id: ExecutorOrderId::new("ORD1"),
-            price: Dollars(dec!(150.00)),
+            price: Dollars(ed("150")),
             broker_timestamp: Utc::now(),
         }
     }
@@ -1433,7 +1453,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let (sender, mut receiver) = mpsc::channel(10);
         let inventory = Arc::new(RwLock::new(
-            InventoryView::default().with_usdc(Usdc(dec!(1000000)), Usdc(dec!(1000000))),
+            InventoryView::default().with_usdc(usdc(1_000_000), usdc(1_000_000)),
         ));
         let pool = crate::test_utils::setup_test_db().await;
 
@@ -1494,7 +1514,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(1000000)), Usdc(dec!(1000000)));
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
 
         let (trigger, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
@@ -1533,7 +1553,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(1000000)), Usdc(dec!(1000000)))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000))
             .update_equity(
                 &symbol,
                 Inventory::available(Venue::MarketMaking, Operator::Add, shares(50)),
@@ -1574,7 +1594,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(1000000)), Usdc(dec!(1000000)))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000))
             .update_equity(
                 &symbol,
                 Inventory::available(Venue::MarketMaking, Operator::Add, shares(20)),
@@ -1640,7 +1660,7 @@ mod tests {
         );
     }
 
-    fn make_mint_requested(symbol: &Symbol, quantity: Decimal) -> TokenizedEquityMintEvent {
+    fn make_mint_requested(symbol: &Symbol, quantity: ExactDecimal) -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::MintRequested {
             symbol: symbol.clone(),
             quantity,
@@ -1687,7 +1707,7 @@ mod tests {
         }
     }
 
-    fn make_wrapping_failed(symbol: &Symbol, quantity: Decimal) -> TokenizedEquityMintEvent {
+    fn make_wrapping_failed(symbol: &Symbol, quantity: ExactDecimal) -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::WrappingFailed {
             symbol: symbol.clone(),
             quantity,
@@ -1825,13 +1845,13 @@ mod tests {
     #[test]
     fn extract_mint_info_returns_symbol_and_quantity() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let event = make_mint_requested(&symbol, dec!(42.5));
+        let event = make_mint_requested(&symbol, ed("42.5"));
 
         let (extracted_symbol, extracted_quantity) =
             RebalancingTrigger::extract_mint_info(&event).unwrap();
 
         assert_eq!(extracted_symbol, symbol);
-        assert_eq!(extracted_quantity.inner(), dec!(42.5));
+        assert_eq!(extracted_quantity.inner(), ed("42.5"));
     }
 
     #[test]
@@ -1844,7 +1864,7 @@ mod tests {
     fn non_terminal_mint_events_are_not_terminal() {
         let symbol = Symbol::new("AAPL").unwrap();
         assert!(!RebalancingTrigger::is_terminal_mint_event(
-            &make_mint_requested(&symbol, dec!(30))
+            &make_mint_requested(&symbol, ed("30"))
         ));
         assert!(!RebalancingTrigger::is_terminal_mint_event(
             &make_mint_accepted()
@@ -1869,7 +1889,7 @@ mod tests {
         let id = IssuerRequestId::new("mint-1");
 
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(10)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("10")))
             .await
             .unwrap();
 
@@ -1906,7 +1926,7 @@ mod tests {
         let id = RedemptionAggregateId::new("redemption-1");
 
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(10)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("10")))
             .await
             .unwrap();
 
@@ -1955,7 +1975,7 @@ mod tests {
 
         // Send MintRequested + MintAccepted through reactor
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -1998,7 +2018,7 @@ mod tests {
 
         // Full mint flow: MintRequested -> MintAccepted -> TokensReceived
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2048,7 +2068,7 @@ mod tests {
 
         // MintRequested -> MintAccepted -> MintAcceptanceFailed
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2103,7 +2123,7 @@ mod tests {
 
         // Full happy-path: MintRequested -> MintAccepted -> TokensReceived -> DepositedIntoRaindex
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2158,12 +2178,12 @@ mod tests {
         let id = IssuerRequestId::new("mint-wrapping-fail");
 
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_wrapping_failed(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_wrapping_failed(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2203,7 +2223,7 @@ mod tests {
         let id = IssuerRequestId::new("mint-deposit-fail");
 
         harness
-            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, dec!(30)))
+            .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2242,7 +2262,7 @@ mod tests {
         let id = RedemptionAggregateId::new("redemption-transfer-fail");
 
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(10)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("10")))
             .await
             .unwrap();
 
@@ -2281,7 +2301,7 @@ mod tests {
         let id = RedemptionAggregateId::new("redemption-detection-fail");
 
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(10)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("10")))
             .await
             .unwrap();
 
@@ -2320,7 +2340,7 @@ mod tests {
         let id = RedemptionAggregateId::new("redemption-rejected");
 
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(10)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("10")))
             .await
             .unwrap();
 
@@ -2375,7 +2395,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(10000)), Usdc(dec!(10000)));
+            .with_usdc(usdc(10000), usdc(10000));
 
         let (trigger, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
@@ -2396,7 +2416,7 @@ mod tests {
             .usdc_available(Venue::MarketMaking)
             .unwrap();
 
-        assert_eq!(onchain_usdc, Usdc(dec!(8500)));
+        assert_eq!(onchain_usdc, usdc(8500));
     }
 
     #[tokio::test]
@@ -2404,7 +2424,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(10000)), Usdc(dec!(10000)))
+            .with_usdc(usdc(10000), usdc(10000))
             .update_equity(
                 &symbol,
                 Inventory::available(Venue::MarketMaking, Operator::Add, shares(100)),
@@ -2431,7 +2451,7 @@ mod tests {
             .usdc_available(Venue::MarketMaking)
             .unwrap();
 
-        assert_eq!(onchain_usdc, Usdc(dec!(11500)));
+        assert_eq!(onchain_usdc, usdc(11500));
     }
 
     #[tokio::test]
@@ -2439,7 +2459,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(10000)), Usdc(dec!(10000)));
+            .with_usdc(usdc(10000), usdc(10000));
 
         let (trigger, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
@@ -2460,7 +2480,7 @@ mod tests {
             .usdc_available(Venue::Hedging)
             .unwrap();
 
-        assert_eq!(offchain_usdc, Usdc(dec!(8500)));
+        assert_eq!(offchain_usdc, usdc(8500));
     }
 
     #[tokio::test]
@@ -2468,7 +2488,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(Usdc(dec!(10000)), Usdc(dec!(10000)))
+            .with_usdc(usdc(10000), usdc(10000))
             .update_equity(
                 &symbol,
                 Inventory::available(Venue::Hedging, Operator::Add, shares(100)),
@@ -2495,7 +2515,7 @@ mod tests {
             .usdc_available(Venue::Hedging)
             .unwrap();
 
-        assert_eq!(offchain_usdc, Usdc(dec!(11500)));
+        assert_eq!(offchain_usdc, usdc(11500));
     }
 
     #[tokio::test]
@@ -2645,7 +2665,7 @@ mod tests {
 
         // Send WithdrawnFromRaindex through reactor
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(30)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2683,7 +2703,7 @@ mod tests {
 
         // Full redemption flow: WithdrawnFromRaindex -> Completed
         harness
-            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, dec!(30)))
+            .receive::<EquityRedemption>(id.clone(), make_withdrawn_from_raindex(&symbol, ed("30")))
             .await
             .unwrap();
 
@@ -2861,7 +2881,10 @@ mod tests {
         );
     }
 
-    fn make_withdrawn_from_raindex(symbol: &Symbol, quantity: Decimal) -> EquityRedemptionEvent {
+    fn make_withdrawn_from_raindex(
+        symbol: &Symbol,
+        quantity: ExactDecimal,
+    ) -> EquityRedemptionEvent {
         EquityRedemptionEvent::WithdrawnFromRaindex {
             symbol: symbol.clone(),
             quantity,
@@ -2981,13 +3004,13 @@ mod tests {
     #[test]
     fn extract_redemption_info_returns_symbol_and_quantity() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let event = make_withdrawn_from_raindex(&symbol, dec!(42.5));
+        let event = make_withdrawn_from_raindex(&symbol, ed("42.5"));
 
         let (extracted_symbol, extracted_quantity) =
             RebalancingTrigger::extract_redemption_info(&event).unwrap();
 
         assert_eq!(extracted_symbol, symbol);
-        assert_eq!(extracted_quantity.inner(), dec!(42.5));
+        assert_eq!(extracted_quantity.inner(), ed("42.5"));
     }
 
     #[test]
@@ -3000,7 +3023,7 @@ mod tests {
     fn non_terminal_redemption_events_are_not_terminal() {
         let symbol = Symbol::new("AAPL").unwrap();
         assert!(!RebalancingTrigger::is_terminal_redemption_event(
-            &make_withdrawn_from_raindex(&symbol, dec!(30))
+            &make_withdrawn_from_raindex(&symbol, ed("30"))
         ));
         assert!(!RebalancingTrigger::is_terminal_redemption_event(
             &make_redemption_detected()
@@ -3008,7 +3031,7 @@ mod tests {
     }
 
     fn usdc(n: i64) -> Usdc {
-        Usdc(Decimal::from(n))
+        Usdc(ed(&n.to_string()))
     }
 
     fn make_usdc_initiated(direction: RebalanceDirection, amount: Usdc) -> UsdcRebalanceEvent {
@@ -3043,8 +3066,8 @@ mod tests {
     fn make_usdc_bridged() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::Bridged {
             mint_tx_hash: TxHash::random(),
-            amount_received: Usdc(dec!(99.99)),
-            fee_collected: Usdc(dec!(0.01)),
+            amount_received: Usdc(ed("99.99")),
+            fee_collected: Usdc(ed("0.01")),
             minted_at: Utc::now(),
         }
     }
@@ -3222,14 +3245,14 @@ mod tests {
     fn deserialize_config_succeeds() {
         let config: RebalancingConfig = toml::from_str(valid_rebalancing_config_toml()).unwrap();
 
-        assert_eq!(config.equity.target, dec!(0.5));
-        assert_eq!(config.equity.deviation, dec!(0.2));
+        assert_eq!(config.equity.target, ed("0.5"));
+        assert_eq!(config.equity.deviation, ed("0.2"));
 
         let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
             panic!("expected enabled");
         };
-        assert_eq!(target, dec!(0.5));
-        assert_eq!(deviation, dec!(0.3));
+        assert_eq!(target, ed("0.5"));
+        assert_eq!(deviation, ed("0.3"));
         assert_eq!(
             config.redemption_wallet,
             address!("1234567890123456789012345678901234567890")
@@ -3284,14 +3307,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(config.equity.target, dec!(0.6));
-        assert_eq!(config.equity.deviation, dec!(0.1));
+        assert_eq!(config.equity.target, ed("0.6"));
+        assert_eq!(config.equity.deviation, ed("0.1"));
 
         let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
             panic!("expected enabled");
         };
-        assert_eq!(target, dec!(0.4));
-        assert_eq!(deviation, dec!(0.15));
+        assert_eq!(target, ed("0.4"));
+        assert_eq!(deviation, ed("0.15"));
     }
 
     #[test]
@@ -3442,7 +3465,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::Initiate {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(500)),
+                    amount: Usdc(ed("500")),
                     withdrawal: TransferRef::OnchainTx(tx_hash),
                 },
             )
@@ -3478,8 +3501,8 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ConfirmBridging {
                     mint_tx: tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                 },
             )
             .await
@@ -3528,7 +3551,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::Initiate {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000)),
+                    amount: Usdc(ed("1000")),
                     withdrawal: TransferRef::AlpacaId(transfer_id),
                 },
             )
@@ -3564,8 +3587,8 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ConfirmBridging {
                     mint_tx: tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                 },
             )
             .await
@@ -3610,7 +3633,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::Initiate {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100)),
+                    amount: Usdc(ed("100")),
                     withdrawal: TransferRef::AlpacaId(transfer_id),
                 },
             )
@@ -3653,7 +3676,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::Initiate {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100)),
+                    amount: Usdc(ed("100")),
                     withdrawal: TransferRef::AlpacaId(transfer_id),
                 },
             )
@@ -3706,7 +3729,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::InitiateConversion {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100)),
+                    amount: Usdc(ed("100")),
                     order_id: uuid::Uuid::new_v4(),
                 },
             )
@@ -3739,7 +3762,7 @@ mod tests {
         let (sender, _receiver) = mpsc::channel(10);
         let pool = crate::test_utils::setup_test_db().await;
         let inventory = Arc::new(tokio::sync::RwLock::new(
-            InventoryView::default().with_usdc(Usdc(dec!(5000)), Usdc(dec!(5000))),
+            InventoryView::default().with_usdc(Usdc(ed("5000")), Usdc(ed("5000"))),
         ));
 
         let trigger = Arc::new(RebalancingTrigger::new(
@@ -3769,7 +3792,7 @@ mod tests {
                 id.clone(),
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000)),
+                    amount: Usdc(ed("1000")),
                     withdrawal_ref: TransferRef::OnchainTx(tx_hash),
                     initiated_at: chrono::Utc::now(),
                 },
@@ -3809,7 +3832,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::Initiate {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(500)),
+                    amount: Usdc(ed("500")),
                     withdrawal: TransferRef::OnchainTx(tx_hash),
                 },
             )
@@ -3845,8 +3868,8 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ConfirmBridging {
                     mint_tx: tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                 },
             )
             .await
@@ -3873,7 +3896,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::InitiatePostDepositConversion {
                     order_id: uuid::Uuid::new_v4(),
-                    amount: Usdc(dec!(500)),
+                    amount: Usdc(ed("500")),
                 },
             )
             .await
@@ -3898,7 +3921,7 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: Usdc(dec!(499)), // ~0.2% slippage
+                    filled_amount: Usdc(ed("499")), // ~0.2% slippage
                 },
             )
             .await
@@ -4196,8 +4219,8 @@ mod tests {
 
         let config = RebalancingConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             },
             usdc: UsdcRebalancing::Disabled,
             redemption_wallet: Address::ZERO,
@@ -4252,8 +4275,8 @@ mod tests {
         // Anvil's default chain ID is 31337
         let config = RebalancingConfig {
             equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+                target: ed("0.5"),
+                deviation: ed("0.2"),
             },
             usdc: UsdcRebalancing::Disabled,
             redemption_wallet: Address::ZERO,

--- a/src/rebalancing/usdc/mock.rs
+++ b/src/rebalancing/usdc/mock.rs
@@ -136,9 +136,13 @@ impl CrossVenueTransfer<MarketMakingVenue, HedgingVenue> for MockUsdcRebalance {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
+    use std::str::FromStr;
 
     use super::*;
+
+    fn usdc(value: &str) -> Usdc {
+        Usdc::from_str(value).unwrap()
+    }
 
     #[test]
     fn new_mock_starts_with_zero_counts() {
@@ -158,13 +162,13 @@ mod tests {
     async fn alpaca_to_base_increments_count() {
         let mock = MockUsdcRebalance::new();
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(100)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("100"))
             .await
             .unwrap();
 
         assert_eq!(mock.alpaca_to_base_calls(), 1);
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(200)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("200"))
             .await
             .unwrap();
 
@@ -175,13 +179,13 @@ mod tests {
     async fn base_to_alpaca_increments_count() {
         let mock = MockUsdcRebalance::new();
 
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, Usdc(dec!(100)))
+        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, usdc("100"))
             .await
             .unwrap();
 
         assert_eq!(mock.base_to_alpaca_calls(), 1);
 
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, Usdc(dec!(200)))
+        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, usdc("200"))
             .await
             .unwrap();
 
@@ -192,24 +196,24 @@ mod tests {
     async fn alpaca_to_base_captures_parameters() {
         let mock = MockUsdcRebalance::new();
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(999.99)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("999.99"))
             .await
             .unwrap();
 
         let call = mock.last_alpaca_to_base_call().unwrap();
-        assert_eq!(call.amount, Usdc(dec!(999.99)));
+        assert_eq!(call.amount, usdc("999.99"));
     }
 
     #[tokio::test]
     async fn base_to_alpaca_captures_parameters() {
         let mock = MockUsdcRebalance::new();
 
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, Usdc(dec!(1234.56)))
+        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, usdc("1234.56"))
             .await
             .unwrap();
 
         let call = mock.last_base_to_alpaca_call().unwrap();
-        assert_eq!(call.amount, Usdc(dec!(1234.56)));
+        assert_eq!(call.amount, usdc("1234.56"));
     }
 
     #[tokio::test]
@@ -217,8 +221,7 @@ mod tests {
         let mock = MockUsdcRebalance::failing_alpaca_to_base();
 
         let result =
-            CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(1)))
-                .await;
+            CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("1")).await;
 
         assert!(matches!(
             result,
@@ -231,8 +234,7 @@ mod tests {
         let mock = MockUsdcRebalance::failing_base_to_alpaca();
 
         let result =
-            CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, Usdc(dec!(1)))
-                .await;
+            CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, usdc("1")).await;
 
         assert!(matches!(
             result,
@@ -244,7 +246,7 @@ mod tests {
     async fn failing_mock_still_increments_count() {
         let mock = MockUsdcRebalance::failing_alpaca_to_base();
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(1)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("1"))
             .await
             .unwrap_err();
 
@@ -255,23 +257,23 @@ mod tests {
     async fn failing_mock_still_captures_last_call() {
         let mock = MockUsdcRebalance::failing_alpaca_to_base();
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(42)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("42"))
             .await
             .unwrap_err();
 
         let call = mock.last_alpaca_to_base_call().unwrap();
-        assert_eq!(call.amount, Usdc(dec!(42)));
+        assert_eq!(call.amount, usdc("42"));
     }
 
     #[tokio::test]
     async fn operations_are_independent() {
         let mock = MockUsdcRebalance::new();
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, Usdc(dec!(100)))
+        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(&mock, usdc("100"))
             .await
             .unwrap();
 
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, Usdc(dec!(200)))
+        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(&mock, usdc("200"))
             .await
             .unwrap();
 
@@ -281,7 +283,7 @@ mod tests {
         let atb = mock.last_alpaca_to_base_call().unwrap();
         let bta = mock.last_base_to_alpaca_call().unwrap();
 
-        assert_eq!(atb.amount, Usdc(dec!(100)));
-        assert_eq!(bta.amount, Usdc(dec!(200)));
+        assert_eq!(atb.amount, usdc("100"));
+        assert_eq!(bta.amount, usdc("200"));
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,9 +7,8 @@ use alloy::rpc::client::RpcClient;
 use alloy::rpc::types::{Log, TransactionReceipt};
 use async_trait::async_trait;
 use chrono::Utc;
-use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
+use st0x_exact_decimal::ExactDecimal;
 use std::sync::Arc;
 
 use st0x_evm::{Evm, EvmError, Wallet};
@@ -173,9 +172,9 @@ impl OnchainTradeBuilder {
                     .parse::<TokenizedSymbol<WrappedTokenizedShares>>()
                     .unwrap(),
                 equity_token: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                amount: FractionalShares::new(Decimal::ONE),
+                amount: FractionalShares::new(ExactDecimal::parse("1").unwrap()),
                 direction: Direction::Buy,
-                price: Usdc::new(dec!(150)).unwrap(),
+                price: Usdc::new(ExactDecimal::parse("150").unwrap()).unwrap(),
                 block_timestamp: Some(Utc::now()),
                 created_at: None,
                 gas_used: None,
@@ -203,13 +202,13 @@ impl OnchainTradeBuilder {
     }
 
     #[must_use]
-    pub(crate) fn with_amount(mut self, amount: Decimal) -> Self {
+    pub(crate) fn with_amount(mut self, amount: ExactDecimal) -> Self {
         self.trade.amount = FractionalShares::new(amount);
         self
     }
 
     #[must_use]
-    pub(crate) fn with_price(mut self, price: Decimal) -> Self {
+    pub(crate) fn with_price(mut self, price: ExactDecimal) -> Self {
         self.trade.price = Usdc::new(price).unwrap();
         self
     }

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -726,15 +726,19 @@ pub(crate) mod tests {
     use alloy::providers::ProviderBuilder;
     use httpmock::MockServer;
     use httpmock::prelude::*;
-    use rust_decimal_macros::dec;
     use serde_json::json;
     use std::time::Duration;
     use uuid::uuid;
 
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_evm::{Evm, OpenChainErrorRegistry};
+    use st0x_exact_decimal::ExactDecimal;
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
     use crate::bindings::TestERC20;
 
     pub(crate) const TEST_REDEMPTION_WALLET: Address =
@@ -808,7 +812,7 @@ pub(crate) mod tests {
     fn create_mint_request() -> MintRequest {
         MintRequest {
             underlying_symbol: Symbol::new("AAPL").unwrap(),
-            quantity: FractionalShares::new(dec!(100.5)),
+            quantity: FractionalShares::new(ed("100.5")),
             issuer: Issuer::new("st0x"),
             network: Network::new("base"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
@@ -863,7 +867,7 @@ pub(crate) mod tests {
             result.token_symbol.as_ref().map(ToString::to_string),
             Some("tAAPL".to_string())
         );
-        assert_eq!(result.quantity, FractionalShares::new(dec!(100.5)));
+        assert_eq!(result.quantity, FractionalShares::new(ed("100.5")));
         assert_eq!(result.issuer, Issuer::new("st0x"));
         assert_eq!(result.network, Network::new("base"));
         assert_eq!(
@@ -1421,7 +1425,7 @@ pub(crate) mod tests {
         });
 
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = FractionalShares::new(dec!(100.0));
+        let quantity = FractionalShares::new(ed("100.0"));
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let mint_result = service
@@ -1550,7 +1554,7 @@ pub(crate) mod tests {
         });
 
         let symbol = Symbol::new("AAPL").unwrap();
-        let quantity = FractionalShares::new(dec!(100.5));
+        let quantity = FractionalShares::new(ed("100.5"));
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let result = service

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -1261,12 +1261,16 @@ impl UsdcRebalance {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::fixed_bytes;
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
     use uuid::Uuid;
 
     use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     #[tokio::test]
     async fn test_initiate_alpaca_to_base() {
@@ -1276,7 +1280,7 @@ mod tests {
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal: TransferRef::AlpacaId(transfer_id),
             })
             .await
@@ -1295,7 +1299,7 @@ mod tests {
         };
 
         assert_eq!(*direction, RebalanceDirection::AlpacaToBase);
-        assert_eq!(*amount, Usdc(dec!(1000.00)));
+        assert_eq!(*amount, Usdc(ed("1000.00")));
         assert_eq!(*withdrawal_ref, TransferRef::AlpacaId(transfer_id));
     }
 
@@ -1308,7 +1312,7 @@ mod tests {
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::BaseToAlpaca,
-                amount: Usdc(dec!(500.50)),
+                amount: Usdc(ed("500.50")),
                 withdrawal: TransferRef::OnchainTx(tx_hash),
             })
             .await
@@ -1327,7 +1331,7 @@ mod tests {
         };
 
         assert_eq!(*direction, RebalanceDirection::BaseToAlpaca);
-        assert_eq!(*amount, Usdc(dec!(500.50)));
+        assert_eq!(*amount, Usdc(ed("500.50")));
         assert_eq!(*withdrawal_ref, TransferRef::OnchainTx(tx_hash));
     }
 
@@ -1338,13 +1342,13 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::BaseToAlpaca,
-                amount: Usdc(dec!(500.00)),
+                amount: Usdc(ed("500.00")),
                 withdrawal: TransferRef::AlpacaId(transfer_id),
             })
             .await
@@ -1371,13 +1375,13 @@ mod tests {
         let error = replay::<UsdcRebalance>(vec![
             UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                 initiated_at: Utc::now(),
             },
             UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::BaseToAlpaca,
-                amount: Usdc(dec!(500.00)),
+                amount: Usdc(ed("500.00")),
                 withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
                     "0x0000000000000000000000000000000000000000000000000000000000000001"
                 )),
@@ -1396,7 +1400,7 @@ mod tests {
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
@@ -1433,7 +1437,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1458,7 +1462,7 @@ mod tests {
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
@@ -1499,7 +1503,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1527,7 +1531,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1558,7 +1562,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1612,7 +1616,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
@@ -1638,7 +1642,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1669,7 +1673,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1704,7 +1708,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1759,7 +1763,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
@@ -1784,7 +1788,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1813,7 +1817,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1845,7 +1849,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1887,7 +1891,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1906,8 +1910,8 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ConfirmBridging {
                 mint_tx: mint_tx_hash,
-                amount_received: Usdc(dec!(99.99)),
-                fee_collected: Usdc(dec!(0.01)),
+                amount_received: Usdc(ed("99.99")),
+                fee_collected: Usdc(ed("0.01")),
             })
             .await
             .events();
@@ -1936,7 +1940,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -1950,8 +1954,8 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ConfirmBridging {
                 mint_tx: mint_tx_hash,
-                amount_received: Usdc(dec!(99.99)),
-                fee_collected: Usdc(dec!(0.01)),
+                amount_received: Usdc(ed("99.99")),
+                fee_collected: Usdc(ed("0.01")),
             })
             .await
             .then_expect_error();
@@ -1972,7 +1976,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2017,7 +2021,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2066,7 +2070,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2116,7 +2120,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2134,8 +2138,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
             ])
@@ -2143,8 +2147,8 @@ mod tests {
                 mint_tx: fixed_bytes!(
                     "0x2222222222222222222222222222222222222222222222222222222222222222"
                 ),
-                amount_received: Usdc(dec!(99.99)),
-                fee_collected: Usdc(dec!(0.01)),
+                amount_received: Usdc(ed("99.99")),
+                fee_collected: Usdc(ed("0.01")),
             })
             .await
             .then_expect_error();
@@ -2167,7 +2171,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2185,8 +2189,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
             ])
@@ -2212,7 +2216,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2257,7 +2261,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2275,8 +2279,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
             ])
@@ -2314,7 +2318,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(500.00)),
+                    amount: Usdc(ed("500.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2332,8 +2336,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
             ])
@@ -2366,7 +2370,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2410,7 +2414,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2428,8 +2432,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2461,7 +2465,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2479,8 +2483,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
             ])
@@ -2509,7 +2513,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(500.00)),
+                    amount: Usdc(ed("500.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2527,8 +2531,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2572,7 +2576,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2590,8 +2594,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2631,7 +2635,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(10000.00)),
+                    amount: Usdc(ed("10000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                     initiated_at: Utc::now(),
                 },
@@ -2649,8 +2653,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2683,7 +2687,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(5000.00)),
+                    amount: Usdc(ed("5000.00")),
                     withdrawal_ref: TransferRef::OnchainTx(withdrawal_tx),
                     initiated_at: Utc::now(),
                 },
@@ -2701,8 +2705,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2727,7 +2731,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2755,7 +2759,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2783,7 +2787,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2825,7 +2829,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2845,8 +2849,8 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ConfirmBridging {
                 mint_tx,
-                amount_received: Usdc(dec!(99.99)),
-                fee_collected: Usdc(dec!(0.01)),
+                amount_received: Usdc(ed("99.99")),
+                fee_collected: Usdc(ed("0.01")),
             })
             .await
             .then_expect_error();
@@ -2868,7 +2872,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2886,8 +2890,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2921,7 +2925,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2939,8 +2943,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -2954,7 +2958,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(100.00)),
+                amount: Usdc(ed("100.00")),
                 withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
             })
             .await
@@ -2977,7 +2981,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(100.00)),
+                    amount: Usdc(ed("100.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -2995,8 +2999,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -3026,7 +3030,7 @@ mod tests {
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 order_id,
             })
             .await
@@ -3044,7 +3048,7 @@ mod tests {
         };
 
         assert_eq!(*direction, RebalanceDirection::AlpacaToBase);
-        assert_eq!(*amount, Usdc(dec!(1000.00)));
+        assert_eq!(*amount, Usdc(ed("1000.00")));
         assert_eq!(*event_order_id, order_id);
     }
 
@@ -3055,13 +3059,13 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 order_id,
                 initiated_at: Utc::now(),
             }])
             .when(UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(500.00)),
+                amount: Usdc(ed("500.00")),
                 order_id: Uuid::new_v4(),
             })
             .await
@@ -3076,12 +3080,12 @@ mod tests {
     #[tokio::test]
     async fn test_confirm_conversion_from_converting_state() {
         let order_id = Uuid::new_v4();
-        let filled_amount = Usdc(dec!(998));
+        let filled_amount = Usdc(ed("998"));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 order_id,
                 initiated_at: Utc::now(),
             }])
@@ -3101,7 +3105,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc(dec!(998)),
+                filled_amount: Usdc(ed("998")),
             })
             .await
             .then_expect_error();
@@ -3120,18 +3124,18 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     order_id,
                     initiated_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc(dec!(998)),
+                    filled_amount: Usdc(ed("998")),
                     converted_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc(dec!(998)),
+                filled_amount: Usdc(ed("998")),
             })
             .await
             .then_expect_error();
@@ -3149,7 +3153,7 @@ mod tests {
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 order_id,
                 initiated_at: Utc::now(),
             }])
@@ -3190,13 +3194,13 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     order_id,
                     initiated_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc(dec!(998)),
+                    filled_amount: Usdc(ed("998")),
                     converted_at: Utc::now(),
                 },
             ])
@@ -3216,13 +3220,13 @@ mod tests {
     async fn test_initiate_withdrawal_after_conversion_complete() {
         let order_id = Uuid::new_v4();
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc(dec!(998));
+        let filled_amount = Usdc(ed("998"));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     order_id,
                     initiated_at: Utc::now(),
                 },
@@ -3248,13 +3252,13 @@ mod tests {
     async fn test_initiate_with_mismatched_amount_from_conversion_complete_fails() {
         let order_id = Uuid::new_v4();
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc(dec!(998));
+        let filled_amount = Usdc(ed("998"));
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     order_id,
                     initiated_at: Utc::now(),
                 },
@@ -3266,7 +3270,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(999.00)),
+                amount: Usdc(ed("999.00")),
                 withdrawal: TransferRef::AlpacaId(transfer_id),
             })
             .await
@@ -3294,7 +3298,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::OnchainTx(burn_tx),
                     initiated_at: Utc::now(),
                 },
@@ -3312,8 +3316,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -3327,7 +3331,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
                 order_id,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
             })
             .await
             .events();
@@ -3344,7 +3348,7 @@ mod tests {
         };
 
         assert_eq!(*direction, RebalanceDirection::BaseToAlpaca);
-        assert_eq!(*amount, Usdc(dec!(1000.00)));
+        assert_eq!(*amount, Usdc(ed("1000.00")));
         assert_eq!(*event_order_id, order_id);
     }
 
@@ -3359,7 +3363,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::AlpacaToBase,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                     initiated_at: Utc::now(),
                 },
@@ -3377,8 +3381,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -3392,7 +3396,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
                 order_id: Uuid::new_v4(),
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
             })
             .await
             .then_expect_error();
@@ -3409,7 +3413,7 @@ mod tests {
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
                 order_id: Uuid::new_v4(),
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
             })
             .await
             .then_expect_error();
@@ -3431,7 +3435,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::OnchainTx(burn_tx),
                     initiated_at: Utc::now(),
                 },
@@ -3449,8 +3453,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -3464,7 +3468,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
                 order_id: Uuid::new_v4(),
-                amount: Usdc(dec!(500.00)),
+                amount: Usdc(ed("500.00")),
             })
             .await
             .then_expect_error();
@@ -3473,7 +3477,7 @@ mod tests {
             matches!(
                 &error,
                 LifecycleError::Apply(UsdcRebalanceError::ConversionAmountMismatch { expected, provided })
-                    if *expected == Usdc(dec!(1000.00)) && *provided == Usdc(dec!(500.00))
+                    if *expected == Usdc(ed("1000.00")) && *provided == Usdc(ed("500.00"))
             ),
             "Expected ConversionAmountMismatch with expected=1000 and provided=500, got: {error:?}"
         );
@@ -3491,7 +3495,7 @@ mod tests {
             .given(vec![
                 UsdcRebalanceEvent::Initiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     withdrawal_ref: TransferRef::OnchainTx(burn_tx),
                     initiated_at: Utc::now(),
                 },
@@ -3509,8 +3513,8 @@ mod tests {
                 },
                 UsdcRebalanceEvent::Bridged {
                     mint_tx_hash: mint_tx,
-                    amount_received: Usdc(dec!(99.99)),
-                    fee_collected: Usdc(dec!(0.01)),
+                    amount_received: Usdc(ed("99.99")),
+                    fee_collected: Usdc(ed("0.01")),
                     minted_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::DepositInitiated {
@@ -3523,13 +3527,13 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::BaseToAlpaca,
-                    amount: Usdc(dec!(1000.00)),
+                    amount: Usdc(ed("1000.00")),
                     order_id,
                     initiated_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc(dec!(998)),
+                filled_amount: Usdc(ed("998")),
             })
             .await
             .events();
@@ -3545,7 +3549,7 @@ mod tests {
     fn conversion_confirmed_on_uninitialized_produces_failed_state() {
         let error = replay::<UsdcRebalance>(vec![UsdcRebalanceEvent::ConversionConfirmed {
             direction: RebalanceDirection::BaseToAlpaca,
-            filled_amount: Usdc(dec!(998)),
+            filled_amount: Usdc(ed("998")),
             converted_at: Utc::now(),
         }])
         .unwrap_err();
@@ -3558,13 +3562,13 @@ mod tests {
         let error = replay::<UsdcRebalance>(vec![
             UsdcRebalanceEvent::Initiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
                 initiated_at: Utc::now(),
             },
             UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: Usdc(dec!(1000.00)),
+                amount: Usdc(ed("1000.00")),
                 order_id: Uuid::new_v4(),
                 initiated_at: Utc::now(),
             },

--- a/src/wrapper/ratio.rs
+++ b/src/wrapper/ratio.rs
@@ -77,9 +77,13 @@ impl UnderlyingPerWrapped {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal_macros::dec;
+    use st0x_exact_decimal::ExactDecimal;
 
     use super::*;
+
+    fn ed(value: &str) -> ExactDecimal {
+        ExactDecimal::parse(value).unwrap()
+    }
 
     #[test]
     fn one_to_one_ratio_converts_identity() {
@@ -142,11 +146,11 @@ mod tests {
     #[test]
     fn fractional_one_to_one_converts_identity() {
         let ratio = UnderlyingPerWrapped::new(RATIO_ONE).unwrap();
-        let wrapped = FractionalShares::new(dec!(100));
+        let wrapped = FractionalShares::new(ed("100"));
 
         let underlying = ratio.to_underlying_fractional(wrapped).unwrap();
 
-        assert_eq!(underlying.inner(), dec!(100));
+        assert_eq!(underlying.inner(), ed("100"));
     }
 
     #[test]
@@ -156,10 +160,10 @@ mod tests {
         let ratio = UnderlyingPerWrapped::new(assets_per_share).unwrap();
 
         // 100 wrapped should give 105 underlying
-        let wrapped = FractionalShares::new(dec!(100));
+        let wrapped = FractionalShares::new(ed("100"));
         let underlying = ratio.to_underlying_fractional(wrapped).unwrap();
 
-        assert_eq!(underlying.inner(), dec!(105));
+        assert_eq!(underlying.inner(), ed("105"));
     }
 
     #[test]
@@ -169,10 +173,10 @@ mod tests {
         let ratio = UnderlyingPerWrapped::new(assets_per_share).unwrap();
 
         // 50 wrapped should give 100 underlying
-        let wrapped = FractionalShares::new(dec!(50));
+        let wrapped = FractionalShares::new(ed("50"));
         let underlying = ratio.to_underlying_fractional(wrapped).unwrap();
 
-        assert_eq!(underlying.inner(), dec!(100));
+        assert_eq!(underlying.inner(), ed("100"));
     }
 
     #[test]
@@ -189,10 +193,10 @@ mod tests {
     #[test]
     fn fractional_conversion_handles_small_values() {
         let ratio = UnderlyingPerWrapped::new(RATIO_ONE).unwrap();
-        let wrapped = FractionalShares::new(dec!(0.000001));
+        let wrapped = FractionalShares::new(ed("0.000001"));
 
         let underlying = ratio.to_underlying_fractional(wrapped).unwrap();
 
-        assert_eq!(underlying.inner(), dec!(0.000001));
+        assert_eq!(underlying.inner(), ed("0.000001"));
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> Chained to #320, #319, #318, #317, #316

Closes #312

## Motivation

`rust_decimal::Decimal` has a 96-bit mantissa (~28 significant digits). When converting from Rain's onchain `Float` type (224-bit coefficient + 32-bit exponent) or from `U256` values with 18 decimal places, `Decimal` introduces **spurious trailing digits** beyond the token's native precision. For example, a 7.5-share trade becomes `7.5000000000000000000000000375`.

These precision artifacts are not cosmetic. They cause **hard production failures**:

1. **Equity rebalancing blocked**: `to_u256_18_decimals()` calls `scaled.fract() != 0` check, which rejects the noisy value with `SharesConversion(PrecisionLoss(...))`. Equity rebalancing can never fire.
2. **Inventory checks fail**: `InsufficientAvailable` errors because `7.500...375 != 0` comparison mismatches prevent position reconciliation.
3. **Position drift**: Accumulated long/short positions carry noise, compounding over time across trades.

This was discovered via E2E rebalancing tests exercising the full pipeline on Anvil — the same failures would occur on mainnet.

## Solution

### New `ExactDecimal` type (`crates/exact-decimal/`)

A newtype wrapper around Rain's `Float` (224-bit coefficient + 32-bit exponent) that provides the standard Rust trait implementations (`PartialEq`, `Eq`, `Ord`, `Add`, `Sub`, `Mul`, `Div`, `Serialize`, `Deserialize`, `Display`, `FromStr`) that `Float` itself cannot offer because its operations are fallible EVM calls.

Key design decisions:
- **All arithmetic returns `Result<Self, FloatError>`** — no silent overflow, no precision loss, no panics in production code
- **Serde backward compatibility**: serializes as decimal strings (`"1.5"`), deserializes from both decimal strings AND hex B256 strings (for existing event payloads)
- **`PartialEq`/`Eq`/`Ord`** delegate to Float's EVM-based comparison. These panic only on malformed B256 data that cannot occur through valid construction paths (documented invariant)
- **No `rust_decimal` dependency** — the exact-decimal crate is intentionally free of the library it replaces

### Migration strategy

**Internal computation**: All `Decimal` usage replaced with `ExactDecimal` throughout the codebase — position tracking, onchain trade conversion, inventory snapshots, rebalancing triggers, threshold checks, USDC amounts.

**Broker API boundaries**: `rust_decimal::Decimal` is retained **only** at the edges where third-party crates require it:
- **Alpaca Trading API** (`apca` crate): `FractionalShares::to_decimal()` converts to `Decimal` for the `Num` type
- **Alpaca Broker API**: Response parsing converts `Decimal` fields to `ExactDecimal` via `from_decimal()`
- **Schwab**: Weighted-average fill price computation stays in `Decimal` internally, converts at the boundary

These boundary conversions use a string roundtrip (`ExactDecimal -> format_decimal() -> parse::<Decimal>()` and vice versa). This preserves all significant digits within Decimal's 96-bit mantissa, which is sufficient for typical share quantities and dollar amounts at broker APIs.

### What changed in `FractionalShares` (`crates/execution/src/lib.rs`)

| Before | After |
|--------|-------|
| `FractionalShares(Decimal)` | `FractionalShares(ExactDecimal)` |
| `Add/Sub/Mul` return `Result<Self, ArithmeticError<Self>>` | `Add/Sub/Mul` return `Result<Self, FloatError>` |
| `abs()` returns `Self` (infallible) | `abs()` returns `Result<Self, FloatError>` |
| `is_whole()` returns `bool` | `is_whole()` returns `Result<bool, FloatError>` |
| `to_u256_18_decimals()` uses `TOKENIZED_EQUITY_SCALE` constant + `checked_mul` | Uses `ExactDecimal::to_fixed_decimal_lossy(18)` directly |
| `from_u256_18_decimals()` parses string, divides by scale | Uses `ExactDecimal::from_fixed_decimal(value, 18)` directly |
| `to_whole_shares()` used `Decimal::to_u64()` | Uses `integer() -> format_decimal() -> parse::<u64>()` |

### What changed in `Usdc` (`src/threshold.rs`)

Same pattern: inner type changed from `Decimal` to `ExactDecimal`. `Add`/`Sub`/`Mul` now return `Result<Self, FloatError>`.

### What changed in `SharesConversionError`

Simplified from 5 variants (`NegativeValue`, `Underflow`, `Overflow`, `DecimalConversion`, `PrecisionLoss`) to 2 variants (`NegativeValue`, `FloatConversion`). The `Underflow` and `PrecisionLoss` variants are no longer needed because `to_fixed_decimal_lossy` handles truncation explicitly (documented as acceptable since ERC-20 tokens are 18 decimals and extra precision is representational noise).

### What changed in `UsdcTransferError` (`src/rebalancing/usdc/mod.rs`)

The `Aggregate` variant's `SendError<UsdcRebalance>` (128+ bytes) is now boxed to eliminate `clippy::result_large_err` warnings on all USDC transfer functions. A manual `From<SendError<...>>` impl auto-boxes at conversion.

### Error handling discipline

Every `ExactDecimal` operation is fallible. Throughout the migration:
- **Production code**: uses `?` propagation or `.ok()?` for optional contexts
- **Test code**: uses `.unwrap()` (allowed by project convention)
- **Property tests**: use `TestCaseError::Fail` to surface `FloatError` as test failures (not silently swallowed)

### Test coverage

- **New crate tests**: 29 tests (6 property-based) covering parsing roundtrips, serde, fixed-point conversions, arithmetic, comparisons
- **Restored proptests on `FractionalShares`**: 5 property-based tests (construction preserves value, positive rejects zero/negative, is_whole matches frac, to_whole roundtrips integers, to_whole rejects fractional)
- **Arithmetic error test**: division by zero returns `FloatError`
- **All existing tests migrated**: `dec!(...)` -> `ed("...")` throughout, assertions updated for Result-returning operations
- **1378 unit/integration tests pass**, 0 clippy errors

## Risk Assessment

### What could break

1. **Serde format change**: `ExactDecimal` serializes as `"1.5"` (string) — same as `Decimal`. Existing event payloads in the database are backward-compatible. Deserialization accepts both decimal strings and hex B256 strings.

2. **Comparison semantics**: `ExactDecimal` comparisons use EVM-based Float comparison, not Decimal's. For values that originated from the same source, these are equivalent. For values constructed from strings (e.g., `"1.5"`), Float's representation may differ from Decimal's bit pattern but the logical comparison is identical.

3. **Lossy U256 conversion**: `to_u256_18_decimals` now uses `to_fixed_decimal_lossy(18)` which truncates beyond 18 decimal places. This is intentional — ERC-20 tokens have exactly 18 decimals, so sub-wei precision is noise. The old code rejected these values with `PrecisionLoss` error, which caused the production failures described in #312.

4. **Broker API boundary precision**: The string roundtrip through `Decimal` at Alpaca/Schwab boundaries could theoretically lose precision for values exceeding Decimal's 96-bit mantissa. In practice, share quantities (0.001 to 1,000,000) and dollar amounts fit comfortably.

### What cannot break

- **Onchain operations**: `ExactDecimal` wraps the same `Float` type used by Rain's onchain contracts. Roundtrips through `from_fixed_decimal`/`to_fixed_decimal` are lossless for values that fit in the requested decimal places.
- **Event sourcing**: Serde format is identical (decimal strings). No migration needed.
- **Database schema**: No schema changes. Events are stored as JSON with string-encoded decimals.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)