### PR TITLE
feat: track in-flight equity from Alpaca tokenization polling

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1944,19 +1944,22 @@ know about cross-venue inventory.
   (completes transfer to Raindex, already counted at TokensReceived)
 - `TokenizedEquityMintEvent::RaindexDepositFailed` - No balance change (tokens
   await retry or manual recovery)
-- `TokenizedEquityMintEvent::MintRejected` - Reconciles inflight back to Alpaca
-  available
+- `TokenizedEquityMintEvent::MintRejected` - No balance change (rejected before
+  shares left Alpaca)
 - `TokenizedEquityMintEvent::MintAcceptanceFailed` - Reconciles inflight back to
   Alpaca available
 - `EquityRedemptionEvent::WithdrawnFromRaindex` - Moves tokens to inflight
   (leaving Raindex vault)
 - `EquityRedemptionEvent::TokensUnwrapped` - No balance change (conversion
   between wrapped/unwrapped forms)
+- `EquityRedemptionEvent::TransferFailed` - Cancels inflight back to Raindex
+  available (tokens never left our wallet)
 - `EquityRedemptionEvent::TokensSent` - Tokens sent to Alpaca (still inflight)
 - `EquityRedemptionEvent::Completed` - Moves from inflight to Alpaca available
 - `EquityRedemptionEvent::DetectionFailed` - Tokens stranded (manual recovery)
-- `EquityRedemptionEvent::RedemptionRejected` - Reconciles inflight back to
-  Raindex available (tokens returned by Alpaca)
+- `EquityRedemptionEvent::RedemptionRejected` - Token disposition uncertain
+  after rejection; keep inflight until an operator manually resolves the asset
+  location and a subsequent snapshot captures the corrected state
 - `UsdcRebalanceEvent::WithdrawalConfirmed` - Moves USDC to inflight (leaving
   source)
 - `UsdcRebalanceEvent::DepositConfirmed` - Terminal success for AlpacaToBase;
@@ -1973,6 +1976,10 @@ know about cross-venue inventory.
   from broker
 - `InventorySnapshotEvent::OffchainCash` - Offchain cash balance fetched from
   broker
+- `InventorySnapshotEvent::InflightEquity` - Pending tokenization requests
+  polled from Alpaca; sets inflight at Hedging (mints) and MarketMaking
+  (redemptions). Available balances are unchanged -- they are set by separate
+  available-balance snapshots
 
 ##### Separation of concerns
 

--- a/crates/execution/src/schwab/tokens.rs
+++ b/crates/execution/src/schwab/tokens.rs
@@ -176,7 +176,7 @@ impl SchwabTokens {
 
     #[cfg(test)]
     pub(crate) async fn db_count(pool: &SqlitePool) -> Result<i64, SchwabError> {
-        let count = sqlx::query_scalar!("SELECT COUNT(*) FROM schwab_auth")
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM schwab_auth")
             .fetch_one(pool)
             .await?;
         Ok(count)

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -73,6 +73,7 @@ pub(crate) struct WithDexStreams {
     event_receiver: UnboundedReceiver<(TradeEvent, Log)>,
     rebalancer: Option<JoinHandle<()>>,
     wallet_polling: WalletPollingCtx,
+    tokenizer: Option<Arc<dyn crate::tokenization::Tokenizer>>,
 }
 
 pub(crate) struct ConductorBuilder<P, E, State> {
@@ -146,6 +147,7 @@ impl<P: Provider + Clone + Send + 'static, E: Executor + Clone + Send + 'static>
                 event_receiver,
                 rebalancer: None,
                 wallet_polling: WalletPollingCtx::default(),
+                tokenizer: None,
             },
         }
     }
@@ -188,6 +190,14 @@ where
         self
     }
 
+    pub(crate) fn with_tokenizer(
+        mut self,
+        tokenizer: Arc<dyn crate::tokenization::Tokenizer>,
+    ) -> Self {
+        self.state.tokenizer = Some(tokenizer);
+        self
+    }
+
     pub(crate) fn spawn(self) -> Conductor {
         info!("Starting conductor orchestration");
 
@@ -206,15 +216,16 @@ where
             order_owner,
         ));
 
