### PR TITLE
Preserve original USDC rebalance start time across phases

### DIFF
--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -353,8 +353,6 @@ impl DomainEvent for UsdcRebalanceEvent {
 ///
 /// Uses the typestate pattern via enum variants to make invalid states unrepresentable.
 /// Each variant contains exactly the data valid for that state.
-/// `started_at` is the immutable business-operation start time, while
-/// `initiated_at` tracks the most recent phase boundary when needed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum UsdcRebalance {
     /// USD/USDC conversion has been initiated (AlpacaToBase: USD->USDC, BaseToAlpaca: USDC->USD)
@@ -362,7 +360,6 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         order_id: Uuid,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
     },
     /// Conversion has completed, ready for next phase
@@ -372,7 +369,6 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         /// Actual USDC amount from the conversion (may differ due to slippage)
         filled_amount: Usdc,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         converted_at: DateTime<Utc>,
     },
@@ -382,7 +378,6 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         order_id: Uuid,
         reason: String,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
@@ -391,14 +386,12 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         withdrawal_ref: TransferRef,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
     },
     /// Withdrawal from source has been confirmed, ready for bridging
     WithdrawalComplete {
         direction: RebalanceDirection,
         amount: Usdc,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         confirmed_at: DateTime<Utc>,
     },
@@ -408,7 +401,6 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         withdrawal_ref: TransferRef,
         reason: String,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
@@ -418,7 +410,6 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         burned_at: DateTime<Utc>,
     },
@@ -429,7 +420,6 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: TxHash,
         cctp_nonce: u64,
         attestation: Vec<u8>,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
     },
@@ -444,7 +434,6 @@ pub(crate) enum UsdcRebalance {
         fee_collected: Usdc,
         burn_tx_hash: TxHash,
         mint_tx_hash: TxHash,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         minted_at: DateTime<Utc>,
     },
@@ -455,7 +444,6 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: Option<TxHash>,
         cctp_nonce: Option<u64>,
         reason: String,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
@@ -466,7 +454,6 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: TxHash,
         mint_tx_hash: TxHash,
         deposit_ref: TransferRef,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         deposit_initiated_at: DateTime<Utc>,
     },
@@ -476,7 +463,6 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         burn_tx_hash: TxHash,
         mint_tx_hash: TxHash,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         deposit_confirmed_at: DateTime<Utc>,
     },
