### PR TITLE
config: move cash rebalancing to [assets.cash] with trading toggle

### DIFF
--- a/example.config.toml
+++ b/example.config.toml
@@ -10,7 +10,6 @@ deployment_block = 1
 [rebalancing]
 redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 equity = { target = 0.5, deviation = 0.2 }
-usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
 
 # Wallet provider — select via `kind`:
 #   "turnkey"     — Turnkey secure enclave signing   (requires --features wallet-turnkey)
@@ -23,6 +22,12 @@ kind = "private-key"
 # kind = "turnkey"
 # address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # organization_id = "org-example-turnkey-org-id"
+
+[assets.cash]
+trading = "disabled"
+rebalancing = "enabled"
+usdc_ratio = 0.5
+max_deviation = 0.3
 
 [assets.equities.EXAMPLE]
 tokenized_equity = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
## Motivation

Relates to the broader effort to add per-asset trading/rebalancing switches
(see also #498 for the soft-disable trading feature).

Previously, USDC rebalancing parameters (`target`, `deviation`, `mode`) lived
under `[rebalancing]` as a flat `usdc = { ... }` inline table. This was
inconsistent with the equity asset configuration, which already lives under
`[assets.equities.<SYMBOL>]` with explicit `trading` and `rebalancing` toggles.

## Solution

Moves USDC/cash rebalancing config from `[rebalancing].usdc` to a dedicated
`[assets.cash]` section in `example.config.toml`, mirroring the per-equity
asset config pattern:

- **`trading = "disabled"`** — explicit toggle for cash trading (disabled by
  default, consistent with the incremental prod re-enable strategy)
- **`rebalancing = "enabled"`** — explicit toggle for cash rebalancing
- **`usdc_ratio`** / **`max_deviation`** — renamed from `target`/`deviation`
  for clarity about what they control

This unifies the config surface: every asset type (equities and cash) now lives
under `[assets.*]` with consistent `trading`/`rebalancing` switches.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)