### PR TITLE
Add configurations to bot ctx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ name = "st0x-hedge"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+test-support = ["st0x-bridge/test-support"]
+
 [dependencies]
 alloy.workspace = true
 anyhow = "1.0.98"

--- a/crates/bridge/Cargo.toml
+++ b/crates/bridge/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 default = []
+test-support = []
 cctp = [
   "dep:backon",
   "dep:reqwest",

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -117,11 +117,20 @@ impl BridgeDirection {
 }
 
 /// CCTP TokenMessengerV2 contract address (same on all supported chains).
+#[cfg(any(test, feature = "test-support"))]
+pub const TOKEN_MESSENGER_V2: Address = address!("0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d");
+#[cfg(not(any(test, feature = "test-support")))]
 const TOKEN_MESSENGER_V2: Address = address!("0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d");
 
 /// CCTP MessageTransmitterV2 contract address (same on all supported chains).
+#[cfg(any(test, feature = "test-support"))]
+pub const MESSAGE_TRANSMITTER_V2: Address = address!("0x81D40F21F12A8F0E3252Bccb954D722d4c464B64");
+#[cfg(not(any(test, feature = "test-support")))]
 const MESSAGE_TRANSMITTER_V2: Address = address!("0x81D40F21F12A8F0E3252Bccb954D722d4c464B64");
 
+#[cfg(any(test, feature = "test-support"))]
+pub const CIRCLE_API_BASE: &str = "https://iris-api.circle.com";
+#[cfg(not(any(test, feature = "test-support")))]
 const CIRCLE_API_BASE: &str = "https://iris-api.circle.com";
 
 /// Minimum finality threshold for CCTP V2 fast transfer (enables ~30 second transfers)
@@ -223,9 +232,9 @@ fn extract_nonce_from_message(message: &[u8]) -> Result<FixedBytes<32>, CctpErro
 /// Runtime context for constructing a [`CctpBridge`].
 ///
 /// Provides the minimal set of values needed to construct the bridge.
-/// CCTP contract addresses are hardcoded internally since they're the
-/// same on all supported chains. Providers are obtained from the wallets
-/// via [`Wallet::provider()`].
+/// CCTP contract addresses default to production addresses but can be
+/// overridden for testing with locally deployed contracts.
+/// Providers are obtained from the wallets via [`Wallet::provider()`].
 pub struct CctpCtx<EthWallet, BaseWallet> {
     /// USDC token address on Ethereum
     pub usdc_ethereum: Address,
@@ -235,6 +244,15 @@ pub struct CctpCtx<EthWallet, BaseWallet> {
     pub ethereum_wallet: EthWallet,
     /// Wallet for submitting transactions on Base
     pub base_wallet: BaseWallet,
+    /// Circle attestation/fee API base URL (test-only override).
+    #[cfg(any(test, feature = "test-support"))]
+    pub circle_api_base: String,
+    /// `TokenMessengerV2` contract address (test-only override).
+    #[cfg(any(test, feature = "test-support"))]
+    pub token_messenger: Address,
+    /// `MessageTransmitterV2` contract address (test-only override).
+    #[cfg(any(test, feature = "test-support"))]
+    pub message_transmitter: Address,
 }
 
 /// Circle CCTP bridge for Ethereum <-> Base USDC transfers.
@@ -329,20 +347,38 @@ struct FeeEntry {
 impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     /// Constructs a `CctpBridge` from a runtime context.
     pub fn try_from_ctx(ctx: CctpCtx<EthWallet, BaseWallet>) -> Result<Self, CctpError> {
+        #[cfg(any(test, feature = "test-support"))]
+        let token_messenger = ctx.token_messenger;
+        #[cfg(not(any(test, feature = "test-support")))]
+        let token_messenger = TOKEN_MESSENGER_V2;
+
+        #[cfg(any(test, feature = "test-support"))]
+        let message_transmitter = ctx.message_transmitter;
+        #[cfg(not(any(test, feature = "test-support")))]
+        let message_transmitter = MESSAGE_TRANSMITTER_V2;
+
         let ethereum = CctpEndpoint::new(
             ctx.usdc_ethereum,
-            TOKEN_MESSENGER_V2,
-            MESSAGE_TRANSMITTER_V2,
+            token_messenger,
+            message_transmitter,
             ctx.ethereum_wallet,
         );
 
         let base = CctpEndpoint::new(
             ctx.usdc_base,
-            TOKEN_MESSENGER_V2,
-            MESSAGE_TRANSMITTER_V2,
+            token_messenger,
+            message_transmitter,
             ctx.base_wallet,
         );
 
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            let mut bridge = Self::new(ethereum, base)?;
+            bridge.circle_api_base = ctx.circle_api_base;
+            Ok(bridge)
+        }
+
+        #[cfg(not(any(test, feature = "test-support")))]
         Self::new(ethereum, base)
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -119,6 +119,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -549,6 +549,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -601,6 +603,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::AlpacaBrokerApi(AlpacaBrokerApiCtx {
                 api_key: "test-key".to_string(),
                 api_secret: "test-secret".to_string(),
@@ -610,7 +614,6 @@ mod tests {
                 time_in_force: TimeInForce::default(),
             }),
             telemetry: None,
-            equities: HashMap::new(),
             trading_mode: TradingMode::Rebalancing(Box::new(RebalancingCtx::stub(
                 ImbalanceThreshold {
                     target: dec!(0.5),
@@ -629,6 +632,7 @@ mod tests {
                 },
             ))),
             execution_threshold: ExecutionThreshold::whole_share(),
+            equities: HashMap::new(),
         }
     }
 

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -137,6 +137,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(schwab_auth.clone()),
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -90,6 +90,12 @@ pub(super) async fn cctp_bridge_command<Registry: IntoErrorRegistry, Writer: Wri
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        #[cfg(feature = "test-support")]
+        circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+        #[cfg(feature = "test-support")]
+        token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+        #[cfg(feature = "test-support")]
+        message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
     })?;
 
     let direction = from.to_bridge_direction();
@@ -144,6 +150,12 @@ pub(super) async fn cctp_recover_command<Writer: Write>(
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        #[cfg(feature = "test-support")]
+        circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+        #[cfg(feature = "test-support")]
+        token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+        #[cfg(feature = "test-support")]
+        message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
     })?;
 
     // Use the V2 API which returns both message and attestation from tx hash
