### PR TITLE
Configurable polling, CCTP overrides, SQLite auto-create, and misc improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ rocket_ws = "0.1.1"
 toml = "0.9.11"
 rust_decimal_macros = "1.38.0"
 st0x-evm = { workspace = true, features = ["fireblocks"] }
+bon = "3.9.0"
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 default = []
 # Enable mock mode for testing from downstream crates
 mock = []
+# Expose test-only constructors (e.g. Symbol::force_new)
+test-support = []
 
 [dependencies]
 alloy.workspace = true

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -99,6 +99,10 @@ impl Symbol {
         }
         Ok(Self(symbol))
     }
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn force_new(symbol: String) -> Self {
+        Self(symbol)
+    }
 }
 
 impl<'de> Deserialize<'de> for Symbol {
@@ -745,7 +749,7 @@ mod tests {
     #[test]
     fn mul_decimal_succeeds() {
         let shares = FractionalShares::new(Decimal::from(100));
-        let ratio = Decimal::new(5, 1); // 0.5
+        let ratio = dec!(0.5);
         let result = (shares * ratio).unwrap();
         assert_eq!(result.inner(), Decimal::from(50));
     }

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -187,6 +187,7 @@ impl TryIntoExecutor for MockExecutorCtx {
 #[cfg(test)]
 mod tests {
     use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
 
     use super::*;
     use crate::{Direction, FractionalShares, Positive, Symbol};
@@ -287,7 +288,7 @@ mod tests {
             positions: vec![crate::EquityPosition {
                 symbol: Symbol::new("AAPL").unwrap(),
                 quantity: FractionalShares::new(Decimal::from(100)),
-                market_value: Some(Decimal::new(1_500_000, 2)),
+                market_value: Some(dec!(15000)),
             }],
             cash_balance_cents: 5_000_000,
         };

--- a/src/alpaca_wallet/transfer.rs
+++ b/src/alpaca_wallet/transfer.rs
@@ -346,11 +346,11 @@ mod tests {
 
         assert_eq!(transfer.id, AlpacaTransferId::new(transfer_id));
         assert_eq!(transfer.direction, TransferDirection::Outgoing);
-        assert_eq!(transfer.amount, Decimal::new(1005, 1));
+        assert_eq!(transfer.amount, dec!(100.5));
         assert_eq!(transfer.asset.as_ref(), "USDC");
         assert_eq!(transfer.to, expected_address);
         assert_eq!(transfer.status, TransferStatus::Pending);
-        assert_eq!(transfer.network_fee, Decimal::new(5, 1));
+        assert_eq!(transfer.network_fee, dec!(0.5));
 
         withdrawal_mock.assert();
     }
@@ -366,8 +366,8 @@ mod tests {
     #[test]
     fn test_initiate_withdrawal_negative_amount() {
         assert!(matches!(
-            Positive::new(Usdc(Decimal::new(-100, 0))).unwrap_err(),
-            InvalidSharesError::NonPositive(value) if value == Decimal::new(-100, 0)
+            Positive::new(Usdc(dec!(-100))).unwrap_err(),
+            InvalidSharesError::NonPositive(value) if value == dec!(-100)
         ));
     }
 
@@ -860,7 +860,7 @@ mod tests {
         );
         assert_eq!(
             transfer.amount,
-            Decimal::new(100, 0),
+            dec!(100),
             "Should return the 100 USDC withdrawal, not a 0.01 USDC deposit"
         );
         assert_eq!(transfer.direction, TransferDirection::Outgoing);

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -592,12 +592,14 @@ where
     })
 }
 
+#[bon::builder]
 fn spawn_periodic_accumulated_position_check<E>(
     executor: E,
     position: Arc<Store<Position>>,
     position_projection: Arc<Projection<Position>>,
     offchain_order: Arc<Store<OffchainOrder>>,
     execution_threshold: ExecutionThreshold,
+    check_interval: Duration,
     operational_limits: OperationalLimits,
     ctx: Ctx,
 ) -> JoinHandle<()>
@@ -608,9 +610,7 @@ where
     info!("Starting periodic accumulated position checker");
 
     tokio::spawn(async move {
-        const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
-
-        let mut interval = tokio::time::interval(CHECK_INTERVAL);
+        let mut interval = tokio::time::interval(check_interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
@@ -640,6 +640,7 @@ fn spawn_inventory_poller<Chain, Exe>(
     orderbook: Address,
     order_owner: Address,
     snapshot: Arc<Store<InventorySnapshot>>,
+    poll_interval: std::time::Duration,
 ) -> JoinHandle<()>
 where
     Chain: st0x_evm::Evm,
@@ -657,9 +658,7 @@ where
     );
 
     tokio::spawn(async move {
-        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
-
-        let mut interval = tokio::time::interval(POLL_INTERVAL);
+        let mut interval = tokio::time::interval(poll_interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {

--- a/src/config.rs
+++ b/src/config.rs
@@ -415,6 +415,20 @@ impl Ctx {
             }
         }
 
+        let position_check_interval = config.position_check_interval.unwrap_or(60);
+        if position_check_interval == 0 {
+            return Err(CtxError::ZeroPollingInterval {
+                field: "position_check_interval",
+            });
+        }
+
+        let inventory_poll_interval = config.inventory_poll_interval.unwrap_or(60);
+        if inventory_poll_interval == 0 {
+            return Err(CtxError::ZeroPollingInterval {
+                field: "inventory_poll_interval",
+            });
+        }
+
         Ok(Self {
             database_url: config.database_url,
             log_level,
@@ -423,8 +437,8 @@ impl Ctx {
             evm,
             order_polling_interval: config.order_polling_interval.unwrap_or(15),
             order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
-            position_check_interval: config.position_check_interval.unwrap_or(60),
-            inventory_poll_interval: config.inventory_poll_interval.unwrap_or(60),
+            position_check_interval,
+            inventory_poll_interval,
             broker,
             telemetry,
             trading_mode,
@@ -520,6 +534,8 @@ pub enum CtxError {
          minimum withdrawal of {minimum}"
     )]
     OperationalLimitBelowMinimumWithdrawal { configured: Usdc, minimum: Usdc },
+    #[error("{field} must be greater than 0")]
+    ZeroPollingInterval { field: &'static str },
 }
 
 #[cfg(test)]
@@ -543,6 +559,7 @@ impl CtxError {
             Self::OperationalLimitBelowMinimumWithdrawal { .. } => {
                 "operational limit below minimum withdrawal"
             }
+            Self::ZeroPollingInterval { .. } => "zero polling interval",
         }
     }
 }

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -248,6 +248,7 @@ mod tests {
     use alloy::providers::mock::Asserter;
     use alloy::providers::{Provider, ProviderBuilder};
     use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
     use sqlx::{Row, SqlitePool};
 
     use st0x_event_sorcery::{StoreBuilder, test_store};
@@ -314,12 +315,12 @@ mod tests {
                 EquityPosition {
                     symbol: test_symbol("AAPL"),
                     quantity: test_shares(100),
-                    market_value: Some(Decimal::new(1_500_000, 2)),
+                    market_value: Some(dec!(15000)),
                 },
                 EquityPosition {
                     symbol: test_symbol("MSFT"),
                     quantity: test_shares(50),
-                    market_value: Some(Decimal::new(2_000_000, 2)),
+                    market_value: Some(dec!(20000)),
                 },
             ],
             cash_balance_cents: 10_000_000,
@@ -498,7 +499,7 @@ mod tests {
             positions: vec![EquityPosition {
                 symbol: test_symbol("AAPL"),
                 quantity: test_shares(1000),
-                market_value: Some(Decimal::new(15_000_000, 2)),
+                market_value: Some(dec!(150000)),
             }],
             cash_balance_cents: -5_000_000, // -$50,000 (margin debt)
         };
@@ -540,12 +541,12 @@ mod tests {
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
         let (orderbook, order_owner) = test_addresses();
 
-        let fractional_qty = FractionalShares::new(Decimal::new(12345, 3)); // 12.345 shares
+        let fractional_qty = FractionalShares::new(dec!(12.345)); // 12.345 shares
         let inventory = Inventory {
             positions: vec![EquityPosition {
                 symbol: test_symbol("AAPL"),
                 quantity: fractional_qty,
-                market_value: Some(Decimal::new(185_175, 2)), // ~$1851.75
+                market_value: Some(dec!(1851.75)),
             }],
             cash_balance_cents: 1_000_000,
         };

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -223,7 +223,7 @@ pub(crate) enum InventorySnapshotEvent {
 }
 
 impl InventorySnapshotEvent {
-    fn timestamp(&self) -> DateTime<Utc> {
+    pub(crate) fn timestamp(&self) -> DateTime<Utc> {
         match self {
             Self::OnchainEquity { fetched_at, .. }
             | Self::OnchainCash { fetched_at, .. }

--- a/src/onchain/io.rs
+++ b/src/onchain/io.rs
@@ -577,6 +577,43 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "known precision dust bug - not yet patched"]
+    fn test_trade_details_normalizes_spurious_precision_beyond_onchain_scales() {
+        let usdc_with_dust = Decimal::from_str("64.169234000001").unwrap();
+        let shares_with_dust = Decimal::from_str("0.374000000000000000001").unwrap();
+
+        let details =
+            TradeDetails::try_from_io("USDC", usdc_with_dust, "wtNVDA", shares_with_dust).unwrap();
+
+        assert_eq!(details.usdc_amount().value(), dec!(64.169234));
+        assert_eq!(details.equity_amount().inner(), dec!(0.374));
+    }
+
+    #[test]
+    #[ignore = "known precision dust bug - not yet patched"]
+    fn test_trade_details_regression_precision_dust_breaks_exact_equality_without_normalization() {
+        let shares_with_dust = Decimal::from_str("0.200000000000000000001").unwrap();
+        let pre_fix_shares = FractionalShares::new(shares_with_dust);
+
+        assert_ne!(
+            pre_fix_shares,
+            FractionalShares::new(dec!(0.2)),
+            "Pre-fix behavior preserved dust and broke exact equality checks",
+        );
+
+        let details = TradeDetails::try_from_io(
+            "USDC",
+            Decimal::from_str("34.645024000001").unwrap(),
+            "wtNVDA",
+            shares_with_dust,
+        )
+        .unwrap();
+
+        assert_eq!(details.equity_amount().inner(), dec!(0.2));
+        assert_eq!(details.usdc_amount().value(), dec!(34.645024));
+    }
+
+    #[test]
     fn test_edge_case_validation_very_small_amounts() {
         let details =
             TradeDetails::try_from_io("USDC", dec!(0.01), "wtAAPL", dec!(0.0001)).unwrap();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -8,6 +8,7 @@ use alloy::rpc::types::{Log, TransactionReceipt};
 use async_trait::async_trait;
 use chrono::Utc;
 use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
@@ -174,7 +175,7 @@ impl OnchainTradeBuilder {
                 equity_token: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 amount: FractionalShares::new(Decimal::ONE),
                 direction: Direction::Buy,
-                price: Usdc::new(Decimal::new(150, 0)).unwrap(),
+                price: Usdc::new(dec!(150)).unwrap(),
                 block_timestamp: Some(Utc::now()),
                 created_at: None,
                 gas_used: None,

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn usdc_mul_decimal_succeeds() {
         let usdc = Usdc(Decimal::from(100));
-        let ratio = Decimal::new(5, 1); // 0.5
+        let ratio = dec!(0.5);
 
         let result = (usdc * ratio).unwrap();
 
@@ -309,13 +309,13 @@ mod tests {
     #[test]
     fn from_cents_converts_positive_cents_to_dollars() {
         let usdc = Usdc::from_cents(12345).unwrap();
-        assert_eq!(usdc.0, Decimal::new(12345, 2)); // 123.45
+        assert_eq!(usdc.0, dec!(123.45));
     }
 
     #[test]
     fn from_cents_converts_negative_cents_to_dollars() {
         let usdc = Usdc::from_cents(-500).unwrap();
-        assert_eq!(usdc.0, Decimal::new(-5, 0)); // -5.00
+        assert_eq!(usdc.0, dec!(-5));
     }
 
     #[test]

--- a/src/wrapper/ratio.rs
+++ b/src/wrapper/ratio.rs
@@ -77,7 +77,6 @@ impl UnderlyingPerWrapped {
 
 #[cfg(test)]
 mod tests {
-    use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
 
     use super::*;
@@ -190,10 +189,10 @@ mod tests {
     #[test]
     fn fractional_conversion_handles_small_values() {
         let ratio = UnderlyingPerWrapped::new(RATIO_ONE).unwrap();
-        let wrapped = FractionalShares::new(Decimal::new(1, 6)); // 0.000001
+        let wrapped = FractionalShares::new(dec!(0.000001));
 
         let underlying = ratio.to_underlying_fractional(wrapped).unwrap();
 
-        assert_eq!(underlying.inner(), Decimal::new(1, 6));
+        assert_eq!(underlying.inner(), dec!(0.000001));
     }
 }


### PR DESCRIPTION
## Motivation

Stacked on #342.

Several hardcoded values and missing configurability needed addressing:
- Position checker and inventory poller used hardcoded 60-second intervals
- CCTP bridge contract addresses and Circle API URL were hardcoded, blocking e2e tests with locally deployed contracts
- SQLite pool didn't auto-create the database file
- Test code used verbose `Decimal::new()` constructors instead of the `dec!()` macro

## Solution

**Configurable polling intervals:**
- Replace hardcoded `CHECK_INTERVAL` / `POLL_INTERVAL` constants with runtime parameters sourced from `Ctx.position_check_interval` and `Ctx.inventory_poll_interval`
- Use `#[bon::builder]` on `spawn_periodic_accumulated_position_check` for call-site readability
- New config fields default to 60s when omitted

**CCTP contract/API overrides:**
- Add optional `circle_api_base`, `token_messenger`, and `message_transmitter` fields to `CctpCtx` and `RebalancingCtx`
- When `None`, production addresses are used; when `Some`, the override is applied
- Enables e2e tests against locally deployed CCTP contracts

**SQLite auto-create:**
- Add `.create_if_missing(true)` to `configure_sqlite_pool` so the database file is created automatically on first run

**Execution crate additions:**
- Add `Symbol::inner()` accessor and `Symbol::force_new()` (gated behind `test-support` feature)

**Visibility change:**
- Widen `InventorySnapshotEvent::timestamp()` from private to `pub(crate)`

**Test improvements:**
- Replace `Decimal::new(...)` with `dec!(...)` macro across test assertions
- Add two `#[ignore]` regression tests documenting a known precision dust bug in `TradeDetails`

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background polling and spawn entry points now use a builder-style interface and accept configurable check/poll intervals.

* **Changes**
  * Runtime validation added for polling intervals; zero values now produce a specific configuration error.

* **Tests**
  * Many tests updated to use decimal literal macros for clearer numeric literals.
  * Two ignored regression tests added for decimal precision edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->