### PR TITLE
fix: replace Rocket with Axum, mount apalis-board

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "apalis-board"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef709d9a3bcabd9f6fb09404c29df8d0acc789511b0e7e7b29cb804d05774d5"
+dependencies = [
+ "apalis-board-api",
+]
+
+[[package]]
+name = "apalis-board-api"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed583947f906bd99574c42a1ac0d2cdf5c202ffcc9e946fc995df43bce4d21f"
+dependencies = [
+ "apalis-board-types",
+ "apalis-core",
+ "axum",
+ "futures",
+ "include_dir",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing-core",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "apalis-board-types"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5bf2d4d8965f74922d850ed40a4fe240219dfebc93df6ef06c561abfd46d27c"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "apalis-codec"
 version = "0.1.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,21 +1574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1605,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backon"
@@ -1623,12 +1701,6 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
-name = "binascii"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
@@ -1834,12 +1906,6 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -2051,17 +2117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
 ]
 
 [[package]]
@@ -2376,39 +2431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "devise"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d90b0c4c777a2cad215e3c7be59ac7c15adf45cf76317009b7d096d46f651d"
-dependencies = [
- "devise_codegen",
- "devise_core",
-]
-
-[[package]]
-name = "devise_codegen"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b28680d8be17a570a2334922518be6adc3f58ecc880cbb404eaeb8624fd867"
-dependencies = [
- "devise_core",
- "quote",
-]
-
-[[package]]
-name = "devise_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b035a542cf7abf01f2e3c4d5a7acbaebfefe120ae4efc7bde3df98186e4b8af7"
-dependencies = [
- "bitflags 2.11.0",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,20 +2714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic 0.6.1",
- "pear",
- "serde",
- "toml 0.8.23",
- "uncased",
- "version_check",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,19 +2916,6 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
-
-[[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
 
 [[package]]
 name = "generic-array"
@@ -3595,6 +3590,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,12 +3631,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
@@ -3662,17 +3670,6 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3918,21 +3915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3966,6 +3948,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4014,25 +4002,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.4.0",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "tokio",
- "tokio-util",
- "version_check",
 ]
 
 [[package]]
@@ -4637,29 +4606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4892,7 +4838,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4924,19 +4870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -5633,98 +5566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocket"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a516907296a31df7dc04310e7043b61d71954d703b603cc6867a026d7e72d73f"
-dependencies = [
- "async-stream",
- "async-trait",
- "atomic 0.5.3",
- "binascii",
- "bytes",
- "either",
- "figment",
- "futures",
- "indexmap 2.13.0",
- "log",
- "memchr",
- "multer",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "rand 0.8.5",
- "ref-cast",
- "rocket_codegen",
- "rocket_http",
- "serde",
- "serde_json",
- "state",
- "tempfile",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "ubyte",
- "version_check",
- "yansi",
-]
-
-[[package]]
-name = "rocket_codegen"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
-dependencies = [
- "devise",
- "glob",
- "indexmap 2.13.0",
- "proc-macro2",
- "quote",
- "rocket_http",
- "syn 2.0.117",
- "unicode-xid",
- "version_check",
-]
-
-[[package]]
-name = "rocket_http"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e274915a20ee3065f611c044bd63c40757396b6dbc057d6046aec27f14f882b9"
-dependencies = [
- "cookie",
- "either",
- "futures",
- "http 0.2.12",
- "hyper 0.14.32",
- "indexmap 2.13.0",
- "log",
- "memchr",
- "pear",
- "percent-encoding",
- "pin-project-lite",
- "ref-cast",
- "serde",
- "smallvec",
- "stable-pattern",
- "state",
- "time",
- "tokio",
- "uncased",
-]
-
-[[package]]
-name = "rocket_ws"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1877668c937b701177c349f21383c556cd3bb4ba8fa1d07fa96ccb3a8782e"
-dependencies = [
- "rocket",
- "tokio-tungstenite 0.21.0",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,12 +5777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6129,21 +5964,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
  "serde",
 ]
 
@@ -6906,11 +6743,13 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "apalis",
+ "apalis-board",
  "apalis-codec",
  "apalis-core",
  "apalis-sqlite",
  "approx",
  "async-trait",
+ "axum",
  "backon",
  "base64 0.22.1",
  "bon",
@@ -6931,8 +6770,6 @@ dependencies = [
  "rain-math-float",
  "rand 0.8.5",
  "reqwest 0.12.28",
- "rocket",
- "rocket_ws",
  "rsa",
  "serde",
  "serde_json",
@@ -6956,6 +6793,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.28.0",
  "toml 0.9.12+spec-1.1.0",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.23",
@@ -6968,28 +6806,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable-pattern"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "state"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
-dependencies = [
- "loom",
-]
 
 [[package]]
 name = "static_assertions"
@@ -7410,18 +7230,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -7465,25 +7273,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -7498,20 +7294,11 @@ checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7534,20 +7321,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
@@ -7566,12 +7339,6 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -7725,6 +7492,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7743,12 +7520,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -7842,25 +7622,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -7938,15 +7699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "ubyte"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7980,16 +7732,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "serde",
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -8384,15 +8126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8826,15 +8559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-dependencies = [
- "is-terminal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,8 +166,6 @@ rain-error-decoding.workspace = true
 rain-math-float.workspace = true
 rand.workspace = true
 reqwest.workspace = true
-rocket.workspace = true
-rocket_ws.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlite-es.workspace = true
@@ -184,6 +182,8 @@ apalis = "1.0.0-rc.4"
 apalis-codec = "0.1.0-rc.4"
 apalis-sqlite = "1.0.0-rc.4"
 task-supervisor = "0.4"
+axum = { version = "0.8.8", features = ["ws", "json"] }
+apalis-board = { version = "1.0.0-rc.4", features = ["axum"] }
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
@@ -216,6 +216,7 @@ temp-env.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 tokio-tungstenite.workspace = true
+tower = { version = "0.5.3", features = ["util"] }
 tracing-subscriber.workspace = true
 tracing-test.workspace = true
 url.workspace = true

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,14 +1,14 @@
 //! HTTP API endpoints for health checks and broker authentication.
 
+use axum::extract::State;
+use axum::routing::{get, post};
+use axum::{Json, Router};
 use chrono::{DateTime, Utc};
-use rocket::serde::json::Json;
-use rocket::serde::{Deserialize, Serialize};
-use rocket::{Route, State, get, post, routes};
-use sqlx::SqlitePool;
+use serde::{Deserialize, Serialize};
 
 use st0x_execution::extract_code_from_url;
 
-use crate::config::{BrokerCtx, Ctx};
+use crate::config::BrokerCtx;
 
 #[derive(Serialize, Deserialize)]
 struct HealthResponse {
@@ -16,8 +16,7 @@ struct HealthResponse {
     timestamp: DateTime<Utc>,
 }
 
-#[get("/health")]
-fn health() -> Json<HealthResponse> {
+async fn health() -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "healthy".to_string(),
         timestamp: Utc::now(),
@@ -38,13 +37,11 @@ enum AuthRefreshResponse {
     Error { error: String },
 }
 
-#[post("/auth/refresh", format = "json", data = "<request>")]
 async fn auth_refresh(
-    request: Json<AuthRefreshRequest>,
-    pool: &State<SqlitePool>,
-    ctx: &State<Ctx>,
+    State(state): State<super::AppState>,
+    Json(request): Json<AuthRefreshRequest>,
 ) -> Json<AuthRefreshResponse> {
-    let BrokerCtx::Schwab(schwab_auth) = &ctx.broker else {
+    let BrokerCtx::Schwab(schwab_auth) = &state.ctx.broker else {
         return Json(AuthRefreshResponse::Error {
             error: "Auth refresh is only supported for Schwab broker".to_string(),
         });
@@ -59,7 +56,7 @@ async fn auth_refresh(
         }
     };
 
-    let schwab_ctx = schwab_auth.to_schwab_ctx(pool.inner().clone());
+    let schwab_ctx = schwab_auth.to_schwab_ctx(state.pool.clone());
     let tokens = match schwab_ctx.get_tokens_from_code(&code).await {
         Ok(tokens) => tokens,
         Err(error) => {
@@ -69,10 +66,7 @@ async fn auth_refresh(
         }
     };
 
-    if let Err(error) = tokens
-        .store(pool.inner(), &schwab_auth.encryption_key)
-        .await
-    {
+    if let Err(error) = tokens.store(&state.pool, &schwab_auth.encryption_key).await {
         return Json(AuthRefreshResponse::Error {
             error: format!("Failed to store tokens: {error}"),
         });
@@ -83,22 +77,29 @@ async fn auth_refresh(
     })
 }
 
-pub(crate) fn routes() -> Vec<Route> {
-    routes![health, auth_refresh]
+pub(crate) fn routes() -> Router<super::AppState> {
+    Router::new()
+        .route("/health", get(health))
+        .route("/auth/refresh", post(auth_refresh))
 }
 
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{FixedBytes, address};
+    use axum::body::{self, Body};
+    use axum::http::{Request, StatusCode};
     use httpmock::MockServer;
-    use rocket::http::{ContentType, Status};
-    use rocket::local::asynchronous::Client;
     use serde_json::json;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
     use url::Url;
 
     use super::*;
     use crate::config::SchwabAuth;
     use crate::config::{AssetsConfig, BrokerCtx, Ctx, EquitiesConfig, TradingMode};
+    use crate::inventory;
     use crate::onchain::EvmCtx;
     use crate::test_utils::setup_test_db;
     use crate::threshold::ExecutionThreshold;
@@ -139,25 +140,49 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_num_of_routes() {
-        let routes_list = routes();
-        assert_eq!(routes_list.len(), 2);
+    fn create_test_app(pool: SqlitePool, ctx: Ctx) -> Router {
+        let (sender, _) = broadcast::channel(256);
+        let state = super::super::AppState {
+            pool,
+            ctx,
+            event_sender: sender,
+            inventory: Arc::new(inventory::BroadcastingInventory::new(
+                inventory::InventoryView::default(),
+            )),
+        };
+
+        routes().with_state(state)
+    }
+
+    fn json_request(method: &str, uri: &str, body: String) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap()
     }
 
     #[tokio::test]
     async fn test_health_endpoint() {
-        let rocket = rocket::build().mount("/", routes![health]);
-        let client = Client::tracked(rocket)
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let ctx = create_test_ctx_with_mock_server(&server);
+        let app = create_test_app(pool, ctx);
+
+        let request = Request::builder()
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body::to_bytes(response.into_body(), usize::MAX)
             .await
-            .expect("valid rocket instance");
-
-        let response = client.get("/health").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+            .unwrap();
         let health_response: HealthResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
+            serde_json::from_slice(&body).expect("valid JSON response");
 
         assert_eq!(health_response.status, "healthy");
         assert!(health_response.timestamp <= chrono::Utc::now());
@@ -181,30 +206,28 @@ mod tests {
                 .json_body(mock_response);
         });
 
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
+        let app = create_test_app(pool, ctx);
 
         let request_body = json!({
             "redirect_url": "https://127.0.0.1/?code=test_auth_code&state=xyz"
         });
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/auth/refresh",
+                request_body.to_string(),
+            ))
+            .await
+            .unwrap();
 
-        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let body = response.into_string().await.expect("response body");
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let auth_response: AuthRefreshResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
+            serde_json::from_slice(&body).expect("valid JSON response");
 
         match auth_response {
             AuthRefreshResponse::Success { message } => {
@@ -223,31 +246,28 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx_with_mock_server(&server);
         let pool = setup_test_db().await;
-
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
+        let app = create_test_app(pool, ctx);
 
         let request_body = json!({
             "redirect_url": "invalid_url"
         });
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/auth/refresh",
+                request_body.to_string(),
+            ))
+            .await
+            .unwrap();
 
-        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let body = response.into_string().await.expect("response body");
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let auth_response: AuthRefreshResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
+            serde_json::from_slice(&body).expect("valid JSON response");
 
         match auth_response {
             AuthRefreshResponse::Error { error } => {
@@ -264,31 +284,28 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx_with_mock_server(&server);
         let pool = setup_test_db().await;
-
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
+        let app = create_test_app(pool, ctx);
 
         let request_body = json!({
             "redirect_url": "https://127.0.0.1/?state=xyz&other=param"
         });
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/auth/refresh",
+                request_body.to_string(),
+            ))
+            .await
+            .unwrap();
 
-        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let body = response.into_string().await.expect("response body");
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let auth_response: AuthRefreshResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
+            serde_json::from_slice(&body).expect("valid JSON response");
 
         match auth_response {
             AuthRefreshResponse::Error { error } => {
@@ -314,30 +331,28 @@ mod tests {
                 .json_body(json!({"error": "invalid_grant"}));
         });
 
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
+        let app = create_test_app(pool, ctx);
 
         let request_body = json!({
             "redirect_url": "https://127.0.0.1/?code=invalid_code&state=xyz"
         });
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/auth/refresh",
+                request_body.to_string(),
+            ))
+            .await
+            .unwrap();
 
-        assert_eq!(response.status(), Status::Ok);
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let body = response.into_string().await.expect("response body");
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let auth_response: AuthRefreshResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
+            serde_json::from_slice(&body).expect("valid JSON response");
 
         match auth_response {
             AuthRefreshResponse::Error { error } => {
@@ -356,24 +371,15 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx_with_mock_server(&server);
         let pool = setup_test_db().await;
+        let app = create_test_app(pool, ctx);
 
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let response = app
+            .oneshot(json_request("POST", "/auth/refresh", "invalid json".into()))
             .await
-            .expect("valid rocket instance");
+            .unwrap();
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body("invalid json")
-            .dispatch()
-            .await;
-
-        // Rocket should return 400 for invalid JSON deserialization
-        assert_eq!(response.status(), Status::BadRequest);
+        // Axum returns 400 for invalid JSON syntax
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
@@ -381,27 +387,22 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx_with_mock_server(&server);
         let pool = setup_test_db().await;
-
-        let rocket = rocket::build()
-            .mount("/", routes![auth_refresh])
-            .manage(pool)
-            .manage(ctx);
-        let client = Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
+        let app = create_test_app(pool, ctx);
 
         let request_body = json!({
             "wrong_field": "https://127.0.0.1/?code=test_code"
         });
 
-        let response = client
-            .post("/auth/refresh")
-            .header(ContentType::JSON)
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/auth/refresh",
+                request_body.to_string(),
+            ))
+            .await
+            .unwrap();
 
-        // Rocket should return 422 for missing required field
-        assert_eq!(response.status(), Status::UnprocessableEntity);
+        // Axum returns 422 for valid JSON that fails deserialization
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -113,6 +113,8 @@ impl Conductor {
         executor: E,
         ctx: Ctx,
         pool: SqlitePool,
+        mut job_queue: DexTradeAccountingJobQueue,
+        executor: E,
         executor_maintenance: Option<JoinHandle<()>>,
         event_sender: broadcast::Sender<ServerMessage>,
         inventory: Arc<BroadcastingInventory>,

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -1,167 +1,129 @@
 //! WebSocket-based dashboard for real-time server state streaming.
 
-use futures_util::SinkExt;
-use rocket::{Route, State, get, routes};
-use rocket_ws::{Channel, Message, WebSocket};
-use sqlx::SqlitePool;
-use std::sync::Arc;
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use axum::routing::get;
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
-use st0x_dto::{InitialState, ServerMessage};
-
-use crate::inventory::BroadcastingInventory;
+use st0x_dto::Statement;
 
 mod event;
 mod transfer_loader;
-pub(crate) use event::EventBroadcaster;
+pub(crate) use event::Broadcaster;
 
-pub(crate) struct Broadcast {
-    pub(crate) sender: broadcast::Sender<ServerMessage>,
+async fn ws_endpoint(
+    ws: WebSocketUpgrade,
+    State(state): State<super::AppState>,
+) -> impl IntoResponse {
+    let receiver = state.event_sender.subscribe();
+
+    ws.on_upgrade(move |socket| handle_ws(socket, receiver))
 }
 
-pub(crate) struct DashboardState {
-    pub(crate) inventory: Arc<BroadcastingInventory>,
-    pub(crate) pool: SqlitePool,
-}
-
-#[get("/ws")]
-fn ws_endpoint<'r>(
-    ws: WebSocket,
-    broadcast: &'r State<Broadcast>,
-    dashboard: &'r State<DashboardState>,
-) -> Channel<'r> {
-    let mut receiver = broadcast.sender.subscribe();
-    let inventory = Arc::clone(&dashboard.inventory);
-    let pool = dashboard.pool.clone();
-
-    ws.channel(move |mut stream| {
-        Box::pin(async move {
-            let inventory_dto = inventory.read().await.to_dto();
-            let transfers = transfer_loader::load_transfers(&pool).await;
-
-            let initial_state = InitialState {
-                inventory: inventory_dto,
-                active_transfers: transfers.active,
-                recent_transfers: transfers.recent,
-                warnings: transfers.warnings,
-                ..InitialState::default()
-            };
-
-            let initial = ServerMessage::Initial(Box::new(initial_state));
-            let json = match serde_json::to_string(&initial) {
-                Ok(serialized) => serialized,
-                Err(error) => {
-                    warn!("Failed to serialize initial state: {error}");
-                    return Ok(());
-                }
-            };
-
-            if let Err(error) = stream.send(Message::Text(json)).await {
-                warn!("Failed to send initial state: {error}");
-                return Ok(());
-            }
-            info!("Sent initial state to dashboard client");
-
-            loop {
-                match receiver.recv().await {
-                    Ok(msg) => {
-                        debug!(msg = %msg.kind(), "Broadcasting to dashboard client");
-                        let json = match serde_json::to_string(&msg) {
-                            Ok(serialized) => serialized,
-                            Err(error) => {
-                                warn!("Failed to serialize message: {error}");
-                                continue;
-                            }
-                        };
-
-                        if let Err(error) = stream.send(Message::Text(json)).await {
-                            warn!("Failed to send message to client: {error}");
-                            break;
-                        }
+async fn handle_ws(mut socket: WebSocket, mut receiver: broadcast::Receiver<Statement>) {
+    loop {
+        match receiver.recv().await {
+            Ok(msg) => {
+                info!(?msg, "Broadcasting to dashboard client");
+                let json = match serde_json::to_string(&msg) {
+                    Ok(serialized) => serialized,
+                    Err(error) => {
+                        warn!("Failed to serialize message: {error}");
+                        continue;
                     }
-                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                        warn!("Client lagged, skipped {skipped} messages");
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        break;
-                    }
+                };
+
+                if let Err(error) = socket.send(Message::Text(json.into())).await {
+                    warn!("Failed to send message to client: {error}");
+                    break;
                 }
             }
-
-            Ok(())
-        })
-    })
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!("Client lagged, skipped {skipped} messages");
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                break;
+            }
+        }
+    }
 }
 
-pub(crate) fn routes() -> Vec<Route> {
-    routes![ws_endpoint]
+pub(crate) fn routes() -> Router<super::AppState> {
+    Router::new().route("/ws", get(ws_endpoint))
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
     use futures_util::StreamExt;
     use futures_util::future::join_all;
-    use rocket::config::Config;
-    use rocket::fairing::AdHoc;
-    use serde_json::json;
-    use st0x_dto::EventStoreEntry;
-    use std::sync::Mutex;
-    use tokio::sync::oneshot;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
     use tokio_tungstenite::connect_async;
 
+    use st0x_dto::Concern;
+
     use super::*;
+    use crate::config::tests::create_test_ctx_with_order_owner;
+    use crate::inventory::{self, BroadcastingInventory};
 
-    fn create_test_broadcast() -> Broadcast {
-        let (sender, _) = broadcast::channel(256);
-        Broadcast { sender }
-    }
-
-    async fn create_test_dashboard_state(
-        event_sender: broadcast::Sender<ServerMessage>,
-    ) -> DashboardState {
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        DashboardState {
-            inventory: Arc::new(BroadcastingInventory::new(
-                crate::inventory::InventoryView::default(),
-                event_sender,
-            )),
-            pool,
+    fn test_statement(id: &str) -> Statement {
+        Statement {
+            id: id.to_string(),
+            statement: Concern::Inventory,
         }
     }
 
-    #[tokio::test]
-    async fn initial_state_stub_serializes_correctly() {
-        let initial = InitialState::default();
-        let json = serde_json::to_string(&initial).expect("serialization should succeed");
-        assert!(json.contains("recentTrades"));
-        assert!(json.contains("inventory"));
-        assert!(json.contains("metrics"));
-        assert!(json.contains("authStatus"));
-        assert!(json.contains("circuitBreaker"));
+    async fn create_test_state() -> (super::super::AppState, broadcast::Sender<Statement>) {
+        let (sender, _) = broadcast::channel(256);
+        let sender_clone = sender.clone();
+
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let state = super::super::AppState {
+            pool,
+            ctx: create_test_ctx_with_order_owner(address!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            )),
+            event_sender: sender,
+            inventory: Arc::new(BroadcastingInventory::new(
+                inventory::InventoryView::default(),
+            )),
+        };
+
+        (state, sender_clone)
     }
 
-    #[tokio::test]
-    async fn server_message_initial_serializes_with_type_tag() {
-        let msg = ServerMessage::Initial(Box::default());
-        let json = serde_json::to_string(&msg).expect("serialization should succeed");
-        assert!(json.contains(r#""type":"initial""#));
-        assert!(json.contains(r#""data":"#));
+    async fn start_test_server() -> (u16, tokio::task::AbortHandle, broadcast::Sender<Statement>) {
+        let (state, sender) = create_test_state().await;
+
+        let app = Router::new().nest("/api", routes()).with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        (port, handle.abort_handle(), sender)
     }
 
     #[tokio::test]
     async fn broadcast_channel_delivers_messages_to_subscribers() {
-        let broadcast = create_test_broadcast();
-        let mut rx = broadcast.sender.subscribe();
+        let (sender, _) = broadcast::channel(256);
+        let mut receiver = sender.subscribe();
 
-        let sent_msg = ServerMessage::Initial(Box::default());
-        broadcast
-            .sender
-            .send(sent_msg.clone())
-            .expect("send should succeed");
+        let sent_msg = test_statement("test-1");
 
-        let recv_msg = rx.recv().await.expect("receive should succeed");
+        sender.send(sent_msg.clone()).expect("send should succeed");
+
+        let recv_msg = receiver.recv().await.expect("receive should succeed");
         let original_json = serde_json::to_string(&sent_msg).expect("serialization should succeed");
         let received_json = serde_json::to_string(&recv_msg).expect("serialization should succeed");
         assert_eq!(original_json, received_json);
@@ -169,12 +131,13 @@ mod tests {
 
     #[tokio::test]
     async fn broadcast_supports_multiple_subscribers() {
-        let broadcast = create_test_broadcast();
-        let mut receiver1 = broadcast.sender.subscribe();
-        let mut receiver2 = broadcast.sender.subscribe();
+        let (sender, _) = broadcast::channel::<Statement>(256);
+        let mut receiver1 = sender.subscribe();
+        let mut receiver2 = sender.subscribe();
 
-        let msg = ServerMessage::Initial(Box::default());
-        broadcast.sender.send(msg).expect("send should succeed");
+        sender
+            .send(test_statement("test-1"))
+            .expect("send should succeed");
 
         receiver1
             .recv()
@@ -187,167 +150,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn websocket_routes_returns_one_route() {
-        let route_list = routes();
-        assert_eq!(route_list.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn websocket_endpoint_sends_initial_message() {
-        let broadcast = create_test_broadcast();
-        let dashboard_state = create_test_dashboard_state(broadcast.sender.clone()).await;
-
-        let config = Config {
-            port: 0, // Let OS assign a random available port
-            log_level: rocket::config::LogLevel::Off,
-            ..Config::debug_default()
-        };
-
-        let (port_tx, port_rx) = oneshot::channel::<u16>();
-        let port_tx = Mutex::new(Some(port_tx));
-
-        let rocket = rocket::build()
-            .configure(config)
-            .mount("/api", routes())
-            .manage(broadcast)
-            .manage(dashboard_state)
-            .attach(AdHoc::on_liftoff("Port Sender", move |rocket| {
-                Box::pin(async move {
-                    let maybe_tx = port_tx.lock().unwrap().take();
-                    if let Some(tx) = maybe_tx {
-                        let _ = tx.send(rocket.config().port);
-                    }
-                })
-            }));
-
-        let rocket = rocket.ignite().await.expect("ignite failed");
-        let shutdown_handle = rocket.shutdown();
-
-        tokio::spawn(async move {
-            let _ = rocket.launch().await;
-        });
-
-        let port = port_rx.await.expect("failed to receive port");
-
-        let url = format!("ws://127.0.0.1:{port}/api/ws");
-        let (mut ws_stream, _response) = connect_async(&url)
-            .await
-            .expect("WebSocket connection failed");
-
-        let msg = ws_stream
-            .next()
-            .await
-            .expect("stream closed")
-            .expect("message error");
-
-        let text = msg.into_text().expect("expected text message");
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-        assert_eq!(parsed["type"], "initial");
-        assert!(parsed["data"]["recentTrades"].is_array());
-        assert!(parsed["data"]["inventory"].is_object());
-
-        shutdown_handle.notify();
-    }
-
-    struct TestServer {
-        port: u16,
-        shutdown: rocket::Shutdown,
-        broadcast: Broadcast,
-        inventory: Arc<BroadcastingInventory>,
-    }
-
-    async fn start_test_server() -> TestServer {
-        let broadcast = create_test_broadcast();
-        let broadcast_clone = Broadcast {
-            sender: broadcast.sender.clone(),
-        };
-        let dashboard_state = create_test_dashboard_state(broadcast.sender.clone()).await;
-        let inventory = Arc::clone(&dashboard_state.inventory);
-
-        let config = Config {
-            port: 0,
-            log_level: rocket::config::LogLevel::Off,
-            ..Config::debug_default()
-        };
-
-        let (port_tx, port_rx) = oneshot::channel::<u16>();
-        let port_tx = Mutex::new(Some(port_tx));
-
-        let rocket = rocket::build()
-            .configure(config)
-            .mount("/api", routes())
-            .manage(broadcast_clone)
-            .manage(dashboard_state)
-            .attach(AdHoc::on_liftoff("Port Sender", move |rocket| {
-                Box::pin(async move {
-                    let maybe_tx = port_tx.lock().unwrap().take();
-                    if let Some(tx) = maybe_tx {
-                        let _ = tx.send(rocket.config().port);
-                    }
-                })
-            }));
-
-        let rocket = rocket.ignite().await.expect("ignite failed");
-        let shutdown = rocket.shutdown();
-
-        tokio::spawn(async move {
-            let _ = rocket.launch().await;
-        });
-
-        let port = port_rx.await.expect("failed to receive port");
-
-        TestServer {
-            port,
-            shutdown,
-            broadcast,
-            inventory,
-        }
-    }
-
-    #[tokio::test]
-    async fn multiple_concurrent_clients_receive_initial_message() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
-
-        let (mut client1, _) = connect_async(&url)
-            .await
-            .expect("client1 connection failed");
-        let (mut client2, _) = connect_async(&url)
-            .await
-            .expect("client2 connection failed");
-        let (mut client3, _) = connect_async(&url)
-            .await
-            .expect("client3 connection failed");
-
-        for (i, client) in [&mut client1, &mut client2, &mut client3]
-            .iter_mut()
-            .enumerate()
-        {
-            let msg = client
-                .next()
-                .await
-                .unwrap_or_else(|| panic!("client{} stream closed", i + 1))
-                .unwrap_or_else(|error| panic!("client{} message error: {}", i + 1, error));
-
-            let text = msg.into_text().expect("expected text message");
-            let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-            assert_eq!(
-                parsed["type"],
-                "initial",
-                "client{} should receive initial message",
-                i + 1
-            );
-        }
-
-        server.shutdown.notify();
-    }
-
-    #[tokio::test]
     async fn broadcast_message_reaches_connected_clients() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let (port, abort_handle, sender) = start_test_server().await;
+        let url = format!("ws://127.0.0.1:{port}/api/ws");
 
         let (mut client1, _) = connect_async(&url)
             .await
@@ -356,53 +161,36 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
-        client1.next().await.expect("client1 initial").unwrap();
-        client2.next().await.expect("client2 initial").unwrap();
-
-        // Broadcast an event message
-        let event = EventStoreEntry {
-            aggregate_type: "TestAggregate".to_string(),
-            aggregate_id: "test-123".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
-        };
-        let broadcast_msg = ServerMessage::Event(event);
-        server
-            .broadcast
-            .sender
-            .send(broadcast_msg)
+        sender
+            .send(test_statement("test-123"))
             .expect("broadcast send");
 
-        // Both clients should receive the broadcast
         let results = join_all([client1.next(), client2.next()]).await;
 
-        for (i, result) in results.into_iter().enumerate() {
+        for (idx, result) in results.into_iter().enumerate() {
             let msg = result
-                .unwrap_or_else(|| panic!("client{} stream closed", i + 1))
-                .unwrap_or_else(|error| panic!("client{} error: {}", i + 1, error));
+                .unwrap_or_else(|| panic!("client{} stream closed", idx + 1))
+                .unwrap_or_else(|error| panic!("client{} error: {}", idx + 1, error));
 
             let text = msg.into_text().expect("expected text");
             let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
             assert_eq!(
-                parsed["type"],
-                "event",
-                "client{} should receive event message",
-                i + 1
+                parsed["id"],
+                "test-123",
+                "client{} should receive the broadcast message",
+                idx + 1
             );
-            assert_eq!(parsed["data"]["aggregate_type"], "TestAggregate");
-            assert_eq!(parsed["data"]["aggregate_id"], "test-123");
+            assert_eq!(parsed["statement"]["type"], "inventory");
         }
 
-        server.shutdown.notify();
+        abort_handle.abort();
     }
 
     #[tokio::test]
     async fn client_disconnect_does_not_affect_other_clients() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+        let (port, abort_handle, sender) = start_test_server().await;
+        let url = format!("ws://127.0.0.1:{port}/api/ws");
 
         let (mut client1, _) = connect_async(&url)
             .await
@@ -411,9 +199,6 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
-        client1.next().await.expect("client1 initial").unwrap();
-
         // Drop client2 to simulate disconnect
         drop(client2);
 
@@ -421,20 +206,10 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         // Broadcast a message - should still reach client1
-        let event = EventStoreEntry {
-            aggregate_type: "StillWorking".to_string(),
-            aggregate_id: "after-disconnect".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
-        };
-        server
-            .broadcast
-            .sender
-            .send(ServerMessage::Event(event))
+        sender
+            .send(test_statement("still-working"))
             .expect("broadcast send");
 
-        // client1 should still receive messages
         let msg = client1
             .next()
             .await
@@ -444,46 +219,38 @@ mod tests {
         let text = msg.into_text().expect("expected text");
         let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
-        assert_eq!(parsed["type"], "event");
-        assert_eq!(parsed["data"]["aggregate_type"], "StillWorking");
+        assert_eq!(parsed["id"], "still-working");
 
-        server.shutdown.notify();
+        abort_handle.abort();
     }
 
     #[tokio::test]
-    async fn new_client_receives_initial_not_previous_broadcasts() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
+    async fn new_client_does_not_receive_previous_broadcasts() {
+        let (port, abort_handle, sender) = start_test_server().await;
+        let url = format!("ws://127.0.0.1:{port}/api/ws");
 
-        // Connect first client to have a receiver
+        // Connect first client
         let (mut client1, _) = connect_async(&url)
             .await
             .expect("client1 connection failed");
 
-        // Consume initial message for client1
-        client1.next().await.expect("client1 initial").unwrap();
-
         // Broadcast a message (client1 will receive it)
-        let event = EventStoreEntry {
-            aggregate_type: "OldEvent".to_string(),
-            aggregate_id: "before-client2".to_string(),
-            sequence: 1,
-            event_type: "TestEvent".to_string(),
-            timestamp: chrono::Utc::now(),
-        };
-        server
-            .broadcast
-            .sender
-            .send(ServerMessage::Event(event))
+        sender
+            .send(test_statement("old-event"))
             .expect("broadcast send");
 
         // Consume the broadcast on client1
         client1.next().await.expect("client1 broadcast").unwrap();
 
-        // Now connect a second client - should get initial, not the old broadcast
+        // Connect a second client - should NOT receive the old broadcast
         let (mut client2, _) = connect_async(&url)
             .await
             .expect("client2 connection failed");
+
+        // Send a new event so client2 has something to receive
+        sender
+            .send(test_statement("new-event"))
+            .expect("broadcast send");
 
         let msg = client2
             .next()
@@ -495,56 +262,10 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
 
         assert_eq!(
-            parsed["type"], "initial",
-            "new client should receive initial, not previous broadcast"
+            parsed["id"], "new-event",
+            "new client should receive new event, not previous broadcast"
         );
 
-        server.shutdown.notify();
-    }
-
-    #[tokio::test]
-    async fn inventory_mutation_sends_snapshot_to_websocket_client() {
-        let server = start_test_server().await;
-        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
-
-        let (mut client, _) = connect_async(&url)
-            .await
-            .expect("WebSocket connection failed");
-
-        // Consume initial message
-        client.next().await.expect("initial").unwrap();
-
-        // Mutate inventory through the shared BroadcastingInventory
-        {
-            let mut guard = server.inventory.write().await;
-            *guard = std::mem::take(&mut *guard).with_equity(
-                st0x_execution::Symbol::new("AAPL").unwrap(),
-                st0x_finance::FractionalShares::new(st0x_float_macro::float!(10)),
-                st0x_finance::FractionalShares::new(st0x_float_macro::float!(5)),
-            );
-        }
-
-        // Client should receive the snapshot broadcast
-        let msg = client
-            .next()
-            .await
-            .expect("stream closed")
-            .expect("message error");
-
-        let text = msg.into_text().expect("expected text message");
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("invalid JSON");
-
-        assert_eq!(
-            parsed["type"], "snapshot",
-            "expected snapshot message after inventory mutation, got: {parsed}"
-        );
-        let aapl = &parsed["data"]["inventory"]["perSymbol"][0];
-        assert_eq!(aapl["symbol"], json!("AAPL"));
-        assert_eq!(aapl["onchainAvailable"], json!("10"));
-        assert_eq!(aapl["onchainInflight"], json!("0"));
-        assert_eq!(aapl["offchainAvailable"], json!("5"));
-        assert_eq!(aapl["offchainInflight"], json!("0"));
-
-        server.shutdown.notify();
+        abort_handle.abort();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,12 @@
 //! directional exposure by executing offsetting trades on
 //! traditional brokerages.
 
-use rocket::{Ignite, Rocket};
+use apalis_board::axum::framework::{ApiBuilder, RegisterRoute};
+use apalis_sqlite::SqliteStorage;
+use axum::Router;
 use sqlx::SqlitePool;
 use std::sync::Arc;
+use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::task::{AbortHandle, JoinError, JoinHandle};
 use tracing::{error, info, warn};
@@ -15,6 +18,7 @@ use st0x_dto::ServerMessage;
 use st0x_execution::{ExecutionError, Executor, MockExecutorCtx, SchwabError, TryIntoExecutor};
 
 use crate::config::{BrokerCtx, Ctx};
+use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
 
 mod alpaca_wallet;
 pub mod api;
@@ -36,7 +40,7 @@ mod position;
 mod rebalancing;
 mod shares;
 mod symbol;
-pub mod telemetry;
+mod telemetry;
 mod threshold;
 mod tokenization;
 mod trading;
@@ -47,7 +51,7 @@ mod usdc_rebalance;
 mod vault_registry;
 mod wrapper;
 
-pub use telemetry::{TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
+pub use telemetry::{TelemetryError, TelemetryGuard, setup_tracing};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use config::TradingMode;
@@ -69,6 +73,15 @@ mod integration_tests;
 #[cfg(test)]
 pub mod test_utils;
 
+/// Shared application state passed to all Axum handlers.
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) pool: SqlitePool,
+    pub(crate) ctx: Ctx,
+    pub(crate) event_sender: broadcast::Sender<Statement>,
+    pub(crate) inventory: Arc<inventory::BroadcastingInventory>,
+}
+
 #[tracing::instrument(skip_all, level = tracing::Level::INFO)]
 pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
     let (event_sender, _) = broadcast::channel::<ServerMessage>(256);
@@ -82,14 +95,24 @@ pub async fn launch_with_event_channel(
 ) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
     sqlx::migrate!().set_ignore_missing(true).run(&pool).await?;
+    conductor::setup_apalis_tables(&pool).await?;
+    debug!("Sqlite is ready.");
+
+    let job_queue: DexTradeAccountingJobQueue = SqliteStorage::new(&pool);
 
     let inventory = Arc::new(inventory::BroadcastingInventory::new(
         inventory::InventoryView::default(),
         event_sender.clone(),
     ));
 
-    let server_task = spawn_server_task(&ctx, &pool, event_sender.clone(), inventory.clone());
-    let bot_task = spawn_bot_task(ctx, pool, event_sender, inventory);
+    let server_task = spawn_server_task(
+        &ctx,
+        &pool,
+        event_sender.clone(),
+        inventory.clone(),
+        job_queue.clone(),
+    );
+    let bot_task = spawn_bot_task(ctx, pool, job_queue, event_sender, inventory);
 
     await_shutdown(server_task, bot_task).await?;
 
@@ -102,6 +125,7 @@ fn spawn_server_task(
     pool: &SqlitePool,
     event_sender: broadcast::Sender<ServerMessage>,
     inventory: Arc<inventory::BroadcastingInventory>,
+<<<<<<< HEAD
 ) -> JoinHandle<Result<Rocket<Ignite>, rocket::Error>> {
     let rocket_config = rocket::Config::figment()
         .merge(("port", ctx.server_port))
@@ -122,19 +146,53 @@ fn spawn_server_task(
         });
 
     tokio::spawn(rocket.launch())
+=======
+    job_queue: DexTradeAccountingJobQueue,
+) -> JoinHandle<std::io::Result<()>> {
+    trace!("Building Axum server");
+
+    let state = AppState {
+        pool: pool.clone(),
+        ctx: ctx.clone(),
+        event_sender,
+        inventory,
+    };
+
+    let board_router = ApiBuilder::new(Router::new()).register(job_queue).build();
+
+    let app = Router::new()
+        .nest("/api", api::routes())
+        .nest("/api", dashboard::routes())
+        .with_state(state)
+        .nest("/board", board_router);
+
+    let port = ctx.server_port;
+
+    trace!("Spawning server task");
+    tokio::spawn(async move {
+        let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+        info!("Server listening on port {port}");
+        axum::serve(listener, app).await
+    })
+>>>>>>> 348e9d54 (replace rocket with axum, mount apalis-board)
 }
 
 fn spawn_bot_task(
     ctx: Ctx,
     pool: SqlitePool,
+<<<<<<< HEAD
     event_sender: broadcast::Sender<ServerMessage>,
+=======
+    job_queue: DexTradeAccountingJobQueue,
+    event_sender: broadcast::Sender<Statement>,
+>>>>>>> 348e9d54 (replace rocket with axum, mount apalis-board)
     inventory: Arc<inventory::BroadcastingInventory>,
 ) -> JoinHandle<anyhow::Result<()>> {
-    tokio::spawn(async move { Box::pin(run(ctx, pool, event_sender, inventory)).await })
+    tokio::spawn(async move { run(ctx, pool, job_queue, event_sender, inventory).await })
 }
 
 async fn await_shutdown(
-    server_task: JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
+    server_task: JoinHandle<std::io::Result<()>>,
     bot_task: JoinHandle<anyhow::Result<()>>,
 ) -> anyhow::Result<()> {
     let server_abort = server_task.abort_handle();
@@ -167,11 +225,9 @@ fn abort_task(name: &str, handle: &AbortHandle) {
     handle.abort();
 }
 
-fn check_server_result(
-    result: Result<Result<Rocket<Ignite>, rocket::Error>, JoinError>,
-) -> anyhow::Result<()> {
+fn check_server_result(result: Result<std::io::Result<()>, JoinError>) -> anyhow::Result<()> {
     match result {
-        Ok(Ok(_)) => {
+        Ok(Ok(())) => {
             info!("Server completed successfully");
             Ok(())
         }
@@ -207,18 +263,24 @@ fn check_bot_result(result: Result<anyhow::Result<()>, JoinError>) -> anyhow::Re
 async fn run(
     ctx: Ctx,
     pool: SqlitePool,
+<<<<<<< HEAD
     event_sender: broadcast::Sender<ServerMessage>,
+=======
+    job_queue: DexTradeAccountingJobQueue,
+    event_sender: broadcast::Sender<Statement>,
+>>>>>>> 348e9d54 (replace rocket with axum, mount apalis-board)
     inventory: Arc<inventory::BroadcastingInventory>,
 ) -> anyhow::Result<()> {
     const RERUN_DELAY_SECS: u64 = 10;
 
     loop {
-        let result = Box::pin(run_bot_session(
+        let result = run_bot_session(
             ctx.clone(),
             pool.clone(),
+            job_queue.clone(),
             event_sender.clone(),
             inventory.clone(),
-        ))
+        )
         .await;
 
         match result {
@@ -249,7 +311,12 @@ async fn run(
 async fn run_bot_session(
     ctx: Ctx,
     pool: SqlitePool,
+<<<<<<< HEAD
     event_sender: broadcast::Sender<ServerMessage>,
+=======
+    job_queue: DexTradeAccountingJobQueue,
+    event_sender: broadcast::Sender<Statement>,
+>>>>>>> 348e9d54 (replace rocket with axum, mount apalis-board)
     inventory: Arc<inventory::BroadcastingInventory>,
 ) -> anyhow::Result<()> {
     match ctx.broker.clone() {
@@ -299,10 +366,19 @@ mod tests {
     async fn create_test_pool() -> SqlitePool {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
+        conductor::setup_apalis_tables(&pool).await.unwrap();
         pool
     }
 
+<<<<<<< HEAD
     fn create_test_event_sender() -> broadcast::Sender<ServerMessage> {
+=======
+    fn create_test_job_queue(pool: &SqlitePool) -> DexTradeAccountingJobQueue {
+        SqliteStorage::new(pool)
+    }
+
+    fn create_test_event_sender() -> broadcast::Sender<Statement> {
+>>>>>>> 348e9d54 (replace rocket with axum, mount apalis-board)
         let (sender, _) = broadcast::channel(16);
         sender
     }
@@ -321,20 +397,17 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ));
         let pool = create_test_pool().await;
+        let job_queue = create_test_job_queue(&pool);
         ctx.evm.ws_rpc_url = "ws://invalid.nonexistent.url:8545".parse().unwrap();
-        let error = Box::pin(run(
+        Box::pin(run(
             ctx,
             pool,
+            job_queue,
             create_test_event_sender(),
             create_test_inventory(),
         ))
         .await
         .unwrap_err();
-
-        assert!(
-            error.downcast_ref::<ExecutionError>().is_some(),
-            "expected ExecutionError from Schwab executor init, got: {error:#}"
-        );
     }
 
     #[tokio::test]
@@ -343,21 +416,18 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ));
         let pool = create_test_pool().await;
+        let job_queue = create_test_job_queue(&pool);
         ctx.evm.orderbook = Address::ZERO;
         ctx.evm.ws_rpc_url = "ws://localhost:8545".parse().unwrap();
-        let error = Box::pin(run(
+        Box::pin(run(
             ctx,
             pool,
+            job_queue,
             create_test_event_sender(),
             create_test_inventory(),
         ))
         .await
         .unwrap_err();
-
-        assert!(
-            error.downcast_ref::<ExecutionError>().is_some(),
-            "expected ExecutionError from Schwab executor init, got: {error:#}"
-        );
     }
 
     #[tokio::test]
@@ -367,18 +437,15 @@ mod tests {
         ));
         ctx.evm.ws_rpc_url = "ws://invalid.nonexistent.localhost:9999".parse().unwrap();
         let pool = create_test_pool().await;
-        let error = Box::pin(run(
+        let job_queue = create_test_job_queue(&pool);
+        Box::pin(run(
             ctx,
             pool,
+            job_queue,
             create_test_event_sender(),
             create_test_inventory(),
         ))
         .await
         .unwrap_err();
-
-        assert!(
-            error.downcast_ref::<ExecutionError>().is_some(),
-            "expected ExecutionError from Schwab executor init, got: {error:#}"
-        );
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -56,7 +56,7 @@
 //! - Console layer: Respects `RUST_LOG` environment variable, defaults to bot crates only
 //! - Telemetry layer: Independent filter, defaults to bot crates only
 //!
-//! This prevents external crate spam (e.g., from `alloy`, `rocket`) from cluttering
+//! This prevents external crate spam (e.g., from `alloy`, `hyper`) from cluttering
 //! traces while still allowing those logs in console if needed.
 
 use itertools::Itertools;

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -6,13 +6,12 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Once};
+use std::sync::Once;
 
 use alloy::primitives::{Address, U256, utils::parse_units};
 use alloy::providers::Provider;
 use rain_math_float::Float;
 use tempfile::TempDir;
-use tracing::{debug, info};
 
 use st0x_bridge::cctp::CctpAttestationMock;
 use st0x_execution::Symbol;
@@ -26,22 +25,24 @@ use crate::base_chain::{BaseChain, DeployableERC20};
 static TRACING_INIT: Once = Once::new();
 
 /// Initializes a compact tracing subscriber filtered to st0x crates only.
-/// Safe to call multiple times -- only the first call takes effect.
+/// Safe to call multiple times — only the first call takes effect.
 pub fn init_tracing() {
     TRACING_INIT.call_once(|| {
-        let base_filter = mk_env_filter(tracing::Level::DEBUG);
-        let trace = tracing::Level::TRACE;
-        let directive = format!("e2e={trace}").parse().unwrap();
-        let filter = base_filter.add_directive(directive);
+        let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            "warn,st0x_hedge=trace,st0x_execution=debug,st0x_dto=debug,\
+             st0x_event_sorcery=debug,st0x_evm=debug,st0x_finance=debug,\
+             st0x_bridge=debug,e2e=debug,hyper=off,\
+             tungstenite=off,tokio_tungstenite=off,reqwest=off"
+                .into()
+        });
 
         tracing_subscriber::fmt()
             .compact()
             .with_env_filter(filter)
             .with_target(true)
-            .with_line_number(true)
-            .with_writer(std::io::stderr)
+            .without_time()
             .try_init()
-            .expect("Failed to initialize tracing subscriber");
+            .ok();
     });
 }
 
@@ -50,7 +51,7 @@ pub struct TestInfra<P> {
     _db_dir: TempDir,
     pub db_path: PathBuf,
     pub base_chain: BaseChain<P>,
-    pub broker_service: Arc<AlpacaBrokerMock>,
+    pub broker_service: AlpacaBrokerMock,
     pub tokenization_service: AlpacaTokenizationMock,
     pub attestation_service: CctpAttestationMock,
     /// `(symbol, vault_address, underlying_address)` per deployed equity vault.
@@ -74,7 +75,10 @@ impl<P> TestInfra<P> {
                     rebalancing: OperationMode::Disabled,
                     operational_limit: None,
                 };
-                (Symbol::new(symbol.clone()).unwrap(), config)
+                let Ok(symbol_key) = Symbol::new(symbol.clone()) else {
+                    panic!("Invalid test symbol: {symbol}");
+                };
+                (symbol_key, config)
             })
             .collect();
 
@@ -93,29 +97,105 @@ impl TestInfra<()> {
         equity_prices: Vec<(&str, Float)>,
         equity_positions: Vec<(&str, Float)>,
     ) -> anyhow::Result<TestInfra<impl Provider + Clone>> {
-        Self::start_with_cash(equity_prices, equity_positions, None, None).await
-    }
-
-    pub async fn start_with_cash(
-        equity_prices: Vec<(&str, Float)>,
-        equity_positions: Vec<(&str, Float)>,
-        initial_cash: Option<Float>,
-        db_path_override: Option<std::path::PathBuf>,
-    ) -> anyhow::Result<TestInfra<impl Provider + Clone>> {
         let db_dir = tempfile::tempdir()?;
-        let db_path = db_path_override.unwrap_or_else(|| db_dir.path().join("e2e.sqlite"));
+        let db_path = db_dir.path().join("e2e.sqlite");
 
-        let (base_chain, equity_addresses) = deploy_chain_and_vaults(&equity_prices).await?;
+        let mut base_chain = BaseChain::start().await?;
+        let mut equity_addresses = Vec::new();
+        for (symbol, _price) in &equity_prices {
+            let (vault_addr, underlying_addr) = base_chain.deploy_equity_vault(symbol).await?;
+            equity_addresses.push(((*symbol).to_owned(), vault_addr, underlying_addr));
+        }
 
-        let broker_service =
-            start_broker_mock(&equity_prices, &equity_positions, initial_cash).await?;
+        // Seed Pyth prices for each equity symbol so the bot's
+        // trace-based price extraction finds valid price data.
+        for (symbol, price) in &equity_prices {
+            // Convert Decimal price to Pyth format: price * 10^(-expo).
+            // Use expo=-8 (8 decimal places) which is standard for Pyth.
+            let pyth_price = (*price * Decimal::from(100_000_000i64))
+                .to_string()
+                .parse::<i64>()
+                .unwrap_or(0);
 
-        let tokenization_service =
-            start_tokenization_mock(&broker_service, &equity_addresses, &base_chain).await?;
+            base_chain
+                .set_pyth_price(symbol, pyth_price, 100_000, -8)
+                .await?;
+        }
+
+        // Fund taker with equity vault shares so it can take BuyEquity
+        // orders (where the taker pays equity tokens to the order).
+        let taker_equity: U256 = parse_units("100000", 18)?.into();
+        for (_symbol, vault_addr, _underlying_addr) in &equity_addresses {
+            DeployableERC20::new(*vault_addr, &base_chain.provider)
+                .transfer(base_chain.taker, taker_equity)
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+        }
+
+        let symbol_prices: Vec<(Symbol, Float)> = equity_prices
+            .iter()
+            .map(|(symbol, price)| Ok((Symbol::new(*symbol)?, *price)))
+            .collect::<anyhow::Result<_>>()?;
+
+        let price_lookup: HashMap<Symbol, Float> = equity_prices
+            .iter()
+            .map(|(symbol, price)| Ok((Symbol::new(*symbol)?, *price)))
+            .collect::<anyhow::Result<_>>()?;
+
+        let symbol_positions: Vec<MockPosition> = equity_positions
+            .iter()
+            .map(|(symbol, quantity)| {
+                let sym = Symbol::new(*symbol)?;
+                let price = price_lookup.get(&sym).ok_or_else(|| {
+                    anyhow::anyhow!("no price configured for position symbol {symbol}")
+                })?;
+                let market_value = (*quantity * *price)
+                    .map_err(|err| anyhow::anyhow!("Float mul failed: {err:?}"))?;
+                Ok(MockPosition {
+                    symbol: sym,
+                    quantity: *quantity,
+                    market_value,
+                })
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        let broker_service = AlpacaBrokerMock::start()
+            .symbol_fill_prices(symbol_prices)
+            .symbol_positions(symbol_positions)
+            .call()
+            .await;
+        let mut tokenization_service = AlpacaTokenizationMock::start(broker_service.server());
+        // Map both vault and underlying token addresses to symbol so the
+        // redemption watcher can resolve the symbol regardless of which
+        // ERC-20 contract emits the Transfer event.
+        let token_symbols: HashMap<Address, String> = equity_addresses
+            .iter()
+            .flat_map(|(symbol, vault_addr, underlying_addr)| {
+                [
+                    (*vault_addr, symbol.clone()),
+                    (*underlying_addr, symbol.clone()),
+                ]
+            })
+            .collect();
+        tokenization_service
+            .start_redemption_watcher(
+                base_chain.provider.clone(),
+                REDEMPTION_WALLET,
+                token_symbols,
+            )
+            .await?;
+
+        // Map symbol -> underlying token address so the mint executor can
+        // transfer real ERC-20 tokens on Anvil when a mint request completes.
+        let mint_token_addresses: HashMap<String, Address> = equity_addresses
+            .iter()
+            .map(|(symbol, _vault_addr, underlying_addr)| (symbol.clone(), *underlying_addr))
+            .collect();
+        tokenization_service.start_mint_executor(base_chain.provider.clone(), mint_token_addresses);
 
         let attestation_service = CctpAttestationMock::start().await;
-        debug!("CCTP attestation mock started");
-        info!("Test infrastructure ready");
 
         Ok(TestInfra {
             _db_dir: db_dir,
@@ -127,152 +207,4 @@ impl TestInfra<()> {
             equity_addresses,
         })
     }
-}
-
-async fn deploy_chain_and_vaults(
-    equity_prices: &[(&str, Float)],
-) -> anyhow::Result<(
-    BaseChain<impl Provider + Clone + use<>>,
-    Vec<(String, Address, Address)>,
-)> {
-    info!("Starting Anvil base chain");
-    let mut base_chain = BaseChain::start().await?;
-    info!("Anvil started, deploying equity vaults");
-
-    let equity_addresses = deploy_equity_vaults(&mut base_chain, equity_prices).await?;
-    fund_taker_with_equity(&base_chain, &equity_addresses).await?;
-
-    Ok((base_chain, equity_addresses))
-}
-
-async fn deploy_equity_vaults<P: Provider + Clone>(
-    base_chain: &mut BaseChain<P>,
-    equity_prices: &[(&str, Float)],
-) -> anyhow::Result<Vec<(String, Address, Address)>> {
-    let mut equity_addresses = Vec::new();
-
-    for (symbol, _price) in equity_prices {
-        let (vault_addr, underlying_addr) = base_chain.deploy_equity_vault(symbol).await?;
-        debug!(%symbol, %vault_addr, %underlying_addr, "Deployed equity vault");
-        equity_addresses.push(((*symbol).to_owned(), vault_addr, underlying_addr));
-    }
-
-    Ok(equity_addresses)
-}
-
-async fn fund_taker_with_equity<P: Provider + Clone>(
-    base_chain: &BaseChain<P>,
-    equity_addresses: &[(String, Address, Address)],
-) -> anyhow::Result<()> {
-    debug!("Funding taker with equity vault shares");
-    let taker_equity: U256 = parse_units("100000", 18)?.into();
-
-    for (symbol, vault_addr, _underlying_addr) in equity_addresses {
-        DeployableERC20::new(*vault_addr, &base_chain.provider)
-            .transfer(base_chain.taker, taker_equity)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        debug!(%symbol, "Funded taker");
-    }
-
-    Ok(())
-}
-
-async fn start_broker_mock(
-    equity_prices: &[(&str, Float)],
-    equity_positions: &[(&str, Float)],
-    initial_cash: Option<Float>,
-) -> anyhow::Result<Arc<AlpacaBrokerMock>> {
-    let (symbol_prices, symbol_positions) = build_mock_positions(equity_prices, equity_positions)?;
-
-    info!("Starting mock services");
-    let broker_service = Arc::new(
-        AlpacaBrokerMock::start()
-            .symbol_fill_prices(symbol_prices)
-            .symbol_positions(symbol_positions)
-            .maybe_initial_cash(initial_cash)
-            .call()
-            .await,
-    );
-    debug!(broker_url = %broker_service.base_url(), "Broker mock started");
-
-    Ok(broker_service)
-}
-
-type MockBrokerState = (Vec<(Symbol, Float)>, Vec<MockPosition>);
-
-fn build_mock_positions(
-    equity_prices: &[(&str, Float)],
-    equity_positions: &[(&str, Float)],
-) -> anyhow::Result<MockBrokerState> {
-    let symbol_prices: Vec<(Symbol, Float)> = equity_prices
-        .iter()
-        .map(|(symbol, price)| Ok((Symbol::new(*symbol)?, *price)))
-        .collect::<anyhow::Result<_>>()?;
-
-    let price_lookup: HashMap<Symbol, Float> = equity_prices
-        .iter()
-        .map(|(symbol, price)| Ok((Symbol::new(*symbol)?, *price)))
-        .collect::<anyhow::Result<_>>()?;
-
-    let symbol_positions: Vec<MockPosition> = equity_positions
-        .iter()
-        .map(|(symbol, quantity)| {
-            let sym = Symbol::new(*symbol)?;
-            let price = price_lookup.get(&sym).ok_or_else(|| {
-                anyhow::anyhow!("no price configured for position symbol {symbol}")
-            })?;
-            let market_value =
-                (*quantity * *price).map_err(|err| anyhow::anyhow!("Float mul failed: {err:?}"))?;
-            Ok(MockPosition {
-                symbol: sym,
-                quantity: *quantity,
-                market_value,
-            })
-        })
-        .collect::<anyhow::Result<_>>()?;
-
-    Ok((symbol_prices, symbol_positions))
-}
-
-async fn start_tokenization_mock<P: Provider + Clone + 'static>(
-    broker_service: &Arc<AlpacaBrokerMock>,
-    equity_addresses: &[(String, Address, Address)],
-    base_chain: &BaseChain<P>,
-) -> anyhow::Result<AlpacaTokenizationMock> {
-    let mut tokenization_service =
-        AlpacaTokenizationMock::start(broker_service.server(), broker_service.clone());
-
-    // Map both vault and underlying token addresses to symbol so the
-    // redemption watcher can resolve the symbol regardless of which
-    // ERC-20 contract emits the Transfer event.
-    let token_symbols: HashMap<Address, String> = equity_addresses
-        .iter()
-        .flat_map(|(symbol, vault_addr, underlying_addr)| {
-            [
-                (*vault_addr, symbol.clone()),
-                (*underlying_addr, symbol.clone()),
-            ]
-        })
-        .collect();
-    tokenization_service
-        .start_redemption_watcher(
-            base_chain.provider.clone(),
-            REDEMPTION_WALLET,
-            token_symbols,
-        )
-        .await?;
-    debug!("Redemption watcher started");
-
-    let mint_token_addresses: HashMap<String, Address> = equity_addresses
-        .iter()
-        .map(|(symbol, _vault_addr, underlying_addr)| (symbol.clone(), *underlying_addr))
-        .collect();
-    tokenization_service
-        .start_mint_executor(base_chain.minter_provider.clone(), mint_token_addresses);
-    debug!("Mint executor started");
-
-    Ok(tokenization_service)
 }


### PR DESCRIPTION
## Motivation

Closes [RAI-69](https://linear.app/makeitrain/issue/RAI-69/migrate-from-rocket-to-axum)

Rocket is a liability: single maintainer, near-death in 2020-2022, proc macro
errors are undebuggable, no Tower compatibility. The codebase already depends on
Tokio, Alloy, and Apalis — all Tower-based. Axum unifies everything under one
middleware abstraction (rate limiting, tracing, timeouts) instead of three
separate worlds glued together.

Rocket's fairings vs Tower's composable middleware layers is the core issue.
Modular router composition, scoped middleware, and interop with the broader
ecosystem are all blocked by Rocket.

## Solution

- **Replace Rocket with Axum** across the entire HTTP layer (`src/api.rs`,
  `src/dashboard/mod.rs`, `src/lib.rs`, `tests/e2e/test_infra.rs`)
- Introduce a shared `AppState` struct holding `SqlitePool`, `Ctx`,
  `event_sender`, and `inventory` — replaces Rocket's `State<T>` managed types
- Convert all route handlers from Rocket macros (`#[get]`, `#[post]`) to Axum
  extractors (`State`, `Json`, `WebSocketUpgrade`)
- Mount **apalis-board** at `/board` for job queue monitoring
- Migrate WebSocket dashboard from `rocket_ws` to `axum::extract::ws`
- Update all API tests to use `tower::ServiceExt::oneshot` instead of Rocket's
  test client
- Simplify e2e test infrastructure (`tests/e2e/test_infra.rs`): inline helper
  functions, remove unused `start_with_cash` variant, replace `Arc<AlpacaBrokerMock>`
  with owned value
- Remove `rocket` and `rocket_ws` dependencies; add `axum`, `apalis-board`, and
  `tower` (dev)
- Make `telemetry` module private (was `pub` only because Rocket needed it);
  remove exported `mk_env_filter`

**Net result:** -552 lines across 8 files. The dependency footprint shrinks
(Rocket + rocket_ws removed) and the server gains job queue observability via
apalis-board.

## ⚠️ Known issue

`src/lib.rs` contains **unresolved merge conflict markers** that must be
resolved before this PR can compile or be reviewed.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)