@@ -254,6 +266,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1279,6 +1279,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -194,6 +194,12 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         usdc_base: USDC_BASE,
         ethereum_wallet: rebalancing_ctx.ethereum_wallet().clone(),
         base_wallet: rebalancing_ctx.base_wallet().clone(),
+        #[cfg(feature = "test-support")]
+        circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+        #[cfg(feature = "test-support")]
+        token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+        #[cfg(feature = "test-support")]
+        message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
     })?);
 
     let (_vault_store, vault_registry_projection) =
@@ -556,6 +562,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -528,6 +528,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_app_key".to_string(),
                 app_secret: "test_app_secret".to_string(),

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -167,6 +167,8 @@ mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,8 @@ struct Config {
     operational_limits: OperationalLimits,
     order_polling_interval: Option<u64>,
     order_polling_max_jitter: Option<u64>,
+    position_check_interval: Option<u64>,
+    inventory_poll_interval: Option<u64>,
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetryConfig>,
     rebalancing: Option<RebalancingConfig>,
@@ -132,6 +134,8 @@ pub struct Ctx {
     pub(crate) evm: EvmCtx,
     pub(crate) order_polling_interval: u64,
     pub(crate) order_polling_max_jitter: u64,
+    pub(crate) position_check_interval: u64,
+    pub(crate) inventory_poll_interval: u64,
     pub(crate) broker: BrokerCtx,
     pub telemetry: Option<TelemetryCtx>,
     pub(crate) trading_mode: TradingMode,
@@ -278,6 +282,8 @@ impl std::fmt::Debug for Ctx {
             .field("evm", &self.evm)
             .field("order_polling_interval", &self.order_polling_interval)
             .field("order_polling_max_jitter", &self.order_polling_max_jitter)
+            .field("position_check_interval", &self.position_check_interval)
+            .field("inventory_poll_interval", &self.inventory_poll_interval)
             .field("broker", &self.broker)
             .field("telemetry", &self.telemetry)
             .field("trading_mode", &self.trading_mode)
@@ -417,6 +423,8 @@ impl Ctx {
             evm,
             order_polling_interval: config.order_polling_interval.unwrap_or(15),
             order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
+            position_check_interval: config.position_check_interval.unwrap_or(60),
+            inventory_poll_interval: config.inventory_poll_interval.unwrap_or(60),
             broker,
             telemetry,
             trading_mode,
@@ -553,6 +561,7 @@ pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePo
     // (single INSERT per trade) to avoid blocking the main bot.
     let options: SqliteConnectOptions = database_url
         .parse::<SqliteConnectOptions>()?
+        .create_if_missing(true)
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(std::time::Duration::from_secs(10));
 
@@ -593,6 +602,8 @@ pub(crate) mod tests {
             },
             order_polling_interval: 15,
             order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
             broker: BrokerCtx::Schwab(SchwabAuth {
                 app_key: "test_key".to_owned(),
                 app_secret: "test_secret".to_owned(),
@@ -771,6 +782,8 @@ pub(crate) mod tests {
         assert_eq!(ctx.server_port, 8080);
         assert_eq!(ctx.order_polling_interval, 15);
         assert_eq!(ctx.order_polling_max_jitter, 5);
+        assert_eq!(ctx.position_check_interval, 60);
+        assert_eq!(ctx.inventory_poll_interval, 60);
     }
 
     #[tokio::test]
@@ -871,6 +884,8 @@ pub(crate) mod tests {
             server_port = 9090
             order_polling_interval = 30
             order_polling_max_jitter = 10
+            position_check_interval = 120
+            inventory_poll_interval = 90
 
             [equities]
 
@@ -892,6 +907,8 @@ pub(crate) mod tests {
         assert_eq!(ctx.server_port, 9090);
         assert_eq!(ctx.order_polling_interval, 30);
         assert_eq!(ctx.order_polling_max_jitter, 10);
+        assert_eq!(ctx.position_check_interval, 120);
+        assert_eq!(ctx.inventory_poll_interval, 90);
     }
 
     #[tokio::test]

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -84,6 +84,12 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             usdc_base: USDC_BASE,
             ethereum_wallet,
             base_wallet: base_wallet.clone(),
+            #[cfg(feature = "test-support")]
+            circle_api_base: ctx.circle_api_base.clone(),
+            #[cfg(feature = "test-support")]
+            token_messenger: ctx.token_messenger,
+            #[cfg(feature = "test-support")]
+            message_transmitter: ctx.message_transmitter,
         })?);
 
         let wrapper = Arc::new(WrapperService::new(base_wallet, equities));
@@ -329,6 +335,12 @@ mod tests {
                 usdc_base: USDC_BASE,
                 ethereum_wallet,
                 base_wallet: base_wallet.clone(),
+                #[cfg(feature = "test-support")]
+                circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+                #[cfg(feature = "test-support")]
+                token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+                #[cfg(feature = "test-support")]
+                message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
             })
             .unwrap(),
         );

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -132,6 +132,15 @@ pub(crate) struct RebalancingCtx {
     base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
     /// Pre-built wallet for Ethereum mainnet.
     ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+    /// Circle attestation/fee API base URL (test-only override).
+    #[cfg(feature = "test-support")]
+    pub circle_api_base: String,
+    /// `TokenMessengerV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub token_messenger: Address,
+    /// `MessageTransmitterV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub message_transmitter: Address,
 }
 
 impl RebalancingCtx {
@@ -177,6 +186,12 @@ impl RebalancingCtx {
             alpaca_broker_auth: broker_auth,
             base_wallet: Arc::new(base_wallet),
             ethereum_wallet: Arc::new(ethereum_wallet),
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
         })
     }
 
@@ -241,6 +256,12 @@ impl RebalancingCtx {
             alpaca_broker_auth,
             base_wallet: wallet.clone(),
             ethereum_wallet: wallet,
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
         }
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1043,6 +1043,12 @@ mod tests {
             usdc_base: USDC_ADDRESS,
             ethereum_wallet: wallet.clone(),
             base_wallet: wallet.clone(),
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
         })
         .unwrap();
 


