### PR TITLE
feat: in-flight inventory tracking for accurate imbalance detection

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,193 @@
+# Plan: Extend InventoryView with In-Flight Balance Tracking (#433)
+
+## Context
+
+InventoryPollingService polls 6+ locations but InventoryView only processes 4.
+The in-flight location events (`EthereumCash`, `BaseWalletCash`) are explicitly
+ignored in the rebalancing trigger:
+
+```rust
+// src/rebalancing/trigger/mod.rs:664
+EthereumCash { .. } | BaseWalletCash { .. } => Ok(inventory.clone()),
+```
+
+Capital at intermediate locations is invisible to imbalance detection. If USDC
+is stuck on Ethereum between bridging steps, the system doesn't know and may
+trigger unnecessary rebalancing or miscount total capital.
+
+### Dependency Status
+
+- #429 (Ethereum USDC), #430 (Base USDC), #432 (wrapped equity) — **merged**
+- #428 (Alpaca USDC) — PR #485 **open**
+- #431 (unwrapped equity) — PR #461 **open, blocked**
+
+PRs #461/#485 add `BaseWalletUnwrappedEquity`, `BaseWalletWrappedEquity`,
+`AlpacaWalletCash` variants. Not on master yet.
+
+### What We Can Do Now
+
+Everything that touches `EthereumCash` and `BaseWalletCash` (already on master).
+The data model, types, imbalance logic, and unit tests for all 5 locations can
+be built now. Wiring the 3 not-yet-landed variants is deferred.
+
+## Design
+
+### Two Kinds of "In-Flight"
+
+1. **Transfer inflight** (existing `VenueBalance.inflight`): Bookkeeping for
+   system-initiated transfers. Managed by `TransferOp::Start/Complete/Cancel`.
+   Suppresses imbalance detection entirely.
+
+2. **Location balances** (new): Polled balances at intermediate locations.
+   Observed reality. Affect the imbalance ratio denominator.
+
+These are complementary, not conflicting.
+
+### Data Model
+
+```rust
+// src/inventory/view.rs
+
+/// Locations where cash (USDC) can sit between primary venues.
+enum InFlightCashLocation {
+    Ethereum,
+    BaseWallet,
+    AlpacaCryptoWallet,
+}
+
+/// Locations where equity tokens can sit between primary venues.
+enum InFlightEquityLocation {
+    BaseUnwrapped,
+    BaseWrapped,
+}
+
+struct InventoryView {
+    usdc: Inventory<Usdc>,
+    equities: HashMap<Symbol, Inventory<FractionalShares>>,
+    inflight_cash: HashMap<InFlightCashLocation, Usdc>,
+    inflight_equity: HashMap<(Symbol, InFlightEquityLocation), FractionalShares>,
+    last_updated: DateTime<Utc>,
+}
+```
+
+### Imbalance Detection
+
+Current: `ratio = onchain / (onchain + offchain)`, returns None if
+transfer-inflight exists.
+
+New: `ratio = onchain / (onchain + offchain + inflight_total)`, still returns
+None if transfer-inflight exists.
+
+In-flight balances dilute the ratio, preventing false triggers when capital is
+in transit.
+
+## Workflow
+
+Following [docs/workflow.md](docs/workflow.md):
+
+### Step 1: Update SPEC.md
+
+Add the in-flight snapshot events to the "InventoryView listens to" list.
+Document the updated imbalance formula that includes in-flight balances in the
+denominator. Document in-flight location types and the conservation invariant.
+
+### Step 2: Write failing e2e test
+
+Using TestInfra from `tests/e2e/`: configure a scenario where capital exists at
+both venue locations and in-flight locations (Ethereum wallet, Base wallet). Run
+the full polling loop. Assert that InventoryView reflects in-flight balances
+alongside venue balances. This test fails today because InventoryView ignores
+`EthereumCash` and `BaseWalletCash` events.
+
+### Step 3: Identify root cause and write failing unit tests
+
+The root cause is at the unit level: InventoryView lacks the data model and
+logic to process in-flight snapshot events. Write unit tests:
+
+**InventoryView unit tests** (`src/inventory/view.rs`):
+
+- Given in-flight cash updates, InventoryView stores and exposes them
+- Given both venue and in-flight events, tracks independently without
+  interference
+- Given in-flight balances exist, imbalance detection includes them in
+  denominator (not double-counted, not ignored)
+- Conservation invariant:
+  `available + transfer_inflight + location_balances =
+  total` holds before and
+  after transfers
+
+**Rebalancing trigger unit tests** (`src/rebalancing/trigger/mod.rs`):
+
+- `EthereumCash` event updates InventoryView inflight cash (not ignored)
+- `BaseWalletCash` event updates InventoryView inflight cash (not ignored)
+- In-flight USDC affects USDC imbalance ratio calculation
+
+### Step 4: Types and signatures (compile, don't implement)
+
+**File: `src/inventory/view.rs`**
+
+- Define `InFlightCashLocation`, `InFlightEquityLocation` enums
+- Add fields to `InventoryView`
+- Add method signatures with `todo!()`: `update_inflight_cash()`,
+  `update_inflight_equity()`, `total_inflight_cash()`,
+  `inflight_equity_for_symbol()`
+- Update `Default`, `Serialize`/`Deserialize`
+
+Confirm `cargo check` passes.
+
+### Step 5: Implement to make unit tests pass
+
+- Implement mutation methods for in-flight location tracking
+- Update `detect_imbalance()` to add `total_inflight_cash` to denominator
+- Update `detect_imbalance_normalized()` to add inflight equity to denominator
+- Update `check_equity_imbalance()` and `check_usdc_imbalance()` to thread
+  in-flight data through
+
+### Step 6: Wire into rebalancing trigger
+
+**File: `src/rebalancing/trigger/mod.rs`**
+
+Replace the no-op arm:
+
+```rust
+EthereumCash { .. } | BaseWalletCash { .. } => Ok(inventory.clone()),
+```
+
+with actual `update_inflight_cash()` calls in both `on_snapshot()` and
+`on_snapshot_recovery()`.
+
+### Step 7: Make e2e test pass
+
+Confirm the e2e test from step 2 now passes with the wired-up implementation.
+
+### Step 8: Cleanup
+
+- Run full test suite
+- Run clippy, fmt
+- Review diff for unjustified changes
+- Update ROADMAP.md
+
+### Deferred (after #428 and #431 land)
+
+- Wire `AlpacaWalletCash` -> `InFlightCashLocation::AlpacaCryptoWallet`
+- Wire `BaseWalletUnwrappedEquity` -> `InFlightEquityLocation::BaseUnwrapped`
+- Wire `BaseWalletWrappedEquity` -> `InFlightEquityLocation::BaseWrapped`
+- E2e tests covering all 5 in-flight locations
+
+## Key Files
+
+| File                             | Changes                                                         |
+| -------------------------------- | --------------------------------------------------------------- |
+| `SPEC.md`                        | Document in-flight location tracking, updated imbalance formula |
+| `src/inventory/view.rs`          | Data model, imbalance detection, unit tests                     |
+| `src/inventory/venue_balance.rs` | May need `total()` public accessor                              |
+| `src/rebalancing/trigger/mod.rs` | Wire events, trigger tests                                      |
+| `tests/e2e/rebalancing/`         | E2e test for in-flight visibility                               |
+
+## Verification
+
+1. `cargo check`
+2. `cargo nextest run --workspace`
+3. `cargo clippy`
+4. `cargo fmt`
+5. Diff review

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,232 +1,489 @@
 # Roadmap
 
