### PR TITLE
feat: introduce TryIntoWallet trait and WalletSpec abstraction

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 default = []
 mock = ["local-signer", "dep:url", "dep:anyhow"]
 local-signer = []
-turnkey = ["dep:alloy-signer-turnkey", "dep:serde"]
+turnkey = ["dep:alloy-signer-turnkey"]
 
 [dependencies]
 alloy.workspace = true
@@ -16,7 +16,7 @@ anyhow = { version = "1.0.102", optional = true }
 async-trait.workspace = true
 url = { workspace = true, optional = true }
 rain-error-decoding = { git = "https://github.com/rainlanguage/rain.error" }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -24,7 +24,7 @@ use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::sol_types::SolCall;
 use async_trait::async_trait;
 use rain_error_decoding::AbiDecodedErrorType;
-
+use serde::Deserialize;
 pub mod error_decoding;
 
 pub use error_decoding::{IntoErrorRegistry, NoOpErrorRegistry, OpenChainErrorRegistry};
@@ -37,6 +37,82 @@ pub mod turnkey;
 
 #[cfg(feature = "mock")]
 pub mod test_chain;
+
+/// Wallet backend discriminant. Deserialized from a `kind` field in
+/// wallet config sections. Variants are feature-gated so unconfigured
+/// backends fail at parse time with "unknown variant".
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WalletKind {
+    #[cfg(feature = "turnkey")]
+    Turnkey,
+    #[cfg(feature = "local-signer")]
+    PrivateKey,
+}
+
+/// Deserializes `self` into any `DeserializeOwned` target.
+///
+/// Implement this for your config format (e.g. a TOML newtype) so
+/// [`WalletKind::try_into_wallet`] and [`TryIntoWallet::try_into_wallet`]
+/// can parse backend-specific settings and credentials from it.
+pub trait Parser: Send {
+    type Error: Into<EvmError>;
+
+    fn parse<Target: serde::de::DeserializeOwned>(self) -> Result<Target, Self::Error>;
+}
+
+impl WalletKind {
+    /// Dispatch wallet construction by variant.
+    ///
+    /// Parses the backend's `Settings` and `Credentials` from the
+    /// raw config/secrets via [`Parser::parse`], then delegates to
+    /// [`TryIntoWallet::try_from_ctx`].
+    pub async fn try_into_wallet<Raw, Node>(
+        &self,
+        _ctx: WalletCtx<Raw, Raw, Node>,
+    ) -> Result<Arc<dyn Wallet<Provider = Node>>, EvmError>
+    where
+        Raw: Parser,
+        Node: Provider + Clone + Send + Sync + 'static,
+    {
+        match *self {
+            #[cfg(feature = "turnkey")]
+            WalletKind::Turnkey => {
+                let WalletCtx {
+                    settings,
+                    credentials,
+                    provider,
+                    required_confirmations,
+                } = _ctx;
+                let wallet = turnkey::TurnkeyWallet::try_from_ctx(WalletCtx {
+                    settings: settings.parse().map_err(Into::into)?,
+                    credentials: credentials.parse().map_err(Into::into)?,
+                    provider,
+                    required_confirmations,
+                })
+                .await?;
+                Ok(Arc::new(wallet))
+            }
+            #[cfg(feature = "local-signer")]
+            WalletKind::PrivateKey => {
+                let WalletCtx {
+                    settings: _,
+                    credentials,
+                    provider,
+                    required_confirmations,
+                } = _ctx;
+                let wallet = local::RawPrivateKeyWallet::try_from_ctx(WalletCtx {
+                    settings: (),
+                    credentials: credentials.parse().map_err(Into::into)?,
+                    provider,
+                    required_confirmations,
+                })
+                .await?;
+                Ok(Arc::new(wallet))
+            }
+        }
+    }
+}
 
 /// Errors that can occur during EVM operations.
 #[derive(Debug, thiserror::Error)]
