### PR TITLE
CLI Withdraw improvement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ TURNKEY_API_PRIVATE_KEY=<hex-encoded-p256-api-private-key>
 TURNKEY_ORG_ID=<turnkey-organization-id>
 TURNKEY_ADDRESS=<0x-ethereum-address-managed-by-turnkey>
 
-# Alpaca sandbox credentials for the ignored test `alpaca_wallet::whitelist::tests::sandbox_whitelist_operations`
-ALPACA_BROKER_API_KEY=
-ALPACA_BROKER_API_SECRET=
-ALPACA_BROKER_ACCOUNT_ID=
+# Alpaca Broker API sandbox credentials for whitelist/travel-rule integration test
+# `alpaca_wallet::whitelist::tests::sandbox_whitelist_operations`
+ALPACA_BROKER_ACCOUNT_ID=<account-uuid>
+ALPACA_BROKER_API_KEY=<broker-api-key>
+ALPACA_BROKER_API_SECRET=<broker-api-secret>

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -38,7 +38,7 @@ use st0x_finance::{HasZero, Usdc};
 pub(crate) use client::{AlpacaWalletClient, AlpacaWalletError};
 pub(crate) use status::PollingConfig;
 pub(crate) use transfer::{AlpacaTransferId, Network, TokenSymbol, Transfer, TransferStatus};
-pub(crate) use whitelist::{TravelRuleInfo, WhitelistStatus};
+pub(crate) use whitelist::{TravelRuleInfo, WhitelistEntry, WhitelistStatus};
 
 /// Service facade for Alpaca crypto wallet operations.
 ///

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -13,7 +13,8 @@ use st0x_finance::Usdc;
 
 use super::ConvertDirection;
 use crate::alpaca_wallet::{
-    AlpacaWalletService, Network, TokenSymbol, TransferStatus, TravelRuleInfo, WhitelistStatus,
+    AlpacaWalletService, Network, TokenSymbol, TransferStatus, TravelRuleInfo, WhitelistEntry,
+    WhitelistStatus,
 };
 use crate::bindings::IERC20;
 use crate::config::{BrokerCtx, Ctx};
@@ -123,6 +124,73 @@ pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write
     Ok(())
 }
 