@@ -488,7 +474,6 @@ pub(crate) enum UsdcRebalance {
         mint_tx_hash: TxHash,
         deposit_ref: Option<TransferRef>,
         reason: String,
-        started_at: DateTime<Utc>,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
@@ -500,21 +485,20 @@ impl UsdcRebalance {
             Self::Converting {
                 direction,
                 amount,
-                started_at,
                 initiated_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Converting,
-                *started_at,
+                *initiated_at,
                 *initiated_at,
             ),
 
             Self::ConversionComplete {
                 direction,
                 filled_amount,
-                started_at,
+                initiated_at,
                 converted_at,
                 ..
             } => {
@@ -531,7 +515,7 @@ impl UsdcRebalance {
                     direction,
                     *filled_amount,
                     status,
-                    *started_at,
+                    *initiated_at,
                     *converted_at,
                 )
             }
@@ -539,28 +523,28 @@ impl UsdcRebalance {
             Self::ConversionFailed {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 failed_at,
                 ..
             }
             | Self::WithdrawalFailed {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 failed_at,
                 ..
             }
             | Self::BridgingFailed {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 failed_at,
                 ..
             }
             | Self::DepositFailed {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 failed_at,
                 ..
             } => (
@@ -569,98 +553,97 @@ impl UsdcRebalance {
                 UsdcBridgeStatus::Failed {
                     failed_at: *failed_at,
                 },
-                *started_at,
+                *initiated_at,
                 *failed_at,
             ),
 
             Self::Withdrawing {
                 direction,
                 amount,
-                started_at,
                 initiated_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Withdrawing,
-                *started_at,
+                *initiated_at,
                 *initiated_at,
             ),
 
             Self::WithdrawalComplete {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 confirmed_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Withdrawing,
-                *started_at,
+                *initiated_at,
                 *confirmed_at,
             ),
 
             Self::Bridging {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 burned_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Bridging,
-                *started_at,
+                *initiated_at,
                 *burned_at,
             ),
 
             Self::Attested {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 attested_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Bridging,
-                *started_at,
+                *initiated_at,
                 *attested_at,
             ),
 
             Self::Bridged {
                 direction,
                 amount_received,
-                started_at,
+                initiated_at,
                 minted_at,
                 ..
             } => (
                 direction,
                 *amount_received,
                 UsdcBridgeStatus::Bridging,
-                *started_at,
+                *initiated_at,
                 *minted_at,
             ),
 
             Self::DepositInitiated {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 deposit_initiated_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Depositing,
-                *started_at,
+                *initiated_at,
                 *deposit_initiated_at,
             ),
 
             Self::DepositConfirmed {
                 direction,
                 amount,
-                started_at,
+                initiated_at,
                 deposit_confirmed_at,
                 ..
             } => {
@@ -677,7 +660,7 @@ impl UsdcRebalance {
                     direction,
                     *amount,
                     status,
-                    *started_at,
+                    *initiated_at,
                     *deposit_confirmed_at,
                 )
             }
@@ -708,7 +691,7 @@ impl EventSourced for UsdcRebalance {
 
     const AGGREGATE_TYPE: &'static str = "UsdcRebalance";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 1;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -722,7 +705,6 @@ impl EventSourced for UsdcRebalance {
                 direction: direction.clone(),
                 amount: *amount,
                 order_id: *order_id,
-                started_at: *initiated_at,
                 initiated_at: *initiated_at,
             }),
 
@@ -735,7 +717,6 @@ impl EventSourced for UsdcRebalance {
                 direction: direction.clone(),
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
-                started_at: *initiated_at,
                 initiated_at: *initiated_at,
             }),
 
@@ -756,14 +737,13 @@ impl EventSourced for UsdcRebalance {
                     direction,
                     amount,
                     order_id,
-                    initiated_at,
+                    ..
                 },
-                Self::DepositConfirmed { started_at, .. },
+                Self::DepositConfirmed { initiated_at, .. },
             ) => Self::Converting {
                 direction: direction.clone(),
                 amount: *amount,
                 order_id: *order_id,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
             },
 
@@ -776,7 +756,6 @@ impl EventSourced for UsdcRebalance {
                 Self::Converting {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -784,7 +763,6 @@ impl EventSourced for UsdcRebalance {
                 direction: direction.clone(),
                 amount: *amount,
                 filled_amount: *filled_amount,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 converted_at: *converted_at,
             },
@@ -795,7 +773,6 @@ impl EventSourced for UsdcRebalance {
                     direction,
                     amount,
                     order_id,
-                    started_at,
                     initiated_at,
                 },
             ) => Self::ConversionFailed {
@@ -803,28 +780,22 @@ impl EventSourced for UsdcRebalance {
                 amount: *amount,
                 order_id: *order_id,
                 reason: reason.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 failed_at: *failed_at,
             },
 
             (
-                Initiated {
-                    withdrawal_ref,
-                    initiated_at,
-                    ..
-                },
+                Initiated { withdrawal_ref, .. },
                 Self::ConversionComplete {
                     direction,
                     filled_amount,
-                    started_at,
+                    initiated_at,
                     ..
                 },
             ) => Self::Withdrawing {
                 direction: direction.clone(),
                 amount: *filled_amount,
                 withdrawal_ref: withdrawal_ref.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
             },
 
@@ -833,14 +804,12 @@ impl EventSourced for UsdcRebalance {
                 Self::Withdrawing {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 },
             ) => Self::WithdrawalComplete {
                 direction: direction.clone(),
                 amount: *amount,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 confirmed_at: *confirmed_at,
             },
@@ -851,7 +820,6 @@ impl EventSourced for UsdcRebalance {
                     direction,
                     amount,
                     withdrawal_ref,
-                    started_at,
                     initiated_at,
                 },
             ) => Self::WithdrawalFailed {
@@ -859,7 +827,6 @@ impl EventSourced for UsdcRebalance {
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 reason: reason.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 failed_at: *failed_at,
             },
@@ -872,7 +839,6 @@ impl EventSourced for UsdcRebalance {
                 Self::WithdrawalComplete {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -880,7 +846,6 @@ impl EventSourced for UsdcRebalance {
                 direction: direction.clone(),
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 burned_at: *burned_at,
             },
@@ -895,7 +860,6 @@ impl EventSourced for UsdcRebalance {
                     direction,
                     amount,
                     burn_tx_hash,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -905,7 +869,6 @@ impl EventSourced for UsdcRebalance {
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
                 attestation: attestation.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 attested_at: *attested_at,
             },
@@ -921,7 +884,6 @@ impl EventSourced for UsdcRebalance {
                     direction,
                     amount,
                     burn_tx_hash,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -932,7 +894,6 @@ impl EventSourced for UsdcRebalance {
                 fee_collected: *fee_collected,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 minted_at: *minted_at,
             },
@@ -947,21 +908,18 @@ impl EventSourced for UsdcRebalance {
                 Self::WithdrawalComplete {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 }
                 | Self::Bridging {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 }
                 | Self::Attested {
                     direction,
                     amount,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -971,7 +929,6 @@ impl EventSourced for UsdcRebalance {
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
                 reason: reason.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 failed_at: *failed_at,
             },
@@ -986,7 +943,6 @@ impl EventSourced for UsdcRebalance {
                     amount_received,
                     burn_tx_hash,
                     mint_tx_hash,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -996,7 +952,6 @@ impl EventSourced for UsdcRebalance {
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
                 deposit_ref: deposit_ref.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 deposit_initiated_at: *deposit_initiated_at,
             },
@@ -1011,7 +966,6 @@ impl EventSourced for UsdcRebalance {
                     amount,
                     burn_tx_hash,
                     mint_tx_hash,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -1020,7 +974,6 @@ impl EventSourced for UsdcRebalance {
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 deposit_confirmed_at: *deposit_confirmed_at,
             },
@@ -1036,7 +989,6 @@ impl EventSourced for UsdcRebalance {
                     amount,
                     burn_tx_hash,
                     mint_tx_hash,
-                    started_at,
                     initiated_at,
                     ..
                 },
@@ -1047,7 +999,6 @@ impl EventSourced for UsdcRebalance {
                 mint_tx_hash: *mint_tx_hash,
                 deposit_ref: deposit_ref.clone(),
                 reason: reason.clone(),
-                started_at: *started_at,
                 initiated_at: *initiated_at,
                 failed_at: *failed_at,
             },
@@ -3842,7 +3793,7 @@ mod tests {
     }
 
     #[test]
-    fn to_dto_preserves_original_started_at_when_post_deposit_conversion_begins() {
+    fn to_dto_preserves_original_initiated_at_when_post_deposit_conversion_begins() {
         let id = UsdcRebalanceId(Uuid::new_v4());
         let order_id = Uuid::new_v4();
         let original_initiated_at = Utc::now();
@@ -3850,7 +3801,6 @@ mod tests {
         let bridged_at = original_initiated_at + chrono::Duration::seconds(90);
         let deposit_initiated_at = original_initiated_at + chrono::Duration::seconds(120);
         let deposit_confirmed_at = original_initiated_at + chrono::Duration::seconds(150);
-        let conversion_initiated_at = original_initiated_at + chrono::Duration::seconds(180);
         let burn_tx =
             fixed_bytes!("0x000000000000000000000000000000000000000000000000000000000000000c");
         let mint_tx =
@@ -3893,7 +3843,7 @@ mod tests {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount: Usdc::new(float!(999.99)),
                 order_id,
-                initiated_at: conversion_initiated_at,
+                initiated_at: original_initiated_at + chrono::Duration::seconds(180),
             },
         ])
         .expect("event stream should replay into post-deposit conversion state");
@@ -3911,19 +3861,17 @@ mod tests {
         );
         assert_eq!(
             bridge.started_at, original_initiated_at,
-            "started_at should remain anchored to the original rebalance initiation time"
+            "initiated_at should remain anchored to the original rebalance initiation time"
         );
-        assert_eq!(bridge.updated_at, conversion_initiated_at);
+        assert_eq!(bridge.updated_at, original_initiated_at);
     }
 
     #[test]
-    fn to_dto_preserves_original_started_at_when_withdrawal_begins_after_conversion() {
+    fn to_dto_preserves_original_initiated_at_when_withdrawal_begins_after_conversion() {
         let id = UsdcRebalanceId(Uuid::new_v4());
         let order_id = Uuid::new_v4();
         let original_initiated_at = Utc::now();
         let conversion_completed_at = original_initiated_at + chrono::Duration::seconds(30);
-        let withdrawal_initiated_at = original_initiated_at + chrono::Duration::seconds(60);
-
         let state = replay::<UsdcRebalance>(vec![
             UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
@@ -3940,7 +3888,7 @@ mod tests {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(999.99)),
                 withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
-                initiated_at: withdrawal_initiated_at,
+                initiated_at: original_initiated_at + chrono::Duration::seconds(60),
             },
         ])
         .expect("event stream should replay into withdrawing state");
@@ -3954,9 +3902,9 @@ mod tests {
         assert!(matches!(bridge.status, UsdcBridgeStatus::Withdrawing));
         assert_eq!(
             bridge.started_at, original_initiated_at,
-            "started_at should remain anchored to the original rebalance initiation time"
+            "initiated_at should remain anchored to the original rebalance initiation time"
         );
-        assert_eq!(bridge.updated_at, withdrawal_initiated_at);
+        assert_eq!(bridge.updated_at, original_initiated_at);
     }
 
     #[test]
@@ -4000,7 +3948,6 @@ mod tests {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(500)),
             order_id: Uuid::new_v4(),
-            started_at: initiated_at,
             initiated_at,
         };
 
@@ -4031,7 +3978,6 @@ mod tests {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(2000)),
             burn_tx_hash: burn_tx,
-            started_at: initiated_at,
             initiated_at,
             burned_at,
         };
@@ -4065,7 +4011,6 @@ mod tests {
             amount: Usdc::new(float!(1000)),
             burn_tx_hash: burn_tx,
             mint_tx_hash: mint_tx,
-            started_at: initiated_at,
             initiated_at,
             deposit_confirmed_at: confirmed_at,
         };
@@ -4097,7 +4042,6 @@ mod tests {
             amount: Usdc::new(float!(1000)),
             burn_tx_hash: burn_tx,
             mint_tx_hash: mint_tx,
-            started_at: initiated_at,
             initiated_at,
             deposit_confirmed_at: confirmed_at,
         };
@@ -4121,7 +4065,6 @@ mod tests {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(500)),
             filled_amount: Usdc::new(float!(499)),
-            started_at: initiated_at,
             initiated_at,
             converted_at,
         };
@@ -4146,7 +4089,6 @@ mod tests {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(500)),
             filled_amount: Usdc::new(float!(499)),
-            started_at: initiated_at,
             initiated_at,
             converted_at,
         };
@@ -4181,7 +4123,6 @@ mod tests {
             mint_tx_hash: mint_tx,
             deposit_ref: None,
             reason: "deposit timeout".to_string(),
-            started_at: initiated_at,
             initiated_at,
             failed_at,
         };
@@ -4207,7 +4148,6 @@ mod tests {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(1000)),
             withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
-            started_at: initiated_at,
             initiated_at,
         };
 
@@ -4234,7 +4174,6 @@ mod tests {
         let state = UsdcRebalance::WithdrawalComplete {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(800)),
-            started_at: initiated_at,
             initiated_at,
             confirmed_at,
         };
@@ -4263,7 +4202,6 @@ mod tests {
             burn_tx_hash: burn_tx,
             cctp_nonce: 42,
             attestation: vec![0xAA, 0xBB],
-            started_at: initiated_at,
             initiated_at,
             attested_at,
         };
@@ -4299,7 +4237,6 @@ mod tests {
             fee_collected: Usdc::new(float!(2)),
             burn_tx_hash: burn_tx,
             mint_tx_hash: mint_tx,
-            started_at: initiated_at,
             initiated_at,
             minted_at,
         };
@@ -4334,7 +4271,6 @@ mod tests {
             burn_tx_hash: burn_tx,
             mint_tx_hash: mint_tx,
             deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
-            started_at: initiated_at,
             initiated_at,
             deposit_initiated_at,
         };


### PR DESCRIPTION
## Motivation

Closes #510.

The `UsdcRebalance` aggregate reused `initiated_at` for both the overall business operation and later phase transitions. When a rebalance crossed a phase boundary, the dashboard `started_at` value jumped forward to the most recent phase instead of staying anchored to the original operation start.

## Solution

- Add an immutable `started_at` field to each `UsdcRebalance` state variant and keep `initiated_at` as the phase-local timestamp.
- Preserve `started_at` across state transitions so the aggregate no longer loses the original operation start time.
- Update `to_dto()` to surface the preserved operation start time while still using the latest phase timestamp for `updated_at`.
- Bump `UsdcRebalance::SCHEMA_VERSION` to `2` so stale snapshots are cleared automatically.
- Add regressions for both previously broken paths:
  - post-deposit conversion in the `BaseToAlpaca` flow
  - post-conversion withdrawal in the `AlpacaToBase` flow

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced timestamp tracking for USDC rebalancing so initiation times are consistently preserved across conversion, withdrawal, bridging and deposit flows.
* **Tests**
  * Added unit tests that replay event streams to verify the original rebalance start time is maintained and reflected in bridge timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->