### PR TITLE
feat: apalis-driven mock broker orchestration for e2e tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ alloy-primitives = "1.4"
 alloy-signer-turnkey = "=1.0.41"
 anyhow = "1.0.102"
 apalis-board = { version = "1.0.0-rc.8", features = ["axum", "ui"] }
-apalis-workflow = "0.1.0-rc.7"
+apalis-workflow = "0.1.0-rc.9"
 apca = "0.30.0"
 approx = "0.5.1"
 async-trait = "0.1.81"
 axum = { version = "0.8.9", features = ["ws", "json"] }
 backon = { version = "1.5.1", features = ["tokio"] }
 base64 = "0.22"
-bon = "3.9.0"
+bon = "3.9.1"
 chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = "0.10.4"
 clap = { version = "4.5.40", features = ["derive", "env"] }
@@ -165,11 +165,11 @@ mock = [
 ]
 
 [dependencies]
-apalis = "1.0.0-rc.7"
-apalis-sqlite = "1.0.0-rc.7"
-apalis-codec = "0.1.0-rc.7"
-apalis-core = "1.0.0-rc.4"
-apalis-cron = { version = "1.0.0-rc.7", default-features = false }
+apalis = "1.0.0-rc.9"
+apalis-sqlite = "1.0.0-rc.8"
+apalis-codec = "0.1.0-rc.9"
+apalis-core = "1.0.0-rc.9"
+apalis-cron = { version = "1.0.0-rc.8", default-features = false }
 task-supervisor = { version = "0.4", features = ["tracing"] }
 
 aes-gcm.workspace = true

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1177,6 +1177,10 @@ pub async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sql
 }
 
 #[cfg(any(test, feature = "test-support"))]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test helper parsing a static, known-valid URL"
+)]
 pub fn create_test_ctx_with_order_owner(order_owner: Address) -> Ctx {
     Ctx {
         database_url: ":memory:".to_owned(),

--- a/crates/config/src/threshold.rs
+++ b/crates/config/src/threshold.rs
@@ -38,6 +38,10 @@ impl ExecutionThreshold {
     }
 
     #[cfg(any(test, feature = "test-support"))]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test helper constructing a known-positive literal"
+    )]
     pub fn whole_share() -> Self {
         // float!(1) is a compile-time positive constant, so Positive::new
         // cannot fail at runtime here.

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -5,10 +5,6 @@
 //! (happy path, rejected, placement fails) and optionally set initial account
 //! state via the builder - no per-request mock setup needed.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
-use std::time::Duration;
-
 use alloy::primitives::Address;
 use alloy::providers::Provider;
 use alloy::sol;
@@ -18,10 +14,15 @@ use chrono::Utc;
 use httpmock::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use rain_math_float::Float;
+use st0x_finance::{Usd, Usdc};
 use st0x_float_serde::format_float_with_fallback;
 
 use crate::Symbol;
@@ -32,206 +33,54 @@ sol! {
     event Transfer(address indexed from, address indexed to, uint256 value);
 }
 
-pub const TEST_ACCOUNT_ID: &str = "904837e3-3b76-47ec-b432-046db621571b";
-pub const TEST_API_KEY: &str = "e2e_test_key";
-pub const TEST_API_SECRET: &str = "e2e_test_secret";
-
-/// Controls how the mock responds to order placement and polling.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum MockMode {
-    /// Place succeeds, first poll returns filled.
-    HappyPath,
-    /// Place succeeds, poll returns rejected.
-    OrderRejected,
-    /// Place returns HTTP 422.
-    PlacementFails,
-    /// Place succeeds, order stays "new" for N polls before filling.
-    /// Simulates real broker latency where fills aren't instant.
-    DelayedFill { polls_before_fill: usize },
+/// A command that controls mock broker behavior at runtime.
+///
+/// Submitted to the Apalis job queue by e2e tests and processed by a
+/// worker running alongside the production workers. Each variant maps
+/// to a method on [`AlpacaBrokerMock`].
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum MockBrokerCommand {
+    /// Switch the broker mock's response mode.
+    SetMode(MockMode),
+    /// Open the simulated market.
+    OpenMarket,
+    /// Close the simulated market.
+    CloseMarket,
+    /// Set the fill price for a specific symbol.
+    SetFillPrice { symbol: Symbol, price: Usd },
+    /// Set how many polls before a symbol's order fills.
+    SetFillDelay {
+        symbol: Symbol,
+        polls_before_fill: usize,
+    },
+    /// Set the mock wallet's USDC balance.
+    SetWalletBalance { balance: Usdc },
 }
 
-pub struct MockPosition {
-    pub symbol: Symbol,
-    pub quantity: Float,
-    pub market_value: Float,
-}
-
-struct MockAccount {
-    cash: Float,
-    buying_power: Float,
-    positions: HashMap<Symbol, MockPosition>,
-}
-
-/// Side of a broker order (buy or sell).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OrderSide {
-    Buy,
-    Sell,
-}
-
-impl std::fmt::Display for OrderSide {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl MockBrokerCommand {
+    /// Applies this command to the given broker mock.
+    pub fn apply(self, broker: &AlpacaBrokerMock) {
         match self {
-            Self::Buy => write!(formatter, "buy"),
-            Self::Sell => write!(formatter, "sell"),
+            Self::SetMode(mode) => broker.set_mode(mode),
+            Self::OpenMarket => broker.set_market_open(),
+            Self::CloseMarket => broker.set_market_closed(),
+
+            Self::SetFillPrice { symbol, price } => {
+                broker.set_symbol_fill_price(symbol, price.inner());
+            }
+
+            Self::SetFillDelay {
+                symbol,
+                polls_before_fill,
+            } => {
+                broker.set_symbol_fill_delay(symbol, polls_before_fill);
+            }
+
+            Self::SetWalletBalance { balance } => {
+                broker.set_wallet_usdc_balance(balance.inner());
+            }
         }
     }
-}
-
-/// Status of a broker order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OrderStatus {
-    New,
-    Filled,
-    Rejected,
-}
-
-impl std::fmt::Display for OrderStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::New => write!(formatter, "new"),
-            Self::Filled => write!(formatter, "filled"),
-            Self::Rejected => write!(formatter, "rejected"),
-        }
-    }
-}
-
-struct MockOrder {
-    symbol: Symbol,
-    quantity: Float,
-    side: OrderSide,
-    status: OrderStatus,
-    poll_count: usize,
-    filled_price: Option<Float>,
-}
-
-/// A single calendar entry controlling market open/close times.
-struct CalendarEntry {
-    pub date: String,
-    pub open: String,
-    pub close: String,
-}
-
-/// A mock wallet transfer tracked in shared state.
-struct MockWalletTransfer {
-    transfer_id: String,
-    direction: TransferDirection,
-    amount: Float,
-    asset: String,
-    from_address: Address,
-    to_address: Address,
-    status: TransferStatus,
-    tx_hash: String,
-    poll_count: usize,
-    /// Number of polls before transitioning from "pending" to "complete".
-    polls_until_complete: usize,
-}
-
-struct MockState {
-    account: MockAccount,
-    orders: HashMap<String, MockOrder>,
-    symbol_fill_prices: HashMap<Symbol, Float>,
-    mode: MockMode,
-    /// Per-symbol fill delays: number of polls before filling.
-    /// Symbols without an entry fill immediately in `HappyPath` mode.
-    symbol_fill_delays: HashMap<Symbol, usize>,
-    /// Dynamic calendar entries. The endpoint reads from this on each request.
-    calendar_entries: Vec<CalendarEntry>,
-    /// Wallet transfers (withdrawals and deposits).
-    wallet_transfers: Vec<MockWalletTransfer>,
-    /// Alpaca deposit wallet address for incoming USDC.
-    alpaca_deposit_address: String,
-    /// Wallet balances by asset symbol (e.g. USDC in the crypto wallet).
-    wallet_balances: HashMap<String, Float>,
-    /// Whitelisted withdrawal addresses.
-    whitelisted_addresses: Vec<WhitelistEntry>,
-}
-
-/// Status of a whitelisted address.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WhitelistStatus {
-    Approved,
-    Pending,
-}
-
-impl std::fmt::Display for WhitelistStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Approved => write!(formatter, "APPROVED"),
-            Self::Pending => write!(formatter, "PENDING"),
-        }
-    }
-}
-
-/// A whitelisted address entry in the mock state.
-struct WhitelistEntry {
-    id: String,
-    address: Address,
-    asset: String,
-    chain: String,
-    status: WhitelistStatus,
-}
-
-/// Snapshot of a placed order, returned by [`AlpacaBrokerMock::orders`].
-pub struct MockOrderSnapshot {
-    pub order_id: String,
-    pub symbol: String,
-    pub quantity: Float,
-    pub side: OrderSide,
-    pub status: OrderStatus,
-    pub poll_count: usize,
-    pub filled_price: Option<Float>,
-}
-
-/// Snapshot of a position, returned by [`AlpacaBrokerMock::positions`].
-pub struct MockPositionSnapshot {
-    pub symbol: String,
-    pub quantity: Float,
-    pub market_value: Float,
-}
-
-/// Direction of a wallet transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransferDirection {
-    Incoming,
-    Outgoing,
-}
-
-impl std::fmt::Display for TransferDirection {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Incoming => write!(formatter, "INCOMING"),
-            Self::Outgoing => write!(formatter, "OUTGOING"),
-        }
-    }
-}
-
-/// Status of a wallet transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransferStatus {
-    Pending,
-    Processing,
-    Complete,
-}
-
-impl std::fmt::Display for TransferStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pending => write!(formatter, "PENDING"),
-            Self::Processing => write!(formatter, "PROCESSING"),
-            Self::Complete => write!(formatter, "COMPLETE"),
-        }
-    }
-}
-
-/// Snapshot of a wallet transfer, returned by
-/// [`AlpacaBrokerMock::wallet_transfers`].
-pub struct MockWalletTransferSnapshot {
-    pub transfer_id: String,
-    pub direction: TransferDirection,
-    pub amount: Float,
-    pub asset: String,
-    pub status: TransferStatus,
 }
 
 /// Owns the `MockServer` and shared state. All endpoints respond dynamically
