### PR TITLE
httmock upgrade to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,15 +1309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,39 +1316,6 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1375,134 +1333,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-object-pool"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+checksum = "e1ac0219111eb7bb7cb76d4cf2cb50c598e7ae549091d3616f9e95442c18486f"
 dependencies = [
- "async-std",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
  "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
+ "event-listener",
 ]
 
 [[package]]
@@ -1526,12 +1374,6 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1648,17 +1490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "basic-cookies"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
-dependencies = [
- "lalrpop",
- "lalrpop-util",
- "regex",
-]
-
-[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,27 +1512,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1782,19 +1598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -2439,27 +2242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,15 +2359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,12 +2416,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -2664,7 +2431,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2787,12 +2554,6 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2923,19 +2684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +2705,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -3162,6 +2916,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.3.1",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,29 +3072,35 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
- "async-std",
  "async-trait",
- "base64 0.21.7",
- "basic-cookies",
+ "base64 0.22.1",
+ "bytes",
  "crossbeam-utils",
  "form_urlencoded",
+ "futures-timer",
  "futures-util",
- "hyper 0.14.32",
- "lazy_static",
- "levenshtein",
- "log",
+ "headers",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "path-tree",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
  "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror 2.0.17",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -3358,6 +3142,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3693,15 +3478,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -3800,15 +3576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,37 +3590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3861,12 +3597,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -3974,9 +3704,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "loom"
@@ -4116,12 +3843,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4643,6 +4364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "pear"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4698,16 +4428,6 @@ checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
 dependencies = [
  "memchr",
  "ucd-trie",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -4782,12 +4502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
-
-[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,17 +4534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,20 +4559,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "polyval"
@@ -4906,12 +4595,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -5002,8 +4685,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
@@ -5278,17 +4961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5999,15 +5671,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6630,7 +6293,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -6994,16 +6657,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
+name = "stringmetrics"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
-]
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
 name = "stringprep"
@@ -7152,6 +6809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,17 +6843,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -7908,6 +7563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7984,12 +7645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8008,16 +7663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -8227,22 +7872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8250,12 +7879,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ base64 = "0.22"
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.40", features = ["derive", "env"] }
 flate2 = "1.0"
-httpmock = "0.7.0"
+httpmock = "0.8"
 rain-math-float = { path = "lib/rain.orderbook/lib/rain.orderbook.interface/lib/rain.interpreter.interface/lib/rain.math.float/crates/float" }
 reqwest = { version = "0.12.4", features = [
   "json",

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -767,7 +767,7 @@ mod tests {
         };
 
         fetch_attestation.retry(backoff).await.unwrap();
-        assert_eq!(mock.hits(), 1, "Expected exactly 1 API call");
+        assert_eq!(mock.calls(), 1, "Expected exactly 1 API call");
     }
 
     #[tokio::test]
@@ -827,7 +827,7 @@ mod tests {
             "Expected AttestationError::NotYetAvailable with status 404"
         );
         assert!(
-            mock.hits() == 4,
+            mock.calls() == 4,
             "Expected exactly 4 attempts (1 initial + 3 retries)"
         );
     }
@@ -1357,7 +1357,7 @@ mod tests {
             let fee_mock_server = MockServer::start();
             // Mock fee endpoint for any domain pair - returns fast (1000) and standard (2000) fees
             fee_mock_server.mock(|when, then| {
-                when.method(GET).path_contains("/v2/burn/USDC/fees/");
+                when.method(GET).path_includes("/v2/burn/USDC/fees/");
                 then.status(200).json_body(serde_json::json!([
                     {"finalityThreshold": 1000, "minimumFee": 1},
                     {"finalityThreshold": 2000, "minimumFee": 0}

--- a/crates/evm/src/fireblocks.rs
+++ b/crates/evm/src/fireblocks.rs
@@ -803,7 +803,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert!(
@@ -860,7 +860,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert!(
@@ -932,7 +932,7 @@ mod tests {
         contracts_mock.assert();
         create_mock.assert();
         assert!(
-            poll_mock.hits() >= 1,
+            poll_mock.calls() >= 1,
             "poll endpoint should be hit at least once"
         );
         assert_eq!(result.transaction_hash, tx_hash);
@@ -1293,10 +1293,10 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            poll_mock.hits() >= 2,
+            poll_mock.calls() >= 2,
             "should have polled multiple times before timing out, \
              but only polled {} time(s)",
-            poll_mock.hits()
+            poll_mock.calls()
         );
         assert!(
             matches!(

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -394,7 +394,7 @@ mod tests {
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
         let mock = server.mock(|when, then| {
-            when.method(POST).path("/v1/journals").json_body_partial(
+            when.method(POST).path("/v1/journals").json_body_includes(
                 r#"{
                         "from_account":"904837e3-3b76-47ec-b432-046db621571b",
                         "to_account":"11111111-2222-3333-4444-555555555555",

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -568,7 +568,7 @@ mod tests {
 
         // Account endpoint is hit twice: once during try_from_ctx (verify_account)
         // and once during get_inventory (get_account_details for cash balance)
-        account_mock.assert_hits(2);
+        account_mock.assert_calls(2);
         positions_mock.assert();
         assert!(matches!(result, crate::InventoryResult::Fetched(_)));
     }
@@ -753,9 +753,9 @@ mod tests {
         executor.place_market_order(order2).await.unwrap();
 
         // Asset endpoint should only be called once
-        asset_mock.assert_hits(1);
+        asset_mock.assert_calls(1);
         // Order endpoint should be called twice
-        order_mock.assert_hits(2);
+        order_mock.assert_calls(2);
     }
 
     #[tokio::test]
@@ -825,7 +825,7 @@ mod tests {
         executor.place_market_order(order2).await.unwrap();
 
         // Asset endpoint should be called twice due to cache expiration
-        asset_mock.assert_hits(2);
-        order_mock.assert_hits(2);
+        asset_mock.assert_calls(2);
+        order_mock.assert_calls(2);
     }
 }

--- a/crates/execution/src/schwab/auth/oauth.rs
+++ b/crates/execution/src/schwab/auth/oauth.rs
@@ -345,9 +345,9 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=authorization_code")
-                .body_contains("code=test_code")
-                .body_contains("redirect_uri=https%3A%2F%2F127.0.0.1%2F");
+                .body_includes("grant_type=authorization_code")
+                .body_includes("code=test_code")
+                .body_includes("redirect_uri=https%3A%2F%2F127.0.0.1%2F");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -477,8 +477,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=old_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=old_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -734,7 +734,7 @@ mod tests {
 
         let error = ctx.get_tokens_from_code("test_code").await.unwrap_err();
 
-        assert_eq!(mock.hits(), 1);
+        assert_eq!(mock.calls(), 1);
         match error {
             SchwabError::RequestFailed { action, status, .. } => {
                 assert_eq!(action, "get tokens");

--- a/crates/execution/src/schwab/executor.rs
+++ b/crates/execution/src/schwab/executor.rs
@@ -327,8 +327,8 @@ mod tests {
             when.method(POST)
                 .path("/v1/oauth/token")
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/crates/execution/src/schwab/mod.rs
+++ b/crates/execution/src/schwab/mod.rs
@@ -188,8 +188,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=authorization_code")
-                .body_contains("code=invalid_code");
+                .body_includes("grant_type=authorization_code")
+                .body_includes("code=invalid_code");
             then.status(401)
                 .header("content-type", "application/json")
                 .json_body(json!({"error": "invalid_grant"}));

--- a/crates/execution/src/schwab/order.rs
+++ b/crates/execution/src/schwab/order.rs
@@ -674,7 +674,7 @@ mod tests {
 
         // At least one attempt should have been made
         assert!(
-            order_mock.hits() >= 1,
+            order_mock.calls() >= 1,
             "Expected at least one API call attempt"
         );
     }
@@ -1169,7 +1169,7 @@ mod tests {
         account_mock.assert();
 
         // Should have made at least one request (retry logic is handled by backon)
-        assert!(order_status_mock.hits() >= 1);
+        assert!(order_status_mock.calls() >= 1);
         assert!(matches!(
             error,
             SchwabError::RequestFailed { action, status, .. }

--- a/crates/execution/src/schwab/tokens.rs
+++ b/crates/execution/src/schwab/tokens.rs
@@ -518,8 +518,8 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -611,8 +611,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -708,8 +708,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);
@@ -756,8 +756,8 @@ mod tests {
                     "Basic dGVzdF9hcHBfa2V5OnRlc3RfYXBwX3NlY3JldA==",
                 )
                 .header("content-type", "application/x-www-form-urlencoded")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(mock_response);

--- a/src/alpaca_wallet/status.rs
+++ b/src/alpaca_wallet/status.rs
@@ -424,7 +424,7 @@ mod tests {
 
         assert!(matches!(error, AlpacaWalletError::TransferTimeout { .. }));
 
-        assert!(status_mock.hits() >= 2);
+        assert!(status_mock.calls() >= 2);
     }
 
     #[tokio::test]
@@ -458,7 +458,7 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            error_mock.hits() >= 1,
+            error_mock.calls() >= 1,
             "Expected at least one retry attempt"
         );
         assert!(
@@ -514,7 +514,7 @@ mod tests {
             poll_transfer_status(&client_clone, &transfer_id_clone, &config).await
         });
 
-        while processing_mock.hits() < 1 {
+        while processing_mock.calls() < 1 {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
@@ -722,7 +722,7 @@ mod tests {
                 async move { poll_deposit_by_tx_hash(&client_clone, &tx_hash, &config).await },
             );
 
-        while empty_mock.hits() < 1 {
+        while empty_mock.calls() < 1 {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
@@ -793,7 +793,10 @@ mod tests {
             "Expected DepositTimeout error, got: {error:?}"
         );
 
-        assert!(empty_mock.hits() >= 1, "Expected at least one poll attempt");
+        assert!(
+            empty_mock.calls() >= 1,
+            "Expected at least one poll attempt"
+        );
     }
 
     #[tokio::test]

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -186,7 +186,7 @@ mod tests {
         let refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token");
+                .body_includes("grant_type=refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1015,8 +1015,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -1636,8 +1636,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_but_rejected_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_but_rejected_refresh_token");
             then.status(400)
                 .header("content-type", "application/json")
                 .json_body(
@@ -1687,8 +1687,8 @@ mod tests {
         let token_refresh_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/oauth/token")
-                .body_contains("grant_type=refresh_token")
-                .body_contains("refresh_token=valid_refresh_token");
+                .body_includes("grant_type=refresh_token")
+                .body_includes("refresh_token=valid_refresh_token");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2153,8 +2153,8 @@ mod tests {
         assert!(stdout_str2.contains("Processing trade with TradeAccumulator"));
         assert!(stdout_str2.contains("Trade accumulated but did not trigger execution yet"));
 
-        account_mock.assert_hits(1);
-        order_mock.assert_hits(1);
+        account_mock.assert_calls(1);
+        order_mock.assert_calls(1);
     }
 
     #[test]

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -428,7 +428,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
     let mint_mock = server.mock(|when, then| {
         when.method(POST)
             .path(tokenization_mint_path())
-            .json_body_partial(r#"{"underlying_symbol":"AAPL","qty":"30.500000000","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
+            .json_body_includes(r#"{"underlying_symbol":"AAPL","qty":"30.500000000","wallet_address":"0x0000000000000000000000000000000000000000"}"#);
         then.status(200)
             .header("content-type", "application/json")
             .json_body(sample_pending_response("mint_int_test"));

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -377,7 +377,7 @@ mod tests {
         let server = MockServer::start();
 
         let _account_mock = server.mock(|when, then| {
-            when.method(GET).path_contains("/trading/accounts/");
+            when.method(GET).path_includes("/trading/accounts/");
             then.status(401)
                 .header("content-type", "application/json")
                 .json_body(json!({"message": "Invalid API credentials"}));

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1972,7 +1972,7 @@ mod tests {
         let conversion_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body_partial(r#"{"symbol":"USDCUSD"}"#);
+                .json_body_includes(r#"{"symbol":"USDCUSD"}"#);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2005,7 +2005,7 @@ mod tests {
 
         // Conversion MUST be called before withdrawal
         assert!(
-            conversion_mock.hits() >= 1,
+            conversion_mock.calls() >= 1,
             "execute_alpaca_to_base MUST call USD-to-USDC conversion \
              before withdrawal"
         );
@@ -2042,7 +2042,7 @@ mod tests {
         let conversion_mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body_partial(r#"{"symbol":"USDCUSD"}"#);
+                .json_body_includes(r#"{"symbol":"USDCUSD"}"#);
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
@@ -2075,7 +2075,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            conversion_mock.hits() >= 1,
+            conversion_mock.calls() >= 1,
             "execute_base_to_alpaca MUST call USDC-to-USD conversion \
              after deposit confirmation"
         );
@@ -2207,7 +2207,7 @@ mod tests {
 
         // Verify no order was placed - CQRS failure should prevent side effects
         assert_eq!(
-            order_mock.hits(),
+            order_mock.calls(),
             0,
             "Order API should not be called when InitiateConversion fails"
         );


### PR DESCRIPTION
## Motivation
Stacked on #343

Upgrade `httpmock` from 0.7 to 0.8 because e2e tests need the new api that lets you add a closure to the canned response that takes the request data.

## Solution
Bumped `httpmock` from `0.7.0` to `0.8` in the workspace `Cargo.toml` and updated all call sites across the codebase to match the renamed APIs introduced in 0.8:

### API renames applied

| httpmock 0.7 | httpmock 0.8 |
|---|---|
| `mock.hits()` | `mock.calls()` |
| `mock.assert_hits(n)` | `mock.assert_calls(n)` |
| `when.body_contains(...)` | `when.body_includes(...)` |
| `when.path_contains(...)` | `when.path_includes(...)` |
| `when.json_body_partial(...)` | `when.json_body_includes(...)` |

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped test/mock framework dependency to a newer version.

* **Tests**
  * Updated tests to use the new mock API (call-count checks replace hit-count checks).
  * Relaxed request matching in tests from strict contains/partial checks to includes-style checks for bodies, JSON and paths.
  * No production behavior or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->