-        let polling_service = InventoryPollingService::new(
-            raindex_service,
-            self.common.executor.clone(),
-            self.common.frameworks.vault_registry.clone(),
-            self.common.ctx.evm.orderbook,
-            order_owner,
-            self.common.frameworks.snapshot,
-            self.state.wallet_polling,
-        );
+        let polling_service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(self.common.executor.clone())
+            .vault_registry(self.common.frameworks.vault_registry.clone())
+            .orderbook(self.common.ctx.evm.orderbook)
+            .order_owner(order_owner)
+            .snapshot(self.common.frameworks.snapshot)
+            .wallet_polling(self.state.wallet_polling)
+            .maybe_tokenizer(self.state.tokenizer)
+            .build();
         let inventory_poller = Some(spawn_inventory_poller(
             polling_service,
             std::time::Duration::from_secs(self.common.ctx.inventory_poll_interval),

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -10,6 +10,7 @@ use alloy::primitives::{Address, IntoLogData};
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use alloy::rpc::types::Log;
 use alloy::sol_types;
+use chrono::Utc;
 use futures_util::{Stream, StreamExt};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -33,7 +34,10 @@ use crate::alpaca_wallet::AlpacaWalletService;
 use crate::bindings::IOrderBookV6::{ClearV3, IOrderBookV6Instance, TakeOrderV3};
 use crate::config::{AssetsConfig, Ctx, CtxError};
 use crate::dashboard::EventBroadcaster;
-use crate::inventory::{BroadcastingInventory, InventoryPollingService, InventorySnapshot};
+use crate::equity_redemption::symbols_with_stuck_redemptions;
+use crate::inventory::{
+    BroadcastingInventory, Inventory, InventoryPollingService, InventorySnapshot, Venue,
+};
 use crate::offchain::order_poller::OrderStatusPoller;
 use crate::offchain_order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId, OrderPlacer,
@@ -192,13 +196,39 @@ impl Conductor {
             let cutoff_block =
                 get_cutoff_block(&mut clear_stream, &mut take_stream, &provider, &pool).await?;
 
-            if let Some(end_block) = cutoff_block.checked_sub(1) {
-                backfill_events(&pool, &provider, &ctx.evm, end_block).await?;
-            }
+            // Backfill up to and including cutoff_block. The queue uses
+            // INSERT OR IGNORE so any events also delivered by the live
+            // WebSocket subscription are silently deduplicated. Including
+            // cutoff_block closes the race window where a block is mined
+            // at the exact moment the subscription is established: without
+            // this, that block falls in neither the backfill range nor the
+            // live stream.
+            backfill_events(&pool, &provider, &ctx.evm, cutoff_block).await?;
 
             let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
                 .build(())
                 .await?;
+
+            // Recover inflight state from event history. Redemptions that
+            // ended in DetectionFailed or RedemptionRejected have tokens
+            // physically in Alpaca's wallet with no snapshot source -- set
+            // their inflight directly so the system doesn't re-trigger.
+            let stuck_redemptions = symbols_with_stuck_redemptions(&pool).await?;
+            if !stuck_redemptions.is_empty() {
+                let mut view = inventory.write().await;
+                for (symbol, quantity) in &stuck_redemptions {
+                    *view = view.clone().update_equity(
+                        symbol,
+                        Inventory::set_inflight(Venue::MarketMaking, *quantity),
+                        Utc::now(),
+                    )?;
+                }
+                drop(view);
+                info!(
+                    stuck = ?stuck_redemptions,
+                    "Recovered inflight from event history"
+                );
+            }
 
             let (vault_registry, vault_registry_projection) =
                 StoreBuilder::<VaultRegistry>::new(pool.clone())
@@ -221,6 +251,7 @@ impl Conductor {
                 ethereum_wallet,
                 base_wallet,
                 alpaca_wallet,
+                tokenizer,
             ) = if let Some(rebalancing_ctx) = rebalancing {
                 let ethereum_wallet = rebalancing_ctx.ethereum_wallet().clone();
                 let base_wallet = rebalancing_ctx.base_wallet().clone();
@@ -249,6 +280,7 @@ impl Conductor {
                     Some(ethereum_wallet),
                     Some(base_wallet),
                     Some(components.alpaca_wallet),
+                    Some(components.tokenizer),
                 )
             } else {
                 let (position, position_projection) = build_position_cqrs(&pool).await?;
@@ -260,6 +292,7 @@ impl Conductor {
                     position,
                     position_projection,
                     snapshot,
+                    None,
                     None,
                     None,
                     None,
@@ -320,6 +353,10 @@ impl Conductor {
 
             if let Some(wallet) = alpaca_wallet {
                 builder = builder.with_alpaca_wallet(wallet);
+            }
+
+            if let Some(tokenizer) = tokenizer {
+                builder = builder.with_tokenizer(tokenizer);
             }
 
             Ok(builder.spawn())
@@ -383,6 +420,7 @@ struct RebalancingComponents<Chain: Wallet> {
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
     alpaca_wallet: Arc<AlpacaWalletService>,
+    tokenizer: Arc<dyn Tokenizer>,
     spawner: RebalancerSpawner<Chain>,
 }
 
@@ -580,7 +618,7 @@ fn build_rebalancing_infrastructure<Chain: Wallet + Clone>(
             ethereum_wallet,
             base_wallet,
             raindex_service,
-            tokenizer,
+            tokenizer.clone(),
         )
         .await?;
 
@@ -597,6 +635,7 @@ fn build_rebalancing_infrastructure<Chain: Wallet + Clone>(
             position_projection: built.position_projection,
             snapshot: built.snapshot,
             alpaca_wallet,
+            tokenizer,
             spawner: RebalancerSpawner {
                 services,
                 usdc_vault_id: RaindexVaultId(usdc_vault_id),
@@ -3024,7 +3063,7 @@ mod tests {
     }
 
     async fn get_vault_registry_events(pool: &SqlitePool) -> Vec<String> {
-        sqlx::query_scalar!("SELECT event_type FROM events WHERE aggregate_type = 'VaultRegistry'")
+        sqlx::query_scalar("SELECT event_type FROM events WHERE aggregate_type = 'VaultRegistry'")
             .fetch_all(pool)
             .await
             .unwrap()
@@ -3181,8 +3220,8 @@ mod tests {
         }
         .to_string();
 
-        let aggregate_ids: Vec<String> = sqlx::query_scalar!(
-            "SELECT DISTINCT aggregate_id FROM events WHERE aggregate_type = 'VaultRegistry'"
+        let aggregate_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT DISTINCT aggregate_id FROM events WHERE aggregate_type = 'VaultRegistry'",
         )
         .fetch_all(&pool)
         .await
@@ -4610,8 +4649,8 @@ mod tests {
         .await
         .unwrap();
 
-        let event_types = sqlx::query_scalar!(
-            "SELECT event_type FROM events WHERE aggregate_type = 'OnChainTrade'"
+        let event_types: Vec<String> = sqlx::query_scalar(
+            "SELECT event_type FROM events WHERE aggregate_type = 'OnChainTrade'",
         )
         .fetch_all(&pool)
         .await
@@ -4656,8 +4695,8 @@ mod tests {
         .await
         .unwrap();
 
-        let event_types = sqlx::query_scalar!(
-            "SELECT event_type FROM events WHERE aggregate_type = 'OnChainTrade'"
+        let event_types: Vec<String> = sqlx::query_scalar(
+            "SELECT event_type FROM events WHERE aggregate_type = 'OnChainTrade'",
         )
         .fetch_all(&pool)
         .await

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -60,6 +60,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use std::collections::HashMap;
 use std::str::FromStr;
 use tracing::{info, warn};
 
@@ -1046,6 +1048,119 @@ impl EventSourced for EquityRedemption {
     }
 }
 
+/// Returns symbols and quantities from `EquityRedemption` aggregates that
+/// ended in `DetectionFailed` or `RedemptionRejected`.
+///
+/// `DetectionFailed` leaves tokens physically in Alpaca's redemption wallet.
+/// `RedemptionRejected` has uncertain disposition -- tokens may or may not
+/// have been returned. In both cases, no snapshot source tracks the actual
+/// location. The caller should set their inflight balance directly so the
+/// system does not re-trigger redemptions for tokens it no longer holds.
+pub(crate) async fn symbols_with_stuck_redemptions(
+    pool: &SqlitePool,
+) -> Result<HashMap<Symbol, FractionalShares>, sqlx::Error> {
+    let rows: Vec<(String, Option<String>, Option<String>)> = sqlx::query_as(
+        "WITH latest AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'EquityRedemption' \
+             GROUP BY aggregate_id \
+         ) \
+         SELECT latest.aggregate_id, \
+                json_extract(first_ev.payload, \
+                '$.WithdrawnFromRaindex.symbol'), \
+                json_extract(first_ev.payload, \
+                '$.WithdrawnFromRaindex.quantity') \
+         FROM events last_ev \
+         INNER JOIN latest \
+             ON last_ev.aggregate_id = latest.aggregate_id \
+            AND last_ev.sequence = latest.max_seq \
+         INNER JOIN events first_ev \
+             ON first_ev.aggregate_type = 'EquityRedemption' \
+            AND first_ev.aggregate_id = latest.aggregate_id \
+            AND first_ev.sequence = 0 \
+         WHERE last_ev.aggregate_type = 'EquityRedemption' \
+           AND last_ev.event_type IN ( \
+               'EquityRedemptionEvent::DetectionFailed', \
+               'EquityRedemptionEvent::RedemptionRejected' \
+           )",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut result: HashMap<Symbol, FractionalShares> = HashMap::new();
+
+    for (aggregate_id, raw_symbol, raw_quantity) in rows {
+        let Some(symbol) = parse_stuck_symbol(&aggregate_id, raw_symbol) else {
+            continue;
+        };
+
+        let Some(quantity) = parse_stuck_quantity(&aggregate_id, raw_quantity) else {
+            continue;
+        };
+
+        let entry = result.entry(symbol).or_insert(FractionalShares::ZERO);
+        match *entry + quantity {
+            Ok(sum) => *entry = sum,
+            Err(error) => {
+                warn!(
+                    %error,
+                    %aggregate_id,
+                    "Float overflow summing stuck redemption quantities, \
+                     keeping accumulated value"
+                );
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+fn parse_stuck_symbol(aggregate_id: &str, raw: Option<String>) -> Option<Symbol> {
+    let value = raw.or_else(|| {
+        warn!(
+            %aggregate_id,
+            "Stuck redemption has NULL symbol in \
+             WithdrawnFromRaindex payload, skipping"
+        );
+        None
+    })?;
+
+    Symbol::new(&value)
+        .inspect_err(|error| {
+            warn!(
+                %error,
+                %aggregate_id,
+                raw_symbol = %value,
+                "Stuck redemption has invalid symbol, skipping"
+            );
+        })
+        .ok()
+}
+
+fn parse_stuck_quantity(aggregate_id: &str, raw: Option<String>) -> Option<FractionalShares> {
+    let value = raw.or_else(|| {
+        warn!(
+            %aggregate_id,
+            "Stuck redemption has NULL quantity in \
+             WithdrawnFromRaindex payload, skipping"
+        );
+        None
+    })?;
+
+    Float::parse(value.clone())
+        .inspect_err(|error| {
+            warn!(
+                %error,
+                %aggregate_id,
+                raw_quantity = %value,
+                "Stuck redemption has invalid quantity, skipping"
+            );
+        })
+        .ok()
+        .map(FractionalShares::new)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -1705,6 +1820,253 @@ mod tests {
             err,
             AggregateError::UserError(LifecycleError::Apply(EquityRedemptionError::AlreadyStarted))
         ));
+    }
+
+    /// Insert a minimal event row into the events table.
+    async fn insert_event(
+        pool: &SqlitePool,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, \
+              event_version, payload, metadata) \
+             VALUES ('EquityRedemption', ?1, ?2, ?3, '1', ?4, '{}')",
+        )
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn withdrawn_payload(symbol: &str) -> String {
+        format!(
+            r#"{{"WithdrawnFromRaindex":{{"symbol":"{symbol}","quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","raindex_withdraw_tx":"0x0000000000000000000000000000000000000000000000000000000000000001","withdrawn_at":"2026-01-01T00:00:00Z"}}}}"#
+        )
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_returns_detection_failed_symbols() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // AAPL: WithdrawnFromRaindex -> DetectionFailed (stuck)
+        insert_event(
+            &pool,
+            "redemption-1",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "redemption-1",
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(result.len(), 1);
+        let aapl = Symbol::new("AAPL").unwrap();
+        assert!(result.contains_key(&aapl));
+        assert!(
+            result[&aapl].inner().eq(float!("10")).unwrap(),
+            "Recovered quantity should be 10, got {:?}",
+            result[&aapl]
+        );
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_returns_rejection_symbols() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // TSLA: WithdrawnFromRaindex -> RedemptionRejected (stuck)
+        insert_event(
+            &pool,
+            "redemption-2",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("TSLA"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "redemption-2",
+            1,
+            "EquityRedemptionEvent::RedemptionRejected",
+            r#"{"RedemptionRejected":{"reason":"test","rejected_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(result.len(), 1);
+        let tsla = Symbol::new("TSLA").unwrap();
+        assert!(result.contains_key(&tsla));
+        assert!(
+            result[&tsla].inner().eq(float!("10")).unwrap(),
+            "Recovered quantity should be 10, got {:?}",
+            result[&tsla]
+        );
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_excludes_completed_and_transfer_failed() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // AAPL: DetectionFailed (stuck)
+        insert_event(
+            &pool,
+            "stuck",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "stuck",
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // MSFT: Completed (not stuck)
+        insert_event(
+            &pool,
+            "completed",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("MSFT"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "completed",
+            1,
+            "EquityRedemptionEvent::Completed",
+            r#"{"Completed":{"completed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // GOOG: TransferFailed (not stuck — tokens still in our wallet)
+        insert_event(
+            &pool,
+            "transfer-failed",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("GOOG"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "transfer-failed",
+            1,
+            "EquityRedemptionEvent::TransferFailed",
+            r#"{"TransferFailed":{"tx_hash":null,"failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(result.len(), 1, "Only AAPL should be stuck: {result:?}");
+        let aapl = Symbol::new("AAPL").unwrap();
+        assert!(result.contains_key(&aapl));
+        assert!(
+            result[&aapl].inner().eq(float!("10")).unwrap(),
+            "Recovered quantity should be 10, got {:?}",
+            result[&aapl]
+        );
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_empty_when_no_events() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_recovers_valid_symbol_alongside_malformed_rows() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // AAPL: valid stuck redemption (DetectionFailed)
+        insert_event(
+            &pool,
+            "valid-stuck",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "valid-stuck",
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // NULL symbol: malformed WithdrawnFromRaindex payload missing symbol
+        insert_event(
+            &pool,
+            "null-symbol",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            r#"{"WithdrawnFromRaindex":{"quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","raindex_withdraw_tx":"0x0000000000000000000000000000000000000000000000000000000000000001","withdrawn_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_event(
+            &pool,
+            "null-symbol",
+            1,
+            "EquityRedemptionEvent::RedemptionRejected",
+            r#"{"RedemptionRejected":{"reason":"test","rejected_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // Invalid symbol: symbol fails Symbol::new validation
+        insert_event(
+            &pool,
+            "invalid-symbol",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload(""),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "invalid-symbol",
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // Only AAPL should be recovered; the NULL and invalid rows are
+        // skipped with warnings.
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "Only valid AAPL should be recovered, got: {result:?}"
+        );
+        let aapl = Symbol::new("AAPL").unwrap();
+        assert!(result.contains_key(&aapl));
+        assert!(
+            result[&aapl].inner().eq(float!("10")).unwrap(),
+            "Recovered quantity should be 10, got {:?}",
+            result[&aapl]
+        );
     }
 
     #[test]

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -145,13 +145,13 @@ async fn seed_event_queue(pool: &SqlitePool, queued_event: &QueuedEvent) -> i64 
     let block_number = i64::try_from(queued_event.block_number).unwrap();
     let event_data = serde_json::to_string(&queued_event.event).unwrap();
 
-    sqlx::query_scalar!(
+    sqlx::query_scalar(
         "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data) VALUES (?, ?, ?, ?) RETURNING id",
-        tx_hash_str,
-        log_index,
-        block_number,
-        event_data
     )
+    .bind(&tx_hash_str)
+    .bind(log_index)
+    .bind(block_number)
+    .bind(&event_data)
     .fetch_one(pool)
     .await
     .unwrap()

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -31,14 +31,15 @@ use crate::bindings::{IERC20, TestERC20};
 use crate::config::{
     AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
 };
-use crate::equity_redemption::EquityRedemption;
-use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView};
+use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
+use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain_order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
 use crate::onchain::raindex::Raindex;
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
-use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
+use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::rebalancing::usdc::mock::MockUsdcRebalance;
 use crate::rebalancing::{
     Rebalancer, RebalancingTrigger, RebalancingTriggerConfig, TriggeredOperation,
@@ -50,6 +51,7 @@ use crate::tokenization::alpaca::tests::{
     TEST_REDEMPTION_WALLET, create_test_service_from_mock, setup_anvil, tokenization_mint_path,
     tokenization_requests_path,
 };
+use crate::tokenization::mock::MockTokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
 use crate::wrapper::mock::MockWrapper;
@@ -165,6 +167,7 @@ struct EquityTriggerFixture {
     symbol: Symbol,
     aggregate_id: String,
     trigger: Arc<RebalancingTrigger>,
+    inventory: Arc<BroadcastingInventory>,
     position_cqrs: Arc<Store<Position>>,
     receiver: mpsc::Receiver<TriggeredOperation>,
 }
@@ -208,6 +211,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
         symbol,
         aggregate_id,
         trigger,
+        inventory,
         position_cqrs,
         receiver,
     }
@@ -407,6 +411,48 @@ fn build_equity_transfer_with_wrapper(
     ))
 }
 
+/// Builds `CrossVenueEquityTransfer` with mint and redemption stores wired to
+/// the `RebalancingTrigger` as a query processor. This mirrors the production
+/// wiring in `Conductor` via `QueryManifest::build()`, ensuring mint/redemption
+/// lifecycle events flow through the trigger and update inflight state.
+async fn build_equity_transfer_with_trigger(
+    pool: &SqlitePool,
+    raindex: Arc<dyn crate::onchain::raindex::Raindex>,
+    tokenizer: Arc<dyn Tokenizer>,
+    mock_wrapper: MockWrapper,
+    wallet: Address,
+    trigger: &Arc<RebalancingTrigger>,
+) -> Arc<CrossVenueEquityTransfer> {
+    let wrapper: Arc<dyn crate::wrapper::Wrapper> = Arc::new(mock_wrapper);
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::clone(&raindex),
+        tokenizer: Arc::clone(&tokenizer),
+        wrapper: Arc::clone(&wrapper),
+    };
+
+    let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+        .with(Arc::clone(trigger))
+        .build(equity_services.clone())
+        .await
+        .unwrap();
+
+    let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+        .with(Arc::clone(trigger))
+        .build(equity_services)
+        .await
+        .unwrap();
+
+    Arc::new(CrossVenueEquityTransfer::new(
+        raindex,
+        tokenizer,
+        wrapper,
+        wallet,
+        mint_store,
+        redemption_store,
+    ))
+}
+
 /// Verifies the full equity mint rebalancing pipeline: position CQRS commands
 /// flow through the RebalancingTrigger (registered as a Query processor),
 /// update the InventoryView, detect an equity imbalance, and dispatch a Mint
@@ -420,6 +466,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
         symbol,
         aggregate_id,
         trigger,
+        inventory: _,
         position_cqrs,
         receiver,
     } = setup_equity_trigger().await;
@@ -660,6 +707,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         symbol,
         aggregate_id,
         trigger,
+        inventory: _,
         position_cqrs,
         receiver,
     } = setup_equity_trigger().await;
@@ -1077,6 +1125,7 @@ async fn mint_api_failure_produces_rejected_event() {
         symbol,
         aggregate_id,
         trigger,
+        inventory: _,
         position_cqrs,
         receiver,
     } = setup_equity_trigger().await;
@@ -1566,4 +1615,477 @@ async fn threshold_config_controls_trigger_sensitivity() {
             _ => panic!("Expected UsdcAlpacaToBase operation"),
         }
     }
+}
+
+/// Verifies that a dispatched mint operation sets offchain inflight balance
+/// in the InventoryView. The trigger dispatches a Mint, and MintAccepted flows
+/// through `on_mint` which calls `Inventory::transfer(Hedging, Start, qty)`.
+/// This moves shares from offchain available to offchain inflight, recording
+/// the pending tokenization as in-flight equity.
+#[tokio::test]
+async fn mint_accepted_sets_offchain_inflight() {
+    let EquityTriggerFixture {
+        pool,
+        symbol,
+        aggregate_id: _,
+        trigger,
+        inventory,
+        position_cqrs,
+        mut receiver,
+    } = setup_equity_trigger().await;
+
+    // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain
+    build_imbalanced_inventory(Imbalance::Equity {
+        position_cqrs: &position_cqrs,
+        symbol: &symbol,
+        onchain: float!("20"),
+        offchain: float!("80"),
+    })
+    .await;
+
+    // Confirm initial state: offchain has 80 available, 0 inflight
+    let inv = inventory.read().await;
+    let initial_offchain_available = inv.equity_available(&symbol, Venue::Hedging).unwrap();
+    let initial_offchain_inflight = inv.equity_inflight(&symbol, Venue::Hedging).unwrap();
+    drop(inv);
+
+    assert!(
+        initial_offchain_available.inner().eq(float!("80")).unwrap(),
+        "Initial offchain available should be 80"
+    );
+    assert!(
+        initial_offchain_inflight.inner().is_zero().unwrap(),
+        "Initial offchain inflight should be 0"
+    );
+
+    let server = MockServer::start();
+    let (_anvil, endpoint, key) = setup_anvil();
+
+    let signer = PrivateKeySigner::from_bytes(&key).unwrap();
+    let wallet = EthereumWallet::from(signer.clone());
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect(&endpoint)
+        .await
+        .unwrap();
+    let token_contract = TestERC20::deploy(&provider).await.unwrap();
+    let token_address = *token_contract.address();
+
+    seed_vault_registry(&pool, &symbol, token_address).await;
+
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+        create_test_service_from_mock(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await,
+    );
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let mock_wrapper = MockWrapper::new().with_tokenized_shares(token_address);
+
+    // Wire mint/redemption stores with trigger so lifecycle events update
+    // inflight state through the trigger's Reactor
+    let equity_transfer = build_equity_transfer_with_trigger(
+        &pool,
+        raindex,
+        tokenizer,
+        mock_wrapper,
+        signer.address(),
+        &trigger,
+    )
+    .await;
+
+    // Mock the mint API to accept but never complete (stays pending forever)
+    server.mock(|when, then| {
+        when.method(POST).path(tokenization_mint_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(sample_pending_response("inflight_test"));
+    });
+
+    // Mock the poll endpoint to keep returning pending
+    server.mock(|when, then| {
+        when.method(GET).path(tokenization_requests_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([sample_pending_response("inflight_test")]));
+    });
+
+    // Trigger the imbalance via a position command to dispatch the Mint
+    position_cqrs
+        .send(
+            &symbol,
+            PositionCommand::AcknowledgeOnChainFill {
+                symbol: symbol.clone(),
+                threshold: ExecutionThreshold::whole_share(),
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 2,
+                },
+                amount: FractionalShares::new(float!("1")),
+                direction: Direction::Sell,
+                price_usdc: float!("150.0"),
+                block_timestamp: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Receive the dispatched Mint operation and get the quantity
+    let operation = receiver
+        .try_recv()
+        .expect("Trigger should dispatch a Mint operation for the imbalance");
+    let TriggeredOperation::Mint {
+        symbol: mint_symbol,
+        quantity: mint_quantity,
+    } = operation
+    else {
+        panic!("Expected Mint operation, got {operation:?}");
+    };
+    assert_eq!(mint_symbol, symbol);
+
+    // Execute the mint transfer. This calls the Alpaca API, gets MintAccepted,
+    // which triggers on_mint -> Inventory::transfer(Hedging, Start, qty).
+    // The poll will return pending, so the mint aggregate will time out or loop,
+    // but MintAccepted has already fired by then. We spawn and cancel to
+    // get just the MintAccepted event through.
+    let transfer_handle = tokio::spawn({
+        let equity_transfer = Arc::clone(&equity_transfer);
+        let mint_symbol = mint_symbol.clone();
+        async move {
+            let _ = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
+                equity_transfer.as_ref(),
+                Equity {
+                    symbol: mint_symbol,
+                    quantity: mint_quantity,
+                },
+            )
+            .await;
+        }
+    });
+
+    // Wait for MintAccepted to propagate: poll until inflight becomes non-zero
+    // rather than relying on a fixed sleep duration that can race on busy CI.
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    loop {
+        let inv = inventory.read().await;
+        let inflight = inv.equity_inflight(&symbol, Venue::Hedging);
+        drop(inv);
+
+        if let Some(inflight) = inflight
+            && inflight.inner().gt(float!("0")).unwrap()
+        {
+            break;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for MintAccepted to set inflight balance"
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+    transfer_handle.abort();
+
+    // After MintAccepted, offchain inflight should have increased by the
+    // mint quantity and available decreased by the same amount
+    let inv = inventory.read().await;
+    let offchain_inflight = inv.equity_inflight(&symbol, Venue::Hedging).unwrap();
+    let offchain_available = inv.equity_available(&symbol, Venue::Hedging).unwrap();
+    drop(inv);
+
+    assert!(
+        offchain_inflight.inner().gt(float!("0")).unwrap(),
+        "Offchain inflight should be non-zero after MintAccepted, got {offchain_inflight:?}"
+    );
+
+    // The mint quantity was dispatched from available to inflight
+    let mint_qty_float = mint_quantity.inner();
+    assert!(
+        offchain_inflight.inner().eq(mint_qty_float).unwrap(),
+        "Offchain inflight should equal mint quantity {mint_quantity:?}, \
+         got {offchain_inflight:?}"
+    );
+
+    // available should have decreased: original 80 - mint_quantity
+    let expected_available = (float!("80") - mint_qty_float).unwrap();
+    assert!(
+        offchain_available.inner().eq(expected_available).unwrap(),
+        "Offchain available should be 80 - {mint_quantity:?} = {expected_available:?}, \
+         got {offchain_available:?}"
+    );
+}
+
+/// Verifies that a completed mint clears the offchain inflight balance and
+/// increases the onchain available balance. With mint stores wired to the
+/// trigger (mirroring Conductor's `QueryManifest::build()`), the full mint
+/// lifecycle flows through `on_mint`. `MintAccepted` sets offchain inflight,
+/// and `TokensReceived` clears offchain inflight while adding to onchain
+/// available -- proving the full transfer lifecycle updates InventoryView
+/// correctly.
+#[tokio::test]
+async fn completed_mint_clears_inflight_and_updates_inventory() {
+    let EquityTriggerFixture {
+        pool,
+        symbol,
+        aggregate_id: _,
+        trigger,
+        inventory,
+        position_cqrs,
+        mut receiver,
+    } = setup_equity_trigger().await;
+
+    // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain
+    build_imbalanced_inventory(Imbalance::Equity {
+        position_cqrs: &position_cqrs,
+        symbol: &symbol,
+        onchain: float!("20"),
+        offchain: float!("80"),
+    })
+    .await;
+
+    let server = MockServer::start();
+    let (_anvil, endpoint, key) = setup_anvil();
+
+    let signer = PrivateKeySigner::from_bytes(&key).unwrap();
+    let wallet = EthereumWallet::from(signer.clone());
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect(&endpoint)
+        .await
+        .unwrap();
+
+    let token_contract = TestERC20::deploy(&provider).await.unwrap();
+    let token_address = *token_contract.address();
+
+    // Mint tokens so balanceOf verification passes during verify_mint_tx
+    let mint_amount = U256::from(30_500_000_000_000_000_000_u128);
+    let mint_receipt = token_contract
+        .mint(signer.address(), mint_amount)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let mint_tx_hash = mint_receipt.transaction_hash;
+
+    seed_vault_registry(&pool, &symbol, token_address).await;
+
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+        create_test_service_from_mock(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await,
+    );
+    let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+    let mock_wrapper = MockWrapper::new().with_tokenized_shares(token_address);
+
+    let equity_transfer = build_equity_transfer_with_trigger(
+        &pool,
+        raindex,
+        tokenizer,
+        mock_wrapper,
+        signer.address(),
+        &trigger,
+    )
+    .await;
+
+    let wallet_hex = format!("{:#x}", signer.address());
+
+    let mint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path(tokenization_mint_path())
+            .json_body_includes(
+                json!({
+                    "underlying_symbol": "AAPL",
+                    "qty": "30.5",
+                    "wallet_address": wallet_hex,
+                })
+                .to_string(),
+            );
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(sample_pending_response("completed_mint_test"));
+    });
+
+    let poll_mock = server.mock(|when, then| {
+        when.method(GET).path(tokenization_requests_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([sample_completed_response(
+                "completed_mint_test",
+                mint_tx_hash
+            )]));
+    });
+
+    // Trigger the mint via a position command
+    position_cqrs
+        .send(
+            &symbol,
+            PositionCommand::AcknowledgeOnChainFill {
+                symbol: symbol.clone(),
+                threshold: ExecutionThreshold::whole_share(),
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 2,
+                },
+                amount: FractionalShares::new(float!("1")),
+                direction: Direction::Sell,
+                price_usdc: float!("150.0"),
+                block_timestamp: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Receive the dispatched Mint operation
+    let operation = receiver
+        .try_recv()
+        .expect("Trigger should dispatch a Mint operation");
+    let TriggeredOperation::Mint {
+        symbol: mint_symbol,
+        quantity: mint_quantity,
+    } = operation
+    else {
+        panic!("Expected Mint operation, got {operation:?}");
+    };
+
+    // Record initial onchain available before the mint executes
+    let initial_onchain_available = {
+        let inv = inventory.read().await;
+        inv.equity_available(&symbol, Venue::MarketMaking).unwrap()
+    };
+
+    // Execute the full mint lifecycle through CrossVenueTransfer
+    CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
+        equity_transfer.as_ref(),
+        Equity {
+            symbol: mint_symbol,
+            quantity: mint_quantity,
+        },
+    )
+    .await
+    .unwrap();
+
+    mint_mock.assert();
+    poll_mock.assert();
+
+    // Drop the equity transfer to release Arc refs held by wired stores
+    drop(equity_transfer);
+
+    // After TokensReceived, offchain inflight should be cleared (back to 0)
+    let inv = inventory.read().await;
+    let offchain_inflight = inv.equity_inflight(&symbol, Venue::Hedging).unwrap();
+    let onchain_available = inv.equity_available(&symbol, Venue::MarketMaking).unwrap();
+    drop(inv);
+
+    assert!(
+        offchain_inflight.inner().is_zero().unwrap(),
+        "Offchain inflight should be 0 after mint completes, got {offchain_inflight:?}"
+    );
+
+    // Onchain available should have increased by the mint quantity
+    let mint_qty_float = mint_quantity.inner();
+    let expected_onchain = (initial_onchain_available.inner() + mint_qty_float).unwrap();
+    assert!(
+        onchain_available.inner().eq(expected_onchain).unwrap(),
+        "Onchain available should have increased by {mint_quantity:?}: \
+         expected {expected_onchain:?}, got {onchain_available:?}"
+    );
+}
+
+/// TransferFailed during redemption cancels inflight and restores available.
+///
+/// When tokens are withdrawn from Raindex (WithdrawnFromRaindex), inflight
+/// is set at MarketMaking. If the subsequent send to Alpaca's redemption
+/// wallet fails (TransferFailed), inflight must be cancelled back to
+/// available -- tokens never left our wallet.
+#[tokio::test]
+async fn transfer_failed_cancels_redemption_inflight() {
+    let EquityTriggerFixture {
+        pool,
+        symbol,
+        aggregate_id: _,
+        trigger,
+        inventory,
+        position_cqrs,
+        receiver: _,
+    } = setup_equity_trigger().await;
+
+    // Build inventory: 80 onchain, 20 offchain = 80% ratio -> TooMuchOnchain
+    build_imbalanced_inventory(Imbalance::Equity {
+        position_cqrs: &position_cqrs,
+        symbol: &symbol,
+        onchain: float!("80"),
+        offchain: float!("20"),
+    })
+    .await;
+
+    let token_address = Address::random();
+    seed_vault_registry(&pool, &symbol, token_address).await;
+
+    // Build a redemption store wired to the trigger so events flow through
+    let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new().with_send_failure());
+
+    let equity_services = EquityTransferServices {
+        raindex: Arc::new(MockRaindex::new()),
+        tokenizer,
+        wrapper: Arc::new(MockWrapper::new()),
+    };
+
+    let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+        .with(Arc::clone(&trigger))
+        .build(equity_services)
+        .await
+        .unwrap();
+
+    let redemption_id = RedemptionAggregateId::new("redemption-transfer-failed");
+
+    // Redeem: withdraws tokens from Raindex vault -> WithdrawnFromRaindex
+    redemption_store
+        .send(
+            &redemption_id,
+            EquityRedemptionCommand::Redeem {
+                symbol: symbol.clone(),
+                quantity: float!("10"),
+                token: token_address,
+                amount: U256::from(10_000_000_000_000_000_000_u128),
+            },
+        )
+        .await
+        .unwrap();
+
+    // After WithdrawnFromRaindex, inflight should be set at MarketMaking
+    let inflight_after_withdraw = inventory
+        .read()
+        .await
+        .equity_inflight(&symbol, Venue::MarketMaking)
+        .unwrap();
+    assert!(
+        !inflight_after_withdraw.inner().is_zero().unwrap(),
+        "Inflight should be non-zero after WithdrawnFromRaindex, got {inflight_after_withdraw:?}"
+    );
+
+    // UnwrapTokens -> TokensUnwrapped (no inventory change)
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::UnwrapTokens)
+        .await
+        .unwrap();
+
+    // SendTokens: mock tokenizer fails -> TransferFailed event
+    // The aggregate emits TransferFailed, trigger cancels inflight
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::SendTokens)
+        .await
+        .unwrap();
+
+    // After TransferFailed, inflight should be cleared
+    let inv = inventory.read().await;
+    let inflight_after_fail = inv.equity_inflight(&symbol, Venue::MarketMaking).unwrap();
+    let available_after_fail = inv.equity_available(&symbol, Venue::MarketMaking).unwrap();
+    drop(inv);
+
+    assert!(
+        inflight_after_fail.inner().is_zero().unwrap(),
+        "Inflight should be zero after TransferFailed, got {inflight_after_fail:?}"
+    );
+
+    // Available should have the tokens back (80 original)
+    assert!(
+        available_after_fail.inner().eq(float!("80")).unwrap(),
+        "Available should be restored to 80 after TransferFailed, got {available_after_fail:?}"
+    );
 }

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -9,9 +9,10 @@
 use alloy::primitives::Address;
 use alloy::providers::RootProvider;
 use futures_util::future::try_join_all;
+use rain_math_float::FloatError;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
@@ -27,7 +28,14 @@ use crate::inventory::snapshot::{
 use crate::onchain::raindex::{RaindexError, RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
+use crate::tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
+
+/// Pending mints and redemptions aggregated by symbol.
+struct PendingRequests {
+    mints: BTreeMap<Symbol, FractionalShares>,
+    redemptions: BTreeMap<Symbol, FractionalShares>,
+}
 
 /// Error type for inventory polling operations.
 #[derive(Debug, thiserror::Error)]
@@ -46,6 +54,10 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
     UsdcConversion(#[from] UsdcTransferError),
     #[error(transparent)]
     AlpacaWallet(#[from] AlpacaWalletError),
+    #[error(transparent)]
+    Tokenizer(#[from] TokenizerError),
+    #[error(transparent)]
+    Float(#[from] FloatError),
     #[error("vault balance mismatch: expected {expected:?}, got {actual:?}")]
     VaultBalanceMismatch {
         expected: Vec<Address>,
@@ -76,13 +88,16 @@ where
     order_owner: Address,
     snapshot: Arc<Store<InventorySnapshot>>,
     wallet_polling: WalletPollingCtx,
+    tokenizer: Option<Arc<dyn Tokenizer>>,
 }
 
+#[bon::bon]
 impl<Chain, Exe> InventoryPollingService<Chain, Exe>
 where
     Chain: Evm,
     Exe: Executor,
 {
+    #[builder]
     pub(crate) fn new(
         raindex_service: Arc<RaindexService<Chain>>,
         executor: Exe,
@@ -91,6 +106,7 @@ where
         order_owner: Address,
         snapshot: Arc<Store<InventorySnapshot>>,
         wallet_polling: WalletPollingCtx,
+        tokenizer: Option<Arc<dyn Tokenizer>>,
     ) -> Self {
         Self {
             raindex_service,
@@ -100,6 +116,7 @@ where
             order_owner,
             snapshot,
             wallet_polling,
+            tokenizer,
         }
     }
 
@@ -116,6 +133,12 @@ where
             owner: self.order_owner,
         };
 
+        // Inflight must be polled first. Balance snapshots trigger
+        // check_and_trigger_equity, which skips when has_inflight() is true.
+        // On startup the first poll tick runs immediately -- if balance
+        // snapshots land before inflight, the system can trigger a duplicate
+        // operation for a request Alpaca already has pending.
+        self.poll_inflight_equity(&snapshot_id).await?;
         self.poll_onchain(&snapshot_id).await?;
         self.poll_ethereum_cash(&snapshot_id).await?;
         self.poll_base_wallet_cash(&snapshot_id).await?;
@@ -450,6 +473,98 @@ where
 
         Ok(())
     }
+
+    /// Aggregate pending tokenization requests into mint and redemption maps.
+    fn aggregate_pending_requests(
+        requests: impl Iterator<Item = crate::tokenization::TokenizationRequest>,
+    ) -> Result<PendingRequests, FloatError> {
+        let mut mints: BTreeMap<Symbol, FractionalShares> = BTreeMap::new();
+        let mut redemptions: BTreeMap<Symbol, FractionalShares> = BTreeMap::new();
+
+        for request in requests {
+            let target = match request.r#type {
+                Some(TokenizationRequestType::Mint) => &mut mints,
+                Some(TokenizationRequestType::Redeem) => &mut redemptions,
+                None => {
+                    warn!(
+                        request_id = %request.id.0,
+                        symbol = %request.underlying_symbol,
+                        "Pending tokenization request has no type, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            let entry = target
+                .entry(request.underlying_symbol.clone())
+                .or_insert(FractionalShares::ZERO);
+
+            *entry = (*entry + request.quantity)?;
+        }
+
+        Ok(PendingRequests { mints, redemptions })
+    }
+
+    /// Whether a pending request belongs to this conductor's wallet.
+    /// Returns `false` for requests from other wallets (should be filtered
+    /// out). Returns `true` for matching wallets or when `wallet` is `None`
+    /// (older requests may lack the field).
+    // TODO: wallet=None claims the request for every conductor sharing the
+    // tokenizer account, which overstates inflight in multi-conductor setups.
+    // Consider warning+skipping None wallets once the provider reliably
+    // populates the field.
+    fn is_own_request(&self, request: &crate::tokenization::TokenizationRequest) -> bool {
+        match request.wallet {
+            Some(wallet) if wallet != self.order_owner => {
+                warn!(
+                    request_id = %request.id.0,
+                    ?wallet,
+                    expected = ?self.order_owner,
+                    "Skipping pending request from different wallet"
+                );
+                false
+            }
+            _ => true,
+        }
+    }
+
+    /// Poll the tokenization provider for pending requests and emit an
+    /// inflight equity snapshot.
+    ///
+    /// Pending mint requests represent shares leaving the offchain broker
+    /// (hedging venue inflight). Pending redemption requests represent
+    /// tokens leaving onchain (market-making venue inflight).
+    async fn poll_inflight_equity(
+        &self,
+        snapshot_id: &InventorySnapshotId,
+    ) -> Result<(), InventoryPollingError<Exe::Error>> {
+        let Some(tokenizer) = &self.tokenizer else {
+            debug!("No tokenizer configured, skipping inflight equity polling");
+            return Ok(());
+        };
+
+        let pending = tokenizer.list_pending_requests().await?;
+        let PendingRequests { mints, redemptions } = Self::aggregate_pending_requests(
+            pending
+                .into_iter()
+                .filter(|request| self.is_own_request(request)),
+        )?;
+
+        debug!(
+            mint_symbols = mints.len(),
+            redemption_symbols = redemptions.len(),
+            "Polled inflight equity from tokenization provider"
+        );
+
+        self.snapshot
+            .send(
+                snapshot_id,
+                InventorySnapshotCommand::InflightEquity { mints, redemptions },
+            )
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -635,15 +750,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory.clone());
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -682,15 +797,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -725,15 +840,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -759,15 +874,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         // Should succeed without error
         service.poll_and_record().await.unwrap();
@@ -815,15 +930,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -863,15 +978,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -905,15 +1020,15 @@ mod tests {
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -998,15 +1113,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1047,15 +1162,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1097,15 +1212,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1146,15 +1261,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
 
@@ -1178,15 +1293,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
 
@@ -1251,18 +1366,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 ethereum: Some(ethereum_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1294,18 +1409,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1345,18 +1460,18 @@ mod tests {
                 ]));
         });
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(MockExecutor::new())
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 alpaca_wallet: Some(alpaca_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1383,15 +1498,15 @@ mod tests {
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
         let (orderbook, order_owner) = test_addresses();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(MockExecutor::new())
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1426,18 +1541,18 @@ mod tests {
             }));
         });
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(MockExecutor::new())
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 alpaca_wallet: Some(alpaca_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(matches!(
@@ -1469,18 +1584,18 @@ mod tests {
                 ]));
         });
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(MockExecutor::new())
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 alpaca_wallet: Some(alpaca_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
         service.poll_and_record().await.unwrap();
@@ -1508,15 +1623,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1545,15 +1660,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1585,18 +1700,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 ethereum: Some(ethereum_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(matches!(error, InventoryPollingError::Evm(_)));
@@ -1615,21 +1730,381 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(matches!(error, InventoryPollingError::Evm(_)));
+    }
+
+    fn mock_pending_request(
+        request_type: crate::tokenization::TokenizationRequestType,
+        symbol: &str,
+        quantity: i64,
+    ) -> crate::tokenization::TokenizationRequest {
+        mock_pending_request_with_wallet(request_type, symbol, quantity, None)
+    }
+
+    fn mock_pending_request_no_type(
+        symbol: &str,
+        quantity: i64,
+    ) -> crate::tokenization::TokenizationRequest {
+        crate::tokenization::TokenizationRequest {
+            id: crate::tokenized_equity_mint::TokenizationRequestId(format!(
+                "REQ_{symbol}_{quantity}_notype"
+            )),
+            r#type: None,
+            status: crate::tokenization::TokenizationRequestStatus::Pending,
+            underlying_symbol: test_symbol(symbol),
+            quantity: test_shares(quantity),
+            wallet: None,
+            issuer_request_id: None,
+            tx_hash: None,
+            token_symbol: None,
+            fees: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    fn mock_pending_request_with_wallet(
+        request_type: crate::tokenization::TokenizationRequestType,
+        symbol: &str,
+        quantity: i64,
+        wallet: Option<Address>,
+    ) -> crate::tokenization::TokenizationRequest {
+        crate::tokenization::TokenizationRequest {
+            id: crate::tokenized_equity_mint::TokenizationRequestId(format!(
+                "REQ_{symbol}_{quantity}"
+            )),
+            r#type: Some(request_type),
+            status: crate::tokenization::TokenizationRequestStatus::Pending,
+            underlying_symbol: test_symbol(symbol),
+            quantity: test_shares(quantity),
+            wallet,
+            issuer_request_id: None,
+            tx_hash: None,
+            token_symbol: None,
+            fees: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_emits_mints_and_redemptions() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                mock_pending_request(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    10,
+                ),
+                mock_pending_request(
+                    crate::tokenization::TokenizationRequestType::Redeem,
+                    "MSFT",
+                    5,
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .tokenizer(tokenizer)
+            .build();
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity {
+            mints, redemptions, ..
+        } = inflight_event
+        else {
+            panic!("Expected InflightEquity event");
+        };
+
+        assert_eq!(mints.len(), 1);
+        assert_eq!(mints.get(&test_symbol("AAPL")), Some(&test_shares(10)));
+        assert_eq!(redemptions.len(), 1);
+        assert_eq!(redemptions.get(&test_symbol("MSFT")), Some(&test_shares(5)));
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_aggregates_same_symbol() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                mock_pending_request(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    10,
+                ),
+                mock_pending_request(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    25,
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .tokenizer(tokenizer)
+            .build();
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity { mints, .. } = inflight_event else {
+            panic!("Expected InflightEquity event");
+        };
+
+        // Two pending mints for AAPL should be summed: 10 + 25 = 35
+        assert_eq!(mints.len(), 1);
+        assert_eq!(mints.get(&test_symbol("AAPL")), Some(&test_shares(35)));
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_skipped_without_tokenizer() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }));
+
+        assert!(
+            inflight_event.is_none(),
+            "No InflightEquity event expected without tokenizer"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_emits_empty_snapshot_when_no_requests_pending() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let executor = MockExecutor::new();
+
+        let tokenizer =
+            Arc::new(crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![]));
+
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .tokenizer(tokenizer)
+            .build();
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event even with empty pending requests");
+
+        let InventorySnapshotEvent::InflightEquity {
+            mints, redemptions, ..
+        } = inflight_event
+        else {
+            panic!("Expected InflightEquity event");
+        };
+
+        assert!(mints.is_empty(), "No pending mints expected");
+        assert!(redemptions.is_empty(), "No pending redemptions expected");
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_filters_by_wallet() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+        let other_wallet = address!("0x9999999999999999999999999999999999999999");
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                // Matching wallet
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    10,
+                    Some(order_owner),
+                ),
+                // Non-matching wallet -- should be filtered out
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "MSFT",
+                    20,
+                    Some(other_wallet),
+                ),
+                // No wallet -- should be included
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Redeem,
+                    "TSLA",
+                    5,
+                    None,
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .tokenizer(tokenizer)
+            .build();
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity {
+            mints, redemptions, ..
+        } = inflight_event
+        else {
+            panic!("Expected InflightEquity event");
+        };
+
+        // Only matching wallet (AAPL) should be in mints
+        assert_eq!(mints.len(), 1, "Only matching wallet should be included");
+        assert_eq!(mints.get(&test_symbol("AAPL")), Some(&test_shares(10)));
+
+        // No-wallet request (TSLA) should be included in redemptions
+        assert_eq!(
+            redemptions.len(),
+            1,
+            "No-wallet requests should be included"
+        );
+        assert_eq!(redemptions.get(&test_symbol("TSLA")), Some(&test_shares(5)));
+    }
+
+    #[test]
+    fn aggregate_pending_requests_skips_none_type_but_keeps_valid_rows() {
+        // A request with r#type: None should be skipped (with a warning),
+        // but valid mint/redemption rows in the same batch must still
+        // aggregate correctly.
+        let requests = vec![
+            mock_pending_request_no_type("AAPL", 5),
+            mock_pending_request(
+                crate::tokenization::TokenizationRequestType::Mint,
+                "AAPL",
+                10,
+            ),
+            mock_pending_request(
+                crate::tokenization::TokenizationRequestType::Redeem,
+                "TSLA",
+                20,
+            ),
+            mock_pending_request(
+                crate::tokenization::TokenizationRequestType::Mint,
+                "AAPL",
+                3,
+            ),
+        ];
+
+        let PendingRequests { mints, redemptions } = InventoryPollingService::<
+            ReadOnlyEvm<RootProvider>,
+            MockExecutor,
+        >::aggregate_pending_requests(
+            requests.into_iter()
+        )
+        .unwrap();
+
+        // AAPL mints: 10 + 3 = 13 (the None-type row was skipped)
+        assert_eq!(
+            mints.get(&test_symbol("AAPL")),
+            Some(&test_shares(13)),
+            "Valid mint rows should aggregate despite a None-type row"
+        );
+
+        // TSLA redemptions: 20
+        assert_eq!(
+            redemptions.get(&test_symbol("TSLA")),
+            Some(&test_shares(20)),
+            "Redemption row should be unaffected by the None-type row"
+        );
+
+        // No other symbols
+        assert_eq!(mints.len(), 1);
+        assert_eq!(redemptions.len(), 1);
     }
 
     #[tokio::test]
@@ -1653,19 +2128,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 unwrapped_equity_token_addresses: equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1702,15 +2177,15 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx::default(),
-        );
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx::default())
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1747,18 +2222,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1800,19 +2275,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 unwrapped_equity_token_addresses: equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(
@@ -1843,19 +2318,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 unwrapped_equity_token_addresses: equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(
@@ -1888,19 +2363,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -1955,19 +2430,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -2007,18 +2482,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -2055,18 +2530,18 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
 
@@ -2108,19 +2583,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         let error = service.poll_and_record().await.unwrap_err();
         assert!(
@@ -2154,19 +2629,19 @@ mod tests {
 
         let executor = MockExecutor::new();
 
-        let service = InventoryPollingService::new(
-            raindex_service,
-            executor,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            WalletPollingCtx {
+        let service = InventoryPollingService::builder()
+            .raindex_service(raindex_service)
+            .executor(executor)
+            .vault_registry(Arc::new(test_store::<VaultRegistry>(pool.clone(), ())))
+            .orderbook(orderbook)
+            .order_owner(order_owner)
+            .snapshot(Arc::new(test_store(pool.clone(), ())))
+            .wallet_polling(WalletPollingCtx {
                 base: Some(base_wallet),
                 wrapped_equity_token_addresses: wrapped_equity_tokens,
                 ..WalletPollingCtx::default()
-            },
-        );
+            })
+            .build();
 
         service.poll_and_record().await.unwrap();
         service.poll_and_record().await.unwrap();

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -83,6 +83,10 @@ pub(crate) struct InventorySnapshot {
     pub(crate) base_wallet_unwrapped_equity: BTreeMap<Symbol, FractionalShares>,
     /// Latest Base wallet wrapped equity token balances
     pub(crate) base_wallet_wrapped_equity: BTreeMap<Symbol, FractionalShares>,
+    /// Equity currently in-flight via mints (shares leaving Alpaca for issuer)
+    pub(crate) inflight_mints: BTreeMap<Symbol, FractionalShares>,
+    /// Equity currently in-flight via redemptions (tokens sent to Alpaca)
+    pub(crate) inflight_redemptions: BTreeMap<Symbol, FractionalShares>,
     /// When this snapshot was last updated
     pub(crate) last_updated: DateTime<Utc>,
 }
@@ -108,6 +112,8 @@ impl EventSourced for InventorySnapshot {
             offchain_cash_cents: None,
             ethereum_cash: None,
             base_wallet_usdc: None,
+            inflight_mints: BTreeMap::new(),
+            inflight_redemptions: BTreeMap::new(),
             alpaca_wallet_cash: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
             base_wallet_wrapped_equity: BTreeMap::new(),
@@ -152,6 +158,11 @@ impl EventSourced for InventorySnapshot {
             },
             BaseWalletCash { usdc_balance } => InventorySnapshotEvent::BaseWalletCash {
                 usdc_balance,
+                fetched_at: now,
+            },
+            InflightEquity { mints, redemptions } => InventorySnapshotEvent::InflightEquity {
+                mints,
+                redemptions,
                 fetched_at: now,
             },
             AlpacaWalletCash { usdc_balance } => InventorySnapshotEvent::AlpacaWalletCash {
@@ -216,6 +227,16 @@ impl EventSourced for InventorySnapshot {
                     fetched_at: now,
                 }])
             }
+            InflightEquity { mints, redemptions } => {
+                if self.inflight_mints == mints && self.inflight_redemptions == redemptions {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::InflightEquity {
+                    mints,
+                    redemptions,
+                    fetched_at: now,
+                }])
+            }
             AlpacaWalletCash { usdc_balance } => {
                 if self.alpaca_wallet_cash == Some(usdc_balance) {
                     return Ok(vec![]);
@@ -272,6 +293,12 @@ impl InventorySnapshot {
             InventorySnapshotEvent::BaseWalletCash { usdc_balance, .. } => {
                 self.base_wallet_usdc = Some(*usdc_balance);
             }
+            InventorySnapshotEvent::InflightEquity {
+                mints, redemptions, ..
+            } => {
+                self.inflight_mints = mints.clone();
+                self.inflight_redemptions = redemptions.clone();
+            }
             InventorySnapshotEvent::AlpacaWalletCash { usdc_balance, .. } => {
                 self.alpaca_wallet_cash = Some(*usdc_balance);
             }
@@ -314,6 +341,14 @@ pub(crate) enum InventorySnapshotCommand {
     BaseWalletWrappedEquity {
         balances: BTreeMap<Symbol, FractionalShares>,
     },
+    /// Equity currently in-flight through Alpaca's tokenization pipeline.
+    /// Fetched by polling Alpaca's `list_requests` endpoint for pending requests.
+    InflightEquity {
+        /// Pending mints by symbol (shares leaving Alpaca for issuer).
+        mints: BTreeMap<Symbol, FractionalShares>,
+        /// Pending redemptions by symbol (tokens sent to Alpaca).
+        redemptions: BTreeMap<Symbol, FractionalShares>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -342,6 +377,13 @@ pub(crate) enum InventorySnapshotEvent {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
     },
+    /// Equity currently in-flight through Alpaca's tokenization pipeline,
+    /// fetched by polling Alpaca's `list_requests` endpoint.
+    InflightEquity {
+        mints: BTreeMap<Symbol, FractionalShares>,
+        redemptions: BTreeMap<Symbol, FractionalShares>,
+        fetched_at: DateTime<Utc>,
+    },
     AlpacaWalletCash {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
@@ -367,7 +409,8 @@ impl InventorySnapshotEvent {
             | Self::BaseWalletCash { fetched_at, .. }
             | Self::AlpacaWalletCash { fetched_at, .. }
             | Self::BaseWalletUnwrappedEquity { fetched_at, .. }
-            | Self::BaseWalletWrappedEquity { fetched_at, .. } => *fetched_at,
+            | Self::BaseWalletWrappedEquity { fetched_at, .. }
+            | Self::InflightEquity { fetched_at, .. } => *fetched_at,
         }
     }
 }
@@ -388,6 +431,7 @@ impl DomainEvent for InventorySnapshotEvent {
             Self::BaseWalletWrappedEquity { .. } => {
                 "InventorySnapshotEvent::BaseWalletWrappedEquity".to_string()
             }
+            Self::InflightEquity { .. } => "InventorySnapshotEvent::InflightEquity".to_string(),
         }
     }
 
@@ -1081,5 +1125,241 @@ mod tests {
             .unwrap();
 
         assert_eq!(snapshot.base_wallet_wrapped_equity, balances);
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_initializes_aggregate() {
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let mut redemptions = BTreeMap::new();
+        redemptions.insert(test_symbol("TSLA"), test_shares(5));
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given_no_previous_events()
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: mints.clone(),
+                redemptions: redemptions.clone(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity {
+            mints: event_mints,
+            redemptions: event_redemptions,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+        assert_eq!(event_mints, &mints);
+        assert_eq!(event_redemptions, &redemptions);
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_emits_when_only_redemptions_change() {
+        let mut initial_redemptions = BTreeMap::new();
+        initial_redemptions.insert(test_symbol("TSLA"), test_shares(5));
+
+        let mut updated_redemptions = BTreeMap::new();
+        updated_redemptions.insert(test_symbol("TSLA"), test_shares(10));
+
+        let mints = BTreeMap::new();
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: mints.clone(),
+                redemptions: initial_redemptions,
+                fetched_at: Utc::now(),
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: mints.clone(),
+                redemptions: updated_redemptions.clone(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity {
+            redemptions: event_redemptions,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+        assert_eq!(event_redemptions, &updated_redemptions);
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_skips_when_unchanged() {
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: mints.clone(),
+                redemptions: BTreeMap::new(),
+                fetched_at: Utc::now(),
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints,
+                redemptions: BTreeMap::new(),
+            })
+            .await
+            .events();
+
+        assert!(
+            events.is_empty(),
+            "Should not emit event when inflight unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_emits_on_change() {
+        let mut initial_mints = BTreeMap::new();
+        initial_mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let mut updated_mints = BTreeMap::new();
+        updated_mints.insert(test_symbol("AAPL"), test_shares(5));
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: initial_mints,
+                redemptions: BTreeMap::new(),
+                fetched_at: Utc::now(),
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: updated_mints.clone(),
+                redemptions: BTreeMap::new(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity {
+            mints: event_mints, ..
+        } = &events[0]
+        else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+        assert_eq!(event_mints, &updated_mints);
+    }
+
+    #[test]
+    fn apply_event_updates_inflight_mints_and_redemptions() {
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let mut redemptions = BTreeMap::new();
+        redemptions.insert(test_symbol("TSLA"), test_shares(5));
+
+        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::InflightEquity {
+            mints: mints.clone(),
+            redemptions: redemptions.clone(),
+            fetched_at: Utc::now(),
+        }])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(snapshot.inflight_mints, mints);
+        assert_eq!(snapshot.inflight_redemptions, redemptions);
+    }
+
+    #[tokio::test]
+    async fn initialize_inflight_equity_preserves_fetched_at() {
+        // The aggregate's initialize() generates fetched_at from Utc::now().
+        // This test pins that the emitted event carries a fetched_at close to
+        // the wall-clock time at command submission -- proving the aggregate
+        // threads a real timestamp rather than e.g. a stale default.
+        let before = Utc::now();
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given_no_previous_events()
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: BTreeMap::new(),
+                redemptions: BTreeMap::new(),
+            })
+            .await
+            .events();
+
+        let after = Utc::now();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = &events[0] else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+
+        assert!(
+            *fetched_at >= before && *fetched_at <= after,
+            "fetched_at ({fetched_at:?}) should be between \
+             before ({before:?}) and after ({after:?})"
+        );
+    }
+
+    #[tokio::test]
+    async fn transition_inflight_equity_preserves_fetched_at() {
+        // Same as above but for the transition path (existing aggregate).
+        // The aggregate deduplicates unchanged inflight, so we must provide
+        // data different from the prior state to get an emitted event.
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let before = Utc::now();
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::OnchainCash {
+                usdc_balance: Usdc::from_str("1000").unwrap(),
+                fetched_at: Utc::now(),
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints,
+                redemptions: BTreeMap::new(),
+            })
+            .await
+            .events();
+
+        let after = Utc::now();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = &events[0] else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+
+        assert!(
+            *fetched_at >= before && *fetched_at <= after,
+            "transition fetched_at ({fetched_at:?}) should be between \
+             before ({before:?}) and after ({after:?})"
+        );
+    }
+
+    #[test]
+    fn apply_event_replaces_previous_inflight() {
+        let mut first_mints = BTreeMap::new();
+        first_mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let mut second_mints = BTreeMap::new();
+        second_mints.insert(test_symbol("TSLA"), test_shares(3));
+
+        let snapshot = replay::<InventorySnapshot>(vec![
+            InventorySnapshotEvent::InflightEquity {
+                mints: first_mints,
+                redemptions: BTreeMap::new(),
+                fetched_at: Utc::now(),
+            },
+            InventorySnapshotEvent::InflightEquity {
+                mints: second_mints.clone(),
+                redemptions: BTreeMap::new(),
+                fetched_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(snapshot.inflight_mints, second_mints);
+        assert!(
+            !snapshot.inflight_mints.contains_key(&test_symbol("AAPL")),
+            "Previous inflight mints should be fully replaced"
+        );
     }
 }

--- a/src/inventory/venue_balance.rs
+++ b/src/inventory/venue_balance.rs
@@ -27,6 +27,8 @@ pub(crate) enum InventoryError<T> {
         "insufficient inflight balance: requested {requested:?}, but only {inflight:?} inflight"
     )]
     InsufficientInflight { requested: T, inflight: T },
+    #[error("negative inflight value: {value:?}")]
+    NegativeInflight { value: T },
     #[error("arithmetic error: {0}")]
     Arithmetic(#[from] FloatError),
 }
@@ -157,6 +159,23 @@ where
         Ok(Self {
             available: new_available,
             inflight: self.inflight,
+        })
+    }
+
+    /// Replace the inflight balance with a polled value from an external system.
+    ///
+    /// Unlike `move_to_inflight` which transfers from available, this directly
+    /// sets the inflight amount -- used when the external system (Alpaca's
+    /// tokenization API) reports pending operations. The available balance is
+    /// unchanged because it was already set by a separate available snapshot.
+    pub(super) fn set_inflight(self, inflight: T) -> Result<Self, InventoryError<T>> {
+        if inflight.is_negative()? {
+            return Err(InventoryError::NegativeInflight { value: inflight });
+        }
+
+        Ok(Self {
+            available: self.available,
+            inflight,
         })
     }
 
@@ -406,6 +425,40 @@ mod tests {
     #[derive(Debug)]
     struct TestError {
         _reason: &'static str,
+    }
+
+    #[test]
+    fn set_inflight_replaces_inflight_without_changing_available() {
+        let balance = equity_balance(100, 10);
+
+        let result = balance
+            .set_inflight(FractionalShares::new(float!("25")))
+            .unwrap();
+
+        assert!(
+            result.available().inner().eq(float!("100")).unwrap(),
+            "set_inflight should not change available"
+        );
+        assert!(
+            result.inflight().inner().eq(float!("25")).unwrap(),
+            "set_inflight should replace inflight with the new value"
+        );
+    }
+
+    #[test]
+    fn set_inflight_to_zero_clears_inflight() {
+        let balance = equity_balance(100, 30);
+
+        let result = balance.set_inflight(FractionalShares::ZERO).unwrap();
+
+        assert!(
+            result.available().inner().eq(float!("100")).unwrap(),
+            "set_inflight(ZERO) should not change available"
+        );
+        assert!(
+            result.inflight().is_zero().unwrap(),
+            "set_inflight(ZERO) should zero out inflight"
+        );
     }
 
     #[test]

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -1,6 +1,6 @@
 //! Inventory view for tracking cross-venue asset positions.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::{Add, Sub};
 use std::sync::LazyLock;
 
@@ -137,7 +137,7 @@ impl TryFrom<RawImbalanceThreshold> for ImbalanceThreshold {
 }
 
 /// Discriminant for the two venues tracked by an [`Inventory`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) enum Venue {
     /// Onchain venue (Raindex) -- where market making happens.
     MarketMaking,
@@ -489,6 +489,10 @@ where
         })
     }
 
+    pub(crate) fn last_rebalancing(&self) -> Option<DateTime<Utc>> {
+        self.last_rebalancing
+    }
+
     pub(crate) fn with_last_rebalancing(
         timestamp: DateTime<Utc>,
     ) -> Box<dyn FnOnce(Self) -> Result<Self, InventoryError<T>> + Send> {
@@ -497,6 +501,32 @@ where
                 last_rebalancing: Some(timestamp),
                 ..inventory
             })
+        })
+    }
+
+    /// Replace the inflight balance at a venue with a polled value
+    /// from an external system (Alpaca's tokenization API).
+    ///
+    /// Unlike `transfer(TransferOp::Start)` which moves from available to
+    /// inflight, this directly sets inflight without touching available.
+    /// The available balance is already correct from a separate snapshot.
+    pub(crate) fn set_inflight(
+        venue: Venue,
+        amount: T,
+    ) -> Box<dyn FnOnce(Self) -> Result<Self, InventoryError<T>> + Send> {
+        Box::new(move |inventory| {
+            let existing = inventory.get_venue(venue);
+
+            // Don't initialize a venue that doesn't exist yet when the
+            // inflight amount is zero — that would create a spurious
+            // Some(0, 0) balance for an uninitialized venue.
+            if existing.is_none() && amount.is_zero()? {
+                return Ok(inventory);
+            }
+
+            let balance = existing.unwrap_or_default().set_inflight(amount)?;
+
+            Ok(inventory.set_venue(venue, Some(balance)))
         })
     }
 
@@ -690,6 +720,28 @@ impl InventoryView {
         self
     }
 
+    /// Returns the equity available balance at the given venue for a symbol.
+    #[cfg(test)]
+    pub(crate) fn equity_available(
+        &self,
+        symbol: &Symbol,
+        venue: Venue,
+    ) -> Option<FractionalShares> {
+        let inventory = self.equities.get(symbol)?;
+        inventory.get_venue(venue).map(VenueBalance::available)
+    }
+
+    /// Returns the equity inflight balance at the given venue for a symbol.
+    #[cfg(test)]
+    pub(crate) fn equity_inflight(
+        &self,
+        symbol: &Symbol,
+        venue: Venue,
+    ) -> Option<FractionalShares> {
+        let inventory = self.equities.get(symbol)?;
+        inventory.get_venue(venue).map(VenueBalance::inflight)
+    }
+
     /// Returns the USDC available balance at the given venue.
     #[cfg(test)]
     pub(crate) fn usdc_available(&self, venue: Venue) -> Option<Usdc> {
@@ -747,6 +799,92 @@ impl InventoryView {
             last_updated: now,
             equities: self.equities,
         })
+    }
+
+    /// Returns the set of symbols that currently have inflight balances
+    /// at any venue.
+    #[cfg(test)]
+    pub(crate) fn symbols_with_inflight(&self) -> std::collections::HashSet<Symbol> {
+        self.equities
+            .iter()
+            .filter(|(_, inventory)| {
+                inventory
+                    .has_inflight()
+                    .expect("has_inflight should not fail on valid inventory")
+            })
+            .map(|(symbol, _)| symbol.clone())
+            .collect()
+    }
+
+    /// Whether a symbol's inflight snapshot predates its last rebalancing.
+    fn is_stale_for_symbol(&self, symbol: &Symbol, fetched_at: DateTime<Utc>) -> bool {
+        self.equities
+            .get(symbol)
+            .and_then(Inventory::last_rebalancing)
+            .is_some_and(|last_rebalancing| fetched_at < last_rebalancing)
+    }
+
+    /// Apply an inflight equity snapshot from the tokenization provider poll.
+    ///
+    /// Only sets inflight for symbols **present** in the maps. Symbols absent
+    /// from the maps are left untouched — their inflight is managed exclusively
+    /// by CQRS terminal events (`TransferOp::Complete`, `TransferOp::Cancel`).
+    /// This prevents a race where the poll sees no pending request (e.g. after
+    /// a fast rejection) and zeros inflight before the CQRS event arrives.
+    ///
+    /// Skips symbols whose `last_rebalancing` is more recent than `fetched_at`,
+    /// because a stale poll could otherwise re-introduce inflight that was
+    /// already cleared by a completed transfer.
+    ///
+    /// Mints are inflight at Hedging (shares leaving offchain broker toward
+    /// onchain). Redemptions are inflight at MarketMaking (shares leaving
+    /// onchain toward offchain broker).
+    pub(crate) fn apply_inflight_snapshot(
+        self,
+        mints: &BTreeMap<Symbol, FractionalShares>,
+        redemptions: &BTreeMap<Symbol, FractionalShares>,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<Self, InventoryViewError> {
+        let mut view = self;
+
+        for (symbol, &quantity) in mints {
+            if view.is_stale_for_symbol(symbol, fetched_at) {
+                debug!(
+                    %symbol,
+                    ?fetched_at,
+                    "Skipping mint inflight snapshot: \
+                     fetched before last rebalancing"
+                );
+                continue;
+            }
+
+            view = view.update_equity(
+                symbol,
+                Inventory::set_inflight(Venue::Hedging, quantity),
+                now,
+            )?;
+        }
+
+        for (symbol, &quantity) in redemptions {
+            if view.is_stale_for_symbol(symbol, fetched_at) {
+                debug!(
+                    %symbol,
+                    ?fetched_at,
+                    "Skipping redemption inflight snapshot: \
+                     fetched before last rebalancing"
+                );
+                continue;
+            }
+
+            view = view.update_equity(
+                symbol,
+                Inventory::set_inflight(Venue::MarketMaking, quantity),
+                now,
+            )?;
+        }
+
+        Ok(view)
     }
 }
 
@@ -1333,6 +1471,222 @@ mod tests {
 
         let onchain = result.onchain.unwrap();
         assert_eq!(onchain.total().unwrap(), shares(999));
+    }
+
+    #[test]
+    fn inflight_snapshot_skipped_when_fetched_before_last_rebalancing() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let last_rebalancing = Utc::now();
+        let stale_fetched_at = last_rebalancing - Duration::seconds(5);
+
+        let view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::with_last_rebalancing(last_rebalancing),
+                Utc::now(),
+            )
+            .unwrap();
+
+        // Snapshot with the symbol present but stale fetched_at -- should NOT
+        // update inflight because the snapshot predates last_rebalancing.
+        let mut stale_redemptions = BTreeMap::new();
+        stale_redemptions.insert(symbol.clone(), shares(5));
+
+        let result = view
+            .apply_inflight_snapshot(
+                &BTreeMap::new(),
+                &stale_redemptions,
+                stale_fetched_at,
+                Utc::now(),
+            )
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+        assert_eq!(
+            inventory.onchain.unwrap().inflight(),
+            shares(10),
+            "Stale snapshot should preserve original inflight of 10, not update to 5"
+        );
+    }
+
+    #[test]
+    fn present_symbol_inflight_updated_when_fetched_after_last_rebalancing() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let last_rebalancing = Utc::now();
+        let fresh_fetched_at = last_rebalancing + Duration::seconds(5);
+
+        let view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::with_last_rebalancing(last_rebalancing),
+                Utc::now(),
+            )
+            .unwrap();
+
+        // Snapshot with symbol present and fresh fetched_at: should update inflight.
+        let mut redemptions = BTreeMap::new();
+        redemptions.insert(symbol.clone(), shares(5));
+
+        let result = view
+            .apply_inflight_snapshot(&BTreeMap::new(), &redemptions, fresh_fetched_at, Utc::now())
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+        assert_eq!(
+            inventory.onchain.unwrap().inflight(),
+            shares(5),
+            "Fresh snapshot should update MarketMaking inflight to the snapshot value"
+        );
+    }
+
+    #[test]
+    fn present_symbol_inflight_updated_when_no_last_rebalancing() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        // Snapshot with symbol present: should update inflight to the new value.
+        let mut redemptions = BTreeMap::new();
+        redemptions.insert(symbol.clone(), shares(5));
+
+        let result = view
+            .apply_inflight_snapshot(&BTreeMap::new(), &redemptions, Utc::now(), Utc::now())
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+        assert_eq!(
+            inventory.onchain.unwrap().inflight(),
+            shares(5),
+            "Should update MarketMaking inflight to the snapshot value"
+        );
+    }
+
+    #[test]
+    fn absent_symbol_inflight_preserved_by_snapshot() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        // Empty snapshot (symbol absent from both maps) should not zero inflight.
+        // Only CQRS terminal events (TransferOp::Complete/Cancel) zero inflight.
+        let result = view
+            .apply_inflight_snapshot(&BTreeMap::new(), &BTreeMap::new(), Utc::now(), Utc::now())
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+        assert_eq!(
+            inventory.onchain.unwrap().inflight(),
+            shares(10),
+            "Absent symbol should preserve original MarketMaking inflight of 10"
+        );
+    }
+
+    #[test]
+    fn apply_inflight_snapshot_does_not_initialize_missing_venue() {
+        // When a symbol has only one venue initialized (e.g. offchain only),
+        // applying an empty inflight snapshot should NOT conjure a
+        // Some(0, 0) VenueBalance for the missing venue.
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let view = InventoryView {
+            equities: std::iter::once((
+                symbol.clone(),
+                Inventory {
+                    onchain: None,
+                    offchain: Some(VenueBalance::new(shares(100), FractionalShares::ZERO)),
+                    last_rebalancing: None,
+                },
+            ))
+            .collect(),
+            ..InventoryView::default()
+        };
+
+        // Onchain (MarketMaking) is None before the snapshot
+        let pre = view.equities.get(&symbol).unwrap();
+        assert!(
+            pre.onchain.is_none(),
+            "Precondition: onchain should be None"
+        );
+
+        let result = view
+            .apply_inflight_snapshot(&BTreeMap::new(), &BTreeMap::new(), Utc::now(), Utc::now())
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+
+        // The bug: set_inflight calls unwrap_or_default() which creates
+        // Some(available=0, inflight=0) for the missing venue.
+        // After fix, the missing venue should remain None.
+        assert!(
+            inventory.onchain.is_none(),
+            "Empty inflight snapshot should not initialize a missing venue to Some(0, 0)"
+        );
+
+        // Imbalance detection should still return None since one venue is uninitialized
+        let thresh = threshold("0.5", "0.2");
+        assert_eq!(
+            inventory.detect_imbalance(&thresh).unwrap(),
+            None,
+            "Imbalance detection should return None when a venue is uninitialized"
+        );
+    }
+
+    #[test]
+    fn present_symbol_inflight_updated_by_snapshot() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let view = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        // When the symbol IS in the snapshot map, inflight is updated to
+        // the snapshot's value.
+        let mut redemptions = BTreeMap::new();
+        redemptions.insert(symbol.clone(), shares(5));
+
+        let result = view
+            .apply_inflight_snapshot(&BTreeMap::new(), &redemptions, Utc::now(), Utc::now())
+            .unwrap();
+
+        let inventory = result.equities.get(&symbol).unwrap();
+        assert_eq!(
+            inventory.onchain.unwrap().inflight(),
+            shares(5),
+            "Present symbol should have MarketMaking inflight updated from 10 to 5"
+        );
     }
 
     #[test]

--- a/src/offchain/order_poller.rs
+++ b/src/offchain/order_poller.rs
@@ -502,11 +502,11 @@ mod tests {
             .unwrap();
 
         let aggregate_id = offchain_order_id.to_string();
-        let offchain_order_events: Vec<String> = sqlx::query_scalar!(
+        let offchain_order_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
             WHERE aggregate_type = 'OffchainOrder' AND aggregate_id = ? ORDER BY sequence",
-            aggregate_id
         )
+        .bind(&aggregate_id)
         .fetch_all(&pool)
         .await
         .unwrap();
@@ -516,9 +516,9 @@ mod tests {
         assert_eq!(offchain_order_events[1], "OffchainOrderEvent::Submitted");
         assert_eq!(offchain_order_events[2], "OffchainOrderEvent::Filled");
 
-        let position_events: Vec<String> = sqlx::query_scalar!(
+        let position_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
-            WHERE aggregate_type = 'Position' AND aggregate_id = 'AAPL' ORDER BY sequence"
+            WHERE aggregate_type = 'Position' AND aggregate_id = 'AAPL' ORDER BY sequence",
         )
         .fetch_all(&pool)
         .await
@@ -582,11 +582,11 @@ mod tests {
             .unwrap();
 
         let aggregate_id = offchain_order_id.to_string();
-        let offchain_order_events: Vec<String> = sqlx::query_scalar!(
+        let offchain_order_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
             WHERE aggregate_type = 'OffchainOrder' AND aggregate_id = ? ORDER BY sequence",
-            aggregate_id
         )
+        .bind(&aggregate_id)
         .fetch_all(&pool)
         .await
         .unwrap();
@@ -596,9 +596,9 @@ mod tests {
         assert_eq!(offchain_order_events[1], "OffchainOrderEvent::Submitted");
         assert_eq!(offchain_order_events[2], "OffchainOrderEvent::Failed");
 
-        let position_events: Vec<String> = sqlx::query_scalar!(
+        let position_events: Vec<String> = sqlx::query_scalar(
             "SELECT event_type FROM events \
-            WHERE aggregate_type = 'Position' AND aggregate_id = 'TSLA' ORDER BY sequence"
+            WHERE aggregate_type = 'Position' AND aggregate_id = 'TSLA' ORDER BY sequence",
         )
         .fetch_all(&pool)
         .await

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -1548,11 +1548,9 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert a processed event at block 100
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1)",
         )
         .execute(&pool)
         .await
@@ -1604,11 +1602,9 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert processed event at block 150
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 150, '{}', 1)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 150, '{}', 1)",
         )
         .execute(&pool)
         .await
@@ -1635,15 +1631,13 @@ mod tests {
         let pool = setup_test_db().await;
 
         // Insert events with mixed processed states - only processed ones should affect resume point
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES 
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 50, '{}', 1),
-                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 75, '{}', 0),
-                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 100, '{}', 1),
-                ('0x4444444444444444444444444444444444444444444444444444444444444444', 0, 125, '{}', 0)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 50, '{}', 1), \
+                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 75, '{}', 0), \
+                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 100, '{}', 1), \
+                ('0x4444444444444444444444444444444444444444444444444444444444444444', 0, 125, '{}', 0)",
         )
         .execute(&pool)
         .await

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -507,13 +507,11 @@ mod tests {
     async fn test_get_max_processed_block_only_unprocessed() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 0),
-                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 0)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 0), \
+                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 0)",
         )
         .execute(&pool)
         .await