+/// Prints whitelisted addresses for the given asset, splitting them into
+/// approved (usable for withdrawals) and non-approved (pending/rejected).
+///
+/// Accepts a pre-fetched whitelist when available to avoid redundant API
+/// calls. Falls back to fetching from the API when `None`.
+async fn print_whitelisted_addresses<W: Write>(
+    stdout: &mut W,
+    alpaca_wallet: &AlpacaWalletService,
+    asset: &TokenSymbol,
+    prefetched: Option<&[WhitelistEntry]>,
+) -> anyhow::Result<()> {
+    let owned;
+    let entries: &[WhitelistEntry] = if let Some(entries) = prefetched {
+        entries
+    } else {
+        owned = alpaca_wallet.get_whitelisted_addresses().await?;
+        &owned
+    };
+
+    // Filter by asset only -- chain comparison is intentionally omitted
+    // because Alpaca's API returns inconsistent chain values ("ETH" vs
+    // "ethereum"). See is_address_whitelisted_and_approved for context.
+    let relevant: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry.asset == *asset)
+        .collect();
+
+    if relevant.is_empty() {
+        writeln!(stdout, "\nNo whitelisted addresses found for {asset}.")?;
+        writeln!(
+            stdout,
+            "Use `alpaca-whitelist` to whitelist an address first."
+        )?;
+        return Ok(());
+    }
+
+    let (approved, other): (Vec<_>, Vec<_>) = relevant
+        .into_iter()
+        .partition(|entry| entry.status == WhitelistStatus::Approved);
+
+    if approved.is_empty() {
+        writeln!(
+            stdout,
+            "\nNo approved addresses available for {asset} withdrawal."
+        )?;
+    } else {
+        writeln!(
+            stdout,
+            "\nApproved addresses (usable for {asset} withdrawal):"
+        )?;
+
+        for entry in &approved {
+            writeln!(stdout, "   {}", entry.address)?;
+        }
+    }
+
+    if !other.is_empty() {
+        writeln!(stdout, "\nNot yet usable:")?;
+
+        for entry in &other {
+            writeln!(stdout, "   {} ({:?})", entry.address, entry.status,)?;
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) async fn alpaca_withdraw_command<Registry: IntoErrorRegistry, W: Write>(
     stdout: &mut W,
     amount: Usdc,
@@ -137,31 +205,7 @@ pub(super) async fn alpaca_withdraw_command<Registry: IntoErrorRegistry, W: Writ
     };
 
     let rebalancing_ctx = ctx.rebalancing_ctx()?;
-    let sender_address = rebalancing_ctx.base_wallet().address();
 
-    let destination = to_address.unwrap_or(sender_address);
-    writeln!(stdout, "   Destination address: {destination}")?;
-
-    let (usdc_address, network) = if alpaca_auth.is_sandbox() {
-        (USDC_ETHEREUM_SEPOLIA, "Ethereum Sepolia")
-    } else {
-        (USDC_ETHEREUM, "Ethereum Mainnet")
-    };
-
-    writeln!(stdout, "   Network: {network}")?;
-    writeln!(stdout, "   USDC contract: {usdc_address}")?;
-
-    let balance_before = rebalancing_ctx
-        .ethereum_wallet()
-        .call::<Registry, _>(
-            usdc_address,
-            IERC20::balanceOfCall {
-                account: destination,
-            },
-        )
-        .await?;
-
-    writeln!(stdout, "   Balance before: {balance_before}")?;
     let alpaca_wallet = AlpacaWalletService::new(
         alpaca_auth.base_url().to_string(),
         rebalancing_ctx.alpaca_broker_auth.account_id,
@@ -170,11 +214,64 @@ pub(super) async fn alpaca_withdraw_command<Registry: IntoErrorRegistry, W: Writ
     );
 
     let usdc_asset = TokenSymbol::new("USDC");
+
+    let Some(to_address) = to_address else {
+        writeln!(stdout, "\nNo --to address provided.")?;
+        print_whitelisted_addresses(stdout, &alpaca_wallet, &usdc_asset, None).await?;
+        anyhow::bail!("--to is required. See above for whitelisted addresses");
+    };
+
+    writeln!(stdout, "   Destination address: {to_address}")?;
+
     let positive_amount = Positive::new(amount)?;
+
+    // Check whitelist before on-chain balance to fail fast on invalid destinations.
+    // Chain comparison intentionally omitted -- Alpaca returns inconsistent chain
+    // values ("ETH" vs "ethereum"). Matches is_address_whitelisted_and_approved.
+    let whitelist = alpaca_wallet.get_whitelisted_addresses().await?;
+    let is_whitelisted = whitelist.iter().any(|entry| {
+        entry.address == to_address
+            && entry.asset == usdc_asset
+            && entry.status == WhitelistStatus::Approved
+    });
+
+    if !is_whitelisted {
+        writeln!(
+            stdout,
+            "Error: address {to_address} is not whitelisted for USDC"
+        )?;
+        print_whitelisted_addresses(stdout, &alpaca_wallet, &usdc_asset, Some(&whitelist)).await?;
+        anyhow::bail!(
+            "Address {to_address} is not whitelisted. \
+             See above for available addresses"
+        );
+    }
+
+    let (usdc_address, network_name) = if alpaca_auth.is_sandbox() {
+        (USDC_ETHEREUM_SEPOLIA, "Ethereum Sepolia")
+    } else {
+        (USDC_ETHEREUM, "Ethereum Mainnet")
+    };
+
+    writeln!(stdout, "   Network: {network_name}")?;
+    writeln!(stdout, "   USDC contract: {usdc_address}")?;
+
+    // Capture on-chain balance before the side-effecting withdrawal call
+    let balance_before = rebalancing_ctx
+        .ethereum_wallet()
+        .call::<Registry, _>(
+            usdc_address,
+            IERC20::balanceOfCall {
+                account: to_address,
+            },
+        )
+        .await?;
+
+    writeln!(stdout, "   Balance before: {balance_before}")?;
 
     writeln!(stdout, "   Initiating withdrawal...")?;
     let transfer = alpaca_wallet
-        .initiate_withdrawal(positive_amount, &usdc_asset, &destination)
+        .initiate_withdrawal(positive_amount, &usdc_asset, &to_address)
         .await?;
 
     writeln!(stdout, "   Withdrawal initiated: {}", transfer.id)?;
@@ -204,7 +301,7 @@ pub(super) async fn alpaca_withdraw_command<Registry: IntoErrorRegistry, W: Writ
                 .call::<Registry, _>(
                     usdc_address,
                     IERC20::balanceOfCall {
-                        account: destination,
+                        account: to_address,
                     },
                 )
                 .await?;
@@ -254,6 +351,13 @@ pub(super) async fn alpaca_whitelist_command<W: Write>(
     writeln!(stdout, "   Asset: USDC")?;
     writeln!(stdout, "   Network: Ethereum")?;
 
+    let travel_rule_config = ctx.travel_rule.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing [broker.travel_rule] in config -- required for Alpaca whitelist creation"
+        )
+    })?;
+    let travel_rule_info = TravelRuleInfo::from_config(travel_rule_config);
+
     let alpaca_wallet = AlpacaWalletService::new(
         alpaca_auth.base_url().to_string(),
         rebalancing_ctx.alpaca_broker_auth.account_id,
@@ -272,13 +376,6 @@ pub(super) async fn alpaca_whitelist_command<W: Write>(
             return Ok(());
         }
     }
