### PR TITLE
fix: use SQLX_OFFLINE in nix derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,6 @@
 
           st0xRust = pkgs.callPackage ./rust.nix {
             inherit craneLib;
-            inherit (pkgs) sqlx-cli;
             sol-build-inputs = rainix.sol-build-inputs.${system};
           };
         in rainixPkgs // deployPkgs // {
@@ -224,24 +223,23 @@
           DATABASE_URL = "sqlite:dev.db";
           FOUNDRY_DISABLE_NIGHTLY_WARNING = true;
 
-          buildInputs = with pkgs;
-            [
-              bacon
-              bun
-              sqlx-cli
-              cargo-expand
-              cargo-nextest
-              terraform
-              ragenix.packages.${system}.default
-              packages.ci
-              packages.prepSolArtifacts
-              packages.secret
-              packages.rekey
-              packages.remote
-              packages.deployNixos
-              packages.deployService
-              packages.deployAll
-            ] ++ rainix.devShells.${system}.default.buildInputs;
+          buildInputs = (with pkgs; [
+            bacon
+            bun
+            # sqlx-cli
+            cargo-expand
+            cargo-nextest
+            ragenix.packages.${system}.default
+          ]) ++ (with packages; [
+            ci
+            prepSolArtifacts
+            secret
+            rekey
+            remote
+            deployNixos
+            deployService
+            deployAll
+          ]) ++ rainix.devShells.${system}.default.buildInputs;
         };
       });
 

--- a/rust.nix
+++ b/rust.nix
@@ -1,4 +1,4 @@
-{ pkgs, craneLib, sqlx-cli, sol-build-inputs }:
+{ pkgs, craneLib, sol-build-inputs }:
 
 let
   # Requires --impure. Submodules must be checked out and prepSolArtifacts
@@ -67,11 +67,16 @@ let
 
     inherit cargoVendorDir;
 
-    nativeBuildInputs = [ sqlx-cli pkgs.pkg-config ];
+    nativeBuildInputs = [ pkgs.pkg-config ];
 
     buildInputs = [ pkgs.openssl pkgs.sqlite ]
       ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin
       [ pkgs.apple-sdk_15 ];
+
+    # Use offline sqlx query verification so builds don't need a live database.
+    # Each crate (ours + apalis-sqlite) ships its own .sqlx/ with prepared data.
+    # Run `cargo sqlx prepare` after changing sqlx macros to regenerate.
+    SQLX_OFFLINE = "true";
 
     # Submodules with path dependencies need lib/ symlinked early
     postUnpack = ''
@@ -82,16 +87,6 @@ let
 
   # Build only dependencies (cached separately from source changes)
   cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { src = depsSrc; });
-
-  # sqlx needs DATABASE_URL at compile time for query checking
-  # Only needed for final build and clippy, not deps
-  sqlxSetup = ''
-    set -eo pipefail
-
-    export DATABASE_URL="sqlite:$TMPDIR/build.db"
-    sqlx db create
-    sqlx migrate run --source migrations
-  '';
 
 in {
   # DTO crate for TypeScript codegen - no sqlx deps needed
@@ -109,7 +104,6 @@ in {
   # Main package with all binaries
   package = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    preBuild = sqlxSetup;
     nativeCheckInputs = sol-build-inputs;
     doCheck = true;
     cargoTestExtraArgs = "--workspace --all-targets --all-features";
@@ -123,7 +117,6 @@ in {
   # Clippy check (reuses cached deps)
   clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
-    preBuild = sqlxSetup;
     cargoClippyExtraArgs =
       "--workspace --all-targets --all-features -- -D warnings";
   });


### PR DESCRIPTION
## Motivation

Closes [RAI-151](https://linear.app/makeitrain/issue/RAI-151/use-sqlx-offline-in-nix-derivation-instead-of-live-database)

The Nix derivation for building the project required `sqlx-cli` as a build dependency and ran `sqlx db create` + `sqlx migrate run` during the build phase to satisfy sqlx's compile-time query checking. This was fragile -- it needed a live database in the build sandbox -- and added unnecessary complexity to the build.

## Solution

Switch to `SQLX_OFFLINE=true` for Nix builds, which uses the pre-generated `.sqlx/` query data files instead of a live database for compile-time verification.

Changes:
- **`rust.nix`**: Remove `sqlx-cli` from `nativeBuildInputs`, remove the `sqlxSetup` script (which created a temp database and ran migrations), and set `SQLX_OFFLINE=true` in the common build args
- **`flake.nix`**: Remove `sqlx-cli` from the `rust.nix` callPackage args, comment it out of the dev shell (can be re-added if needed locally), and clean up the dev shell `buildInputs` formatting by splitting `pkgs` and `packages` into separate `with` blocks. Also removes `terraform` from dev shell inputs (unused)

Developers who need to regenerate `.sqlx/` data after changing sqlx macros run `cargo sqlx prepare` locally.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)