@@ -497,6 +346,208 @@ impl AlpacaBrokerMock {
             }
         }))
     }
+}
+
+pub const TEST_ACCOUNT_ID: &str = "904837e3-3b76-47ec-b432-046db621571b";
+pub const TEST_API_KEY: &str = "e2e_test_key";
+pub const TEST_API_SECRET: &str = "e2e_test_secret";
+
+/// Controls how the mock responds to order placement and polling.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum MockMode {
+    /// Place succeeds, first poll returns filled.
+    HappyPath,
+    /// Place succeeds, poll returns rejected.
+    OrderRejected,
+    /// Place returns HTTP 422.
+    PlacementFails,
+    /// Place succeeds, order stays "new" for N polls before filling.
+    /// Simulates real broker latency where fills aren't instant.
+    DelayedFill { polls_before_fill: usize },
+}
+
+pub struct MockPosition {
+    pub symbol: Symbol,
+    pub quantity: Float,
+    pub market_value: Float,
+}
+
+struct MockAccount {
+    cash: Float,
+    buying_power: Float,
+    positions: HashMap<Symbol, MockPosition>,
+}
+
+/// Side of a broker order (buy or sell).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+}
+
+impl std::fmt::Display for OrderSide {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Buy => write!(formatter, "buy"),
+            Self::Sell => write!(formatter, "sell"),
+        }
+    }
+}
+
+/// Status of a broker order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderStatus {
+    New,
+    Filled,
+    Rejected,
+}
+
+impl std::fmt::Display for OrderStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::New => write!(formatter, "new"),
+            Self::Filled => write!(formatter, "filled"),
+            Self::Rejected => write!(formatter, "rejected"),
+        }
+    }
+}
+
+struct MockOrder {
+    symbol: Symbol,
+    quantity: Float,
+    side: OrderSide,
+    status: OrderStatus,
+    poll_count: usize,
+    filled_price: Option<Float>,
+}
+
+/// A single calendar entry controlling market open/close times.
+struct CalendarEntry {
+    pub date: String,
+    pub open: String,
+    pub close: String,
+}
+
+/// A mock wallet transfer tracked in shared state.
+struct MockWalletTransfer {
+    transfer_id: String,
+    direction: TransferDirection,
+    amount: Float,
+    asset: String,
+    from_address: Address,
+    to_address: Address,
+    status: TransferStatus,
+    tx_hash: String,
+    poll_count: usize,
+    /// Number of polls before transitioning from "pending" to "complete".
+    polls_until_complete: usize,
+}
+
+struct MockState {
+    account: MockAccount,
+    orders: HashMap<String, MockOrder>,
+    symbol_fill_prices: HashMap<Symbol, Float>,
+    mode: MockMode,
+    /// Per-symbol fill delays: number of polls before filling.
+    /// Symbols without an entry fill immediately in `HappyPath` mode.
+    symbol_fill_delays: HashMap<Symbol, usize>,
+    /// Dynamic calendar entries. The endpoint reads from this on each request.
+    calendar_entries: Vec<CalendarEntry>,
+    /// Wallet transfers (withdrawals and deposits).
+    wallet_transfers: Vec<MockWalletTransfer>,
+    /// Alpaca deposit wallet address for incoming USDC.
+    alpaca_deposit_address: String,
+    /// Wallet balances by asset symbol (e.g. USDC in the crypto wallet).
+    wallet_balances: HashMap<String, Float>,
+    /// Whitelisted withdrawal addresses.
+    whitelisted_addresses: Vec<WhitelistEntry>,
+}
+
+/// Status of a whitelisted address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WhitelistStatus {
+    Approved,
+    Pending,
+}
+
+impl std::fmt::Display for WhitelistStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Approved => write!(formatter, "APPROVED"),
+            Self::Pending => write!(formatter, "PENDING"),
+        }
+    }
+}
+
+/// A whitelisted address entry in the mock state.
+struct WhitelistEntry {
+    id: String,
+    address: Address,
+    asset: String,
+    chain: String,
+    status: WhitelistStatus,
+}
+
+/// Snapshot of a placed order, returned by [`AlpacaBrokerMock::orders`].
+pub struct MockOrderSnapshot {
+    pub order_id: String,
+    pub symbol: String,
+    pub quantity: Float,
+    pub side: OrderSide,
+    pub status: OrderStatus,
+    pub poll_count: usize,
+    pub filled_price: Option<Float>,
+}
+
+/// Snapshot of a position, returned by [`AlpacaBrokerMock::positions`].
+pub struct MockPositionSnapshot {
+    pub symbol: String,
+    pub quantity: Float,
+    pub market_value: Float,
+}
+
+/// Direction of a wallet transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferDirection {
+    Incoming,
+    Outgoing,
+}
+
+impl std::fmt::Display for TransferDirection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Incoming => write!(formatter, "INCOMING"),
+            Self::Outgoing => write!(formatter, "OUTGOING"),
+        }
+    }
+}
+
+/// Status of a wallet transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferStatus {
+    Pending,
+    Processing,
+    Complete,
+}
+
+impl std::fmt::Display for TransferStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(formatter, "PENDING"),
+            Self::Processing => write!(formatter, "PROCESSING"),
+            Self::Complete => write!(formatter, "COMPLETE"),
+        }
+    }
+}
+
+/// Snapshot of a wallet transfer, returned by
+/// [`AlpacaBrokerMock::wallet_transfers`].
+pub struct MockWalletTransferSnapshot {
+    pub transfer_id: String,
+    pub direction: TransferDirection,
+    pub amount: Float,
+    pub asset: String,
+    pub status: TransferStatus,
 }
 
 /// Scans a single block for USDC Transfer events to `mint_recipient`

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -16,6 +16,7 @@ use alloy::sol_types::SolEvent;
 use bon::bon;
 use chrono::Utc;
 use httpmock::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
