### PR TITLE
Alpaca API Update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@
 TURNKEY_API_PRIVATE_KEY=<hex-encoded-p256-api-private-key>
 TURNKEY_ORG_ID=<turnkey-organization-id>
 TURNKEY_ADDRESS=<0x-ethereum-address-managed-by-turnkey>
+
+# Alpaca sandbox credentials for the ignored test `alpaca_wallet::whitelist::tests::sandbox_whitelist_operations`
+ALPACA_BROKER_API_KEY=
+ALPACA_BROKER_API_SECRET=
+ALPACA_BROKER_ACCOUNT_ID=

--- a/config/st0x-hedge.toml
+++ b/config/st0x-hedge.toml
@@ -3,6 +3,9 @@ log_level = "debug"
 database_url = "sqlite:///mnt/data/st0x-hedge.db"
 hyperdx.service_name = "st0x-hedge"
 
+[broker.travel_rule]
+beneficiary_entity_name = "T0 TRADE (BVI) LTD"
+
 [raindex]
 orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 deployment_block = 41715047

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -412,26 +412,18 @@ mod tests {
 
     #[ignore = "requires TURNKEY_* env vars -- run with `cargo test -- --ignored`"]
     #[tokio::test]
-    async fn turnkey_wallet_address_matches_configured() {
-        let (api_key, org_id, expected) = turnkey_env()
-            .expect("TURNKEY_API_PRIVATE_KEY, TURNKEY_ORG_ID, and TURNKEY_ADDRESS must be set");
-
-        let (wallet, _anvil) = integration_wallet(api_key, org_id, expected).await;
-
-        assert_eq!(wallet.address(), expected);
-    }
-
-    #[ignore = "requires TURNKEY_* env vars -- run with `cargo test -- --ignored`"]
-    #[tokio::test]
-    async fn turnkey_signs_and_submits_transaction() {
+    async fn turnkey_integration() {
         let (api_key, org_id, address) = turnkey_env()
             .expect("TURNKEY_API_PRIVATE_KEY, TURNKEY_ORG_ID, and TURNKEY_ADDRESS must be set");
 
         let (wallet, _anvil) = integration_wallet(api_key, org_id, address).await;
         let self_address = wallet.address();
 
-        // 0-value self-transfer: minimal gas (21000), exercises the
-        // full Turnkey signing round-trip.
+        // Wallet address matches configured address.
+        assert_eq!(wallet.address(), address);
+
+        // Sequential 0-value self-transfer: exercises the full Turnkey
+        // signing round-trip.
         let receipt = wallet
             .send(self_address, Bytes::new(), "integration test self-transfer")
             .await
@@ -446,16 +438,6 @@ mod tests {
             receipt.from, self_address,
             "transaction should be from the configured wallet"
         );
-    }
-
-    #[ignore = "requires TURNKEY_* env vars -- run with `cargo test -- --ignored`"]
-    #[tokio::test]
-    async fn turnkey_concurrent_signing() {
-        let (api_key, org_id, address) = turnkey_env()
-            .expect("TURNKEY_API_PRIVATE_KEY, TURNKEY_ORG_ID, and TURNKEY_ADDRESS must be set");
-
-        let (wallet, _anvil) = integration_wallet(api_key, org_id, address).await;
-        let self_address = wallet.address();
 
         // Two parallel 0-value self-transfers to verify nonce
         // management doesn't collide under concurrent signing.

--- a/example.config.toml
+++ b/example.config.toml
@@ -3,6 +3,11 @@ log_level = "debug"
 database_url = ":memory:"
 hyperdx.service_name = "st0x-hedge"
 
+# Travel Rule info for Alpaca whitelist creation (required since 2026-03-27).
+# Only needed when using Alpaca Broker API.
+[broker.travel_rule]
+beneficiary_entity_name = "Acme Corp"
+
 [raindex]
 orderbook = "0x1111111111111111111111111111111111111111"
 deployment_block = 1

--- a/src/alpaca_wallet/client.rs
+++ b/src/alpaca_wallet/client.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use st0x_execution::AlpacaAccountId;
 
 use super::transfer::{AlpacaTransferId, Network, TokenSymbol, TransferStatus};
-use super::whitelist::{WhitelistEntry, WhitelistStatus};
+use super::whitelist::{TravelRuleInfo, WhitelistEntry, WhitelistStatus};
 
 #[derive(Debug, Error)]
 pub enum AlpacaWalletError {
@@ -172,6 +172,37 @@ impl AlpacaWalletClient {
         Ok(response)
     }
 
+    pub(super) async fn patch<T: serde::Serialize + Sync>(
+        &self,
+        path: &str,
+        body: &T,
+    ) -> Result<Response, AlpacaWalletError> {
+        let url = format!("{}{}", self.base_url, path);
+        debug!("PATCH {url}");
+
+        let response = self
+            .client
+            .patch(&url)
+            .basic_auth(&self.api_key, Some(&self.api_secret))
+            .header("APCA-API-KEY-ID", &self.api_key)
+            .header("APCA-API-SECRET-KEY", &self.api_secret)
+            .json(body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+
+            return Err(AlpacaWalletError::ApiError { status, message });
+        }
+
+        Ok(response)
+    }
+
     pub(super) fn account_id(&self) -> &AlpacaAccountId {
         &self.account_id
     }
@@ -209,16 +240,20 @@ impl AlpacaWalletClient {
     ///
     /// The address will be in PENDING status initially and must be approved
     /// before withdrawals can be made (typically within 24 hours).
+    /// Alpaca requires `travel_rule_info` on all whitelist creation requests,
+    /// effective 2026-03-27.
     pub(super) async fn create_whitelist_entry(
         &self,
         address: &Address,
         asset: &TokenSymbol,
         _network: &Network,
+        travel_rule_info: &TravelRuleInfo,
     ) -> Result<WhitelistEntry, AlpacaWalletError> {
         #[derive(serde::Serialize)]
         struct Request<'a> {
             address: String,
             asset: &'a str,
+            travel_rule_info: &'a TravelRuleInfo,
         }
 
         let path = format!("/v1/accounts/{}/wallets/whitelists", self.account_id);
@@ -228,6 +263,7 @@ impl AlpacaWalletClient {
             // Fine for now since this system only handles Ethereum mainnet.
             address: address.to_checksum(None),
             asset: asset.as_ref(),
+            travel_rule_info,
         };
 
         let response = self.post(&path, &request).await?;
@@ -250,6 +286,31 @@ impl AlpacaWalletClient {
         self.delete(&path).await?;
         Ok(())
     }
+
+    /// Updates travel rule info on an existing whitelisted address.
+    ///
+    /// Uses the PATCH endpoint added by Alpaca for the March 2026 travel
+    /// rule requirement. Existing whitelists that were created without
+    /// travel rule info must be patched before they can be used for
+    /// withdrawals.
+    pub(super) async fn patch_whitelist_travel_rule(
+        &self,
+        whitelist_id: &str,
+        travel_rule_info: &TravelRuleInfo,
+    ) -> Result<(), AlpacaWalletError> {
+        #[derive(serde::Serialize)]
+        struct Request<'a> {
+            travel_rule_info: &'a TravelRuleInfo,
+        }
+
+        let path = format!(
+            "/v1/accounts/{}/wallets/whitelists/{}/travel-rule-info",
+            self.account_id, whitelist_id
+        );
+
+        self.patch(&path, &Request { travel_rule_info }).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -257,6 +318,8 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
     use uuid::uuid;
+
+    use crate::config::TravelRuleConfig;
 
     use super::*;
 
@@ -414,5 +477,46 @@ mod tests {
         ));
 
         error_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_patch_whitelist_travel_rule_sends_expected_body() {
+        let server = MockServer::start();
+
+        let travel_rule = TravelRuleInfo::from_config(&TravelRuleConfig {
+            beneficiary_entity_name: "Acme Corp".to_string(),
+        });
+
+        let whitelist_id = "wl-abc-123";
+
+        let patch_mock = server.mock(|when, then| {
+            when.method(PATCH)
+                .path(format!(
+                    "/v1/accounts/{TEST_ACCOUNT_ID}/wallets/whitelists/{whitelist_id}/travel-rule-info"
+                ))
+                .header("APCA-API-KEY-ID", "test_key_id")
+                .header("APCA-API-SECRET-KEY", "test_secret_key")
+                .json_body(json!({
+                    "travel_rule_info": {
+                        "beneficiary_is_self_hosted": true,
+                        "beneficiary_entity_name": "Acme Corp"
+                    }
+                }));
+            then.status(204);
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        client
+            .patch_whitelist_travel_rule(whitelist_id, &travel_rule)
+            .await
+            .unwrap();
+
+        patch_mock.assert();
     }
 }

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -30,6 +30,7 @@ mod whitelist;
 use alloy::primitives::{Address, TxHash};
 use rain_math_float::Float;
 use std::sync::Arc;
+use tracing::error;
 
 use st0x_execution::{AlpacaAccountId, Positive};
 use st0x_finance::{HasZero, Usdc};
@@ -37,7 +38,7 @@ use st0x_finance::{HasZero, Usdc};
 pub(crate) use client::{AlpacaWalletClient, AlpacaWalletError};
 pub(crate) use status::PollingConfig;
 pub(crate) use transfer::{AlpacaTransferId, Network, TokenSymbol, Transfer, TransferStatus};
-pub(crate) use whitelist::WhitelistStatus;
+pub(crate) use whitelist::{TravelRuleInfo, WhitelistStatus};
 
 /// Service facade for Alpaca crypto wallet operations.
 ///
@@ -175,9 +176,10 @@ impl AlpacaWalletService {
         address: &Address,
         asset: &TokenSymbol,
         network: &Network,
+        travel_rule_info: &TravelRuleInfo,
     ) -> Result<whitelist::WhitelistEntry, AlpacaWalletError> {
         self.client
-            .create_whitelist_entry(address, asset, network)
+            .create_whitelist_entry(address, asset, network, travel_rule_info)
             .await
     }
 
@@ -205,6 +207,32 @@ impl AlpacaWalletService {
         }
 
         Ok(matching)
+    }
+
+    /// Patches travel rule info on all existing whitelisted addresses.
+    ///
+    /// Returns all whitelist entries that were patched.
+    pub(crate) async fn patch_all_whitelist_travel_rules(
+        &self,
+        travel_rule_info: &TravelRuleInfo,
+    ) -> Result<Vec<whitelist::WhitelistEntry>, AlpacaWalletError> {
+        let entries = self.client.get_whitelisted_addresses().await?;
+
+        for entry in &entries {
+            self.client
+                .patch_whitelist_travel_rule(&entry.id, travel_rule_info)
+                .await
+                .inspect_err(|err| {
+                    error!(
+                        whitelist_id = %entry.id,
+                        address = %entry.address,
+                        ?err,
+                        "failed to patch travel rule on whitelist entry"
+                    );
+                })?;
+        }
+
+        Ok(entries)
     }
 
     /// Gets all whitelisted addresses for this account.

--- a/src/alpaca_wallet/whitelist.rs
+++ b/src/alpaca_wallet/whitelist.rs
@@ -8,7 +8,34 @@ use alloy::primitives::Address;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::config::TravelRuleConfig;
+
 use super::transfer::{Network, TokenSymbol};
+
+/// Travel Rule beneficiary info for Alpaca whitelist creation requests.
+///
+/// Alpaca requires this on all `POST /whitelists` calls effective 2026-03-27.
+/// We only support self-hosted wallets, so `is_self_hosted` is always `true`.
+///
+/// Field names use `serde(rename)` to match the Alpaca API's
+/// `beneficiary_*` JSON keys while avoiding the `struct_field_names` lint.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TravelRuleInfo {
+    #[serde(rename = "beneficiary_is_self_hosted")]
+    is_self_hosted: bool,
+
+    #[serde(rename = "beneficiary_entity_name")]
+    entity_name: String,
+}
+
+impl TravelRuleInfo {
+    pub(crate) fn from_config(config: &TravelRuleConfig) -> Self {
+        Self {
+            is_self_hosted: true,
+            entity_name: config.beneficiary_entity_name.clone(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
@@ -35,9 +62,9 @@ mod tests {
     use serde_json::json;
     use uuid::uuid;
 
-    use super::super::client::AlpacaWalletClient;
     use st0x_execution::AlpacaAccountId;
 
+    use super::super::client::AlpacaWalletClient;
     use super::super::transfer::{Network, TokenSymbol};
     use super::*;
 
@@ -219,6 +246,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_whitelist_entry_sends_travel_rule_info() {
+        let server = MockServer::start();
+        let target = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        let travel_rule = TravelRuleInfo::from_config(&TravelRuleConfig {
+            beneficiary_entity_name: "T0 TRADE (BVI) LTD".to_string(),
+        });
+
+        let checksummed = target.to_checksum(None);
+
+        let create_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/whitelists"))
+                .json_body(json!({
+                    "address": checksummed,
+                    "asset": "USDC",
+                    "travel_rule_info": {
+                        "beneficiary_is_self_hosted": true,
+                        "beneficiary_entity_name": "T0 TRADE (BVI) LTD"
+                    }
+                }));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "whitelist-new",
+                    "address": target.to_string(),
+                    "asset": "USDC",
+                    "chain": "Ethereum",
+                    "status": "PENDING",
+                    "created_at": "2024-01-01T00:00:00Z"
+                }));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let asset = TokenSymbol::new("USDC");
+        let network = Network::new("Ethereum");
+
+        let entry = client
+            .create_whitelist_entry(&target, &asset, &network, &travel_rule)
+            .await
+            .unwrap();
+
+        assert_eq!(entry.id, "whitelist-new");
+        assert_eq!(entry.status, WhitelistStatus::Pending);
+
+        // httpmock asserts the full JSON body matched, confirming
+        // travel_rule_info was serialized correctly.
+        create_mock.assert();
+    }
+
+    #[tokio::test]
     async fn test_is_address_whitelisted_and_approved_not_found() {
         let server = MockServer::start();
         let other_address = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
@@ -259,5 +343,80 @@ mod tests {
         assert!(!result);
 
         whitelist_mock.assert();
+    }
+
+    /// Helper that reads Alpaca sandbox credentials from environment variables.
+    /// Returns `None` if any required var is missing, allowing `#[ignore]`
+    /// tests to skip gracefully.
+    fn sandbox_client() -> Option<AlpacaWalletClient> {
+        let api_key = std::env::var("ALPACA_BROKER_API_KEY").ok()?;
+        let api_secret = std::env::var("ALPACA_BROKER_API_SECRET").ok()?;
+        let account_id_str = std::env::var("ALPACA_BROKER_ACCOUNT_ID").ok()?;
+        let account_id =
+            AlpacaAccountId::new(account_id_str.parse::<uuid::Uuid>().expect("valid UUID"));
+
+        Some(AlpacaWalletClient::new(
+            "https://broker-api.sandbox.alpaca.markets".to_string(),
+            account_id,
+            api_key,
+            api_secret,
+        ))
+    }
+
+    /// Exercises the Alpaca sandbox wallet API: list, create, patch, delete.
+    ///
+    /// Combined into a single test to control execution order — parallel
+    /// sandbox calls cause 409 "account is being created" errors.
+    #[tokio::test]
+    #[ignore = "hits real Alpaca sandbox — requires ALPACA_BROKER_* env vars"]
+    async fn sandbox_whitelist_operations() {
+        let Some(client) = sandbox_client() else {
+            eprintln!("skipping: missing ALPACA_BROKER_* env vars");
+            return;
+        };
+
+        let travel_rule = TravelRuleInfo::from_config(&TravelRuleConfig {
+            beneficiary_entity_name: "T0 TRADE (BVI) LTD".to_string(),
+        });
+
+        // 1. List existing whitelist entries.
+        let entries = client.get_whitelisted_addresses().await.unwrap();
+        eprintln!("found {} whitelist entries", entries.len());
+
+        for entry in &entries {
+            eprintln!(
+                "  {} | {} | {} | {:?}",
+                entry.id,
+                entry.address,
+                entry.asset.as_ref(),
+                entry.status
+            );
+        }
+
+        // 2. Create a new whitelist entry with travel rule info.
+        let address = Address::random();
+        let asset = TokenSymbol::new("USDC");
+        let network = Network::new("ethereum");
+
+        eprintln!("creating whitelist entry for {address}");
+        let created = client
+            .create_whitelist_entry(&address, &asset, &network, &travel_rule)
+            .await
+            .unwrap();
+
+        eprintln!("created: id={}, status={:?}", created.id, created.status);
+        assert_eq!(created.address, address);
+
+        // 3. Patch travel rule info on the entry we just created.
+        eprintln!("patching travel rule on {}", created.id);
+        client
+            .patch_whitelist_travel_rule(&created.id, &travel_rule)
+            .await
+            .unwrap();
+        eprintln!("patched successfully");
+
+        // 4. Clean up: delete the entry.
+        client.delete_whitelist_entry(&created.id).await.unwrap();
+        eprintln!("cleaned up: deleted {}", created.id);
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -136,6 +136,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -13,7 +13,7 @@ use st0x_finance::Usdc;
 
 use super::ConvertDirection;
 use crate::alpaca_wallet::{
-    AlpacaWalletService, Network, TokenSymbol, TransferStatus, WhitelistStatus,
+    AlpacaWalletService, Network, TokenSymbol, TransferStatus, TravelRuleInfo, WhitelistStatus,
 };
 use crate::bindings::IERC20;
 use crate::config::{BrokerCtx, Ctx};
@@ -273,12 +273,20 @@ pub(super) async fn alpaca_whitelist_command<W: Write>(
         }
     }
 
+    let travel_rule_config = ctx.travel_rule.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing [broker.travel_rule] in config — required for Alpaca whitelist creation"
+        )
+    })?;
+    let travel_rule_info = TravelRuleInfo::from_config(travel_rule_config);
+
     writeln!(stdout, "   Creating whitelist entry...")?;
     let entry = alpaca_wallet
         .create_whitelist_entry(
             &target_address,
             &TokenSymbol::new("USDC"),
             &Network::new("ethereum"),
+            &travel_rule_info,
         )
         .await?;
 
@@ -335,6 +343,55 @@ pub(super) async fn alpaca_whitelist_list_command<W: Write>(
         writeln!(stdout, "   Status: {:?}", entry.status)?;
         writeln!(stdout, "   Created: {}", entry.created_at)?;
         writeln!(stdout)?;
+    }
+
+    Ok(())
+}
+
+pub(super) async fn alpaca_whitelist_patch_travel_rule_command<W: Write>(
+    stdout: &mut W,
+    ctx: &Ctx,
+) -> anyhow::Result<()> {
+    let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
+        anyhow::bail!(
+            "alpaca-whitelist-patch-travel-rule requires Alpaca Broker API configuration"
+        );
+    };
+
+    let travel_rule_config = ctx.travel_rule.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing [broker.travel_rule] in config — required for travel rule patching"
+        )
+    })?;
+    let travel_rule_info = TravelRuleInfo::from_config(travel_rule_config);
+
+    writeln!(
+        stdout,
+        "Patching travel rule info on all whitelisted addresses"
+    )?;
+
+    let alpaca_wallet = AlpacaWalletService::new(
+        alpaca_auth.base_url().to_string(),
+        alpaca_auth.account_id,
+        alpaca_auth.api_key.clone(),
+        alpaca_auth.api_secret.clone(),
+    );
+
+    let patched = alpaca_wallet
+        .patch_all_whitelist_travel_rules(&travel_rule_info)
+        .await?;
+
+    if patched.is_empty() {
+        writeln!(stdout, "No whitelist entries found to patch.")?;
+    } else {
+        writeln!(stdout, "Patched {} whitelist entry/entries:", patched.len())?;
+
+        for entry in &patched {
+            writeln!(stdout, "   ID: {}", entry.id)?;
+            writeln!(stdout, "   Address: {}", entry.address)?;
+            writeln!(stdout, "   Asset: {}", entry.asset.as_ref())?;
+            writeln!(stdout, "   Status: {:?}", entry.status)?;
+        }
     }
 
     Ok(())
