### PR TITLE
chore: unify client-server WebSocket messaging protocol

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2637,6 +2637,7 @@ enum EnvelopePayload {
 }
 ```
 
+<<<<<<< variant A
 The `Batch` variant handles atomic multi-category updates. For example, a trade
 completion affects both Trading and Inventory — these arrive as a single batch
 with one sequence number so the client applies them together without flashing
@@ -2655,6 +2656,9 @@ enum Inquiry {
     // Future: Adjust(Adjustment) — circuit breakers, spread tweaks, etc.
 }
 ```
+>>>>>>> variant B
+##### Future: client-to-server messages
+======= end
 
 **Sync protocol**: On connect, the client sends a `Sync` inquiry. For a fresh
 page load, `last_sequence: None` — the server responds with full statements for
@@ -2691,7 +2695,11 @@ produces a `TransferStatementDelta` containing only the changed status field.
 Full statements are produced for new entities (first time the client learns
 about something) and sync responses.
 
-##### TanStack Query Integration
+1. Reactor receives the event for entity X
+2. Rebuilds entity state (standard event sourcing)
+3. Converts to DTO (each tracked aggregate implements a DTO conversion trait)
+4. Compares to the last-broadcast DTO for that entity
+5. If different: broadcasts `{ entity_type, entity_id, sequence, trigger, dto }`
 
 WebSocket messages populate the TanStack Query cache. Each `PublicStatement`
 variant maps to query keys (e.g., `["trades"]`, `["inventory"]`,
@@ -2800,16 +2808,18 @@ Supports two bot instances (Schwab and Alpaca) via broker selector in header.
 
 #### Panels
 
-1. **Performance Metrics**: Key metrics (AUM, P&L, volume, trade count, Sharpe,
-   Sortino, max drawdown, hedge lag, uptime) with timeframe selector (1h, 1d,
-   1w, 1m, all-time).
+Two panels, one per core concern. Both update live via WebSocket snapshots.
 
-2. **Inventory**: Per-symbol equity holdings and cash balances across venues,
-   with available/inflight breakdowns. Includes an "Inventory Transfers" section
-   showing active and recent transfer operations with status.
+1. **Inventory**: Per-symbol equity holdings and cash balances across onchain
+   vaults and the offchain broker, with available/inflight breakdowns. Below the
+   balances, an "Inventory Transfers" section shows active and recent transfer
+   operations (minting, redemption, USDC bridging) with status.
 
-3. **Spreads**: Last realized spreads per asset (buy/sell prices, Pyth
-   reference, spread bps) and per-symbol price charts over time.
+2. **Trading Activity**: The core operational view. Shows onchain trades as they
+   are detected, the current net position per asset, pending offchain hedge
+   orders, and their fills. This is the panel that makes live testing viable --
+   if the bot detects a trade and places a hedge, the operator sees it
+   immediately.
 
 4. **Trade History**: Recent trades filterable by venue (onchain/offchain/both).
 

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -42,8 +42,6 @@ pub enum Concern {
     Trading,
 }
 
-/// Full dashboard snapshot sent to the frontend on connection.
-
 /// Completed trade record.
 #[derive(Debug, Clone, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -129,28 +127,6 @@ pub enum EquityRedemptionTag {}
 
 /// Tag type for USDC bridge operation IDs.
 pub enum UsdcBridgeTag {}
-
-/// Category of transfer aggregate that failed to load.
-#[derive(Debug, Clone, Serialize, TS)]
-#[serde(rename_all = "snake_case")]
-pub enum TransferCategory {
-    EquityMint,
-    EquityRedemption,
-    UsdcBridge,
-}
-
-/// Warning emitted when transfer data is partially loaded.
-#[derive(Debug, Clone, Serialize, TS)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum Warning {
-    /// Failed to query aggregate IDs for an entire category.
-    CategoryUnavailable { category: TransferCategory },
-    /// An individual aggregate's events failed to replay.
-    AggregateReplayFailed {
-        category: TransferCategory,
-        aggregate_id: String,
-    },
-}
 
 /// Transfer operation: a tagged union per operation type.
 #[derive(Debug, Clone, Serialize, TS)]
@@ -508,21 +484,14 @@ mod tests {
     }
 
     #[test]
