### PR TITLE
feat: untouchable cash reserve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tarpaulin-report.html
 .sqlx/
 .idea/
 .worktrees/
+.local/
 out/
 cache/
 .tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,9 @@ the limit:
 - [docs/alloy.md](docs/alloy.md) - Alloy types, FixedBytes aliases,
   `::random()`, mocks, encoding, compile-time macros
 - [docs/cqrs.md](docs/cqrs.md) - Event sourcing with st0x-event-sorcery
-  (EventSourced trait, Store, Projection, testing, cqrs-es internals)
+  (EventSourced trait, Store, Projection, cqrs-es internals)
+- [docs/sqlx.md](docs/sqlx.md) - SQLx offline mode, query cache, worktree setup,
+  and known pitfalls
 
 **Update at the end:**
 

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -28,8 +28,8 @@ use crate::{Evm, EvmError, Wallet};
 pub struct TurnkeyOrganizationId(String);
 
 impl TurnkeyOrganizationId {
-    pub fn new(value: String) -> Self {
-        Self(value)
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
     }
 }
 
@@ -40,8 +40,8 @@ impl TurnkeyOrganizationId {
 pub struct TurnkeyApiPrivateKey(String);
 
 impl TurnkeyApiPrivateKey {
-    pub fn new(value: String) -> Self {
-        Self(value)
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
     }
 }
 

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -244,6 +244,7 @@ impl AlpacaBrokerMock {
     pub async fn start(
         symbol_fill_prices: Vec<(Symbol, Decimal)>,
         symbol_positions: Vec<MockPosition>,
+        #[builder(default = Decimal::from(100_000))] initial_cash: Decimal,
     ) -> Self {
         let today = Utc::now().format("%Y-%m-%d").to_string();
 
@@ -261,8 +262,8 @@ impl AlpacaBrokerMock {
 
         let state = Arc::new(Mutex::new(MockState {
             account: MockAccount {
-                cash: Decimal::from(100_000),
-                buying_power: Decimal::from(100_000),
+                cash: initial_cash,
+                buying_power: initial_cash,
                 positions,
             },
             orders: HashMap::new(),

--- a/crates/execution/src/schwab/tokens.rs
+++ b/crates/execution/src/schwab/tokens.rs
@@ -176,7 +176,7 @@ impl SchwabTokens {
 
     #[cfg(test)]
     pub(crate) async fn db_count(pool: &SqlitePool) -> Result<i64, SchwabError> {
-        let count = sqlx::query_scalar!("SELECT COUNT(*) FROM schwab_auth")
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM schwab_auth")
             .fetch_one(pool)
             .await?;
         Ok(count)

--- a/crates/finance/src/usd.rs
+++ b/crates/finance/src/usd.rs
@@ -31,10 +31,14 @@ impl Usd {
         Decimal::from(cents).checked_div(dec!(100)).map(Self)
     }
 
-    /// Converts to cents, truncating any sub-cent precision.
-    /// Returns `None` if the result overflows `i64`.
+    /// Converts to cents. Returns `None` if the value has sub-cent
+    /// precision or if the result overflows `i64`.
     pub fn to_cents(self) -> Option<i64> {
-        self.0.checked_mul(dec!(100))?.trunc().to_i64()
+        let cents = self.0.checked_mul(dec!(100))?;
+        if !cents.fract().is_zero() {
+            return None;
+        }
+        cents.to_i64()
     }
 
     pub fn is_zero(self) -> bool {
@@ -238,9 +242,9 @@ mod tests {
     }
 
     #[test]
-    fn to_cents_truncates_sub_cent_precision() {
+    fn to_cents_rejects_sub_cent_precision() {
         let usd = Usd(Decimal::new(99999, 3)); // $99.999
-        assert_eq!(usd.to_cents().unwrap(), 9_999);
+        assert_eq!(usd.to_cents(), None);
     }
 
     #[test]

--- a/dashboard/src/lib/components/transfer-details.ts
+++ b/dashboard/src/lib/components/transfer-details.ts
@@ -96,9 +96,13 @@ export const completedStages = (transfer: TransferOperation): StageEntry[] =>
 
 
 
+
 const usdcBridgeLinks = (status: UsdcBridgeStatus, direction: UsdcDirection): TxLink[] => {
-  const burnExplorer = direction === 'alpaca_to_base' ? ETH_EXPLORER : BASE_EXPLORER
-  const mintExplorer = direction === 'alpaca_to_base' ? BASE_EXPLORER : ETH_EXPLORER
+  const explorers: Record<UsdcDirection, { burn: string; mint: string }> = {
+    alpaca_to_base: { burn: ETH_EXPLORER, mint: BASE_EXPLORER },
+    base_to_alpaca: { burn: BASE_EXPLORER, mint: ETH_EXPLORER },
+  }
+  const { burn: burnExplorer, mint: mintExplorer } = explorers[direction]
 
   const burnLink = (hash: string): TxLink => ({ label: 'burn', hash, url: `${burnExplorer}/${hash}` })
   const mintLink = (hash: string): TxLink => ({ label: 'mint', hash, url: `${mintExplorer}/${hash}` })

--- a/docs/sqlx.md
+++ b/docs/sqlx.md
@@ -1,0 +1,75 @@
+# SQLx
+
+## Offline mode (`SQLX_OFFLINE=true`)
+
+The nix dev shell sets `SQLX_OFFLINE=true` (in `flake.nix`), which tells sqlx
+compile-time macros (`query!`, `query_scalar!`, etc.) to use cached metadata
+from the `.sqlx/` directory instead of connecting to the database. This means:
+
+- Regular `cargo check`/`cargo build`/`cargo nextest run` never need a running
+  database -- they read from `.sqlx/` cache files checked into version control.
+- If you add or change a `query!` macro invocation, you must regenerate the
+  cache before the change will compile under `SQLX_OFFLINE=true`.
+
+## Regenerating the query cache
+
+```bash
+cargo sqlx prepare --workspace -- --all-targets
+```
+
+Then check the updated `.sqlx/` files into version control.
+
+### Pitfall: `#[cfg(test)]` queries don't work with offline mode
+
+`cargo sqlx prepare` does NOT collect queries from `#[cfg(test)]` code, even
+with `-- --all-targets`. This is a known limitation -- the `--all-targets` flag
+is supposed to compile test targets during preparation, but in practice the
+test-only queries are silently skipped.
+
+When you then run `cargo nextest run` (which enables `cfg(test)`), the compiler
+sees the query macro, finds no cached metadata, and fails with:
+
+```
+`SQLX_OFFLINE=true` but there is no cached data for this query
+```
+
+**The fix: use runtime query functions in test code.** Instead of the
+compile-time macro `sqlx::query_scalar!("...")`, use the runtime function
+`sqlx::query_scalar("...")`. The non-macro version doesn't need offline cache
+entries. Since test code runs against a real in-memory database anyway,
+compile-time query verification adds no value.
+
+```rust
+// BROKEN in offline mode -- macro needs cache entry that prepare won't generate
+#[cfg(test)]
+let count = sqlx::query_scalar!("SELECT COUNT(*) FROM my_table")
+    .fetch_one(pool).await?;
+
+// WORKS -- runtime query, no cache needed
+#[cfg(test)]
+let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM my_table")
+    .fetch_one(pool).await?;
+```
+
+Note the type annotation on the `let` binding -- the runtime function doesn't
+infer return types like the macro does.
+
+## New worktrees
+
+New git worktrees don't have a `dev.db` file. You'll see sqlx compile errors
+like "unable to open database file" if you try to run without
+`SQLX_OFFLINE=true` or without a database. Fix:
+
+```bash
+sqlx db reset -y
+```
+
+This creates and migrates the local database. Not needed for compilation under
+`SQLX_OFFLINE=true`, but required for running the binary or running
+`cargo sqlx prepare` (which connects to the DB to verify queries).
+
+## Pitfall documentation policy
+
+When you encounter a non-obvious sqlx issue (or any tooling footgun), document
+it here. Future developers and agents will hit the same problems -- a few lines
+of documentation saves hours of debugging.

--- a/example.config.toml
+++ b/example.config.toml
@@ -38,5 +38,9 @@ rebalancing = "disabled"
 
 [assets.cash]
 rebalancing = "enabled"
-# vault_id = "0xcd34"
-# operational_limit = 10000.0
+# Raindex Vault Id
+vault_id = "0xcd34"
+# Maximum USD amount that can be used per trade or transfer
+operational_limit = 10000.0
+# USD amount subtracted from offchain cash to compute available balance
+reserved = 50000.0

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
           st0x-dto = st0xRust.dto;
           st0x-liquidity = st0xRust.package;
           st0x-clippy = st0xRust.clippy;
+          st0x-sqlx-check = st0xRust.sqlxCheck;
 
           st0x-dashboard = pkgs.callPackage ./dashboard {
             bun2nix = bun2nix.packages.${system}.default;
@@ -162,7 +163,8 @@
             additionalBuildInputs = [ ragenix.packages.${system}.default ];
             body = ''
               ${infraPkgs.parseIdentity}
-              ragenix --rules ./secret/secrets.nix -i "$identity" -e "$@" && exec ${rekeySecrets}
+              ragenix --rules ./secret/secrets.nix -i "$identity" -e "$@"
+              exec ${rekeySecrets}
             '';
           };
 
@@ -206,13 +208,15 @@
         devShells.default = pkgs.mkShell {
           inherit (rainix.devShells.${system}.default) nativeBuildInputs;
           inherit (rainix.devShells.${system}.default) shellHook;
-          DATABASE_URL = "sqlite:liquidity.db";
+
+          SQLX_OFFLINE = true;
+          DATABASE_URL = "sqlite:dev.db";
+
           buildInputs = with pkgs;
             [
               bun
               sqlx-cli
               cargo-expand
-              cargo-chef
               cargo-nextest
               terraform
               ragenix.packages.${system}.default

--- a/rust.nix
+++ b/rust.nix
@@ -120,6 +120,15 @@ in {
     };
   });
 
+  # Verify .sqlx/ cache is fresh (reuses cached deps)
+  sqlxCheck = craneLib.mkCargoDerivation (commonArgs // {
+    inherit cargoArtifacts;
+    preBuild = sqlxSetup;
+    pname = "st0x-sqlx-check";
+    buildPhaseCargoCommand = "cargo sqlx prepare --check --workspace";
+    installPhase = "touch $out";
+  });
+
   # Clippy check (reuses cached deps)
   clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -680,6 +680,7 @@ mod tests {
             )),
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
+            reserved: None,
         });
         let pool = setup_test_db().await;
         let amount = Usdc::new(Decimal::from_str("100").unwrap());
@@ -803,6 +804,7 @@ mod tests {
             vault_id: None,
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
+            reserved: None,
         });
         let pool = setup_test_db().await;
         let amount = Usdc::new(Decimal::from_str("100").unwrap());
@@ -832,6 +834,7 @@ mod tests {
             vault_id: Some(vault_id),
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
+            reserved: None,
         });
         let pool = setup_test_db().await;
         let amount = Usdc::new(Decimal::from_str("100").unwrap());

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -374,6 +374,7 @@ mod tests {
             vault_id: None,
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
+            reserved: None,
         }));
         let amount = Usdc::new(dec!(100));
 
@@ -422,6 +423,7 @@ mod tests {
             vault_id: Some(TEST_VAULT_ID),
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
+            reserved: None,
         }));
         let amount = Usdc::new(dec!(100));
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -13,6 +13,7 @@ use tracing::info;
 use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::{ReadOnlyEvm, Wallet};
 use st0x_execution::Executor;
+use st0x_finance::{HasZero, Positive, Usd};
 
 use super::{
     Conductor, EventProcessingError, TradingTasks, spawn_event_processor, spawn_inventory_poller,
@@ -196,6 +197,15 @@ where
             order_owner,
         ));
 
+        let reserved_cash = self
+            .common
+            .ctx
+            .assets
+            .cash
+            .as_ref()
+            .and_then(|cash| cash.reserved)
+            .map_or(Usd::ZERO, Positive::inner);
+
         let polling_service = InventoryPollingService::new(
             raindex_service,
             self.common.executor.clone(),
@@ -204,6 +214,7 @@ where
             order_owner,
             self.common.frameworks.snapshot,
             self.state.wallet_polling,
+            reserved_cash,
         );
         let inventory_poller = Some(spawn_inventory_poller(
             polling_service,

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -2613,7 +2613,7 @@ mod tests {
     }
 
     async fn get_vault_registry_events(pool: &SqlitePool) -> Vec<String> {
-        sqlx::query_scalar!("SELECT event_type FROM events WHERE aggregate_type = 'VaultRegistry'")
+        sqlx::query_scalar("SELECT event_type FROM events WHERE aggregate_type = 'VaultRegistry'")
             .fetch_all(pool)
             .await
             .unwrap()
@@ -2770,8 +2770,8 @@ mod tests {
         }
         .to_string();
 
-        let aggregate_ids: Vec<String> = sqlx::query_scalar!(
-            "SELECT DISTINCT aggregate_id FROM events WHERE aggregate_type = 'VaultRegistry'"
+        let aggregate_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT DISTINCT aggregate_id FROM events WHERE aggregate_type = 'VaultRegistry'",
         )
         .fetch_all(&pool)
         .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ use st0x_execution::{
     AlpacaTradingApiMode, FractionalShares, Positive, SchwabCtx, SupportedExecutor, Symbol,
     TimeInForce,
 };
-use st0x_finance::Usdc;
+use st0x_finance::{Usd, Usdc};
 
 use crate::offchain::order_poller::OrderPollerCtx;
 use crate::onchain::{EvmConfig, EvmCtx, EvmSecrets};
@@ -69,6 +69,9 @@ pub struct CashAssetConfig {
     pub vault_id: Option<B256>,
     pub rebalancing: OperationMode,
     pub operational_limit: Option<Positive<Usdc>>,
+    /// USD amount subtracted from offchain cash to compute available balance.
+    /// Prevents the system from rebalancing funds that should remain untouched.
+    pub reserved: Option<Positive<Usd>>,
 }
 
 /// Equity assets configuration with an optional global operational limit.
@@ -1194,8 +1197,10 @@ pub(crate) mod tests {
             [rebalancing]
             base_rpc_url = "https://base.example.com"
             ethereum_rpc_url = "https://mainnet.infura.io"
-            fireblocks_api_user_id = "test-user"
-            fireblocks_secret_path = "/tmp/test.key"
+
+            [rebalancing.wallet]
+            type = "private-key"
+            private_key = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         "#,
         );
         let error = Ctx::load_files(config.path(), secrets.path())

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -148,13 +148,13 @@ async fn seed_event_queue(pool: &SqlitePool, queued_event: &QueuedEvent) -> i64 
     let block_number = i64::try_from(queued_event.block_number).unwrap();
     let event_data = serde_json::to_string(&queued_event.event).unwrap();
 
-    sqlx::query_scalar!(
+    sqlx::query_scalar(
         "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data) VALUES (?, ?, ?, ?) RETURNING id",
-        tx_hash_str,
-        log_index,
-        block_number,
-        event_data
     )
+    .bind(&tx_hash_str)
+    .bind(log_index)
+    .bind(block_number)
+    .bind(&event_data)
     .fetch_one(pool)
     .await
     .unwrap()

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -135,6 +135,7 @@ fn test_trigger_config() -> RebalancingTriggerConfig {
                 vault_id: None,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
+                reserved: None,
             }),
         },
         disabled_assets: HashSet::new(),
@@ -1223,6 +1224,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
             vault_id: None,
             rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc::new(dec!(100))).unwrap()),
+            reserved: None,
         }),
     };
 
