### PR TITLE
wire TurnkeyWallet into main crate, replacing Fireblocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,11 @@ ts-rs = { version = "11.1.0", features = [
 rocket_ws = "0.1.1"
 toml = "0.9.11"
 rust_decimal_macros = "1.38.0"
-st0x-evm = { workspace = true, features = ["fireblocks"] }
+st0x-evm = { workspace = true, features = [
+  "turnkey",
+  "fireblocks",
+  "local-signer",
+] }
 bon = "3.9.0"
 
 [dev-dependencies]
@@ -154,7 +158,7 @@ tokio-tungstenite = "0.28.0"
 st0x-event-sorcery = { path = "crates/event-sorcery", features = [
   "test-support",
 ] }
-st0x-evm = { workspace = true, features = ["local-signer"] }
+st0x-evm.workspace = true
 st0x-execution = { path = "crates/execution", features = ["mock"] }
 tempfile = "3.24.0"
 tracing-test = "0.2.5"

--- a/config/st0x-hedge.toml
+++ b/config/st0x-hedge.toml
@@ -7,18 +7,19 @@ hyperdx.service_name = "st0x-hedge"
 orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 deployment_block = 41715047
 
+[wallet]
+type = "turnkey"
+organization_id = "org-TODO"
+address = "0x0000000000000000000000000000000000000000"
+
 [rebalancing]
 redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
-fireblocks_vault_account_id = 1
-fireblocks_environment = "production"
 
-fireblocks_chain_asset_ids = { 1 = "ETH", 8453 = "BASECHAIN_ETH" }
-equity = { target = 0.5, deviation = 0.15 }
-usdc = { target = 0.5, deviation = 0.3 }
+[rebalancing.liquidity_venue_ratio]
+equities = { target = 0.5, deviation = 0.15 }
 
 [assets.cash]
 vault_id = "0xfab"
-rebalancing = "disabled"
 operational_limit = 100
 
 [assets.equities.RKLB]

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -181,6 +181,27 @@ impl<W: Wallet> CctpEndpoint<W> {
         IERC20::new(self.usdc_address, self.wallet.provider())
     }
 
+    /// Approves USDC spending via the wallet's signing path.
+    ///
+    /// Unlike `usdc().approve().send()`, this goes through `Wallet::submit`
+    /// which handles signing regardless of whether `Evm::Provider` is a
+    /// signing or read-only provider.
+    #[cfg(test)]
+    pub(super) async fn test_approve_usdc(
+        &self,
+        spender: Address,
+        amount: U256,
+    ) -> Result<(), CctpError> {
+        self.wallet
+            .submit::<st0x_evm::OpenChainErrorRegistry, _>(
+                self.usdc_address,
+                IERC20::approveCall { spender, amount },
+                "test USDC approve",
+            )
+            .await?;
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(super) fn owner(&self) -> Address {
         self.wallet.address()

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -936,12 +936,7 @@ mod tests {
 
         bridge
             .ethereum
-            .usdc()
-            .approve(spender, higher_amount)
-            .send()
-            .await
-            .unwrap()
-            .get_receipt()
+            .test_approve_usdc(spender, higher_amount)
             .await
             .unwrap();
 
@@ -995,12 +990,7 @@ mod tests {
 
         bridge
             .ethereum
-            .usdc()
-            .approve(spender, initial_allowance_amount)
-            .send()
-            .await
-            .unwrap()
-            .get_receipt()
+            .test_approve_usdc(spender, initial_allowance_amount)
             .await
             .unwrap();
 
@@ -1133,12 +1123,7 @@ mod tests {
 
         bridge
             .base
-            .usdc()
-            .approve(spender, higher_amount)
-            .send()
-            .await
-            .unwrap()
-            .get_receipt()
+            .test_approve_usdc(spender, higher_amount)
             .await
             .unwrap();
 
@@ -1190,12 +1175,7 @@ mod tests {
 
         bridge
             .base
-            .usdc()
-            .approve(spender, initial_allowance_amount)
-            .send()
-            .await
-            .unwrap()
-            .get_receipt()
+            .test_approve_usdc(spender, initial_allowance_amount)
             .await
             .unwrap();
 

--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -38,20 +38,28 @@ type SignerProvider<P> = FillProvider<
 /// wraps the provider with signing capabilities internally.
 ///
 /// `P` is the **base** provider type (e.g., from
-/// `ProviderBuilder::new().connect_http(url)`). The wallet-equipped provider
-/// is derived internally and exposed via [`Evm::provider()`].
+/// `ProviderBuilder::new().connect_http(url)`). Stores both the base
+/// provider (exposed via [`Evm::provider()`] for read-only access) and
+/// a signing provider (used internally by [`Wallet::send()`]).
 #[derive(Clone)]
 pub struct RawPrivateKeyWallet<P: Provider> {
-    provider: SignerProvider<P>,
+    /// Base provider for read-only chain access (view calls, balance
+    /// checks, block subscriptions).
+    provider: P,
+    /// Provider wrapped with gas/nonce/chain-id/wallet fillers for
+    /// transaction signing and submission.
+    signing_provider: SignerProvider<P>,
     required_confirmations: u64,
 }
 
 impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
-    /// Creates a new `RawPrivateKeyWallet` from a private key and base provider.
+    /// Creates a new `RawPrivateKeyWallet` from a private key and base
+    /// provider.
     ///
-    /// The base provider is wrapped with gas, nonce, chain ID, and wallet
-    /// fillers. Use [`Evm::provider()`] to access the signing provider for
-    /// contract deployments in tests.
+    /// The base provider is cloned and stored separately for read-only
+    /// access. Use [`signing_provider()`](Self::signing_provider) to
+    /// access the wallet-equipped provider for contract deployments in
+    /// tests.
     pub fn new(
         private_key: &B256,
         provider: P,
@@ -60,14 +68,22 @@ impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
         let signer = PrivateKeySigner::from_bytes(private_key)?;
         let eth_wallet = EthereumWallet::from(signer);
 
+        let base_provider = provider.clone();
+
         let signing_provider = ProviderBuilder::new()
             .wallet(eth_wallet)
             .connect_provider(provider);
 
         Ok(Self {
-            provider: signing_provider,
+            provider: base_provider,
+            signing_provider,
             required_confirmations,
         })
+    }
+
+    /// Returns the signing provider for contract deployments in tests.
+    pub fn signing_provider(&self) -> &SignerProvider<P> {
+        &self.signing_provider
     }
 }
 
@@ -76,9 +92,9 @@ impl<P> Evm for RawPrivateKeyWallet<P>
 where
     P: Provider + Clone + Send + Sync + 'static,
 {
-    type Provider = SignerProvider<P>;
+    type Provider = P;
 
-    fn provider(&self) -> &SignerProvider<P> {
+    fn provider(&self) -> &P {
         &self.provider
     }
 }
@@ -89,7 +105,7 @@ where
     P: Provider + Clone + Send + Sync + 'static,
 {
     fn address(&self) -> Address {
-        self.provider.default_signer_address()
+        self.signing_provider.default_signer_address()
     }
 
     async fn send(
@@ -104,7 +120,7 @@ where
             .to(contract)
             .input(calldata.into());
 
-        let pending = self.provider.send_transaction(tx).await?;
+        let pending = self.signing_provider.send_transaction(tx).await?;
 
         info!(tx_hash = %pending.tx_hash(), note, "Transaction submitted");
 
@@ -151,7 +167,7 @@ mod tests {
         let wallet = RawPrivateKeyWallet::new(&private_key, base_provider, 1).unwrap();
         let signer_address = wallet.address();
 
-        let token = TestERC20::deploy(wallet.provider()).await.unwrap();
+        let token = TestERC20::deploy(wallet.signing_provider()).await.unwrap();
         let token_address = *token.address();
 
         let mint_amount = U256::from(1_000_000) * U256::from(10).pow(U256::from(18));

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -51,8 +51,7 @@ pub enum TurnkeyError {
 ///
 /// Contains everything needed to build a wallet: Turnkey API
 /// credentials, the wallet address, and a base provider. Callers
-/// construct this directly via its public fields and pass it to
-/// [`TurnkeyWallet::new`].
+/// construct this directly via struct literal syntax.
 pub struct TurnkeyCtx<P> {
     pub api_private_key: TurnkeyApiPrivateKey,
     pub organization_id: TurnkeyOrganizationId,

--- a/example.config.toml
+++ b/example.config.toml
@@ -7,14 +7,17 @@ hyperdx.service_name = "st0x-hedge"
 orderbook = "0x1111111111111111111111111111111111111111"
 deployment_block = 1
 
+[wallet]
+type = "turnkey"
+organization_id = "org-..."
+address = "0x0000000000000000000000000000000000000000"
+
 [rebalancing]
 redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-fireblocks_vault_account_id = 0
-fireblocks_environment = "sandbox"
 
-fireblocks_chain_asset_ids = { 1 = "ETH", 8453 = "BASECHAIN_ETH" }
-equity = { target = 0.5, deviation = 0.2 }
-usdc = { target = 0.5, deviation = 0.3 }
+[rebalancing.liquidity_venue_ratio]
+equities = { target = 0.5, deviation = 0.2 }
+cash = { target = 0.5, deviation = 0.3 }
 
 [assets.equities.EXAMPLE]
 tokenized_equity = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -25,6 +28,5 @@ rebalancing = "disabled"
 # operational_limit = 100.0
 
 [assets.cash]
-rebalancing = "enabled"
 # vault_id = "0xcd34"
 # operational_limit = 10000.0

--- a/example.secrets.toml
+++ b/example.secrets.toml
@@ -10,8 +10,10 @@ api_key = "test_key"
 api_secret = "test_secret"
 account_id = "dddddddd-eeee-aaaa-dddd-beeeeeeeeeef"
 
+[wallet]
+type = "turnkey"
+api_private_key = "hex-encoded-p256-api-private-key"
+
 [rebalancing]
 base_rpc_url = "https://mainnet.base.org"
 ethereum_rpc_url = "https://mainnet.infura.io"
-fireblocks_api_user_id = "example-api-user-id"
-fireblocks_secret_path = "/path/to/fireblocks_secret.pem"

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -77,7 +77,7 @@ pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write
         anyhow::bail!("Insufficient USDC balance: have {balance}, need {amount_u256}");
     }
 
-    writeln!(stdout, "   Sending USDC transfer via Fireblocks...")?;
+    writeln!(stdout, "   Sending USDC transfer via wallet...")?;
     let ethereum_wallet = rebalancing_ctx.ethereum_wallet().clone();
     let tx_receipt = ethereum_wallet
         .submit::<Registry, _>(
@@ -531,7 +531,7 @@ mod tests {
     use crate::config::{AssetsConfig, EquitiesConfig, LogLevel, TradingMode};
     use crate::inventory::ImbalanceThreshold;
     use crate::onchain::EvmCtx;
-    use crate::rebalancing::RebalancingCtx;
+    use crate::rebalancing::{LiquidityVenueRatio, RebalancingCtx};
     use crate::threshold::ExecutionThreshold;
 
     fn create_ctx_without_alpaca() -> Ctx {
@@ -618,13 +618,15 @@ mod tests {
                 cash: None,
             },
             trading_mode: TradingMode::Rebalancing(Box::new(RebalancingCtx::stub(
-                ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.1),
-                },
-                ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.3),
+                LiquidityVenueRatio {
+                    equities: ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.1),
+                    },
+                    cash: Some(ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.3),
+                    }),
                 },
                 Address::ZERO,
                 AlpacaBrokerApiCtx {

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -217,7 +217,7 @@ pub(super) async fn reset_allowance_command<Registry: IntoErrorRegistry, Writer:
         return Ok(());
     }
 
-    writeln!(stdout, "   Sending approval tx via Fireblocks...")?;
+    writeln!(stdout, "   Sending approval tx via wallet...")?;
     let receipt = caller
         .submit::<Registry, _>(
             usdc_address,

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -93,7 +93,7 @@ pub(super) async fn vault_deposit_command<Writer: Write>(
 
     writeln!(
         stdout,
-        "   Depositing to vault (approve + deposit via Fireblocks)..."
+        "   Depositing to vault (approve + deposit via wallet)..."
     )?;
     let deposit_tx = raindex_service
         .deposit::<OpenChainErrorRegistry>(token, RaindexVaultId(vault_id), amount_u256, decimals)

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -126,20 +126,22 @@ mod tests {
     use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::{ImbalanceThreshold, InventoryView};
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::RebalancingTriggerConfig;
+    use crate::rebalancing::{LiquidityVenueRatio, RebalancingTriggerConfig};
     use crate::test_utils::setup_test_db;
     use crate::tokenization::mock::MockTokenizer;
     use crate::wrapper::mock::MockWrapper;
 
     fn test_trigger_config() -> RebalancingTriggerConfig {
         RebalancingTriggerConfig {
-            equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
-            },
-            usdc: ImbalanceThreshold {
-                target: dec!(0.6),
-                deviation: dec!(0.15),
+            liquidity_venue_ratio: LiquidityVenueRatio {
+                equities: ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.2),
+                },
+                cash: Some(ImbalanceThreshold {
+                    target: dec!(0.6),
+                    deviation: dec!(0.15),
+                }),
             },
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -440,8 +440,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let rebalancing_trigger = Arc::new(RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: rebalancing_ctx.equity,
-                usdc: rebalancing_ctx.usdc,
+                liquidity_venue_ratio: rebalancing_ctx.liquidity_venue_ratio.clone(),
                 assets: deps.ctx.assets.clone(),
                 disabled_assets,
             },
@@ -476,17 +475,23 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         )
         .await?;
 
-        let usdc_vault_id = deps
-            .ctx
-            .assets
-            .cash
-            .as_ref()
-            .and_then(|cash| cash.vault_id)
-            .ok_or(CtxError::MissingCashVaultId)?;
+        let usdc_vault_id = if rebalancing_ctx.liquidity_venue_ratio.cash.is_some() {
+            let vault_id = deps
+                .ctx
+                .assets
+                .cash
+                .as_ref()
+                .and_then(|cash| cash.vault_id)
+                .ok_or(CtxError::MissingCashVaultId)?;
+
+            RaindexVaultId(vault_id)
+        } else {
+            RaindexVaultId(alloy::primitives::B256::ZERO)
+        };
 
         let handle = services.spawn(
             market_maker_wallet,
-            RaindexVaultId(usdc_vault_id),
+            usdc_vault_id,
             operation_receiver,
             frameworks,
         );
@@ -1600,7 +1605,7 @@ mod tests {
     use crate::inventory::{ImbalanceThreshold, Inventory, Venue};
     use crate::offchain_order::Dollars;
     use crate::onchain::trade::OnchainTrade;
-    use crate::rebalancing::{RebalancingTrigger, TriggeredOperation};
+    use crate::rebalancing::{LiquidityVenueRatio, RebalancingTrigger, TriggeredOperation};
     use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
     use crate::threshold::{ExecutionThreshold, Usdc};
     use crate::wrapper::mock::MockWrapper;
@@ -3450,13 +3455,15 @@ mod tests {
 
         let trigger = Arc::new(RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
-                },
-                usdc: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    },
+                    cash: Some(ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    }),
                 },
                 assets: test_assets_config(),
                 disabled_assets: HashSet::new(),
@@ -3541,8 +3548,10 @@ mod tests {
 
         let trigger = Arc::new(RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: threshold,
-                usdc: threshold,
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: threshold,
+                    cash: Some(threshold),
+                },
                 assets: test_assets_config(),
                 disabled_assets: HashSet::new(),
             },
@@ -3646,13 +3655,15 @@ mod tests {
 
         let trigger = Arc::new(RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
-                },
-                usdc: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    },
+                    cash: Some(ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    }),
                 },
                 assets: test_assets_config(),
                 disabled_assets: HashSet::new(),
@@ -3770,13 +3781,15 @@ mod tests {
 
         let trigger = Arc::new(RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
-                },
-                usdc: ImbalanceThreshold {
-                    target: dec!(0.5),
-                    deviation: dec!(0.2),
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    },
+                    cash: Some(ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    }),
                 },
                 assets: test_assets_config(),
                 disabled_assets: HashSet::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,8 @@ use st0x_execution::{
 use crate::offchain::order_poller::OrderPollerCtx;
 use crate::onchain::{EvmConfig, EvmCtx, EvmSecrets};
 use crate::rebalancing::{
-    RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets,
+    RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets, WalletConfig,
+    WalletSecrets,
 };
 use crate::telemetry::{TelemetryConfig, TelemetryCtx, TelemetrySecrets};
 use crate::threshold::{ExecutionThreshold, InvalidThresholdError, Usdc};
@@ -74,7 +75,6 @@ pub(crate) struct CashAssetConfig {
     /// when omitted, it is discovered from onchain trade events.
     #[serde(default, deserialize_with = "deserialize_padded_b256")]
     pub(crate) vault_id: Option<B256>,
-    pub(crate) rebalancing: OperationMode,
     pub(crate) operational_limit: Option<Positive<Usdc>>,
 }
 
@@ -144,6 +144,7 @@ struct Config {
     inventory_poll_interval: Option<u64>,
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetryConfig>,
+    wallet: Option<WalletConfig>,
     rebalancing: Option<RebalancingConfig>,
     assets: AssetsConfig,
 }
@@ -156,6 +157,7 @@ struct Secrets {
     broker: BrokerSecrets,
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetrySecrets>,
+    wallet: Option<WalletSecrets>,
     rebalancing: Option<RebalancingSecrets>,
 }
 
@@ -190,7 +192,7 @@ enum BrokerSecrets {
 /// Encodes the two mutually exclusive operating modes at the type level.
 ///
 /// `Standalone`: order_owner comes from config, no rebalancing.
-/// `Rebalancing`: order_owner resolved from Fireblocks at runtime.
+/// `Rebalancing`: order_owner resolved from Turnkey wallet at runtime.
 #[derive(Clone, Debug)]
 pub(crate) enum TradingMode {
     Standalone { order_owner: Address },
@@ -449,8 +451,8 @@ impl Ctx {
 
                 let minimum = crate::rebalancing::trigger::ALPACA_MINIMUM_WITHDRAWAL;
 
-                if let Some(cash) = &config.assets.cash
-                    && cash.rebalancing == OperationMode::Enabled
+                if rebalancing_config.liquidity_venue_ratio.cash.is_some()
+                    && let Some(cash) = &config.assets.cash
                     && let Some(cash_limit) = &cash.operational_limit
                     && cash_limit.inner() < minimum
                 {
@@ -460,17 +462,27 @@ impl Ctx {
                     });
                 }
 
+                let Some(wallet_config) = config.wallet else {
+                    return Err(CtxError::WalletConfigMissing);
+                };
+
+                let Some(wallet_secrets) = secrets.wallet else {
+                    return Err(CtxError::WalletSecretsMissing);
+                };
+
                 TradingMode::Rebalancing(Box::new(
                     RebalancingCtx::new(
                         rebalancing_config,
                         rebalancing_secrets,
+                        wallet_config,
+                        wallet_secrets,
                         alpaca_auth.clone(),
                     )
                     .await?,
                 ))
             }
             (Some(_), Some(_), Some(configured)) => {
-                return Err(CtxError::OrderOwnerConflictsWithFireblocks { configured });
+                return Err(CtxError::OrderOwnerConflictsWithRebalancing { configured });
             }
             (None, None, Some(order_owner)) => TradingMode::Standalone { order_owner },
             (None, None, None) => return Err(CtxError::MissingOrderOwner),
@@ -532,7 +544,7 @@ impl Ctx {
     /// Returns the wallet address that owns orders on the orderbook.
     ///
     /// In `Standalone` mode this is the statically-configured order owner.
-    /// In `Rebalancing` mode this is the Fireblocks wallet address resolved
+    /// In `Rebalancing` mode this is the Turnkey wallet address resolved
     /// during async construction.
     pub(crate) fn order_owner(&self) -> Address {
         match &self.trading_mode {
@@ -602,11 +614,15 @@ pub enum CtxError {
     RebalancingSecretsMissing,
     #[error("rebalancing secrets present but rebalancing config missing in config")]
     RebalancingConfigMissing,
+    #[error("[wallet] config section required when rebalancing is enabled")]
+    WalletConfigMissing,
+    #[error("[wallet] secrets section required when rebalancing is enabled")]
+    WalletSecretsMissing,
     #[error(
-        "order_owner {configured} must not be set when Fireblocks \
-         rebalancing is enabled (address is derived from vault)"
+        "order_owner {configured} must not be set when rebalancing \
+         is enabled (address is derived from Turnkey wallet)"
     )]
-    OrderOwnerConflictsWithFireblocks { configured: Address },
+    OrderOwnerConflictsWithRebalancing { configured: Address },
     #[error(
         "assets.cash operational_limit {configured} is below Alpaca's \
          minimum withdrawal of {minimum}"
@@ -647,8 +663,10 @@ impl CtxError {
             Self::Telemetry(_) => "telemetry assembly error",
             Self::RebalancingSecretsMissing => "rebalancing secrets missing",
             Self::RebalancingConfigMissing => "rebalancing config missing",
-            Self::OrderOwnerConflictsWithFireblocks { .. } => {
-                "order_owner conflicts with fireblocks"
+            Self::WalletConfigMissing => "wallet config missing",
+            Self::WalletSecretsMissing => "wallet secrets missing",
+            Self::OrderOwnerConflictsWithRebalancing { .. } => {
+                "order_owner conflicts with rebalancing"
             }
             Self::CashOperationalLimitBelowMinimumWithdrawal { .. } => {
                 "cash operational limit below minimum withdrawal"
@@ -801,10 +819,6 @@ pub(crate) mod tests {
         file
     }
 
-    fn example_config_toml() -> &'static Path {
-        Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/example.config.toml"))
-    }
-
     fn example_secrets_toml() -> &'static Path {
         Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/example.secrets.toml"))
     }
@@ -908,11 +922,13 @@ pub(crate) mod tests {
             account_id = "dddddddd-eeee-aaaa-dddd-beeeeeeeeeef"
             mode = "sandbox"
 
+            [wallet]
+            type = "turnkey"
+            api_private_key = "test-api-key"
+
             [rebalancing]
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
-            fireblocks_api_user_id = "test-user"
-            fireblocks_secret_path = "/tmp/test.key"
         "#,
         );
 
@@ -923,29 +939,23 @@ pub(crate) mod tests {
             [assets.equities]
 
             [assets.cash]
-            rebalancing = "enabled"
             operational_limit = 5
 
             [raindex]
             orderbook = "0x1111111111111111111111111111111111111111"
             deployment_block = 1
 
+            [wallet]
+            type = "turnkey"
+            organization_id = "org-test"
+            address = "0x0000000000000000000000000000000000000000"
+
             [rebalancing]
             redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [rebalancing.fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [rebalancing.equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [rebalancing.usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [rebalancing.liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#,
         );
 
@@ -1008,11 +1018,13 @@ pub(crate) mod tests {
             app_secret = "test_secret"
             encryption_key = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
+            [wallet]
+            type = "turnkey"
+            api_private_key = "test-api-key"
+
             [rebalancing]
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
-            fireblocks_api_user_id = "test-user"
-            fireblocks_secret_path = "/tmp/test.key"
         "#,
         );
 
@@ -1026,22 +1038,17 @@ pub(crate) mod tests {
             orderbook = "0x1111111111111111111111111111111111111111"
             deployment_block = 1
 
+            [wallet]
+            type = "turnkey"
+            organization_id = "org-test"
+            address = "0x0000000000000000000000000000000000000000"
+
             [rebalancing]
             redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [rebalancing.fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [rebalancing.equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [rebalancing.usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [rebalancing.liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#,
         );
 
@@ -1082,20 +1089,6 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn rebalancing_with_missing_secret_file_fails() {
-        let error = Ctx::load_files(example_config_toml(), example_secrets_toml())
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(
-                error,
-                CtxError::Rebalancing(ref inner) if matches!(**inner, RebalancingCtxError::FireblocksSecretRead { .. })
-            ),
-            "Expected FireblocksSecretRead IO error for non-existent secret file, got {error:?}"
-        );
-    }
-
-    #[tokio::test]
     async fn rebalancing_with_order_owner_configured_fails() {
         let config = toml_file(
             r#"
@@ -1115,21 +1108,17 @@ pub(crate) mod tests {
             [hyperdx]
             service_name = "st0x-hedge"
 
+            [wallet]
+            type = "turnkey"
+            organization_id = "org-test"
+            address = "0x0000000000000000000000000000000000000000"
+
             [rebalancing]
             redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [rebalancing.fireblocks_chain_asset_ids]
-            1 = "ETH"
-
-            [rebalancing.equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [rebalancing.usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [rebalancing.liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#,
         );
 
@@ -1137,8 +1126,8 @@ pub(crate) mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(error, CtxError::OrderOwnerConflictsWithFireblocks { .. }),
-            "Expected OrderOwnerConflictsWithFireblocks, got: {error:?}"
+            matches!(error, CtxError::OrderOwnerConflictsWithRebalancing { .. }),
+            "Expected OrderOwnerConflictsWithRebalancing, got: {error:?}"
         );
     }
 
@@ -1254,20 +1243,10 @@ pub(crate) mod tests {
 
             [rebalancing]
             redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [rebalancing.fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [rebalancing.equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [rebalancing.usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [rebalancing.liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#,
         );
 
@@ -1387,11 +1366,13 @@ pub(crate) mod tests {
             app_secret = "test_secret"
             encryption_key = "0x0000000000000000000000000000000000000000000000000000000000000000"
 
+            [wallet]
+            type = "turnkey"
+            api_private_key = "test-api-key"
+
             [rebalancing]
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
-            fireblocks_api_user_id = "test-user"
-            fireblocks_secret_path = "/tmp/test.key"
         "#,
         );
 
@@ -1405,22 +1386,17 @@ pub(crate) mod tests {
             orderbook = "0x1111111111111111111111111111111111111111"
             deployment_block = 1
 
+            [wallet]
+            type = "turnkey"
+            organization_id = "org-test"
+            address = "0x0000000000000000000000000000000000000000"
+
             [rebalancing]
             redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [rebalancing.fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [rebalancing.equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [rebalancing.usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [rebalancing.liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#,
         );
 
@@ -1756,7 +1732,6 @@ pub(crate) mod tests {
 
             [cash]
             vault_id = "0x0000000000000000000000000000000000000000000000000000000000000fab"
-            rebalancing = "disabled"
             operational_limit = 100
         "#;
 
@@ -1777,7 +1752,6 @@ pub(crate) mod tests {
         assert!(rklb.operational_limit.is_some());
 
         let cash = config.cash.unwrap();
-        assert_eq!(cash.rebalancing, OperationMode::Disabled);
         assert!(cash.vault_id.is_some());
     }
 
@@ -2143,12 +2117,10 @@ pub(crate) mod tests {
         fn cash_asset_config_parses_without_token_addresses() {
             let toml_str = r#"
                 vault_id = "0xfab"
-                rebalancing = "disabled"
                 operational_limit = 100
             "#;
 
             let config: CashAssetConfig = toml::from_str(toml_str).unwrap();
-            assert_eq!(config.rebalancing, OperationMode::Disabled);
             assert!(config.vault_id.is_some());
         }
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -40,7 +40,8 @@ use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::usdc::mock::MockUsdcRebalance;
 use crate::rebalancing::{
-    Rebalancer, RebalancingTrigger, RebalancingTriggerConfig, TriggeredOperation,
+    LiquidityVenueRatio, Rebalancer, RebalancingTrigger, RebalancingTriggerConfig,
+    TriggeredOperation,
 };
 use crate::test_utils::setup_test_db;
 use crate::threshold::{ExecutionThreshold, Usdc};
@@ -108,13 +109,15 @@ async fn discover_deterministic_tx_hash(
 
 fn test_trigger_config() -> RebalancingTriggerConfig {
     RebalancingTriggerConfig {
-        equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
-        },
-        usdc: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+        liquidity_venue_ratio: LiquidityVenueRatio {
+            equities: ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            },
+            cash: Some(ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            }),
         },
         assets: AssetsConfig {
             equities: EquitiesConfig {
@@ -132,7 +135,6 @@ fn test_trigger_config() -> RebalancingTriggerConfig {
             },
             cash: Some(CashAssetConfig {
                 vault_id: None,
-                rebalancing: OperationMode::Enabled,
                 operational_limit: None,
             }),
         },
@@ -1112,19 +1114,20 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         equities: EquitiesConfig::default(),
         cash: Some(CashAssetConfig {
             vault_id: None,
-            rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc(dec!(100))).unwrap()),
         }),
     };
 
     let config = RebalancingTriggerConfig {
-        equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
-        },
-        usdc: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+        liquidity_venue_ratio: LiquidityVenueRatio {
+            equities: ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            },
+            cash: Some(ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            }),
         },
         assets,
         disabled_assets: HashSet::new(),
@@ -1228,18 +1231,19 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         equities: EquitiesConfig::default(),
         cash: Some(CashAssetConfig {
             vault_id: None,
-            rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc(dec!(100))).unwrap()),
         }),
     };
     let config = RebalancingTriggerConfig {
-        equity: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
-        },
-        usdc: ImbalanceThreshold {
-            target: dec!(0.5),
-            deviation: dec!(0.2),
+        liquidity_venue_ratio: LiquidityVenueRatio {
+            equities: ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            },
+            cash: Some(ImbalanceThreshold {
+                target: dec!(0.5),
+                deviation: dec!(0.2),
+            }),
         },
         assets,
         disabled_assets: HashSet::new(),
@@ -1326,19 +1330,20 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
         let (sender, mut receiver) = mpsc::channel(10);
         let wide_config = RebalancingTriggerConfig {
-            equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.4),
-            },
-            usdc: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.4),
+            liquidity_venue_ratio: LiquidityVenueRatio {
+                equities: ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.4),
+                },
+                cash: Some(ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.4),
+                }),
             },
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
                     vault_id: None,
-                    rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),
             },
@@ -1381,19 +1386,20 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
         let (sender, mut receiver) = mpsc::channel(10);
         let tight_config = RebalancingTriggerConfig {
-            equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.1),
-            },
-            usdc: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.1),
+            liquidity_venue_ratio: LiquidityVenueRatio {
+                equities: ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.1),
+                },
+                cash: Some(ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.1),
+                }),
             },
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
                     vault_id: None,
-                    rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),
             },

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -453,11 +453,12 @@ mod tests {
             let base_provider = ProviderBuilder::new().connect_http(endpoint.parse()?);
             let wallet = RawPrivateKeyWallet::new(&private_key, base_provider, 1)?;
 
-            Self::deploy_tofu_decimals(wallet.provider()).await?;
+            Self::deploy_tofu_decimals(wallet.signing_provider()).await?;
 
-            let orderbook_address = Self::deploy_orderbook(wallet.provider()).await?;
+            let orderbook_address = Self::deploy_orderbook(wallet.signing_provider()).await?;
 
-            let token_address = Self::deploy_token(wallet.provider(), wallet.address()).await?;
+            let token_address =
+                Self::deploy_token(wallet.signing_provider(), wallet.address()).await?;
 
             Ok(Self {
                 anvil,
@@ -512,7 +513,7 @@ mod tests {
             spender: Address,
             amount: U256,
         ) -> Result<(), LocalEvmError> {
-            let token_contract = TestERC20::new(token, self.wallet.provider());
+            let token_contract = TestERC20::new(token, self.wallet.signing_provider());
 
             token_contract
                 .approve(spender, amount)

--- a/src/rebalancing/mod.rs
+++ b/src/rebalancing/mod.rs
@@ -14,5 +14,8 @@ pub(crate) use rebalancer::Rebalancer;
 pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks};
 pub(crate) use trigger::{
     RebalancingConfig, RebalancingCtx, RebalancingCtxError, RebalancingSecrets, RebalancingTrigger,
-    RebalancingTriggerConfig, TriggeredOperation,
+    RebalancingTriggerConfig, TriggeredOperation, WalletConfig, WalletSecrets,
 };
+
+#[cfg(test)]
+pub(crate) use trigger::LiquidityVenueRatio;

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -182,8 +182,8 @@ mod tests {
     use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::ImbalanceThreshold;
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::RebalancingTriggerConfig;
     use crate::rebalancing::equity::EquityTransferServices;
+    use crate::rebalancing::{LiquidityVenueRatio, RebalancingTriggerConfig};
     use crate::tokenization::alpaca::AlpacaTokenizationService;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_registry::VaultRegistry;
@@ -202,13 +202,15 @@ mod tests {
 
     fn make_ctx() -> RebalancingCtx {
         RebalancingCtx::stub(
-            ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
-            },
-            ImbalanceThreshold {
-                target: dec!(0.6),
-                deviation: dec!(0.15),
+            LiquidityVenueRatio {
+                equities: ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.2),
+                },
+                cash: Some(ImbalanceThreshold {
+                    target: dec!(0.6),
+                    deviation: dec!(0.15),
+                }),
             },
             address!("0x1234567890123456789012345678901234567890"),
             AlpacaBrokerApiCtx {
@@ -241,8 +243,7 @@ mod tests {
         let ctx = make_ctx();
 
         let trigger_config = RebalancingTriggerConfig {
-            equity: ctx.equity,
-            usdc: ctx.usdc,
+            liquidity_venue_ratio: ctx.liquidity_venue_ratio,
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: None,
@@ -250,8 +251,14 @@ mod tests {
             disabled_assets: HashSet::new(),
         };
 
-        assert_eq!(trigger_config.equity.target, dec!(0.5));
-        assert_eq!(trigger_config.equity.deviation, dec!(0.2));
+        assert_eq!(
+            trigger_config.liquidity_venue_ratio.equities.target,
+            dec!(0.5)
+        );
+        assert_eq!(
+            trigger_config.liquidity_venue_ratio.equities.deviation,
+            dec!(0.2)
+        );
     }
 
     #[test]
@@ -259,8 +266,7 @@ mod tests {
         let ctx = make_ctx();
 
         let trigger_config = RebalancingTriggerConfig {
-            equity: ctx.equity,
-            usdc: ctx.usdc,
+            liquidity_venue_ratio: ctx.liquidity_venue_ratio,
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: None,
@@ -268,8 +274,9 @@ mod tests {
             disabled_assets: HashSet::new(),
         };
 
-        assert_eq!(trigger_config.usdc.target, dec!(0.6));
-        assert_eq!(trigger_config.usdc.deviation, dec!(0.15));
+        let cash = trigger_config.liquidity_venue_ratio.cash.unwrap();
+        assert_eq!(cash.target, dec!(0.6));
+        assert_eq!(cash.deviation, dec!(0.15));
     }
 
     async fn make_services_with_mock_wallet(

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -5,7 +5,7 @@ mod usdc;
 
 pub(crate) use usdc::ALPACA_MINIMUM_WITHDRAWAL;
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use alloy::providers::{Provider, RootProvider};
 use async_trait::async_trait;
 use chrono::Utc;
@@ -15,7 +15,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::fs;
 use tokio::sync::{RwLock, mpsc};
 use tracing::{debug, error, info, warn};
 use url::Url;
@@ -23,12 +22,14 @@ use url::Url;
 use st0x_event_sorcery::{AggregateError, EntityList, LifecycleError, Reactor, Store, deps};
 use st0x_evm::Wallet;
 use st0x_evm::fireblocks::{
-    ChainAssetIds, FireblocksApiUserId, FireblocksCtx, FireblocksEnvironment,
+    ChainAssetIds, FireblocksApiUserId, FireblocksCtx, FireblocksEnvironment, FireblocksError,
     FireblocksVaultAccountId, FireblocksWallet,
 };
+use st0x_evm::local::RawPrivateKeyWallet;
+use st0x_evm::turnkey::{TurnkeyApiPrivateKey, TurnkeyCtx, TurnkeyOrganizationId, TurnkeyWallet};
 use st0x_execution::{AlpacaBrokerApiCtx, FractionalShares, Positive, Symbol};
 
-use crate::config::{AssetsConfig, OperationMode};
+use crate::config::AssetsConfig;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent, RedemptionAggregateId};
 use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
 use crate::inventory::{
@@ -70,20 +71,67 @@ pub(crate) enum TokenAddressError {
 pub enum RebalancingCtxError {
     #[error("rebalancing requires alpaca-broker-api broker type")]
     NotAlpacaBroker,
+    #[error("RPC error during wallet setup: {0}")]
+    Rpc(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
     #[error(transparent)]
-    Fireblocks(#[from] st0x_evm::fireblocks::FireblocksError),
-    #[error("failed to read Fireblocks secret file at {path:?}")]
+    Evm(#[from] st0x_evm::EvmError),
+    #[error(transparent)]
+    Fireblocks(#[from] FireblocksError),
+    #[error("failed to read Fireblocks secret from {path}")]
     FireblocksSecretRead {
         path: PathBuf,
         #[source]
         error: std::io::Error,
     },
-    #[error("missing Fireblocks asset ID for chain ID {chain_id}")]
+    #[error("no Fireblocks chain asset ID configured for chain {chain_id}")]
     MissingChainAssetId { chain_id: u64 },
-    #[error("RPC error during wallet setup: {0}")]
-    Rpc(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
-    #[error(transparent)]
-    Evm(#[from] st0x_evm::EvmError),
+    #[error(
+        "wallet config and secrets must use the same type \
+         (e.g. both 'turnkey' or both 'fireblocks')"
+    )]
+    WalletConfigSecretsMismatch,
+}
+
+/// Wallet backend selection (plaintext config).
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) enum WalletConfig {
+    Turnkey {
+        organization_id: TurnkeyOrganizationId,
+        address: Address,
+    },
+    Fireblocks {
+        vault_account_id: FireblocksVaultAccountId,
+        environment: FireblocksEnvironment,
+        chain_asset_ids: ChainAssetIds,
+    },
+    RawPrivateKey,
+}
+
+/// Wallet backend secrets (encrypted config).
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
+pub(crate) enum WalletSecrets {
+    Turnkey {
+        api_private_key: TurnkeyApiPrivateKey,
+    },
+    Fireblocks {
+        api_user_id: FireblocksApiUserId,
+        secret_path: PathBuf,
+    },
+    RawPrivateKey {
+        private_key: B256,
+    },
+}
+
+impl std::fmt::Debug for WalletSecrets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Turnkey { .. } => write!(f, "Turnkey {{ redacted }}"),
+            Self::Fireblocks { .. } => write!(f, "Fireblocks {{ redacted }}"),
+            Self::RawPrivateKey { .. } => write!(f, "RawPrivateKey {{ redacted }}"),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -91,34 +139,39 @@ pub enum RebalancingCtxError {
 pub(crate) struct RebalancingSecrets {
     pub(crate) base_rpc_url: Url,
     pub(crate) ethereum_rpc_url: Url,
-    pub(crate) fireblocks_api_user_id: FireblocksApiUserId,
-    pub(crate) fireblocks_secret_path: PathBuf,
+}
+
+/// The proportion of each asset type's total inventory (regular + tokenized)
+/// allocated to the market-making liquidity venue (Raindex).
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LiquidityVenueRatio {
+    /// Target ratio and deviation for tokenized equities.
+    pub(crate) equities: ImbalanceThreshold,
+    /// Target ratio and deviation for USDC. When absent, USDC rebalancing
+    /// is disabled.
+    pub(crate) cash: Option<ImbalanceThreshold>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RebalancingConfig {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: ImbalanceThreshold,
     pub(crate) redemption_wallet: Address,
-    pub(crate) fireblocks_vault_account_id: FireblocksVaultAccountId,
-    pub(crate) fireblocks_environment: FireblocksEnvironment,
-    pub(crate) fireblocks_chain_asset_ids: ChainAssetIds,
+    pub(crate) liquidity_venue_ratio: LiquidityVenueRatio,
 }
 
 /// Runtime configuration for rebalancing operations.
 ///
 /// Constructed asynchronously from `RebalancingConfig`,
-/// `RebalancingSecrets`, and broker auth. During construction, Fireblocks
-/// wallets are pre-built for both chains. After construction, all
-/// fields are immutable.
+/// `RebalancingSecrets`, wallet config/secrets, and broker auth.
+/// During construction, wallets are pre-built for both chains. After
+/// construction, all fields are immutable.
 ///
 /// Read-only provider access for either chain is available via
 /// `base_wallet().provider()` and `ethereum_wallet().provider()`.
 #[derive(Clone)]
 pub(crate) struct RebalancingCtx {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: ImbalanceThreshold,
+    pub(crate) liquidity_venue_ratio: LiquidityVenueRatio,
     /// Issuer's wallet for tokenized equity redemptions.
     pub(crate) redemption_wallet: Address,
     pub(crate) alpaca_broker_auth: AlpacaBrokerApiCtx,
@@ -138,52 +191,43 @@ pub(crate) struct RebalancingCtx {
 }
 
 impl RebalancingCtx {
-    /// Construct from config, secrets, and broker auth.
+    /// Construct from config, secrets, wallet config/secrets, and
+    /// broker auth.
     ///
-    /// Builds Fireblocks wallets for both chains and stores them
-    /// immutably. Read-only provider access for either chain is
-    /// available via `base_wallet().provider()` and
-    /// `ethereum_wallet().provider()`.
+    /// Builds wallets for both chains and stores them immutably.
+    /// Read-only provider access for either chain is available via
+    /// `base_wallet().provider()` and `ethereum_wallet().provider()`.
     pub(crate) async fn new(
         config: RebalancingConfig,
         secrets: RebalancingSecrets,
+        wallet_config: WalletConfig,
+        wallet_secrets: WalletSecrets,
         broker_auth: AlpacaBrokerApiCtx,
     ) -> Result<Self, RebalancingCtxError> {
-        let fireblocks_secret =
-            fs::read(&secrets.fireblocks_secret_path)
-                .await
-                .map_err(|error| RebalancingCtxError::FireblocksSecretRead {
-                    path: secrets.fireblocks_secret_path.clone(),
-                    error,
-                })?;
-
         let (base_wallet, ethereum_wallet) = tokio::try_join!(
             Self::build_wallet(
-                &config,
-                &secrets.fireblocks_api_user_id,
-                &fireblocks_secret,
-                secrets.base_rpc_url,
+                &wallet_config,
+                &wallet_secrets,
+                secrets.base_rpc_url.clone()
             ),
             Self::build_wallet(
-                &config,
-                &secrets.fireblocks_api_user_id,
-                &fireblocks_secret,
-                secrets.ethereum_rpc_url,
+                &wallet_config,
+                &wallet_secrets,
+                secrets.ethereum_rpc_url.clone()
             ),
         )?;
 
         info!(
             wallet = %base_wallet.address(),
-            "Initialized Fireblocks wallet"
+            "Initialized wallet"
         );
 
         Ok(Self {
-            equity: config.equity,
-            usdc: config.usdc,
+            liquidity_venue_ratio: config.liquidity_venue_ratio,
             redemption_wallet: config.redemption_wallet,
             alpaca_broker_auth: broker_auth,
-            base_wallet: Arc::new(base_wallet),
-            ethereum_wallet: Arc::new(ethereum_wallet),
+            base_wallet,
+            ethereum_wallet,
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -194,30 +238,80 @@ impl RebalancingCtx {
     }
 
     async fn build_wallet(
-        config: &RebalancingConfig,
-        api_user_id: &FireblocksApiUserId,
-        api_secret: &[u8],
+        config: &WalletConfig,
+        secrets: &WalletSecrets,
         rpc_url: Url,
-    ) -> Result<FireblocksWallet<RootProvider>, RebalancingCtxError> {
-        let provider = RootProvider::new(crate::onchain::http_client_with_retry(rpc_url));
-        let chain_id = provider.get_chain_id().await?;
-        let asset_id = config
-            .fireblocks_chain_asset_ids
-            .get(chain_id)
-            .cloned()
-            .ok_or(RebalancingCtxError::MissingChainAssetId { chain_id })?;
+    ) -> Result<Arc<dyn Wallet<Provider = RootProvider>>, RebalancingCtxError> {
+        let provider = RootProvider::new(crate::onchain::http_client_with_retry(rpc_url.clone()));
 
-        Ok(FireblocksWallet::new(FireblocksCtx {
-            api_user_id: api_user_id.clone(),
-            secret: api_secret.to_vec(),
-            vault_account_id: config.fireblocks_vault_account_id,
-            environment: config.fireblocks_environment,
-            asset_id,
-            base_url: None,
-            provider,
-            required_confirmations: REQUIRED_CONFIRMATIONS,
-        })
-        .await?)
+        match (config, secrets) {
+            (
+                WalletConfig::Turnkey {
+                    organization_id,
+                    address,
+                },
+                WalletSecrets::Turnkey { api_private_key },
+            ) => {
+                let wallet = TurnkeyWallet::new(TurnkeyCtx {
+                    api_private_key: api_private_key.clone(),
+                    organization_id: organization_id.clone(),
+                    address: *address,
+                    provider,
+                    required_confirmations: REQUIRED_CONFIRMATIONS,
+                })
+                .await?;
+
+                Ok(Arc::new(wallet))
+            }
+
+            (
+                WalletConfig::Fireblocks {
+                    vault_account_id,
+                    environment,
+                    chain_asset_ids,
+                },
+                WalletSecrets::Fireblocks {
+                    api_user_id,
+                    secret_path,
+                },
+            ) => {
+                let secret = tokio::fs::read(secret_path).await.map_err(|error| {
+                    RebalancingCtxError::FireblocksSecretRead {
+                        path: secret_path.clone(),
+                        error,
+                    }
+                })?;
+
+                let chain_id = provider.get_chain_id().await?;
+                let asset_id = chain_asset_ids
+                    .get(chain_id)
+                    .ok_or(RebalancingCtxError::MissingChainAssetId { chain_id })?
+                    .clone();
+
+                let wallet = FireblocksWallet::new(FireblocksCtx {
+                    api_user_id: api_user_id.clone(),
+                    secret,
+                    vault_account_id: *vault_account_id,
+                    environment: *environment,
+                    asset_id,
+                    provider,
+                    required_confirmations: REQUIRED_CONFIRMATIONS,
+                    base_url: None,
+                })
+                .await?;
+
+                Ok(Arc::new(wallet))
+            }
+
+            (WalletConfig::RawPrivateKey, WalletSecrets::RawPrivateKey { private_key }) => {
+                let wallet =
+                    RawPrivateKeyWallet::new(private_key, provider, REQUIRED_CONFIRMATIONS)?;
+
+                Ok(Arc::new(wallet))
+            }
+
+            _ => Err(RebalancingCtxError::WalletConfigSecretsMismatch),
+        }
     }
 
     pub(crate) fn base_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
@@ -234,16 +328,14 @@ impl RebalancingCtx {
     /// transactions through the rebalancing wallet.
     #[cfg(test)]
     pub(crate) fn stub(
-        equity: ImbalanceThreshold,
-        usdc: ImbalanceThreshold,
+        liquidity_venue_ratio: LiquidityVenueRatio,
         redemption_wallet: Address,
         alpaca_broker_auth: AlpacaBrokerApiCtx,
     ) -> Self {
         let wallet = crate::test_utils::StubWallet::stub(Address::ZERO);
 
         Self {
-            equity,
-            usdc,
+            liquidity_venue_ratio,
             redemption_wallet,
             alpaca_broker_auth,
             base_wallet: wallet.clone(),
@@ -261,8 +353,7 @@ impl RebalancingCtx {
 impl std::fmt::Debug for RebalancingCtx {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RebalancingCtx")
-            .field("equity", &self.equity)
-            .field("usdc", &self.usdc)
+            .field("liquidity_venue_ratio", &self.liquidity_venue_ratio)
             .field("redemption_wallet", &self.redemption_wallet)
             .field("alpaca_broker_auth", &"[REDACTED]")
             .field("wallet", &self.base_wallet.address())
@@ -273,8 +364,7 @@ impl std::fmt::Debug for RebalancingCtx {
 /// Configuration for the rebalancing trigger (runtime).
 #[derive(Debug, Clone)]
 pub(crate) struct RebalancingTriggerConfig {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: ImbalanceThreshold,
+    pub(crate) liquidity_venue_ratio: LiquidityVenueRatio,
     pub(crate) assets: AssetsConfig,
     pub(crate) disabled_assets: HashSet<Symbol>,
 }
@@ -683,7 +773,7 @@ impl RebalancingTrigger {
 
         let Some(operation) = equity::check_imbalance_and_build_operation(
             symbol,
-            &self.config.equity,
+            &self.config.liquidity_venue_ratio.equities,
             &self.inventory,
             wrapped_token,
             unwrapped_token,
@@ -723,21 +813,23 @@ impl RebalancingTrigger {
         Ok(registry.token_by_symbol(symbol))
     }
 
-    /// Returns USDC rebalancing parameters if rebalancing is enabled in config.
+    /// Returns USDC rebalancing parameters if rebalancing is enabled.
+    ///
+    /// USDC rebalancing is enabled when `liquidity_venue_ratio.cash` is
+    /// `Some` in the rebalancing config.
     fn usdc_rebalancing_params(&self) -> Option<(ImbalanceThreshold, Option<Usdc>)> {
-        let Some(cash) = self.config.assets.cash.as_ref() else {
-            debug!("No assets.cash configured, USDC rebalancing disabled");
-            return None;
-        };
+        let threshold = self.config.liquidity_venue_ratio.cash?;
 
-        if matches!(cash.rebalancing, OperationMode::Disabled) {
-            debug!("USDC rebalancing disabled via assets.cash config");
-            return None;
-        }
+        debug!("USDC rebalancing enabled");
 
-        let usdc_limit = cash.operational_limit.map(Positive::inner);
+        let usdc_limit = self
+            .config
+            .assets
+            .cash
+            .as_ref()
+            .and_then(|cash| cash.operational_limit.map(Positive::inner));
 
-        Some((self.config.usdc, usdc_limit))
+        Some((threshold, usdc_limit))
     }
 
     /// Checks inventory for USDC imbalance and triggers operation if needed.
@@ -1003,7 +1095,7 @@ impl RebalancingTrigger {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, B256, TxHash, U256, address, fixed_bytes};
+    use alloy::primitives::{Address, TxHash, U256, address, fixed_bytes};
     use chrono::Utc;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
@@ -1034,19 +1126,20 @@ mod tests {
 
     fn test_config() -> RebalancingTriggerConfig {
         RebalancingTriggerConfig {
-            equity: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
-            },
-            usdc: ImbalanceThreshold {
-                target: dec!(0.5),
-                deviation: dec!(0.2),
+            liquidity_venue_ratio: LiquidityVenueRatio {
+                equities: ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.2),
+                },
+                cash: Some(ImbalanceThreshold {
+                    target: dec!(0.5),
+                    deviation: dec!(0.2),
+                }),
             },
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
                     vault_id: None,
-                    rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),
             },
@@ -1111,7 +1204,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_usdc_disabled_via_cash_config_does_not_send() {
+    async fn test_usdc_disabled_via_no_cash_ratio_does_not_send() {
         let (sender, mut receiver) = mpsc::channel(10);
         let inventory = Arc::new(RwLock::new(InventoryView::default()));
         let pool = crate::test_utils::setup_test_db().await;
@@ -1119,15 +1212,13 @@ mod tests {
 
         let trigger = RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: test_config().equity,
-                usdc: test_config().usdc,
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: test_config().liquidity_venue_ratio.equities,
+                    cash: None,
+                },
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
-                    cash: Some(CashAssetConfig {
-                        vault_id: Some(B256::ZERO),
-                        rebalancing: OperationMode::Disabled,
-                        operational_limit: None,
-                    }),
+                    cash: None,
                 },
                 disabled_assets: HashSet::new(),
             },
@@ -1160,8 +1251,7 @@ mod tests {
 
         let trigger = RebalancingTrigger::new(
             RebalancingTriggerConfig {
-                equity: test_config().equity,
-                usdc: test_config().usdc,
+                liquidity_venue_ratio: test_config().liquidity_venue_ratio,
                 assets: AssetsConfig {
                     equities: EquitiesConfig::default(),
                     cash: None,
@@ -3145,20 +3235,10 @@ mod tests {
     fn valid_rebalancing_config_toml() -> &'static str {
         r#"
             redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#
     }
 
@@ -3166,8 +3246,6 @@ mod tests {
         r#"
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://eth.example.com"
-            fireblocks_api_user_id = "test-user"
-            fireblocks_secret_path = "/tmp/test.key"
         "#
     }
 
@@ -3175,11 +3253,12 @@ mod tests {
     fn deserialize_config_succeeds() {
         let config: RebalancingConfig = toml::from_str(valid_rebalancing_config_toml()).unwrap();
 
-        assert_eq!(config.equity.target, dec!(0.5));
-        assert_eq!(config.equity.deviation, dec!(0.2));
+        assert_eq!(config.liquidity_venue_ratio.equities.target, dec!(0.5));
+        assert_eq!(config.liquidity_venue_ratio.equities.deviation, dec!(0.2));
 
-        assert_eq!(config.usdc.target, dec!(0.5));
-        assert_eq!(config.usdc.deviation, dec!(0.3));
+        let cash = config.liquidity_venue_ratio.cash.unwrap();
+        assert_eq!(cash.target, dec!(0.5));
+        assert_eq!(cash.deviation, dec!(0.3));
         assert_eq!(
             config.redemption_wallet,
             address!("1234567890123456789012345678901234567890")
@@ -3197,48 +3276,28 @@ mod tests {
         let config: RebalancingConfig = toml::from_str(
             r#"
             redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
 
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.6"
-            deviation = "0.1"
-
-            [usdc]
-            target = "0.4"
-            deviation = "0.15"
+            [liquidity_venue_ratio]
+            equities = { target = "0.6", deviation = "0.1" }
+            cash = { target = "0.4", deviation = "0.15" }
         "#,
         )
         .unwrap();
 
-        assert_eq!(config.equity.target, dec!(0.6));
-        assert_eq!(config.equity.deviation, dec!(0.1));
+        assert_eq!(config.liquidity_venue_ratio.equities.target, dec!(0.6));
+        assert_eq!(config.liquidity_venue_ratio.equities.deviation, dec!(0.1));
 
-        assert_eq!(config.usdc.target, dec!(0.4));
-        assert_eq!(config.usdc.deviation, dec!(0.15));
+        let cash = config.liquidity_venue_ratio.cash.unwrap();
+        assert_eq!(cash.target, dec!(0.4));
+        assert_eq!(cash.deviation, dec!(0.15));
     }
 
     #[test]
     fn deserialize_missing_redemption_wallet_fails() {
         let toml_str = r#"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
-
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
+            cash = { target = "0.5", deviation = "0.3" }
         "#;
 
         let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
@@ -3249,119 +3308,66 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_missing_fireblocks_fields_fails() {
-        let toml_str = r#"
-            base_rpc_url = "https://base.example.com"
-            ethereum_rpc_url = "https://eth.example.com"
-        "#;
-
-        let error = toml::from_str::<RebalancingSecrets>(toml_str).unwrap_err();
-        assert!(
-            error.message().contains("fireblocks_api_user_id"),
-            "Expected missing fireblocks_api_user_id error, got: {error}"
-        );
-    }
-
-    #[test]
-    fn deserialize_string_vault_account_id_fails() {
-        // Reproduces production error: Fireblocks API returns 400 with
-        // "vaultAccountId: should match format \"numeric\"" when a
-        // non-numeric value is used. The vault account ID must be a bare
-        // integer in TOML, not a quoted string.
+    fn deserialize_missing_liquidity_venue_ratio_fails() {
         let toml_str = r#"
             redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = "1"
-            fireblocks_environment = "sandbox"
-
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            target = "0.5"
-            deviation = "0.3"
         "#;
 
         let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
         assert!(
-            error.message().contains("invalid type: string")
-                && error.message().contains("expected u64"),
-            "Expected string-to-u64 type mismatch for \
-             fireblocks_vault_account_id, got: {error}"
+            error.message().contains("liquidity_venue_ratio"),
+            "Expected missing liquidity_venue_ratio error, got: {error}"
         );
     }
 
     #[test]
-    fn deserialize_integer_vault_account_id_succeeds() {
+    fn deserialize_config_without_cash_succeeds() {
         let toml_str = r#"
             redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = 1
-            fireblocks_environment = "sandbox"
 
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            target = "0.5"
-            deviation = "0.3"
+            [liquidity_venue_ratio]
+            equities = { target = "0.5", deviation = "0.2" }
         "#;
 
         let config = toml::from_str::<RebalancingConfig>(toml_str).unwrap();
-        assert_eq!(config.fireblocks_vault_account_id.to_string(), "1");
+        assert!(config.liquidity_venue_ratio.cash.is_none());
     }
 
-    #[test]
-    fn deserialize_missing_equity_fails() {
-        let toml_str = r#"
-            redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
+    #[tokio::test]
+    async fn usdc_rebalancing_disabled_when_cash_ratio_absent() {
+        // Regression: when liquidity_venue_ratio.cash is None, startup must
+        // not require assets.cash.vault_id. The trigger returns no USDC
+        // rebalancing params, so no USDC vault lookup occurs.
+        let (sender, _receiver) = mpsc::channel(10);
+        let pool = crate::test_utils::setup_test_db().await;
+        let wrapper = Arc::new(MockWrapper::new());
 
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [usdc]
-            target = "0.5"
-            deviation = "0.3"
-        "#;
-
-        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
-        assert!(
-            error.message().contains("equity"),
-            "Expected missing equity error, got: {error}"
+        let trigger = RebalancingTrigger::new(
+            RebalancingTriggerConfig {
+                liquidity_venue_ratio: LiquidityVenueRatio {
+                    equities: ImbalanceThreshold {
+                        target: dec!(0.5),
+                        deviation: dec!(0.2),
+                    },
+                    cash: None,
+                },
+                assets: AssetsConfig {
+                    equities: EquitiesConfig::default(),
+                    cash: None,
+                },
+                disabled_assets: HashSet::new(),
+            },
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            Arc::new(RwLock::new(InventoryView::default())),
+            sender,
+            wrapper,
         );
-    }
 
-    #[test]
-    fn deserialize_missing_usdc_fails() {
-        let toml_str = r#"
-            redemption_wallet = "0x1234567890123456789012345678901234567890"
-            fireblocks_vault_account_id = 0
-            fireblocks_environment = "sandbox"
-
-            [fireblocks_chain_asset_ids]
-            1 = "ETH"
-            8453 = "BASECHAIN_ETH"
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-        "#;
-
-        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
         assert!(
-            error.message().contains("usdc"),
-            "Expected missing usdc error, got: {error}"
+            trigger.usdc_rebalancing_params().is_none(),
+            "Expected usdc_rebalancing_params to be None when cash ratio is absent"
         );
     }
 

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -731,8 +731,8 @@ pub(crate) mod tests {
     use std::time::Duration;
     use uuid::uuid;
 
+    use st0x_evm::OpenChainErrorRegistry;
     use st0x_evm::local::RawPrivateKeyWallet;
-    use st0x_evm::{Evm, OpenChainErrorRegistry};
 
     use super::*;
     use crate::bindings::TestERC20;
@@ -1101,7 +1101,7 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let provider = wallet.provider().clone();
+        let provider = wallet.signing_provider().clone();
         let token = TestERC20::deploy(&provider).await.unwrap();
         let token_address = *token.address();
 
@@ -1152,7 +1152,7 @@ pub(crate) mod tests {
         )
         .unwrap();
 
-        let provider = wallet.provider().clone();
+        let provider = wallet.signing_provider().clone();
         let token = TestERC20::deploy(&provider).await.unwrap();
         let token_address = *token.address();
 


### PR DESCRIPTION
## Motivation

Closes #380. After #390 added TurnkeyWallet to st0x-evm, the main crate still
hardcoded Fireblocks for wallet construction. Operators need to select between
Turnkey, Fireblocks, and RawPrivateKey at startup via config.

## Solution

- Added `WalletProvider` enum to config (Turnkey / Fireblocks / RawPrivateKey)
- Wallet construction in rebalancing setup dispatches on the configured provider
- Turnkey credentials (API key, org ID, wallet references) read from secrets config
- Separates read-only vs signing providers so read calls don't go through the signing enclave
- CLI commands (vault, cctp, alpaca_wallet) updated to use generic wallet references
- Logs and error messages reference "wallet" instead of "Fireblocks"
- Updated example.config.toml and example.secrets.toml with Turnkey entries
- No silent fallback -- missing or mismatched provider fails fast at startup

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a change to the dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Turnkey wallet backend support as an alternative configuration option
  * Introduced new liquidity venue ratio configuration structure for rebalancing settings

* **Configuration**
  * Updated configuration file structure and examples to reflect new wallet setup patterns
  * Reorganized rebalancing configuration for improved clarity

* **Improvements**
  * Updated user-facing messages to use generic wallet terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->