-    fn initial_state_default_serializes_correctly() {
-        let initial = InitialState::default();
-        let json = serde_json::to_string(&initial).expect("serialization should succeed");
-        assert!(json.contains("recentTrades"));
-        assert!(json.contains("inventory"));
-        assert!(json.contains("metrics"));
-        assert!(json.contains("authStatus"));
-        assert!(json.contains("circuitBreaker"));
-        assert!(json.contains("activeTransfers"));
-        assert!(json.contains("recentTransfers"));
-        assert!(json.contains("warnings"));
-        assert!(
-            !json.contains("\"0x"),
-            "dashboard DTOs should serialize decimal strings, got: {json}"
-        );
+    fn statement_serializes_correctly() {
+        let statement = Statement {
+            id: "test-123".to_string(),
+            statement: Concern::Transfer,
+        };
+        let json = serde_json::to_string(&statement).expect("serialization should succeed");
+        assert!(json.contains(r#""id":"test-123""#));
+        assert!(json.contains(r#""statement""#));
     }
 
     #[test]

--- a/crates/event-sorcery/src/testing.rs
+++ b/crates/event-sorcery/src/testing.rs
@@ -176,7 +176,7 @@ pub fn test_store<Entity: EventSourced>(
 ///
 /// ```ignore
 /// let (sender, mut receiver) = broadcast::channel(16);
-/// let harness = ReactorHarness::new(EventBroadcaster::new(sender));
+/// let harness = ReactorHarness::new(EventBroadcaster::new(sender, pool));
 ///
 /// // No manual OneOf nesting -- depth inferred from types
 /// harness.receive(mint_id, mint_event).await.unwrap();

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1,6 +1,8 @@
 //! Orchestrates the bot lifecycle: startup sequencing, runtime task management,
 //! and trade processing. [`Conductor::run`] is the entry point.
 
+pub(crate) mod job;
+
 mod builder;
 pub(crate) mod job;
 mod manifest;
@@ -8,27 +10,32 @@ mod order_fill_monitor;
 
 use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::rpc::types::Log;
+use alloy::sol_types;
+use apalis::prelude::TaskSink;
 use apalis_sqlite::SqliteStorage;
-use futures_util::StreamExt;
+use futures_util::{Stream, StreamExt};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use task_supervisor::SupervisorHandle;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
-use st0x_dto::ServerMessage;
+use st0x_dto::Statement;
 use st0x_event_sorcery::{Projection, Store, StoreBuilder};
-use st0x_evm::Wallet;
+use st0x_evm::{Evm, Wallet};
 use st0x_execution::{Executor, FractionalShares, Symbol};
 
 use crate::alpaca_wallet::AlpacaWalletService;
-use crate::bindings::IOrderBookV6::{self, IOrderBookV6Instance};
-use crate::config::{AssetsConfig, Ctx, CtxError};
-use crate::dashboard::EventBroadcaster;
-use crate::inventory::{BroadcastingInventory, InventoryPollingService, InventorySnapshot};
+use crate::bindings::IOrderBookV6::{ClearV3, IOrderBookV6Instance, TakeOrderV3};
+use crate::config::{AssetsConfig, Ctx, CtxError, OperationMode};
+use crate::dashboard::Broadcaster;
+use crate::inventory::{
+    BroadcastingInventory, InventoryPollingService, InventorySnapshot, WalletPollingCtx,
+};
 use crate::offchain::order_poller::OrderStatusPoller;
 use crate::offchain_order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId, OrderPlacer,
@@ -36,7 +43,7 @@ use crate::offchain_order::{
 use crate::onchain::OnchainTrade;
 use crate::onchain::USDC_BASE;
 use crate::onchain::accumulator::{ExecutionCtx, check_all_positions, check_execution_readiness};
-use crate::onchain::backfill::{backfill_events, get_backfill_retry_strat};
+use crate::onchain::backfill::backfill_events;
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
@@ -55,11 +62,19 @@ use crate::trading::onchain::trade_accountant::{DexTradeAccountingJobQueue, Trad
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
 use crate::wrapper::WrapperService;
 
-pub(crate) use builder::CqrsFrameworks;
-use manifest::QueryManifest;
+use self::manifest::QueryManifest;
+use crate::trading::onchain::inclusion::ChainIncluded;
+use crate::trading::onchain::trade_accountant::{
+    AccountForDexTrade, DexTradeAccountingJobQueue, TradeAccountingError,
+};
+pub(crate) use builder::{ConductorBuilder, ConductorCtx, CqrsFrameworks};
 
-/// Sets up apalis SQLite storage tables, tolerating pre-existing
+/// Sets up apalis `SQLite` storage tables, tolerating pre-existing
 /// application migrations in the shared `_sqlx_migrations` table.
+///
+/// # Errors
+///
+/// Returns an error if the migration fails.
 pub(crate) async fn setup_apalis_tables(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     apalis_sqlite::SqliteStorage::migrations()
         .set_ignore_missing(true)
@@ -80,13 +95,16 @@ pub(crate) struct TradeProcessingCqrs {
 }
 
 pub(crate) struct Conductor {
-    supervisor: SupervisorHandle,
-    monitor: JoinHandle<()>,
-    executor_maintenance: Option<JoinHandle<()>>,
-    rebalancer: Option<JoinHandle<()>>,
-    inventory_poller: Option<JoinHandle<()>>,
+    pub(crate) supervisor: task_supervisor::SupervisorHandle,
+    pub(crate) monitor: JoinHandle<()>,
+    pub(crate) order_poller: JoinHandle<()>,
+    pub(crate) position_checker: JoinHandle<()>,
+    pub(crate) executor_maintenance: Option<JoinHandle<()>>,
+    pub(crate) rebalancer: Option<JoinHandle<()>>,
+    pub(crate) inventory_poller: Option<JoinHandle<()>>,
 }
 
+<<<<<<< variant A
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
     ctx.assets
         .equities
@@ -96,7 +114,31 @@ fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Ad
         .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity))
         .collect()
 }
+>>>>>>> variant B
+pub(crate) async fn run_market_hours_loop<E>(
+    executor: E,
+    ctx: Ctx,
+    pool: SqlitePool,
+    executor_maintenance: Option<JoinHandle<()>>,
+    event_sender: broadcast::Sender<Statement>,
+    inventory: Arc<BroadcastingInventory>,
+) -> anyhow::Result<()>
+where
+    E: Executor + Clone + Send + Sync + 'static,
+    TradeAccountingError: From<E::Error>,
+{
+    let mut conductor = Conductor::start(
+        ctx,
+        pool,
+        executor,
+        executor_maintenance,
+        event_sender,
+        inventory,
+    )
+    .await?;
+======= end
 
+<<<<<<< variant A
 fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
     ctx.assets
         .equities
@@ -105,6 +147,12 @@ fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Addr
         .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
         .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
         .collect()
+>>>>>>> variant B
+    info!("Conductor running");
+    let result = conductor.wait_for_completion().await;
+    conductor.abort_all();
+    result
+======= end
 }
 
 /// Context for vault discovery operations during trade processing.
@@ -120,11 +168,15 @@ impl Conductor {
         ctx: Ctx,
         pool: SqlitePool,
         executor_maintenance: Option<JoinHandle<()>>,
-        event_sender: broadcast::Sender<ServerMessage>,
+        event_sender: broadcast::Sender<Statement>,
         inventory: Arc<BroadcastingInventory>,
     ) -> anyhow::Result<()>
     where
+<<<<<<< variant A
         E: Executor + Clone + Send + 'static,
+>>>>>>> variant B
+        E: Executor + Clone + Send + Sync + 'static,
+======= end
         TradeAccountingError: From<E::Error>,
     {
         // Phase 1: connect WS and set up apalis tables (parallel)
@@ -133,14 +185,50 @@ impl Conductor {
         let cache = SymbolCache::default();
         let orderbook = IOrderBookV6Instance::new(ctx.evm.orderbook, &provider);
 
+<<<<<<< variant A
         setup_apalis_tables(&pool).await?;
         let job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
+>>>>>>> variant B
+            setup_apalis_tables(&pool).await?;
+            let mut job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
+======= end
 
+<<<<<<< variant A
         let mut clear_stream = orderbook.ClearV3_filter().watch().await?.into_stream();
         let mut take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
+>>>>>>> variant B
+            let mut clear_stream = orderbook.ClearV3_filter().watch().await?.into_stream();
+            let mut take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
+======= end
 
+<<<<<<< variant A
         // Phase 2: determine cutoff block from WS subscription
         let cutoff_block = get_cutoff_block(&mut clear_stream, &mut take_stream, &provider).await?;
+>>>>>>> variant B
+            let cutoff_block = get_cutoff_block(
+                &mut clear_stream,
+                &mut take_stream,
+                &provider,
+                &mut job_queue,
+            )
+            .await?;
+
+            let dex_streams = order_fill_monitor::DexEventStreams {
+                clear: Box::pin(clear_stream),
+                take: Box::pin(take_stream),
+            };
+
+            if let Some(end_block) = cutoff_block.checked_sub(1) {
+                backfill_events(
+                    &provider,
+                    &ctx.evm,
+                    end_block,
+                    crate::onchain::backfill::get_backfill_retry_strat(),
+                    job_queue.clone(),
+                )
+                .await?;
+            }
+======= end
 
         // Phase 3: backfill historical events to the job queue
         if let Some(end_block) = cutoff_block.checked_sub(1) {
@@ -171,6 +259,7 @@ impl Conductor {
             Err(error) => return Err(error.into()),
         };
 
+<<<<<<< variant A
         let (position, position_projection, snapshot, rebalancer, wallet_polling) =
             if let Some(rebalancing_ctx) = rebalancing {
                 let ethereum_wallet = rebalancing_ctx.ethereum_wallet().clone();
@@ -201,7 +290,15 @@ impl Conductor {
                         &ctx,
                     ),
                 };
+>>>>>>> variant B
+            let rebalancing = match ctx.rebalancing_ctx() {
+                Ok(ctx) => Some(ctx.clone()),
+                Err(CtxError::NotRebalancing) => None,
+                Err(error) => return Err(error.into()),
+            };
+======= end
 
+<<<<<<< variant A
                 (
                     infra.position,
                     infra.position_projection,
@@ -213,9 +310,57 @@ impl Conductor {
                 let (position, position_projection) = build_position_cqrs(&pool).await?;
                 let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
                     .build(())
+>>>>>>> variant B
+            let (position, position_projection, snapshot, rebalancer, wallet_polling) =
+                if let Some(rebalancing_ctx) = rebalancing {
+                    let ethereum_wallet = rebalancing_ctx.ethereum_wallet().clone();
+                    let base_wallet = rebalancing_ctx.base_wallet().clone();
+                    let infra = spawn_rebalancing_infrastructure(
+                        rebalancing_ctx,
+                        ethereum_wallet.clone(),
+                        base_wallet.clone(),
+                        RebalancingDeps {
+                            pool: pool.clone(),
+                            ctx: ctx.clone(),
+                            inventory: inventory.clone(),
+                            event_sender,
+                            vault_registry: vault_registry.clone(),
+                            vault_registry_projection: vault_registry_projection.clone(),
+                        },
+                    )
+======= end
                     .await?;
+<<<<<<< variant A
                 (position, position_projection, snapshot, None, None)
             };
+>>>>>>> variant B
+
+                    let wallet_polling = WalletPollingCtx {
+                        ethereum: Some(ethereum_wallet),
+                        base: Some(base_wallet),
+                        alpaca_wallet: Some(infra.alpaca_wallet),
+                        unwrapped_equity_token_addresses:
+                            base_wallet_unwrapped_equity_token_addresses(&ctx),
+                        wrapped_equity_token_addresses: base_wallet_wrapped_equity_token_addresses(
+                            &ctx,
+                        ),
+                    };
+
+                    (
+                        infra.position,
+                        infra.position_projection,
+                        infra.snapshot,
+                        Some(infra.rebalancer),
+                        Some(wallet_polling),
+                    )
+                } else {
+                    let (position, position_projection) = build_position_cqrs(&pool).await?;
+                    let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
+                        .build(())
+                        .await?;
+                    (position, position_projection, snapshot, None, None)
+                };
+======= end
 
         let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
 
@@ -235,10 +380,26 @@ impl Conductor {
             snapshot,
         };
 
+<<<<<<< variant A
         let dex_streams = order_fill_monitor::DexEventStreams {
             clear: Box::pin(clear_stream),
             take: Box::pin(take_stream),
         };
+>>>>>>> variant B
+            let conductor_ctx = ConductorCtx {
+                ctx: ctx.clone(),
+                cache,
+                provider,
+                executor,
+                execution_threshold: ctx.execution_threshold,
+                frameworks,
+                poll_notify: Arc::new(tokio::sync::Notify::new()),
+                wallet_polling,
+            };
+
+            let mut builder = ConductorBuilder::new(conductor_ctx, job_queue, dex_streams)
+                .with_executor_maintenance(executor_maintenance);
+======= end
 
         let conductor_ctx = builder::ConductorCtx {
             ctx: ctx.clone(),
@@ -251,6 +412,7 @@ impl Conductor {
             wallet_polling,
         };
 
+<<<<<<< variant A
         let mut conductor = builder::spawn()
             .context(conductor_ctx)
             .job_queue(job_queue)
@@ -263,35 +425,95 @@ impl Conductor {
         let result = conductor.wait_for_completion().await;
         conductor.abort_all();
         result
+>>>>>>> variant B
+            Ok(builder.spawn())
+        })
+======= end
     }
 }
 
 impl Conductor {
+<<<<<<< variant A
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
+>>>>>>> variant B
+    pub(crate) async fn wait_for_completion(&mut self) -> Result<(), anyhow::Error> {
+======= end
         tokio::select! {
             result = self.supervisor.wait() => {
                 result?;
                 info!("Supervisor exited");
             }
             result = &mut self.monitor => {
+<<<<<<< variant A
                 if let Err(join_error) = result
                     && !join_error.is_cancelled()
                 {
                     return Err(anyhow::anyhow!("Apalis monitor failed: {join_error}"));
                 }
                 info!("Apalis monitor exited");
+>>>>>>> variant B
+                check_task_result(result, "Apalis monitor")?;
+            }
+            result = &mut self.order_poller => {
+                check_task_result(result, "Order poller")?;
+            }
+            result = &mut self.position_checker => {
+                check_task_result(result, "Position checker")?;
+======= end
             }
         }
 
         Ok(())
     }
+<<<<<<< variant A
+>>>>>>> variant B
+}
 
+fn check_task_result(
+    result: Result<(), tokio::task::JoinError>,
+    task_name: &str,
+) -> Result<(), anyhow::Error> {
+    if let Err(join_error) = result
+        && !join_error.is_cancelled()
+    {
+        return Err(anyhow::anyhow!("{task_name} failed: {join_error}"));
+    }
+
+    info!("{task_name} exited");
+    Ok(())
+}
+
+impl Conductor {
+    pub(crate) fn abort_trading_tasks(&self) {
+        info!(
+            "Aborting trading tasks (keeping rebalancer, inventory poller, and broker maintenance alive)"
+        );
+======= end
+
+<<<<<<< variant A
     pub(crate) fn abort_all(&self) {
         info!("Aborting all conductor tasks");
+>>>>>>> variant B
+======= end
         if let Err(error) = self.supervisor.shutdown() {
+<<<<<<< variant A
             error!(%error, "Failed to shutdown supervisor");
+>>>>>>> variant B
+            error!(%error, "Supervisor shutdown failed");
+======= end
         }
         self.monitor.abort();
+<<<<<<< variant A
+>>>>>>> variant B
+        self.order_poller.abort();
+        self.position_checker.abort();
+
+        info!("Trading tasks aborted successfully");
+    }
+
+    pub(crate) fn abort_all(&self) {
+        self.abort_trading_tasks();
+======= end
 
         if let Some(ref handle) = self.rebalancer {
             handle.abort();
@@ -318,7 +540,7 @@ struct RebalancingDeps {
     pool: SqlitePool,
     ctx: Ctx,
     inventory: Arc<BroadcastingInventory>,
-    event_sender: broadcast::Sender<ServerMessage>,
+    event_sender: broadcast::Sender<Statement>,
     vault_registry: Arc<Store<VaultRegistry>>,
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
 }
@@ -332,17 +554,6 @@ async fn seed_vault_registry_from_config(
     vault_registry: &Store<VaultRegistry>,
     ctx: &Ctx,
 ) -> anyhow::Result<()> {
-    // Pre-flight validation: ensure every rebalancing-enabled equity has a
-    // vault_id before performing any writes to the vault registry.
-    for (symbol, equity_config) in &ctx.assets.equities.symbols {
-        if equity_config.vault_id.is_none() && ctx.is_rebalancing_enabled(symbol) {
-            return Err(CtxError::MissingEquityVaultId {
-                symbol: symbol.clone(),
-            }
-            .into());
-        }
-    }
-
     let vault_registry_id = VaultRegistryId {
         orderbook: ctx.evm.orderbook,
         owner: ctx.order_owner(),
@@ -350,6 +561,12 @@ async fn seed_vault_registry_from_config(
 
     for (symbol, equity_config) in &ctx.assets.equities.symbols {
         let Some(vault_id) = equity_config.vault_id else {
+            if ctx.is_rebalancing_enabled(symbol) {
+                return Err(CtxError::MissingEquityVaultId {
+                    symbol: symbol.clone(),
+                }
+                .into());
+            }
             continue;
         };
 
@@ -388,6 +605,35 @@ async fn seed_vault_registry_from_config(
     Ok(())
 }
 
+/// Returns `tokenized_equity` addresses for assets that have at least one
+/// operation (trading or rebalancing) enabled — i.e. assets we should poll
+/// Base-wallet balances for.
+fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
+    ctx.assets
+        .equities
+        .symbols
+        .iter()
+        .filter(|(_, config)| {
+            config.trading == OperationMode::Enabled || config.rebalancing == OperationMode::Enabled
+        })
+        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity))
+        .collect()
+}
+
+/// Returns `tokenized_equity_derivative` (wrapped) addresses for assets that
+/// have at least one operation enabled.
+fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
+    ctx.assets
+        .equities
+        .symbols
+        .iter()
+        .filter(|(_, config)| {
+            config.trading == OperationMode::Enabled || config.rebalancing == OperationMode::Enabled
+        })
+        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
+        .collect()
+}
+
 fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
     rebalancing_ctx: RebalancingCtx,
     ethereum_wallet: Chain,
@@ -397,11 +643,12 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
     Box<dyn std::future::Future<Output = anyhow::Result<RebalancingInfrastructure>> + Send>,
 > {
     Box::pin(async move {
+        const OPERATION_CHANNEL_CAPACITY: usize = 100;
+
         info!("Initializing rebalancing infrastructure");
 
         let market_maker_wallet = base_wallet.address();
 
-        const OPERATION_CHANNEL_CAPACITY: usize = 100;
         let (operation_sender, operation_receiver) = mpsc::channel(OPERATION_CHANNEL_CAPACITY);
 
         let raindex_service = Arc::new(RaindexService::new(
@@ -458,8 +705,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             wrapper,
         ));
 
-        let event_broadcaster =
-            Arc::new(EventBroadcaster::new(deps.event_sender, deps.pool.clone()));
+        let event_broadcaster = Arc::new(Broadcaster::new(deps.event_sender));
         let manifest = QueryManifest::new(rebalancing_trigger, event_broadcaster);
 
         let built = manifest
@@ -490,17 +736,23 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         )
         .await?;
 
-        let usdc_vault_id = deps
-            .ctx
-            .assets
-            .cash
-            .as_ref()
-            .and_then(|cash| cash.vault_id)
-            .ok_or(CtxError::MissingCashVaultId)?;
+        let usdc_vault_id = if rebalancing_ctx.usdc.is_some() {
+            let vault_id = deps
+                .ctx
+                .assets
+                .cash
+                .as_ref()
+                .and_then(|cash| cash.vault_id)
+                .ok_or(CtxError::MissingCashVaultId)?;
+
+            RaindexVaultId(vault_id)
+        } else {
+            RaindexVaultId(alloy::primitives::B256::ZERO)
+        };
 
         let handle = services.spawn(
             market_maker_wallet,
-            RaindexVaultId(usdc_vault_id),
+            usdc_vault_id,
             operation_receiver,
             frameworks,
         );
@@ -658,7 +910,7 @@ where
 
         loop {
             interval.tick().await;
-            debug!("Running periodic accumulated position check");
+            trace!("Running periodic accumulated position check");
             if let Err(error) = check_and_execute_accumulated_positions(
                 &executor,
                 &position,
@@ -676,15 +928,11 @@ where
     })
 }
 
-fn spawn_inventory_poller<Chain, Exe>(
+fn spawn_inventory_poller<Chain: Evm, Exe: Executor + Send + 'static>(
     service: InventoryPollingService<Chain, Exe>,
     poll_interval: std::time::Duration,
     poll_notify: Arc<tokio::sync::Notify>,
-) -> JoinHandle<()>
-where
-    Chain: st0x_evm::Evm,
-    Exe: Executor + Clone + Send + 'static,
-{
+) -> JoinHandle<()> {
     info!("Starting inventory poller");
 
     tokio::spawn(async move {
@@ -695,11 +943,11 @@ where
             tokio::select! {
                 _ = interval.tick() => {}
                 () = poll_notify.notified() => {
-                    debug!("Inventory poll triggered by notification");
+                    trace!("Inventory poll triggered by notification");
                 }
             }
 
-            debug!("Running inventory poll");
+            trace!("Running inventory poll");
             if let Err(error) = service.poll_and_record().await {
                 error!(%error, "Inventory polling failed");
             }
@@ -707,14 +955,76 @@ where
     })
 }
 
-/// Discovers vaults from a trade and emits VaultRegistryCommands.
+pub(crate) async fn get_cutoff_block<S1, S2, P>(
+    clear_stream: &mut S1,
+    take_stream: &mut S2,
+    provider: &P,
+    job_queue: &mut DexTradeAccountingJobQueue,
+) -> anyhow::Result<u64>
+where
+    S1: Stream<Item = Result<(ClearV3, Log), sol_types::Error>> + Unpin,
+    S2: Stream<Item = Result<(TakeOrderV3, Log), sol_types::Error>> + Unpin,
+    P: Provider + Clone,
+{
+    info!("Starting WebSocket subscriptions and waiting for first event...");
+
+    let first_event_result = wait_for_first_event_with_timeout(
+        clear_stream,
+        take_stream,
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+
+    let Some((mut event_buffer, block_number)) = first_event_result else {
+        let current_block = provider.get_block_number().await?;
+        info!(
+            "No subscription events within timeout, \
+             using current block {current_block} as cutoff"
+        );
+        return Ok(current_block);
+    };
+
+    buffer_live_events(clear_stream, take_stream, &mut event_buffer, block_number).await;
+
+    enqueue_buffered_events(job_queue, event_buffer).await;
+
+    Ok(block_number)
+}
+
+/// Pushes buffered events from the coordination phase into apalis storage.
+async fn enqueue_buffered_events(
+    job_queue: &mut DexTradeAccountingJobQueue,
+    event_buffer: Vec<(RaindexTradeEvent, Log)>,
+) {
+    info!(
+        "Coordination Phase: Processing {} buffered events from subscription",
+        event_buffer.len()
+    );
+
+    let trade_events = event_buffer.into_iter().filter_map(|(event, log)| {
+        ChainIncluded::<RaindexTradeEvent>::from_log(event, &log)
+            .inspect_err(|error| error!(%error, "Failed to extract block inclusion metadata"))
+            .ok()
+    });
+
+    for trade_event in trade_events {
+        if let Err(error) = job_queue
+            .push(AccountForDexTrade { trade: trade_event })
+            .await
+        {
+            error!(%error, "Failed to push buffered event into apalis storage");
+        }
+    }
+}
+
+/// Discovers vaults from a trade and emits `VaultRegistryCommand`s.
 ///
 /// This function is called AFTER trade conversion succeeds, using the trade's
 /// already-resolved symbol. It extracts vault information from the queued event
-/// and registers vaults owned by the specified order_owner.
+/// and registers vaults owned by the specified `order_owner`.
 ///
 /// Vaults are classified as:
-/// - USDC vault: token == USDC_BASE
+/// - USDC vault: token == `USDC_BASE`
 /// - Equity vault: token matches the trade's symbol (via cache lookup)
 pub(crate) async fn discover_vaults_for_trade(
     trade_event: &EmittedOnChain<RaindexTradeEvent>,
@@ -778,7 +1088,8 @@ pub(crate) async fn discover_vaults_for_trade(
     Ok(())
 }
 
-/// Returns `true` if the witness was accepted, `false` if rejected.
+/// Witnesses the trade in the OnChainTrade aggregate. Returns `true` if this
+/// is a new trade, `false` if it was already witnessed (duplicate).
 async fn execute_witness_trade(
     onchain_trade: &Store<OnChainTrade>,
     trade: &OnchainTrade,
@@ -818,8 +1129,8 @@ async fn execute_witness_trade(
             true
         }
         Err(error) => {
-            warn!(
-                "OnChainTrade::Witness rejected: {error}, tx_hash={:?}, log_index={}, symbol={}",
+            error!(
+                "Failed to execute OnChainTrade::Witness command: {error}, tx_hash={:?}, log_index={}, symbol={}",
                 trade.tx_hash, trade.log_index, trade.symbol
             );
             false
@@ -827,19 +1138,18 @@ async fn execute_witness_trade(
     }
 }
 
+/// Enriches the OnChainTrade aggregate with gas and pyth price data extracted
+/// from the transaction receipt and trace. Runs after a successful Witness.
 async fn execute_enrich_trade(onchain_trade: &Store<OnChainTrade>, trade: &OnchainTrade) {
     let (Some(gas_used), Some(effective_gas_price), Some(pyth_price)) = (
         trade.gas_used,
         trade.effective_gas_price,
         trade.pyth_price.clone(),
     ) else {
-        warn!(
+        debug!(
             tx_hash = ?trade.tx_hash,
             log_index = trade.log_index,
-            gas_used = ?trade.gas_used,
-            effective_gas_price = ?trade.effective_gas_price,
-            pyth_price = ?trade.pyth_price,
-            "Cannot enrich trade: missing gas_used, effective_gas_price, or pyth_price"
+            "Skipping enrichment: missing gas or pyth data"
         );
         return;
     };
@@ -855,15 +1165,13 @@ async fn execute_enrich_trade(onchain_trade: &Store<OnChainTrade>, trade: &Oncha
         pyth_price,
     };
 
-    match onchain_trade.send(&trade_id, command).await {
-        Ok(()) => info!(
-            "Successfully executed OnChainTrade::Enrich command: tx_hash={:?}, log_index={}",
-            trade.tx_hash, trade.log_index
-        ),
-        Err(error) => error!(
-            "Failed to execute OnChainTrade::Enrich command: {error}, tx_hash={:?}, log_index={}",
-            trade.tx_hash, trade.log_index
-        ),
+    if let Err(error) = onchain_trade.send(&trade_id, command).await {
+        error!(
+            tx_hash = ?trade.tx_hash,
+            log_index = trade.log_index,
+            %error,
+            "Failed to enrich OnChainTrade"
+        );
     }
 }
 
@@ -917,27 +1225,23 @@ pub(crate) async fn process_queued_trade<E: Executor>(
     cqrs: &TradeProcessingCqrs,
     asset_enabled: bool,
 ) -> Result<Option<OffchainOrderId>, TradeAccountingError> {
-    let trade_id = OnChainTradeId {
-        tx_hash: trade.tx_hash,
-        log_index: trade.log_index,
-    };
+    // Witness first — the OnChainTrade aggregate is keyed by (tx_hash, log_index)
+    // and rejects duplicates. Only acknowledge the fill on the Position aggregate
+    // if this is a genuinely new trade, preventing double-counting.
+    let is_new_trade =
+        execute_witness_trade(&cqrs.onchain_trade, &trade, trade_event.block_number).await;
 
-    if let Ok(Some(_)) = cqrs.onchain_trade.load(&trade_id).await {
+    if is_new_trade {
+        execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
+    }
+
+    if !is_new_trade {
         info!(
-            ?trade_id,
-            "Trade already processed (duplicate event), skipping"
+            "Skipping duplicate trade: tx_hash={:?}, log_index={}",
+            trade_event.tx_hash, trade_event.log_index
         );
         return Ok(None);
     }
-
-    let witnessed =
-        execute_witness_trade(&cqrs.onchain_trade, &trade, trade_event.block_number).await;
-
-    if !witnessed {
-        return Ok(None);
-    }
-
-    execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
 
     execute_acknowledge_fill(&cqrs.position, &trade, cqrs.execution_threshold).await;
 
@@ -1100,7 +1404,7 @@ where
     .await?;
 
     if ready_positions.is_empty() {
-        debug!("No accumulated positions ready for execution");
+        trace!("No accumulated positions ready for execution");
         return Ok(());
     }
 
@@ -1181,6 +1485,78 @@ where
     Ok(())
 }
 
+/// Maps database symbols to current executor-recognized tickers.
+async fn wait_for_first_event_with_timeout<S1, S2>(
+    clear_stream: &mut S1,
+    take_stream: &mut S2,
+    timeout: std::time::Duration,
+) -> Option<(Vec<(RaindexTradeEvent, Log)>, u64)>
+where
+    S1: Stream<Item = Result<(ClearV3, Log), sol_types::Error>> + Unpin,
+    S2: Stream<Item = Result<(TakeOrderV3, Log), sol_types::Error>> + Unpin,
+{
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+
+    let mut events = Vec::new();
+
+    loop {
+        let event_result = tokio::select! {
+            Some(result) = clear_stream.next() => {
+                result.map(|(event, log)| (RaindexTradeEvent::ClearV3(Box::new(event)), log))
+            }
+            Some(result) = take_stream.next() => {
+                result.map(|(event, log)| (RaindexTradeEvent::TakeOrderV3(Box::new(event)), log))
+            }
+            () = &mut deadline => return None,
+        };
+
+        match event_result {
+            Ok((event, log)) => {
+                let Some(block_number) = log.block_number else {
+                    error!("Event missing block number during startup");
+                    continue;
+                };
+                events.push((event, log));
+                return Some((std::mem::take(&mut events), block_number));
+            }
+            Err(error) => {
+                error!("Error in event stream during startup: {error}");
+            }
+        }
+    }
+}
+
+async fn buffer_live_events<S1, S2>(
+    clear_stream: &mut S1,
+    take_stream: &mut S2,
+    event_buffer: &mut Vec<(RaindexTradeEvent, Log)>,
+    cutoff_block: u64,
+) where
+    S1: Stream<Item = Result<(ClearV3, Log), sol_types::Error>> + Unpin,
+    S2: Stream<Item = Result<(TakeOrderV3, Log), sol_types::Error>> + Unpin,
+{
+    loop {
+        tokio::select! {
+            Some(result) = clear_stream.next() => match result {
+                Ok((event, log)) if log.block_number.unwrap_or(0) >= cutoff_block => {
+                    event_buffer.push((RaindexTradeEvent::ClearV3(Box::new(event)), log));
+                }
+                Err(error) => error!("Error in clear event stream during backfill: {error}"),
+                _ => {}
+            },
+            Some(result) = take_stream.next() => match result {
+                Ok((event, log)) if log.block_number.unwrap_or(0) >= cutoff_block => {
+                    event_buffer.push((RaindexTradeEvent::TakeOrderV3(Box::new(event)), log));
+                }
+                Err(error) => error!("Error in take event stream during backfill: {error}"),
+                _ => {}
+            },
+            else => break,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, TxHash, U256, address, bytes, fixed_bytes};
@@ -1189,9 +1565,7 @@ mod tests {
     use rain_math_float::Float;
     use std::collections::HashSet;
     use std::sync::Arc;
-    use tokio::sync::broadcast;
 
-    use st0x_dto::ServerMessage;
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_execution::{Direction, ExecutorOrderId, MarketOrder, MockExecutor, Positive, Symbol};
     use st0x_finance::{Usd, Usdc};
@@ -1206,6 +1580,7 @@ mod tests {
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::onchain::trade::OnchainTrade;
+    use crate::onchain_trade::PythPrice;
     use crate::rebalancing::{RebalancingTrigger, TriggeredOperation};
     use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
     use crate::threshold::ExecutionThreshold;
@@ -1216,6 +1591,13 @@ mod tests {
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
+    }
+
+    fn empty_dex_streams() -> super::order_fill_monitor::DexEventStreams {
+        super::order_fill_monitor::DexEventStreams {
+            clear: Box::pin(stream::empty()),
+            take: Box::pin(stream::empty()),
+        }
     }
 
     #[test]
@@ -1362,8 +1744,158 @@ mod tests {
         );
     }
 
+    async fn build_test_conductor(pool: &SqlitePool) -> Conductor {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(pool, succeeding_order_placer()).await;
+
+        setup_apalis_tables(pool).await.unwrap();
+        let job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(pool);
+
+        ConductorBuilder::new(
+            ConductorCtx {
+                ctx,
+                cache,
+                provider,
+                executor,
+                execution_threshold: ExecutionThreshold::whole_share(),
+                frameworks,
+                poll_notify: Arc::new(tokio::sync::Notify::new()),
+                wallet_polling: None,
+            },
+            job_queue,
+            empty_dex_streams(),
+        )
+        .with_executor_maintenance(None)
+        .spawn()
+    }
+
+    #[tokio::test]
+    async fn test_conductor_abort_all() {
+        let pool = setup_test_db().await;
+        let conductor = build_test_conductor(&pool).await;
+        conductor.abort_all();
+    }
+
+    #[tokio::test]
+    async fn test_conductor_builder_returns_immediately() {
+        let pool = setup_test_db().await;
+        let conductor = build_test_conductor(&pool).await;
+
+        assert!(!conductor.order_poller.is_finished());
+        assert!(!conductor.position_checker.is_finished());
+
+        conductor.abort_all();
+    }
+
+    #[tokio::test]
+    async fn test_conductor_without_rebalancer() {
+        let pool = setup_test_db().await;
+        let conductor = build_test_conductor(&pool).await;
+
+        assert!(conductor.rebalancer.is_none());
+
+        conductor.abort_all();
+    }
+
+    #[tokio::test]
+    async fn test_conductor_with_rebalancer() {
+        let pool = setup_test_db().await;
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+
+        setup_apalis_tables(&pool).await.unwrap();
+        let job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
+
+        let fake_rebalancer = tokio::spawn(async {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            }
+        });
+
+        let conductor = ConductorBuilder::new(
+            ConductorCtx {
+                ctx,
+                cache,
+                provider,
+                executor,
+                execution_threshold: ExecutionThreshold::whole_share(),
+                frameworks,
+                poll_notify: Arc::new(tokio::sync::Notify::new()),
+                wallet_polling: None,
+            },
+            job_queue,
+            empty_dex_streams(),
+        )
+        .with_executor_maintenance(None)
+        .with_rebalancer(fake_rebalancer)
+        .spawn();
+
+        assert!(conductor.rebalancer.is_some());
+
+        conductor.abort_all();
+    }
+
+    #[tokio::test]
+    async fn test_conductor_rebalancer_survives_abort_trading_tasks() {
+        let pool = setup_test_db().await;
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let cache = SymbolCache::default();
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+
+        setup_apalis_tables(&pool).await.unwrap();
+        let job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
+
+        let fake_rebalancer = tokio::spawn(async {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            }
+        });
+
+        let conductor = ConductorBuilder::new(
+            ConductorCtx {
+                ctx,
+                cache,
+                provider,
+                executor,
+                execution_threshold: ExecutionThreshold::whole_share(),
+                frameworks,
+                poll_notify: Arc::new(tokio::sync::Notify::new()),
+                wallet_polling: None,
+            },
+            job_queue,
+            empty_dex_streams(),
+        )
+        .with_executor_maintenance(None)
+        .with_rebalancer(fake_rebalancer)
+        .spawn();
+
+        conductor.abort_trading_tasks();
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert!(!conductor.rebalancer.as_ref().unwrap().is_finished());
+
+        conductor.abort_all();
+    }
+
     #[tokio::test]
     async fn test_get_cutoff_block_with_timeout() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+        let mut job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
         let asserter = Asserter::new();
 
         asserter.push_success(&serde_json::Value::from(12345u64));
@@ -1372,11 +1904,135 @@ mod tests {
         let mut clear_stream = futures_util::stream::empty();
         let mut take_stream = futures_util::stream::empty();
 
-        let cutoff_block = get_cutoff_block(&mut clear_stream, &mut take_stream, &provider)
-            .await
-            .unwrap();
+        let cutoff_block = get_cutoff_block(
+            &mut clear_stream,
+            &mut take_stream,
+            &provider,
+            &mut job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(cutoff_block, 12345);
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_first_event_with_timeout_no_events() {
+        let mut clear_stream = stream::empty();
+        let mut take_stream = stream::empty();
+
+        let result = wait_for_first_event_with_timeout(
+            &mut clear_stream,
+            &mut take_stream,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_first_event_with_clear_event() {
+        let clear_event = ClearV3 {
+            sender: address!("0x1111111111111111111111111111111111111111"),
+            alice: get_test_order(),
+            bob: get_test_order(),
+            clearConfig: ClearConfigV2 {
+                aliceInputIOIndex: U256::from(0),
+                aliceOutputIOIndex: U256::from(1),
+                bobInputIOIndex: U256::from(1),
+                bobOutputIOIndex: U256::from(0),
+                aliceBountyVaultId: B256::ZERO,
+                bobBountyVaultId: B256::ZERO,
+            },
+        };
+
+        let mut log = get_test_log();
+        log.block_number = Some(1000);
+
+        let mut clear_stream = stream::iter(vec![Ok((clear_event, log.clone()))]);
+        let mut take_stream = stream::empty::<Result<(TakeOrderV3, Log), sol_types::Error>>();
+
+        let (events, block_number) = wait_for_first_event_with_timeout(
+            &mut clear_stream,
+            &mut take_stream,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(block_number, 1000);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].0, RaindexTradeEvent::ClearV3(_)));
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_first_event_missing_block_number() {
+        let clear_event = ClearV3 {
+            sender: address!("0x1111111111111111111111111111111111111111"),
+            alice: get_test_order(),
+            bob: get_test_order(),
+            clearConfig: ClearConfigV2 {
+                aliceInputIOIndex: U256::from(0),
+                aliceOutputIOIndex: U256::from(1),
+                bobInputIOIndex: U256::from(1),
+                bobOutputIOIndex: U256::from(0),
+                aliceBountyVaultId: B256::ZERO,
+                bobBountyVaultId: B256::ZERO,
+            },
+        };
+
+        let mut log = get_test_log();
+        log.block_number = None;
+
+        let mut clear_stream = stream::iter(vec![Ok((clear_event, log))]);
+        let mut take_stream = stream::empty::<Result<(TakeOrderV3, Log), sol_types::Error>>();
+
+        assert!(
+            wait_for_first_event_with_timeout(
+                &mut clear_stream,
+                &mut take_stream,
+                std::time::Duration::from_millis(100),
+            )
+            .await
+            .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_buffer_live_events_filtering() {
+        let clear_event = ClearV3 {
+            sender: address!("0x1111111111111111111111111111111111111111"),
+            alice: get_test_order(),
+            bob: get_test_order(),
+            clearConfig: ClearConfigV2 {
+                aliceInputIOIndex: U256::from(0),
+                aliceOutputIOIndex: U256::from(1),
+                bobInputIOIndex: U256::from(1),
+                bobOutputIOIndex: U256::from(0),
+                aliceBountyVaultId: B256::ZERO,
+                bobBountyVaultId: B256::ZERO,
+            },
+        };
+
+        let mut early_log = get_test_log();
+        early_log.block_number = Some(99);
+
+        let mut late_log = get_test_log();
+        late_log.block_number = Some(101);
+
+        let events = vec![
+            Ok((clear_event.clone(), early_log)),
+            Ok((clear_event, late_log)),
+        ];
+
+        let mut clear_stream = stream::iter(events);
+        let mut take_stream = stream::empty::<Result<(TakeOrderV3, Log), sol_types::Error>>();
+        let mut event_buffer = Vec::new();
+
+        buffer_live_events(&mut clear_stream, &mut take_stream, &mut event_buffer, 100).await;
+
+        assert_eq!(event_buffer.len(), 1);
+        assert_eq!(event_buffer[0].1.block_number.unwrap(), 101);
     }
 
     const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");
@@ -1488,6 +2144,16 @@ mod tests {
             .with_equity_token(TEST_EQUITY_TOKEN)
             .with_amount(amount)
             .with_log_index(log_index)
+            .with_enrichment(
+                50_000,
+                1_000_000_000,
+                PythPrice {
+                    value: "15000000000".to_string(),
+                    expo: -8,
+                    conf: "10000000".to_string(),
+                    publish_time: chrono::Utc::now(),
+                },
+            )
             .build()
     }
 
@@ -1512,7 +2178,7 @@ mod tests {
         let trade = create_test_trade("AAPL");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed when cache is populated");
 
@@ -1537,7 +2203,7 @@ mod tests {
         let trade = create_test_trade("AAPL");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed when cache is populated");
 
@@ -1561,7 +2227,7 @@ mod tests {
         let trade = create_test_trade("MSFT");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed when cache is populated");
 
@@ -1590,7 +2256,7 @@ mod tests {
         let trade = create_test_trade("AAPL");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed even when no vaults match");
 
@@ -1613,7 +2279,7 @@ mod tests {
         let trade = create_test_trade("AAPL");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed");
 
@@ -1636,7 +2302,7 @@ mod tests {
         let trade = create_test_trade("GOOG");
 
         let context = create_vault_discovery_context(&vault_registry);
-        discover_vaults_for_trade(&queued_event, &trade, &context)
+        discover_vaults_for_trade(&trade_event, &trade, &context)
             .await
             .expect("Should succeed");
 
@@ -1755,11 +2421,8 @@ mod tests {
             },
         };
 
-        let mut log = get_test_log();
-        log.log_index = Some(log_index);
         let mut hash_bytes = [0u8; 32];
         hash_bytes[31] = u8::try_from(log_index).unwrap_or(0);
-        log.transaction_hash = Some(B256::from(hash_bytes));
 
         EmittedOnChain::from_log(RaindexTradeEvent::ClearV3(Box::new(event)), &log).unwrap()
     }
@@ -2024,8 +2687,38 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn trade_above_threshold_triggers_execution() {
+        let pool = setup_test_db().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs =
+            trade_processing_cqrs_with_threshold(&frameworks, ExecutionThreshold::whole_share());
+
+        let trade_event = included_trade_event(60);
+        let trade = test_trade_with_amount(float!(2.0), 60);
+
+        let result =
+            process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true).await;
+
+        assert!(
+            result.unwrap().is_some(),
+            "2.0 shares should trigger execution with 1-share threshold"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("position should exist");
+
+        assert!(position.net.inner().eq(float!(2.0)).unwrap());
+        assert!(position.pending_offchain_order_id.is_some());
+    }
+
     /// Builds an `InventoryView` with an equity imbalance: 20% onchain, 80% offchain.
-    /// With a 50% target +/- 20% deviation, 20% < 30% lower bound -> TooMuchOffchain.
+    /// With a 50% target +/- 20% deviation, 20% < 30% lower bound -> `TooMuchOffchain`.
     fn imbalanced_inventory(symbol: &Symbol) -> InventoryView {
         InventoryView::default()
             .with_equity(
@@ -2084,10 +2777,8 @@ mod tests {
             .await
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             imbalanced_inventory(&symbol),
-            event_sender,
         ));
         let (operation_sender, mut operation_receiver) = mpsc::channel(10);
 
@@ -2183,8 +2874,9 @@ mod tests {
             )
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
+            initial_inventory,
+        ));
         let (operation_sender, _operation_receiver) = mpsc::channel(10);
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
@@ -2296,8 +2988,9 @@ mod tests {
             )
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
+            initial_inventory,
+        ));
         let (operation_sender, mut receiver) = mpsc::channel(10);
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
@@ -2424,8 +3117,9 @@ mod tests {
             )
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(initial_inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
+            initial_inventory,
+        ));
         let (operation_sender, receiver) = mpsc::channel(10);
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -163,9 +163,8 @@ mod tests {
             vault_registry,
             Address::ZERO,
             Address::ZERO,
-            Arc::new(BroadcastingInventory::new(
+            Arc::new(BroadcastingInventory::new_without_broadcast(
                 InventoryView::default(),
-                event_sender.clone(),
             )),
             operation_sender,
             Arc::new(MockWrapper::new()),

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -1,58 +1,49 @@
-//! Reactor that broadcasts aggregate events to WebSocket dashboard clients.
+//! Reactor that broadcasts aggregate events to WebSocket dashboard
+//! clients as [`Statement`] notifications.
+//!
+//! Each domain event produces a [`Statement`] with the appropriate
+//! [`Concern`] variant, notifying connected clients that something
+//! changed. Clients use the concern type to know what to
+//! refetch/invalidate.
 
 use async_trait::async_trait;
-use chrono::Utc;
-use sqlx::SqlitePool;
-use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::broadcast;
 use tracing::warn;
 
-use st0x_dto::{EventStoreEntry, ServerMessage};
-use st0x_event_sorcery::{
-    DomainEvent, EntityList, EventSourced, Never, Reactor, deps, load_entity,
-};
+use st0x_dto::{Concern, Statement};
+use st0x_event_sorcery::{DomainEvent, EntityList, EventSourced, Never, Reactor, deps};
 
 use crate::equity_redemption::EquityRedemption;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 
 deps!(
-    EventBroadcaster,
+    Broadcaster,
     [TokenizedEquityMint, EquityRedemption, UsdcRebalance,]
 );
 
-/// Reactor that broadcasts events to connected WebSocket clients.
+/// Reactor that broadcasts [`Statement`] notifications to connected
+/// WebSocket clients when domain events occur.
 ///
 /// Implements [`Reactor`] with exhaustive handling for all
 /// broadcast-eligible aggregate types.
-pub(crate) struct EventBroadcaster {
-    sender: broadcast::Sender<ServerMessage>,
-    sequence: AtomicU64,
-    pool: SqlitePool,
+pub(crate) struct Broadcaster {
+    sender: broadcast::Sender<Statement>,
 }
 
-impl EventBroadcaster {
-    pub(crate) fn new(sender: broadcast::Sender<ServerMessage>, pool: SqlitePool) -> Self {
-        Self {
-            sender,
-            sequence: AtomicU64::new(0),
-            pool,
-        }
+impl Broadcaster {
+    pub(crate) fn new(sender: broadcast::Sender<Statement>) -> Self {
+        Self { sender }
     }
 
-    fn broadcast_event<Entity: EventSourced>(&self, id: &Entity::Id, event: &Entity::Event) {
-        let entry = EventStoreEntry {
-            aggregate_type: Entity::AGGREGATE_TYPE.to_string(),
-            aggregate_id: id.to_string(),
-            sequence: self.sequence.fetch_add(1, Ordering::Relaxed),
-            event_type: event.event_type(),
-            timestamp: Utc::now(),
+    fn notify<Entity: EventSourced>(&self, id: &Entity::Id) {
+        let statement = Statement {
+            id: id.to_string(),
+            statement: Concern::Transfer,
         };
 
-        let msg = ServerMessage::Event(entry);
-
-        if let Err(error) = self.sender.send(msg) {
-            warn!("Failed to broadcast event (no receivers): {error}");
+        if let Err(error) = self.sender.send(statement) {
+            warn!("Failed to broadcast statement (no receivers): {error}");
         }
     }
 
@@ -64,7 +55,7 @@ impl EventBroadcaster {
 }
 
 #[async_trait]
-impl Reactor for EventBroadcaster {
+impl Reactor for Broadcaster {
     type Error = Never;
 
     async fn react(
@@ -72,36 +63,14 @@ impl Reactor for EventBroadcaster {
         event: <Self::Dependencies as EntityList>::Event,
     ) -> Result<(), Self::Error> {
         event
-            .on(|id, event| async move {
-                self.broadcast_event::<TokenizedEquityMint>(&id, &event);
-
-                match load_entity::<TokenizedEquityMint>(&self.pool, &id).await {
-                    Ok(Some(entity)) => self.broadcast_transfer(entity.to_dto(&id)),
-                    Ok(None) => warn!(%id, "Mint entity not found for transfer broadcast"),
-                    Err(error) => warn!(%id, ?error, "Failed to load mint entity for broadcast"),
-                }
+            .on(|id, _event| async move {
+                self.notify::<TokenizedEquityMint>(&id);
             })
-            .on(|id, event| async move {
-                self.broadcast_event::<EquityRedemption>(&id, &event);
-
-                match load_entity::<EquityRedemption>(&self.pool, &id).await {
-                    Ok(Some(entity)) => self.broadcast_transfer(entity.to_dto(&id)),
-                    Ok(None) => warn!(%id, "Redemption entity not found for transfer broadcast"),
-                    Err(error) => {
-                        warn!(%id, ?error, "Failed to load redemption entity for broadcast");
-                    }
-                }
+            .on(|id, _event| async move {
+                self.notify::<EquityRedemption>(&id);
             })
-            .on(|id, event| async move {
-                self.broadcast_event::<UsdcRebalance>(&id, &event);
-
-                match load_entity::<UsdcRebalance>(&self.pool, &id).await {
-                    Ok(Some(entity)) => self.broadcast_transfer(entity.to_dto(&id)),
-                    Ok(None) => warn!(%id, "USDC rebalance entity not found for broadcast"),
-                    Err(error) => {
-                        warn!(%id, ?error, "Failed to load USDC rebalance entity for broadcast");
-                    }
-                }
+            .on(|id, _event| async move {
+                self.notify::<UsdcRebalance>(&id);
             })
             .exhaustive()
             .await;
@@ -112,8 +81,6 @@ impl Reactor for EventBroadcaster {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Address;
-    use rain_math_float::Float;
     use uuid::Uuid;
 
     use st0x_event_sorcery::ReactorHarness;
@@ -125,17 +92,22 @@ mod tests {
     use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMintEvent};
     use crate::usdc_rebalance::{UsdcRebalanceEvent, UsdcRebalanceId};
 
-    fn make_mint_requested_float(symbol: &str, quantity: Float) -> TokenizedEquityMintEvent {
+    fn test_broadcaster() -> (Broadcaster, broadcast::Receiver<Statement>) {
+        let (sender, receiver) = broadcast::channel(16);
+        let broadcaster = Broadcaster::new(sender);
+        (broadcaster, receiver)
+    }
+
+    fn make_mint_requested(symbol: &str) -> TokenizedEquityMintEvent {
+        use alloy::primitives::Address;
+        use rain_math_float::Float;
+
         TokenizedEquityMintEvent::MintRequested {
             symbol: Symbol::new(symbol).unwrap(),
-            quantity,
+            quantity: Float::parse("100".to_string()).unwrap(),
             wallet: Address::ZERO,
             requested_at: chrono::Utc::now(),
         }
-    }
-
-    fn make_mint_requested(symbol: &str, quantity: u64) -> TokenizedEquityMintEvent {
-        make_mint_requested_float(symbol, Float::parse(quantity.to_string()).unwrap())
     }
 
     fn make_redemption_completed() -> EquityRedemptionEvent {
@@ -151,66 +123,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_broadcaster_sends_to_channel() {
-        let pool = setup_test_db().await;
-        let (sender, mut receiver) = broadcast::channel(16);
-        let broadcaster = EventBroadcaster::new(sender, pool);
+    async fn broadcaster_sends_transfer_statement() {
+        let (broadcaster, mut receiver) = test_broadcaster();
 
         let id = IssuerRequestId::new("mint-123".to_string());
-
-        broadcaster.broadcast_event::<TokenizedEquityMint>(&id, &make_mint_requested("TSLA", 50));
+        broadcaster.notify::<TokenizedEquityMint>(&id);
 
         let msg = receiver.recv().await.expect("should receive message");
 
-        match msg {
-            ServerMessage::Event(entry) => {
-                assert_eq!(entry.aggregate_type, "TokenizedEquityMint");
-                assert_eq!(entry.aggregate_id, "mint-123");
-                assert_eq!(entry.event_type, "TokenizedEquityMintEvent::MintRequested");
-            }
-            other => panic!("expected Event message, got {other:?}"),
-        }
+        assert_eq!(msg.id, "mint-123");
+        assert!(
+            matches!(msg.statement, Concern::Transfer),
+            "expected Transfer concern, got {:?}",
+            msg.statement
+        );
     }
 
     #[tokio::test]
-    async fn event_broadcaster_handles_no_receivers() {
-        let pool = setup_test_db().await;
-        let (sender, _) = broadcast::channel::<ServerMessage>(16);
-        let broadcaster = EventBroadcaster::new(sender, pool);
+    async fn broadcaster_handles_no_receivers() {
+        let (sender, _) = broadcast::channel::<Statement>(16);
+        let broadcaster = Broadcaster::new(sender);
 
         let id = IssuerRequestId::new("mint-456".to_string());
-
-        broadcaster.broadcast_event::<TokenizedEquityMint>(&id, &make_mint_requested("GOOG", 10));
+        broadcaster.notify::<TokenizedEquityMint>(&id);
     }
 
     #[tokio::test]
-    async fn reactor_receive_broadcasts_mint_event() {
-        let pool = setup_test_db().await;
-        let (sender, mut receiver) = broadcast::channel(16);
-        let harness = ReactorHarness::new(EventBroadcaster::new(sender, pool));
+    async fn reactor_broadcasts_mint_event() {
+        let (broadcaster, mut receiver) = test_broadcaster();
+        let harness = ReactorHarness::new(broadcaster);
 
         let id = IssuerRequestId::new("mint-multi".to_string());
 
         harness
-            .receive::<TokenizedEquityMint>(id, make_mint_requested("NVDA", 25))
+            .receive::<TokenizedEquityMint>(id, make_mint_requested("NVDA"))
             .await
             .unwrap();
 
         let msg = receiver.recv().await.expect("should receive message");
 
-        match msg {
-            ServerMessage::Event(entry) => {
-                assert_eq!(entry.event_type, "TokenizedEquityMintEvent::MintRequested");
-            }
-            other => panic!("expected Event message, got {other:?}"),
-        }
+        assert_eq!(msg.id, "mint-multi");
+        assert!(matches!(msg.statement, Concern::Transfer));
     }
 
     #[tokio::test]
-    async fn reactor_receive_works_for_equity_redemption() {
-        let pool = setup_test_db().await;
-        let (sender, mut receiver) = broadcast::channel(16);
-        let harness = ReactorHarness::new(EventBroadcaster::new(sender, pool));
+    async fn reactor_broadcasts_equity_redemption() {
+        let (broadcaster, mut receiver) = test_broadcaster();
+        let harness = ReactorHarness::new(broadcaster);
 
         let id = RedemptionAggregateId::new("redemption-123".to_string());
 
@@ -221,52 +180,37 @@ mod tests {
 
         let msg = receiver.recv().await.expect("should receive message");
 
-        match msg {
-            ServerMessage::Event(entry) => {
-                assert_eq!(entry.aggregate_type, "EquityRedemption");
-                assert_eq!(entry.aggregate_id, "redemption-123");
-                assert_eq!(entry.event_type, "EquityRedemptionEvent::Completed");
-            }
-            other => panic!("expected Event message, got {other:?}"),
-        }
+        assert_eq!(msg.id, "redemption-123");
+        assert!(matches!(msg.statement, Concern::Transfer));
     }
 
     #[tokio::test]
-    async fn reactor_receive_works_for_usdc_rebalance() {
-        let pool = setup_test_db().await;
-        let (sender, mut receiver) = broadcast::channel(16);
-        let harness = ReactorHarness::new(EventBroadcaster::new(sender, pool));
+    async fn reactor_broadcasts_usdc_rebalance() {
+        let (broadcaster, mut receiver) = test_broadcaster();
+        let harness = ReactorHarness::new(broadcaster);
 
         let id = UsdcRebalanceId(Uuid::new_v4());
+        let expected_id = id.to_string();
 
         harness
-            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_confirmed())
+            .receive::<UsdcRebalance>(id, make_usdc_withdrawal_confirmed())
             .await
             .unwrap();
 
         let msg = receiver.recv().await.expect("should receive message");
 
-        match msg {
-            ServerMessage::Event(entry) => {
-                assert_eq!(entry.aggregate_type, "UsdcRebalance");
-                assert_eq!(entry.aggregate_id, id.to_string());
-                assert_eq!(entry.event_type, "UsdcRebalanceEvent::WithdrawalConfirmed");
-            }
-            other => panic!("expected Event message, got {other:?}"),
-        }
+        assert_eq!(msg.id, expected_id);
+        assert!(matches!(msg.statement, Concern::Transfer));
     }
 
     #[tokio::test]
-    async fn multiple_subscribers_receive_same_event() {
+    async fn multiple_subscribers_receive_same_statement() {
         let (sender, mut receiver1) = broadcast::channel(16);
         let mut receiver2 = sender.subscribe();
-        let mut receiver3 = sender.subscribe();
-        let pool = setup_test_db().await;
-        let broadcaster = EventBroadcaster::new(sender, pool);
+        let broadcaster = Broadcaster::new(sender);
 
         let id = IssuerRequestId::new("multi-sub".to_string());
-
-        broadcaster.broadcast_event::<TokenizedEquityMint>(&id, &make_mint_requested("MSFT", 100));
+        broadcaster.notify::<TokenizedEquityMint>(&id);
 
         let msg1 = receiver1
             .recv()
@@ -276,89 +220,20 @@ mod tests {
             .recv()
             .await
             .expect("receiver2 should get message");
-        let msg3 = receiver3
-            .recv()
-            .await
-            .expect("receiver3 should get message");
 
-        for (i, msg) in [msg1, msg2, msg3].into_iter().enumerate() {
-            match msg {
-                ServerMessage::Event(entry) => {
-                    assert_eq!(
-                        entry.aggregate_id,
-                        "multi-sub",
-                        "receiver {} got wrong aggregate_id",
-                        i + 1
-                    );
-                }
-                other => {
-                    panic!("receiver {} expected Event message, got {other:?}", i + 1)
-                }
-            }
+        for (idx, msg) in [msg1, msg2].into_iter().enumerate() {
+            assert_eq!(msg.id, "multi-sub", "receiver {} got wrong id", idx + 1);
         }
     }
 
     #[tokio::test]
-    async fn broadcast_empty_does_nothing() {
-        let pool = setup_test_db().await;
+    async fn no_broadcast_without_events() {
         let (sender, mut receiver) = broadcast::channel(16);
-        let _broadcaster = EventBroadcaster::new(sender, pool);
+        let _broadcaster = Broadcaster::new(sender);
 
         let result =
             tokio::time::timeout(std::time::Duration::from_millis(10), receiver.recv()).await;
 
         assert!(result.is_err(), "should timeout with no messages");
-    }
-
-    #[tokio::test]
-    async fn event_store_entry_serializes_correctly() {
-        let pool = setup_test_db().await;
-        let (sender, _) = broadcast::channel(16);
-        let broadcaster = EventBroadcaster::new(sender, pool);
-
-        let id = IssuerRequestId::new("serialize-test".to_string());
-
-        broadcaster.broadcast_event::<TokenizedEquityMint>(&id, &make_mint_requested("GOOG", 10));
-
-        // Verify the entry via JSON (can't get the msg since receiver was dropped,
-        // but we can test the entry construction directly)
-        let entry = EventStoreEntry {
-            aggregate_type: "TokenizedEquityMint".to_string(),
-            aggregate_id: "serialize-test".to_string(),
-            sequence: 42,
-            event_type: "TokenizedEquityMintEvent::MintRequested".to_string(),
-            timestamp: Utc::now(),
-        };
-        let json = serde_json::to_string(&entry).expect("serialization should succeed");
-
-        assert!(json.contains("\"aggregate_type\":\"TokenizedEquityMint\""));
-        assert!(json.contains("\"aggregate_id\":\"serialize-test\""));
-        assert!(json.contains("\"sequence\":42"));
-        assert!(json.contains("\"event_type\":\"TokenizedEquityMintEvent::MintRequested\""));
-        assert!(json.contains("\"timestamp\""));
-    }
-
-    #[tokio::test]
-    async fn reactor_broadcasts_mint_event_with_fractional_quantity() {
-        let pool = setup_test_db().await;
-        let (sender, mut receiver) = broadcast::channel(16);
-        let harness = ReactorHarness::new(EventBroadcaster::new(sender, pool));
-
-        let id = IssuerRequestId::new("mint-frac".to_string());
-        let fractional_qty = Float::parse("25.5".to_string()).unwrap();
-
-        harness
-            .receive::<TokenizedEquityMint>(id, make_mint_requested_float("TSLA", fractional_qty))
-            .await
-            .unwrap();
-
-        let msg = receiver.recv().await.expect("should receive message");
-
-        match msg {
-            ServerMessage::Event(entry) => {
-                assert_eq!(entry.event_type, "TokenizedEquityMintEvent::MintRequested");
-            }
-            other => panic!("expected Event message, got {other:?}"),
-        }
     }
 }

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -29,40 +29,12 @@ pub(crate) struct DashboardState {
 fn ws_endpoint<'r>(
     ws: WebSocket,
     broadcast: &'r State<Broadcast>,
-    dashboard: &'r State<DashboardState>,
+    _dashboard: &'r State<DashboardCtx>,
 ) -> Channel<'r> {
     let mut receiver = broadcast.sender.subscribe();
-    let inventory = Arc::clone(&dashboard.inventory);
-    let pool = dashboard.pool.clone();
 
     ws.channel(move |mut stream| {
         Box::pin(async move {
-            let inventory_dto = inventory.read().await.to_dto();
-            let transfers = transfer_loader::load_transfers(&pool).await;
-
-            let initial_state = InitialState {
-                inventory: inventory_dto,
-                active_transfers: transfers.active,
-                recent_transfers: transfers.recent,
-                warnings: transfers.warnings,
-                ..InitialState::default()
-            };
-
-            let initial = ServerMessage::Initial(Box::new(initial_state));
-            let json = match serde_json::to_string(&initial) {
-                Ok(serialized) => serialized,
-                Err(error) => {
-                    warn!("Failed to serialize initial state: {error}");
-                    return Ok(());
-                }
-            };
-
-            if let Err(error) = stream.send(Message::Text(json)).await {
-                warn!("Failed to send initial state: {error}");
-                return Ok(());
-            }
-            info!("Sent initial state to dashboard client");
-
             loop {
                 match receiver.recv().await {
                     Ok(msg) => {
@@ -104,13 +76,19 @@ mod tests {
     use futures_util::future::join_all;
     use rocket::config::Config;
     use rocket::fairing::AdHoc;
-    use serde_json::json;
-    use st0x_dto::EventStoreEntry;
+    use st0x_dto::Concern;
     use std::sync::Mutex;
     use tokio::sync::oneshot;
     use tokio_tungstenite::connect_async;
 
     use super::*;
+
+    fn test_statement() -> Statement {
+        Statement {
+            id: "test-123".to_string(),
+            statement: Concern::Transfer,
+        }
+    }
 
     fn create_test_broadcast() -> Broadcast {
         let (sender, _) = broadcast::channel(256);
@@ -122,8 +100,8 @@ mod tests {
     ) -> DashboardState {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        DashboardState {
-            inventory: Arc::new(BroadcastingInventory::new(
+        DashboardCtx {
+            inventory: Arc::new(BroadcastingInventory::new_without_broadcast(
                 crate::inventory::InventoryView::default(),
                 event_sender,
             )),
@@ -132,22 +110,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initial_state_stub_serializes_correctly() {
-        let initial = InitialState::default();
-        let json = serde_json::to_string(&initial).expect("serialization should succeed");
-        assert!(json.contains("recentTrades"));
-        assert!(json.contains("inventory"));
-        assert!(json.contains("metrics"));
-        assert!(json.contains("authStatus"));
-        assert!(json.contains("circuitBreaker"));
-    }
-
-    #[tokio::test]
-    async fn server_message_initial_serializes_with_type_tag() {
-        let msg = ServerMessage::Initial(Box::default());
+    async fn statement_serializes_with_type_tag() {
+        let msg = test_statement();
         let json = serde_json::to_string(&msg).expect("serialization should succeed");
-        assert!(json.contains(r#""type":"initial""#));
-        assert!(json.contains(r#""data":"#));
+        assert!(json.contains(r#""id":"test-123""#));
+        assert!(json.contains(r#""statement""#));
     }
 
     #[tokio::test]
@@ -155,7 +122,7 @@ mod tests {
         let broadcast = create_test_broadcast();
         let mut rx = broadcast.sender.subscribe();
 
-        let sent_msg = ServerMessage::Initial(Box::default());
+        let sent_msg = test_statement();
         broadcast
             .sender
             .send(sent_msg.clone())
@@ -173,7 +140,7 @@ mod tests {
         let mut receiver1 = broadcast.sender.subscribe();
         let mut receiver2 = broadcast.sender.subscribe();
 
-        let msg = ServerMessage::Initial(Box::default());
+        let msg = test_statement();
         broadcast.sender.send(msg).expect("send should succeed");
 
         receiver1
@@ -192,72 +159,7 @@ mod tests {
         assert_eq!(route_list.len(), 1);
     }
 
-    #[tokio::test]
-    async fn websocket_endpoint_sends_initial_message() {
-        let broadcast = create_test_broadcast();
-        let dashboard_state = create_test_dashboard_state(broadcast.sender.clone()).await;
-
-        let config = Config {
-            port: 0, // Let OS assign a random available port
-            log_level: rocket::config::LogLevel::Off,
-            ..Config::debug_default()
-        };
-
-        let (port_tx, port_rx) = oneshot::channel::<u16>();
-        let port_tx = Mutex::new(Some(port_tx));
-
-        let rocket = rocket::build()
-            .configure(config)
-            .mount("/api", routes())
-            .manage(broadcast)
-            .manage(dashboard_state)
-            .attach(AdHoc::on_liftoff("Port Sender", move |rocket| {
-                Box::pin(async move {
-                    let maybe_tx = port_tx.lock().unwrap().take();
-                    if let Some(tx) = maybe_tx {
-                        let _ = tx.send(rocket.config().port);
-                    }
-                })
-            }));
-
-        let rocket = rocket.ignite().await.expect("ignite failed");
-        let shutdown_handle = rocket.shutdown();
-
-        tokio::spawn(async move {
-            let _ = rocket.launch().await;
-        });
-
-        let port = port_rx.await.expect("failed to receive port");
-
-        let url = format!("ws://127.0.0.1:{port}/api/ws");
-        let (mut ws_stream, _response) = connect_async(&url)
-            .await
-            .expect("WebSocket connection failed");
-
-        let msg = ws_stream
-            .next()
-            .await
-            .expect("stream closed")
-            .expect("message error");
-
-        let text = msg.into_text().expect("expected text message");
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-        assert_eq!(parsed["type"], "initial");
-        assert!(parsed["data"]["recentTrades"].is_array());
-        assert!(parsed["data"]["inventory"].is_object());
-
-        shutdown_handle.notify();
-    }
-
-    struct TestServer {
-        port: u16,
-        shutdown: rocket::Shutdown,
-        broadcast: Broadcast,
-        inventory: Arc<BroadcastingInventory>,
-    }
-
-    async fn start_test_server() -> TestServer {
+    async fn start_test_server() -> (u16, rocket::Shutdown, Broadcast) {
         let broadcast = create_test_broadcast();
         let broadcast_clone = Broadcast {
             sender: broadcast.sender.clone(),
@@ -306,45 +208,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multiple_concurrent_clients_receive_initial_message() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
-
-        let (mut client1, _) = connect_async(&url)
-            .await
-            .expect("client1 connection failed");
-        let (mut client2, _) = connect_async(&url)
-            .await
-            .expect("client2 connection failed");
-        let (mut client3, _) = connect_async(&url)
-            .await
-            .expect("client3 connection failed");
-
-        for (i, client) in [&mut client1, &mut client2, &mut client3]
-            .iter_mut()
-            .enumerate()
-        {
-            let msg = client
-                .next()
-                .await
-                .unwrap_or_else(|| panic!("client{} stream closed", i + 1))
-                .unwrap_or_else(|error| panic!("client{} message error: {}", i + 1, error));
-
-            let text = msg.into_text().expect("expected text message");
-            let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-            assert_eq!(
-                parsed["type"],
-                "initial",
-                "client{} should receive initial message",
-                i + 1
-            );
-        }
-
-        server.shutdown.notify();
-    }
-
-    #[tokio::test]
     async fn broadcast_message_reaches_connected_clients() {
         let server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
@@ -356,44 +219,31 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
-        client1.next().await.expect("client1 initial").unwrap();
-        client2.next().await.expect("client2 initial").unwrap();
-
-        // Broadcast an event message
-        let event = EventStoreEntry {
-            aggregate_type: "TestAggregate".to_string(),
-            aggregate_id: "test-123".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
+        let broadcast_msg = Statement {
+            id: "test-broadcast".to_string(),
+            statement: Concern::Transfer,
         };
-        let broadcast_msg = ServerMessage::Event(event);
-        server
-            .broadcast
+        broadcast
             .sender
             .send(broadcast_msg)
             .expect("broadcast send");
 
-        // Both clients should receive the broadcast
         let results = join_all([client1.next(), client2.next()]).await;
 
-        for (i, result) in results.into_iter().enumerate() {
+        for (idx, result) in results.into_iter().enumerate() {
             let msg = result
-                .unwrap_or_else(|| panic!("client{} stream closed", i + 1))
-                .unwrap_or_else(|error| panic!("client{} error: {}", i + 1, error));
+                .unwrap_or_else(|| panic!("client{} stream closed", idx + 1))
+                .unwrap_or_else(|error| panic!("client{} error: {}", idx + 1, error));
 
             let text = msg.into_text().expect("expected text");
             let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
             assert_eq!(
-                parsed["type"],
-                "event",
-                "client{} should receive event message",
-                i + 1
+                parsed["id"],
+                "test-broadcast",
+                "client{} should receive broadcast",
+                idx + 1
             );
-            assert_eq!(parsed["data"]["aggregate_type"], "TestAggregate");
-            assert_eq!(parsed["data"]["aggregate_id"], "test-123");
         }
 
         server.shutdown.notify();
@@ -411,30 +261,20 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
-        client1.next().await.expect("client1 initial").unwrap();
-
-        // Drop client2 to simulate disconnect
         drop(client2);
 
-        // Give the server a moment to process the disconnect
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-        // Broadcast a message - should still reach client1
-        let event = EventStoreEntry {
-            aggregate_type: "StillWorking".to_string(),
-            aggregate_id: "after-disconnect".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
+        let broadcast_msg = Statement {
+            id: "after-disconnect".to_string(),
+            statement: Concern::Transfer,
         };
         server
             .broadcast
             .sender
-            .send(ServerMessage::Event(event))
+            .send(broadcast_msg)
             .expect("broadcast send");
 
-        // client1 should still receive messages
         let msg = client1
             .next()
             .await
@@ -444,60 +284,7 @@ mod tests {
         let text = msg.into_text().expect("expected text");
         let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
-        assert_eq!(parsed["type"], "event");
-        assert_eq!(parsed["data"]["aggregate_type"], "StillWorking");
-
-        server.shutdown.notify();
-    }
-
-    #[tokio::test]
-    async fn new_client_receives_initial_not_previous_broadcasts() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
-
-        // Connect first client to have a receiver
-        let (mut client1, _) = connect_async(&url)
-            .await
-            .expect("client1 connection failed");
-
-        // Consume initial message for client1
-        client1.next().await.expect("client1 initial").unwrap();
-
-        // Broadcast a message (client1 will receive it)
-        let event = EventStoreEntry {
-            aggregate_type: "OldEvent".to_string(),
-            aggregate_id: "before-client2".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
-        };
-        server
-            .broadcast
-            .sender
-            .send(ServerMessage::Event(event))
-            .expect("broadcast send");
-
-        // Consume the broadcast on client1
-        client1.next().await.expect("client1 broadcast").unwrap();
-
-        // Now connect a second client - should get initial, not the old broadcast
-        let (mut client2, _) = connect_async(&url)
-            .await
-            .expect("client2 connection failed");
-
-        let msg = client2
-            .next()
-            .await
-            .expect("stream closed")
-            .expect("message error");
-
-        let text = msg.into_text().expect("expected text");
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-        assert_eq!(
-            parsed["type"], "initial",
-            "new client should receive initial, not previous broadcast"
-        );
+        assert_eq!(parsed["id"], "after-disconnect");
 
         server.shutdown.notify();
     }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -16,10 +16,9 @@ use serde_json::json;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 use rain_math_float::Float;
-use st0x_dto::ServerMessage;
 use st0x_event_sorcery::{Store, StoreBuilder, test_store};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor, Symbol,
@@ -175,8 +174,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
     let symbol = Symbol::new("AAPL").unwrap();
     let aggregate_id = symbol.to_string();
 
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default()
             .with_equity(
                 symbol.clone(),
@@ -184,7 +182,6 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
                 FractionalShares::ZERO,
             )
             .with_usdc(Usdc::new(float!(1000000)), Usdc::new(float!(1000000))),
-        event_sender,
     ));
     let (sender, receiver) = mpsc::channel(10);
 
@@ -879,10 +876,8 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
 
     // 100 onchain, 900 offchain = 10% onchain ratio -> below 30% -> TooMuchOffchain
     // Excess = target_onchain - onchain = 500 - 100 = 400 USDC (above $51 minimum)
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default(),
-        event_sender,
     ));
 
     build_imbalanced_inventory(Imbalance::Usdc {
@@ -956,10 +951,8 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
 
     // 900 onchain, 100 offchain = 90% onchain ratio -> above 70% -> TooMuchOnchain
     // Excess = onchain - target_onchain = 900 - 500 = 400 USDC
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default(),
-        event_sender,
     ));
 
     build_imbalanced_inventory(Imbalance::Usdc {
@@ -1030,10 +1023,8 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
 async fn usdc_none_disables_usdc_rebalancing() {
     let pool = setup_test_db().await;
 
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default(),
-        event_sender,
     ));
 
     build_imbalanced_inventory(Imbalance::Usdc {
@@ -1217,10 +1208,8 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // 50 onchain, 950 offchain = 5% ratio -> TooMuchOffchain
     // Excess to reach 50% target = 500 - 50 = 450 USDC
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default().with_usdc(Usdc::new(float!(50)), Usdc::new(float!(950))),
-        event_sender,
     ));
 
     let assets = AssetsConfig {
@@ -1348,10 +1337,8 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     let pool = setup_test_db().await;
 
     // Large imbalance: 100 onchain, 900 offchain
-    let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-    let inventory = Arc::new(BroadcastingInventory::new(
+    let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
         InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900))),
-        event_sender,
     ));
 
     let assets = AssetsConfig {
@@ -1450,10 +1437,8 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
     // Scenario 1: Wide threshold - no trigger
     {
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
 
         build_imbalanced_inventory(Imbalance::Usdc {
@@ -1510,10 +1495,8 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
     // Scenario 2: Tight threshold - triggers
     {
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
 
         build_imbalanced_inventory(Imbalance::Usdc {

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -11,7 +11,7 @@ use alloy::providers::RootProvider;
 use futures_util::future::try_join_all;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,10 +311,8 @@ mod tests {
     }
 
     fn create_test_inventory() -> Arc<inventory::BroadcastingInventory> {
-        let sender = create_test_event_sender();
-        Arc::new(inventory::BroadcastingInventory::new(
+        Arc::new(inventory::BroadcastingInventory::new_without_broadcast(
             inventory::InventoryView::default(),
-            sender,
         ))
     }
 

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -192,9 +192,7 @@ mod tests {
     use alloy::primitives::{U256, address};
     use chrono::Utc;
     use rain_math_float::Float;
-    use tokio::sync::broadcast;
 
-    use st0x_dto::ServerMessage;
     use st0x_execution::FractionalShares;
 
     use super::*;
@@ -231,8 +229,7 @@ mod tests {
             )
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        Arc::new(BroadcastingInventory::new(view, event_sender))
+        Arc::new(BroadcastingInventory::new_without_broadcast(view))
     }
 
     #[test]
@@ -281,8 +278,7 @@ mod tests {
     async fn test_balanced_inventory_returns_no_imbalance() {
         let symbol = Symbol::new("AAPL").unwrap();
         let view = InventoryView::default().with_equity(symbol.clone(), shares(0), shares(0));
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(view, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(view));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -434,8 +430,7 @@ mod tests {
             )
             .unwrap();
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        Arc::new(BroadcastingInventory::new(view, event_sender))
+        Arc::new(BroadcastingInventory::new_without_broadcast(view))
     }
 
     /// Verifies that quantity truncation doesn't lose the truncated portion from inventory.

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1185,12 +1185,9 @@ mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
-    use tokio::sync::broadcast;
     use tokio::sync::mpsc;
     use tokio::sync::mpsc::error::TryRecvError;
     use uuid::Uuid;
-
-    use st0x_dto::ServerMessage;
 
     use super::*;
 
@@ -1234,10 +1231,8 @@ mod tests {
 
     async fn make_trigger() -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
@@ -1295,10 +1290,8 @@ mod tests {
     #[tokio::test]
     async fn test_usdc_disabled_via_cash_config_does_not_send() {
         let (sender, mut receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
@@ -1336,10 +1329,8 @@ mod tests {
     async fn disabled_asset_skips_equity_trigger() {
         let symbol = Symbol::new("AAPL").unwrap();
         let (sender, mut receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
@@ -1481,8 +1472,7 @@ mod tests {
         inventory: InventoryView,
     ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let pool = crate::test_utils::setup_test_db().await;
 
         (
@@ -1517,8 +1507,7 @@ mod tests {
         wrapper: Arc<MockWrapper>,
     ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let pool = crate::test_utils::setup_test_db().await;
 
         seed_vault_registry(&pool, symbol).await;
@@ -1588,10 +1577,8 @@ mod tests {
         // inventory update failure from the rebalancing check).
         let symbol = Symbol::new("AAPL").unwrap();
         let (sender, mut receiver) = mpsc::channel(10);
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(usdc(1_000_000), usdc(1_000_000)),
-            event_sender,
         ));
         let pool = crate::test_utils::setup_test_db().await;
 
@@ -3356,7 +3343,7 @@ mod tests {
             redemption_wallet = "0x1234567890123456789012345678901234567890"
 
             [wallet]
-            kind = "private-key"
+            type = "private-key"
             address = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
             [equity]
@@ -3378,6 +3365,7 @@ mod tests {
             ethereum_rpc_url = "https://eth.example.com"
 
             [wallet]
+            type = "private-key"
             private_key = "{key}"
         "#
         )
@@ -3523,13 +3511,9 @@ mod tests {
             Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
-            {
-                let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-                Arc::new(BroadcastingInventory::new(
-                    InventoryView::default(),
-                    event_sender,
-                ))
-            },
+            Arc::new(BroadcastingInventory::new_without_broadcast(
+                InventoryView::default(),
+            )),
             sender,
             wrapper,
         );
@@ -3911,10 +3895,8 @@ mod tests {
     async fn trigger_clears_in_progress_flag_when_terminal_event_received() {
         let (sender, _receiver) = mpsc::channel(10);
         let pool = crate::test_utils::setup_test_db().await;
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(usdc(5000), usdc(5000)),
-            event_sender,
         ));
 
         let trigger = Arc::new(RebalancingTrigger::new(
@@ -4042,15 +4024,13 @@ mod tests {
             .await
             .unwrap();
 
-        // Now start post-deposit conversion (USDC to USD).
-        // Amount must match amount_received from bridging (99.99), not the
-        // originally requested amount (500), since that's what was deposited.
+        // Now start post-deposit conversion (USDC to USD)
         store
             .send(
                 &id,
                 UsdcRebalanceCommand::InitiatePostDepositConversion {
                     order_id: uuid::Uuid::new_v4(),
-                    amount: Usdc::new(float!(99.99)),
+                    amount: Usdc::new(float!(500)),
                 },
             )
             .await
@@ -4109,10 +4089,8 @@ mod tests {
         let symbol = Symbol::new("RKLB").unwrap();
 
         // Empty inventory - simulates startup state before polling completes
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
 
         let (sender, mut receiver) = mpsc::channel(10);
@@ -4177,10 +4155,8 @@ mod tests {
     async fn trigger_fires_when_both_venues_have_data() {
         let pool = crate::test_utils::setup_test_db().await;
         let symbol = Symbol::new("RKLB").unwrap();
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let (sender, mut receiver) = mpsc::channel(10);
 
@@ -4258,10 +4234,8 @@ mod tests {
     async fn logs_show_partial_data_skips_imbalance_check() {
         let pool = crate::test_utils::setup_test_db().await;
         let symbol = Symbol::new("RKLB").unwrap();
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let (sender, _receiver) = mpsc::channel(10);
 
@@ -4320,10 +4294,8 @@ mod tests {
     async fn logs_show_trigger_fires_with_complete_data() {
         let pool = crate::test_utils::setup_test_db().await;
         let symbol = Symbol::new("RKLB").unwrap();
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let (sender, _receiver) = mpsc::channel(10);
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -138,13 +138,9 @@ fn cap_usdc(amount: Usdc, usdc_limit: Option<Usdc>) -> Usdc {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::broadcast;
-
-    use st0x_dto::ServerMessage;
-    use st0x_float_macro::float;
-
     use super::*;
     use crate::inventory::InventoryView;
+    use st0x_float_macro::float;
 
     #[test]
     fn test_guard_releases_on_drop() {
@@ -185,10 +181,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_balanced_inventory_returns_no_imbalance() {
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default(),
-            event_sender,
         ));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
@@ -216,8 +210,7 @@ mod tests {
         let inventory =
             InventoryView::default().with_usdc(Usdc::new(float!(10)), Usdc::new(float!(90)));
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -238,8 +231,7 @@ mod tests {
         let inventory =
             InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)));
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -261,8 +253,7 @@ mod tests {
         let inventory =
             InventoryView::default().with_usdc(Usdc::new(float!(0)), Usdc::new(float!(102)));
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -285,8 +276,7 @@ mod tests {
         let inventory =
             InventoryView::default().with_usdc(Usdc::new(float!(90)), Usdc::new(float!(10)));
 
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -304,8 +294,7 @@ mod tests {
     async fn operational_limits_cap_usdc_amount() {
         let inventory =
             InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)));
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(inventory));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -329,10 +318,8 @@ mod tests {
         let usdc_limit = Some(Usdc::new(float!(100)));
 
         // 100 onchain / 500 offchain -> 83% offchain, excess = 200
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500))),
-            event_sender,
         ));
 
         let first = check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit).await;
@@ -343,10 +330,8 @@ mod tests {
 
         // After transferring 100: 200 onchain / 400 offchain -> 67% offchain
         // Still above 70% threshold? No - 400/600 = 66.7%, within 30%-70%. No trigger.
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let after_first = Arc::new(BroadcastingInventory::new(
+        let after_first = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(Usdc::new(float!(200)), Usdc::new(float!(400))),
-            event_sender,
         ));
 
         let second =
@@ -359,10 +344,8 @@ mod tests {
 
         // But if only 50 was transferred: 150 onchain / 450 offchain -> 75% offchain
         // Still above 70%, so triggers again
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let partially_resolved = Arc::new(BroadcastingInventory::new(
+        let partially_resolved = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(Usdc::new(float!(150)), Usdc::new(float!(450))),
-            event_sender,
         ));
 
         let third =
@@ -376,10 +359,8 @@ mod tests {
     #[tokio::test]
     async fn capped_amount_below_minimum_skips_withdrawal() {
         // excess = $200 (above $51 minimum), but limit = $30 caps it below minimum
-        let (event_sender, _) = broadcast::channel::<ServerMessage>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
+        let inventory = Arc::new(BroadcastingInventory::new_without_broadcast(
             InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500))),
-            event_sender,
         ));
         let threshold = ImbalanceThreshold {
             target: float!(0.5),


### PR DESCRIPTION
## Motivation

Closes [RAI-150](https://linear.app/makeitrain/issue/RAI-150/dashboard-redesign-websocket-protocol-and-strip-old-live-events-panel)

The existing WebSocket protocol (`ServerMessage`/`InitialState`/`EventStoreEntry`) streamed raw event-store entries to the frontend -- aggregate type strings, sequence counters, full event type names. This was a quick bootstrap to get the dashboard working but doesn't scale: the frontend had to understand internal CQRS event types, the `InitialState` payload loaded transfer aggregates on every connection, and the protocol mixed concerns (entity snapshots vs. event-store metadata) in one message type.

This PR replaces that with a simpler `Statement`/`Concern` protocol where the server broadcasts lightweight notifications ("something changed in Transfer domain") and the client decides what to refetch. This is the teardown half of the protocol redesign -- the full Statement/Inquiry protocol with proc macros and TypeScript codegen will follow in subsequent PRs.

## Solution

**WebSocket protocol simplification:**
- Replaced `ServerMessage` (tagged enum with `Initial`/`Event` variants) with `Statement` -- a flat struct containing an entity `id` and a `Concern` discriminant (currently just `Transfer`)
- Removed `InitialState` -- the server no longer sends a snapshot on connection. Clients will use the upcoming Sync inquiry to request initial state
- Removed `EventStoreEntry`, `TransferCategory`, and `Warning` from the DTO crate -- these were artifacts of the old protocol
- Renamed `EventBroadcaster` -> `Broadcaster`; it now calls `notify()` (sends a `Statement`) instead of `broadcast_event()` (which serialized raw event-store entries and then loaded full entity state from the DB)

**Conductor restructuring:**
- Extracted `ConductorBuilder` pattern -- the conductor is now constructed via a builder that accepts `ConductorCtx`, `DexTradeAccountingJobQueue`, and `DexEventStreams`, with optional rebalancer/inventory-poller/executor-maintenance handles
- Added `abort_trading_tasks()` -- aborts only trading-related tasks (supervisor, monitor, order poller, position checker) while keeping rebalancer, inventory poller, and broker maintenance alive. This supports the upcoming market-hours-aware lifecycle where trading stops outside market hours but rebalancing continues
- Moved `get_cutoff_block` and event buffering logic (`wait_for_first_event_with_timeout`, `buffer_live_events`, `enqueue_buffered_events`) into standalone functions with proper stream generics, making them testable independently
- Moved `base_wallet_unwrapped_equity_token_addresses` and `base_wallet_wrapped_equity_token_addresses` out of the old inline position, added doc comments, and unified their filter to `OperationMode::Enabled` check

**`BroadcastingInventory` decoupling:**
- Added `new_without_broadcast()` constructor that creates inventory without requiring a broadcast channel -- used extensively in tests to remove boilerplate (`broadcast::channel::<ServerMessage>(16)` + unwanted sender wiring)

**Misc cleanup:**
- Downgraded noisy periodic poll logs from `debug!` to `trace!`
- Improved `execute_witness_trade` duplicate handling: witness first (aggregate rejects duplicates), then enrich -- instead of pre-loading the aggregate to check for duplicates
- Conflict markers in SPEC.md from the parent PR's variant-A/variant-B spec exploration (to be resolved in a follow-up)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)