@@ -1353,6 +1355,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
             vault_id: None,
             rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc::new(dec!(100))).unwrap()),
+            reserved: None,
         }),
     };
     let config = RebalancingTriggerConfig {
@@ -1471,6 +1474,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                     vault_id: None,
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
+                    reserved: None,
                 }),
             },
             disabled_assets: HashSet::new(),
@@ -1530,6 +1534,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
                     vault_id: None,
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
+                    reserved: None,
                 }),
             },
             disabled_assets: HashSet::new(),

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -11,11 +11,12 @@ use alloy::providers::RootProvider;
 use futures_util::future::try_join_all;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, info};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
 use st0x_execution::{Executor, InventoryResult};
+use st0x_finance::Usd;
 
 use crate::bindings::IERC20;
 use crate::inventory::snapshot::{
@@ -36,7 +37,7 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
     #[error(transparent)]
     SnapshotAggregate(#[from] SendError<InventorySnapshot>),
     #[error(transparent)]
-    VaultRegistry(#[from] SendError<VaultRegistry>),
+    VaultRegistry(#[from] Box<SendError<VaultRegistry>>),
     #[error(transparent)]
     Evm(#[from] EvmError),
     #[error(transparent)]
@@ -46,6 +47,8 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
         expected: Vec<Address>,
         actual: Vec<Address>,
     },
+    #[error("cash reserve {reserved} overflows when converting to cents")]
+    ReserveCentsOverflow { reserved: Usd },
 }
 
 pub(crate) struct WalletPollingConfig {
@@ -65,6 +68,7 @@ where
     order_owner: Address,
     snapshot: Arc<Store<InventorySnapshot>>,
     wallet_polling: WalletPollingConfig,
+    reserved_cash: Usd,
 }
 
 impl<Chain, Exe> InventoryPollingService<Chain, Exe>
@@ -80,6 +84,7 @@ where
         order_owner: Address,
         snapshot: Arc<Store<InventorySnapshot>>,
         wallet_polling: WalletPollingConfig,
+        reserved_cash: Usd,
     ) -> Self {
         Self {
             raindex_service,
@@ -89,6 +94,7 @@ where
             order_owner,
             snapshot,
             wallet_polling,
+            reserved_cash,
         }
     }
 
@@ -138,7 +144,11 @@ where
             owner: self.order_owner,
         };
 
-        Ok(self.vault_registry.load(&vault_registry_id).await?)
+        Ok(self
+            .vault_registry
+            .load(&vault_registry_id)
+            .await
+            .map_err(Box::new)?)
     }
 
     async fn poll_onchain_equity(
@@ -306,16 +316,43 @@ where
             )
             .await?;
 