@@ -590,6 +647,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 
@@ -671,6 +729,7 @@ mod tests {
                     .call(),
             )),
             execution_threshold: ExecutionThreshold::whole_share(),
+            travel_rule: None,
         }
     }
 

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -147,6 +147,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         };
 
         (ctx, schwab_auth)

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -278,6 +278,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -175,6 +175,13 @@ pub enum Commands {
     /// Shows all whitelist entries with their status, asset, and creation date.
     AlpacaWhitelistList,
 
+    /// Patch travel rule info on all existing whitelisted addresses
+    ///
+    /// Updates all whitelisted addresses with the beneficiary identity
+    /// from [broker.travel_rule] in the config. Required for addresses
+    /// whitelisted before the March 27 2026 travel rule deadline.
+    AlpacaWhitelistPatchTravelRule,
+
     /// Remove an address from Alpaca withdrawal whitelist
     ///
     /// Deletes all whitelist entries matching the given address.
@@ -446,6 +453,7 @@ enum SimpleCommand {
         address: Option<Address>,
     },
     AlpacaWhitelistList,
+    AlpacaWhitelistPatchTravelRule,
     AlpacaUnwhitelist {
         address: Address,
     },
@@ -564,6 +572,9 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         }
         Commands::AlpacaWhitelist { address } => Ok(SimpleCommand::AlpacaWhitelist { address }),
         Commands::AlpacaWhitelistList => Ok(SimpleCommand::AlpacaWhitelistList),
