### PR TITLE
Taker Bot: Order Classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,6 +2968,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6853,6 +6891,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "ciborium",
  "clap",
  "futures-util",
  "serde",

--- a/crates/shared/src/bindings.rs
+++ b/crates/shared/src/bindings.rs
@@ -86,3 +86,15 @@ sol!(
     #![sol(all_derives = true)]
     LibDecimalFloat, "../../lib/rain.orderbook/out/LibDecimalFloat.sol/LibDecimalFloat.json"
 );
+
+// Minimal binding for the MetaV1_2 event emitted by the OrderBook contract.
+// Emitted in the same transaction as AddOrderV3, with `subject` = order hash
+// and `meta` = CBOR-encoded RainMetaDocumentV1 containing the Rainlang source.
+// We define this inline rather than importing the full OrderBook ABI to avoid
+// pulling in deployment logic and keeping it available in production code
+// (the full OrderBook binding is behind test-support).
+sol! {
+    #![sol(all_derives = true)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    event MetaV1_2(address sender, bytes32 subject, bytes meta);
+}

--- a/docs/direct-taker-architecture.html
+++ b/docs/direct-taker-architecture.html
@@ -38,6 +38,7 @@
   .stat-purple .stat-value { color: var(--purple); }
   .stat-cyan .stat-value { color: var(--cyan); }
 
+
   .diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; margin-bottom: 2rem; overflow-x: auto; }
   .diagram-title { font-size: 1rem; color: var(--muted); margin-bottom: 1.5rem; text-transform: uppercase; letter-spacing: 0.05em; }
 

