### PR TITLE
ops: soft-disable all trading for incremental prod re-enable

### DIFF
--- a/config/st0x-hedge.toml
+++ b/config/st0x-hedge.toml
@@ -1,7 +1,7 @@
 server_port = 8001
 log_level = "debug"
 database_url = "sqlite:///mnt/data/st0x-hedge.db"
-hyperdx.service_name = "st0x-hedge"
+hyperdx.service_name = "st0x.liquidity"
 
 [raindex]
 orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
@@ -9,23 +9,25 @@ deployment_block = 41715047
 
 [rebalancing]
 redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
-equity = { target = 0.5, deviation = 0.15 }
-usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
-
-[rebalancing.wallet]
-type = "private-key"
-address = "0x0000000000000000000000000000000000000000"
+# started implementing a proper noop, realized there are more things
+# to improve about the config, so decided on soft noop for now
+equity = { target = 0.5, deviation = 1 }
+usdc = { mode = "disabled" }
 
 [assets.cash]
 vault_id = "0xfab"
 rebalancing = "disabled"
-operational_limit = 100
+# alpaca fractional trading requires orders to be at least $1 USD
+# in notional value so this should effectively disable counter trading
+operational_limit = 0.01
 
 [assets.equities.RKLB]
 trading = "disabled"
-rebalancing = "enabled"
+# disabling everything temporarily 
+rebalancing = "disabled"
+# operational_limit = 1
+
 vault_id = "0xfab"
-operational_limit = 5
 tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
 tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
 


### PR DESCRIPTION
## Motivation

We're preparing to re-enable production features gradually after the recent conductor redesign and rebalancing work. Rather than deploying with everything active, this PR sets the production config to a "soft noop" state -- all trading and rebalancing effectively disabled -- so we can redeploy safely and re-enable features one at a time while monitoring.

Related: [RAI-137](https://linear.app/makeitrain/issue/RAI-137/redeploy-rklb-dca-with-lower-frequency-and-asymmetric-amounts) (redeploy with controlled parameters)

## Solution

Config-only changes to `config/st0x-hedge.toml`:

- **Rebalancing**: Set equity deviation to `1` (100% -- effectively never triggers) and disabled USDC rebalancing. Removed the placeholder wallet config (proper noop deferred to a config improvement pass).
- **Counter trading**: Set `operational_limit = 0.01` for cash -- below Alpaca's $1 minimum notional, effectively preventing counter trades from executing.
- **RKLB**: Disabled both trading and rebalancing explicitly; commented out `operational_limit`.
- **Service name**: Updated HyperDX service name from `st0x-hedge` to `st0x.liquidity` to match the project name.

All other equities (SPYM, TSLA, AMZN, etc.) remain explicitly disabled as before.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

> No logic changes -- config-only PR, no tests needed. No dashboard changes.