@@ -36,7 +37,7 @@ pub const TEST_API_KEY: &str = "e2e_test_key";
 pub const TEST_API_SECRET: &str = "e2e_test_secret";
 
 /// Controls how the mock responds to order placement and polling.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum MockMode {
     /// Place succeeds, first poll returns filled.
     HappyPath,

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -5,10 +5,6 @@
 //! (happy path, rejected, placement fails) and optionally set initial account
 //! state via the builder - no per-request mock setup needed.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
-use std::time::Duration;
-
 use alloy::primitives::Address;
 use alloy::providers::Provider;
 use alloy::sol;
@@ -16,11 +12,16 @@ use alloy::sol_types::SolEvent;
 use bon::bon;
 use chrono::Utc;
 use httpmock::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use rain_math_float::Float;
+use st0x_finance::{Usd, Usdc};
 use st0x_float_serde::format_float_with_fallback;
 
 use crate::Symbol;
@@ -31,228 +32,52 @@ sol! {
     event Transfer(address indexed from, address indexed to, uint256 value);
 }
 
-pub const TEST_ACCOUNT_ID: &str = "904837e3-3b76-47ec-b432-046db621571b";
-pub const TEST_API_KEY: &str = "e2e_test_key";
-pub const TEST_API_SECRET: &str = "e2e_test_secret";
-
-/// Controls how the mock responds to order placement and polling.
-#[derive(Debug, Clone, Copy)]
-pub enum MockMode {
-    /// Place succeeds, first poll returns filled.
-    HappyPath,
-    /// Place succeeds, poll returns rejected.
-    OrderRejected,
-    /// Place returns HTTP 422.
-    PlacementFails,
-    /// Place succeeds, order stays "new" for N polls before filling.
-    /// Simulates real broker latency where fills aren't instant.
-    DelayedFill { polls_before_fill: usize },
-}
-
-pub struct MockPosition {
-    pub symbol: Symbol,
-    pub quantity: Float,
-    pub market_value: Float,
-}
-
-struct MockAccount {
-    cash: Float,
-    buying_power: Float,
-    positions: HashMap<Symbol, MockPosition>,
-}
-
-/// Side of a broker order (buy or sell).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OrderSide {
-    Buy,
-    Sell,
-}
-
-impl std::fmt::Display for OrderSide {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Buy => write!(formatter, "buy"),
-            Self::Sell => write!(formatter, "sell"),
-        }
-    }
-}
-
-/// Status of a broker order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum OrderStatus {
-    New,
-    Filled,
-    Rejected,
-}
-
-impl std::fmt::Display for OrderStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::New => write!(formatter, "new"),
-            Self::Filled => write!(formatter, "filled"),
-            Self::Rejected => write!(formatter, "rejected"),
-        }
-    }
-}
-
-struct MockOrder {
-    symbol: Symbol,
-    quantity: Float,
-    side: OrderSide,
-    status: OrderStatus,
-    poll_count: usize,
-    filled_price: Option<Float>,
-}
-
-/// A single calendar entry controlling market open/close times.
-struct CalendarEntry {
-    pub date: String,
-    pub open: String,
-    pub close: String,
-}
-
-/// A mock wallet transfer tracked in shared state.
-struct MockWalletTransfer {
-    transfer_id: String,
-    direction: TransferDirection,
-    amount: Float,
-    asset: String,
-    from_address: Address,
-    to_address: Address,
-    status: TransferStatus,
-    tx_hash: String,
-    poll_count: usize,
-    /// Number of polls before transitioning from "pending" to "complete".
-    polls_until_complete: usize,
-}
-
-struct MockState {
-    account: MockAccount,
-    orders: HashMap<String, MockOrder>,
-    symbol_fill_prices: HashMap<Symbol, Float>,
-    mode: MockMode,
-    /// Per-symbol fill delays: number of polls before filling.
-    /// Symbols without an entry fill immediately in `HappyPath` mode.
-    symbol_fill_delays: HashMap<Symbol, usize>,
-    /// Dynamic calendar entries. The endpoint reads from this on each request.
-    calendar_entries: Vec<CalendarEntry>,
-    /// Wallet transfers (withdrawals and deposits).
-    wallet_transfers: Vec<MockWalletTransfer>,
-    /// Alpaca deposit wallet address for incoming USDC.
-    alpaca_deposit_address: String,
-    /// Wallet balances by asset symbol (e.g. USDC in the crypto wallet).
-    wallet_balances: HashMap<String, Float>,
-    /// Whitelisted withdrawal addresses.
-    whitelisted_addresses: Vec<WhitelistEntry>,
-}
-
-/// Status of a whitelisted address.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WhitelistStatus {
-    Approved,
-    Pending,
-}
-
-impl std::fmt::Display for WhitelistStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Approved => write!(formatter, "APPROVED"),
-            Self::Pending => write!(formatter, "PENDING"),
-        }
-    }
-}
-
-/// A whitelisted address entry in the mock state.
-struct WhitelistEntry {
-    id: String,
-    address: Address,
-    asset: String,
-    chain: String,
-    status: WhitelistStatus,
-}
-
-/// Snapshot of a placed order, returned by [`AlpacaBrokerMock::orders`].
-pub struct MockOrderSnapshot {
-    pub order_id: String,
-    pub symbol: String,
-    pub quantity: Float,
-    pub side: OrderSide,
-    pub status: OrderStatus,
-    pub poll_count: usize,
-    pub filled_price: Option<Float>,
-}
-
-/// Snapshot of a position, returned by [`AlpacaBrokerMock::positions`].
-pub struct MockPositionSnapshot {
-    pub symbol: String,
-    pub quantity: Float,
-    pub market_value: Float,
-}
-
-/// Direction of a wallet transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransferDirection {
-    Incoming,
-    Outgoing,
-}
-
-impl std::fmt::Display for TransferDirection {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Incoming => write!(formatter, "INCOMING"),
-            Self::Outgoing => write!(formatter, "OUTGOING"),
-        }
-    }
-}
-
-/// Status of a wallet transfer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransferStatus {
-    Pending,
-    Processing,
-    Complete,
-}
-
-impl std::fmt::Display for TransferStatus {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pending => write!(formatter, "PENDING"),
-            Self::Processing => write!(formatter, "PROCESSING"),
-            Self::Complete => write!(formatter, "COMPLETE"),
-        }
-    }
-}
-
-/// Snapshot of a wallet transfer, returned by
-/// [`AlpacaBrokerMock::wallet_transfers`].
+/// A command that controls mock broker behavior at runtime.
 ///