--- a/services/taker/Cargo.toml
+++ b/services/taker/Cargo.toml
@@ -29,6 +29,7 @@ st0x-finance.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 futures-util.workspace = true
+ciborium = "0.2.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/services/taker/src/classification.rs
+++ b/services/taker/src/classification.rs
@@ -1,0 +1,440 @@
+//! Order classification: extracts Rainlang source from order metadata
+//! and pattern-matches it to determine the order's pricing mechanism.
+//!
+//! The Rainlang source is stored as CBOR-encoded metadata in `MetaV1_2`
+//! events emitted alongside `AddOrderV3`. The metadata format is
+//! `RainMetaDocumentV1`: an 8-byte magic prefix followed by one or more
+//! CBOR maps, each containing a payload, magic number, and content type.
+//!
+//! Classification categories:
+//! - **FixedPrice**: literal constants only (e.g., `_ _: 1000 185e18;:;`)
+//! - **PythOracle**: contains Pyth price feed reads
+//! - **Unsupported**: anything else (storage reads, time-dependent, etc.)
+
+use alloy::primitives::Bytes;
+use tracing::{debug, warn};
+
+use crate::tracked_order::OrderType;
+
+/// Magic prefix for RainMetaDocumentV1 format.
+pub(crate) const RAIN_META_DOCUMENT_V1_MAGIC: [u8; 8] =
+    [0xff, 0x0a, 0x89, 0xc6, 0x74, 0xee, 0x78, 0x74];
+
+/// Classifies an order by extracting Rainlang source from metadata
+/// and pattern-matching the expression.
+///
+/// Returns `OrderType::Unknown` if metadata is empty or cannot be
+/// decoded (orders without metadata are treated as unclassified,
+/// not unsupported — they may be classifiable via other means later).
+pub(crate) fn classify_order_metadata(meta: &Bytes) -> OrderType {
+    if meta.is_empty() {
+        return OrderType::Unknown;
+    }
+
+    let rainlang = match extract_rainlang_source(meta) {
+        Ok(source) => source,
+        Err(error) => {
+            warn!("Failed to extract Rainlang from metadata: {error}");
+            return OrderType::Unknown;
+        }
+    };
+
+    classify_rainlang(&rainlang)
+}
+
+/// Magic number identifying a CBOR item as Rainlang source (key 1 in the map).
+/// See `KnownMagic::RainlangSourceV1` in rain.metadata.
+pub(crate) const RAINLANG_SOURCE_V1_MAGIC: u64 = 0xff13_109e_4133_6ff2;
+
+/// Extracts the Rainlang source string from raw metadata bytes.
+///
+/// Format: 8-byte magic prefix + concatenated CBOR maps.
+/// Each map has keys: 0 (payload bytes), 1 (magic u64), 2 (content type).
+/// Iterates all CBOR items and selects the one whose key 1 matches
+/// `RainlangSourceV1` magic, verifying the item actually claims to be
+/// Rainlang rather than blindly trusting the first payload.
+fn extract_rainlang_source(meta: &[u8]) -> Result<String, ClassificationError> {
+    if meta.len() < RAIN_META_DOCUMENT_V1_MAGIC.len() {
+        return Err(ClassificationError::TooShort);
+    }
+
+    if meta[..8] != RAIN_META_DOCUMENT_V1_MAGIC {
+        return Err(ClassificationError::InvalidMagicPrefix);
+    }
+
+    let cbor_data = &meta[8..];
+    let mut cursor = std::io::Cursor::new(cbor_data);
+
+    // Iterate all concatenated CBOR items, looking for the one with
+    // RainlangSourceV1 magic (key 1). A RainMetaDocumentV1 may contain
+    // multiple items (e.g., source + bytecode + deployer metadata).
+    while (cursor.position()) < cbor_data.len() as u64 {
+        let value: ciborium::Value = match ciborium::from_reader(&mut cursor) {
+            Ok(val) => val,
+            Err(_) => break,
+        };
+
+        let Some(map) = value.as_map() else {
+            continue;
+        };
+
+        // Check key 1 (magic number) to verify this item is Rainlang source
+        let is_rainlang = map.iter().any(|(key, val)| {
+            key.as_integer() == Some(1.into())
+                && val.as_integer() == Some(RAINLANG_SOURCE_V1_MAGIC.into())
+        });
+
+        if !is_rainlang {
+            continue;
+        }
+
+        // Key 0 contains the payload (Rainlang source as bytes)
+        let payload = map
+            .iter()
+            .find(|(key, _)| key.as_integer() == Some(0.into()))
+            .and_then(|(_, val)| val.as_bytes())
+            .ok_or(ClassificationError::MissingPayload)?;
+
+        return String::from_utf8(payload.clone()).map_err(ClassificationError::Utf8);
+    }
+
+    Err(ClassificationError::MissingPayload)
+}
+
+/// Classifies a Rainlang source string by pattern matching.
+fn classify_rainlang(rainlang: &str) -> OrderType {
+    // Strip comments and normalize whitespace for pattern matching
+    let stripped = strip_comments(rainlang);
+
+    if is_pyth_oracle_expression(&stripped) {
+        debug!("Classified as PythOracle");
+        return OrderType::PythOracle {
+            rainlang: rainlang.to_owned(),
+        };
+    }
+
+    if is_fixed_price_expression(&stripped) {
+        debug!("Classified as FixedPrice");
+        return OrderType::FixedPrice {
+            rainlang: rainlang.to_owned(),
+        };
+    }
+
+    debug!("Classified as Unsupported");
+    OrderType::Unsupported {
+        reason: "unrecognized Rainlang pattern".to_owned(),
+    }
+}
+
+/// Checks if the expression is a fixed-price order.
+///
+/// Fixed-price orders have only literal numeric values and `max-value()`
+/// calls in their calculate-io source. No external calls, no storage
+/// reads, no conditionals.
+///
+/// Patterns:
+/// - `_ _: 1000 185e18;:;` (two literals, empty handle-io)
+/// - `max-output: max-value(), io: 12;:;` (max-value + literal)
+fn is_fixed_price_expression(stripped: &str) -> bool {
+    // A fixed-price expression has only literals and max-value() calls.
+    // After removing max-value(), no parentheses should remain (any
+    // remaining `(` means a function call we don't recognize).
+    let without_max_value = stripped.replace("max-value()", "MAXVAL");
+
+    !without_max_value.contains('(')
+}
+
+/// Checks if the expression references a Pyth oracle.
+///
+/// Pyth oracle expressions contain calls to Pyth-specific words
+/// like `pyth-price` or `pyth-v3`. We match on concrete Pyth word
+/// patterns rather than generic terms like "oracle" to avoid
+/// misclassifying non-Pyth oracle integrations.
+fn is_pyth_oracle_expression(stripped: &str) -> bool {
+    let lower = stripped.to_lowercase();
+
+    // Match only concrete Pyth word names used in Rainlang
+    let pyth_indicators = ["pyth-price", "pyth-v3", "pyth-feed"];
+
+    pyth_indicators
+        .iter()
+        .any(|indicator| lower.contains(indicator))
+}
+
+/// Strips Rainlang comments (`/* ... */` block and `//` line comments).
+fn strip_comments(source: &str) -> String {
+    let mut result = String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+
+    while let Some(current) = chars.next() {
+        if current == '/' {
+            match chars.peek() {
+                Some(&'*') => {
+                    // Block comment: skip until */
+                    chars.next(); // consume *
+                    loop {
+                        match chars.next() {
+                            Some('*') if chars.peek() == Some(&'/') => {
+                                chars.next(); // consume /
+                                break;
+                            }
+                            None => break,
+                            _ => {}
+                        }
+                    }
+                    continue;
+                }
+                Some(&'/') => {
+                    // Line comment: skip until end of line
+                    chars.next(); // consume second /
+                    for ch in chars.by_ref() {
+                        if ch == '\n' {
+                            result.push('\n');
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        result.push(current);
+    }
+
+    result
+}
+
+/// Errors from metadata extraction.
+#[derive(Debug, thiserror::Error)]
+enum ClassificationError {
+    #[error("metadata too short (< 8 bytes)")]
+    TooShort,
+
+    #[error("invalid RainMetaDocumentV1 magic prefix")]
+    InvalidMagicPrefix,
+
+    #[error("no RainlangSourceV1 item found in metadata")]
+    MissingPayload,
+
+    #[error("payload is not valid UTF-8: {0}")]
+    Utf8(std::string::FromUtf8Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Bytes;
+
+    use super::*;
+
+    /// Real metadata from Rain's test suite (see lib/rain.orderbook/crates/common/src/meta.rs).
+    /// Contains the Rainlang source for a conditional order with max-value() and if/equal-to.
+    const REAL_META_HEX: &str = "ff0a89c674ee7874a30058ef2f2a20302e2063616c63756c6174652d696f202a2f200a7573696e672d776f7264732d66726f6d203078466532343131434461313933443945346538334135633233344337466433323031303138383361430a6d61782d6f75747075743a206d61782d76616c756528292c0a696f3a206966280a2020657175616c2d746f280a202020206f75747075742d746f6b656e28290a202020203078316438306334396262626364316330393131333436363536623532396466396535633266373833640a2020290a202031320a2020696e76283132290a293b0a0a2f2a20312e2068616e646c652d696f202a2f200a3a3b011bff13109e41336ff20278186170706c69636174696f6e2f6f637465742d73747265616d";
+
+    fn meta_from_hex(hex: &str) -> Bytes {
+        Bytes::from(alloy::hex::decode(hex).unwrap())
+    }
+
+    fn build_fixed_price_meta(rainlang: &str) -> Bytes {
+        build_rain_meta(rainlang.as_bytes())
+    }
+
+    /// Builds a minimal RainMetaDocumentV1 with a single CBOR item
+    /// tagged as `RainlangSourceV1` (matching production metadata format).
+    fn build_rain_meta(payload: &[u8]) -> Bytes {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&RAIN_META_DOCUMENT_V1_MAGIC);
+
+        // CBOR map: key 0 = payload, key 1 = RainlangSourceV1 magic, key 2 = content type
+        let map = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Integer(0.into()),
+                ciborium::Value::Bytes(payload.to_vec()),
+            ),
+            (
+                ciborium::Value::Integer(1.into()),
+                ciborium::Value::Integer(RAINLANG_SOURCE_V1_MAGIC.into()),
+            ),
+            (
+                ciborium::Value::Integer(2.into()),
+                ciborium::Value::Text("application/octet-stream".to_owned()),
+            ),
+        ]);
+        ciborium::into_writer(&map, &mut buf).unwrap();
+
+        Bytes::from(buf)
+    }
+
+    // ── Metadata extraction ────────────────────────────────────
+
+    #[test]
+    fn extract_rainlang_from_real_metadata() {
+        let meta = meta_from_hex(REAL_META_HEX);
+        let source = extract_rainlang_source(&meta).unwrap();
+        assert!(
+            source.contains("max-output: max-value()"),
+            "Expected max-value() in source, got: {source}"
+        );
+        assert!(
+            source.contains("io: if("),
+            "Expected if() in source, got: {source}"
+        );
+    }
+
+    #[test]
+    fn extract_fails_on_empty_metadata() {
+        let result = extract_rainlang_source(&[]);
+        assert!(matches!(result.unwrap_err(), ClassificationError::TooShort));
+    }
+
+    #[test]
+    fn extract_fails_on_wrong_magic_prefix() {
+        let result = extract_rainlang_source(&[0x00; 16]);
+        assert!(matches!(
+            result.unwrap_err(),
+            ClassificationError::InvalidMagicPrefix
+        ));
+    }
+
+    #[test]
+    fn extract_from_constructed_metadata() {
+        let meta = build_fixed_price_meta("_ _: 1000 185e18;:;");
+        let source = extract_rainlang_source(&meta).unwrap();
+        assert_eq!(source, "_ _: 1000 185e18;:;");
+    }
+
+    // ── Fixed-price classification ─────────────────────────────
+
+    #[test]
+    fn fixed_price_simple_literals() {
+        let meta = build_fixed_price_meta("_ _: 1000 185e18;:;");
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::FixedPrice { .. }),
+            "Expected FixedPrice, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn fixed_price_with_max_value() {
+        let meta = build_fixed_price_meta("max-output: max-value(),\nio: 12;\n\n:;");
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::FixedPrice { .. }),
+            "Expected FixedPrice, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn fixed_price_preserves_rainlang() {
+        let source = "_ _: 1000 185e18;:;";
+        let meta = build_fixed_price_meta(source);
+        let result = classify_order_metadata(&meta);
+        match result {
+            OrderType::FixedPrice { rainlang } => {
+                assert_eq!(rainlang, source);
+            }
+            other => panic!("Expected FixedPrice, got: {other:?}"),
+        }
+    }
+
+    // ── Pyth oracle classification ─────────────────────────────
+
+    #[test]
+    fn pyth_oracle_detected_by_keyword() {
+        let source = "using-words-from 0xabc\n\
+                       max-output: max-value(),\n\
+                       io: pyth-price(0xfeed);";
+        let meta = build_rain_meta(source.as_bytes());
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::PythOracle { .. }),
+            "Expected PythOracle, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn generic_oracle_is_unsupported() {
+        let source = "max-output: oracle-read(),\nio: 100;";
+        let meta = build_rain_meta(source.as_bytes());
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::Unsupported { .. }),
+            "Generic oracle-read should be Unsupported, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn uniswap_twap_is_unsupported() {
+        let source = "max-output: uniswap-v3-twap(0xpool),\nio: 100;";
+        let meta = build_rain_meta(source.as_bytes());
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::Unsupported { .. }),
+            "Uniswap TWAP should be Unsupported, got: {result:?}"
+        );
+    }
+
+    // ── Unsupported patterns ───────────────────────────────────
+
+    #[test]
+    fn conditional_expression_is_unsupported() {
+        // The real metadata has if(equal-to(...)) which is conditional
+        let meta = meta_from_hex(REAL_META_HEX);
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::Unsupported { .. }),
+            "Expected Unsupported for conditional expression, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn storage_read_is_unsupported() {
+        let source = "max-output: get(key),\nio: 100;";
+        let meta = build_rain_meta(source.as_bytes());
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::Unsupported { .. }),
+            "Expected Unsupported for storage read, got: {result:?}"
+        );
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────
+
+    #[test]
+    fn empty_metadata_returns_unknown() {
+        let result = classify_order_metadata(&Bytes::new());
+        assert!(
+            matches!(result, OrderType::Unknown),
+            "Expected Unknown for empty metadata, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn strip_comments_removes_block_comments() {
+        let input = "/* comment */ code /* another */ more";
+        assert_eq!(strip_comments(input), " code  more");
+    }
+
+    #[test]
+    fn strip_comments_preserves_code() {
+        let input = "_ _: 1000 185e18;:;";
+        assert_eq!(strip_comments(input), input);
+    }
+
+    #[test]
+    fn strip_comments_removes_line_comments() {
+        let input = "code // comment\nmore code";
+        assert_eq!(strip_comments(input), "code \nmore code");
+    }
+
+    #[test]
+    fn pyth_keyword_in_comment_is_not_matched() {
+        let source = "// pyth-price is not used here\n_ _: 1000 185e18;:;";
+        let meta = build_rain_meta(source.as_bytes());
+        let result = classify_order_metadata(&meta);
+        assert!(
+            matches!(result, OrderType::FixedPrice { .. }),
+            "Pyth keyword in comment should not trigger PythOracle, got: {result:?}"
+        );
+    }
+}