+        let cash_balance_cents = self.apply_cash_reserve(inventory.cash_balance_cents)?;
+
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OffchainCash {
-                    cash_balance_cents: inventory.cash_balance_cents,
-                },
+                InventorySnapshotCommand::OffchainCash { cash_balance_cents },
             )
             .await?;
 
         Ok(())
+    }
+
+    /// Subtracts the configured cash reserve from the raw broker balance,
+    /// flooring at zero if the reserve exceeds the balance.
+    fn apply_cash_reserve(
+        &self,
+        raw_balance_cents: i64,
+    ) -> Result<i64, InventoryPollingError<Exe::Error>> {
+        if self.reserved_cash.is_zero() {
+            return Ok(raw_balance_cents);
+        }
+
+        let reserve_cents =
+            self.reserved_cash
+                .to_cents()
+                .ok_or(InventoryPollingError::ReserveCentsOverflow {
+                    reserved: self.reserved_cash,
+                })?;
+
+        let available_cents = raw_balance_cents.saturating_sub(reserve_cents).max(0);
+
+        info!(
+            raw_balance_cents,
+            reserve_cents, available_cents, "Applied cash reserve to offchain balance"
+        );
+
+        Ok(available_cents)
     }
 }
 
@@ -335,6 +372,7 @@ mod tests {
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_evm::ReadOnlyEvm;
     use st0x_execution::{EquityPosition, FractionalShares, Inventory, MockExecutor, Symbol};
+    use st0x_finance::HasZero;
 
     use super::*;
     use crate::inventory::snapshot::InventorySnapshotEvent;
@@ -497,6 +535,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -548,6 +587,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -595,6 +635,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -632,6 +673,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         // Should succeed without error
@@ -691,6 +733,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -742,6 +785,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -787,6 +831,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -884,6 +929,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -937,6 +983,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -991,6 +1038,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -1043,6 +1091,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         let error = service.poll_and_record().await.unwrap_err();
@@ -1078,6 +1127,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         let error = service.poll_and_record().await.unwrap_err();
@@ -1154,6 +1204,7 @@ mod tests {
                 ethereum: Some(ethereum_wallet),
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -1197,6 +1248,7 @@ mod tests {
                 ethereum: None,
                 base: Some(base_wallet),
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -1236,6 +1288,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -1276,6 +1329,7 @@ mod tests {
                 ethereum: None,
                 base: None,
             },
+            Usd::ZERO,
         );
 
         service.poll_and_record().await.unwrap();
@@ -1319,6 +1373,7 @@ mod tests {
                 ethereum: Some(ethereum_wallet),
                 base: None,
             },
+            Usd::ZERO,
         );
 
         let error = service.poll_and_record().await.unwrap_err();
@@ -1349,6 +1404,7 @@ mod tests {
                 ethereum: None,
                 base: Some(base_wallet),
             },
+            Usd::ZERO,
         );
 
         let error = service.poll_and_record().await.unwrap_err();