-/// Direction-specific counterparty data lives in [`TransferFlow`]; common
-/// metadata stays on the snapshot so consumers don't pay a match cost for
-/// status / amount / id checks. The `flow` discriminant subsumes any
-/// separate "direction" tag, so neither the meaning of an address nor the
-/// invariant linking address-to-direction needs to be reasoned about.
-pub struct MockWalletTransferSnapshot {
-    pub transfer_id: String,
-    pub amount: Float,
-    pub asset: String,
-    pub status: TransferStatus,
-    pub flow: TransferFlow,
+/// Submitted to the Apalis job queue by e2e tests and processed by a
+/// worker running alongside the production workers. Each variant maps
+/// to a method on [`AlpacaBrokerMock`].
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum MockBrokerCommand {
+    /// Switch the broker mock's response mode.
+    SetMode(MockMode),
+    /// Open the simulated market.
+    OpenMarket,
+    /// Close the simulated market.
+    CloseMarket,
+    /// Set the fill price for a specific symbol.
+    SetFillPrice { symbol: Symbol, price: Usd },
+    /// Set how many polls before a symbol's order fills.
+    SetFillDelay {
+        symbol: Symbol,
+        polls_before_fill: usize,
+    },
+    /// Set the mock wallet's USDC balance.
+    SetWalletBalance { balance: Usdc },
 }
 
-/// Direction-specific counterparty data attached to a wallet transfer.
-pub enum TransferFlow {
-    /// USDC moving from Alpaca to an on-chain `recipient`.
-    Outgoing { recipient: Address },
-    /// USDC arriving at Alpaca from an on-chain `sender`.
-    Incoming { sender: Address },
-}
-
-impl TransferFlow {
-    #[must_use]
-    pub fn direction(&self) -> TransferDirection {
+impl MockBrokerCommand {
+    /// Applies this command to the given broker mock.
+    pub fn apply(self, broker: &AlpacaBrokerMock) {
         match self {
-            Self::Outgoing { .. } => TransferDirection::Outgoing,
-            Self::Incoming { .. } => TransferDirection::Incoming,
+            Self::SetMode(mode) => broker.set_mode(mode),
+            Self::OpenMarket => broker.set_market_open(),
+            Self::CloseMarket => broker.set_market_closed(),
+
+            Self::SetFillPrice { symbol, price } => {
+                broker.set_symbol_fill_price(symbol, price.inner());
+            }
+
+            Self::SetFillDelay {
+                symbol,
+                polls_before_fill,
+            } => {
+                broker.set_symbol_fill_delay(symbol, polls_before_fill);
+            }
+
+            Self::SetWalletBalance { balance } => {
+                broker.set_wallet_usdc_balance(balance.inner());
+            }
         }
     }
 }
@@ -545,6 +370,232 @@ impl AlpacaBrokerMock {
                 }
             }
         }))
