### PR TITLE
add butt tool: automate stacked branch propagation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
             name = "butt";
             runtimeInputs = [ gitbutler-cli pkgs.gh pkgs.git pkgs.jq ];
             text = ''
+              set -x
               branch=""
               while [[ $# -gt 0 ]]; do
                 case $1 in
@@ -97,17 +98,17 @@
                 exit 1
               fi
 
-              echo "Propagating changes from $branch through the stack..."
+              if ! git diff --quiet || ! git diff --cached --quiet; then
+                echo "ERROR: working tree is dirty -- commit or stash changes first" >&2
+                exit 1
+              fi
 
               default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
                 | sed 's|refs/remotes/origin/||' || echo master)
 
               git fetch origin
-
-              echo "Tearing down GitButler..."
               but teardown || true
 
-              echo "Finding stacked branches..."
               chain=()
               current="$branch"
               while true; do
@@ -118,35 +119,22 @@
                 current="$child"
               done
 
-              if [[ ''${#chain[@]} -eq 0 ]]; then
-                echo "No stacked branches found on top of $branch."
-              else
-                echo "Stack: $branch -> ''${chain[*]}"
-              fi
-
               parent="origin/$branch"
               for child in "''${chain[@]}"; do
-                echo "Rebasing $child onto $parent..."
                 git checkout "$child"
                 if ! git rebase "$parent"; then
-                  echo ""
-                  echo "Rebase conflict in $child!"
-                  echo "Resolve conflicts, then run:"
+                  echo "Rebase conflict in $child. Resolve, then run:"
                   echo "  git rebase --continue"
                   echo "  git push --force-with-lease origin $child"
                   echo "  git checkout $default_branch && but setup"
                   exit 1
                 fi
-                echo "Pushing $child..."
                 git push --force-with-lease origin "$child"
                 parent="$child"
               done
 
-              echo "Setting up GitButler..."
               git checkout "$default_branch"
               but setup
-
-              echo "Done! All branches propagated."
             '';
           };
 


### PR DESCRIPTION
## Motivation

Propagating changes through stacked GitButler branches requires a manual teardown -> rebase -> push -> setup cycle for each branch in the chain. This is tedious and error-prone.

## Solution

Add a `butt` CLI tool (available in the nix dev shell) that automates the entire propagation flow:

- `butt -b BRANCH` or `butt -p PR_NUMBER`
- Fetches latest, tears down GitButler, discovers the stack via `gh pr list --base`, rebases each child onto its updated parent, force-pushes, then re-enters GitButler mode
- On rebase conflict, stops and prints instructions for manual resolution

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a change to the dashboard)