@@ -527,14 +525,12 @@ mod tests {
     async fn test_get_max_processed_block_only_processed() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1),
-                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 1),
-                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 75, '{}', 1)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1), \
+                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 1), \
+                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 75, '{}', 1)",
         )
         .execute(&pool)
         .await
@@ -548,15 +544,13 @@ mod tests {
     async fn test_get_max_processed_block_mixed_states() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1),
-                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 1),
-                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 200, '{}', 0),
-                ('0x4444444444444444444444444444444444444444444444444444444444444444', 0, 175, '{}', 0)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 100, '{}', 1), \
+                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 150, '{}', 1), \
+                ('0x3333333333333333333333333333333333333333333333333333333333333333', 0, 200, '{}', 0), \
+                ('0x4444444444444444444444444444444444444444444444444444444444444444', 0, 175, '{}', 0)",
         )
         .execute(&pool)
         .await
@@ -570,13 +564,11 @@ mod tests {
     async fn test_get_max_processed_block_zero_block() {
         let pool = setup_test_db().await;
 
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 0, '{}', 1),
-                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 50, '{}', 0)
-            "#
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, 0, '{}', 1), \
+                ('0x2222222222222222222222222222222222222222222222222222222222222222', 0, 50, '{}', 0)",
         )
         .execute(&pool)
         .await