@@ -53,12 +129,20 @@ pub enum EvmError {
     DecodedRevert(#[from] AbiDecodedErrorType),
     #[error("transaction reverted: {tx_hash}")]
     Reverted { tx_hash: alloy::primitives::TxHash },
+    #[error("wallet config parse error: {0}")]
+    WalletConfigParse(Box<dyn std::error::Error + Send + Sync>),
     #[cfg(feature = "local-signer")]
     #[error("invalid private key: {0}")]
     InvalidPrivateKey(#[from] alloy::signers::k256::ecdsa::Error),
     #[cfg(feature = "turnkey")]
     #[error("Turnkey error: {0}")]
     Turnkey(#[from] turnkey::TurnkeyError),
+}
+
+impl From<std::convert::Infallible> for EvmError {
+    fn from(never: std::convert::Infallible) -> Self {
+        match never {}
+    }
 }
 
 #[cfg(feature = "turnkey")]
@@ -112,6 +196,9 @@ pub trait Evm: Send + Sync + 'static {
 /// via Turnkey secure enclaves when the `turnkey` feature is enabled,
 /// while `RawPrivateKeyWallet` signs locally with a raw private key
 /// when the `local-signer` feature is enabled.
+///
+/// Implementations that support construction from config + secrets
+/// should also implement [`TryIntoWallet`].
 #[async_trait]
 pub trait Wallet: Evm {
     /// Returns the address this wallet signs transactions from.
@@ -153,6 +240,65 @@ pub trait Wallet: Evm {
             calldata,
             receipt,
         )
+        .await
+    }
+}
+
+/// Everything needed to construct a wallet: parsed settings,
+/// credentials, an RPC provider, and confirmation depth.
+pub struct WalletCtx<Settings, Credentials, Node> {
+    pub settings: Settings,
+    pub credentials: Credentials,
+    pub provider: Node,
+    pub required_confirmations: u64,
+}
+
+/// Async constructor for wallet implementations.
+///
+/// Each backend defines what it needs as `Settings` (non-secret
+/// config like address, org ID) and `Credentials` (secrets like
+/// private keys). The caller parses raw config into these types
+/// and passes them via [`WalletCtx`].
+#[async_trait]
+pub trait TryIntoWallet: Wallet + Sized {
+    /// Non-secret configuration (address, organization ID, etc.).
+    type Settings: Send;
+
+    /// Secret material (private keys, API keys, etc.).
+    type Credentials: Send;
+
+    /// Construct the wallet from parsed settings and credentials.
+    async fn try_from_ctx(
+        ctx: WalletCtx<Self::Settings, Self::Credentials, Self::Provider>,
+    ) -> Result<Self, EvmError>;
+
+    /// Construct the wallet from raw config/secrets, parsing each
+    /// via [`Parser::parse`] into the backend's `Settings` and
+    /// `Credentials`.
+    async fn try_into_wallet<Raw>(
+        ctx: WalletCtx<Raw, Raw, Self::Provider>,
+    ) -> Result<Self, EvmError>
+    where
+        Raw: Parser,
+        Self::Settings: serde::de::DeserializeOwned,
+        Self::Credentials: serde::de::DeserializeOwned,
+    {
+        let WalletCtx {
+            settings,
+            credentials,
+            provider,
+            required_confirmations,
+        } = ctx;
+
+        let settings: Self::Settings = settings.parse().map_err(Into::into)?;
+        let credentials: Self::Credentials = credentials.parse().map_err(Into::into)?;
+
+        Self::try_from_ctx(WalletCtx {
+            settings,
+            credentials,
+            provider,
+            required_confirmations,
+        })
         .await
     }
 }

--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -15,7 +15,15 @@ use alloy::signers::local::PrivateKeySigner;
 use async_trait::async_trait;
 use tracing::info;
 
-use crate::{Evm, EvmError, Wallet};
+use serde::Deserialize;
+
+use crate::{Evm, EvmError, TryIntoWallet, Wallet, WalletCtx};
+
+/// Secrets needed to construct a [`RawPrivateKeyWallet`].
+#[derive(Deserialize)]
+pub struct PrivateKeySecrets {
+    pub private_key: B256,
+}
 
 /// Provider type produced by wrapping a base provider with default fillers
 /// and a [`WalletFiller`].
@@ -131,6 +139,23 @@ where
         info!(tx_hash = %receipt.transaction_hash, note, "Transaction confirmed");
 
         Ok(receipt)
+    }
+}
+
+#[async_trait]
+impl<P> TryIntoWallet for RawPrivateKeyWallet<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    type Settings = ();
+    type Credentials = PrivateKeySecrets;
+
+    async fn try_from_ctx(ctx: WalletCtx<(), PrivateKeySecrets, P>) -> Result<Self, EvmError> {
+        Self::new(
+            &ctx.credentials.private_key,
+            ctx.provider,
+            ctx.required_confirmations,
+        )
     }
 }
 

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use tracing::info;
 