+        Commands::AlpacaWhitelistPatchTravelRule => {
+            Ok(SimpleCommand::AlpacaWhitelistPatchTravelRule)
+        }
         Commands::AlpacaUnwhitelist { address } => Ok(SimpleCommand::AlpacaUnwhitelist { address }),
         Commands::AlpacaTransfers { pending } => Ok(SimpleCommand::AlpacaTransfers { pending }),
         Commands::AlpacaConvert { direction, amount } => {
@@ -687,6 +698,9 @@ async fn run_simple_command<W: Write>(
         }
         SimpleCommand::AlpacaWhitelistList => {
             alpaca_wallet::alpaca_whitelist_list_command(stdout, ctx).await
+        }
+        SimpleCommand::AlpacaWhitelistPatchTravelRule => {
+            alpaca_wallet::alpaca_whitelist_patch_travel_rule_command(stdout, ctx).await
         }
         SimpleCommand::AlpacaUnwhitelist { address } => {
             alpaca_wallet::alpaca_unwhitelist_command(stdout, address, ctx).await
@@ -1340,6 +1354,7 @@ mod tests {
                 },
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -581,6 +581,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -563,6 +563,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -184,6 +184,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 
@@ -231,6 +232,7 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash,
             },
+            travel_rule: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,57 @@ struct Config {
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetryConfig>,
     rebalancing: Option<RebalancingConfig>,
+    broker: Option<BrokerConfig>,
     assets: AssetsConfig,
+}
+
+/// Non-secret broker settings from the plaintext config TOML.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BrokerConfig {
+    travel_rule: TravelRuleConfig,
+}
+
+/// Alpaca Travel Rule beneficiary identity, required for whitelist
+/// creation, effective 2026-03-27.
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TravelRuleConfig {
+    pub(crate) beneficiary_entity_name: String,
+}
+
+impl TravelRuleConfig {
+    /// Validates that beneficiary name fields are not blank or placeholder
+    /// values, and returns a normalized copy with trimmed whitespace.
+    fn validated(self) -> Result<Self, CtxError> {
+        let trimmed = self.beneficiary_entity_name.trim();
+
+        if trimmed.is_empty() {
+            return Err(CtxError::InvalidTravelRule {
+                field: "beneficiary_entity_name",
+                reason: "must not be blank",
+            });
+        }
+
+        if trimmed.eq_ignore_ascii_case("PLACEHOLDER") {
+            return Err(CtxError::InvalidTravelRule {
+                field: "beneficiary_entity_name",
+                reason: "must be set to a real value, not a placeholder",
+            });
+        }
+
+        Ok(Self {
+            beneficiary_entity_name: trimmed.to_owned(),
+        })
+    }
+}
+
+impl std::fmt::Debug for TravelRuleConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TravelRuleConfig")
+            .field("beneficiary_entity_name", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Secret credentials deserialized from the encrypted secrets TOML.
@@ -219,6 +269,7 @@ pub struct Ctx {
     pub trading_mode: TradingMode,
     pub execution_threshold: ExecutionThreshold,
     pub(crate) assets: AssetsConfig,
+    pub(crate) travel_rule: Option<TravelRuleConfig>,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -364,6 +415,7 @@ impl std::fmt::Debug for Ctx {
             .field("trading_mode", &self.trading_mode)
             .field("execution_threshold", &self.execution_threshold)
             .field("assets", &self.assets)
+            .field("travel_rule_configured", &self.travel_rule.is_some())
             .finish()
     }
 }
@@ -514,6 +566,10 @@ impl Ctx {
             trading_mode,
             execution_threshold,
             assets: config.assets,
+            travel_rule: config
+                .broker
+                .map(|broker_config| broker_config.travel_rule.validated())
+                .transpose()?,
         })
     }
 