+    }
+}
+
+pub const TEST_ACCOUNT_ID: &str = "904837e3-3b76-47ec-b432-046db621571b";
+pub const TEST_API_KEY: &str = "e2e_test_key";
+pub const TEST_API_SECRET: &str = "e2e_test_secret";
+
+/// Controls how the mock responds to order placement and polling.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum MockMode {
+    /// Place succeeds, first poll returns filled.
+    HappyPath,
+    /// Place succeeds, poll returns rejected.
+    OrderRejected,
+    /// Place returns HTTP 422.
+    PlacementFails,
+    /// Place succeeds, order stays "new" for N polls before filling.
+    /// Simulates real broker latency where fills aren't instant.
+    DelayedFill { polls_before_fill: usize },
+}
+
+pub struct MockPosition {
+    pub symbol: Symbol,
+    pub quantity: Float,
+    pub market_value: Float,
+}
+
+struct MockAccount {
+    cash: Float,
+    buying_power: Float,
+    positions: HashMap<Symbol, MockPosition>,
+}
+
+/// Side of a broker order (buy or sell).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderSide {
+    Buy,
+    Sell,
+}
+
+impl std::fmt::Display for OrderSide {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Buy => write!(formatter, "buy"),
+            Self::Sell => write!(formatter, "sell"),
+        }
+    }
+}
+
+/// Status of a broker order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderStatus {
+    New,
+    Filled,
+    Rejected,
+}
+
+impl std::fmt::Display for OrderStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::New => write!(formatter, "new"),
+            Self::Filled => write!(formatter, "filled"),
+            Self::Rejected => write!(formatter, "rejected"),
+        }
+    }
+}
+
+struct MockOrder {
+    symbol: Symbol,
+    quantity: Float,
+    side: OrderSide,
+    status: OrderStatus,
+    poll_count: usize,
+    filled_price: Option<Float>,
+}
+
+/// A single calendar entry controlling market open/close times.
+struct CalendarEntry {
+    pub date: String,
+    pub open: String,
+    pub close: String,
+}
+
+/// A mock wallet transfer tracked in shared state.
+struct MockWalletTransfer {
+    transfer_id: String,
+    direction: TransferDirection,
+    amount: Float,
+    asset: String,
+    from_address: Address,
+    to_address: Address,
+    status: TransferStatus,
+    tx_hash: String,
+    poll_count: usize,
+    /// Number of polls before transitioning from "pending" to "complete".
+    polls_until_complete: usize,
+}
+
+struct MockState {
+    account: MockAccount,
+    orders: HashMap<String, MockOrder>,
+    symbol_fill_prices: HashMap<Symbol, Float>,
+    mode: MockMode,
+    /// Per-symbol fill delays: number of polls before filling.
+    /// Symbols without an entry fill immediately in `HappyPath` mode.
+    symbol_fill_delays: HashMap<Symbol, usize>,
+    /// Dynamic calendar entries. The endpoint reads from this on each request.
+    calendar_entries: Vec<CalendarEntry>,
+    /// Wallet transfers (withdrawals and deposits).
+    wallet_transfers: Vec<MockWalletTransfer>,
+    /// Alpaca deposit wallet address for incoming USDC.
+    alpaca_deposit_address: String,
+    /// Wallet balances by asset symbol (e.g. USDC in the crypto wallet).
+    wallet_balances: HashMap<String, Float>,
+    /// Whitelisted withdrawal addresses.
+    whitelisted_addresses: Vec<WhitelistEntry>,
+}
+
+/// Status of a whitelisted address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WhitelistStatus {
+    Approved,
+    Pending,
+}
+
+impl std::fmt::Display for WhitelistStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Approved => write!(formatter, "APPROVED"),
+            Self::Pending => write!(formatter, "PENDING"),
+        }
+    }
+}
+
+/// A whitelisted address entry in the mock state.
+struct WhitelistEntry {
+    id: String,
+    address: Address,
+    asset: String,
+    chain: String,
+    status: WhitelistStatus,
+}
+
+/// Snapshot of a placed order, returned by [`AlpacaBrokerMock::orders`].
+pub struct MockOrderSnapshot {
+    pub order_id: String,
+    pub symbol: String,
+    pub quantity: Float,
+    pub side: OrderSide,
+    pub status: OrderStatus,
+    pub poll_count: usize,
+    pub filled_price: Option<Float>,
+}
+
+/// Snapshot of a position, returned by [`AlpacaBrokerMock::positions`].
+pub struct MockPositionSnapshot {
+    pub symbol: String,
+    pub quantity: Float,
+    pub market_value: Float,
+}
+
+/// Direction of a wallet transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferDirection {
+    Incoming,
+    Outgoing,
+}
+
+impl std::fmt::Display for TransferDirection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Incoming => write!(formatter, "INCOMING"),
+            Self::Outgoing => write!(formatter, "OUTGOING"),
+        }
+    }
+}
+
+/// Status of a wallet transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransferStatus {
+    Pending,
+    Processing,
+    Complete,
+}
+
+impl std::fmt::Display for TransferStatus {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(formatter, "PENDING"),
+            Self::Processing => write!(formatter, "PROCESSING"),
+            Self::Complete => write!(formatter, "COMPLETE"),
+        }
+    }
+}
+
+/// Snapshot of a wallet transfer, returned by
+/// [`AlpacaBrokerMock::wallet_transfers`].
+///
+/// Direction-specific counterparty data lives in [`TransferFlow`]; common
+/// metadata stays on the snapshot so consumers don't pay a match cost for
+/// status / amount / id checks. The `flow` discriminant subsumes any
+/// separate "direction" tag, so neither the meaning of an address nor the
+/// invariant linking address-to-direction needs to be reasoned about.
+pub struct MockWalletTransferSnapshot {
+    pub transfer_id: String,
+    pub amount: Float,
+    pub asset: String,
+    pub status: TransferStatus,
+    pub flow: TransferFlow,
+}
+
+/// Direction-specific counterparty data attached to a wallet transfer.
+pub enum TransferFlow {
+    /// USDC moving from Alpaca to an on-chain `recipient`.
+    Outgoing { recipient: Address },
+    /// USDC arriving at Alpaca from an on-chain `sender`.
+    Incoming { sender: Address },
+}
+
+impl TransferFlow {
+    #[must_use]
+    pub fn direction(&self) -> TransferDirection {
+        match self {
+            Self::Outgoing { .. } => TransferDirection::Outgoing,
+            Self::Incoming { .. } => TransferDirection::Incoming,
+        }
     }
 }
 

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -33,9 +33,9 @@ mod market_hours;
 mod mock_api;
 #[cfg(feature = "mock")]
 pub use mock_api::{
-    AlpacaBrokerMock, MockMode, MockOrderSnapshot, MockPosition, MockPositionSnapshot,
-    MockWalletTransferSnapshot, OrderSide, OrderStatus, TEST_ACCOUNT_ID, TEST_API_KEY,
-    TEST_API_SECRET, TransferDirection, TransferStatus, WhitelistStatus,
+    AlpacaBrokerMock, MockBrokerCommand, MockMode, MockOrderSnapshot, MockPosition,
+    MockPositionSnapshot, MockWalletTransferSnapshot, OrderSide, OrderStatus, TEST_ACCOUNT_ID,
+    TEST_API_KEY, TEST_API_SECRET, TransferDirection, TransferStatus, WhitelistStatus,
 };
 mod order;
 mod positions;

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -34,9 +34,10 @@ mod market_hours;
 mod mock_api;
 #[cfg(feature = "mock")]
 pub use mock_api::{
-    AlpacaBrokerMock, MockMode, MockOrderSnapshot, MockPosition, MockPositionSnapshot,
-    MockWalletTransferSnapshot, OrderSide, OrderStatus, TEST_ACCOUNT_ID, TEST_API_KEY,
-    TEST_API_SECRET, TransferDirection, TransferFlow, TransferStatus, WhitelistStatus,
+    AlpacaBrokerMock, MockBrokerCommand, MockMode, MockOrderSnapshot, MockPosition,
+    MockPositionSnapshot, MockWalletTransferSnapshot, OrderSide, OrderStatus, TEST_ACCOUNT_ID,
+    TEST_API_KEY, TEST_API_SECRET, TransferDirection, TransferFlow, TransferStatus,
+    WhitelistStatus,
 };
 mod order;
 mod positions;

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -312,6 +312,7 @@ pub enum JobKind {
     SeedVaultRegistry,
     WrappedEquityRecovery,
     CheckPositions,
+    MockBroker,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -347,6 +348,7 @@ pub struct FailureInjector {
     seed_vault_registry: Arc<Mutex<InjectionState>>,
     wrapped_equity_recovery: Arc<Mutex<InjectionState>>,
     check_positions: Arc<Mutex<InjectionState>>,
+    mock_broker: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -380,6 +382,7 @@ impl FailureInjector {
             seed_vault_registry: Arc::new(Mutex::new(InjectionState::Idle)),
             wrapped_equity_recovery: Arc::new(Mutex::new(InjectionState::Idle)),
             check_positions: Arc::new(Mutex::new(InjectionState::Idle)),
+            mock_broker: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -425,6 +428,7 @@ impl FailureInjector {
             JobKind::SeedVaultRegistry => &self.seed_vault_registry,
             JobKind::WrappedEquityRecovery => &self.wrapped_equity_recovery,
             JobKind::CheckPositions => &self.check_positions,
+            JobKind::MockBroker => &self.mock_broker,
         };
 
         match mutex.lock() {

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -6,18 +6,16 @@
 //! the fetched values. The InventoryView reacts to these events to reconcile
 //! tracked inventory.
 
-use alloy::primitives::Address;
-use alloy::providers::RootProvider;
+use alloy::primitives::{Address, RootProvider};
 use futures_util::future::try_join_all;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use tracing::debug;
+use tracing::{debug, info, trace};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
-use st0x_execution::{
-    Executor, FractionalShares, InventoryResult, SharesBlockchain, SharesConversionError, Symbol,
-};
+use st0x_execution::{Executor, InventoryResult};
+use st0x_finance::{FloatError, FractionalShares, HasZero, Symbol, Usd};
 
 use crate::alpaca_wallet::{AlpacaWalletError, AlpacaWalletService};
 use crate::bindings::IERC20;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub(crate) mod dashboard;
 mod equity_redemption;
 mod inventory;
 #[cfg(feature = "mock")]
-pub mod mock_orchestration;
+mod mock_orchestration;
 mod offchain;
 mod offchain_order;
 mod onchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod config;
 pub(crate) mod dashboard;
 mod equity_redemption;
 mod inventory;
+#[cfg(feature = "mock")]
+pub mod mock_orchestration;
 mod offchain;
 mod offchain_order;
 mod onchain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ mod conductor;
 pub(crate) mod dashboard;
 mod equity_redemption;
 mod inventory;
+#[cfg(feature = "mock")]
+mod mock_orchestration;
 mod offchain;
 mod onchain;
 mod onchain_trade;

--- a/src/mock_orchestration.rs
+++ b/src/mock_orchestration.rs
@@ -1,0 +1,138 @@
+//! Apalis-driven mock orchestration for e2e tests.
+//!
+//! Defines job types and a worker that controls mock broker behavior
+//! at runtime via the same Apalis job queue the production system uses.
+//! This gives test orchestration visibility through apalis-board and
+//! enables deterministic, job-driven test scenarios.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! // In e2e test setup, after creating TestInfra:
+//! let broker = Arc::new(infra.broker_service);
+//! let mock_monitor = spawn_mock_monitor(&pool, broker).await;
+//!
+//! // Submit commands via the queue:
+//! let mut queue: MockCommandQueue = SqliteStorage::new(&pool);
+//! queue.push_task(TaskBuilder::new(MockBrokerCommand::CloseMarket).build()).await?;
+//! ```
+
+use std::sync::Arc;
+
+use apalis::prelude::{Data, Monitor, WorkerBuilder};
+use apalis_codec::json::JsonCodec;
+use apalis_sqlite::fetcher::SqliteFetcher;
+use apalis_sqlite::{CompactType, SqliteStorage};
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+use st0x_execution::Symbol;
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, MockMode};
+use st0x_finance::{Usd, Usdc};
+
+/// Persistent job queue for mock broker commands.
+pub type MockCommandQueue = SqliteStorage<MockBrokerCommand, JsonCodec<CompactType>, SqliteFetcher>;
+
+/// A job that controls mock broker behavior at runtime.
+///
+/// Submitted to the Apalis job queue by e2e tests and processed by a
+/// worker running alongside the production workers. Each command maps
+/// to a method on [`AlpacaBrokerMock`].
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum MockBrokerCommand {
+    /// Switch the broker mock's response mode.
+    SetMode(MockMode),
+
+    /// Open the simulated market.
+    OpenMarket,
+
+    /// Close the simulated market.
+    CloseMarket,
+
+    /// Set the fill price for a specific symbol.
+    SetFillPrice { symbol: Symbol, price: Usd },
+
+    /// Set how many polls before a symbol's order fills.
+    SetFillDelay {
+        symbol: Symbol,
+        polls_before_fill: usize,
+    },
+
+    /// Set the mock wallet's USDC balance.
+    SetWalletBalance { balance: Usdc },
+}
+
+/// Shared context passed to the mock orchestration worker via Apalis `data()`.
+pub struct MockOrchestrationCtx {
+    pub broker: Arc<AlpacaBrokerMock>,
+}
+
+/// Spawns a background Apalis monitor that processes [`MockBrokerCommand`]s.
+///
+/// Run this alongside the production bot in e2e tests. The monitor
+/// connects to the same SQLite database, so commands pushed by the
+/// test are visible in apalis-board alongside production jobs.
+pub async fn spawn_mock_monitor(
+    pool: &SqlitePool,
+    broker: Arc<AlpacaBrokerMock>,
+) -> JoinHandle<()> {
+    let mock_queue: MockCommandQueue = SqliteStorage::new(pool);
+    let ctx = Arc::new(MockOrchestrationCtx { broker });
+
+    tokio::spawn(async move {
+        let monitor = Monitor::new().register(move |index| {
+            WorkerBuilder::new(format!("mock-broker-worker-{index}"))
+                .backend(mock_queue.clone())
+                .data(ctx.clone())
+                .build(handle_mock_broker_command)
+        });
+
+        if let Err(error) = monitor.run().await {
+            warn!(%error, "Mock orchestration monitor exited");
+        }
+    })
+}
+
+/// Apalis worker function that applies [`MockBrokerCommand`]s to the
+/// broker mock.
+async fn handle_mock_broker_command(
+    command: MockBrokerCommand,
+    ctx: Data<Arc<MockOrchestrationCtx>>,
+) {
+    match command {
+        MockBrokerCommand::SetMode(mode) => {
+            debug!(?mode, "Setting broker mode");
+            ctx.broker.set_mode(mode);
+        }
+
+        MockBrokerCommand::OpenMarket => {
+            debug!("Opening market");
+            ctx.broker.set_market_open();
+        }
+
+        MockBrokerCommand::CloseMarket => {
+            debug!("Closing market");
+            ctx.broker.set_market_closed();
+        }
+
+        MockBrokerCommand::SetFillPrice { symbol, price } => {
+            debug!(%symbol, %price, "Setting fill price");
+            ctx.broker.set_symbol_fill_price(symbol, price.inner());
+        }
+
+        MockBrokerCommand::SetFillDelay {
+            symbol,
+            polls_before_fill,
+        } => {
+            debug!(%symbol, polls_before_fill, "Setting fill delay");
+            ctx.broker.set_symbol_fill_delay(symbol, polls_before_fill);
+        }
+
+        MockBrokerCommand::SetWalletBalance { balance } => {
+            debug!(%balance, "Setting wallet USDC balance");
+            ctx.broker.set_wallet_usdc_balance(balance.inner());
+        }
+    }
+}

--- a/src/mock_orchestration.rs
+++ b/src/mock_orchestration.rs
@@ -1,138 +1,25 @@
-//! Apalis-driven mock orchestration for e2e tests.
+//! [`Job`] implementation for [`MockBrokerCommand`].
 //!
-//! Defines job types and a worker that controls mock broker behavior
-//! at runtime via the same Apalis job queue the production system uses.
-//! This gives test orchestration visibility through apalis-board and
-//! enables deterministic, job-driven test scenarios.
-//!
-//! # Usage
-//!
-//! ```ignore
-//! // In e2e test setup, after creating TestInfra:
-//! let broker = Arc::new(infra.broker_service);
-//! let mock_monitor = spawn_mock_monitor(&pool, broker).await;
-//!
-//! // Submit commands via the queue:
-//! let mut queue: MockCommandQueue = SqliteStorage::new(&pool);
-//! queue.push_task(TaskBuilder::new(MockBrokerCommand::CloseMarket).build()).await?;
-//! ```
+//! Bridges the execution crate's mock broker commands with the conductor's
+//! job infrastructure, enabling e2e tests to control mock behavior through
+//! the same Apalis job queue the production system uses.
 
-use std::sync::Arc;
+use tracing::debug;
 
-use apalis::prelude::{Data, Monitor, WorkerBuilder};
-use apalis_codec::json::JsonCodec;
-use apalis_sqlite::fetcher::SqliteFetcher;
-use apalis_sqlite::{CompactType, SqliteStorage};
-use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
-use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, MockBrokerCommand};
 
-use st0x_execution::Symbol;
-use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, MockMode};
-use st0x_finance::{Usd, Usdc};
+use crate::conductor::job::{Job, Label};
 
-/// Persistent job queue for mock broker commands.
-pub type MockCommandQueue = SqliteStorage<MockBrokerCommand, JsonCodec<CompactType>, SqliteFetcher>;
+impl Job<AlpacaBrokerMock> for MockBrokerCommand {
+    type Error = std::convert::Infallible;
 
-/// A job that controls mock broker behavior at runtime.
-///
-/// Submitted to the Apalis job queue by e2e tests and processed by a
-/// worker running alongside the production workers. Each command maps
-/// to a method on [`AlpacaBrokerMock`].
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum MockBrokerCommand {
-    /// Switch the broker mock's response mode.
-    SetMode(MockMode),
+    fn label(&self) -> Label {
+        Label::new(format!("mock:{self:?}"))
+    }
 
-    /// Open the simulated market.
-    OpenMarket,
-
-    /// Close the simulated market.
-    CloseMarket,
-
-    /// Set the fill price for a specific symbol.
-    SetFillPrice { symbol: Symbol, price: Usd },
-
-    /// Set how many polls before a symbol's order fills.
-    SetFillDelay {
-        symbol: Symbol,
-        polls_before_fill: usize,
-    },
-
-    /// Set the mock wallet's USDC balance.
-    SetWalletBalance { balance: Usdc },
-}
-
-/// Shared context passed to the mock orchestration worker via Apalis `data()`.
-pub struct MockOrchestrationCtx {
-    pub broker: Arc<AlpacaBrokerMock>,
-}
-
-/// Spawns a background Apalis monitor that processes [`MockBrokerCommand`]s.
-///
-/// Run this alongside the production bot in e2e tests. The monitor
-/// connects to the same SQLite database, so commands pushed by the
-/// test are visible in apalis-board alongside production jobs.
-pub async fn spawn_mock_monitor(
-    pool: &SqlitePool,
-    broker: Arc<AlpacaBrokerMock>,
-) -> JoinHandle<()> {
-    let mock_queue: MockCommandQueue = SqliteStorage::new(pool);
-    let ctx = Arc::new(MockOrchestrationCtx { broker });
-
-    tokio::spawn(async move {
-        let monitor = Monitor::new().register(move |index| {
-            WorkerBuilder::new(format!("mock-broker-worker-{index}"))
-                .backend(mock_queue.clone())
-                .data(ctx.clone())
-                .build(handle_mock_broker_command)
-        });
-
-        if let Err(error) = monitor.run().await {
-            warn!(%error, "Mock orchestration monitor exited");
-        }
-    })
-}
-
-/// Apalis worker function that applies [`MockBrokerCommand`]s to the
-/// broker mock.
-async fn handle_mock_broker_command(
-    command: MockBrokerCommand,
-    ctx: Data<Arc<MockOrchestrationCtx>>,
-) {
-    match command {
-        MockBrokerCommand::SetMode(mode) => {
-            debug!(?mode, "Setting broker mode");
-            ctx.broker.set_mode(mode);
-        }
-
-        MockBrokerCommand::OpenMarket => {
-            debug!("Opening market");
-            ctx.broker.set_market_open();
-        }
-
-        MockBrokerCommand::CloseMarket => {
-            debug!("Closing market");
-            ctx.broker.set_market_closed();
-        }
-
-        MockBrokerCommand::SetFillPrice { symbol, price } => {
-            debug!(%symbol, %price, "Setting fill price");
-            ctx.broker.set_symbol_fill_price(symbol, price.inner());
-        }
-
-        MockBrokerCommand::SetFillDelay {
-            symbol,
-            polls_before_fill,
-        } => {
-            debug!(%symbol, polls_before_fill, "Setting fill delay");
-            ctx.broker.set_symbol_fill_delay(symbol, polls_before_fill);
-        }
-
-        MockBrokerCommand::SetWalletBalance { balance } => {
-            debug!(%balance, "Setting wallet USDC balance");
-            ctx.broker.set_wallet_usdc_balance(balance.inner());
-        }
+    async fn perform(&self, broker: &AlpacaBrokerMock) -> Result<(), Self::Error> {
+        debug!(?self, "Applying mock broker command");
+        self.clone().apply(broker);
+        Ok(())
     }
 }

--- a/src/mock_orchestration.rs
+++ b/src/mock_orchestration.rs
@@ -1,0 +1,31 @@
+//! [`Job`] implementation for [`MockBrokerCommand`].
+//!
+//! Bridges the execution crate's mock broker commands with the conductor's
+//! job infrastructure, enabling e2e tests to control mock behavior through
+//! the same Apalis job queue the production system uses.
+
+use tracing::debug;
+
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, MockBrokerCommand};
+
+use crate::conductor::job::{Job, Label};
+
+impl Job<AlpacaBrokerMock> for MockBrokerCommand {
+    type Output = ();
+    type Error = std::convert::Infallible;
+
+    const WORKER_NAME: &'static str = "mock-broker-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::MockBroker;
+
+    fn label(&self) -> Label {
+        Label::new(format!("mock:{self:?}"))
+    }
+
+    async fn perform(&self, broker: &AlpacaBrokerMock) -> Result<Self::Output, Self::Error> {
+        debug!(?self, "Applying mock broker command");
+        self.clone().apply(broker);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Motivation

Closes [RAI-138](https://linear.app/makeitrain/issue/RAI-138/make-the-mock-infrastructure-be-orchestrated-in-the-same-way-as-the)

The e2e tests need to control mock broker behavior at runtime (switch modes,
set fill prices, open/close market, etc.). Previously this would require ad-hoc
mechanisms outside the normal job infrastructure. This PR makes mock broker
control flow through the same Apalis job queue that production workers use,
keeping the test infrastructure consistent with the production architecture.

## Solution

Introduces `MockBrokerCommand` -- a serializable enum in the execution crate
that represents all runtime mutations to the `AlpacaBrokerMock` (set mode,
open/close market, set fill price, set fill delay, set wallet balance). Each
variant maps to an existing method on the mock.

A `Job<AlpacaBrokerMock>` implementation in `src/mock_orchestration.rs` bridges
these commands with the conductor's Apalis job infrastructure. E2e tests submit
commands to the job queue, and a worker applies them -- same pattern as every
other job in the system.

Key changes:
- **`MockBrokerCommand` enum** (`mock_api.rs`): 6 variants covering all mock
  mutations, with `Serialize`/`Deserialize` for Apalis transport and an
  `apply()` method that dispatches to the mock
- **`Job` impl** (`mock_orchestration.rs`): Infallible worker that applies
  commands to the broker mock, gated behind `#[cfg(feature = "mock")]`
- **`MockMode` derives** `Serialize`/`Deserialize` so it can travel through the
  job queue
- **Import cleanup** in `polling.rs`: migrated to `st0x_finance` re-exports
  (`Symbol`, `Usd`, `FractionalShares`, etc.) and fixed `RootProvider` import
  path

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Apalis and related dependencies to newer versions for improved stability and compatibility.

* **Tests**
  * Enhanced mock broker with serializable runtime commands for richer end-to-end testing (mode, market state, fills, balance).
  * Added job support to execute mock broker commands.
  * Added targeted lint suppressions for test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->