### PR TITLE
add workspace crates to ci checks

### DIFF
--- a/rust.nix
+++ b/rust.nix
@@ -112,7 +112,7 @@ in {
     preBuild = sqlxSetup;
     nativeCheckInputs = sol-build-inputs;
     doCheck = true;
-    cargoTestExtraArgs = "--workspace";
+    cargoTestExtraArgs = "--workspace --all-targets --all-features";
 
     meta = {
       description = "st0x liquidity market making system";


### PR DESCRIPTION
## Motivation

CI was only running tests and clippy against the root crate (`st0x-hedge`),
silently skipping all workspace member crates (`st0x-execution`,
`st0x-event-sorcery`, `st0x-evm`, `st0x-bridge`, `rain-math-float`,
`st0x-dto`). This meant that compilation errors, test failures, and lint
violations in workspace crates could go undetected in CI and only surface later.

Additionally, the clippy CI step was passing `-- -D clippy::all` which
overrides the project's own lint configuration in `Cargo.toml`
(`clippy::pedantic` + `clippy::nursery` as deny). This meant CI was enforcing a
weaker lint standard than the project intends.

## Solution

Two changes to `rust.nix` (the Nix derivation that defines CI build, test, and
clippy steps):

1. **Tests**: Added `cargoTestExtraArgs = "--workspace"` to the `package`
   derivation so `cargo test` runs against all workspace crates, not just the
   root.

2. **Clippy**: Changed `cargoClippyExtraArgs` from
   `"--all-targets --all-features -- -D clippy::all"` to
   `"--workspace --all-targets --all-features"`. This adds `--workspace` to
   cover all crates, and removes the explicit `-- -D clippy::all` flag so that
   clippy uses the lint configuration defined in `Cargo.toml` (which is
   stricter: `pedantic` + `nursery` as deny).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing and code quality checks to cover the entire project workspace for more comprehensive validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->