### PR TITLE
include transfer details in inventory updates

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -592,4 +592,106 @@ mod tests {
         assert!(json.contains("offchainAvailable"));
         assert!(json.contains("offchainInflight"));
     }
+
+    #[test]
+    fn failed_equity_mint_serializes_with_failed_at() {
+        let status = EquityMintStatus::Failed {
+            failed_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(
+            json.contains(r#""status":"failed""#),
+            "should include failed status tag, got: {json}"
+        );
+        assert!(
+            json.contains("\"failedAt\""),
+            "should include failedAt, got: {json}"
+        );
+    }
+
+    #[test]
+    fn completed_equity_mint_serializes_with_completed_at() {
+        let status = EquityMintStatus::Completed {
+            completed_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(
+            json.contains(r#""status":"completed""#),
+            "should include completed status tag, got: {json}"
+        );
+        assert!(
+            json.contains("\"completedAt\""),
+            "should include completedAt, got: {json}"
+        );
+    }
+
+    #[test]
+    fn failed_usdc_bridge_serializes_with_failed_at() {
+        let status = UsdcBridgeStatus::Failed {
+            failed_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(
+            json.contains(r#""status":"failed""#),
+            "should include failed status tag, got: {json}"
+        );
+        assert!(
+            json.contains("\"failedAt\""),
+            "should include failedAt, got: {json}"
+        );
+    }
+
+    #[test]
+    fn completed_usdc_bridge_serializes_with_completed_at() {
+        let status = UsdcBridgeStatus::Completed {
+            completed_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(
+            json.contains(r#""status":"completed""#),
+            "should include completed status tag, got: {json}"
+        );
+        assert!(
+            json.contains("\"completedAt\""),
+            "should include completedAt, got: {json}"
+        );
+    }
+
+    #[test]
+    fn equity_mint_wrapping_status_serializes() {
+        let operation = TransferOperation::EquityMint(EquityMintOperation {
+            id: Id::new("mint-cs"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(Decimal::new(10, 0)),
+            status: EquityMintStatus::Wrapping,
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        let json = serde_json::to_string(&operation).unwrap();
+        assert!(
+            json.contains(r#""status":"wrapping""#),
+            "should contain wrapping status, got: {json}"
+        );
+        assert!(
+            json.contains(r#""kind":"equity_mint""#),
+            "should contain equity_mint kind, got: {json}"
+        );
+    }
+
+    #[test]
+    fn failed_equity_redemption_serializes_with_failed_at() {
+        let status = EquityRedemptionStatus::Failed {
+            failed_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(
+            json.contains(r#""status":"failed""#),
+            "should include failed status tag, got: {json}"
+        );
+        assert!(
+            json.contains("\"failedAt\""),
+            "should include failedAt, got: {json}"
+        );
+    }
 }

--- a/dashboard/src/lib/components/transfer-details.ts
+++ b/dashboard/src/lib/components/transfer-details.ts
@@ -1,0 +1,122 @@
+import type { CompletedStage } from '$lib/api/CompletedStage'
+import type { TransferOperation } from '$lib/api/TransferOperation'
+import { matcher } from '$lib/fp'
+
+export type TxLink = { label: string; hash: string; url: string }
+export type StageEntry = CompletedStage
+
+const BASE_EXPLORER = 'https://basescan.org/tx'
+const ETH_EXPLORER = 'https://etherscan.io/tx'
+
+const matchKind = matcher<TransferOperation>()('kind')
+
+const baseTxLink = (label: string, hash: string): TxLink => ({
+  label,
+  hash,
+  url: `${BASE_EXPLORER}/${hash}`
+})
+
+export const failureReason = (transfer: TransferOperation): string | null =>
+  matchKind(transfer, {
+    equity_mint: (op) =>
+      op.status.status === 'failed' ? op.status.reason : null,
+    equity_redemption: () => null,
+    usdc_bridge: (op) =>
+      op.status.status === 'failed' ? op.status.reason : null
+  })
+
+export const txLinks = (transfer: TransferOperation): TxLink[] =>
+  matchKind(transfer, {
+    equity_mint: (op) => equityMintLinks(op.status),
+    equity_redemption: (op) => equityRedemptionLinks(op.status),
+    usdc_bridge: (op) => usdcBridgeLinks(op.status, op.direction)
+  })
+
+type EquityMintStatus =
+  (TransferOperation & { kind: 'equity_mint' }) extends { status: infer S } ? S : never
+
+type EquityRedemptionStatus =
+  (TransferOperation & { kind: 'equity_redemption' }) extends { status: infer S } ? S : never
+
+type UsdcBridgeStatus =
+  (TransferOperation & { kind: 'usdc_bridge' }) extends { status: infer S } ? S : never
+
+type UsdcDirection =
+  (TransferOperation & { kind: 'usdc_bridge' }) extends { direction: infer D } ? D : never
+
+const equityMintLinks = (status: EquityMintStatus): TxLink[] => {
+  switch (status.status) {
+    case 'minting':
+      return []
+    case 'wrapping':
+      return [baseTxLink('token', status.token)]
+    case 'depositing':
+      return [baseTxLink('token', status.token), baseTxLink('wrap', status.wrap)]
+    case 'completed':
+      return [
+        baseTxLink('token', status.token),
+        baseTxLink('wrap', status.wrap),
+        baseTxLink('deposit', status.vault_deposit)
+      ]
+    case 'failed':
+      return []
+  }
+}
+
+const equityRedemptionLinks = (status: EquityRedemptionStatus): TxLink[] => {
+  switch (status.status) {
+    case 'withdrawing':
+      return [baseTxLink('withdraw', status.raindex_withdraw)]
+    case 'unwrapping':
+      return [
+        baseTxLink('withdraw', status.raindex_withdraw),
+        baseTxLink('unwrap', status.unwrap)
+      ]
+    case 'sending':
+      return [baseTxLink('withdraw', status.raindex_withdraw)]
+    case 'pending_confirmation':
+      return [baseTxLink('redeem', status.redemption)]
+    case 'completed':
+      return [baseTxLink('redeem', status.redemption)]
+    case 'failed': {
+      const links: TxLink[] = []
+      if (status.raindex_withdraw) links.push(baseTxLink('withdraw', status.raindex_withdraw))
+      if (status.redemption) links.push(baseTxLink('redeem', status.redemption))
+      return links
+    }
+  }
+}
+
+export const completedStages = (transfer: TransferOperation): StageEntry[] =>
+  matchKind(transfer, {
+    equity_mint: (op) => op.completedStages,
+    equity_redemption: (op) => op.completedStages,
+    usdc_bridge: (op) => op.completedStages
+  })
+
+
+const usdcBridgeLinks = (status: UsdcBridgeStatus, direction: UsdcDirection): TxLink[] => {
+  const burnExplorer = direction === 'alpaca_to_base' ? ETH_EXPLORER : BASE_EXPLORER
+  const mintExplorer = direction === 'alpaca_to_base' ? BASE_EXPLORER : ETH_EXPLORER
+
+  const burnLink = (hash: string): TxLink => ({ label: 'burn', hash, url: `${burnExplorer}/${hash}` })
+  const mintLink = (hash: string): TxLink => ({ label: 'mint', hash, url: `${mintExplorer}/${hash}` })
+
+  switch (status.status) {
+    case 'converting':
+    case 'withdrawing':
+      return []
+    case 'bridging':
+      return [burnLink(status.burn)]
+    case 'depositing':
+      return [burnLink(status.burn), mintLink(status.mint)]
+    case 'completed':
+      return [burnLink(status.burn), mintLink(status.mint)]
+    case 'failed': {
+      const links: TxLink[] = []
+      if (status.burn) links.push(burnLink(status.burn))
+      if (status.mint) links.push(mintLink(status.mint))
+      return links
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Failed transfers show "failed" with no details. The aggregates capture error reasons and tx hashes at each stage but DTOs strip this to just `failed_at`. Debugging production issues from the dashboard is impossible.

Closes #399

## Solution

- Add `alloy-primitives::TxHash` to DTO status enums so each transfer stage carries its transaction hashes and failure reasons
- Update `to_dto()` in all three aggregates (tokenized equity mint, equity redemption, USDC rebalance) to populate the new fields from aggregate state
- Add `transfer-details.ts` helper with `failureReason()` and `txLinks()` extractors shared by both dashboard panels
- Show clickable explorer links (basescan.org for Base, etherscan.io for Ethereum) and error reason text in transfer-panel and inventory-panel

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction hashes now tracked across all operation stages (equity mints, redemptions, USDC bridges)
  * Blockchain explorer links added to transaction details for easy verification
  * Failure reasons now displayed for failed operations

* **Improvements**
  * Enhanced status visibility with per-stage transaction references
  * Detailed transaction information available throughout operation lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->