-use crate::{Evm, EvmError, Wallet};
+use crate::{Evm, EvmError, TryIntoWallet, Wallet, WalletCtx};
 
 /// Turnkey organization identifier (non-secret, lives in plaintext
 /// config).
@@ -58,29 +58,28 @@ pub enum TurnkeyError {
     Signer(#[from] TurnkeySignerError),
 }
 
-/// Construction context for `TurnkeyWallet`.
+/// Non-secret Turnkey configuration: organization ID.
 ///
-/// Contains everything needed to build a wallet: Turnkey API
-/// credentials, the wallet address, and a base provider. Callers
-/// construct this directly via its public fields and pass it to
-/// [`TurnkeyWallet::new`].
-pub struct TurnkeyCtx<P> {
-    pub api_private_key: TurnkeyApiPrivateKey,
-    pub organization_id: TurnkeyOrganizationId,
+/// Address lives in [`WalletCtx::settings`] as the outer layer,
+/// while this groups the Turnkey-specific non-secret fields.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TurnkeySettings {
     pub address: Address,
-    pub provider: P,
-    pub required_confirmations: u64,
+    pub organization_id: TurnkeyOrganizationId,
 }
 
-impl<P> std::fmt::Debug for TurnkeyCtx<P> {
+/// Secret Turnkey credential: the P-256 API private key.
+#[derive(Clone, Deserialize)]
+pub struct TurnkeyCredentials {
+    pub api_private_key: TurnkeyApiPrivateKey,
+}
+
+impl std::fmt::Debug for TurnkeyCredentials {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("TurnkeyCtx")
-            .field("api_private_key", &self.api_private_key)
-            .field("organization_id", &self.organization_id)
-            .field("address", &self.address)
-            .field("required_confirmations", &self.required_confirmations)
-            .finish_non_exhaustive()
+            .debug_struct("TurnkeyCredentials")
+            .field("api_private_key", &"[REDACTED]")
+            .finish()
     }
 }
 
@@ -134,19 +133,25 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
     /// wraps it in an `EthereumWallet`, and builds the signing
     /// provider with standard fillers. The base provider is cloned
     /// and stored separately for read-only access.
-    pub async fn new(ctx: TurnkeyCtx<P>) -> Result<Self, EvmError> {
+    pub async fn new(
+        ctx: WalletCtx<TurnkeySettings, TurnkeyCredentials, P>,
+    ) -> Result<Self, EvmError> {
+        let TurnkeySettings {
+            address,
+            organization_id,
+        } = ctx.settings;
+        let TurnkeyCredentials { api_private_key } = ctx.credentials;
+
         let chain_id = ctx.provider.get_chain_id().await?;
 
-        let TurnkeyApiPrivateKey(api_key_hex) = &ctx.api_private_key;
-        let TurnkeyOrganizationId(organization_id) = ctx.organization_id;
+        let TurnkeyApiPrivateKey(api_key_hex) = &api_private_key;
+        let TurnkeyOrganizationId(org_id) = organization_id;
 
-        let signer =
-            TurnkeySigner::from_api_key(api_key_hex, organization_id, ctx.address, Some(chain_id))?;
+        let signer = TurnkeySigner::from_api_key(api_key_hex, org_id, address, Some(chain_id))?;
 
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = ctx.provider.clone();
-
         let signing_provider = ProviderBuilder::new()
             .wallet(eth_wallet)
             .connect_provider(ctx.provider);
@@ -154,7 +159,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
         Ok(Self {
             provider: base_provider,
             signing_provider,
-            address: ctx.address,
+            address,
             required_confirmations: ctx.required_confirmations,
         })
     }
@@ -237,6 +242,21 @@ where
         info!(tx_hash = %receipt.transaction_hash, note, "Transaction confirmed");
 
         Ok(receipt)
+    }
+}
+
+#[async_trait]
+impl<P> TryIntoWallet for TurnkeyWallet<P>
+where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    type Settings = TurnkeySettings;
+    type Credentials = TurnkeyCredentials;
+
+    async fn try_from_ctx(
+        ctx: WalletCtx<TurnkeySettings, TurnkeyCredentials, P>,
+    ) -> Result<Self, EvmError> {
+        Self::new(ctx).await
     }
 }
 