@@ -592,14 +584,12 @@ mod tests {
 
         let large_block: i64 = 999_999_999;
 
-        sqlx::query!(
-            r#"
-            INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed)
-            VALUES
-                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, ?1, '{}', 1)
-            "#,
-            large_block
+        sqlx::query(
+            "INSERT INTO event_queue (tx_hash, log_index, block_number, event_data, processed) \
+            VALUES \
+                ('0x1111111111111111111111111111111111111111111111111111111111111111', 0, ?1, '{}', 1)",
         )
+        .bind(large_block)
         .execute(&pool)
         .await
         .unwrap();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -562,6 +562,12 @@ impl RebalancingTrigger {
                 | AlpacaWalletCash { .. }
                 | BaseWalletUnwrappedEquity { .. }
                 | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
+
+                InflightEquity {
+                    mints, redemptions, ..
+                } => inventory
+                    .clone()
+                    .apply_inflight_snapshot(mints, redemptions, fetched_at, now),
             }?;
 
         *inventory = updated;
@@ -601,11 +607,11 @@ impl RebalancingTrigger {
         *inventory = InventoryView::default();
 
         use InventorySnapshotEvent::*;
-        let updated =
-            match &event {
-                OnchainEquity { balances, .. } => balances.iter().try_fold(
-                    inventory.clone(),
-                    |view, (symbol, snapshot_balance)| {
+        let updated = match &event {
+            OnchainEquity { balances, .. } => {
+                balances
+                    .iter()
+                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
                         view.update_equity(
                             symbol,
                             Inventory::force_on_snapshot(
@@ -615,21 +621,22 @@ impl RebalancingTrigger {
                             ),
                             now,
                         )
-                    },
-                ),
+                    })
+            }
 
-                OnchainCash { usdc_balance, .. } => inventory.clone().update_usdc(
-                    Inventory::force_on_snapshot(
-                        Venue::MarketMaking,
-                        *usdc_balance,
-                        recovery_reason.clone(),
-                    ),
-                    now,
+            OnchainCash { usdc_balance, .. } => inventory.clone().update_usdc(
+                Inventory::force_on_snapshot(
+                    Venue::MarketMaking,
+                    *usdc_balance,
+                    recovery_reason.clone(),
                 ),
+                now,
+            ),
 
-                OffchainEquity { positions, .. } => positions.iter().try_fold(
-                    inventory.clone(),
-                    |view, (symbol, snapshot_balance)| {
+            OffchainEquity { positions, .. } => {
+                positions
+                    .iter()
+                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
                         view.update_equity(
                             symbol,
                             Inventory::force_on_snapshot(
@@ -639,27 +646,37 @@ impl RebalancingTrigger {
                             ),
                             now,
                         )
-                    },
-                ),
+                    })
+            }
 
-                OffchainCash {
-                    cash_balance_cents, ..
-                } => {
-                    let usdc = Usdc::from_cents(*cash_balance_cents).ok_or(
-                        InventoryViewError::CashBalanceConversion(*cash_balance_cents),
-                    )?;
-                    inventory.clone().update_usdc(
-                        Inventory::force_on_snapshot(Venue::Hedging, usdc, recovery_reason),
-                        now,
-                    )
-                }
+            OffchainCash {
+                cash_balance_cents, ..
+            } => {
+                let usdc = Usdc::from_cents(*cash_balance_cents).ok_or(
+                    InventoryViewError::CashBalanceConversion(*cash_balance_cents),
+                )?;
+                inventory.clone().update_usdc(
+                    Inventory::force_on_snapshot(Venue::Hedging, usdc, recovery_reason),
+                    now,
+                )
+            }
 
-                EthereumCash { .. }
-                | BaseWalletCash { .. }
-                | AlpacaWalletCash { .. }
-                | BaseWalletUnwrappedEquity { .. }
-                | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
-            }?;
+            EthereumCash { .. }
+            | BaseWalletCash { .. }
+            | AlpacaWalletCash { .. }
+            | BaseWalletUnwrappedEquity { .. }
+            | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
+
+            // Recovery for inflight snapshots: forward the original fetched_at
+            // so is_stale_for_symbol still rejects pre-rebalancing polls.
+            InflightEquity {
+                mints,
+                redemptions,
+                fetched_at,
+            } => inventory
+                .clone()
+                .apply_inflight_snapshot(mints, redemptions, *fetched_at, now),
+        }?;
 
         *inventory = updated;
         drop(inventory);