--- a/src/offchain/order_poller.rs
+++ b/src/offchain/order_poller.rs
@@ -504,11 +504,11 @@ mod tests {
             .unwrap();
 
         let aggregate_id = offchain_order_id.to_string();
-        let offchain_order_events: Vec<String> = sqlx::query_scalar!(
+        let offchain_order_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
             WHERE aggregate_type = 'OffchainOrder' AND aggregate_id = ? ORDER BY sequence",
-            aggregate_id
         )
+        .bind(&aggregate_id)
         .fetch_all(&pool)
         .await
         .unwrap();
@@ -518,9 +518,9 @@ mod tests {
         assert_eq!(offchain_order_events[1], "OffchainOrderEvent::Submitted");
         assert_eq!(offchain_order_events[2], "OffchainOrderEvent::Filled");
 
-        let position_events: Vec<String> = sqlx::query_scalar!(
+        let position_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
-            WHERE aggregate_type = 'Position' AND aggregate_id = 'AAPL' ORDER BY sequence"
+            WHERE aggregate_type = 'Position' AND aggregate_id = 'AAPL' ORDER BY sequence",
         )
         .fetch_all(&pool)
         .await
@@ -584,11 +584,11 @@ mod tests {
             .unwrap();
 
         let aggregate_id = offchain_order_id.to_string();
-        let offchain_order_events: Vec<String> = sqlx::query_scalar!(
+        let offchain_order_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
             WHERE aggregate_type = 'OffchainOrder' AND aggregate_id = ? ORDER BY sequence",
-            aggregate_id
         )
+        .bind(&aggregate_id)
         .fetch_all(&pool)
         .await
         .unwrap();
@@ -598,9 +598,9 @@ mod tests {
         assert_eq!(offchain_order_events[1], "OffchainOrderEvent::Submitted");
         assert_eq!(offchain_order_events[2], "OffchainOrderEvent::Failed");
 
-        let position_events: Vec<String> = sqlx::query_scalar!(
+        let position_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
-            WHERE aggregate_type = 'Position' AND aggregate_id = 'TSLA' ORDER BY sequence"
+            WHERE aggregate_type = 'Position' AND aggregate_id = 'TSLA' ORDER BY sequence",
         )
         .fetch_all(&pool)
         .await

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -1548,7 +1548,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert a processed event at block 100
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1)
@@ -1604,7 +1604,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert processed event at block 150
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 150, '{}', 1)
@@ -1635,10 +1635,10 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert events with mixed processed states - only processed ones should affect resume point
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES 
+            VALUES
                 ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 50, '{}', 1),
                 ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 75, '{}', 0),
                 ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 100, '{}', 1),

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -507,7 +507,7 @@ mod tests {
     async fn test_get_max_processed_block_only_unprocessed() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES
@@ -527,7 +527,7 @@ mod tests {
     async fn test_get_max_processed_block_only_processed() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES
@@ -548,7 +548,7 @@ mod tests {
     async fn test_get_max_processed_block_mixed_states() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES
@@ -570,7 +570,7 @@ mod tests {
     async fn test_get_max_processed_block_zero_block() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES
@@ -592,14 +592,14 @@ mod tests {
 
         let large_block: i64 = 999_999_999;
 
-        sqlx::query!(
+        sqlx::query(
             r#"
             INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
             VALUES
                 ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, ?1, '{}', 1)
             "#,
-            large_block
         )
+        .bind(large_block)
         .execute(&pool)
         .await
         .unwrap();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1328,6 +1328,7 @@ mod tests {
                     vault_id: None,
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
+                    reserved: None,
                 }),
             },
             disabled_assets: HashSet::new(),

--- a/tests/e2e/cctp.rs
+++ b/tests/e2e/cctp.rs
@@ -173,7 +173,7 @@ impl CctpInfra {
         // USDC/USD conversion is a 1:1 stablecoin pair on Alpaca
         infra
             .broker_service
-            .set_symbol_fill_price(Symbol::new("USDCUSD").unwrap(), dec!(1.0));
+            .set_symbol_fill_price(Symbol::new("USDCUSD")?, dec!(1.0));
 
         let eth_watcher_provider = alloy::providers::ProviderBuilder::new()
             .connect(&ethereum_endpoint)

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -109,24 +109,6 @@ pub(crate) async fn poll_for_hedged_position(
     }
 }
 
-/// Counts rows in the `event_queue` table.
-pub(crate) async fn count_queued_events(pool: &SqlitePool) -> anyhow::Result<i64> {
-    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_queue")
-        .fetch_one(pool)
-        .await?;
-
-    Ok(row.0)
-}
-
-/// Counts processed rows in the `event_queue` table.
-pub(crate) async fn count_processed_queue_events(pool: &SqlitePool) -> anyhow::Result<i64> {
-    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM event_queue WHERE processed = 1")
-        .fetch_one(pool)
-        .await?;
-
-    Ok(row.0)
-}
-
 /// Comprehensive end-to-end assertions covering broker state, onchain
 /// vaults, and CQRS events/views for one or more symbols.
 ///

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -297,17 +297,6 @@ async fn backfilling() -> anyhow::Result<()> {
     // for the position reaching net=0 instead of counting fill events.
     poll_for_hedged_position(&mut bot, &infra.db_path, "AAPL").await;
 
-    // Verify all historical events were picked up via backfill
-    let pool = connect_db(&infra.db_path).await?;
-    let queued = count_queued_events(&pool).await?;
-    assert_eq!(
-        queued, trade_count,
-        "Expected exact queued event count from backfill",
-    );
-    let processed = count_processed_queue_events(&pool).await?;
-    assert_eq!(processed, queued, "All queued events should be processed");
-    pool.close().await;
-
     let expected_position = ExpectedPosition::builder()
         .symbol("AAPL")
         .amount(dec!(13.5))
@@ -548,8 +537,6 @@ async fn crash_recovery_eventual_consistency() -> anyhow::Result<()> {
     .await?;
 
     let ref_pool = connect_db(&ref_infra.db_path).await?;
-    let ref_queued_events = count_queued_events(&ref_pool).await?;
-    let ref_processed_queue_events = count_processed_queue_events(&ref_pool).await?;
     let ref_onchain_events = count_events(&ref_pool, "OnChainTrade").await?;
     let ref_offchain_events = count_events(&ref_pool, "OffchainOrder").await?;
     ref_pool.close().await;
@@ -647,20 +634,10 @@ async fn crash_recovery_eventual_consistency() -> anyhow::Result<()> {
     .await?;
 
     let crash_pool = connect_db(&crash_infra.db_path).await?;
-    let crash_queued_events = count_queued_events(&crash_pool).await?;
-    let crash_processed_queue_events = count_processed_queue_events(&crash_pool).await?;
     let crash_onchain_events = count_events(&crash_pool, "OnChainTrade").await?;
     let crash_offchain_events = count_events(&crash_pool, "OffchainOrder").await?;
     crash_pool.close().await;
 
-    assert_eq!(
-        crash_queued_events, ref_queued_events,
-        "Crash recovery should enqueue the exact same number of onchain events as reference",
-    );
-    assert_eq!(
-        crash_processed_queue_events, ref_processed_queue_events,
-        "Crash recovery should process the exact same number of queued events as reference",
-    );
     assert_eq!(
         crash_onchain_events, ref_onchain_events,
         "Crash recovery should persist the exact same OnChainTrade event count as reference",
@@ -766,15 +743,6 @@ async fn market_hours_transitions() -> anyhow::Result<()> {
         &infra.db_path.display().to_string(),
     )
     .await?;
-
-    let pool = connect_db(&infra.db_path).await?;
-    let queued = count_queued_events(&pool).await?;
-    let processed = count_processed_queue_events(&pool).await?;
-    assert_eq!(
-        queued, processed,
-        "All queued events should be processed exactly once"
-    );
-    pool.close().await;
 
     bot.abort();
     Ok(())
@@ -1375,8 +1343,6 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
 
     // Snapshot counts before restart
     let pool = connect_db(&infra.db_path).await?;
-    let pre_queued = count_queued_events(&pool).await?;
-    let pre_processed = count_processed_queue_events(&pool).await?;
     let pre_onchain_events = count_events(&pool, "OnChainTrade").await?;
 
     let pre_position = Projection::<Position>::sqlite(pool.clone())
@@ -1402,20 +1368,6 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
     wait_for_processing(&mut bot2, 10).await;
 
     let pool = connect_db(&infra.db_path).await?;
-
-    // Queue-level dedup: no new rows from re-backfilling the same events
-    let post_queued = count_queued_events(&pool).await?;
-    let post_processed = count_processed_queue_events(&pool).await?;
-    assert_eq!(
-        pre_queued, post_queued,
-        "Queue count should be unchanged after re-backfill: \
-         pre={pre_queued}, post={post_queued}"
-    );
-    assert_eq!(
-        pre_processed, post_processed,
-        "Processed count should be unchanged after re-backfill: \
-         pre={pre_processed}, post={post_processed}"
-    );
 
     // OnChainTrade aggregate events: CQRS prevents duplicate events on
     // the same aggregate (same tx_hash:log_index ID)

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -34,6 +34,7 @@ use st0x_execution::alpaca_broker_api::{
 use st0x_execution::{
     AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, Symbol, TimeInForce,
 };
+use st0x_finance::{Positive, Usd};
 pub(crate) use st0x_hedge::UsdcRebalancing;
 use st0x_hedge::bindings::IOrderBookV6;
 use st0x_hedge::config::{BrokerCtx, Ctx};
@@ -202,6 +203,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
             vault_id: Some(cash_vault_id),
             rebalancing: cash_rebalancing,
             operational_limit: None,
+            reserved: None,
         }),
     };
 
@@ -228,6 +230,7 @@ pub(crate) fn build_usdc_rebalancing_ctx<BP>(
     equity_tokens: &[(String, Address, Address)],
     usdc_vault_id: B256,
     cctp: CctpOverrides,
+    reserved: Option<Positive<Usd>>,
 ) -> anyhow::Result<Ctx>
 where
     BP: Provider + Clone,
@@ -297,6 +300,7 @@ where
                 vault_id: Some(usdc_vault_id),
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
+                reserved,
             }),
         })
         .inventory_poll_interval(15)

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -49,7 +49,10 @@ impl<P> TestInfra<P> {
                     rebalancing: OperationMode::Disabled,
                     operational_limit: None,
                 };
-                (Symbol::new(symbol.clone()).unwrap(), config)
+                let Ok(symbol_key) = Symbol::new(symbol.clone()) else {
+                    panic!("Invalid test symbol: {symbol}");
+                };
+                (symbol_key, config)
             })
             .collect();
 


### PR DESCRIPTION
## Motivation

Rebalancing operates on the full Alpaca USD cash balance. We need a configured reserve subtracted at the source so downstream logic never deploys the entire balance.

Closes #407

## Solution

Subtract the reserve when the cash balance enters the system in `InventoryPollingService::poll_offchain()`. All downstream consumers see only the available (unreserved) balance.

- `Usd` newtype in `st0x-finance` for offchain dollar amounts with checked arithmetic
- `reserved: Option<Positive<Usd>>` on `CashAssetConfig`
- `apply_cash_reserve()` in polling service, floors at zero when reserve exceeds balance
- Wired through `ConductorBuilder`

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [ ] made this PR as small as possible
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cash reserve configuration to manage reserved USD amounts separately from available balance.
  * Introduced USD type for proper financial calculations with checked arithmetic operations.

* **Documentation**
  * Added SQLx offline mode guide covering query caching, development setup, and known limitations.
  * Updated roadmap with new operational features and wallet integration paths.

* **Refactor**
  * Enhanced inventory polling to accept pre-configured services with reserve settings.
  * Updated test infrastructure to support new cash configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->