@@ -376,10 +396,14 @@ mod tests {
             .await
             .expect("anvil_setBalance should succeed");
 
-        let wallet = TurnkeyWallet::new(TurnkeyCtx {
-            api_private_key: TurnkeyApiPrivateKey::new(api_key),
-            organization_id: TurnkeyOrganizationId::new(org_id),
-            address,
+        let wallet = TurnkeyWallet::new(WalletCtx {
+            settings: TurnkeySettings {
+                address,
+                organization_id: TurnkeyOrganizationId::new(org_id),
+            },
+            credentials: TurnkeyCredentials {
+                api_private_key: TurnkeyApiPrivateKey::new(api_key),
+            },
             provider,
             required_confirmations: 1,
         })

--- a/example.config.toml
+++ b/example.config.toml
@@ -12,19 +12,15 @@ redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
 
-# Wallet provider — select via `type`:
+# Wallet provider — select via `kind`:
 #   "turnkey"     — Turnkey secure enclave signing   (requires --features wallet-turnkey)
 #   "private-key" — local raw private key signing     (requires --features wallet-private-key)
-#
-# The `type` here must match `[rebalancing.wallet].type` in the secrets file.
-# For "private-key", `address` must match the address derived from the secret key.
 [rebalancing.wallet]
-type = "private-key"
-address = "0xfcad0b19bb29d4674531d6f115237e16afce377c"
+kind = "private-key"
 
-# For type = "turnkey", use instead:
+# For kind = "turnkey", use instead:
 # [rebalancing.wallet]
-# type = "turnkey"
+# kind = "turnkey"
 # address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # organization_id = "org-example-turnkey-org-id"
 

--- a/example.secrets.toml
+++ b/example.secrets.toml
@@ -14,13 +14,10 @@ account_id = "dddddddd-eeee-aaaa-dddd-beeeeeeeeeef"
 base_rpc_url = "https://mainnet.base.org"
 ethereum_rpc_url = "https://mainnet.infura.io"
 
-# Wallet secrets — `type` must match the config wallet type.
-# Replace the placeholder key below with your real private key.
+# Wallet secrets — backend-specific credentials.
 [rebalancing.wallet]
-type = "private-key"
 private_key = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-# For type = "turnkey", use instead:
+# For kind = "turnkey" (in config), use instead:
 # [rebalancing.wallet]
-# type = "turnkey"
 # api_private_key = "hex-encoded-p256-api-private-key"

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -349,6 +349,12 @@ async fn seed_vault_registry_from_config(
 
     for (symbol, equity_config) in &ctx.assets.equities.symbols {
         let Some(vault_id) = equity_config.vault_id else {
+            if ctx.is_rebalancing_enabled(symbol) {
+                return Err(CtxError::MissingEquityVaultId {
+                    symbol: symbol.clone(),
+                }
+                .into());
+            }
             continue;
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,7 @@ impl EquitiesConfig {
     /// Symbol-specific limit takes precedence over the global limit.
     /// Returns `None` when neither is configured (unlimited).
     #[cfg(test)]
-    fn shares_limit_for(&self, symbol: &Symbol) -> Option<Positive<FractionalShares>> {
+    pub(crate) fn shares_limit_for(&self, symbol: &Symbol) -> Option<Positive<FractionalShares>> {
         self.symbols
             .get(symbol)
             .and_then(|config| config.operational_limit)

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -7,9 +7,7 @@ pub(crate) use usdc::ALPACA_MINIMUM_WITHDRAWAL;
 
 use alloy::primitives::Address;
 use alloy::providers::{Provider, RootProvider};
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 use alloy::rpc::client::RpcClient;
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 use alloy::transports::layers::RetryBackoffLayer;
 use async_trait::async_trait;
 use chrono::Utc;
@@ -23,9 +21,7 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use st0x_event_sorcery::{AggregateError, EntityList, LifecycleError, Reactor, Store, deps};
-use st0x_evm::Wallet;
-#[cfg(feature = "wallet-turnkey")]
-use st0x_evm::turnkey::{TurnkeyApiPrivateKey, TurnkeyCtx, TurnkeyOrganizationId, TurnkeyWallet};
+use st0x_evm::{Wallet, WalletCtx, WalletKind};
 use st0x_execution::{AlpacaBrokerApiCtx, FractionalShares, Positive, Symbol};
 use st0x_finance::Usdc;
 
@@ -79,57 +75,20 @@ impl std::fmt::Display for Chain {
     }
 }
 
-/// Wallet backend discriminator for error reporting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WalletBackend {
-    Turnkey,
-    PrivateKey,
-}
-
-impl std::fmt::Display for WalletBackend {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Turnkey => write!(formatter, "turnkey"),
-            Self::PrivateKey => write!(formatter, "private-key"),
-        }
-    }
-}
-
 /// Error type for rebalancing configuration validation.
 #[derive(Debug, thiserror::Error)]
 pub enum RebalancingCtxError {
     #[error("rebalancing requires alpaca-broker-api broker type")]
     NotAlpacaBroker,
-    #[error(
-        "wallet config type mismatch: config specifies {config_type} \
-         but secrets specifies {secrets_type}"
-    )]
-    WalletTypeMismatch {
-        config_type: WalletBackend,
-        secrets_type: WalletBackend,
-    },
-    #[error(
-        "configured wallet address {configured} does not match \
-         address {derived} derived from private key"
-    )]
-    AddressMismatch {
-        configured: Address,
-        derived: Address,
-    },
-    #[error(
-        "wallet type \"{wallet_type}\" configured but not compiled \
-         into this binary (missing cargo feature)"
-    )]
-    WalletNotCompiled { wallet_type: WalletBackend },
-    #[error("RPC error during wallet setup: {0}")]
-    Rpc(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
+    #[error("invalid wallet config: {0}")]
+    WalletConfig(#[from] toml::de::Error),
+    #[error(transparent)]
+    Evm(#[from] st0x_evm::EvmError),
     #[error("RPC connectivity check failed for {chain} wallet: {source}")]
     RpcConnectivity {
         chain: Chain,
         source: alloy::transports::RpcError<alloy::transports::TransportErrorKind>,
     },
-    #[error(transparent)]
-    Evm(#[from] st0x_evm::EvmError),
 }
 
 /// USDC rebalancing configuration with explicit enable/disable.
@@ -140,12 +99,44 @@ pub enum UsdcRebalancing {
     Disabled,
 }
 
-#[derive(Debug, Deserialize)]
+/// Extracts just the `kind` discriminant from the wallet TOML table,
+/// ignoring backend-specific fields that vary by wallet type.
+#[derive(Deserialize)]
+struct WalletKindTag {
+    kind: WalletKind,
+}
+
+/// Newtype over [`toml::Value`] implementing [`Parser`] so
+/// [`WalletKind::try_into_wallet`] can deserialize any
+/// `DeserializeOwned` type from raw TOML config/secrets.
+struct TomlValue(toml::Value);
+
+impl st0x_evm::Parser for TomlValue {
+    type Error = st0x_evm::EvmError;
+
+    fn parse<Target: serde::de::DeserializeOwned>(self) -> Result<Target, Self::Error> {
+        Target::deserialize(self.0)
+            .map_err(|error| st0x_evm::EvmError::WalletConfigParse(Box::new(error)))
+    }
+}
+
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct RebalancingSecrets {
     pub(crate) base_rpc_url: Url,
     pub(crate) ethereum_rpc_url: Url,
-    pub(crate) wallet: WalletSecrets,
+    pub(crate) wallet: toml::Value,
+}
+
+impl std::fmt::Debug for RebalancingSecrets {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RebalancingSecrets")
+            .field("base_rpc_url", &self.base_rpc_url)
+            .field("ethereum_rpc_url", &self.ethereum_rpc_url)
+            .field("wallet", &"[REDACTED]")
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -154,59 +145,7 @@ pub(crate) struct RebalancingConfig {
     pub(crate) equity: ImbalanceThreshold,
     pub(crate) usdc: UsdcRebalancing,
     pub(crate) redemption_wallet: Address,
-    pub(crate) wallet: WalletConfig,
-}
-
-/// Wallet provider plaintext configuration, selected by `type` tag.
-///
-/// Both variants always parse from TOML regardless of compiled
-/// features. Feature-gated `build_wallet` arms convert these into
-/// the concrete wallet types at construction time.
-// Serde reads the fields during deserialization, and feature-gated
-// `build_wallet` arms destructure them. Neither is visible to the
-// compiler's dead-code pass when wallet features are disabled.
-#[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize)]
-#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
-pub(crate) enum WalletConfig {
-    Turnkey {
-        address: Address,
-        organization_id: String,
-    },
-    PrivateKey {
-        address: Address,
-    },
-}
-
-/// Wallet provider secret credentials, selected by `type` tag.
-///
-/// Both variants always parse from TOML regardless of compiled
-/// features. See [`WalletConfig`] for rationale.
-#[allow(dead_code)]
-#[derive(Deserialize)]
-#[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
-pub(crate) enum WalletSecrets {
-    Turnkey {
-        api_private_key: String,
-    },
-    PrivateKey {
-        private_key: alloy::primitives::B256,
-    },
-}
-
-impl std::fmt::Debug for WalletSecrets {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Turnkey { .. } => formatter
-                .debug_struct("Turnkey")
-                .field("api_private_key", &"[REDACTED]")
-                .finish(),
-            Self::PrivateKey { .. } => formatter
-                .debug_struct("PrivateKey")
-                .field("private_key", &"[REDACTED]")
-                .finish(),
-        }
-    }
+    pub(crate) wallet: toml::Value,
 }
 
 /// Runtime configuration for rebalancing operations.
@@ -244,26 +183,15 @@ pub struct RebalancingCtx {
 /// operations that depend on the state change. This ensures state propagates
 /// across load-balanced RPC providers (like dRPC) that may route requests to
 /// different backend nodes.
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 const REQUIRED_CONFIRMATIONS: u64 = 3;
-
-/// Maximum retries for transient RPC errors (rate limits, null responses, etc.)
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 const RPC_MAX_RETRIES: u32 = 10;
-
-/// Initial backoff duration in milliseconds before retrying
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 const RPC_INITIAL_BACKOFF_MS: u64 = 1000;
-
-/// Compute units per second budget for rate limiting
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 const RPC_COMPUTE_UNITS_PER_SECOND: u64 = 100;
 
 /// Creates an HTTP RPC client with retry layer for transient errors.
 ///
 /// Use with `ProviderBuilder::new().connect_client(client)` for read-only calls,
 /// or `ProviderBuilder::new().wallet(w).connect_client(client)` for signing.
-#[cfg(any(feature = "wallet-turnkey", feature = "wallet-private-key"))]
 fn http_client_with_retry(url: Url) -> RpcClient {
     let retry_layer = RetryBackoffLayer::new(
         RPC_MAX_RETRIES,
@@ -273,19 +201,49 @@ fn http_client_with_retry(url: Url) -> RpcClient {
     RpcClient::builder().layer(retry_layer).http(url)
 }
 
+async fn build_wallet(
+    kind: &WalletKind,
+    wallet_config: toml::Value,
+    wallet_secrets: toml::Value,
+    rpc_url: Url,
+) -> Result<Arc<dyn Wallet<Provider = RootProvider>>, RebalancingCtxError> {
+    let provider = RootProvider::new(http_client_with_retry(rpc_url));
+
+    Ok(kind
+        .try_into_wallet(WalletCtx {
+            settings: TomlValue(wallet_config),
+            credentials: TomlValue(wallet_secrets),
+            provider,
+            required_confirmations: REQUIRED_CONFIRMATIONS,
+        })
+        .await?)
+}
+
 impl RebalancingCtx {
     /// Construct from config, secrets, and broker auth.
     ///
     /// Builds wallets for both chains (Turnkey or raw private key,
-    /// selected by TOML `type` tag) and stores them immutably.
+    /// selected by TOML `kind` tag) and stores them immutably.
     pub(crate) async fn new(
         config: RebalancingConfig,
         secrets: RebalancingSecrets,
         broker_auth: AlpacaBrokerApiCtx,
     ) -> Result<Self, RebalancingCtxError> {
+        let WalletKindTag { kind } = WalletKindTag::deserialize(config.wallet.clone())?;
+
         let (base_wallet, ethereum_wallet) = tokio::try_join!(
-            Self::build_wallet(&config.wallet, &secrets.wallet, secrets.base_rpc_url),
-            Self::build_wallet(&config.wallet, &secrets.wallet, secrets.ethereum_rpc_url),
+            build_wallet(
+                &kind,
+                config.wallet.clone(),
+                secrets.wallet.clone(),
+                secrets.base_rpc_url,
+            ),
+            build_wallet(
+                &kind,
+                config.wallet,
+                secrets.wallet,
+                secrets.ethereum_rpc_url,
+            ),
         )?;
 
         info!(
@@ -314,86 +272,6 @@ impl RebalancingCtx {
             #[cfg(feature = "test-support")]
             message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
         })
-    }
-
-    // `rpc_url` is consumed by feature-gated wallet arms; when no
-    // wallet feature is compiled, it appears unused.
-    async fn build_wallet(
-        config: &WalletConfig,
-        secrets: &WalletSecrets,
-        #[allow(unused_variables)] rpc_url: Url,
-    ) -> Result<Arc<dyn Wallet<Provider = RootProvider>>, RebalancingCtxError> {
-        match (config, secrets) {
-            #[cfg(feature = "wallet-turnkey")]
-            (
-                WalletConfig::Turnkey {
-                    address,
-                    organization_id,
-                },
-                WalletSecrets::Turnkey { api_private_key },
-            ) => {
-                let provider = RootProvider::new(http_client_with_retry(rpc_url));
-
-                let wallet = TurnkeyWallet::new(TurnkeyCtx {
-                    api_private_key: TurnkeyApiPrivateKey::new(api_private_key.clone()),
-                    organization_id: TurnkeyOrganizationId::new(organization_id.clone()),
-                    address: *address,
-                    provider,
-                    required_confirmations: REQUIRED_CONFIRMATIONS,
-                })
-                .await?;
-
-                Ok(Arc::new(wallet))
-            }
-
-            #[cfg(not(feature = "wallet-turnkey"))]
-            (WalletConfig::Turnkey { .. }, WalletSecrets::Turnkey { .. }) => {
-                Err(RebalancingCtxError::WalletNotCompiled {
-                    wallet_type: WalletBackend::Turnkey,
-                })
-            }
-
-            #[cfg(feature = "wallet-private-key")]
-            (WalletConfig::PrivateKey { address }, WalletSecrets::PrivateKey { private_key }) => {
-                let provider = RootProvider::new(http_client_with_retry(rpc_url));
-
-                let wallet = st0x_evm::local::RawPrivateKeyWallet::new(
-                    private_key,
-                    provider,
-                    REQUIRED_CONFIRMATIONS,
-                )?;
-
-                if wallet.address() != *address {
-                    return Err(RebalancingCtxError::AddressMismatch {
-                        configured: *address,
-                        derived: wallet.address(),
-                    });
-                }
-
-                Ok(Arc::new(wallet))
-            }
-
-            #[cfg(not(feature = "wallet-private-key"))]
-            (WalletConfig::PrivateKey { .. }, WalletSecrets::PrivateKey { .. }) => {
-                Err(RebalancingCtxError::WalletNotCompiled {
-                    wallet_type: WalletBackend::PrivateKey,
-                })
-            }
-
-            (WalletConfig::Turnkey { .. }, WalletSecrets::PrivateKey { .. }) => {
-                Err(RebalancingCtxError::WalletTypeMismatch {
-                    config_type: WalletBackend::Turnkey,
-                    secrets_type: WalletBackend::PrivateKey,
-                })
-            }
-
-            (WalletConfig::PrivateKey { .. }, WalletSecrets::Turnkey { .. }) => {
-                Err(RebalancingCtxError::WalletTypeMismatch {
-                    config_type: WalletBackend::PrivateKey,
-                    secrets_type: WalletBackend::Turnkey,
-                })
-            }
-        }
     }
 
     /// Validate RPC connectivity for both chain wallets.
@@ -4420,111 +4298,46 @@ mod tests {
             });
     }
 
-    #[tokio::test]
-    async fn wallet_type_mismatch_config_turnkey_secrets_private_key() {
-        let config = WalletConfig::Turnkey {
-            address: Address::ZERO,
-            organization_id: "test-org".to_string(),
-        };
-        let secrets = WalletSecrets::PrivateKey {
-            private_key: B256::ZERO,
-        };
-
-        let result =
-            RebalancingCtx::build_wallet(&config, &secrets, "https://example.com".parse().unwrap())
-                .await;
-
-        let error = result.err().expect("expected Err, got Ok");
-        assert!(
-            matches!(
-                error,
-                RebalancingCtxError::WalletTypeMismatch {
-                    config_type: WalletBackend::Turnkey,
-                    secrets_type: WalletBackend::PrivateKey,
-                }
-            ),
-            "expected WalletTypeMismatch, got: {error:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn wallet_type_mismatch_config_private_key_secrets_turnkey() {
-        let config = WalletConfig::PrivateKey {
-            address: Address::ZERO,
-        };
-        let secrets = WalletSecrets::Turnkey {
-            api_private_key: "fake-key".to_string(),
-        };
-
-        let result =
-            RebalancingCtx::build_wallet(&config, &secrets, "https://example.com".parse().unwrap())
-                .await;
-
-        let error = result.err().expect("expected Err, got Ok");
-        assert!(
-            matches!(
-                error,
-                RebalancingCtxError::WalletTypeMismatch {
-                    config_type: WalletBackend::PrivateKey,
-                    secrets_type: WalletBackend::Turnkey,
-                }
-            ),
-            "expected WalletTypeMismatch, got: {error:?}"
-        );
-    }
-
     #[cfg(feature = "wallet-private-key")]
     #[tokio::test]
-    async fn address_mismatch_returns_error() {
-        // A random private key -- the derived address will NOT match Address::ZERO.
-        let private_key = B256::random();
-        let wrong_address = Address::ZERO;
-
-        let config = WalletConfig::PrivateKey {
-            address: wrong_address,
-        };
-        let secrets = WalletSecrets::PrivateKey { private_key };
-
-        // Use a dummy RPC URL -- the RawPrivateKeyWallet constructor doesn't
-        // make RPC calls, so the URL doesn't need to be valid.
-        let result =
-            RebalancingCtx::build_wallet(&config, &secrets, "https://example.com".parse().unwrap())
-                .await;
-
-        let error = result.err().expect("expected Err, got Ok");
-        assert!(
-            matches!(
-                error,
-                RebalancingCtxError::AddressMismatch { configured, derived }
-                    if configured == wrong_address && derived != wrong_address
-            ),
-            "expected AddressMismatch, got: {error:?}"
-        );
-    }
-
-    #[test]
-    fn wallet_secrets_debug_redacts_private_key() {
+    async fn build_wallet_private_key_derives_address_from_key() {
         let private_key =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
-        let secrets = WalletSecrets::PrivateKey { private_key };
 
-        let debug = format!("{secrets:?}");
+        let wallet_config = toml::toml! {
+            kind = "private-key"
+        };
 
-        assert!(
-            debug.contains("[REDACTED]"),
-            "expected redaction marker, got {debug}"
-        );
-        assert!(
-            !debug.contains(&private_key.to_string()),
-            "debug output leaked the private key: {debug}"
+        let private_key_str = private_key.to_string();
+        let wallet_secrets = toml::toml! {
+            private_key = private_key_str
+        };
+
+        let wallet = build_wallet(
+            &WalletKind::PrivateKey,
+            wallet_config.into(),
+            wallet_secrets.into(),
+            "https://example.com".parse().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(
+            wallet.address(),
+            Address::ZERO,
+            "wallet address should be derived from key, not zero"
         );
     }
 
     #[test]
-    fn wallet_secrets_debug_redacts_turnkey_api_private_key() {
-        let api_private_key = "super-secret-turnkey-key".to_string();
-        let secrets = WalletSecrets::Turnkey {
-            api_private_key: api_private_key.clone(),
+    fn rebalancing_secrets_debug_redacts_wallet() {
+        let secrets = RebalancingSecrets {
+            base_rpc_url: "https://base-rpc.example.com".parse().unwrap(),
+            ethereum_rpc_url: "https://eth-rpc.example.com".parse().unwrap(),
+            wallet: toml::toml! {
+                api_private_key = "super-secret-key"
+            }
+            .into(),
         };
 
         let debug = format!("{secrets:?}");
@@ -4534,8 +4347,8 @@ mod tests {
             "expected redaction marker, got {debug}"
         );
         assert!(
-            !debug.contains(&api_private_key),
-            "debug output leaked the API private key: {debug}"
+            !debug.contains("super-secret-key"),
+            "debug output leaked wallet secrets: {debug}"
         );
     }
 }


### PR DESCRIPTION
## Stack Context

This stack adds DTOs for inventory tracking and transfer status, then wires them into the WebSocket broadcast for real-time dashboard updates.

## What?

- Introduce `TryIntoWallet` trait in `st0x-evm` (renamed from ad-hoc construction)
- Add `WalletSpec` enum with feature-gated newtype variants wrapping spec structs
- Add `WalletSpecError` to encapsulate wallet construction failures
- Remove leaked wallet implementation details (`WalletTypeMismatch`, `Evm`, `Rpc`) from `RebalancingCtxError`
- Restore `MissingEquityVaultId` validation in conductor
- Fix `dead_code` warning on `shares_limit_for`

## Why?

PR review feedback identified that `RebalancingCtxError` was leaking EVM wallet abstractions (`EvmError`, `WalletTypeMismatch`) into the rebalancing domain. This PR encapsulates wallet construction behind a `TryIntoWallet` trait with a dedicated `WalletSpecError`, keeping the rebalancing module's error surface clean. The `WalletSpec` enum uses feature-gated newtype variants so unconfigured wallet backends fail at TOML parse time rather than runtime.

## Test plan

- [x] `cargo check --workspace` and `cargo check --workspace --all-features`
- [x] `cargo nextest run --workspace` — 1523 passed
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo fmt`