@@ -590,6 +646,7 @@ impl Ctx {
         assets: AssetsConfig,
         #[builder(default = 2)] inventory_poll_interval: u64,
         execution_threshold_override: Option<ExecutionThreshold>,
+        travel_rule: Option<TravelRuleConfig>,
     ) -> Result<Self, CtxError> {
         let execution_threshold = match execution_threshold_override {
             Some(threshold) => threshold,
@@ -614,6 +671,7 @@ impl Ctx {
             trading_mode,
             execution_threshold,
             assets,
+            travel_rule,
         })
     }
 }
@@ -646,6 +704,11 @@ pub enum CtxError {
     },
     #[error(transparent)]
     InvalidThreshold(#[from] InvalidThresholdError),
+    #[error("invalid travel rule config: {field} {reason}")]
+    InvalidTravelRule {
+        field: &'static str,
+        reason: &'static str,
+    },
     #[error(transparent)]
     Telemetry(#[from] crate::telemetry::TelemetryAssemblyError),
     #[error("operation requires rebalancing mode")]
@@ -711,6 +774,7 @@ impl CtxError {
             Self::MissingEquityVaultId { .. } => "missing equity vault_id",
             Self::ZeroPollingInterval { .. } => "zero polling interval",
             Self::FloatComparison(_) => "float comparison failed",
+            Self::InvalidTravelRule { .. } => "invalid travel rule config",
         }
     }
 }