### PR DESCRIPTION
## Motivation

Several operational parameters and CCTP infrastructure values were either hardcoded or missing from the bot context, creating two problems:

1. **Polling intervals not configurable** — `position_check_interval` and `inventory_poll_interval` were hardcoded, preventing operators from tuning them via the config TOML without code changes.
2. **E2E tests blocked for CCTP** — CCTP contract addresses (`TokenMessengerV2`, `MessageTransmitterV2`) and the Circle API base URL were private constants with no override mechanism, making it impossible to run e2e tests against locally deployed CCTP contracts.

## Solution

**Configurable polling intervals:**
- Added `position_check_interval` and `inventory_poll_interval` to `Config` (TOML-deserialized) and `Ctx` (runtime context), defaulting to 60 seconds when not specified.
- Both values are tested for default fallback and explicit override in the config parsing tests.

**CCTP test-support overrides:**
- Introduced a `test-support` feature flag in `st0x-bridge` (forwarded from the root crate) that conditionally exposes the production CCTP constants (`TOKEN_MESSENGER_V2`, `MESSAGE_TRANSMITTER_V2`, `CIRCLE_API_BASE`) as public and adds override fields to `CctpCtx` and `RebalancingCtx`.
- `CctpBridge::try_from_ctx` reads from the context fields when `test-support` is active, falling back to the hardcoded production addresses otherwise.
- All existing `CctpCtx` construction sites (CLI commands, rebalancer spawn, tests) are updated with the conditional fields.

**SQLite quality-of-life:**
- Added `create_if_missing(true)` to `SqliteConnectOptions` so the database file is created automatically on first run, avoiding a manual `sqlx db create` step.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)