-Each `##` section is an epic -- a goal-oriented group of related issues. Epics
-are ordered by priority (highest first).
-
-## Operational visibility and reliable wallet signing
-
-Stop relying on logs for rebalancing visibility, and replace Fireblocks with
-Turnkey/private-key wallet for onchain signing. All branches stack on #355.
-
-```mermaid
-graph TD
-    A["#355 per-asset-operations-config"] --> B["#381 roadmap update"]
-    B --> C["#354 Turnkey wallet<br/>(evm crate)"]
-    B --> D["#376 DTO schema update"]
-    D --> F["#377 dashboard backend"]
-    D --> G["#378 dashboard frontend"]
-    F --> H["#379 dashboard integration"]
-    G --> H
-    C --> E["#380 wallet provider config<br/>(main crate, last)"]
-    H --> E
-```
-
-### Turnkey wallet (evm crate, independent)
-
-Fireblocks has been unreliable for production signing (30s+ latency, outages).
-Turnkey uses AWS Nitro enclaves for 50-100ms signing. Touches only the evm
-crate, so fully independent from dashboard work.
-
-- [x] [#354 Replace Fireblocks with Turnkey for onchain transaction signing](https://github.com/ST0x-Technology/st0x.liquidity/issues/354)
-  - PR:
-    [#385 add TurnkeyWallet to st0x-evm crate](https://github.com/ST0x-Technology/st0x.liquidity/pull/385)
-
-### Dashboard inventory & transfer monitoring
-
-We are actively testing cross-venue inventory transfers and need dashboard
-panels showing inventory snapshots, change history, and transfer lifecycle
-status. Touches dto + main crate + dashboard frontend -- disjoint from the
-Turnkey work above, so both proceed in parallel.
-
-- [ ] [#376 Review and update DTO types for inventory snapshots and transfer status](https://github.com/ST0x-Technology/st0x.liquidity/issues/376)
-- [ ] [#377 Dashboard backend: serve inventory history and transfer status via WebSocket](https://github.com/ST0x-Technology/st0x.liquidity/issues/377)
-- [ ] [#378 Dashboard frontend: inventory and transfer status panels](https://github.com/ST0x-Technology/st0x.liquidity/issues/378)
-- [ ] [#379 Dashboard integration: verify nix build, deployment, and end-to-end data flow](https://github.com/ST0x-Technology/st0x.liquidity/issues/379)
-
-### Wallet provider config (main crate, depends on everything above)
-
-Wires Turnkey and raw-private-key wallets into the main crate config, removes
-Fireblocks entirely. Wallet type is selected via TOML, while cargo features
-control which wallet backends are compiled into the binary.
-
-- [x] [#380 Configure wallet provider selection (Turnkey vs Fireblocks) in main crate](https://github.com/ST0x-Technology/st0x.liquidity/issues/380)
-  - PR:
-    [#394 Wallet selection on hedge bot](https://github.com/ST0x-Technology/st0x.liquidity/pull/394)
-
-<br>
+This document tracks the current goal, upcoming milestones, and backlog. The
+current focus section has full task breakdown with dependency graphs. Next
+milestones are goals we know are coming but haven't fully planned. Backlog is
+grouped by system aspect.
 
 ---
 
-<br>
+## Current focus: Go to prod with auto-rebalancing
 
-## Not epic
+Manual rebalancing cannot keep up with liquidity demand. Auto-rebalancing is
+essential, but it already stalls after a few cycles in testing - capital gets
+stuck mid-flight and requires manual recovery. Going live requires granular
+balance tracking across venues, crash-safe task management, automatic capital
+recovery, operational observability, and production-grade wallet signing. The
+subsections below break each area down.
 
-Everything below has not been organized into epics yet.
+[Milestone](https://github.com/ST0x-Technology/st0x.liquidity/milestone/1):
+Highly reliable counter trading with auto-rebalancing in prod
 
-### Fireblocks Contract Calls
+### Active work
 
-- [x] [#325 upgrade Rain Orderbook bindings from V5 to V6](https://github.com/ST0x-Technology/st0x.liquidity/issues/325)
+| Priority | Issue                                 | PR     | Why                                        |
+| -------- | ------------------------------------- | ------ | ------------------------------------------ |
+| 1        | [#407] Untouchable cash reserve       | [#484] | Prerequisite for USDC rebalancing in prod  |
+| 2        | [#449] Transfer aggregate ID tracking |        | Recovery needs to resume stalled transfers |
+| 3        | [#421] Order lifecycle -> apalis jobs |        | Crash-safe order polling                   |
+
+#### Ready to pick up
+
+- [#427]: Track tokenization requests and set in-flight balance -- PR [#481]
+- [#434]: Use Turnkey for all onchain operations -- unblocked now that [#380]
+  landed
+
+> Legend: 🔵 in progress | 🟣 in review | 🟡 ready (deps done or have stable
+> branches to stack on) | 🔴 blocked (dep hasn't started, no branch to stack on)
+> | 🟢 done
+>
+> Rectangles are issues. Rounded boxes are prerequisites from other tracks or
+> goals that completing the issues achieves.
+
+```mermaid
+graph LR
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+
+    a["Reliable task management [0/5]"]:::wip
+    b["Granular balance tracking [3/6]"]:::wip
+    c["Production-grade wallet management [2/3]"]:::wip
+    d["Operational observability [0/4]"]:::wip
+    e(["Automatic capital recovery [0/9]"]):::ready
+    f(["Safely go live [1/8]"]):::wip
+
+    a & b --> e
+    c & d & e --> f
+
+    click e href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#automatic-capital-recovery"
+    click a href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#reliable-task-management"
+    click b href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#granular-balance-tracking"
+    click c href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#production-grade-wallet-management"
+    click d href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#operational-observability"
+    click f href "https://github.com/ST0x-Technology/st0x.liquidity/blob/master/ROADMAP.md#safely-go-live"
+```
+
+### Granular balance tracking
+
+Add balance checks for every in-flight location, then wire them into the
+snapshot polling loop. [#429], [#430], and [#432] are done. [#428] (PR [#485])
+and [#431] (PR [#461]) are in review.
+
+```mermaid
+graph LR
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef review fill:#3b1a5c,stroke:#a855f7,color:#d8b4fe
+    classDef done fill:#1a5c3b,stroke:#22c55e,color:#86efac
+
+    id428["#428 USDC on Alpaca"]:::review
+    id429["#429 USDC on Ethereum"]:::done
+    id430["#430 USDC on Base"]:::done
+    id431["#431 Unwrapped equity on Base"]:::review
+    id432["#432 Wrapped equity on Base"]:::done
+    id433(["#433 Extend inventory snapshot"]):::ready
+
+    id428 --> id433
+    id429 --> id433
+    id430 --> id433
+    id431 --> id433
+    id432 --> id433
+
+    click id428 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/428"
+    click id429 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/429"
+    click id430 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/430"
+    click id431 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/431"
+    click id432 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/432"
+    click id433 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/433"
+```
+
+- [ ] [#428 Check USDC balance in Alpaca crypto wallet](https://github.com/ST0x-Technology/st0x.liquidity/issues/428)
   - PR:
-    [#326 upgrade Rain Orderbook bindings from V5 to V6](https://github.com/ST0x-Technology/st0x.liquidity/pull/326)
-- [x] [#323 Fireblocks integration uses OneTimeAddress instead of whitelisted contract wallets](https://github.com/ST0x-Technology/st0x.liquidity/issues/323)
+    [#485 Check USDC balance in Alpaca crypto wallet](https://github.com/ST0x-Technology/st0x.liquidity/pull/485)
+- [x] [#429 Ethereum USDC balance polling](https://github.com/ST0x-Technology/st0x.liquidity/issues/429)
   - PR:
-    [#324 resolve fireblocks contract wallet via API per call](https://github.com/ST0x-Technology/st0x.liquidity/pull/324)
-- [x] [#297 Harden wallet management with Fireblocks contract calls](https://github.com/ST0x-Technology/st0x.liquidity/issues/297)
+    [#459 Poll Ethereum wallet USDC balance in inventory service](https://github.com/ST0x-Technology/st0x.liquidity/pull/459)
+- [x] [#430 Base USDC balance polling (outside Raindex)](https://github.com/ST0x-Technology/st0x.liquidity/issues/430)
   - PR:
-    [#300 add fireblocks integration](https://github.com/ST0x-Technology/st0x.liquidity/pull/300)
-
-### Live testing of auto-rebalancing on the Alpaca instance
-
-- PR:
-  [#315 go live prod configuration](https://github.com/ST0x-Technology/st0x.liquidity/pull/315)
-
-- [x] [#353 Per-asset operations config: independent trading/rebalancing toggles, vault IDs, operational limits](https://github.com/ST0x-Technology/st0x.liquidity/issues/353)
+    [#460 Poll Base wallet USDC balance in inventory service](https://github.com/ST0x-Technology/st0x.liquidity/pull/460)
+- [ ] [#431 Base unwrapped equity token balance polling](https://github.com/ST0x-Technology/st0x.liquidity/issues/431)
   - PR:
-    [#355 per-asset operations config: independent trading/rebalancing toggles](https://github.com/ST0x-Technology/st0x.liquidity/pull/355)
-- [ ] [#332 No way to enable/disable individual asset markets](https://github.com/ST0x-Technology/st0x.liquidity/issues/332)
-  - PR (draft):
-    [#335 add per-asset market enable/disable toggle](https://github.com/ST0x-Technology/st0x.liquidity/pull/335)
-
-#### Wrapped Token Handling
-
-- [x] [#329 Trade validation rejects wrapped tokenized equity symbols (wt prefix)](https://github.com/ST0x-Technology/st0x.liquidity/issues/329)
+    [#461 Add Base wallet equity token balance polling](https://github.com/ST0x-Technology/st0x.liquidity/pull/461)
+- [x] [#432 Base wrapped equity token balance polling](https://github.com/ST0x-Technology/st0x.liquidity/issues/432)
   - PR:
-    [#330 fix trade validation for wrapped tokenized equity symbols](https://github.com/ST0x-Technology/st0x.liquidity/pull/330)
-- [x] [#260 Add support for wrapping and unwrapping of the 1-to-1 share equivalent tokens into/from split/dividend compatibility vault](https://github.com/ST0x-Technology/st0x.liquidity/issues/260)
+    [#476 Add Base wrapped equity token balance polling](https://github.com/ST0x-Technology/st0x.liquidity/pull/476)
+- [ ] [#433 Extend inventory snapshot to include in-flight balances](https://github.com/ST0x-Technology/st0x.liquidity/issues/433)
+
+### Reliable task management
+
+Migrate to apalis, convert the two essential job families (order lifecycle and
+inventory/rebalancing), then unify recovery dispatch so recovery jobs use the
+same pipeline as standard transfers. Position checker and startup/maintenance
+conversions are deferred to the monitoring and optimization epic -- they
+self-heal on the next poll cycle and aren't blocking go-live.
+
+```mermaid
+graph TD
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+
+    id296["#296 Apalis infrastructure"]:::wip
+    id421["#421 Order lifecycle"]:::ready
+    id423["#423 Inventory polling"]:::ready
+    id425(["#425 USDC recovery dispatch"]):::blocked
+    id452(["#452 Equity recovery dispatch"]):::blocked
+
+    id296 --> id421 & id423 --> id425 & id452
+
+    click id296 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/296"
+    click id421 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/421"
+    click id423 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/423"
+    click id425 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/425"
+    click id452 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/452"
+```
+
+- [ ] [#296 Set up apalis + task-supervisor infrastructure and convert event processing pipeline](https://github.com/ST0x-Technology/st0x.liquidity/issues/296)
   - PR:
-    [#241 Wrapped Token Handling](https://github.com/ST0x-Technology/st0x.liquidity/pull/241)
+    [#483 redesign the orchestration layer](https://github.com/ST0x-Technology/st0x.liquidity/pull/483)
+- [ ] [#421 Convert order lifecycle to apalis jobs](https://github.com/ST0x-Technology/st0x.liquidity/issues/421)
+- [ ] [#423 Convert inventory polling and rebalancing to apalis jobs](https://github.com/ST0x-Technology/st0x.liquidity/issues/423)
+- [ ] [#425 Unify USDC recovery dispatch with standard transfer lifecycle](https://github.com/ST0x-Technology/st0x.liquidity/issues/425)
+- [ ] [#452 Unify equity recovery dispatch with standard transfer lifecycle](https://github.com/ST0x-Technology/st0x.liquidity/issues/452)
 
-#### Alpaca Trading Improvements
+### Production-grade wallet management
 
-- [x] PR:
-      [#279 fixes from live testing](https://github.com/ST0x-Technology/st0x.liquidity/pull/279)
+Replace Fireblocks with Turnkey and make wallet provider configurable.
 
-- [ ] [#306 Configurable operational limits for safe deployment rollout](https://github.com/ST0x-Technology/st0x.liquidity/issues/306)
+```mermaid
+graph TD
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef done fill:#1a5c3b,stroke:#22c55e,color:#86efac
+
+    id354["#354 Turnkey signing"]:::done
+    id380["#380 Wallet provider config"]:::done
+    id434(["#434 Turnkey in production"]):::ready
+
+    id354 --> id380 --> id434
+
+    click id354 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/354"
+    click id380 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/380"
+    click id434 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/434"
+```
+
+- [x] [#354 Replace Fireblocks with Turnkey for onchain transaction signing](https://github.com/ST0x-Technology/st0x.liquidity/issues/354)
   - PR:
-    [#307 feat: configurable operational limits](https://github.com/ST0x-Technology/st0x.liquidity/pull/307)
-- [ ] [#333 Alpaca transfer shows Processing then disappears from pending list](https://github.com/ST0x-Technology/st0x.liquidity/issues/333)
-- [x] [#331 Add CLI command to journal equities between Alpaca accounts](https://github.com/ST0x-Technology/st0x.liquidity/issues/331)
+    [#390 add turnkey support to st0x-evm](https://github.com/ST0x-Technology/st0x.liquidity/pull/390)
+- [x] [#380 Configure wallet provider selection (Turnkey vs Fireblocks) in main crate](https://github.com/ST0x-Technology/st0x.liquidity/issues/380)
   - PR:
-    [#334 add CLI command to journal equities between Alpaca accounts](https://github.com/ST0x-Technology/st0x.liquidity/pull/334)
-- [ ] [#263 Check offchain inventory before placing counter trades](https://github.com/ST0x-Technology/st0x.liquidity/issues/263)
-- [x] [#212 Integrate Alpaca list assets endpoint and use it to check that the asset is active before trading](https://github.com/ST0x-Technology/st0x.liquidity/issues/212)
+    [#394 Wallet selection on hedge bot](https://github.com/ST0x-Technology/st0x.liquidity/pull/394)
+- [ ] [#434 Use Turnkey for all onchain operations](https://github.com/ST0x-Technology/st0x.liquidity/issues/434)
+
+### Operational observability
+
+Build out dashboard panels until the system is observable end-to-end. Backend
+and frontend are parallel after DTOs.
+
+```mermaid
+graph TD
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef review fill:#3b1a5c,stroke:#a855f7,color:#d8b4fe
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+
+    id376["#376 DTO types"]:::review
+    id377["#377 Backend WebSocket"]:::wip
+    id378["#378 Frontend panels"]:::review
+    id181["#181 Trade history"]:::ready
+    goal(["Operations are observable"]):::blocked
+
+    id376 --> id377 & id378 --> id181 --> goal
+
+    click id376 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/376"
+    click id377 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/377"
+    click id378 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/378"
+    click id181 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/181"
+```
+
+- [ ] [#376 Review and update DTO types for inventory snapshots and transfer status](https://github.com/ST0x-Technology/st0x.liquidity/issues/376)
   - PR:
-    [#278 check asset status before placing alpaca orders](https://github.com/ST0x-Technology/st0x.liquidity/pull/278)
-- [ ] [#105 Run the Alpaca instance without whole share accumulation](https://github.com/ST0x-Technology/st0x.liquidity/issues/105)
-- [ ] [#258 BUG: Alpaca Broker API should be expected with rebalancing enabled, not Alpaca Trading API](https://github.com/ST0x-Technology/st0x.liquidity/issues/258)
-- [ ] [#282 USDC inventory not updated from Position events (Buy/Sell trades)](https://github.com/ST0x-Technology/st0x.liquidity/issues/282)
-- [ ] [#283 USDC rebalancing trigger doesn't fire after USDC inventory changes](https://github.com/ST0x-Technology/st0x.liquidity/issues/283)
-- [ ] [#284 Equity mint completion trusts Alpaca API without onchain verification](https://github.com/ST0x-Technology/st0x.liquidity/issues/284)
-- [x] [#276 EquityPosition market_value_cents truncates sub-cent precision](https://github.com/ST0x-Technology/st0x.liquidity/issues/276)
+    [#382 update DTO types for inventory snapshots and transfer status](https://github.com/ST0x-Technology/st0x.liquidity/pull/382)
+- [ ] [#377 Dashboard backend: serve inventory history and transfer status via WebSocket](https://github.com/ST0x-Technology/st0x.liquidity/issues/377)
   - PR:
-    [#279 fixes from live testing](https://github.com/ST0x-Technology/st0x.liquidity/pull/279)
-- [ ] [#277 No automatic retry after offchain order failure](https://github.com/ST0x-Technology/st0x.liquidity/issues/277)
-- [ ] [#310 StoreBuilder allows omitting projections that entities declare as required](https://github.com/ST0x-Technology/st0x.liquidity/issues/310)
-- [ ] [#322 CLI should not depend on database](https://github.com/ST0x-Technology/st0x.liquidity/issues/322)
-
-#### CQRS/ES Phase 3 - Complete Migration
-
-All auto-rebalancing logic uses ES/CQRS. Time to disable legacy:
-
-- [x] PR:
-      [#273 Remove legacy persistence layer](https://github.com/ST0x-Technology/st0x.liquidity/pull/273)
-- [x] [#235 Add feature flag to disable legacy persistence layer](https://github.com/ST0x-Technology/st0x.liquidity/issues/235)
-  - Superseded: legacy removed entirely in #273
-- [x] [#131 Add monitoring and validation tooling for dual-write period](https://github.com/ST0x-Technology/st0x.liquidity/issues/131)
-  - Superseded: dual-write removed entirely in #273
-- [ ] [#141 Implement MetricsPnL view](https://github.com/ST0x-Technology/st0x.liquidity/issues/141)
-- [x] [#142 Cutover reads from old tables to views](https://github.com/ST0x-Technology/st0x.liquidity/issues/142)
-  - Superseded: legacy tables removed in #273
-- [x] [#143 Remove dual-write to old tables](https://github.com/ST0x-Technology/st0x.liquidity/issues/143)
-  - Superseded: dual-write removed in #273
-- [x] [#144 Drop old CRUD tables](https://github.com/ST0x-Technology/st0x.liquidity/issues/144)
-  - Superseded: legacy tables removed in #273
-
-### Backlog: Admin Dashboard
-
-Unified web dashboard for monitoring and controlling the liquidity bot.
-Eliminates jumping between Grafana, HyperDX, and CLI for Schwab OAuth. Supports
-both Schwab and Alpaca bot instances.
-
-**Panels:**
-
-- [ ] [#233 Make the dashboard display not only live events happening but also get historical data so that it's clear what's been happening in the system](https://github.com/ST0x-Technology/st0x.liquidity/issues/233)
-- [ ] [#178 Dashboard: Performance Metrics Panel](https://github.com/ST0x-Technology/st0x.liquidity/issues/178)
-- [ ] [#180 Dashboard: Spreads Panel](https://github.com/ST0x-Technology/st0x.liquidity/issues/180)
+    [#482 implement the inventory panel](https://github.com/ST0x-Technology/st0x.liquidity/pull/482)
+- [ ] [#378 Dashboard frontend: inventory and transfer status panels](https://github.com/ST0x-Technology/st0x.liquidity/issues/378)
+  - PR:
+    [#392 inventory frontend](https://github.com/ST0x-Technology/st0x.liquidity/pull/392)
 - [ ] [#181 Dashboard: Trade History Panel](https://github.com/ST0x-Technology/st0x.liquidity/issues/181)
 
-#### Controls
+### Automatic capital recovery
 
-- [ ] [#183 Dashboard: Circuit Breaker](https://github.com/ST0x-Technology/st0x.liquidity/issues/183)
-- [ ] [#184 Dashboard: Schwab OAuth Integration](https://github.com/ST0x-Technology/st0x.liquidity/issues/184)
+Recovery needs to know where capital is stuck (from detection) and how to resume
+stalled transfers (from tracking). Two shared prerequisites feed both USDC and
+equity streams:
 
-#### Integrations
+- **[#449]** stores aggregate IDs alongside inflight balances so recovery can
+  `Store::load(id)` and resume.
+- **[#433]** (from detection) extends the inventory snapshot so recovery knows
+  _where_ capital is stuck.
 
-- [ ] [#185 Dashboard: Grafana Embedding](https://github.com/ST0x-Technology/st0x.liquidity/issues/185)
-- [ ] [#186 Dashboard: HyperDX Health Status](https://github.com/ST0x-Technology/st0x.liquidity/issues/186)
+Each stream then has its own dispatch and per-venue recovery. [#442] converges
+everything.
 
-#### Infrastructure
+- [ ] [#449 Track active transfer aggregate IDs in inventory view](https://github.com/ST0x-Technology/st0x.liquidity/issues/449)
 
-- [ ] [#187 Dashboard: Deployment Configuration](https://github.com/ST0x-Technology/st0x.liquidity/issues/187)
+#### USDC recovery
 
-### Backlog: Multi-Crate Architecture
+Three venues hold USDC in flight: Alpaca crypto wallet, Ethereum, and Base. Each
+gets a parallel recovery implementation. [#425] (from crash-safe) provides the
+dispatch mechanism. [#441] gates go-live.
 
-Split monolith into focused crates for faster builds, stricter abstraction
-boundaries, and reduced coupling. Sequenced around CQRS/ES migration.
+```mermaid
+graph TD
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
 
-#### Prerequisites
+    id449["#449 Transfer aggregate IDs"]:::ready
+    deps(["Balance tracking +<br/>Task management"])
+    id436["#436 USDC on Alpaca"]:::blocked
+    id437["#437 USDC on Ethereum"]:::blocked
+    id438["#438 USDC on Base"]:::blocked
+    id441(["#441 All in-flight USDC"]):::blocked
 
-- [x] [#267 Use cqrs-es Services to make OffchainOrder aggregate self-contained](https://github.com/ST0x-Technology/st0x.liquidity/issues/267)
+    id449 & deps --> id436 & id437 & id438 --> id441
+
+    click id449 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/449"
+    click id436 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/436"
+    click id437 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/437"
+    click id438 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/438"
+    click id441 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/441"
+```
+
+- [ ] [#436 Recover from detected USDC on Alpaca](https://github.com/ST0x-Technology/st0x.liquidity/issues/436)
+- [ ] [#437 Recover from detected USDC on Ethereum](https://github.com/ST0x-Technology/st0x.liquidity/issues/437)
+- [ ] [#438 Recover from detected USDC on Base](https://github.com/ST0x-Technology/st0x.liquidity/issues/438)
+- [ ] [#441 Recover from all detected in-flight USDC](https://github.com/ST0x-Technology/st0x.liquidity/issues/441)
+
+#### Equity recovery
+
+Equity recovery additionally needs [#427] (tokenization tracking) and [#452]
+(equity dispatch from crash-safe). Two venues: wrapped and unwrapped tokens on
+Base. [#442] converges USDC and equity recovery.
+
+```mermaid
+graph TD
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+
+    deps(["Balance tracking +<br/>Task management +<br/>USDC recovery"])
+    id427["#427 Tokenization tracking"]:::wip
+    id439["#439 Wrapped equity on Base"]:::blocked
+    id440["#440 Unwrapped equity on Base"]:::blocked
+    id442(["#442 All in-flight capital"]):::blocked
+
+    deps --> id427 & id439 & id440 --> id442
+
+    click id427 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/427"
+    click id439 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/439"
+    click id440 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/440"
+    click id442 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/442"
+```
+
+- [ ] [#427 Track tokenization requests and set in-flight balance accordingly](https://github.com/ST0x-Technology/st0x.liquidity/issues/427)
   - PR:
-    [#273 Remove legacy persistence layer](https://github.com/ST0x-Technology/st0x.liquidity/pull/273)
+    [#481 Track in-flight tokenization requests and set inflight balance accordingly](https://github.com/ST0x-Technology/st0x.liquidity/pull/481)
+- [ ] [#439 Recover from detected wrapped equity tokens on Base](https://github.com/ST0x-Technology/st0x.liquidity/issues/439)
+- [ ] [#440 Recover from detected unwrapped equity tokens on Base](https://github.com/ST0x-Technology/st0x.liquidity/issues/440)
+- [ ] [#442 Recover from any detected in-flight capital](https://github.com/ST0x-Technology/st0x.liquidity/issues/442)
 
-#### Phase 2: Integration Layer Extraction
+### Safely go live
 
-Extract external API wrappers (no CQRS/ES dependencies):
+Each step verifies a larger slice of the system works. USDC rebalancing and
+single-equity rebalancing can be tested in parallel. Both must be stable before
+multi-equity stability testing, then go live.
 
-- [ ] [#268 Extract st0x-bridge crate with Bridge trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/268)
-- [ ] [#269 Extract st0x-tokenization crate with Tokenizer trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/269)
-- [ ] [#270 Extract st0x-vault crate with Vault trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/270)
+```mermaid
+graph TD
+    classDef wip fill:#1a2e5c,stroke:#3b82f6,color:#93c5fd
+    classDef ready fill:#5c4a1a,stroke:#f59e0b,color:#fcd34d
+    classDef blocked fill:#5c1a1a,stroke:#ef4444,color:#fca5a5
+    classDef done fill:#1a5c3b,stroke:#22c55e,color:#86efac
 
-#### Phase 3: Rebalancing Domain Extraction
+    id453["#453 Bidirectional equity rebalancing"]:::done
+    id407["#407 Cash reserve"]:::wip
+    id491["#491 Trading enable/disable toggle"]:::wip
+    id443["#443 E2e USDC rebalancing"]:::ready
+    id444["#444 Repeated USDC rebalancing"]:::blocked
+    id445["#445 Single-equity rebalancing"]:::ready
+    id446["#446 Multi-equity stability"]:::blocked
+    id447(["#447 Go live"]):::blocked
 
-Extract rebalancing logic (already clean CQRS):
+    id453 & id407 --> id491 --> id443 --> id444
+    id453 --> id445
+    id444 & id445 --> id446 --> id447
 
-- [ ] [#271 Extract st0x-rebalance crate](https://github.com/ST0x-Technology/st0x.liquidity/issues/271)
+    click id453 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/453"
+    click id407 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/407"
+    click id491 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/491"
+    click id443 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/443"
+    click id444 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/444"
+    click id445 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/445"
+    click id446 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/446"
+    click id447 href "https://github.com/ST0x-Technology/st0x.liquidity/issues/447"
+```
 
-#### Phase 4: Hedging Extraction & Application Layer
+- [x] [#453 Live bidirectional equity auto-rebalancing](https://github.com/ST0x-Technology/st0x.liquidity/issues/453)
+- [ ] [#407 Untouchable cash reserve for rebalancing](https://github.com/ST0x-Technology/st0x.liquidity/issues/407)
+  - PR:
+    [#484 add an untouchable brokerage cash reserve](https://github.com/ST0x-Technology/st0x.liquidity/pull/484)
+- [ ] [#491 Runtime trading enable/disable toggle](https://github.com/ST0x-Technology/st0x.liquidity/issues/491)
+  - PR:
+    [#492 feat/trading-switch](https://github.com/ST0x-Technology/st0x.liquidity/pull/492)
+- [ ] [#443 See end-to-end USDC auto rebalancing in both directions](https://github.com/ST0x-Technology/st0x.liquidity/issues/443)
+- [ ] [#444 See repeated USDC auto rebalancing](https://github.com/ST0x-Technology/st0x.liquidity/issues/444)
+- [ ] [#445 See repeated single-equity auto rebalancing with counter trading](https://github.com/ST0x-Technology/st0x.liquidity/issues/445)
+- [ ] [#446 Get a day of stable multi-equity auto rebalancing with counter trading](https://github.com/ST0x-Technology/st0x.liquidity/issues/446)
+- [ ] [#447 Safely go live with production counter trading and auto-rebalancing](https://github.com/ST0x-Technology/st0x.liquidity/issues/447)
 
-After CQRS migration Phase 3. Extract hedging logic and create application
-binary:
+---
 
-- [ ] [#272 Convert st0x-hedge to library crate and create st0x-server binary](https://github.com/ST0x-Technology/st0x.liquidity/issues/272)
+## Next milestones
 
-### Backlog: Quant Research Data
+### Harden production
 
-Ensure the event store captures all data needed for quantitative research —
+Once auto-rebalancing is live, priority shifts to making the deployment robust
+and observable. The system runs on a remote server handling real capital --
+securing access, encrypting traffic, and having visibility into what's happening
+are prerequisites for operating with confidence. The quant researcher also needs
+execution data and monitoring tools to analyze and optimize trading parameters.
+
+#### Infrastructure security
+
+- [ ] [#286 No TLS configured for dashboard and WebSocket traffic](https://github.com/ST0x-Technology/st0x.liquidity/issues/286)
+- [ ] [#293 Granular SSH access control: limit root access and per-user deploy keys](https://github.com/ST0x-Technology/st0x.liquidity/issues/293)
+- [ ] [#294 Document secret management setup and opsec](https://github.com/ST0x-Technology/st0x.liquidity/issues/294)
+
+#### Reliability
+
+- [ ] [#263 Check offchain inventory before placing counter trades](https://github.com/ST0x-Technology/st0x.liquidity/issues/263)
+- [ ] [#277 No automatic retry after offchain order failure](https://github.com/ST0x-Technology/st0x.liquidity/issues/277)
+- [ ] [#240 Conversion slippage not tracked, causing inventory drift](https://github.com/ST0x-Technology/st0x.liquidity/issues/240)
+- [ ] [#469 Verify all onchain operations await required confirmations](https://github.com/ST0x-Technology/st0x.liquidity/issues/469)
+- [ ] [#16 Handle reorgs](https://github.com/ST0x-Technology/st0x.liquidity/issues/16)
+
+#### Remaining job conversions
+
+De-scoped from go-live because they self-heal on the next cycle. Converting to
+apalis improves reliability and gives better observability into job health.
+
+- [ ] [#422 Convert position checker to apalis job](https://github.com/ST0x-Technology/st0x.liquidity/issues/422)
+- [ ] [#424 Convert startup operations and executor maintenance to apalis jobs and supervised tasks](https://github.com/ST0x-Technology/st0x.liquidity/issues/424)
+
+#### Quant research data
+
+Ensure the event store captures all data needed for quantitative research --
 execution timing, market conditions, and operational metrics.
 
 - [ ] [#303 Audit external integrations: record start/end timestamps for all calls in event store](https://github.com/ST0x-Technology/st0x.liquidity/issues/303)
 
+#### Dashboard
+
+- [ ] [#399 Dashboard: surface transfer error details and transaction hashes](https://github.com/ST0x-Technology/st0x.liquidity/issues/399)
+
+### Request for liquidity flow
+
+(Future -- no issues yet)
+
+### Improve capital efficiency
+
+(Future -- no issues yet)
+
 ---
 
-## Backlog: Black-Box E2E Testing Architecture
+## Backlog
 
-E2e tests should exercise the system from the perspective of external services
-(blockchain, broker API, attestation service) rather than inspecting internal
-state. Nobody cares about the internals of a trading bot -- they care that the
-bot reacts to new fills, moves inventory when it should, and maintains correct
-positions. This epic covers reducing exposed internals, adding chaos/fault
-injection, and invariant monitoring under randomized workloads.
+Work that doesn't fit into the current epics. These are organized by area but
+not yet prioritized as epic goals.
 
-```mermaid
-graph LR
-    A[#416 Reduce exposed internals] --> C[#418 Invariant monitoring]
-    A --> B[#417 Chaos/fault injection]
-    B --> D[#419 Adversarial simulation]
-    C --> D
-```
+### Event-sorcery framework
 
+- [ ] [#465 Add test utilities to event-sorcery (regression testing, schema version management)](https://github.com/ST0x-Technology/st0x.liquidity/issues/465)
+- [ ] [#467 Plan event-sorcery library extraction and backend agnosticism](https://github.com/ST0x-Technology/st0x.liquidity/issues/467)
+  - Move corresponding issues to new repo when extracted
+  - Make library agnostic to the `cqrs-es` backend
+- [ ] [#450 Persisted multi-entity Reactor in event-sorcery](https://github.com/ST0x-Technology/st0x.liquidity/issues/450)
+- [ ] [#451 Event replay for in-memory Reactors on startup](https://github.com/ST0x-Technology/st0x.liquidity/issues/451)
+
+### Trading improvements
+
+- [ ] [#413 Add 24/5 limit order support during market close](https://github.com/ST0x-Technology/st0x.liquidity/issues/413)
+- [ ] [#322 CLI should not depend on database](https://github.com/ST0x-Technology/st0x.liquidity/issues/322)
+
+### Admin dashboard
+
+#### Design & specification
+
+- [ ] [#470 Explore CLI/dashboard design for improved usability and consistency](https://github.com/ST0x-Technology/st0x.liquidity/issues/470)
+
+#### Core functionality
+
+- [ ] [#400 Dashboard: add Raindex vault links to inventory equity rows](https://github.com/ST0x-Technology/st0x.liquidity/issues/400)
+- [ ] [#401 Dashboard: distinguish enabled vs disabled assets with toggle](https://github.com/ST0x-Technology/st0x.liquidity/issues/401)
+- [ ] [#405 Dashboard: per-stage transfer balance visibility](https://github.com/ST0x-Technology/st0x.liquidity/issues/405)
+- [ ] [#406 Inventory updates require page refresh after rebalancing operations](https://github.com/ST0x-Technology/st0x.liquidity/issues/406)
+  - PR:
+    [#410 add poll_notify to trigger immediate inventory re-poll](https://github.com/ST0x-Technology/st0x.liquidity/pull/410)
+- [ ] [#233 Historical data display on dashboard](https://github.com/ST0x-Technology/st0x.liquidity/issues/233)
+
+#### Advanced features
+
+- [ ] [#472 Integrate Effect library into dashboard for improved UX](https://github.com/ST0x-Technology/st0x.liquidity/issues/472)
+- [ ] [#178 Dashboard: Performance Metrics Panel](https://github.com/ST0x-Technology/st0x.liquidity/issues/178)
+- [ ] [#180 Dashboard: Spreads Panel](https://github.com/ST0x-Technology/st0x.liquidity/issues/180)
+- [ ] [#183 Dashboard: Circuit Breaker](https://github.com/ST0x-Technology/st0x.liquidity/issues/183)
+- [ ] [#184 Dashboard: Schwab OAuth Integration](https://github.com/ST0x-Technology/st0x.liquidity/issues/184)
+- [ ] [#185 Dashboard: Grafana Embedding](https://github.com/ST0x-Technology/st0x.liquidity/issues/185)
+- [ ] [#186 Dashboard: HyperDX Health Status](https://github.com/ST0x-Technology/st0x.liquidity/issues/186)
+
+### Architecture & code quality
+
+Improve type system, naming consistency, mock configurations, and module
+extraction.
+
+#### Type system & domain modeling
+
+- [ ] [#473 Implement type-level newtype composition (Tagged qualifiers)](https://github.com/ST0x-Technology/st0x.liquidity/issues/473)
+- [ ] [#468 Create abstraction for converting between domain types and DTOs](https://github.com/ST0x-Technology/st0x.liquidity/issues/468)
+
+#### Naming & refactoring
+
+- [ ] [#464 Rename `*_cash` fields to `*_usdc` in InventorySnapshot and related types](https://github.com/ST0x-Technology/st0x.liquidity/issues/464)
+- [ ] [#466 Fix boolean blindness in `wrapper::mock` and other mock modules](https://github.com/ST0x-Technology/st0x.liquidity/issues/466)
+
+#### Build & dependencies
+
+- [ ] [#471 Remove submodule dependencies and provide ABIs via nix derivations](https://github.com/ST0x-Technology/st0x.liquidity/issues/471)
+- [ ] [#479 Verify CI clippy runs without redundant -D flags](https://github.com/ST0x-Technology/st0x.liquidity/issues/479)
+
+#### Monolith extraction
+
+Split monolith into focused crates for faster builds, stricter abstraction
+boundaries, and reduced coupling.
+
+- [ ] [#54 Create BrokerAuthProvider trait to abstract authentication across codebase](https://github.com/ST0x-Technology/st0x.liquidity/issues/54)
+- [ ] [#269 Extract st0x-tokenization crate with Tokenizer trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/269)
+- [ ] [#270 Extract st0x-vault crate with Vault trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/270)
+- [ ] [#271 Extract st0x-rebalance crate](https://github.com/ST0x-Technology/st0x.liquidity/issues/271)
+- [ ] [#272 Convert st0x-hedge to library crate and create st0x-server binary](https://github.com/ST0x-Technology/st0x.liquidity/issues/272)
+
+### Black-box e2e testing
+
+- [ ] [#455 Leaky tests](https://github.com/ST0x-Technology/st0x.liquidity/issues/455)
+  - PR:
+    [#487 fix flaky tests](https://github.com/ST0x-Technology/st0x.liquidity/pull/487)
 - [ ] [#416 E2e tests expose crate internals that should not be public](https://github.com/ST0x-Technology/st0x.liquidity/issues/416)
 - [ ] [#417 No chaos/fault injection testing for failure recovery](https://github.com/ST0x-Technology/st0x.liquidity/issues/417)
 - [ ] [#418 No invariant monitoring under randomized workloads](https://github.com/ST0x-Technology/st0x.liquidity/issues/418)
@@ -234,79 +491,28 @@ graph LR
 
 ---
 
-### Backlog: Testing
+## Completed
 
-- [x] [#292 Work Plan: E2E Test Infrastructure while liquidity bot stabilizes](https://github.com/ST0x-Technology/st0x.liquidity/issues/292)
-- [x] [#285 Integration test plan](https://github.com/ST0x-Technology/st0x.liquidity/issues/285)
-- [ ] [#264 Set up end-to-end testing infrastructure](https://github.com/ST0x-Technology/st0x.liquidity/issues/264)
-  - PR (open):
-    [#346 full e2e test suite](https://github.com/ST0x-Technology/st0x.liquidity/pull/346)
-  - PR (draft):
-    [#420 refactor e2e tests](https://github.com/ST0x-Technology/st0x.liquidity/pull/420)
+### Completed: Alpaca / trading fixes
 
-### Backlog: Infrastructure & Production Enhancements
-
-#### Infrastructure
-
-- [ ] [#296 Replace hand-rolled conductor with apalis + task-supervisor](https://github.com/ST0x-Technology/st0x.liquidity/issues/296)
-- [ ] [#293 Granular SSH access control: limit root access and per-user deploy keys](https://github.com/ST0x-Technology/st0x.liquidity/issues/293)
-- [ ] [#294 Document secret management setup and opsec](https://github.com/ST0x-Technology/st0x.liquidity/issues/294)
-- [ ] [#35 Document the bot](https://github.com/ST0x-Technology/st0x.liquidity/issues/35)
-- [ ] [#286 No TLS configured for dashboard and WebSocket traffic](https://github.com/ST0x-Technology/st0x.liquidity/issues/286)
-- [x] [#275 Optimise Fireblocks transfers](https://github.com/ST0x-Technology/st0x.liquidity/issues/275)
-  - Superseded: Fireblocks removed in
-    [#394](https://github.com/ST0x-Technology/st0x.liquidity/pull/394)
-- [ ] [#77 Set up Kafka](https://github.com/ST0x-Technology/st0x.liquidity/issues/77) -
-      Event streaming infrastructure
-- [ ] [#78 Integrate Kafka in bot](https://github.com/ST0x-Technology/st0x.liquidity/issues/78)
-
-#### Production Enhancements
-
-- [x] [#260 Add support for wrapping and unwrapping of the 1-to-1 share equivalent tokens into/from split/dividend compatibility vault](https://github.com/ST0x-Technology/st0x.liquidity/issues/260)
+- [x] [#105 Run the Alpaca instance without whole share accumulation](https://github.com/ST0x-Technology/st0x.liquidity/issues/105)
+  - Resolved by
+    [#236](https://github.com/ST0x-Technology/st0x.liquidity/pull/236)
+    (dollar-threshold counter trades)
+- [x] [#258 BUG: Alpaca Broker API should be expected with rebalancing enabled, not Alpaca Trading API](https://github.com/ST0x-Technology/st0x.liquidity/issues/258)
   - PR:
-    [#241 Wrapped Token Handling](https://github.com/ST0x-Technology/st0x.liquidity/pull/241)
-- [ ] [#36 Set up Git Hooks for formatting](https://github.com/ST0x-Technology/st0x.liquidity/issues/36) -
-      Automated formatting and linting checks
-
-#### Build Performance
-
-- [ ] [#57 Set up docker build caching in the deployment GitHub Action](https://github.com/ST0x-Technology/st0x.liquidity/issues/57) -
-      Optimize deployment pipeline performance
-- [ ] [#56 Optimize the Dockerfile to cache nix deps at build stage](https://github.com/ST0x-Technology/st0x.liquidity/issues/56) -
-      Cache nix dependencies for faster builds
-
-#### Reliability
-
-- [ ] [#33 Ensure all components have retries/restarts](https://github.com/ST0x-Technology/st0x.liquidity/issues/33) -
-      Component restart strategies
-
-#### Code Quality
-
-- [ ] [#54 Create BrokerAuthProvider trait to abstract authentication across codebase](https://github.com/ST0x-Technology/st0x.liquidity/issues/54) -
-      Authentication abstraction
-- [x] [#247 Financial calculations use f64 instead of fixed-precision types](https://github.com/ST0x-Technology/st0x.liquidity/issues/247)
+    [#257 Fix rebalancing not triggered](https://github.com/ST0x-Technology/st0x.liquidity/pull/257)
+- [x] [#282 USDC inventory not updated from Position events (Buy/Sell trades)](https://github.com/ST0x-Technology/st0x.liquidity/issues/282)
   - PR:
-    [#273 Remove legacy persistence layer](https://github.com/ST0x-Technology/st0x.liquidity/pull/273)
-
-#### Data Quality
-
-- [ ] [#73 Stop storing onchain events unrelated to the arbitrageur](https://github.com/ST0x-Technology/st0x.liquidity/issues/73) -
-      Filter unnecessary event storage
-- [ ] [#240 Conversion slippage not tracked, causing inventory drift](https://github.com/ST0x-Technology/st0x.liquidity/issues/240)
-- [ ] [#254 Track transfers with unique IDs for accurate inventory reconciliation](https://github.com/ST0x-Technology/st0x.liquidity/issues/254)
-
-#### Edge Cases
-
-- [ ] [#16 Handle reorgs](https://github.com/ST0x-Technology/st0x.liquidity/issues/16) -
-      Handle blockchain reorganizations safely
-
-### Completed: CI/CD Improvements
-
-- [x] [#256 Implement CI/CD improvements from infra deployment spec](https://github.com/ST0x-Technology/st0x.liquidity/issues/256)
+    [#336 Track USDC inventory updates alongside equity fills](https://github.com/ST0x-Technology/st0x.liquidity/pull/336)
+- [x] [#283 USDC rebalancing trigger doesn't fire after USDC inventory changes](https://github.com/ST0x-Technology/st0x.liquidity/issues/283)
   - PR:
-    [#259 Terraform infra provisioning and Nix-powered secret management and service deployments](https://github.com/ST0x-Technology/st0x.liquidity/pull/259)
+    [#348 Add USDC rebalancing trigger](https://github.com/ST0x-Technology/st0x.liquidity/pull/348)
+- [x] [#284 Equity mint completion trusts Alpaca API without onchain verification](https://github.com/ST0x-Technology/st0x.liquidity/issues/284)
+  - PR:
+    [#350 Verify equity mints on-chain](https://github.com/ST0x-Technology/st0x.liquidity/pull/350)
 
-### Completed: Production Fixes (Jan 2026)
+### Completed: Production fixes (Jan 2026)
 
 - [x] [#251 Manual operations on trading venues not detected by inventory tracking](https://github.com/ST0x-Technology/st0x.liquidity/issues/251)
   - PR:
@@ -317,7 +523,13 @@ graph LR
 - PR:
   [#266 Fix cqrs inventory management](https://github.com/ST0x-Technology/st0x.liquidity/pull/266)
 
-### Completed: Alpaca Production Go-Live
+### Completed: CI/CD improvements
+
+- [x] [#256 Implement CI/CD improvements from infra deployment spec](https://github.com/ST0x-Technology/st0x.liquidity/issues/256)
+  - PR:
+    [#259 Terraform infra provisioning and Nix-powered secret management and service deployments](https://github.com/ST0x-Technology/st0x.liquidity/pull/259)
+
+### Completed: Alpaca production go-live
 
 - [x] [#223 Auto-rebalancing flow missing USDC/USD conversion step](https://github.com/ST0x-Technology/st0x.liquidity/issues/223)
   - PR:
@@ -335,28 +547,13 @@ graph LR
   - PR:
     [#225 refactor Alpaca services with Broker API client support](https://github.com/ST0x-Technology/st0x.liquidity/pull/225)
 
-### Completed: Admin Dashboard Foundation
+### Completed: CQRS/ES migration with automated rebalancing
 
-- [x] [#188 spec out the dashboard](https://github.com/ST0x-Technology/st0x.liquidity/issues/188)
-  - PR:
-    [#203 Admin Dashboard specification and roadmap](https://github.com/ST0x-Technology/st0x.liquidity/pull/203)
-- [x] [#207 Initialize WS backend for the dashboard](https://github.com/ST0x-Technology/st0x.liquidity/issues/207)
-  - PR:
-    [#204 Add dashboard backend API](https://github.com/ST0x-Technology/st0x.liquidity/pull/204)
-- [x] [#208 Initialize Svelte frontend with shadcn](https://github.com/ST0x-Technology/st0x.liquidity/issues/208)
-  - PR:
-    [#221 init dashboard frontend with SvelteKit and shadcn-svelte](https://github.com/ST0x-Technology/st0x.liquidity/pull/221)
-- [x] [#209 Add dashboard skeleton and live event tracking](https://github.com/ST0x-Technology/st0x.liquidity/issues/209)
-  - PR:
-    [#206 Add dashboard skeleton and live event tracking](https://github.com/ST0x-Technology/st0x.liquidity/pull/206)
+Migrated to event-sourced architecture and implemented automated rebalancing as
+the first major feature on the new architecture (Alpaca-only, Schwab remains
+manual).
 
-### Completed: CQRS/ES Migration with Automated Rebalancing
-
-Migrated to event-sourced architecture through 3 phases. Automated rebalancing
-implemented as first major feature on new architecture (Alpaca-only, Schwab
-remains manual).
-
-#### Phase 1: Dual-Write Foundation (Shadow Mode)
+#### Dual-write foundation (shadow mode)
 
 - [x] [#124 Add CQRS/ES migration specification to SPEC.md](https://github.com/ST0x-Technology/st0x.liquidity/issues/124)
   - PR:
@@ -383,7 +580,7 @@ remains manual).
   - PR:
     [#168 Lifecycle wrapper for event-sourced aggregates](https://github.com/ST0x-Technology/st0x.liquidity/pull/168)
 
-#### Phase 2: Automated Rebalancing (Alpaca-Only)
+#### Automated rebalancing (Alpaca-only)
 
 - [x] [#132 Implement Alpaca crypto wallet service](https://github.com/ST0x-Technology/st0x.liquidity/issues/132)
   - PR:
@@ -419,7 +616,7 @@ remains manual).
   - PR:
     [#190 manual rebalancing CLI](https://github.com/ST0x-Technology/st0x.liquidity/pull/190)
 
-### Completed: Multi-Crate Architecture Phase 1
+### Completed: Multi-crate architecture
 
 - [x] [#199 Proposal: multi-crate architecture for faster builds and stricter boundaries](https://github.com/ST0x-Technology/st0x.liquidity/issues/199)
   - PR:
@@ -427,8 +624,26 @@ remains manual).
 - [x] [#194 Multi-crate architecture: prerequisite refactors](https://github.com/ST0x-Technology/st0x.liquidity/issues/194)
   - PR:
     [#222 decouple VaultService from Evm, remove signer type parameter](https://github.com/ST0x-Technology/st0x.liquidity/pull/222)
+- [x] [#268 Extract st0x-bridge crate with Bridge trait](https://github.com/ST0x-Technology/st0x.liquidity/issues/268)
+  - PR:
+    [#193 Pull out bridging logic into st0x-bridge](https://github.com/ST0x-Technology/st0x.liquidity/pull/193)
 
-### Completed: Bug Fixes
+### Completed: Admin dashboard foundation
+
+- [x] [#188 spec out the dashboard](https://github.com/ST0x-Technology/st0x.liquidity/issues/188)
+  - PR:
+    [#203 Admin Dashboard specification and roadmap](https://github.com/ST0x-Technology/st0x.liquidity/pull/203)
+- [x] [#207 Initialize WS backend for the dashboard](https://github.com/ST0x-Technology/st0x.liquidity/issues/207)
+  - PR:
+    [#204 Add dashboard backend API](https://github.com/ST0x-Technology/st0x.liquidity/pull/204)
+- [x] [#208 Initialize Svelte frontend with shadcn](https://github.com/ST0x-Technology/st0x.liquidity/issues/208)
+  - PR:
+    [#221 init dashboard frontend with SvelteKit and shadcn-svelte](https://github.com/ST0x-Technology/st0x.liquidity/pull/221)
+- [x] [#209 Add dashboard skeleton and live event tracking](https://github.com/ST0x-Technology/st0x.liquidity/issues/209)
+  - PR:
+    [#206 Add dashboard skeleton and live event tracking](https://github.com/ST0x-Technology/st0x.liquidity/pull/206)
+
+### Completed: Bug fixes
 
 - [x] [#261 Fix inventory tracking post-upgrade bugs](https://github.com/ST0x-Technology/st0x.liquidity/issues/261)
   - PR:
@@ -476,7 +691,7 @@ remains manual).
   - PR:
     [#118 Fix: Clean up stale PENDING executions to prevent infinite retry loops](https://github.com/ST0x-Technology/st0x.liquidity/pull/118)
 
-### Completed: Multi-Broker Support
+### Completed: Multi-broker support
 
 - [x] [#60 Create a complete abstraction for Broker](https://github.com/ST0x-Technology/st0x.liquidity/issues/60)
   - PR:
@@ -488,7 +703,7 @@ remains manual).
   - PR:
     [#191 Trading via Alpaca Broker API](https://github.com/ST0x-Technology/st0x.liquidity/pull/191)
 
-### Completed: Performance Monitoring & Profitability Analysis
+### Completed: Performance monitoring & profitability analysis
 
 - [x] [#91 Track onchain Pyth prices](https://github.com/ST0x-Technology/st0x.liquidity/issues/91)
   - PR:
@@ -515,7 +730,7 @@ remains manual).
   - PR:
     [#98 Fix/tokencryption](https://github.com/ST0x-Technology/st0x.liquidity/pull/98)
 
-### Completed: Deployment & Infrastructure
+### Completed: Deployment & infrastructure
 
 - [x] [#11 Set up automated deployment](https://github.com/ST0x-Technology/st0x.liquidity/issues/11)
   - PR: [#39 CD](https://github.com/ST0x-Technology/st0x.liquidity/pull/39)
@@ -529,7 +744,7 @@ remains manual).
   - PR:
     [#111 fix logging and db env vars](https://github.com/ST0x-Technology/st0x.liquidity/pull/111)
 
-### Completed: Code Quality & Documentation
+### Completed: Code quality & documentation
 
 - [x] [#50 Centralize suffix handling logic](https://github.com/ST0x-Technology/st0x.liquidity/issues/50)
 - [x] [#68 Refactor visibility levels to improve dead code identification](https://github.com/ST0x-Technology/st0x.liquidity/issues/68)
@@ -545,7 +760,7 @@ remains manual).
   - PR:
     [#103 broker crate docs and AGENTS.md downsize to fix Claude Code warning](https://github.com/ST0x-Technology/st0x.liquidity/pull/103)
 
-### Completed: MVP Core Functionality
+### Completed: MVP core functionality
 
 The core arbitrage bot functionality is now live and operational:
 
@@ -575,3 +790,52 @@ The core arbitrage bot functionality is now live and operational:
 ### [SPEC.md](https://github.com/ST0x-Technology/st0x.liquidity/blob/master/SPEC.md)
 
 See the specification for detailed system behavior documentation.
+
+<!-- Reference link definitions for the "Go to prod" epic -->
+
+[#16]: https://github.com/ST0x-Technology/st0x.liquidity/issues/16
+[#181]: https://github.com/ST0x-Technology/st0x.liquidity/issues/181
+[#296]: https://github.com/ST0x-Technology/st0x.liquidity/issues/296
+[#354]: https://github.com/ST0x-Technology/st0x.liquidity/issues/354
+[#376]: https://github.com/ST0x-Technology/st0x.liquidity/issues/376
+[#377]: https://github.com/ST0x-Technology/st0x.liquidity/issues/377
+[#378]: https://github.com/ST0x-Technology/st0x.liquidity/issues/378
+[#380]: https://github.com/ST0x-Technology/st0x.liquidity/issues/380
+[#407]: https://github.com/ST0x-Technology/st0x.liquidity/issues/407
+[#421]: https://github.com/ST0x-Technology/st0x.liquidity/issues/421
+[#422]: https://github.com/ST0x-Technology/st0x.liquidity/issues/422
+[#423]: https://github.com/ST0x-Technology/st0x.liquidity/issues/423
+[#424]: https://github.com/ST0x-Technology/st0x.liquidity/issues/424
+[#425]: https://github.com/ST0x-Technology/st0x.liquidity/issues/425
+[#427]: https://github.com/ST0x-Technology/st0x.liquidity/issues/427
+[#428]: https://github.com/ST0x-Technology/st0x.liquidity/issues/428
+[#429]: https://github.com/ST0x-Technology/st0x.liquidity/issues/429
+[#430]: https://github.com/ST0x-Technology/st0x.liquidity/issues/430
+[#431]: https://github.com/ST0x-Technology/st0x.liquidity/issues/431
+[#432]: https://github.com/ST0x-Technology/st0x.liquidity/issues/432
+[#433]: https://github.com/ST0x-Technology/st0x.liquidity/issues/433
+[#434]: https://github.com/ST0x-Technology/st0x.liquidity/issues/434
+[#435]: https://github.com/ST0x-Technology/st0x.liquidity/issues/435
+[#436]: https://github.com/ST0x-Technology/st0x.liquidity/issues/436
+[#437]: https://github.com/ST0x-Technology/st0x.liquidity/issues/437
+[#438]: https://github.com/ST0x-Technology/st0x.liquidity/issues/438
+[#439]: https://github.com/ST0x-Technology/st0x.liquidity/issues/439
+[#440]: https://github.com/ST0x-Technology/st0x.liquidity/issues/440
+[#441]: https://github.com/ST0x-Technology/st0x.liquidity/issues/441
+[#442]: https://github.com/ST0x-Technology/st0x.liquidity/issues/442
+[#443]: https://github.com/ST0x-Technology/st0x.liquidity/issues/443
+[#444]: https://github.com/ST0x-Technology/st0x.liquidity/issues/444
+[#445]: https://github.com/ST0x-Technology/st0x.liquidity/issues/445
+[#446]: https://github.com/ST0x-Technology/st0x.liquidity/issues/446
+[#447]: https://github.com/ST0x-Technology/st0x.liquidity/issues/447
+[#449]: https://github.com/ST0x-Technology/st0x.liquidity/issues/449
+[#452]: https://github.com/ST0x-Technology/st0x.liquidity/issues/452
+[#453]: https://github.com/ST0x-Technology/st0x.liquidity/issues/453
+[#492]: https://github.com/ST0x-Technology/st0x.liquidity/pull/492
+[#461]: https://github.com/ST0x-Technology/st0x.liquidity/pull/461
+[#481]: https://github.com/ST0x-Technology/st0x.liquidity/pull/481
+[#482]: https://github.com/ST0x-Technology/st0x.liquidity/pull/482
+[#483]: https://github.com/ST0x-Technology/st0x.liquidity/pull/483
+[#484]: https://github.com/ST0x-Technology/st0x.liquidity/pull/484
+[#485]: https://github.com/ST0x-Technology/st0x.liquidity/pull/485
+[#491]: https://github.com/ST0x-Technology/st0x.liquidity/issues/491

--- a/SPEC.md
+++ b/SPEC.md
@@ -1880,6 +1880,18 @@ checking per-symbol equity ratios and global USDC ratio against configured
 thresholds. When deviation exceeds the threshold and minimum amounts are met, it
 emits imbalance detection events.
 
+**Imbalance ratio formula**:
+
+```
+ratio = onchain / (onchain + offchain + inflight_locations)
+```
+
+Where `inflight_locations` is the sum of all in-flight location balances for
+that asset type. In-flight balances dilute the ratio, preventing false triggers
+when capital is in transit between venues. Imbalance detection is still
+suppressed entirely when transfer-inflight operations exist (system-initiated
+transfers in progress).
+
 **Rebalancing Parameters** (configurable per environment):
 
 - **Equity per symbol**:
@@ -1970,6 +1982,35 @@ know about cross-venue inventory.
   from broker
 - `InventorySnapshotEvent::OffchainCash` - Offchain cash balance fetched from
   broker
+- `InventorySnapshotEvent::EthereumCash` - USDC balance at Ethereum wallet
+  (in-flight location)
+- `InventorySnapshotEvent::BaseWalletCash` - USDC balance at Base wallet
+  (in-flight location)
+
+##### In-Flight Location Tracking
+
+Capital can sit at intermediate locations between the two primary venues
+(Raindex onchain, brokerage offchain). These balances are polled by the
+InventoryPollingService and tracked separately from venue balances.
+
+**In-flight cash locations** (USDC between venues):
+
+- Ethereum wallet - USDC on Ethereum mainnet during cross-chain bridging
+- Base wallet - USDC in the wallet on Base (not yet deposited into Raindex
+  vault)
+- Alpaca crypto wallet - USDC in Alpaca's crypto wallet (pending conversion)
+
+**In-flight equity locations** (tokens between venues):
+
+- Base unwrapped - Unwrapped equity tokens on Base (not yet wrapped or
+  deposited)
+- Base wrapped - Wrapped equity tokens on Base (not yet deposited into Raindex)
+
+In-flight location balances are observed reality from polling. They are distinct
+from the existing transfer-inflight bookkeeping (`VenueBalance.inflight`), which
+tracks system-initiated transfers. Both can coexist: transfer-inflight
+suppresses imbalance detection entirely, while location balances affect the
+imbalance ratio denominator.
 
 ##### Separation of concerns
 
@@ -2015,15 +2056,23 @@ Each asset type (equities per symbol, USDC) is tracked via a generic
 distinguishes "not yet polled" from "polled with zero balance" — imbalance
 detection requires both venues to have been initialized by snapshot events.
 
+In addition to venue balances, `InventoryView` tracks balances at in-flight
+locations — intermediate points where assets sit during cross-venue transfers
+(e.g., Ethereum wallet, Base wallet). These are stored separately from venue
+balances and included in the imbalance ratio denominator to prevent false
+triggers when capital is in transit.
+
 `InventoryView` listens to trading events (onchain/offchain fills),
 `TokenizedEquityMintEvent`, `EquityRedemptionEvent`, `UsdcRebalanceEvent`, and
 `InventorySnapshotEvent` to maintain venue balances. Inflight tracking ensures
 assets in transit (minting, redeeming, bridging) are accounted for.
 
 Imbalance detection compares each asset's onchain ratio against a configurable
-`ImbalanceThreshold` (target ratio + deviation). Rebalancing is only triggered
-when no inflight operations exist for the asset. Trigger events are emitted to
-`Rebalancer` for execution.
+`ImbalanceThreshold` (target ratio + deviation). The ratio denominator includes
+in-flight location balances so that capital in transit dilutes the ratio rather
+than being invisible. Rebalancing is only triggered when no transfer-inflight
+operations exist for the asset. Trigger events are emitted to `Rebalancer` for
+execution.
 
 #### Failure Handling and Reconciliation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1873,6 +1873,67 @@ The system tracks two separate inventory categories:
    - Offchain: USDC in Alpaca account
    - Single global ratio (not per-symbol)
 
+##### Asset Location Topology
+
+Assets flow between locations during trading, minting, redemption, and USDC
+rebalancing. The system tracks balances at each location to maintain accurate
+inventory accounting.
+
+```mermaid
+graph LR
+    subgraph Alpaca
+        USD[USD]
+        USDC_USD[USDC/USD]
+        SPYM_pos[SPYM position]
+        STOCK_pos[STOCK position]
+    end
+
+    subgraph Ethereum
+        ETH_USDC[USDC balance]
+        ETH_CCTP[CCTP bridge]
+    end
+
+    subgraph Base["Base (wallet)"]
+        BASE_USDC[USDC balance]
+        BASE_tSPYM[tSPYM]
+        BASE_tSTOCK[tSTOCK]
+        BASE_wtSPYM[wtSPYM]
+        BASE_wtSTOCK[wtSTOCK]
+        BASE_CCTP[CCTP bridge]
+    end
+
+    subgraph Raindex["Base (Raindex vaults)"]
+        VAULT_USDC[USDC]
+        VAULT_wtSPYM[wtSPYM]
+        VAULT_wtSTOCK[wtSTOCK]
+    end
+
+    USDC_USD <-->|conversion| ETH_USDC
+    ETH_USDC <-->|CCTP bridge| ETH_CCTP
+    ETH_CCTP <-->|attestation| BASE_CCTP
+    BASE_CCTP <-->|CCTP bridge| BASE_USDC
+    BASE_USDC <-->|deposit/withdraw| VAULT_USDC
+
+    BASE_tSPYM <-->|wrap/unwrap| BASE_wtSPYM
+    BASE_tSTOCK <-->|wrap/unwrap| BASE_wtSTOCK
+    BASE_wtSPYM <-->|deposit/withdraw| VAULT_wtSPYM
+    BASE_wtSTOCK <-->|deposit/withdraw| VAULT_wtSTOCK
+```
+
+**Primary venues** (where inventory is actively used):
+
+- **Raindex vaults** (onchain): USDC and wrapped equity tokens (wtSPYM, wtSTOCK)
+  used for market making
+- **Alpaca** (offchain): USD cash and equity positions (SPYM, STOCK) used for
+  hedging
+
+**In-flight locations** (intermediate points during transfers):
+
+- **Ethereum wallet**: USDC in transit during CCTP bridging
+- **Base wallet**: USDC, unwrapped tokens (tSPYM), or wrapped tokens (wtSPYM)
+  not yet deposited into Raindex vaults
+- **Alpaca crypto wallet**: USDC pending conversion to/from USD
+
 ##### Imbalance Detection
 
 InventoryView calculates imbalances after each position or rebalancing event by

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,122 @@
+# Workflow
+
+This procedure governs all changes to the system — bug fixes and new features
+alike. Every change is either correcting behavior we thought was right (bug fix)
+or providing behavior we didn't have before (new feature). In both cases, the
+process is the same: demonstrate that the system doesn't exhibit the desired
+behavior, then make it so.
+
+## Why this process exists
+
+Without a failing test asserting correct behavior, there is no evidence that a
+change is needed. Without evidence that a change is needed, there is no way to
+tell whether the changes being made actually contribute to achieving the desired
+behavior. This is the scientific method applied to software: state a hypothesis
+("the system should do X"), run an experiment (the test), and observe whether
+the hypothesis holds. Only when the hypothesis is rejected (test fails) do we
+have justification to change the system.
+
+A failing test that asserts correct behavior proves one of two things: either
+the system has a bug, or the system lacks logic that should exist. A passing
+test that asserts correct behavior proves the system already behaves as expected
+— no change is justified for that behavior.
+
+Tests must always assert correct behavior and nothing else. A test that asserts
+wrong behavior tells us nothing about the system. Even following this process
+mechanically without understanding the reasoning leads to mistakes like thinking
+"asserting wrong behavior" achieves the purpose of writing failing tests first.
+It does not — it just produces noise that validates nothing.
+
+## Starting level
+
+- **New feature**: Start with the spec. Define the desired behavior in SPEC.md
+  first. Then write an e2e test asserting that the system exhibits the specified
+  behavior. This fails, proving the system doesn't yet do what the spec says it
+  should.
+- **Production bug**: Start with an e2e test reproducing the exact failure path
+  observed in production, asserting the correct behavior the system should have
+  exhibited. This fails, confirming the bug exists.
+- **Bug identified at unit or integration level that doesn't (yet) produce
+  incorrect system-level behavior**: Start at the level where the incorrect
+  behavior exists. Write a failing integration or unit test reproducing the
+  issue, then drill down to the root cause and build back up with logic changes.
+
+## The process
+
+### Reproduce with a failing test
+
+Write a test at the appropriate starting level (see above) that asserts the
+correct behavior the system should exhibit. This test must fail with the current
+code. If it passes, the system already behaves correctly and no change is
+justified — either the test doesn't reproduce the issue or the issue doesn't
+exist. This failing test is the top-level hypothesis: "the system should behave
+this way, but it doesn't."
+
+Sometimes an existing test already has the scenario you need but doesn't assert
+enough, or needs a few extra steps at the beginning or end to cover the case. In
+that situation, extend the existing test rather than writing a new one from
+scratch. However, only extend if the scenario remains the same — if you need a
+different scenario, add a new test case. Modifying an existing test's scenario
+risks reducing coverage surface and introducing regressions.
+
+### Identify the source of incorrect behavior
+
+Analyze why the test fails. The root cause will be at one of two levels:
+
+- **Unit level**: A component has incorrect logic, or a component that should
+  exist doesn't.
+- **Integration level**: Individual components work correctly in isolation, but
+  they aren't connected properly.
+
+### Unit-level fix (when root cause is at the unit level)
+
+Define any new types, traits, and function signatures needed. Use `todo!()` for
+bodies. `cargo check` must pass. No behavioral logic yet.
+
+Write unit tests for the component in question, asserting what it should do.
+These fail because the logic doesn't exist yet (new unit) or is buggy (existing
+unit). Each failing test is a hypothesis: "this unit should behave this way." As
+above, extend existing tests if they already have the right scenario but lack
+sufficient assertions.
+
+Implement the unit logic. Fill in the `todo!()` stubs or fix the buggy logic.
+Unit tests now pass, confirming the hypothesis. The top-level test still fails
+because the unit isn't integrated into the system yet.
+
+### Integration-level fix (when root cause is at the integration level)
+
+If individual components already work correctly but aren't connected, there are
+no unit-level hypotheses to validate — skip straight to integration.
+
+Adjust signatures, add parameters, update wiring types. Use `todo!()` for new
+wiring logic. `cargo check` must pass.
+
+Write integration tests that verify the components are connected properly,
+asserting the correct integrated behavior. These fail because the wiring doesn't
+exist yet.
+
+Wire the components together. Fill in the integration logic. Integration tests
+now pass, and the top-level test should pass too.
+
+### Iterate if needed
+
+Sometimes the top-level test still fails after fixing one slice. This means
+another unit or integration is also contributing to the incorrect behavior.
+Apply the same approach: hypothesize which unit or integration is the next
+culprit or missing piece, write a failing test asserting correct behavior to
+validate that hypothesis, then fix it. Only make changes after rejecting the
+null hypothesis ("this component is NOT the problem / missing piece").
+
+### Cleanup
+
+**Correct ordering:** SPEC.md describes the desired behavior and must be updated
+_before_ implementation begins — not after. The sequence is:
+
+1. **Update SPEC.md first** with any new or changed behavior
+2. **Implement** the changes following the process above (failing tests, then
+   logic)
+3. **Run the top-level test** to confirm the system exhibits the specified
+   behavior, then run the **full test suite** to ensure nothing else broke
+4. **Refine and clean up**: refactor, fix clippy warnings, improve code quality.
+   Re-validate SPEC.md — refine any details that became clearer during
+   implementation. Update ROADMAP.md and AGENTS.md to reflect what changed

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -11,6 +11,26 @@ use super::venue_balance::{InventoryError, VenueBalance};
 use crate::threshold::Usdc;
 use crate::wrapper::{RatioError, UnderlyingPerWrapped};
 
+/// Locations where cash (USDC) can sit between primary venues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum InFlightCashLocation {
+    /// USDC on Ethereum mainnet during cross-chain bridging.
+    Ethereum,
+    /// USDC in the wallet on Base (not yet deposited into Raindex vault).
+    BaseWallet,
+    /// USDC in Alpaca's crypto wallet (pending conversion to USD).
+    AlpacaCryptoWallet,
+}
+
+/// Locations where equity tokens can sit between primary venues.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum InFlightEquityLocation {
+    /// Unwrapped equity tokens on Base (not yet wrapped or deposited).
+    BaseUnwrapped,
+    /// Wrapped equity tokens on Base (not yet deposited into Raindex).
+    BaseWrapped,
+}
+
 /// Error type for inventory view operations.
 #[derive(Debug, Clone, thiserror::Error)]
 pub(crate) enum InventoryViewError {
@@ -493,6 +513,10 @@ where
 pub(crate) struct InventoryView {
     usdc: Inventory<Usdc>,
     equities: HashMap<Symbol, Inventory<FractionalShares>>,
+    #[serde(default)]
+    inflight_cash: HashMap<InFlightCashLocation, Usdc>,
+    #[serde(default)]
+    inflight_equity: HashMap<(Symbol, InFlightEquityLocation), FractionalShares>,
     last_updated: DateTime<Utc>,
 }
 
@@ -541,12 +565,72 @@ impl Default for InventoryView {
         Self {
             usdc: Inventory::default(),
             equities: HashMap::new(),
+            inflight_cash: HashMap::new(),
+            inflight_equity: HashMap::new(),
             last_updated: Utc::now(),
         }
     }
 }
 
 impl InventoryView {
+    /// Updates the balance at an in-flight cash location.
+    pub(crate) fn update_inflight_cash(
+        self,
+        location: InFlightCashLocation,
+        balance: Usdc,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let mut inflight_cash = self.inflight_cash;
+        inflight_cash.insert(location, balance);
+
+        Self {
+            inflight_cash,
+            last_updated: now,
+            ..self
+        }
+    }
+
+    /// Updates the balance at an in-flight equity location.
+    pub(crate) fn update_inflight_equity(
+        self,
+        symbol: Symbol,
+        location: InFlightEquityLocation,
+        balance: FractionalShares,
+        now: DateTime<Utc>,
+    ) -> Self {
+        let mut inflight_equity = self.inflight_equity;
+        inflight_equity.insert((symbol, location), balance);
+
+        Self {
+            inflight_equity,
+            last_updated: now,
+            ..self
+        }
+    }
+
+    /// Returns the total in-flight cash across all locations.
+    pub(crate) fn total_inflight_cash(&self) -> Usdc {
+        self.inflight_cash
+            .values()
+            .copied()
+            .fold(Usdc(Decimal::ZERO), |acc, usdc| {
+                // In-flight balances are polled reality — addition cannot
+                // overflow in any realistic scenario.
+                (acc + usdc).unwrap_or(acc)
+            })
+    }
+
+    /// Returns the total in-flight equity for a symbol across all locations.
+    pub(crate) fn total_inflight_equity_for_symbol(&self, symbol: &Symbol) -> FractionalShares {
+        self.inflight_equity
+            .iter()
+            .filter(|((sym, _), _)| sym == symbol)
+            .map(|(_, balance)| *balance)
+            .fold(FractionalShares::ZERO, |acc, shares| {
+                (acc + shares).unwrap_or(acc)
+            })
+    }
+
     /// Registers a symbol with specified available balances (zero inflight).
     #[cfg(test)]
     pub(crate) fn with_equity(
@@ -610,7 +694,7 @@ impl InventoryView {
         Ok(Self {
             equities,
             last_updated: now,
-            usdc: self.usdc,
+            ..self
         })
     }
 
@@ -624,7 +708,7 @@ impl InventoryView {
         Ok(Self {
             usdc: updated,
             last_updated: now,
-            equities: self.equities,
+            ..self
         })
     }
 }
@@ -873,6 +957,8 @@ mod tests {
         InventoryView {
             usdc: usdc_make_inventory(1000, 0, 1000, 0),
             equities: equities.into_iter().collect(),
+            inflight_cash: HashMap::new(),
+            inflight_equity: HashMap::new(),
             last_updated: Utc::now(),
         }
     }
@@ -891,6 +977,8 @@ mod tests {
                 offchain_inflight,
             ),
             equities: HashMap::new(),
+            inflight_cash: HashMap::new(),
+            inflight_equity: HashMap::new(),
             last_updated: Utc::now(),
         }
     }

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -1141,6 +1141,27 @@ pub(crate) async fn assert_base_wallet_cash_event_exists(
     Ok(())
 }
 
+/// Asserts that no USDC rebalancing events were emitted.
+pub(crate) async fn assert_no_usdc_rebalancing_events(
+    db_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let pool = connect_db(db_path).await?;
+    let events = fetch_events_by_type(&pool, "UsdcRebalance").await?;
+
+    assert!(
+        events.is_empty(),
+        "Expected no UsdcRebalance events, but found {}: {:?}",
+        events.len(),
+        events
+            .iter()
+            .map(|event| &event.event_type)
+            .collect::<Vec<_>>(),
+    );
+
+    pool.close().await;
+    Ok(())
+}
+
 #[bon::builder]
 pub(crate) async fn assert_usdc_rebalancing_flow<P: Provider>(
     expected_positions: &[ExpectedPosition],

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -734,6 +734,75 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// In-flight USDC at the Ethereum wallet should dilute the imbalance ratio,
+/// preventing a false BaseToAlpaca trigger.
+///
+/// Without in-flight tracking: ratio = 800k / (800k + 100k) = 0.889 > 0.6
+/// → triggers BaseToAlpaca. With in-flight tracking: ratio = 800k /
+/// (800k + 100k + 1M) = 0.421, within [0.4, 0.6] → no trigger.
+///
+/// The CctpInfra pre-funds the bot's Ethereum wallet with 1M USDC. The
+/// Raindex vault is pre-funded with 800k USDC. The broker mock starts with
+/// 100k offchain cash. With in-flight tracking correctly diluting the
+/// denominator, the system should NOT trigger USDC rebalancing.
+///
+/// Currently fails because InventoryView ignores EthereumCash events,
+/// computing ratio = 0.889 and triggering BaseToAlpaca.
+#[test_log::test(tokio::test)]
+async fn inflight_usdc_prevents_false_rebalancing_trigger() -> anyhow::Result<()> {
+    let broker_fill_price = dec!(150.00);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let cctp = CctpInfra::start(&infra).await?;
+
+    // 800k onchain USDC: without in-flight tracking, ratio = 800/900 = 0.889
+    // triggers BaseToAlpaca. With 1M Ethereum in-flight, ratio = 800/1900 = 0.421.
+    let usdc_amount: U256 = parse_units("800000", 6)?.into();
+    let usdc_vault_id = infra.base_chain.create_usdc_vault(usdc_amount).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_usdc_rebalancing_ctx()
+        .base_chain(&infra.base_chain)
+        .ethereum_endpoint(&cctp.ethereum_endpoint)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .usdc_vault_id(usdc_vault_id)
+        .cctp(cctp.cctp_overrides())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    // Wait for at least 2 polling cycles (interval = 15s) to ensure
+    // inventory snapshots are processed. Poll for EthereumCash events
+    // to confirm the Ethereum wallet poller ran.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "InventorySnapshotEvent::EthereumCash",
+        2,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    // Also wait for venue snapshots to ensure the trigger had a chance to fire.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "InventorySnapshotEvent::OnchainCash",
+        2,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    // With in-flight USDC correctly tracked, the ratio should be within
+    // bounds and no USDC rebalancing should trigger.
+    assert_no_usdc_rebalancing_events(&infra.db_path).await?;
+
+    bot.abort();
+    Ok(())
+}
+
 /// USDC rebalancing from Base (onchain) to Alpaca (offchain).
 ///
 /// SellEquity trades cause the bot to receive USDC onchain (from selling


### PR DESCRIPTION
## Motivation

Closes [RAI-142](https://linear.app/makeitrain/issue/RAI-142/track-usdc-transfer-in-flight-balances-in-inventory-view)
Relates to [#433](https://github.com/ST0x-Technology/st0x.liquidity/issues/433)

The `InventoryPollingService` polls 6+ locations but `InventoryView` only processes 4. In-flight location events (`EthereumCash`, `BaseWalletCash`) are explicitly ignored in the rebalancing trigger:

```rust
EthereumCash { .. } | BaseWalletCash { .. } => Ok(inventory.clone()),
```

Capital at intermediate locations (Ethereum wallet during CCTP bridging, Base wallet before Raindex deposit, Alpaca crypto wallet during conversion) is invisible to imbalance detection. This causes false rebalancing triggers — e.g., 800k onchain + 100k offchain gives ratio 0.889, triggering BaseToAlpaca, when in reality 1M USDC sitting on Ethereum should dilute the ratio to 0.421 (within threshold).

## Solution

This PR lays the foundation for in-flight inventory tracking:

**Spec updates (SPEC.md):**
- Documents the asset location topology (mermaid diagram showing all venues and in-flight locations)
- Defines the updated imbalance ratio formula: `ratio = onchain / (onchain + offchain + inflight_locations)`
- Specifies in-flight cash locations (Ethereum, Base wallet, Alpaca crypto wallet) and equity locations (Base unwrapped, Base wrapped)
- Clarifies the distinction between transfer-inflight bookkeeping (suppresses detection) and location balances (dilute ratio)

**Data model (src/inventory/view.rs):**
- `InFlightCashLocation` enum — Ethereum, BaseWallet, AlpacaCryptoWallet
- `InFlightEquityLocation` enum — BaseUnwrapped, BaseWrapped
- New fields on `InventoryView`: `inflight_cash` and `inflight_equity` HashMaps
- Methods: `update_inflight_cash()`, `update_inflight_equity()`, `total_inflight_cash()`, `total_inflight_equity_for_symbol()`

**Failing e2e test (tests/e2e/rebalancing/):**
- `inflight_usdc_prevents_false_rebalancing_trigger` — sets up 800k onchain + 100k offchain + 1M Ethereum in-flight USDC, asserts no rebalancing triggers
- `assert_no_usdc_rebalancing_events()` assertion helper
- Currently fails because `InventoryView` ignores `EthereumCash` events

**Planning & process docs:**
- `PLAN.md` — step-by-step implementation plan for #433
- `docs/workflow.md` — documents the TDD-first development process
- `ROADMAP.md` — restructured around the "go to prod with auto-rebalancing" goal with dependency graphs

**Not yet wired:** The trigger integration (making `EthereumCash`/`BaseWalletCash` events update `InventoryView` instead of being ignored) and unit tests for imbalance detection with in-flight balances are the next steps — this PR establishes the types, spec, and failing e2e test as the target to drive implementation.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)