@@ -786,6 +850,7 @@ pub(crate) mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
+            travel_rule: None,
         }
     }
 
@@ -923,6 +988,111 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(matches!(ctx.broker, BrokerCtx::DryRun));
+    }
+
+    #[tokio::test]
+    async fn travel_rule_parsed_from_broker_section() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+
+            [broker.travel_rule]
+            beneficiary_entity_name = "T0 TRADE (BVI) LTD"
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let ctx = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap();
+
+        let travel_rule = ctx.travel_rule.unwrap();
+        assert_eq!(travel_rule.beneficiary_entity_name, "T0 TRADE (BVI) LTD");
+    }
+
+    #[tokio::test]
+    async fn travel_rule_optional_when_broker_section_absent() {
+        let config = minimal_config_toml();
+        let secrets = dry_run_secrets_toml();
+        let ctx = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap();
+
+        assert!(ctx.travel_rule.is_none());
+    }
+
+    #[tokio::test]
+    async fn travel_rule_rejects_placeholder_entity_name() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+
+            [broker.travel_rule]
+            beneficiary_entity_name = "PLACEHOLDER"
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                CtxError::InvalidTravelRule {
+                    field: "beneficiary_entity_name",
+                    ..
+                }
+            ),
+            "expected InvalidTravelRule for entity_name, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn travel_rule_rejects_blank_entity_name() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+
+            [broker.travel_rule]
+            beneficiary_entity_name = "   "
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                CtxError::InvalidTravelRule {
+                    field: "beneficiary_entity_name",
+                    ..
+                }
+            ),
+            "expected InvalidTravelRule for entity_name, got: {error}"
+        );
     }
 
     #[tokio::test]