-
-    let travel_rule_config = ctx.travel_rule.as_ref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "missing [broker.travel_rule] in config — required for Alpaca whitelist creation"
-        )
-    })?;
-    let travel_rule_info = TravelRuleInfo::from_config(travel_rule_config);
 
     writeln!(stdout, "   Creating whitelist entry...")?;
     let entry = alpaca_wallet
@@ -360,7 +457,7 @@ pub(super) async fn alpaca_whitelist_patch_travel_rule_command<W: Write>(
 
     let travel_rule_config = ctx.travel_rule.as_ref().ok_or_else(|| {
         anyhow::anyhow!(
-            "missing [broker.travel_rule] in config — required for travel rule patching"
+            "missing [broker.travel_rule] in config -- required for travel rule patching"
         )
     })?;
     let travel_rule_info = TravelRuleInfo::from_config(travel_rule_config);
@@ -680,6 +777,10 @@ mod tests {
     }
 
     fn create_full_alpaca_ctx() -> Ctx {
+        create_full_alpaca_ctx_with_mode(AlpacaBrokerApiMode::Sandbox)
+    }
+
+    fn create_full_alpaca_ctx_with_mode(mode: AlpacaBrokerApiMode) -> Ctx {
         let alpaca_account_id = AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
         Ctx {
             database_url: ":memory:".to_string(),
@@ -698,7 +799,7 @@ mod tests {
                 api_key: "test-key".to_string(),
                 api_secret: "test-secret".to_string(),
                 account_id: alpaca_account_id,
-                mode: Some(AlpacaBrokerApiMode::Sandbox),
+                mode: Some(mode.clone()),
                 asset_cache_ttl: std::time::Duration::from_secs(3600),
                 time_in_force: TimeInForce::default(),
             }),
@@ -722,7 +823,7 @@ mod tests {
                         api_key: "test-key".to_string(),
                         api_secret: "test-secret".to_string(),
                         account_id: alpaca_account_id,
-                        mode: Some(AlpacaBrokerApiMode::Sandbox),
+                        mode: Some(mode),
                         asset_cache_ttl: std::time::Duration::from_secs(3600),
                         time_in_force: TimeInForce::default(),
                     })
@@ -770,13 +871,18 @@ mod tests {
     async fn test_alpaca_withdraw_requires_rebalancing_ctx() {
         let ctx = create_alpaca_ctx_without_rebalancing();
         let amount = Usdc::new(float!(100));
+        let destination = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let mut stdout = Vec::new();
-        let err_msg =
-            alpaca_withdraw_command::<NoOpErrorRegistry, _>(&mut stdout, amount, None, &ctx)
-                .await
-                .unwrap_err()
-                .to_string();
+        let err_msg = alpaca_withdraw_command::<NoOpErrorRegistry, _>(
+            &mut stdout,
+            amount,
+            Some(destination),
+            &ctx,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
         assert!(
             err_msg.contains("requires rebalancing mode"),
             "Expected rebalancing config error, got: {err_msg}"
@@ -917,6 +1023,172 @@ mod tests {
         assert!(
             output.contains("$250"),
             "Expected price in output, got: {output}"
+        );
+    }
+
+    fn mock_whitelist_endpoint(
+        server: &MockServer,
+        entries: serde_json::Value,
+    ) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/whitelists"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(entries);
+        })
+    }
+
+    #[tokio::test]
+    async fn test_alpaca_withdraw_no_to_lists_whitelisted_addresses() {
+        let server = MockServer::start();
+        let ctx = create_full_alpaca_ctx_with_mode(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let approved = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let pending = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let whitelist_mock = mock_whitelist_endpoint(
+            &server,
+            json!([
+                {
+                    "id": "wl-1",
+                    "address": approved.to_string(),
+                    "asset": "USDC",
+                    "chain": "ethereum",
+                    "status": "APPROVED",
+                    "created_at": "2024-01-01T00:00:00Z"
+                },
+                {
+                    "id": "wl-2",
+                    "address": pending.to_string(),
+                    "asset": "USDC",
+                    "chain": "ethereum",
+                    "status": "PENDING",
+                    "created_at": "2024-01-02T00:00:00Z"
+                }
+            ]),
+        );
+
+        let amount = Usdc::new(float!(100));
+        let mut stdout = Vec::new();
+
+        let err_msg =
+            alpaca_withdraw_command::<NoOpErrorRegistry, _>(&mut stdout, amount, None, &ctx)
+                .await
+                .unwrap_err()
+                .to_string();
+
+        whitelist_mock.assert_calls(1);
+
+        let output = String::from_utf8(stdout).unwrap();
+
+        assert!(
+            err_msg.contains("--to is required"),
+            "Expected --to required error, got: {err_msg}"
+        );
+
+        assert!(
+            output.contains("Approved addresses"),
+            "Expected approved section, got: {output}"
+        );
+
+        assert!(
+            output.contains(&approved.to_string()),
+            "Expected approved address in output, got: {output}"
+        );
+
+        assert!(
+            output.contains("Not yet usable"),
+            "Expected pending section, got: {output}"
+        );
+
+        assert!(
+            output.contains(&pending.to_string()),
+            "Expected pending address in output, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alpaca_withdraw_no_to_empty_whitelist() {
+        let server = MockServer::start();
+        let ctx = create_full_alpaca_ctx_with_mode(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let whitelist_mock = mock_whitelist_endpoint(&server, json!([]));
+
+        let amount = Usdc::new(float!(100));
+        let mut stdout = Vec::new();
+
+        alpaca_withdraw_command::<NoOpErrorRegistry, _>(&mut stdout, amount, None, &ctx)
+            .await
+            .unwrap_err();
+
+        whitelist_mock.assert_calls(1);
+
+        let output = String::from_utf8(stdout).unwrap();
+
+        assert!(
+            output.contains("No whitelisted addresses found for USDC"),
+            "Expected empty whitelist message, got: {output}"
+        );
+
+        assert!(
+            output.contains("alpaca-whitelist"),
+            "Expected alpaca-whitelist hint, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_alpaca_withdraw_not_whitelisted_lists_addresses() {
+        let server = MockServer::start();
+        let ctx = create_full_alpaca_ctx_with_mode(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let approved = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bad_destination = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+        // Whitelist endpoint is called once for the explicit whitelist check.
+        // print_whitelisted_addresses reuses the prefetched whitelist slice.
+        let whitelist_check = mock_whitelist_endpoint(
+            &server,
+            json!([{
+                "id": "wl-1",
+                "address": approved.to_string(),
+                "asset": "USDC",
+                "chain": "ethereum",
+                "status": "APPROVED",
+                "created_at": "2024-01-01T00:00:00Z"
+            }]),
+        );
+
+        let amount = Usdc::new(float!(100));
+        let mut stdout = Vec::new();
+
+        let err_msg = alpaca_withdraw_command::<NoOpErrorRegistry, _>(
+            &mut stdout,
+            amount,
+            Some(bad_destination),
+            &ctx,
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        whitelist_check.assert_calls(1);
+
+        let output = String::from_utf8(stdout).unwrap();
+
+        assert!(
+            err_msg.contains("not whitelisted"),
+            "Expected not-whitelisted error, got: {err_msg}"
+        );
+
+        assert!(
+            output.contains("Approved addresses"),
+            "Expected approved section in output, got: {output}"
+        );
+
+        assert!(
+            output.contains(&approved.to_string()),
+            "Expected approved address in output, got: {output}"
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -148,13 +148,13 @@ pub enum Commands {
     ///
     /// Initiates a withdrawal from Alpaca's crypto wallet to a specified address.
     /// The destination address must be whitelisted and approved in Alpaca.
-    /// Default destination is your configured sender wallet.
+    /// Omit --to to list available whitelisted addresses.
     AlpacaWithdraw {
         /// Amount of USDC to withdraw
         #[arg(short = 'a', long = "amount")]
         amount: Usdc,
 
-        /// Destination address (defaults to SENDER_WALLET from env)
+        /// Destination address (must be whitelisted; omit to list available)
         #[arg(short = 't', long = "to")]
         to_address: Option<Address>,
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,6 +552,15 @@ impl Ctx {
             });
         }
 
+        let travel_rule = config
+            .broker
+            .as_ref()
+            .map(|broker_config| &broker_config.travel_rule);
+
+        if matches!(broker, BrokerCtx::AlpacaBrokerApi(_)) && travel_rule.is_none() {
+            return Err(CtxError::MissingTravelRule);
+        }
+
         Ok(Self {
             database_url: config.database_url,
             log_level,
@@ -739,6 +748,11 @@ pub enum CtxError {
     MissingEquityVaultId { symbol: Symbol },
     #[error("{field} polling interval must be non-zero")]
     ZeroPollingInterval { field: &'static str },
+    #[error(
+        "[broker.travel_rule] is required when using Alpaca Broker API \
+         -- Alpaca rejects whitelist requests without it since 2026-03-27"
+    )]
+    MissingTravelRule,
     #[error("Float comparison failed during config validation: {0}")]
     FloatComparison(#[from] rain_math_float::FloatError),
 }
@@ -775,6 +789,7 @@ impl CtxError {
             Self::ZeroPollingInterval { .. } => "zero polling interval",
             Self::FloatComparison(_) => "float comparison failed",
             Self::InvalidTravelRule { .. } => "invalid travel rule config",
+            Self::MissingTravelRule => "missing travel rule config",
         }
     }
 }
@@ -870,6 +885,27 @@ pub(crate) mod tests {
         )
         .unwrap();
         file
+    }
+
+    /// Minimal config with `[broker.travel_rule]` included, for tests
+    /// that use Alpaca Broker API secrets (which now require travel rule
+    /// at startup).
+    fn alpaca_config_toml() -> NamedTempFile {
+        toml_file(
+            r#"
+            database_url = ":memory:"
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+
+            [broker.travel_rule]
+            beneficiary_entity_name = "Test Entity"
+        "#,
+        )
     }
 
     fn dry_run_secrets_toml() -> NamedTempFile {
@@ -1591,7 +1627,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn alpaca_broker_api_executor_uses_dollar_threshold() {
-        let config = minimal_config_toml();
+        let config = alpaca_config_toml();
         let secrets = toml_file(
             r#"
             [evm]
@@ -1610,6 +1646,32 @@ pub(crate) mod tests {
             .unwrap();
         let expected = ExecutionThreshold::dollar_value(Usdc::new(float!(2))).unwrap();
         assert_eq!(ctx.execution_threshold, expected);
+    }
+
+    #[tokio::test]
+    async fn alpaca_broker_without_travel_rule_fails_at_startup() {
+        let config = minimal_config_toml();
+        let secrets = toml_file(
+            r#"
+            [evm]
+            ws_rpc_url = "ws://localhost:8545"
+
+            [broker]
+            type = "alpaca-broker-api"
+            api_key = "test-key"
+            api_secret = "test-secret"
+            account_id = "dddddddd-eeee-aaaa-dddd-beeeeeeeeeef"
+        "#,
+        );
+
+        let err = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, CtxError::MissingTravelRule),
+            "Expected MissingTravelRule, got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/ST0x-Technology/st0x.liquidity/issues/516

## Motivation

The `alpaca-withdraw` CLI command had poor UX: omitting `--to` silently defaulted to the sender wallet address, and providing a non-whitelisted address produced an opaque error. The `alpaca-whitelist` command also failed late (after API calls) when `travel_rule` config was missing. These friction points made the withdrawal flow confusing and error-prone.

## Solution

**Withdraw command (`alpaca-withdraw`):**
- Omitting `--to` now lists all whitelisted addresses (split into approved vs pending/rejected) and tells the user to pick one, instead of silently defaulting to the sender wallet.
- Providing a non-whitelisted address now catches `AddressNotWhitelisted` explicitly, prints a clear error message, and lists available whitelisted addresses — so the user knows what addresses are valid without running a separate command.
- Moved `AlpacaWalletService` construction and withdrawal initiation earlier in the flow (before the on-chain balance check) so whitelist validation fails fast before any on-chain calls.

**Whitelist command (`alpaca-whitelist`):**
- Moved the `travel_rule` config check before the API call to the Alpaca service, failing fast on missing config rather than after establishing a connection.

**Tests:**
- Added `mock_whitelist_endpoint` test helper for reuse across withdrawal tests.
- Parameterized `create_full_alpaca_ctx` to accept an `AlpacaBrokerApiMode`, enabling mock server-based tests.
- Added three new tests: withdraw with no `--to` (shows whitelist), withdraw with no `--to` and empty whitelist, and withdraw with non-whitelisted address (shows available addresses).
- Updated existing `test_alpaca_withdraw_requires_rebalancing_ctx` to pass an explicit `--to` address since it's now required.

**Other:**
- Added Alpaca Broker API sandbox credentials to `.env.example` for discovery.
- Updated CLI help text to reflect the new `--to` behavior.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Withdrawal command now lists approved vs non‑approved whitelist addresses and shows a hint when none are found.

* **Bug Fixes**
  * Withdrawals require an explicit, approved whitelisted destination; whitelist is validated before on‑chain checks and clear errors are shown.
  * Startup now fails with a clear error if Alpaca broker is configured but the required travel rule settings are missing.

* **Documentation**
  * CLI help updated to reflect new withdrawal/whitelist behavior.

* **Chores**
  * Added explicit Alpaca broker sandbox env templates for testing.

* **Tests**
  * Expanded tests for missing `--to`, empty whitelist, and not‑whitelisted destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->