@@ -694,7 +711,10 @@ impl RebalancingTrigger {
             | BaseWalletCash { .. }
             | AlpacaWalletCash { .. }
             | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => {}
+            | BaseWalletWrappedEquity { .. }
+            // Inflight snapshots don't trigger rebalancing -- they indicate
+            // transfers already in progress, not new balances to rebalance.
+            | InflightEquity { .. } => {}
         }
 
         Ok(())
@@ -979,11 +999,22 @@ impl RebalancingTrigger {
                 TransferOp::Start,
                 quantity,
             )),
-            MintAcceptanceFailed { .. } => Some(Inventory::transfer(
-                Venue::Hedging,
-                TransferOp::Cancel,
-                quantity,
-            )),
+            MintAcceptanceFailed { .. } => {
+                let now = Utc::now();
+                let composed: Box<
+                    dyn FnOnce(
+                            Inventory<FractionalShares>,
+                        ) -> Result<Inventory<FractionalShares>, _>
+                        + Send,
+                > = Box::new(move |inventory| {
+                    let cancelled =
+                        Inventory::transfer(Venue::Hedging, TransferOp::Cancel, quantity)(
+                            inventory,
+                        )?;
+                    Inventory::with_last_rebalancing(now)(cancelled)
+                });
+                Some(composed)
+            }
             TokensReceived { .. } => {
                 // Compose TransferOp::Complete with with_last_rebalancing so that the
                 // staleness guard is active the instant inflight is cleared. Without this,
@@ -1079,8 +1110,28 @@ impl RebalancingTrigger {
                 Some(composed)
             }
 
+            // Tokens failed to reach Alpaca's wallet -- still in ours.
+            // Cancel the inflight started at WithdrawnFromRaindex.
+            // Compose with with_last_rebalancing so the staleness guard
+            // prevents a stale snapshot from overwriting the restored balance.
+            TransferFailed { .. } => {
+                let now = Utc::now();
+                let composed: Box<
+                    dyn FnOnce(
+                            Inventory<FractionalShares>,
+                        ) -> Result<Inventory<FractionalShares>, _>
+                        + Send,
+                > = Box::new(move |inventory| {
+                    let cancelled =
+                        Inventory::transfer(Venue::MarketMaking, TransferOp::Cancel, quantity)(
+                            inventory,
+                        )?;
+                    Inventory::with_last_rebalancing(now)(cancelled)
+                });
+                Some(composed)
+            }
+
             TokensUnwrapped { .. }
-            | TransferFailed { .. }
             | TokensSent { .. }
             | DetectionFailed { .. }
             | Detected { .. }
@@ -4466,6 +4517,756 @@ mod tests {
             wallet.address(),
             Address::ZERO,
             "wallet address should be derived from key, not zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn transfer_failed_cancels_redemption_inflight_and_restores_imbalance() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = 80% ratio -> TooMuchOnchain triggers Redemption
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = RedemptionAggregateId::new("redemption-transfer-cancel");
+
+        // Verify initial imbalance
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(
+                receiver.try_recv(),
+                Ok(TriggeredOperation::Redemption { .. })
+            ),
+            "80% ratio should trigger Redemption"
+        );
+        trigger.clear_equity_in_progress(&symbol);
+
+        // WithdrawnFromRaindex: 30 tokens move to inflight
+        harness
+            .receive::<EquityRedemption>(
+                id.clone(),
+                make_withdrawn_from_raindex(&symbol, float!("30")),
+            )
+            .await
+            .unwrap();
+
+        // Inflight blocks imbalance detection
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Inflight should block imbalance detection"
+        );
+
+        // TransferFailed: inflight cancelled, tokens return to available
+        harness
+            .receive::<EquityRedemption>(id.clone(), make_transfer_failed())
+            .await
+            .unwrap();
+
+        // After cancel: back to 80 onchain, 20 offchain -> imbalance should re-trigger
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(
+                receiver.try_recv(),
+                Ok(TriggeredOperation::Redemption { .. })
+            ),
+            "Imbalance should re-trigger after TransferFailed cancels inflight"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_snapshot_sets_inflight_balances() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 50 onchain, 50 offchain = balanced (50% ratio, within 30%-70%)
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(50)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(50)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Verify initially balanced
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "50/50 should be balanced"
+        );
+
+        // Emit InflightEquity with pending mints for AAPL
+        // This sets inflight at Hedging venue, which blocks rebalancing
+        let mut mints = BTreeMap::new();
+        mints.insert(symbol.clone(), shares(10));
+
+        harness
+            .receive::<InventorySnapshot>(
+                id.clone(),
+                InventorySnapshotEvent::InflightEquity {
+                    mints,
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Inflight should block rebalancing even though ratios are balanced
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Inflight from InflightEquity snapshot should block rebalancing"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_blocks_then_cqrs_clear_restores_triggerability() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = imbalanced (would trigger Redemption
+        // when not blocked by inflight)
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Set inflight directly (simulating a CQRS TransferOp::Start)
+        {
+            let mut inv = trigger.inventory.write().await;
+            *inv = inv
+                .clone()
+                .update_equity(
+                    &symbol,
+                    Inventory::set_inflight(Venue::Hedging, shares(10)),
+                    Utc::now(),
+                )
+                .unwrap();
+        }
+
+        // Verify inflight blocks rebalancing despite imbalance
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Inflight should block rebalancing"
+        );
+
+        // Empty InflightEquity snapshot: symbol absent, so inflight preserved
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        harness
+            .receive::<InventorySnapshot>(
+                id.clone(),
+                InventorySnapshotEvent::InflightEquity {
+                    mints: BTreeMap::new(),
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Empty snapshot should not clear inflight (symbol absent from maps)"
+        );
+
+        // CQRS terminal event clears inflight (simulating TransferOp::Complete)
+        {
+            let mut inv = trigger.inventory.write().await;
+            *inv = inv
+                .clone()
+                .update_equity(
+                    &symbol,
+                    Inventory::set_inflight(Venue::Hedging, FractionalShares::ZERO),
+                    Utc::now(),
+                )
+                .unwrap();
+        }
+
+        // After CQRS clears inflight, the imbalance should trigger
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+        assert!(
+            matches!(
+                receiver.try_recv(),
+                Ok(TriggeredOperation::Redemption { .. })
+            ),
+            "CQRS-cleared inflight should restore triggerability"
+        );
+    }
+
+    #[tokio::test]
+    async fn redemption_rejected_preserves_inflight_via_absent_skip() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = imbalanced
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = RedemptionAggregateId::new("redemption-rejected-absent-skip");
+
+        // WithdrawnFromRaindex: start inflight
+        harness
+            .receive::<EquityRedemption>(
+                id.clone(),
+                make_withdrawn_from_raindex(&symbol, float!("10")),
+            )
+            .await
+            .unwrap();
+
+        // RedemptionRejected: terminal failure, no inventory update
+        harness
+            .receive::<EquityRedemption>(id.clone(), make_redemption_rejected())
+            .await
+            .unwrap();
+
+        // Empty InflightEquity snapshot: symbol absent from maps, so inflight
+        // is preserved (poll never zeros absent symbols).
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::InflightEquity {
+                    mints: BTreeMap::new(),
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .symbols_with_inflight()
+                .contains(&symbol),
+            "Inflight should be preserved after RedemptionRejected \
+             (symbol absent from poll maps)"
+        );
+    }
+
+    #[tokio::test]
+    async fn detection_failed_preserves_inflight_via_absent_skip() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = RedemptionAggregateId::new("redemption-detection-absent-skip");
+
+        harness
+            .receive::<EquityRedemption>(
+                id.clone(),
+                make_withdrawn_from_raindex(&symbol, float!("10")),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<EquityRedemption>(id.clone(), make_detection_failed())
+            .await
+            .unwrap();
+
+        // Empty InflightEquity snapshot: symbol absent, so inflight preserved
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::InflightEquity {
+                    mints: BTreeMap::new(),
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .symbols_with_inflight()
+                .contains(&symbol),
+            "Inflight should be preserved after DetectionFailed \
+             (symbol absent from poll maps)"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_redemption_inflight_cleared_by_cqrs() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = RedemptionAggregateId::new("redemption-completed-zeroed");
+
+        // WithdrawnFromRaindex -> Completed: TransferOp::Complete zeros inflight
+        harness
+            .receive::<EquityRedemption>(
+                id.clone(),
+                make_withdrawn_from_raindex(&symbol, float!("30")),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<EquityRedemption>(id.clone(), make_redemption_completed())
+            .await
+            .unwrap();
+
+        // Empty InflightEquity skips absent symbol; inflight already 0 from Completed
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::InflightEquity {
+                    mints: BTreeMap::new(),
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger
+                .inventory
+                .read()
+                .await
+                .symbols_with_inflight()
+                .contains(&symbol),
+            "TransferOp::Complete should have zeroed inflight"
+        );
+    }
+
+    #[tokio::test]
+    async fn cqrs_inflight_clear_defers_trigger_to_next_snapshot() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = imbalanced (triggers Redemption)
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Set inflight directly (simulating CQRS TransferOp::Start)
+        {
+            let mut inv = trigger.inventory.write().await;
+            *inv = inv
+                .clone()
+                .update_equity(
+                    &symbol,
+                    Inventory::set_inflight(Venue::Hedging, shares(10)),
+                    Utc::now(),
+                )
+                .unwrap();
+        }
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Inflight should block rebalancing"
+        );
+
+        // CQRS terminal event clears inflight -- should NOT immediately
+        // trigger. The terminal event handler doesn't call
+        // check_and_trigger_equity, so the trigger is deferred.
+        {
+            let mut inv = trigger.inventory.write().await;
+            *inv = inv
+                .clone()
+                .update_equity(
+                    &symbol,
+                    Inventory::set_inflight(Venue::Hedging, FractionalShares::ZERO),
+                    Utc::now(),
+                )
+                .unwrap();
+        }
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Clearing inflight should not immediately trigger -- \
+             no equity recheck from terminal events"
+        );
+
+        // Next poll cycle: an available snapshot arrives. Inflight is cleared,
+        // check_and_trigger_after_snapshot fires with fresh balances.
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol.clone(), shares(80));
+
+        harness
+            .receive::<InventorySnapshot>(
+                id,
+                InventorySnapshotEvent::OnchainEquity {
+                    balances,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(
+                receiver.try_recv(),
+                Ok(TriggeredOperation::Redemption { .. })
+            ),
+            "Available snapshot after inflight cleared should trigger rebalancing"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_still_present_does_not_recheck() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = imbalanced
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Set inflight
+        let mut mints = BTreeMap::new();
+        mints.insert(symbol.clone(), shares(10));
+
+        harness
+            .receive::<InventorySnapshot>(
+                id.clone(),
+                InventorySnapshotEvent::InflightEquity {
+                    mints: mints.clone(),
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Apply same inflight again -- still present, no recheck
+        harness
+            .receive::<InventorySnapshot>(
+                id.clone(),
+                InventorySnapshotEvent::InflightEquity {
+                    mints,
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Inflight still present should not trigger recheck"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_inflight_after_terminal_failure_does_not_reintroduce_inflight() {
+        // Regression test: when a rebalancing operation reaches a terminal
+        // failure (WithdrawnFromRaindex -> TransferFailed), the failure handler
+        // cancels inflight. If an InflightEquity poll arrives with the symbol
+        // present (e.g. a concurrent operation), it must NOT trigger an extra
+        // rebalance.
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 80 onchain, 20 offchain = imbalanced (triggers Redemption)
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        // Simulate: WithdrawnFromRaindex starts inflight for the symbol
+        let redemption_id = RedemptionAggregateId::new("redemption-stale-regression");
+        harness
+            .receive::<EquityRedemption>(
+                redemption_id.clone(),
+                make_withdrawn_from_raindex(&symbol, float!("10")),
+            )
+            .await
+            .unwrap();
+
+        // Verify inflight is present
+        assert!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .symbols_with_inflight()
+                .contains(&symbol),
+            "Inflight should be present after WithdrawnFromRaindex"
+        );
+
+        // TransferFailed: terminal failure, cancels inflight
+        harness
+            .receive::<EquityRedemption>(redemption_id, make_transfer_failed())
+            .await
+            .unwrap();
+
+        // Drain any operations triggered so far
+        while receiver.try_recv().is_ok() {}
+        trigger.clear_equity_in_progress(&symbol);
+
+        // Deliver an InflightEquity snapshot with mints for the symbol.
+        // The snapshot has the symbol present, so inflight is set at Hedging.
+        let mut stale_mints = BTreeMap::new();
+        stale_mints.insert(symbol.clone(), shares(10));
+
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::InflightEquity {
+                    mints: stale_mints,
+                    redemptions: BTreeMap::new(),
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Inflight is present from the mint snapshot (Hedging venue).
+        // No extra rebalance should be triggered by InflightEquity events.
+        assert!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .symbols_with_inflight()
+                .contains(&symbol),
+            "Inflight from snapshot should be present"
+        );
+
+        // No spurious rebalancing operation should have been triggered
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "InflightEquity after terminal failure should not trigger extra rebalancing"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_inflight_after_mint_acceptance_failure_does_not_reintroduce_inflight() {
+        // Same regression but for the MintAccepted -> MintAcceptanceFailed path.
+        let symbol = Symbol::new("AAPL").unwrap();
+        // 20 onchain, 80 offchain = imbalanced (triggers Mint)
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (trigger, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+
+        let mint_id = IssuerRequestId::new("mint-stale-regression");
+
+        // MintRequested starts inflight at Hedging venue
+        harness
+            .receive::<TokenizedEquityMint>(
+                mint_id.clone(),
+                make_mint_requested(&symbol, float!("30")),
+            )
+            .await
+            .unwrap();
+
+        // MintAccepted transitions the mint
+        harness
+            .receive::<TokenizedEquityMint>(mint_id.clone(), make_mint_accepted())
+            .await
+            .unwrap();
+
+        // MintAcceptanceFailed: terminal failure
+        harness
+            .receive::<TokenizedEquityMint>(mint_id, make_mint_acceptance_failed())
+            .await
+            .unwrap();
+
+        // Drain and clear
+        while receiver.try_recv().is_ok() {}
+        trigger.clear_equity_in_progress(&symbol);
+
+        // Deliver stale InflightEquity with redemptions for the symbol
+        let mut stale_redemptions = BTreeMap::new();
+        stale_redemptions.insert(symbol.clone(), shares(5));
+
+        harness
+            .receive::<InventorySnapshot>(
+                snapshot_id,
+                InventorySnapshotEvent::InflightEquity {
+                    mints: BTreeMap::new(),
+                    redemptions: stale_redemptions,
+                    fetched_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // No spurious rebalancing from the snapshot
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "InflightEquity after MintAcceptanceFailed should not \
+             trigger extra rebalancing"
         );
     }
 

--- a/src/tokenization.rs
+++ b/src/tokenization.rs
@@ -16,7 +16,7 @@ use st0x_execution::{FractionalShares, Symbol};
 
 pub(crate) use alpaca::{
     AlpacaTokenizationError, AlpacaTokenizationService, TokenizationRequest,
-    TokenizationRequestStatus,
+    TokenizationRequestStatus, TokenizationRequestType,
 };
 
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
@@ -117,4 +117,10 @@ pub(crate) trait Tokenizer: Send + Sync {
         wallet: Address,
         expected_amount: U256,
     ) -> Result<(), MintVerificationError>;
+
+    /// List all pending tokenization requests from the external provider.
+    ///
+    /// Returns requests that are currently in-flight (status = pending),
+    /// used by inventory polling to reconcile in-flight balances.
+    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError>;
 }

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -878,6 +878,20 @@ impl<W: Wallet> Tokenizer for AlpacaTokenizationService<W> {
     ) -> Result<(), MintVerificationError> {
         Self::verify_mint_tx(self, tx_hash, token_address, wallet, expected_amount).await
     }
+
+    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        let params = ListRequestsParams {
+            status: Some(TokenizationRequestStatus::Pending),
+            ..Default::default()
+        };
+
+        let requests = self.client.list_requests(params).await?;
+
+        Ok(requests
+            .into_iter()
+            .filter(|request| request.status == TokenizationRequestStatus::Pending)
+            .collect())
+    }
 }
 
 #[cfg(test)]
@@ -2346,5 +2360,61 @@ pub(crate) mod tests {
             request.token_symbol, None,
             "Empty token_symbol string should deserialize as None"
         );
+    }
+
+    #[tokio::test]
+    async fn list_pending_requests_sends_status_pending_query_param() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, key) = setup_anvil();
+        let service =
+            create_test_service_from_mock(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
+
+        let list_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(tokenization_requests_path())
+                .query_param("status", "pending");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([sample_tokenization_request_json(
+                    "req_1", "mint", "AAPL"
+                )]));
+        });
+
+        let result = service.list_pending_requests().await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, TokenizationRequestId("req_1".to_string()));
+        list_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn list_pending_requests_filters_non_pending_from_response() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, key) = setup_anvil();
+        let service =
+            create_test_service_from_mock(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
+
+        // Simulate an API response that includes a non-pending request
+        // despite the status=pending query param (defensive against API drift).
+        let mut pending_req = sample_tokenization_request_json("req_1", "mint", "AAPL");
+        pending_req["status"] = json!("pending");
+
+        let mut completed_req = sample_tokenization_request_json("req_2", "redeem", "TSLA");
+        completed_req["status"] = json!("completed");
+
+        let list_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(tokenization_requests_path())
+                .query_param("status", "pending");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([pending_req, completed_req]));
+        });
+
+        let result = service.list_pending_requests().await.unwrap();
+
+        assert_eq!(result.len(), 1, "Should filter out non-pending requests");
+        assert_eq!(result[0].id, TokenizationRequestId("req_1".to_string()));
+        list_mock.assert();
     }
 }

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -77,6 +77,8 @@ pub(crate) struct MockTokenizer {
     verification_outcome: MockVerificationOutcome,
     should_fail_send: bool,
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
+    pending_requests: Vec<TokenizationRequest>,
+    /// Override the token_symbol in completed mint responses.
     token_symbol_behavior: MockTokenSymbolBehavior,
     /// Override fees in completed mint responses.
     fees_override: Option<Float>,
@@ -96,6 +98,7 @@ impl MockTokenizer {
             last_issuer_request_id: Mutex::new(None),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
+            pending_requests: Vec::new(),
         }
     }
 