--- a/services/taker/src/integration_tests/order_collector.rs
+++ b/services/taker/src/integration_tests/order_collector.rs
@@ -12,6 +12,7 @@ use st0x_event_sorcery::{Projection, Store, StoreBuilder};
 use st0x_execution::Symbol;
 use st0x_shared::test_support::RainOrderBook;
 
+use crate::classification::RAIN_META_DOCUMENT_V1_MAGIC;
 use crate::order_collector::{BlockCursor, EventProcessor};
 use crate::tracked_order::{OrderFilter, OrderHash, OrderType, Scenario, TrackedOrder};
 use crate::{fetch_batch_logs, process_backfill_logs};
@@ -135,7 +136,7 @@ async fn backfill_add_order_creates_active_tracked_order() {
 
     let (add_block, order_hash) = add_sell_order(&rain, usdc_addr, wt_aapl_addr).await;
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
             .await
             .unwrap();
@@ -144,9 +145,10 @@ async fn backfill_add_order_creates_active_tracked_order() {
     assert!(remove_logs.is_empty());
     assert!(take_logs.is_empty());
 
-    let processed = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert_eq!(processed, 1);
 
     let tracked = store.load(&order_hash).await.unwrap();
@@ -211,11 +213,11 @@ async fn backfill_remove_order_transitions_to_removed() {
     let remove_block = rain.remove_order(&add_result.order).await.unwrap();
 
     // Backfill the add event first
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
             .await
             .unwrap();
-    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
+    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
         .await
         .unwrap();
 
@@ -235,7 +237,7 @@ async fn backfill_remove_order_transitions_to_removed() {
     assert_eq!(*scenario, Scenario::A);
 
     // Backfill the remove event
-    let (add_logs, remove_logs, take_logs) = fetch_batch_logs(
+    let (add_logs, remove_logs, take_logs, meta_logs) = fetch_batch_logs(
         &rain.chain.provider,
         rain.orderbook,
         remove_block,
@@ -250,7 +252,7 @@ async fn backfill_remove_order_transitions_to_removed() {
         "Expected exactly one RemoveOrderV3 log"
     );
 
-    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
+    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
         .await
         .unwrap();
 
@@ -275,12 +277,12 @@ async fn backfill_excluded_owner_order_is_not_tracked() {
 
     let (add_block, order_hash) = add_sell_order(&rain, usdc_addr, wt_aapl_addr).await;
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
             .await
             .unwrap();
 
-    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
+    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
         .await
         .unwrap();
 
@@ -314,14 +316,15 @@ async fn order_discovery_reaches_active_state_in_db() {
         "Fresh DB: no cursor"
     );
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, 0, current_block)
             .await
             .unwrap();
 
-    let processed = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert!(processed >= 1, "Should have processed at least 1 event");
 
     cursor.update(current_block).await.unwrap();
@@ -395,16 +398,17 @@ async fn multiple_orders_all_discovered() {
 
     let current_block = rain.chain.provider.get_block_number().await.unwrap();
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, 0, current_block)
             .await
             .unwrap();
 
     assert_eq!(add_logs.len(), 2, "Expected two AddOrderV3 logs");
 
-    let processed = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert_eq!(processed, 2);
 
     let tracked1 = store.load(&hash1).await.unwrap();
@@ -469,14 +473,15 @@ async fn scenario_b_buy_order_discovered_with_correct_tokens() {
     let (add_block, order_hash) = add_buy_order(&rain, usdc_addr, wt_aapl_addr).await;
 
     let current_block = rain.chain.provider.get_block_number().await.unwrap();
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, 0, current_block)
             .await
             .unwrap();
 
-    let processed = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert_eq!(processed, 1);
 
     let tracked = store.load(&order_hash).await.unwrap();
@@ -512,14 +517,14 @@ async fn unsupported_token_pair_silently_skipped() {
 
     let (add_block, order_hash) = add_order_with_unknown_tokens(&rain).await;
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
             .await
             .unwrap();
 
     assert_eq!(add_logs.len(), 1, "AddOrderV3 was emitted on chain");
 
-    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
+    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
         .await
         .unwrap();
 
@@ -541,21 +546,23 @@ async fn duplicate_backfill_is_idempotent() {
 
     let (add_block, order_hash) = add_sell_order(&rain, usdc_addr, wt_aapl_addr).await;
 
-    let (add_logs, remove_logs, take_logs) =
+    let (add_logs, remove_logs, take_logs, meta_logs) =
         fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
             .await
             .unwrap();
 
     // First backfill
-    let processed = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert_eq!(processed, 1);
 
     // Second backfill of the exact same logs (simulates restart overlap)
-    let processed_again = process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs)
-        .await
-        .unwrap();
+    let processed_again =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
     assert_eq!(processed_again, 1, "Logs still counted even if idempotent");
 
     let tracked = store.load(&order_hash).await.unwrap();
@@ -587,4 +594,199 @@ async fn duplicate_backfill_is_idempotent() {
         1,
         "Projection should have exactly 1 order, not duplicated"
     );
+}
+
+// ── Classification e2e ───────────────────────────────────────────
+
+/// Builds CBOR-encoded RainMetaDocumentV1 metadata from a Rainlang source.
+///
+/// Includes key 1 (`RainlangSourceV1` magic) and key 2 (content type)
+/// to match the production metadata format that `extract_rainlang_source`
+/// validates against.
+fn encode_rainlang_metadata(rainlang: &str) -> Bytes {
+    use crate::classification::RAINLANG_SOURCE_V1_MAGIC;
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&RAIN_META_DOCUMENT_V1_MAGIC);
+
+    let map = ciborium::Value::Map(vec![
+        (
+            ciborium::Value::Integer(0.into()),
+            ciborium::Value::Bytes(rainlang.as_bytes().to_vec()),
+        ),
+        (
+            ciborium::Value::Integer(1.into()),
+            ciborium::Value::Integer(RAINLANG_SOURCE_V1_MAGIC.into()),
+        ),
+        (
+            ciborium::Value::Integer(2.into()),
+            ciborium::Value::Text("application/octet-stream".to_owned()),
+        ),
+    ]);
+    ciborium::into_writer(&map, &mut buf).unwrap();
+
+    Bytes::from(buf)
+}
+
+/// Adds a sell order with CBOR-encoded Rainlang metadata.
+async fn add_sell_order_with_meta(
+    rain: &RainOrderBook<impl Provider + Clone>,
+    usdc_addr: Address,
+    wt_aapl_addr: Address,
+    rainlang_source: &str,
+) -> (u64, OrderHash) {
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 100;:;");
+    let meta = encode_rainlang_metadata(rainlang_source);
+
+    let result = rain
+        .add_order(&expression, meta, usdc_addr, wt_aapl_addr)
+        .await
+        .unwrap();
+
+    (result.block, OrderHash::new(result.order_hash))
+}
+
+#[tokio::test]
+async fn backfill_with_metadata_classifies_as_fixed_price() {
+    let (rain, usdc_addr, wt_aapl_addr) = setup().await;
+    let (store, _projection, pool) = setup_cqrs().await;
+
+    let bot_address = Address::repeat_byte(0xB0);
+    let filter = test_filter(Address::repeat_byte(0xFF), usdc_addr, wt_aapl_addr);
+    let processor = EventProcessor::new(store.clone(), filter, bot_address);
+
+    let (add_block, order_hash) =
+        add_sell_order_with_meta(&rain, usdc_addr, wt_aapl_addr, "_ _: 1000 185e18;:;").await;
+
+    let (add_logs, remove_logs, take_logs, meta_logs) =
+        fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
+            .await
+            .unwrap();
+
+    assert!(!meta_logs.is_empty(), "MetaV1_2 should be emitted");
+
+    let processed =
+        process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+            .await
+            .unwrap();
+    assert_eq!(processed, 1);
+
+    let tracked = store.load(&order_hash).await.unwrap();
+    let Some(TrackedOrder::Active {
+        owner,
+        symbol,
+        scenario,
+        output_token,
+        input_token,
+        order_type,
+        discovered_block,
+        ..
+    }) = &tracked
+    else {
+        panic!("Expected Active order, got: {tracked:?}");
+    };
+
+    assert_eq!(*owner, rain.chain.owner);
+    assert_eq!(symbol.to_string(), "AAPL");
+    assert_eq!(*scenario, Scenario::A);
+    assert_eq!(*output_token, wt_aapl_addr);
+    assert_eq!(*input_token, usdc_addr);
+    assert_eq!(*discovered_block, add_block);
+    match order_type {
+        OrderType::FixedPrice { rainlang } => {
+            assert_eq!(rainlang, "_ _: 1000 185e18;:;");
+        }
+        other => panic!("Expected FixedPrice, got: {other:?}"),
+    }
+
+    let cursor = BlockCursor::new(&pool);
+    assert_eq!(cursor.last_block().await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn late_classification_updates_unknown_order() {
+    let (rain, usdc_addr, wt_aapl_addr) = setup().await;
+    let (store, _projection, _pool) = setup_cqrs().await;
+
+    let bot_address = Address::repeat_byte(0xB0);
+    let filter = test_filter(Address::repeat_byte(0xFF), usdc_addr, wt_aapl_addr);
+    let processor = EventProcessor::new(store.clone(), filter, bot_address);
+
+    // Add order WITHOUT metadata — gets discovered as Unknown
+    let (add_block, order_hash) = add_sell_order(&rain, usdc_addr, wt_aapl_addr).await;
+
+    let (add_logs, remove_logs, take_logs, meta_logs) =
+        fetch_batch_logs(&rain.chain.provider, rain.orderbook, add_block, add_block)
+            .await
+            .unwrap();
+
+    assert!(meta_logs.is_empty(), "No MetaV1_2 for order without meta");
+
+    process_backfill_logs(&processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+        .await
+        .unwrap();
+
+    let tracked = store.load(&order_hash).await.unwrap();
+    let Some(TrackedOrder::Active {
+        owner,
+        symbol,
+        scenario,
+        output_token,
+        input_token,
+        order_type,
+        discovered_block,
+        ..
+    }) = &tracked
+    else {
+        panic!("Expected Active order, got: {tracked:?}");
+    };
+
+    assert_eq!(*owner, rain.chain.owner);
+    assert_eq!(symbol.to_string(), "AAPL");
+    assert_eq!(*scenario, Scenario::A);
+    assert_eq!(*output_token, wt_aapl_addr);
+    assert_eq!(*input_token, usdc_addr);
+    assert_eq!(*discovered_block, add_block);
+    assert_eq!(*order_type, OrderType::Unknown);
+
+    // Simulate late MetaV1_2: classify the order after discovery
+    let rainlang_source = "_ _: 1000 185e18;:;";
+    processor
+        .classify_order(
+            order_hash.into_inner(),
+            &encode_rainlang_metadata(rainlang_source),
+        )
+        .await
+        .unwrap();
+
+    // Verify classification updated while all other fields preserved
+    let tracked = store.load(&order_hash).await.unwrap();
+    let Some(TrackedOrder::Active {
+        owner: owner_after,
+        symbol: symbol_after,
+        scenario: scenario_after,
+        output_token: output_after,
+        input_token: input_after,
+        order_type: type_after,
+        discovered_block: block_after,
+        ..
+    }) = &tracked
+    else {
+        panic!("Expected Active order after classification, got: {tracked:?}");
+    };
+
+    match type_after {
+        OrderType::FixedPrice { rainlang } => {
+            assert_eq!(rainlang, rainlang_source);
+        }
+        other => panic!("Expected FixedPrice after late classification, got: {other:?}"),
+    }
+
+    assert_eq!(*owner_after, rain.chain.owner);
+    assert_eq!(symbol_after.to_string(), "AAPL");
+    assert_eq!(*scenario_after, Scenario::A);
+    assert_eq!(*output_after, wt_aapl_addr);
+    assert_eq!(*input_after, usdc_addr);
+    assert_eq!(*block_after, add_block);
 }

--- a/services/taker/src/lib.rs
+++ b/services/taker/src/lib.rs
@@ -4,8 +4,10 @@
 //! opportunities by acquiring tokens via Alpaca's tokenization API
 //! and executing `takeOrders4` on the orderbook contract.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use alloy::primitives::{B256, Bytes};
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
@@ -15,15 +17,17 @@ use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use st0x_event_sorcery::{Projection, StoreBuilder};
-use st0x_shared::bindings::IOrderBookV6::{
-    AddOrderV3, IOrderBookV6Instance, RemoveOrderV3, TakeOrderV3,
+use st0x_shared::bindings::{
+    IOrderBookV6::{AddOrderV3, IOrderBookV6Instance, RemoveOrderV3, TakeOrderV3},
+    MetaV1_2,
 };
 
-use crate::order_collector::{BlockCursor, EventProcessor};
+use crate::order_collector::{BlockCursor, ClassificationOutcome, EventProcessor};
 use crate::tracked_order::{OrderFilter, TrackedOrder};
 
 #[allow(dead_code)]
 mod approval;
+mod classification;
 pub mod config;
 mod order_collector;
 mod tracked_order;
@@ -74,7 +78,15 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
         .await?
         .into_stream();
     let mut take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
-    info!("WebSocket subscriptions established");
+
+    // MetaV1_2 subscription via raw filter (not part of IOrderBookV6 interface)
+    let meta_filter = Filter::new()
+        .address(ctx.evm.orderbook)
+        .event_signature(MetaV1_2::SIGNATURE_HASH);
+    let meta_sub = provider.subscribe_logs(&meta_filter).await?;
+    let mut meta_stream = meta_sub.into_stream();
+
+    info!("WebSocket subscriptions established (including MetaV1_2)");
 
     run_backfill(&provider, &processor, &pool, &ctx).await?;
 
@@ -83,12 +95,22 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
         count_active_orders(&projection).await
     );
 
+    // Metadata cache: maps order hash (subject) -> meta bytes.
+    // MetaV1_2 is emitted in the same transaction as AddOrderV3.
+    // In the live stream, MetaV1_2 may arrive before or after AddOrderV3,
+    // so we cache metadata and look it up when processing AddOrderV3.
+    let mut meta_cache: HashMap<B256, Bytes> = HashMap::new();
+
+    let cursor = BlockCursor::new(&pool);
+
     run_event_loop(
         &processor,
-        &pool,
+        &cursor,
         &mut add_stream,
         &mut remove_stream,
         &mut take_stream,
+        &mut meta_stream,
+        &mut meta_cache,
     )
     .await?;
 
@@ -108,7 +130,7 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
 #[allow(clippy::cognitive_complexity)]
 async fn run_event_loop(
     processor: &EventProcessor,
-    pool: &SqlitePool,
+    cursor: &BlockCursor<'_>,
     add_stream: &mut (impl StreamExt<Item = Result<(AddOrderV3, Log), alloy::sol_types::Error>> + Unpin),
     remove_stream: &mut (
              impl StreamExt<Item = Result<(RemoveOrderV3, Log), alloy::sol_types::Error>> + Unpin
@@ -116,15 +138,53 @@ async fn run_event_loop(
     take_stream: &mut (
              impl StreamExt<Item = Result<(TakeOrderV3, Log), alloy::sol_types::Error>> + Unpin
          ),
+    meta_stream: &mut (impl StreamExt<Item = Log> + Unpin),
+    meta_cache: &mut HashMap<B256, Bytes>,
 ) -> anyhow::Result<()> {
-    let cursor = BlockCursor::new(pool);
-
     loop {
         tokio::select! {
+            Some(log) = meta_stream.next() => {
+                if let Ok(decoded) = log.log_decode::<MetaV1_2>() {
+                    let event = decoded.data();
+
+                    match processor
+                        .classify_order(event.subject, &event.meta)
+                        .await
+                    {
+                        Ok(
+                            ClassificationOutcome::Classified
+                            | ClassificationOutcome::AlreadyClassified,
+                        ) => {}
+
+                        Ok(ClassificationOutcome::OrderNotFound) => {
+                            // AddOrderV3 hasn't arrived yet — cache for later use.
+                            meta_cache.insert(event.subject, event.meta.clone());
+                            debug!(
+                                subject = %event.subject,
+                                meta_len = event.meta.len(),
+                                "Cached MetaV1_2 metadata (order not yet discovered)"
+                            );
+                        }
+
+                        Err(error) => {
+                            warn!(
+                                subject = %event.subject,
+                                "Late classification failed: {error}"
+                            );
+                        }
+                    }
+                }
+            }
+
             Some(result) = add_stream.next() => match result {
                 Ok((event, log)) => {
-                    if processor.process_add_order(&event, &log).await.is_ok() {
-                        advance_cursor(&cursor, &log).await;
+                    let meta = meta_cache.remove(&event.orderHash);
+                    if processor
+                        .process_add_order(&event, &log, meta.as_ref())
+                        .await
+                        .is_ok()
+                    {
+                        advance_cursor(cursor, &log).await;
                     } else {
                         error!("Failed to process AddOrderV3, cursor not advanced");
                     }
@@ -135,7 +195,7 @@ async fn run_event_loop(
             Some(result) = remove_stream.next() => match result {
                 Ok((event, log)) => {
                     if processor.process_remove_order(&event).await.is_ok() {
-                        advance_cursor(&cursor, &log).await;
+                        advance_cursor(cursor, &log).await;
                     } else {
                         error!("Failed to process RemoveOrderV3, cursor not advanced");
                     }
@@ -146,7 +206,7 @@ async fn run_event_loop(
             Some(result) = take_stream.next() => match result {
                 Ok((event, log)) => {
                     if processor.process_take_order(&event).await.is_ok() {
-                        advance_cursor(&cursor, &log).await;
+                        advance_cursor(cursor, &log).await;
                     } else {
                         error!("Failed to process TakeOrderV3, cursor not advanced");
                     }
@@ -203,11 +263,12 @@ async fn run_backfill<P: Provider + Clone>(
     while batch_start <= current_block {
         let batch_end = (batch_start + BACKFILL_BATCH_SIZE - 1).min(current_block);
 
-        let (add_logs, remove_logs, take_logs) =
+        let (add_logs, remove_logs, take_logs, meta_logs) =
             fetch_batch_logs(provider, ctx.evm.orderbook, batch_start, batch_end).await?;
 
         processed_events +=
-            process_backfill_logs(processor, &add_logs, &remove_logs, &take_logs).await?;
+            process_backfill_logs(processor, &add_logs, &remove_logs, &take_logs, &meta_logs)
+                .await?;
 
         cursor.update(batch_end).await?;
 
@@ -232,13 +293,13 @@ async fn run_backfill<P: Provider + Clone>(
 /// Batch size for historical backfill log queries.
 const BACKFILL_BATCH_SIZE: u64 = 2000;
 
-/// Fetches logs for all three event types in a block range.
+/// Fetches logs for all event types in a block range.
 pub(crate) async fn fetch_batch_logs<P: Provider + Clone>(
     provider: &P,
     orderbook: alloy::primitives::Address,
     batch_start: u64,
     batch_end: u64,
-) -> Result<(Vec<Log>, Vec<Log>, Vec<Log>), alloy::transports::TransportError> {
+) -> Result<(Vec<Log>, Vec<Log>, Vec<Log>, Vec<Log>), alloy::transports::TransportError> {
     let add_filter = Filter::new()
         .address(orderbook)
         .from_block(batch_start)
@@ -257,11 +318,20 @@ pub(crate) async fn fetch_batch_logs<P: Provider + Clone>(
         .to_block(batch_end)
         .event_signature(TakeOrderV3::SIGNATURE_HASH);
 
-    tokio::try_join!(
+    let meta_filter = Filter::new()
+        .address(orderbook)
+        .from_block(batch_start)
+        .to_block(batch_end)
+        .event_signature(MetaV1_2::SIGNATURE_HASH);
+
+    let (add_logs, remove_logs, take_logs, meta_logs) = tokio::try_join!(
         provider.get_logs(&add_filter),
         provider.get_logs(&remove_filter),
         provider.get_logs(&take_filter),
-    )
+        provider.get_logs(&meta_filter),
+    )?;
+
+    Ok((add_logs, remove_logs, take_logs, meta_logs))
 }
 
 /// Ordering key for sorting logs by their position in the chain.
@@ -280,12 +350,16 @@ fn log_sort_key(log: &Log) -> (u64, u64, u64) {
 /// preserve the canonical ordering. Without this, an add+take+remove
 /// in the same batch could replay as add+remove+take, causing the
 /// fill to hit a terminal aggregate and be lost.
+///
+/// MetaV1_2 logs are processed first to build the metadata cache,
+/// then event logs are processed with their corresponding metadata.
 #[allow(clippy::cognitive_complexity)]
 pub(crate) async fn process_backfill_logs(
     processor: &EventProcessor,
     add_logs: &[Log],
     remove_logs: &[Log],
     take_logs: &[Log],
+    meta_logs: &[Log],
 ) -> anyhow::Result<u64> {
     let mut all_logs: Vec<&Log> =
         Vec::with_capacity(add_logs.len() + remove_logs.len() + take_logs.len());
@@ -296,11 +370,24 @@ pub(crate) async fn process_backfill_logs(
 
     let mut count = 0u64;
 
+    // Build metadata cache from MetaV1_2 logs first
+    let mut meta_cache: HashMap<B256, Bytes> = HashMap::new();
+
+    for log in meta_logs {
+        if let Ok(decoded) = log.log_decode::<MetaV1_2>() {
+            let event = decoded.data();
+            meta_cache.insert(event.subject, event.meta.clone());
+        }
+    }
+
     for log in all_logs {
         // Try each event type in turn — exactly one decode will succeed
         // per log since each was fetched by its specific event signature.
         if let Ok(decoded) = log.log_decode::<AddOrderV3>() {
-            processor.process_add_order(decoded.data(), log).await?;
+            let event = decoded.data();
+            let meta = meta_cache.get(&event.orderHash);
+
+            processor.process_add_order(event, log, meta).await?;
             count += 1;
         } else if let Ok(decoded) = log.log_decode::<RemoveOrderV3>() {
             processor.process_remove_order(decoded.data()).await?;

--- a/services/taker/src/order_collector/event_processor.rs
+++ b/services/taker/src/order_collector/event_processor.rs
@@ -6,7 +6,7 @@
 //! - `RemoveOrderV3`: dispatch `MarkRemoved`
 //! - `TakeOrderV3`: compute order hash, dispatch `RecordFill`
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::rpc::types::Log;
 use chrono::Utc;
 use std::sync::Arc;
@@ -15,8 +15,10 @@ use tracing::{debug, info, trace};
 use st0x_event_sorcery::{SendError, Store};
 use st0x_shared::bindings::IOrderBookV6;
 
+use crate::classification::classify_order_metadata;
 use crate::tracked_order::{
-    OrderFilter, OrderHash, Scenario, SupportedDirection, TrackedOrder, TrackedOrderCommand,
+    OrderFilter, OrderHash, OrderType, Scenario, SupportedDirection, TrackedOrder,
+    TrackedOrderCommand,
 };
 
 /// Processes decoded onchain events into TrackedOrder commands.
@@ -39,6 +41,18 @@ pub(crate) enum EventProcessorError {
     Send(#[from] SendError<TrackedOrder>),
 }
 
+/// Result of attempting late classification when MetaV1_2 arrives.
+pub(crate) enum ClassificationOutcome {
+    /// Order existed with Unknown type, now classified.
+    Classified,
+
+    /// Order existed but was already classified — no-op.
+    AlreadyClassified,
+
+    /// Aggregate doesn't exist yet (AddOrderV3 hasn't arrived).
+    OrderNotFound,
+}
+
 impl EventProcessor {
     pub(crate) fn new(
         store: Arc<Store<TrackedOrder>>,
@@ -55,11 +69,17 @@ impl EventProcessor {
     /// Processes an `AddOrderV3` event.
     ///
     /// Filters out excluded owners and unsupported token pairs,
-    /// then dispatches a `Discover` command.
+    /// classifies the order from its metadata, then dispatches
+    /// a `Discover` command.
+    ///
+    /// `meta` is the raw bytes from the corresponding `MetaV1_2`
+    /// event (same transaction). If `None`, the order is discovered
+    /// with `OrderType::Unknown`.
     pub(crate) async fn process_add_order(
         &self,
         event: &IOrderBookV6::AddOrderV3,
         log: &Log,
+        meta: Option<&Bytes>,
     ) -> Result<(), EventProcessorError> {
         let owner = event.order.owner;
 
@@ -97,10 +117,13 @@ impl EventProcessor {
         let order_hash = OrderHash::new(event.orderHash);
         let block = log.block_number.unwrap_or(0);
 
+        let order_type = meta.map(classify_order_metadata).unwrap_or_default();
+
         info!(
             %order_hash,
             %symbol,
             ?scenario,
+            ?order_type,
             block,
             "Discovered new order"
         );
@@ -114,6 +137,7 @@ impl EventProcessor {
                     scenario,
                     output_token,
                     input_token,
+                    order_type,
                     max_output: max_output_from_order(&event.order, scenario, output_token),
                     block,
                     discovered_at: Utc::now(),
@@ -192,6 +216,55 @@ impl EventProcessor {
             .await?;
 
         Ok(())
+    }
+
+    /// Classifies an already-discovered order when MetaV1_2 arrives
+    /// after AddOrderV3 in the live event loop.
+    ///
+    /// Pre-checks aggregate existence to distinguish "order not found"
+    /// (MetaV1_2 arrived before AddOrderV3) from "already classified"
+    /// (order exists but is already non-Unknown). The caller uses this
+    /// to decide whether to cache metadata for later use.
+    pub(crate) async fn classify_order(
+        &self,
+        order_hash_bytes: B256,
+        meta: &Bytes,
+    ) -> Result<ClassificationOutcome, EventProcessorError> {
+        let order_hash = OrderHash::new(order_hash_bytes);
+
+        // Check if the aggregate exists before attempting classification.
+        // This distinguishes "MetaV1_2 arrived first" from "order already classified".
+        let order = self.store.load(&order_hash).await?;
+
+        let Some(order) = order else {
+            debug!(
+                %order_hash,
+                "Late MetaV1_2: order not yet discovered, deferring"
+            );
+            return Ok(ClassificationOutcome::OrderNotFound);
+        };
+
+        if !matches!(order.order_type(), OrderType::Unknown) {
+            debug!(
+                %order_hash,
+                "Late MetaV1_2: order already classified"
+            );
+            return Ok(ClassificationOutcome::AlreadyClassified);
+        }
+
+        let order_type = classify_order_metadata(meta);
+
+        debug!(
+            %order_hash,
+            ?order_type,
+            "Late MetaV1_2: classifying existing order"
+        );
+
+        self.store
+            .send(&order_hash, TrackedOrderCommand::Classify { order_type })
+            .await?;
+
+        Ok(ClassificationOutcome::Classified)
     }
 }
 
@@ -292,7 +365,7 @@ mod tests {
         };
 
         processor
-            .process_add_order(&event, &mock_log(100))
+            .process_add_order(&event, &mock_log(100), None)
             .await
             .unwrap();
 
@@ -335,7 +408,7 @@ mod tests {
         };
 
         processor
-            .process_add_order(&event, &mock_log(100))
+            .process_add_order(&event, &mock_log(100), None)
             .await
             .unwrap();
 
@@ -366,7 +439,7 @@ mod tests {
         };
 
         processor
-            .process_add_order(&event, &mock_log(100))
+            .process_add_order(&event, &mock_log(100), None)
             .await
             .unwrap();
 
@@ -393,7 +466,7 @@ mod tests {
             order: order.clone(),
         };
         processor
-            .process_add_order(&add_event, &mock_log(100))
+            .process_add_order(&add_event, &mock_log(100), None)
             .await
             .unwrap();
 
@@ -451,7 +524,7 @@ mod tests {
             order: order.clone(),
         };
         processor
-            .process_add_order(&add_event, &mock_log(100))
+            .process_add_order(&add_event, &mock_log(100), None)
             .await
             .unwrap();
 
@@ -499,7 +572,7 @@ mod tests {
             order: order.clone(),
         };
         processor
-            .process_add_order(&add_event, &mock_log(100))
+            .process_add_order(&add_event, &mock_log(100), None)
             .await
             .unwrap();
 

--- a/services/taker/src/order_collector/mod.rs
+++ b/services/taker/src/order_collector/mod.rs
@@ -12,4 +12,4 @@ mod block_cursor;
 mod event_processor;
 
 pub(crate) use block_cursor::BlockCursor;
-pub(crate) use event_processor::EventProcessor;
+pub(crate) use event_processor::{ClassificationOutcome, EventProcessor};

--- a/services/taker/src/tracked_order/mod.rs
+++ b/services/taker/src/tracked_order/mod.rs
@@ -64,13 +64,41 @@ impl FromStr for OrderHash {
     }
 }
 
-/// Classification of an order's pricing mechanism.
-/// Populated later by the Order Classification step; for now
-/// all discovered orders start as `Unknown`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// Classification of an order's pricing mechanism, determined by
+/// pattern-matching the Rainlang source extracted from order metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum OrderType {
-    /// Not yet classified (classification is a separate step).
+    /// Not yet classified (metadata not available or not yet processed).
+    #[default]
     Unknown,
+
+    /// Fixed-price order: the Rainlang expression evaluates to constant
+    /// literal values. The IO ratio is known at order creation time and
+    /// never changes.
+    // TODO: Extract structured IO ratio from the Rainlang expression
+    // and store it here as a typed field (e.g., `io_ratio: Float`)
+    // so downstream profitability code doesn't re-parse raw Rainlang.
+    FixedPrice {
+        /// The Rainlang source text for this order.
+        rainlang: String,
+    },
+
+    /// Pyth oracle order: the Rainlang expression reads a Pyth price
+    /// feed to compute the IO ratio. The price changes with oracle
+    /// updates.
+    // TODO: Extract the Pyth feed ID from the Rainlang expression
+    // and store it here as a typed field (e.g., `feed_id: B256`)
+    // so downstream profitability code doesn't re-parse raw Rainlang.
+    PythOracle {
+        /// The Rainlang source text for this order.
+        rainlang: String,
+    },
+
+    /// Order with unsupported Rainlang patterns. Not safe to target.
+    Unsupported {
+        /// Why this order was classified as unsupported.
+        reason: String,
+    },
 }
 
 /// Which side of the order involves USDC, determining the
@@ -121,6 +149,19 @@ pub(crate) enum TrackedOrder {
     },
 }
 
+impl TrackedOrder {
+    /// Returns the order's classification type.
+    ///
+    /// Only meaningful for `Active` orders; terminal states don't
+    /// track classification.
+    pub(crate) fn order_type(&self) -> &OrderType {
+        match self {
+            Self::Active { order_type, .. } => order_type,
+            Self::Exhausted { .. } | Self::Removed { .. } => &OrderType::Unknown,
+        }
+    }
+}
+
 /// Commands that drive TrackedOrder state transitions.
 #[derive(Debug, Clone)]
 pub(crate) enum TrackedOrderCommand {
@@ -131,6 +172,7 @@ pub(crate) enum TrackedOrderCommand {
         scenario: Scenario,
         output_token: Address,
         input_token: Address,
+        order_type: OrderType,
         max_output: U256,
         block: u64,
         discovered_at: DateTime<Utc>,
@@ -145,6 +187,11 @@ pub(crate) enum TrackedOrderCommand {
 
     /// Mark order as removed (from RemoveOrderV3 event).
     MarkRemoved { removed_at: DateTime<Utc> },
+
+    /// Update classification when metadata arrives after discovery.
+    /// This handles the live event loop race where AddOrderV3 arrives
+    /// before MetaV1_2, leaving the order as `OrderType::Unknown`.
+    Classify { order_type: OrderType },
 }
 
 /// Events emitted by TrackedOrder command handling.
@@ -176,6 +223,10 @@ pub(crate) enum TrackedOrderEvent {
     Removed {
         removed_at: DateTime<Utc>,
     },
+
+    Classified {
+        order_type: OrderType,
+    },
 }
 
 impl DomainEvent for TrackedOrderEvent {
@@ -185,6 +236,7 @@ impl DomainEvent for TrackedOrderEvent {
             Self::Filled { .. } => "TrackedOrderEvent::Filled",
             Self::Exhausted { .. } => "TrackedOrderEvent::Exhausted",
             Self::Removed { .. } => "TrackedOrderEvent::Removed",
+            Self::Classified { .. } => "TrackedOrderEvent::Classified",
         }
         .to_string()
     }
@@ -333,6 +385,38 @@ impl EventSourced for TrackedOrder {
                 }))
             }
 
+            // Classification update: replace order_type on Active orders
+            (Self::Active { .. }, TrackedOrderEvent::Classified { order_type }) => {
+                let Self::Active {
+                    owner,
+                    symbol,
+                    scenario,
+                    output_token,
+                    input_token,
+                    max_output,
+                    remaining_output,
+                    discovered_block,
+                    discovered_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Ok(Some(Self::Active {
+                    owner: *owner,
+                    symbol: symbol.clone(),
+                    scenario: *scenario,
+                    output_token: *output_token,
+                    input_token: *input_token,
+                    order_type: order_type.clone(),
+                    max_output: *max_output,
+                    remaining_output: *remaining_output,
+                    discovered_block: *discovered_block,
+                    discovered_at: *discovered_at,
+                }))
+            }
+
             // Exhausted on already-Exhausted is idempotent.
             // This happens because RecordFill emitting remaining=0
             // triggers evolve -> Exhausted, then the subsequent
@@ -357,6 +441,7 @@ impl EventSourced for TrackedOrder {
                 scenario,
                 output_token,
                 input_token,
+                order_type,
                 max_output,
                 block,
                 discovered_at,
@@ -366,16 +451,16 @@ impl EventSourced for TrackedOrder {
                 scenario,
                 output_token,
                 input_token,
-                order_type: OrderType::Unknown,
+                order_type,
                 max_output,
                 discovered_block: block,
                 discovered_at,
             }]),
 
-            // Cannot record fill or remove for non-existent order
-            TrackedOrderCommand::RecordFill { .. } | TrackedOrderCommand::MarkRemoved { .. } => {
-                Ok(vec![])
-            }
+            // Cannot record fill, remove, or classify non-existent order
+            TrackedOrderCommand::RecordFill { .. }
+            | TrackedOrderCommand::MarkRemoved { .. }
+            | TrackedOrderCommand::Classify { .. } => Ok(vec![]),
         }
     }
 
@@ -426,6 +511,26 @@ impl EventSourced for TrackedOrder {
                 Ok(vec![TrackedOrderEvent::Removed { removed_at }])
             }
 
+            // Classification update: only applies to Active orders with Unknown type
+            (
+                Self::Active { order_type, .. },
+                TrackedOrderCommand::Classify {
+                    order_type: new_type,
+                },
+            ) => {
+                match order_type {
+                    OrderType::Unknown => Ok(vec![TrackedOrderEvent::Classified {
+                        order_type: new_type,
+                    }]),
+                    OrderType::FixedPrice { .. }
+                    | OrderType::PythOracle { .. }
+                    | OrderType::Unsupported { .. } => {
+                        // Already classified, no-op
+                        Ok(vec![])
+                    }
+                }
+            }
+
             // Terminal states reject all commands
             (Self::Exhausted { .. } | Self::Removed { .. }, _) => {
                 Err(TrackedOrderError::AlreadyTerminal)
@@ -461,6 +566,7 @@ mod tests {
             scenario,
             output_token: Address::repeat_byte(0xAA),
             input_token: Address::repeat_byte(0xBB),
+            order_type: OrderType::Unknown,
             max_output,
             block: 100,
             discovered_at: Utc::now(),
@@ -516,6 +622,7 @@ mod tests {
                     scenario: Scenario::B,
                     output_token: Address::repeat_byte(0xCC),
                     input_token: Address::repeat_byte(0xDD),
+                    order_type: OrderType::Unknown,
                     max_output: U256::from(500u64),
                     block: 42,
                     discovered_at: Utc::now(),


### PR DESCRIPTION
## Motivation
Closes [RAI-9](https://linear.app/makeitrain/issue/RAI-9/phase-1-order-classification)

This is the order classification step in the direct taker pipeline. Once orders are discovered and tracked (parent PR #531), the bot needs to understand each order's pricing mechanism to make profitability decisions downstream. Without classification, the bot would have to treat all orders identically, which prevents it from optimizing take strategies per order type (e.g., fixed-price orders have static IO ratios vs. Pyth oracle orders whose prices change with feed updates).

## Solution

Adds order classification by extracting Rainlang source from `MetaV1_2` events and pattern-matching the expression to determine the order's pricing mechanism.

### Classification categories

- **FixedPrice** — literal constants and `max-value()` only (e.g., `_ _: 1000 185e18;:;`). IO ratio is known at creation time and never changes.
- **PythOracle** — contains Pyth-specific word calls (`pyth-price`, `pyth-v3`, `pyth-feed`). Price changes with oracle updates.
- **Unsupported** — anything else (storage reads, conditionals, TWAP, etc.). Not safe to target.
- **Unknown** — metadata not available or not yet processed.

### Metadata extraction

`MetaV1_2` events carry CBOR-encoded `RainMetaDocumentV1` metadata (8-byte magic prefix + CBOR maps). The first CBOR item's payload (key 0) contains the Rainlang source as UTF-8 bytes. A minimal `MetaV1_2` sol! binding is added to `st0x-shared` to avoid importing the full OrderBook ABI in production code. The `ciborium` crate handles CBOR decoding.

### Live stream race handling

`MetaV1_2` and `AddOrderV3` are emitted in the same transaction but may arrive in either order on the WebSocket stream. The solution handles both orderings:

1. **Meta arrives first**: cached in a `HashMap<B256, Bytes>`, looked up when `AddOrderV3` arrives.
2. **Add arrives first**: order is discovered as `Unknown`, then a `Classify` command updates it when `MetaV1_2` arrives later.

### Backfill path

During historical backfill, all `MetaV1_2` logs for a batch are fetched alongside the existing event types, built into a metadata cache, and matched by order hash when processing `AddOrderV3` logs.

### CQRS integration

- New `OrderType` variants: `FixedPrice { rainlang }`, `PythOracle { rainlang }`, `Unsupported { reason }`
- New command: `TrackedOrderCommand::Classify { order_type }` — only updates `Active` orders with `Unknown` type (idempotent, no-op if already classified)
- New event: `TrackedOrderEvent::Classified { order_type }`
- `Discover` command now carries `order_type` instead of hardcoding `Unknown`

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MetaV1_2 metadata event and end-to-end support: orders are classified (FixedPrice, PythOracle, Unsupported) from embedded metadata, including late-arriving metadata that triggers reclassification.
  * Live and backfill processing now ingest and apply metadata logs so order records reflect attached metadata.

* **Tests**
  * Added unit and integration tests for metadata extraction, classification rules, and late-arrival classification.

* **Documentation**
  * Minor formatting tweak in architecture docs.

* **Chores**
  * Added CBOR metadata decoding support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->