### PR TITLE
Expose items for e2e testing

### DIFF
--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -614,23 +614,25 @@ mod tests {
                 time_in_force: TimeInForce::default(),
             }),
             telemetry: None,
-            trading_mode: TradingMode::Rebalancing(Box::new(RebalancingCtx::stub(
-                ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.1),
-                },
-                UsdcRebalancing::Disabled,
-                Address::ZERO,
-                B256::ZERO,
-                AlpacaBrokerApiCtx {
-                    api_key: "test-key".to_string(),
-                    api_secret: "test-secret".to_string(),
-                    account_id: alpaca_account_id,
-                    mode: Some(AlpacaBrokerApiMode::Sandbox),
-                    asset_cache_ttl: std::time::Duration::from_secs(3600),
-                    time_in_force: TimeInForce::default(),
-                },
-            ))),
+            trading_mode: TradingMode::Rebalancing(Box::new(
+                RebalancingCtx::stub()
+                    .equity(ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.1),
+                    })
+                    .usdc(UsdcRebalancing::Disabled)
+                    .redemption_wallet(Address::ZERO)
+                    .usdc_vault_id(B256::ZERO)
+                    .alpaca_broker_auth(AlpacaBrokerApiCtx {
+                        api_key: "test-key".to_string(),
+                        api_secret: "test-secret".to_string(),
+                        account_id: alpaca_account_id,
+                        mode: Some(AlpacaBrokerApiMode::Sandbox),
+                        asset_cache_ttl: std::time::Duration::from_secs(3600),
+                        time_in_force: TimeInForce::default(),
+                    })
+                    .call(),
+            )),
             execution_threshold: ExecutionThreshold::whole_share(),
             equities: HashMap::new(),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ pub struct Env {
 /// between conservative limits or uncapped mode.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(tag = "mode", rename_all = "lowercase")]
-pub(crate) enum OperationalLimits {
+pub enum OperationalLimits {
     Enabled {
         max_amount: Positive<Usdc>,
         max_shares: Positive<FractionalShares>,
@@ -118,7 +118,7 @@ enum BrokerSecrets {
 /// `Standalone`: order_owner comes from config, no rebalancing.
 /// `Rebalancing`: order_owner resolved from Fireblocks at runtime.
 #[derive(Clone, Debug)]
-pub(crate) enum TradingMode {
+pub enum TradingMode {
     Standalone { order_owner: Address },
     Rebalancing(Box<RebalancingCtx>),
 }
@@ -127,19 +127,19 @@ pub(crate) enum TradingMode {
 /// encrypted secrets, and derived runtime state.
 #[derive(Clone)]
 pub struct Ctx {
-    pub(crate) database_url: String,
+    pub database_url: String,
     pub log_level: LogLevel,
-    pub(crate) server_port: u16,
-    pub(crate) operational_limits: OperationalLimits,
-    pub(crate) evm: EvmCtx,
-    pub(crate) order_polling_interval: u64,
-    pub(crate) order_polling_max_jitter: u64,
-    pub(crate) position_check_interval: u64,
-    pub(crate) inventory_poll_interval: u64,
-    pub(crate) broker: BrokerCtx,
+    pub server_port: u16,
+    pub operational_limits: OperationalLimits,
+    pub evm: EvmCtx,
+    pub order_polling_interval: u64,
+    pub order_polling_max_jitter: u64,
+    pub position_check_interval: u64,
+    pub inventory_poll_interval: u64,
+    pub broker: BrokerCtx,
     pub telemetry: Option<TelemetryCtx>,
-    pub(crate) trading_mode: TradingMode,
-    pub(crate) execution_threshold: ExecutionThreshold,
+    pub trading_mode: TradingMode,
+    pub execution_threshold: ExecutionThreshold,
     pub(crate) equities: HashMap<Symbol, EquityTokenAddresses>,
 }
 
@@ -162,7 +162,7 @@ impl BrokerCtx {
         }
     }
 
-    fn execution_threshold(&self) -> Result<ExecutionThreshold, CtxError> {
+    pub fn execution_threshold(&self) -> Result<ExecutionThreshold, CtxError> {
         match self {
             Self::Schwab(_) | Self::DryRun => Ok(ExecutionThreshold::shares(
                 Positive::<FractionalShares>::ONE,

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -75,7 +75,7 @@ const TOKENIZED_EQUITY_DECIMALS: u8 = 18;
 
 /// Unique identifier for a redemption aggregate instance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct RedemptionAggregateId(pub(crate) String);
+pub struct RedemptionAggregateId(pub(crate) String);
 
 impl RedemptionAggregateId {
     pub(crate) fn new(id: impl Into<String>) -> Self {
@@ -101,7 +101,7 @@ impl FromStr for RedemptionAggregateId {
 ///
 /// These errors enforce state machine constraints and prevent invalid transitions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-pub(crate) enum EquityRedemptionError {
+pub enum EquityRedemptionError {
     /// Raindex vault lookup failed for the given token
     #[error("Token {0} not found in Raindex vault registry")]
     RaindexVaultNotFound(Address),
@@ -178,7 +178,7 @@ pub(crate) enum EquityRedemptionError {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum EquityRedemptionCommand {
+pub enum EquityRedemptionCommand {
     /// Withdraws wrapped tokens from the Raindex vault.
     /// Emits WithdrawnFromRaindex.
     Redeem {
@@ -205,13 +205,13 @@ pub(crate) enum EquityRedemptionCommand {
 
 /// Reason for detection failure when polling Alpaca for redemption detection.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum DetectionFailure {
+pub enum DetectionFailure {
     Timeout,
     ApiError { status_code: Option<u16> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum EquityRedemptionEvent {
+pub enum EquityRedemptionEvent {
     /// Tokens withdrawn from Raindex vault to wallet.
     WithdrawnFromRaindex {
         symbol: Symbol,
@@ -290,7 +290,7 @@ impl DomainEvent for EquityRedemptionEvent {
 /// Uses the typestate pattern via enum variants to make invalid states unrepresentable.
 /// Each variant contains exactly the data valid for that state.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum EquityRedemption {
+pub enum EquityRedemption {
     /// Tokens withdrawn from Raindex vault to wallet, not yet sent to Alpaca
     WithdrawnFromRaindex {
         symbol: Symbol,

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -7,7 +7,8 @@ pub(crate) mod view;
 
 pub(crate) use polling::InventoryPollingService;
 pub(crate) use snapshot::InventorySnapshot;
+pub use view::ImbalanceThreshold;
 pub(crate) use view::{
-    EquityImbalanceError, Imbalance, ImbalanceThreshold, Inventory, InventoryView,
-    InventoryViewError, Operator, TransferOp, Venue,
+    EquityImbalanceError, Imbalance, Inventory, InventoryView, InventoryViewError, Operator,
+    TransferOp, Venue,
 };

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -46,11 +46,11 @@ pub(crate) enum Imbalance<T> {
 /// Threshold configuration for imbalance detection.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ImbalanceThreshold {
+pub struct ImbalanceThreshold {
     /// Target ratio of onchain to total (e.g., 0.5 for 50/50 split).
-    pub(crate) target: Decimal,
+    pub target: Decimal,
     /// Deviation from target that triggers rebalancing.
-    pub(crate) deviation: Decimal,
+    pub deviation: Decimal,
 }
 
 /// Discriminant for the two venues tracked by an [`Inventory`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ use crate::config::{BrokerCtx, Ctx};
 
 mod alpaca_wallet;
 pub mod api;
-mod bindings;
+#[cfg(any(test, feature = "test-support"))]
+pub mod bindings;
+#[cfg(not(any(test, feature = "test-support")))]
+pub(crate) mod bindings;
 pub mod cli;
 mod conductor;
 pub mod config;
@@ -42,6 +45,30 @@ mod vault_registry;
 mod wrapper;
 
 pub use telemetry::{TelemetryError, TelemetryGuard, setup_tracing};
+
+#[cfg(any(test, feature = "test-support"))]
+pub use config::TradingMode;
+#[cfg(any(test, feature = "test-support"))]
+pub use inventory::ImbalanceThreshold;
+#[cfg(any(test, feature = "test-support"))]
+pub use offchain_order::{Dollars, OffchainOrder, OffchainOrderId};
+#[cfg(any(test, feature = "test-support"))]
+pub use onchain::EvmCtx;
+#[cfg(any(test, feature = "test-support"))]
+pub use position::Position;
+#[cfg(any(test, feature = "test-support"))]
+pub use rebalancing::{
+    RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets, UsdcRebalancing,
+};
+#[cfg(any(test, feature = "test-support"))]
+pub use threshold::ExecutionThreshold;
+#[cfg(any(test, feature = "test-support"))]
+pub use wrapper::EquityTokenAddresses;
+
+#[cfg(any(test, feature = "test-support"))]
+pub use equity_redemption::{EquityRedemption, RedemptionAggregateId};
+#[cfg(any(test, feature = "test-support"))]
+pub use onchain::USDC_BASE;
 
 #[cfg(test)]
 mod integration_tests;

--- a/src/offchain_order.rs
+++ b/src/offchain_order.rs
@@ -29,8 +29,8 @@ pub(crate) async fn build_offchain_order_cqrs(
     Ok((store, projection))
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub(crate) enum OffchainOrder {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OffchainOrder {
     Pending {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
@@ -431,7 +431,7 @@ impl OffchainOrder {
 /// allowing different executor implementations to be used
 /// via `Arc<dyn OrderPlacer>`.
 #[async_trait]
-pub(crate) trait OrderPlacer: Send + Sync {
+pub trait OrderPlacer: Send + Sync {
     async fn place_market_order(
         &self,
         order: MarketOrder,
@@ -471,10 +471,10 @@ pub(crate) fn noop_order_placer() -> Arc<dyn OrderPlacer> {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct Dollars(pub(crate) Decimal);
+pub struct Dollars(pub Decimal);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum OffchainOrderCommand {
+pub enum OffchainOrderCommand {
     Place {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
@@ -494,7 +494,7 @@ pub(crate) enum OffchainOrderCommand {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum OffchainOrderEvent {
+pub enum OffchainOrderEvent {
     Placed {
         symbol: Symbol,
         shares: Positive<FractionalShares>,
@@ -539,7 +539,7 @@ impl DomainEvent for OffchainOrderEvent {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
-pub(crate) struct OffchainOrderId(Uuid);
+pub struct OffchainOrderId(Uuid);
 
 impl std::fmt::Display for OffchainOrderId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -562,7 +562,7 @@ impl OffchainOrderId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-pub(crate) enum OffchainOrderError {
+pub enum OffchainOrderError {
     #[error("Cannot place order: order has already been placed")]
     AlreadyPlaced,
     #[error(

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -52,10 +52,10 @@ pub(crate) struct EvmSecrets {
 }
 
 #[derive(Clone)]
-pub(crate) struct EvmCtx {
-    pub(crate) ws_rpc_url: Url,
-    pub(crate) orderbook: Address,
-    pub(crate) deployment_block: u64,
+pub struct EvmCtx {
+    pub ws_rpc_url: Url,
+    pub orderbook: Address,
+    pub deployment_block: u64,
 }
 
 impl std::fmt::Debug for EvmCtx {
@@ -131,7 +131,7 @@ pub(crate) enum OnChainError {
 }
 
 pub(crate) const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
-pub(crate) const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 pub(crate) const USDC_ETHEREUM_SEPOLIA: Address =
     address!("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238");
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -24,15 +24,15 @@ use crate::offchain_order::{Dollars, OffchainOrderId};
 use crate::threshold::{ExecutionThreshold, Usdc};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct Position {
-    pub(crate) symbol: Symbol,
-    pub(crate) net: FractionalShares,
-    pub(crate) accumulated_long: FractionalShares,
-    pub(crate) accumulated_short: FractionalShares,
-    pub(crate) pending_offchain_order_id: Option<OffchainOrderId>,
-    pub(crate) threshold: ExecutionThreshold,
-    pub(crate) last_price_usdc: Option<Decimal>,
-    pub(crate) last_updated: Option<DateTime<Utc>>,
+pub struct Position {
+    pub symbol: Symbol,
+    pub net: FractionalShares,
+    pub accumulated_long: FractionalShares,
+    pub accumulated_short: FractionalShares,
+    pub pending_offchain_order_id: Option<OffchainOrderId>,
+    pub threshold: ExecutionThreshold,
+    pub last_price_usdc: Option<Decimal>,
+    pub last_updated: Option<DateTime<Utc>>,
 }
 
 #[async_trait]
@@ -436,7 +436,7 @@ impl Position {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
-pub(crate) enum PositionError {
+pub enum PositionError {
     #[error("Position has not been initialized")]
     Uninitialized,
     #[error(
@@ -470,7 +470,7 @@ pub(crate) enum PositionError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) enum PositionCommand {
+pub enum PositionCommand {
     AcknowledgeOnChainFill {
         symbol: Symbol,
         threshold: ExecutionThreshold,
@@ -505,7 +505,7 @@ pub(crate) enum PositionCommand {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum PositionEvent {
+pub enum PositionEvent {
     Initialized {
         symbol: Symbol,
         threshold: ExecutionThreshold,
@@ -582,9 +582,9 @@ impl DomainEvent for PositionEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct TradeId {
-    pub(crate) tx_hash: TxHash,
-    pub(crate) log_index: u64,
+pub struct TradeId {
+    pub tx_hash: TxHash,
+    pub log_index: u64,
 }
 
 impl std::fmt::Display for TradeId {
@@ -594,7 +594,7 @@ impl std::fmt::Display for TradeId {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum TriggerReason {
+pub enum TriggerReason {
     SharesThreshold {
         net_position_shares: Decimal,
         threshold_shares: Decimal,

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -48,7 +48,7 @@ pub(crate) struct Equity {
 /// `EquityRedemption` (market-making -> hedging) need Raindex for
 /// vault operations and Tokenizer for Alpaca API interactions.
 #[derive(Clone)]
-pub(crate) struct EquityTransferServices {
+pub struct EquityTransferServices {
     pub(crate) raindex: Arc<dyn Raindex>,
     pub(crate) tokenizer: Arc<dyn Tokenizer>,
     pub(crate) wrapper: Arc<dyn Wrapper>,

--- a/src/rebalancing/mod.rs
+++ b/src/rebalancing/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod usdc;
 
 pub(crate) use rebalancer::Rebalancer;
 pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks};
-pub(crate) use trigger::{
-    RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets, RebalancingTrigger,
-    RebalancingTriggerConfig, TriggeredOperation,
-};
+#[cfg(any(test, feature = "test-support"))]
+pub use trigger::UsdcRebalancing;
+pub use trigger::{RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets};
+pub(crate) use trigger::{RebalancingTrigger, RebalancingTriggerConfig, TriggeredOperation};

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -198,26 +198,28 @@ mod tests {
     const TEST_ORDERBOOK: Address = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
 
     fn make_ctx() -> RebalancingCtx {
-        RebalancingCtx::stub(
-            ImbalanceThreshold {
+        RebalancingCtx::stub()
+            .equity(ImbalanceThreshold {
                 target: dec!(0.5),
                 deviation: dec!(0.2),
-            },
-            UsdcRebalancing::Enabled {
+            })
+            .usdc(UsdcRebalancing::Enabled {
                 target: dec!(0.6),
                 deviation: dec!(0.15),
-            },
-            address!("0x1234567890123456789012345678901234567890"),
-            b256!("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"),
-            AlpacaBrokerApiCtx {
+            })
+            .redemption_wallet(address!("0x1234567890123456789012345678901234567890"))
+            .usdc_vault_id(b256!(
+                "0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+            ))
+            .alpaca_broker_auth(AlpacaBrokerApiCtx {
                 api_key: "test_key".to_string(),
                 api_secret: "test_secret".to_string(),
                 account_id: AlpacaAccountId::new(Uuid::nil()),
                 mode: Some(AlpacaBrokerApiMode::Sandbox),
                 asset_cache_ttl: std::time::Duration::from_secs(3600),
                 time_in_force: TimeInForce::default(),
-            },
-        )
+            })
+            .call()
     }
 
     #[test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -82,33 +82,33 @@ pub enum RebalancingCtxError {
 /// USDC rebalancing configuration with explicit enable/disable.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "mode", rename_all = "lowercase")]
-pub(crate) enum UsdcRebalancing {
+pub enum UsdcRebalancing {
     Enabled { target: Decimal, deviation: Decimal },
     Disabled,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct RebalancingSecrets {
-    pub(crate) base_rpc_url: Url,
-    pub(crate) ethereum_rpc_url: Url,
-    pub(crate) fireblocks_api_user_id: FireblocksApiUserId,
-    pub(crate) fireblocks_secret_path: PathBuf,
+pub struct RebalancingSecrets {
+    pub base_rpc_url: Url,
+    pub ethereum_rpc_url: Url,
+    pub fireblocks_api_user_id: FireblocksApiUserId,
+    pub fireblocks_secret_path: PathBuf,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct RebalancingConfig {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: UsdcRebalancing,
-    pub(crate) redemption_wallet: Address,
-    pub(crate) usdc_vault_id: B256,
-    pub(crate) fireblocks_vault_account_id: FireblocksVaultAccountId,
-    pub(crate) fireblocks_chain_asset_ids: ChainAssetIds,
-    pub(crate) fireblocks_environment: FireblocksEnvironment,
+pub struct RebalancingConfig {
+    pub equity: ImbalanceThreshold,
+    pub usdc: UsdcRebalancing,
+    pub redemption_wallet: Address,
+    pub usdc_vault_id: B256,
+    pub fireblocks_vault_account_id: FireblocksVaultAccountId,
+    pub fireblocks_chain_asset_ids: ChainAssetIds,
+    pub fireblocks_environment: FireblocksEnvironment,
     /// Override the Fireblocks API base URL. When absent, determined
     /// by `fireblocks_environment`.
-    pub(crate) fireblocks_base_url: Option<Url>,
+    pub fireblocks_base_url: Option<Url>,
 }
 
 /// Runtime configuration for rebalancing operations.
@@ -121,7 +121,7 @@ pub(crate) struct RebalancingConfig {
 /// Read-only provider access for either chain is available via
 /// `base_wallet().provider()` and `ethereum_wallet().provider()`.
 #[derive(Clone)]
-pub(crate) struct RebalancingCtx {
+pub struct RebalancingCtx {
     pub(crate) equity: ImbalanceThreshold,
     pub(crate) usdc: UsdcRebalancing,
     /// Issuer's wallet for tokenized equity redemptions.
@@ -233,12 +233,16 @@ impl RebalancingCtx {
     pub(crate) fn ethereum_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
         &self.ethereum_wallet
     }
+}
 
+#[cfg(test)]
+#[bon::bon]
+impl RebalancingCtx {
     /// Test constructor that creates a `RebalancingCtx` with stub wallets.
     ///
     /// The wallets panic on `send` -- use only in tests that don't submit
     /// transactions through the rebalancing wallet.
-    #[cfg(test)]
+    #[builder]
     pub(crate) fn stub(
         equity: ImbalanceThreshold,
         usdc: UsdcRebalancing,
@@ -263,6 +267,57 @@ impl RebalancingCtx {
             #[cfg(feature = "test-support")]
             message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
         }
+    }
+}
+
+#[cfg(feature = "test-support")]
+#[bon::bon]
+impl RebalancingCtx {
+    /// Test constructor that accepts pre-built wallets for e2e tests
+    /// that need real onchain interaction (e.g. with Anvil forks).
+    #[builder]
+    pub fn with_wallets(
+        equity: ImbalanceThreshold,
+        usdc: UsdcRebalancing,
+        redemption_wallet: Address,
+        usdc_vault_id: B256,
+        alpaca_broker_auth: AlpacaBrokerApiCtx,
+        base_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+        ethereum_wallet: Arc<dyn Wallet<Provider = RootProvider>>,
+    ) -> Self {
+        Self {
+            equity,
+            usdc,
+            redemption_wallet,
+            usdc_vault_id,
+            alpaca_broker_auth,
+            base_wallet,
+            ethereum_wallet,
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        }
+    }
+
+    /// Sets the Circle API base URL override (for e2e tests with local
+    /// CCTP contracts and a mock attestation server).
+    #[must_use]
+    pub fn with_circle_api_base(mut self, base_url: String) -> Self {
+        self.circle_api_base = base_url;
+        self
+    }
+
+    /// Sets the CCTP contract address overrides (for e2e tests with
+    /// locally deployed CCTP contracts).
+    #[must_use]
+    pub fn with_cctp_addresses(
+        mut self,
+        token_messenger: Address,
+        message_transmitter: Address,
+    ) -> Self {
+        self.token_messenger = token_messenger;
+        self.message_transmitter = message_transmitter;
+        self
     }
 }
 

--- a/src/threshold.rs
+++ b/src/threshold.rs
@@ -133,7 +133,7 @@ impl Sub for Usdc {
 
 /// Threshold configuration that determines when to trigger offchain execution.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) enum ExecutionThreshold {
+pub enum ExecutionThreshold {
     Shares(Positive<FractionalShares>),
     DollarValue(Usdc),
 }

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -78,7 +78,7 @@ impl FromStr for IssuerRequestId {
 
 /// Alpaca tokenization request identifier used to track the mint operation through their API.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct TokenizationRequestId(pub(crate) String);
+pub struct TokenizationRequestId(pub(crate) String);
 
 impl std::fmt::Display for TokenizationRequestId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -14,7 +14,8 @@ use st0x_evm::EvmError;
 use st0x_execution::Symbol;
 
 pub(crate) use ratio::{RatioError, UnderlyingPerWrapped};
-pub(crate) use share::{EquityTokenAddresses, WrapperService};
+pub use share::EquityTokenAddresses;
+pub(crate) use share::WrapperService;
 
 #[cfg(test)]
 pub(crate) use ratio::RATIO_ONE;


### PR DESCRIPTION
## Motivation

The e2e test crate (`e2e-tests`) needs access to internal types from `st0x-hedge` to construct `Ctx`, `RebalancingCtx`, CQRS aggregates, and other domain objects for integration scenarios. Currently these types are `pub(crate)`, making them invisible to external crates.

## Solution

Adds a `test-support` cargo feature flag to `st0x-hedge` that conditionally widens visibility of types needed by e2e tests, without exposing them in production builds.

**Feature flag (`test-support`)**:
- Conditionally re-exports domain types from `lib.rs`: `Position`, `OffchainOrder`, `EvmCtx`, `RebalancingCtx`, `ExecutionThreshold`, `EquityRedemption`, `EquityTokenAddresses`, `ImbalanceThreshold`, `TradingMode`, etc.
- Conditionally exposes `bindings` module as `pub` (needed for contract interaction in e2e tests)

**Visibility widened unconditionally** (these types are part of the public API surface needed by downstream crates regardless):
- `Ctx` fields: `database_url`, `server_port`, `operational_limits`, `evm`, `broker`, `trading_mode`, `execution_threshold`, and polling intervals
- `RebalancingConfig`, `RebalancingSecrets`, `RebalancingCtx` structs and their fields
- `ImbalanceThreshold` struct and fields
- `OperationalLimits`, `TradingMode` enums
- Various CQRS types: `Position`, `OffchainOrder`, `EquityRedemption` and their commands/events/errors

**New `RebalancingCtx::with_wallets()` builder** (behind `test-support`):
- Accepts pre-built `Arc<dyn Wallet>` instances instead of creating stub wallets
- Enables e2e tests to pass real Anvil-backed wallets for onchain interaction
- Includes `with_circle_api_base()` and `with_cctp_addresses()` setters for CCTP testing

**Builder pattern for `RebalancingCtx::stub()`**:
- Converted to `#[bon::builder]` pattern for more readable test construction
- Updated all existing call sites in `alpaca_wallet.rs` and `spawn.rs`

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `test-support` feature flag for enhanced testing capabilities.
  * Expanded public API with additional configuration and domain types now accessible for external use.
  * Builder-style setup patterns introduced for improved usability.

* **Chores**
  * Increased visibility of core configuration and domain entities to support broader library usage.
  * Reorganized public exports for better API organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->