@@ -126,6 +129,11 @@ impl MockTokenizer {
 
     pub(crate) fn with_send_failure(mut self) -> Self {
         self.should_fail_send = true;
+        self
+    }
+
+    pub(crate) fn with_pending_requests(mut self, requests: Vec<TokenizationRequest>) -> Self {
+        self.pending_requests = requests;
         self
     }
 
@@ -301,5 +309,14 @@ impl Tokenizer for MockTokenizer {
                 })
             }
         }
+    }
+
+    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        Ok(self
+            .pending_requests
+            .iter()
+            .filter(|request| request.status == TokenizationRequestStatus::Pending)
+            .cloned()
+            .collect())
     }
 }

--- a/src/tokenization/mock_api.rs
+++ b/src/tokenization/mock_api.rs
@@ -44,6 +44,9 @@ pub enum TokenizationStatus {
     Pending,
     Completed,
     Failed,
+    /// Maps to `"rejected"` in the Alpaca API, which the bot deserializes
+    /// as `TokenizationRequestStatus::Rejected`.
+    Rejected,
 }
 
 impl std::fmt::Display for TokenizationStatus {
@@ -52,6 +55,7 @@ impl std::fmt::Display for TokenizationStatus {
             Self::Pending => write!(formatter, "pending"),
             Self::Completed => write!(formatter, "completed"),
             Self::Failed => write!(formatter, "failed"),
+            Self::Rejected => write!(formatter, "rejected"),
         }
     }
 }