@@ -1538,6 +1708,16 @@ pub(crate) mod tests {
             .equities
             .operational_limit
             .map(Positive::inner);
+
+        let broker = config.broker.expect(
+            "prod config must include [broker.travel_rule] — \
+             Alpaca rejects whitelist requests without it, effective 2026-03-27",
+        );
+
+        broker.travel_rule.validated().expect(
+            "prod travel rule config must have real beneficiary names, \
+             not placeholders or blanks",
+        );
 
         for (symbol, equity) in &config.assets.equities.symbols {
             if equity.rebalancing == OperationMode::Enabled


### PR DESCRIPTION
## Motivation

Closes [#512](https://github.com/ST0x-Technology/st0x.liquidity/issues/512).

Starting March 27, 2026, Alpaca rejects `POST /whitelists` requests that don't include `travel_rule_info`. This affects our whitelist creation flow used by the CLI `alpaca-whitelist` command. Without this change, we cannot whitelist new withdrawal addresses after the deadline, blocking USDC rebalancing operations.

## Solution

**Travel rule info on whitelist requests:**
- Added `TravelRuleInfo` struct (`src/alpaca_wallet/whitelist.rs`) serialized into the `POST /whitelists` request body with `beneficiary_is_self_hosted: true` and a configurable `beneficiary_entity_name`.
- Updated `create_whitelist_entry` through the full call chain: `AlpacaWalletClient` -> `AlpacaWalletService` -> CLI command.

**Configuration:**
- Added `[broker.travel_rule]` section to the plaintext config with a `beneficiary_entity_name` field. This is optional at the `Config` level (non-Alpaca setups don't need it), but required at the CLI callsite when creating whitelists.
- Validation rejects blank or "PLACEHOLDER" values to prevent accidental misconfiguration.
- `TravelRuleConfig` has a custom `Debug` impl that redacts the beneficiary name (PII).

**PATCH support for existing whitelists:**
- Added `patch_whitelist_travel_rule` to the client and `patch_all_whitelist_travel_rules` to the service layer.
- New CLI command `alpaca-whitelist-patch-travel-rule` patches all existing whitelisted addresses with travel rule info from config — needed for addresses whitelisted before the deadline.

**Turnkey test consolidation (unrelated fix):**
- Merged three separate `#[ignore]` Turnkey integration tests into one `turnkey_integration` test. The three tests shared a Turnkey account and when nextest ran them in parallel, nonce conflicts caused timeouts.

**Tests added:**
- Config parsing: travel rule present, absent, placeholder rejected, blank rejected (4 tests)
- Request body serialization: confirms `travel_rule_info` JSON shape via httpmock body matching (1 test)
- Prod config validation: asserts `config/st0x-hedge.toml` has real beneficiary names (existing test extended)
- Alpaca sandbox integration: list/create/patch/delete round-trip (`#[ignore]`, requires env vars)

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added travel-rule handling for whitelist operations and a CLI command to patch travel-rule info across existing whitelist entries

* **Configuration**
  * New [broker.travel_rule] section with beneficiary_entity_name and validation

* **Enhancements**
  * Whitelist creation now includes travel-rule beneficiary info; client supports PATCH requests

* **Tests**
  * Added sandbox integration test for whitelist flows and consolidated some integration tests for stability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->