@@ -93,10 +97,21 @@ struct MockTokenizationRequest {
     needs_mint_execution: bool,
 }
 
+/// Controls what happens when a redemption request reaches its poll threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedemptionOutcome {
+    /// Auto-complete after `polls_until_complete` polls (default behavior).
+    Complete,
+    /// Transition to `Rejected` after `polls_until_complete` polls.
+    Reject,
+}
+
 struct TokenizationState {
     requests: Vec<MockTokenizationRequest>,
     /// Number of polls before mint requests transition to "completed".
     polls_until_complete: usize,
+    /// What happens when a redemption request reaches its poll threshold.
+    redemption_outcome: RedemptionOutcome,
 }
 
 /// Snapshot of a tokenization request, returned by
@@ -137,6 +152,7 @@ impl AlpacaTokenizationMock {
         let state = Arc::new(Mutex::new(TokenizationState {
             requests: Vec::new(),
             polls_until_complete: 2,
+            redemption_outcome: RedemptionOutcome::Complete,
         }));
 
         register_mint_endpoint(server, &state);
@@ -154,6 +170,11 @@ impl AlpacaTokenizationMock {
     /// adds a redemption tokenization request to the mock state so the
     /// bot's `poll_for_redemption` call finds a matching entry.
     ///
+    /// `order_owner` is the bot's wallet address, used as the
+    /// `wallet_address` on created requests (matching real Alpaca API
+    /// behavior where the field identifies the account holder, not the
+    /// transfer destination).
+    ///
     /// `token_symbols` maps token contract address -> underlying symbol
     /// (e.g. vault_addr -> "AAPL"). The Transfer event's `value` field
     /// (U256 with 18 decimals) is decoded to determine the quantity.
@@ -161,6 +182,7 @@ impl AlpacaTokenizationMock {
         &mut self,
         provider: P,
         redemption_wallet: Address,
+        order_owner: Address,
         token_symbols: HashMap<Address, String>,
     ) -> anyhow::Result<()> {
         let state = self.state.clone();
@@ -186,6 +208,7 @@ impl AlpacaTokenizationMock {
                     last_block + 1,
                     current,
                     redemption_wallet,
+                    order_owner,
                     &token_symbols,
                 )
                 .await;
@@ -213,6 +236,44 @@ impl AlpacaTokenizationMock {
                 status: request.status,
             })
             .collect()
+    }
+
+    /// Configures what happens when redemption requests reach their poll
+    /// threshold. Defaults to [`RedemptionOutcome::Complete`].
+    pub fn set_redemption_outcome(&self, outcome: RedemptionOutcome) {
+        lock(&self.state).redemption_outcome = outcome;
+    }
+
+    /// Injects a pending tokenization request with an arbitrary wallet
+    /// address. Used to simulate requests from other conductors sharing
+    /// the same Alpaca account.
+    ///
+    /// Injected requests stay pending indefinitely (`polls_until_complete =
+    /// usize::MAX`): they model external requests that the test harness
+    /// should observe but never fulfill. This avoids nonce collisions when
+    /// the injected wallet matches the bot's signing key.
+    pub fn inject_pending_request(
+        &self,
+        symbol: &str,
+        quantity: Float,
+        wallet: Address,
+        request_type: TokenizationRequestType,
+    ) {
+        let mut state = lock(&self.state);
+
+        state.requests.push(MockTokenizationRequest {
+            tokenization_request_id: Uuid::new_v4().to_string(),
+            issuer_request_id: String::new(),
+            underlying_symbol: symbol.to_string(),
+            quantity,
+            wallet_address: wallet,
+            status: TokenizationStatus::Pending,
+            poll_count: 0,
+            polls_until_complete: usize::MAX,
+            request_type,
+            tx_hash: String::new(),
+            needs_mint_execution: false,
+        });
     }
 
     /// Starts a background task that executes real ERC-20 transfers on the
@@ -321,6 +382,7 @@ async fn scan_block_for_redemptions<P: Provider>(
     state: &Mutex<TokenizationState>,
     block_num: u64,
     redemption_wallet: Address,
+    order_owner: Address,
     token_symbols: &HashMap<Address, String>,
 ) -> bool {
     let Ok(Some(block)) = provider.get_block_by_number(block_num.into()).full().await else {
@@ -383,7 +445,10 @@ async fn scan_block_for_redemptions<P: Provider>(
                 issuer_request_id: String::new(),
                 underlying_symbol: symbol.clone(),
                 quantity,
-                wallet_address: redemption_wallet,
+                // Use the bot's wallet (order_owner), matching real Alpaca
+                // API behavior where wallet_address identifies the account
+                // holder, not the transfer destination.
+                wallet_address: order_owner,
                 status: TokenizationStatus::Pending,
                 poll_count: 0,
                 polls_until_complete,
@@ -405,11 +470,19 @@ async fn scan_redemption_range<P: Provider>(
     from: u64,
     to: u64,
     redemption_wallet: Address,
+    order_owner: Address,
     token_symbols: &HashMap<Address, String>,
 ) -> bool {
     for block_num in from..=to {
-        if !scan_block_for_redemptions(provider, state, block_num, redemption_wallet, token_symbols)
-            .await
+        if !scan_block_for_redemptions(
+            provider,
+            state,
+            block_num,
+            redemption_wallet,
+            order_owner,
+            token_symbols,
+        )
+        .await
         {
             return false;
         }
@@ -535,21 +608,39 @@ fn register_tokenization_requests_with_filter_endpoint(
                 .split('&')
                 .find_map(|param| param.strip_prefix("type="))
                 .unwrap_or("");
+            let status_filter = query
+                .split('&')
+                .find_map(|param| param.strip_prefix("status="))
+                .unwrap_or("");
 
             let requests: Vec<Value> = {
                 let mut state = lock(&state);
 
-                for req in &mut state.requests {
-                    if req.status == TokenizationStatus::Pending && !req.needs_mint_execution {
-                        req.poll_count += 1;
-                        if req.poll_count >= req.polls_until_complete {
-                            if req.request_type == TokenizationRequestType::Mint {
-                                // Mint requests need a real onchain transfer
-                                // before they can report as "completed".
-                                // The background mint executor will handle it.
-                                req.needs_mint_execution = true;
-                            } else {
-                                req.status = TokenizationStatus::Completed;
+                // Only mutate state (poll_count, status transitions) when no
+                // status filter is present. Calls with status= are read-only
+                // observers (e.g. list_pending_requests for inflight polling).
+                if status_filter.is_empty() {
+                    let redemption_outcome = state.redemption_outcome;
+
+                    for req in &mut state.requests {
+                        if req.status == TokenizationStatus::Pending && !req.needs_mint_execution {
+                            req.poll_count += 1;
+                            if req.poll_count >= req.polls_until_complete {
+                                if req.request_type == TokenizationRequestType::Mint {
+                                    // Mint requests need a real onchain transfer
+                                    // before they can report as "completed".
+                                    // The background mint executor will handle it.
+                                    req.needs_mint_execution = true;
+                                } else {
+                                    // Redeem requests transition based on the
+                                    // configured outcome.
+                                    req.status = match redemption_outcome {
+                                        RedemptionOutcome::Complete => {
+                                            TokenizationStatus::Completed
+                                        }
+                                        RedemptionOutcome::Reject => TokenizationStatus::Rejected,
+                                    };
+                                }
                             }
                         }
                     }
@@ -559,7 +650,8 @@ fn register_tokenization_requests_with_filter_endpoint(
                     .requests
                     .iter()
                     .filter(|req| {
-                        type_filter.is_empty() || req.request_type.to_string() == type_filter
+                        (type_filter.is_empty() || req.request_type.to_string() == type_filter)
+                            && (status_filter.is_empty() || req.status.to_string() == status_filter)
                     })
                     .map(tokenization_request_to_json)
                     .collect()

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -37,21 +37,22 @@ pub(crate) use st0x_hedge::UsdcRebalancing;
 use st0x_hedge::bindings::IOrderBookV6;
 use st0x_hedge::config::{BrokerCtx, Ctx};
 pub(crate) use st0x_hedge::mock_api::REDEMPTION_WALLET;
-use st0x_hedge::mock_api::{AlpacaTokenizationMock, TokenizationRequestType, TokenizationStatus};
+use st0x_hedge::mock_api::{AlpacaTokenizationMock, TokenizationStatus};
+pub(crate) use st0x_hedge::mock_api::{RedemptionOutcome, TokenizationRequestType};
 use st0x_hedge::{
     AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, ImbalanceThreshold,
     OperationMode, TradingMode,
 };
 
-pub(crate) use crate::assert::ExpectedPosition;
-use crate::assert::{
-    assert_broker_state, assert_cqrs_state, assert_event_subsequence, assert_single_clean_aggregate,
-};
+pub(crate) use crate::assert::{ExpectedPosition, assert_event_subsequence};
+use crate::assert::{assert_broker_state, assert_cqrs_state, assert_single_clean_aggregate};
 pub(crate) use crate::base_chain::TakeDirection;
 use crate::base_chain::{self, TakeOrderResult};
 pub(crate) use crate::cctp::{CctpInfra, CctpOverrides, USDC_ETHEREUM};
-use crate::poll::{DEFAULT_POLL_TIMEOUT_SECS, connect_db, fetch_events_by_type, sleep_or_crash};
-pub(crate) use crate::poll::{poll_for_events_with_timeout, spawn_bot};
+pub(crate) use crate::poll::{
+    DEFAULT_POLL_TIMEOUT_SECS, connect_db, fetch_events_by_type, poll_for_events_with_timeout,
+    sleep_or_crash, spawn_bot,
+};
 pub(crate) use crate::test_infra::TestInfra;
 use st0x_float_macro::float;
 

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -955,3 +955,558 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
     bot.abort();
     Ok(())
 }
+
+/// Redemption rejected by Alpaca preserves inflight via sticky marker.
+///
+/// When a redemption request is rejected by Alpaca, the bot marks the
+/// `(symbol, MarketMaking)` pair as sticky inflight. Subsequent
+/// `InflightEquity` polls that find no pending requests for that symbol
+/// must NOT zero the inflight -- the tokens are physically in Alpaca's
+/// redemption wallet with no snapshot source tracking them.
+///
+/// Without sticky inflight, the system would lose track of those assets
+/// entirely and make incorrect rebalancing decisions.
+#[test_log::test(tokio::test)]
+async fn redemption_rejected_preserves_inflight_via_sticky() -> anyhow::Result<()> {
+    let onchain_price = float!("112.50");
+    let broker_fill_price = float!("113.60");
+    let trade_amount = float!("12.5");
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!("20"))],
+    )
+    .await?;
+
+    // Configure the mock to reject redemption requests instead of completing.
+    infra
+        .tokenization_service
+        .set_redemption_outcome(RedemptionOutcome::Reject);
+
+    // Set up a BuyEquity order that will create TooMuchOnchain imbalance.
+    let prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(trade_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::BuyEquity)
+        .call()
+        .await?;
+
+    // Deposit extra equity to keep the ratio balanced before the take.
+    // After BuyEquity fill adds 12.5 onchain and hedge sell removes 12.5
+    // offchain, the ratio exceeds threshold -> triggers redemption.
+    let vault_addr = infra.equity_addresses[0].1;
+    let equity_vault_id = prepared.input_vault_id;
+    let extra_equity: U256 = parse_units("20", 18)?.into();
+    infra
+        .base_chain
+        .deposit_into_raindex_vault(vault_addr, equity_vault_id, extra_equity, 18)
+        .await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared.output_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared.input_vault_id)]);
+    let ctx = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    // Take from taker account to create the imbalance.
+    let _take_result = infra.base_chain.take_prepared_order(&prepared).await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Wait for the redemption to reach RedemptionRejected terminal state.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "EquityRedemptionEvent::RedemptionRejected",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // Wait for additional poll cycles after rejection to verify no second
+    // redemption is triggered. The bot polls inventory every ~15s; two
+    // full cycles ensures the InflightEquity snapshot has run post-rejection
+    // and the sticky mechanism has been exercised.
+    tokio::time::sleep(Duration::from_secs(35)).await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // Verify the redemption event sequence includes RedemptionRejected.
+    let redeem_events = fetch_events_by_type(&pool, "EquityRedemption").await?;
+    assert_event_subsequence(
+        &redeem_events,
+        &[
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            "EquityRedemptionEvent::TokensUnwrapped",
+            "EquityRedemptionEvent::TokensSent",
+            "EquityRedemptionEvent::Detected",
+            "EquityRedemptionEvent::RedemptionRejected",
+        ],
+    );
+
+    // Verify that InflightEquity snapshot events were emitted, proving the
+    // poll cycle ran and the bot processed the pending redemption request.
+    // After rejection, the request disappears from pending -- the sticky
+    // marker must prevent the InflightEquity snapshot from zeroing inflight.
+    let snapshot_events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+    let inflight_poll_count = snapshot_events
+        .iter()
+        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .count();
+    assert!(
+        inflight_poll_count >= 1,
+        "Expected at least 1 InflightEquity snapshot event (proving the poll ran and \
+         the sticky mechanism was exercised), got {inflight_poll_count}",
+    );
+
+    // The critical assertion: no second WithdrawnFromRaindex event should
+    // exist. After RedemptionRejected, the sticky marker prevents
+    // InflightEquity polls from zeroing inflight for the symbol. Without
+    // sticky, the poll would zero inflight, the system would see a new
+    // imbalance, and trigger another (incorrect) redemption.
+    let withdrawn_count = redeem_events
+        .iter()
+        .filter(|event| event.event_type == "EquityRedemptionEvent::WithdrawnFromRaindex")
+        .count();
+    assert_eq!(
+        withdrawn_count, 1,
+        "Expected exactly 1 WithdrawnFromRaindex event (sticky inflight should prevent \
+         the system from seeing a new imbalance and triggering another redemption), \
+         got {withdrawn_count}",
+    );
+
+    // Verify the mock shows the rejected redemption request.
+    let redeem_requests: Vec<_> = infra
+        .tokenization_service
+        .tokenization_requests()
+        .into_iter()
+        .filter(|req| req.request_type == TokenizationRequestType::Redeem && req.symbol == "AAPL")
+        .collect();
+    assert_eq!(
+        redeem_requests.len(),
+        1,
+        "Expected exactly 1 redeem request for AAPL"
+    );
+    assert_eq!(
+        redeem_requests[0].status,
+        st0x_hedge::mock_api::TokenizationStatus::Rejected,
+        "Redeem request should have Rejected status"
+    );
+
+    pool.close().await;
+    bot.abort();
+    Ok(())
+}
+
+/// Pending tokenization requests from foreign wallets are filtered out.
+///
+/// When multiple conductors share an Alpaca account, each conductor's
+/// `poll_inflight_equity` should only count pending requests matching its
+/// own wallet address. A foreign request (different wallet) must not
+/// inflate the inflight state.
+#[test_log::test(tokio::test)]
+async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
+    let onchain_price = float!("150.00");
+    let broker_fill_price = float!("148.00");
+    let amount_per_trade = float!("7.5");
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+
+    // Set up SellEquity orders to create TooMuchOffchain imbalance -> mint.
+    let mut prepared_orders = Vec::new();
+    for _ in 0..3 {
+        prepared_orders.push(
+            infra
+                .base_chain
+                .setup_order()
+                .symbol("AAPL")
+                .amount(amount_per_trade)
+                .price(onchain_price)
+                .direction(TakeDirection::SellEquity)
+                .call()
+                .await?,
+        );
+    }
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared_orders[0].input_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared_orders[0].output_vault_id)]);
+    let ctx = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(8)).await;
+
+    // Take all orders to create the imbalance.
+    for prepared in &prepared_orders {
+        infra.base_chain.take_prepared_order(prepared).await?;
+    }
+
+    // Inject a foreign pending mint request from a different wallet.
+    // This simulates another conductor sharing the same Alpaca account.
+    // If the bot doesn't filter by wallet, it would see 1000 extra shares
+    // of inflight and make incorrect rebalancing decisions.
+    let foreign_wallet = alloy::primitives::Address::random();
+    infra.tokenization_service.inject_pending_request(
+        "AAPL",
+        float!("1000"),
+        foreign_wallet,
+        TokenizationRequestType::Mint,
+    );
+
+    // Wait for the mint to complete successfully.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // Verify exactly one mint aggregate completed (the foreign request
+    // didn't cause additional mint operations).
+    let mint_events = fetch_events_by_type(&pool, "TokenizedEquityMint").await?;
+    assert_event_subsequence(
+        &mint_events,
+        &[
+            "TokenizedEquityMintEvent::MintRequested",
+            "TokenizedEquityMintEvent::MintAccepted",
+            "TokenizedEquityMintEvent::TokensReceived",
+            "TokenizedEquityMintEvent::TokensWrapped",
+            "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        ],
+    );
+
+    // Verify only one mint aggregate exists (no spurious second mint
+    // triggered by inflated inflight from the foreign request).
+    let mint_aggregate_ids: std::collections::HashSet<&str> = mint_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert_eq!(
+        mint_aggregate_ids.len(),
+        1,
+        "Expected exactly 1 mint aggregate (foreign wallet request should be filtered), \
+         got {}: {mint_aggregate_ids:?}",
+        mint_aggregate_ids.len(),
+    );
+
+    // Verify the foreign request still exists in the mock but was not
+    // consumed by the bot.
+    let all_requests = infra.tokenization_service.tokenization_requests();
+    let foreign_requests: Vec<_> = all_requests
+        .iter()
+        .filter(|req| req.request_type == TokenizationRequestType::Mint && req.symbol == "AAPL")
+        .collect();
+    assert!(
+        foreign_requests.len() >= 2,
+        "Expected at least 2 mint requests for AAPL (1 from bot + 1 foreign), \
+         got {}",
+        foreign_requests.len(),
+    );
+
+    pool.close().await;
+    bot.abort();
+    Ok(())
+}
+
+/// Inflight polling picks up pending tokenization requests end-to-end.
+///
+/// The conductor's inventory poller calls `list_pending_requests()` on
+/// every poll cycle. When pending requests exist (matching the conductor's
+/// wallet), the poller aggregates them into an `InflightEquity` snapshot
+/// command, which the CQRS aggregate turns into an `InflightEquity` event.
+///
+/// This test injects a pending mint request into the tokenization mock,
+/// starts the bot, and verifies that `InflightEquity` events are emitted
+/// with non-empty mint data -- proving the full pipeline from HTTP poll
+/// through CQRS event emission works end-to-end.
+#[test_log::test(tokio::test)]
+async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<()> {
+    let broker_fill_price = float!("150.00");
+    let onchain_price = float!("150.00");
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        // No offchain positions — avoids rebalancing triggering a real
+        // mint that could satisfy the assertion instead of the injected
+        // pending request.
+        vec![],
+    )
+    .await?;
+
+    // We need at least one order set up so the vault registry gets seeded
+    // and the inventory poller has valid vault IDs to query.
+    let prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!("5"))
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // Inject a pending mint request with the bot's wallet address BEFORE
+    // starting the bot. The first inventory poll should pick this up.
+    infra.tokenization_service.inject_pending_request(
+        "AAPL",
+        float!("25"),
+        infra.base_chain.owner,
+        TokenizationRequestType::Mint,
+    );
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared.input_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared.output_vault_id)]);
+    let ctx = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let mut bot = spawn_bot(ctx);
+
+    // Wait for at least one InflightEquity event to be emitted.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "InventorySnapshotEvent::InflightEquity",
+        1,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // Verify InflightEquity events were emitted.
+    let snapshot_events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+    let inflight_events: Vec<_> = snapshot_events
+        .iter()
+        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .collect();
+    assert!(
+        !inflight_events.is_empty(),
+        "Expected at least 1 InflightEquity event from polling"
+    );
+
+    // Verify the first InflightEquity event payload contains the injected
+    // pending mint for AAPL with the exact quantity we injected (25 shares).
+    let payload = &inflight_events[0].payload;
+    let inner = payload
+        .get("InflightEquity")
+        .expect("Event payload should be wrapped in InflightEquity variant");
+    let mints = inner
+        .get("mints")
+        .expect("InflightEquity should contain mints field");
+    let aapl_quantity = mints
+        .get("AAPL")
+        .expect("InflightEquity mints should contain AAPL from the injected pending request");
+    assert_eq!(
+        aapl_quantity.as_str().unwrap(),
+        "25",
+        "InflightEquity mint quantity for AAPL should match the injected \
+         pending request (25 shares), got: {aapl_quantity}"
+    );
+
+    pool.close().await;
+    bot.abort();
+    Ok(())
+}
+
+/// Inflight state survives bot restart via CQRS event replay.
+///
+/// When the bot restarts against the same database, the CQRS aggregate
+/// replays all previous events including `InflightEquity`. The trigger's
+/// `on_snapshot` handler processes the replayed events and restores the
+/// inflight state in the `InventoryView`.
+///
+/// This test:
+/// 1. Starts a bot, lets it poll and emit `InflightEquity` with a pending
+///    mint
+/// 2. Stops the bot
+/// 3. Starts a new bot on the same database
+/// 4. Verifies the second bot starts successfully (CQRS replay doesn't
+///    crash) and continues emitting snapshot events (is functional)
+/// 5. Verifies dedup: the aggregate suppresses duplicate InflightEquity
+///    events when the pending request state hasn't changed
+#[test_log::test(tokio::test)]
+async fn inflight_state_survives_restart() -> anyhow::Result<()> {
+    let broker_fill_price = float!("150.00");
+    let onchain_price = float!("150.00");
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        // No offchain positions: the test focuses on inflight polling
+        // and restart behavior, not rebalancing decisions.
+        vec![],
+    )
+    .await?;
+
+    let prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!("5"))
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // Inject a pending mint request that will persist across restarts
+    // (the mock server stays alive).
+    infra.tokenization_service.inject_pending_request(
+        "AAPL",
+        float!("25"),
+        infra.base_chain.owner,
+        TokenizationRequestType::Mint,
+    );
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared.input_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared.output_vault_id)]);
+
+    // --- First bot: let it poll and emit InflightEquity events ---
+    let ctx1 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let mut bot1 = spawn_bot(ctx1);
+
+    // Wait for at least one InflightEquity event from the first bot.
+    poll_for_events_with_timeout(
+        &mut bot1,
+        &infra.db_path,
+        "InventorySnapshotEvent::InflightEquity",
+        1,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    // Record the total event count before stopping the first bot.
+    let pool = connect_db(&infra.db_path).await?;
+    let events_before_restart = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+    let total_count_before = events_before_restart.len();
+    let inflight_count_before = events_before_restart
+        .iter()
+        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .count();
+    pool.close().await;
+
+    assert!(
+        inflight_count_before >= 1,
+        "First bot should have emitted at least 1 InflightEquity event"
+    );
+
+    // Stop the first bot.
+    bot1.abort();
+    // Allow the abort to propagate and release the database.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // --- Second bot: restart on the same database ---
+    let ctx2 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let bot2 = spawn_bot(ctx2);
+
+    // Wait for the second bot to start polling and emit new snapshot
+    // events. This proves the CQRS replay succeeded and the bot is
+    // functional after restart.
+    tokio::time::sleep(Duration::from_secs(15)).await;
+
+    // Verify the second bot is still alive (didn't crash on replay).
+    assert!(
+        !bot2.is_finished(),
+        "Second bot should still be running after replaying events"
+    );
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // The second bot should have emitted new snapshot events after
+    // replaying the first bot's events, proving it's functional.
+    let events_after_restart = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+    let total_count_after = events_after_restart.len();
+    assert!(
+        total_count_after > total_count_before,
+        "Second bot should emit new snapshot events after restart \
+         (before: {total_count_before}, after: {total_count_after})"
+    );
+
+    // Verify aggregate dedup: the InflightEquity event count should not
+    // explode after restart. The aggregate replays previous events and
+    // sets its state. When the poller emits the same inflight data, the
+    // aggregate's `handle` method suppresses the duplicate. We allow a
+    // modest increase for natural state transitions (e.g., the pending
+    // request completing after polls_until_complete).
+    let inflight_count_after = events_after_restart
+        .iter()
+        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .count();
+    let new_inflight_events = inflight_count_after - inflight_count_before;
+    assert!(
+        new_inflight_events <= 3,
+        "Expected at most 3 new InflightEquity events after restart \
+         (dedup should suppress duplicates), got {new_inflight_events} \
+         (before: {inflight_count_before}, after: {inflight_count_after})"
+    );
+
+    pool.close().await;
+    bot2.abort();
+    Ok(())
+}

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -139,6 +139,7 @@ impl TestInfra<()> {
             .start_redemption_watcher(
                 base_chain.provider.clone(),
                 REDEMPTION_WALLET,
+                base_chain.owner,
                 token_symbols,
             )
             .await?;


### PR DESCRIPTION
## Motivation

Closes [RAI-81](https://linear.app/makeitrain/issue/RAI-81/track-tokenization-requests-and-set-in-flight-balance-accordingly).
Closes #427.

When equity shares are sent to Alpaca for tokenization (mint) or redemption, the inventory snapshot doesn't account for capital held by third parties during these operations. The system has no way to detect stalled tokenization and no basis for equity recovery.

The existing `RebalancingTrigger` tracks inflight for system-controlled phases (vault withdrawals, onchain transfers), but not the third-party-held phases -- capital sitting with the issuer during minting, or in Alpaca's redemption pipeline. This creates a race condition: if the system polls before the CQRS terminal event arrives, it sees no pending operation and can re-trigger a duplicate mint or redemption.

## Solution

### Inflight equity polling

Added `poll_inflight_equity` to `InventoryPollingService` which queries Alpaca's tokenization API for pending requests on each inventory poll cycle. Pending mints are aggregated as inflight at the Hedging venue; pending redemptions as inflight at MarketMaking. Results are emitted as `InventorySnapshotEvent::InflightEquity` and flow through the existing CQRS snapshot pipeline.

The poller filters requests by wallet address so multi-conductor setups sharing an Alpaca account only count their own pending operations.

### Poll ordering: inflight first

`poll_inflight_equity` now runs **before** any balance snapshots in `poll_and_record()`. On startup, the first poll tick runs immediately -- if onchain/offchain balance snapshots landed first, they would trigger `check_and_trigger_equity` which skips when `has_inflight()` is true. Without inflight being set yet, the system could trigger a duplicate operation for a request Alpaca already has pending.

### Skip-absent semantics

`apply_inflight_snapshot` only sets inflight for symbols **present** in the poll maps -- symbols absent from the maps are left untouched. This prevents a race where Alpaca processes a request before the next poll: the poll returns nothing for that symbol, and the inflight value set by the CQRS event (`TransferOp::Start`) is preserved. Only CQRS terminal events (`TransferOp::Complete`, `TransferOp::Cancel`) can zero inflight.

This means:
- During active operations, CQRS events are the authority for inflight tracking
- The poll serves as reconciliation/discovery (e.g. after restart), not as the primary zeroing mechanism
- No separate state needs to be maintained or recovered

Note: if the bot crashes mid-operation and restarts after Alpaca completes the request, the skip-absent semantics mean inflight persists until manual intervention. Properly fixing this requires resuming interrupted aggregates on startup, tracked in #500.

### Staleness guard

`apply_inflight_snapshot` skips symbols whose `last_rebalancing` timestamp is more recent than the poll's `fetched_at`. This prevents a stale poll (issued before a transfer completed) from re-introducing inflight that was already cleared by a CQRS terminal event. Terminal events (`TokensReceived`, `Completed`, `MintAcceptanceFailed`, `TransferFailed`) now compose `with_last_rebalancing` alongside the inflight update to activate this guard immediately.

### Startup recovery for stuck redemptions

`symbols_with_stuck_redemptions` queries the event store for `EquityRedemption` aggregates whose last event is `DetectionFailed` or `RedemptionRejected`. Returns `HashMap<Symbol, FractionalShares>` (quantities summed per symbol) so the conductor can set inflight directly at startup via `Inventory::set_inflight`, preventing the system from re-triggering for tokens it no longer holds.

### TransferFailed cancels redemption inflight

`TransferFailed` during redemption (tokens failed to reach Alpaca's wallet) now cancels inflight back to MarketMaking available. Previously it was a no-op for inflight, leaving the system unable to retry.

### SPEC corrections

- `MintRejected`: corrected from "reconciles inflight back to Alpaca available" to "no balance change" -- rejection happens before shares leave Alpaca
- `RedemptionRejected`: updated to reflect uncertain token disposition after rejection
- `TransferFailed`: documented as cancelling inflight back to Raindex available
- Added `InflightEquity` snapshot event documentation

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)