### PR TITLE
Taker Bot: profitability strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,10 +6890,12 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
+ "bon",
  "chrono",
  "ciborium",
  "clap",
  "futures-util",
+ "rain-math-float",
  "serde",
  "serde_json",
  "sqlx",
@@ -6902,6 +6904,7 @@ dependencies = [
  "st0x-execution",
  "st0x-finance",
  "st0x-shared",
+ "st0x-taker",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6909,6 +6912,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.23",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/execution/src/alpaca_market_data/client.rs
+++ b/crates/execution/src/alpaca_market_data/client.rs
@@ -1,0 +1,263 @@
+//! HTTP client for the Alpaca Market Data API.
+
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use chrono::{DateTime, Utc};
+use rain_math_float::Float;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::Symbol;
+
+use super::{MarketDataProvider, MarketQuote};
+
+/// Configuration for the Alpaca Market Data API client.
+#[derive(Clone)]
+pub struct AlpacaMarketDataCtx {
+    api_key: String,
+    api_secret: String,
+    base_url: String,
+}
+
+impl AlpacaMarketDataCtx {
+    /// Creates a context with an explicit base URL.
+    #[must_use]
+    pub fn new(api_key: String, api_secret: String, base_url: String) -> Self {
+        Self {
+            api_key,
+            api_secret,
+            base_url,
+        }
+    }
+
+    /// Creates a context for the Alpaca sandbox environment.
+    #[must_use]
+    pub fn sandbox(api_key: String, api_secret: String) -> Self {
+        Self::new(
+            api_key,
+            api_secret,
+            "https://data.sandbox.alpaca.markets".to_owned(),
+        )
+    }
+
+    /// Creates a context for the Alpaca production environment.
+    #[must_use]
+    pub fn production(api_key: String, api_secret: String) -> Self {
+        Self::new(
+            api_key,
+            api_secret,
+            "https://data.alpaca.markets".to_owned(),
+        )
+    }
+}
+
+impl std::fmt::Debug for AlpacaMarketDataCtx {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AlpacaMarketDataCtx")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Alpaca Market Data API HTTP client.
+pub struct AlpacaMarketData {
+    http_client: reqwest::Client,
+    base_url: String,
+}
+
+impl std::fmt::Debug for AlpacaMarketData {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AlpacaMarketData")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AlpacaMarketData {
+    /// Creates a new market data client from the given configuration.
+    pub fn new(ctx: &AlpacaMarketDataCtx) -> Result<Self, AlpacaMarketDataError> {
+        let credentials = format!("{}:{}", ctx.api_key, ctx.api_secret);
+        let encoded = BASE64_STANDARD.encode(credentials.as_bytes());
+        let auth_value = format!("Basic {encoded}");
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&auth_value)?);
+
+        let http_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .map_err(AlpacaMarketDataError::Http)?;
+
+        Ok(Self {
+            http_client,
+            base_url: ctx.base_url.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl MarketDataProvider for AlpacaMarketData {
+    type Error = AlpacaMarketDataError;
+
+    async fn get_latest_quote(&self, symbol: &Symbol) -> Result<MarketQuote, Self::Error> {
+        let url = format!("{}/v2/stocks/{symbol}/quotes/latest", self.base_url);
+        debug!(%symbol, %url, "Fetching latest quote");
+
+        let response = self
+            .http_client
+            .get(&url)
+            .send()
+            .await
+            .map_err(AlpacaMarketDataError::Http)?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .inspect_err(|error| {
+                    tracing::warn!("Failed to read error response body: {error}");
+                })
+                .unwrap_or_default();
+            return Err(AlpacaMarketDataError::ApiError {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let api_response: LatestQuoteResponse =
+            response.json().await.map_err(AlpacaMarketDataError::Http)?;
+
+        // Parse directly from the JSON number's string representation
+        // to avoid f64 precision loss on financial data.
+        let bid_price = Float::parse(api_response.quote.bid_price.to_string())
+            .map_err(AlpacaMarketDataError::Float)?;
+        let ask_price = Float::parse(api_response.quote.ask_price.to_string())
+            .map_err(AlpacaMarketDataError::Float)?;
+
+        Ok(MarketQuote {
+            symbol: symbol.clone(),
+            bid_price,
+            ask_price,
+            timestamp: api_response.quote.timestamp,
+        })
+    }
+}
+
+/// Errors from the Alpaca Market Data API.
+#[derive(Debug, thiserror::Error)]
+pub enum AlpacaMarketDataError {
+    #[error("HTTP error: {0}")]
+    Http(reqwest::Error),
+
+    #[error("authentication error: {0}")]
+    Auth(#[from] reqwest::header::InvalidHeaderValue),
+
+    #[error("API error (status {status}): {body}")]
+    ApiError { status: u16, body: String },
+
+    #[error("float conversion error: {0}")]
+    Float(rain_math_float::FloatError),
+}
+
+/// Alpaca API response for `/v2/stocks/{symbol}/quotes/latest`.
+#[derive(Debug, Deserialize)]
+struct LatestQuoteResponse {
+    quote: QuoteData,
+}
+
+/// Individual quote data from the Alpaca API.
+///
+/// Prices are deserialized via `serde_json::Number` to avoid `f64`
+/// precision loss — financial data must not silently truncate.
+#[derive(Debug, Deserialize)]
+struct QuoteData {
+    /// Bid price
+    #[serde(rename = "bp")]
+    bid_price: serde_json::Number,
+
+    /// Ask price
+    #[serde(rename = "ap")]
+    ask_price: serde_json::Number,
+
+    /// Timestamp
+    #[serde(rename = "t")]
+    timestamp: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::prelude::*;
+
+    use super::*;
+
+    fn test_ctx(server: &MockServer) -> AlpacaMarketDataCtx {
+        AlpacaMarketDataCtx::new(
+            "test_key".to_owned(),
+            "test_secret".to_owned(),
+            server.base_url(),
+        )
+    }
+
+    #[tokio::test]
+    async fn fetches_latest_quote() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v2/stocks/AAPL/quotes/latest")
+                .header("Authorization", "Basic dGVzdF9rZXk6dGVzdF9zZWNyZXQ=");
+            then.status(200).json_body_obj(&serde_json::json!({
+                "quote": {
+                    "bp": 189.50,
+                    "ap": 190.10,
+                    "bs": 100,
+                    "as": 200,
+                    "t": "2026-03-27T12:00:00Z"
+                }
+            }));
+        });
+
+        let ctx = test_ctx(&server);
+        let client = AlpacaMarketData::new(&ctx).unwrap();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let quote = client.get_latest_quote(&symbol).await.unwrap();
+
+        assert_eq!(quote.symbol, symbol);
+
+        let mid = quote.mid_price().unwrap();
+        let mid_formatted = mid.format().unwrap();
+        // Mid-price of 189.50 and 190.10 = 189.80
+        assert!(
+            mid_formatted.starts_with("189.8"),
+            "Expected mid ~189.80, got {mid_formatted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handles_api_error() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/INVALID/quotes/latest");
+            then.status(404).body(r#"{"message": "symbol not found"}"#);
+        });
+
+        let ctx = test_ctx(&server);
+        let client = AlpacaMarketData::new(&ctx).unwrap();
+        let symbol = Symbol::new("INVALID").unwrap();
+
+        let result = client.get_latest_quote(&symbol).await;
+        let error = result.unwrap_err();
+        assert!(
+            matches!(error, AlpacaMarketDataError::ApiError { status: 404, .. }),
+            "Expected 404 ApiError, got: {error:?}"
+        );
+    }
+}

--- a/crates/execution/src/alpaca_market_data/mock.rs
+++ b/crates/execution/src/alpaca_market_data/mock.rs
@@ -1,0 +1,110 @@
+//! Mock market data provider for testing.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rain_math_float::Float;
+
+use crate::Symbol;
+
+use super::{AlpacaMarketDataError, MarketDataProvider, MarketQuote};
+
+fn lock(
+    quotes: &Mutex<HashMap<Symbol, (Float, Float)>>,
+) -> MutexGuard<'_, HashMap<Symbol, (Float, Float)>> {
+    quotes.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// In-memory mock market data provider.
+///
+/// Stores quotes per symbol, returns them when queried.
+/// Thread-safe for use in async test environments.
+pub struct AlpacaMarketDataMock {
+    quotes: Arc<Mutex<HashMap<Symbol, (Float, Float)>>>,
+}
+
+impl AlpacaMarketDataMock {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            quotes: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Sets the bid/ask quote for a symbol.
+    pub fn set_quote(&self, symbol: Symbol, bid: Float, ask: Float) {
+        lock(&self.quotes).insert(symbol, (bid, ask));
+    }
+}
+
+impl Default for AlpacaMarketDataMock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MarketDataProvider for AlpacaMarketDataMock {
+    type Error = AlpacaMarketDataError;
+
+    async fn get_latest_quote(&self, symbol: &Symbol) -> Result<MarketQuote, Self::Error> {
+        let (bid, ask) = {
+            let quotes = lock(&self.quotes);
+            *quotes
+                .get(symbol)
+                .ok_or_else(|| AlpacaMarketDataError::ApiError {
+                    status: 404,
+                    body: format!("no quote configured for {symbol}"),
+                })?
+        };
+
+        Ok(MarketQuote {
+            symbol: symbol.clone(),
+            bid_price: bid,
+            ask_price: ask,
+            timestamp: Utc::now(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+    use rain_math_float::Float;
+
+    use super::*;
+
+    fn float_val(value: u32) -> Float {
+        Float::from_fixed_decimal_lossy(U256::from(value), 0)
+            .unwrap()
+            .0
+    }
+
+    #[tokio::test]
+    async fn returns_configured_quote() {
+        let mock = AlpacaMarketDataMock::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+        mock.set_quote(symbol.clone(), float_val(189), float_val(191));
+
+        let quote = mock.get_latest_quote(&symbol).await.unwrap();
+
+        assert_eq!(quote.symbol, symbol);
+        let mid = quote.mid_price().unwrap();
+        let formatted = mid.format().unwrap();
+        assert_eq!(formatted, "190");
+    }
+
+    #[tokio::test]
+    async fn returns_error_for_unknown_symbol() {
+        let mock = AlpacaMarketDataMock::new();
+        let symbol = Symbol::new("UNKNOWN").unwrap();
+
+        let result = mock.get_latest_quote(&symbol).await;
+        assert!(matches!(
+            result.unwrap_err(),
+            AlpacaMarketDataError::ApiError { status: 404, .. }
+        ),);
+    }
+}

--- a/crates/execution/src/alpaca_market_data/mod.rs
+++ b/crates/execution/src/alpaca_market_data/mod.rs
@@ -1,0 +1,49 @@
+//! Alpaca Market Data API client for real-time stock quotes.
+//!
+//! Provides current bid/ask prices for equities via Alpaca's Market Data
+//! API (`data.alpaca.markets`). Uses the same API credentials as the
+//! Broker API but with a different base URL.
+
+mod client;
+#[cfg(any(test, feature = "mock"))]
+mod mock;
+
+pub use client::{AlpacaMarketData, AlpacaMarketDataCtx, AlpacaMarketDataError};
+#[cfg(any(test, feature = "mock"))]
+pub use mock::AlpacaMarketDataMock;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use rain_math_float::Float;
+
+use crate::Symbol;
+
+/// A real-time stock quote with bid and ask prices.
+#[derive(Debug, Clone)]
+pub struct MarketQuote {
+    pub symbol: Symbol,
+    pub bid_price: Float,
+    pub ask_price: Float,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl MarketQuote {
+    /// Computes the mid-price as `(bid + ask) / 2`.
+    pub fn mid_price(&self) -> Result<Float, rain_math_float::FloatError> {
+        let sum = (self.bid_price + self.ask_price)?;
+        let two = Float::from_fixed_decimal_lossy(alloy::primitives::U256::from(2), 0)?.0;
+        sum / two
+    }
+}
+
+/// Trait for fetching real-time market quotes.
+///
+/// Implemented by [`AlpacaMarketData`] for production and
+/// [`AlpacaMarketDataMock`] for testing.
+#[async_trait]
+pub trait MarketDataProvider: Send + Sync {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Fetches the latest quote for a symbol.
+    async fn get_latest_quote(&self, symbol: &Symbol) -> Result<MarketQuote, Self::Error>;
+}

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) use st0x_float_serde::{
 pub use st0x_float_macro::float;
 
 pub mod alpaca_broker_api;
+pub mod alpaca_market_data;
 pub mod alpaca_trading_api;
 pub mod error;
 pub mod mock;
@@ -27,6 +28,11 @@ pub mod test_utils;
 pub use alpaca_broker_api::{
     AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
     AlpacaBrokerApiMode, ConversionDirection, JournalResponse, JournalStatus, TimeInForce,
+};
+#[cfg(any(test, feature = "mock"))]
+pub use alpaca_market_data::AlpacaMarketDataMock;
+pub use alpaca_market_data::{
+    AlpacaMarketData, AlpacaMarketDataCtx, AlpacaMarketDataError, MarketDataProvider, MarketQuote,
 };
 pub use alpaca_trading_api::{
     AlpacaTradingApi, AlpacaTradingApiCtx, AlpacaTradingApiError, AlpacaTradingApiMode,

--- a/services/taker/Cargo.toml
+++ b/services/taker/Cargo.toml
@@ -5,10 +5,12 @@ edition.workspace = true
 
 [features]
 default = []
-test-support = ["st0x-shared/test-support"]
+test-support = ["st0x-shared/test-support", "dep:bon", "dep:uuid"]
 
 [dependencies]
 alloy.workspace = true
+bon = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 async-trait.workspace = true
 clap.workspace = true
 serde.workspace = true
@@ -20,6 +22,7 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url.workspace = true
 
+rain-math-float.workspace = true
 st0x-evm = { workspace = true }
 st0x-execution.workspace = true
 st0x-shared = { workspace = true }
@@ -32,9 +35,15 @@ futures-util.workspace = true
 ciborium = "0.2.2"
 
 [dev-dependencies]
+anyhow.workspace = true
+bon.workspace = true
+ciborium = "0.2.2"
 tempfile.workspace = true
+uuid.workspace = true
+st0x-execution = { workspace = true, features = ["mock"] }
 st0x-shared = { workspace = true, features = ["test-support"] }
 st0x-event-sorcery = { workspace = true, features = ["test-support"] }
+st0x-taker = { path = ".", features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/services/taker/src/classification.rs
+++ b/services/taker/src/classification.rs
@@ -162,7 +162,7 @@ fn is_pyth_oracle_expression(stripped: &str) -> bool {
 }
 
 /// Strips Rainlang comments (`/* ... */` block and `//` line comments).
-fn strip_comments(source: &str) -> String {
+pub(crate) fn strip_comments(source: &str) -> String {
     let mut result = String::with_capacity(source.len());
     let mut chars = source.chars().peekable();
 

--- a/services/taker/src/config.rs
+++ b/services/taker/src/config.rs
@@ -15,6 +15,8 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
 use tracing::Level;
 use url::Url;
 
+#[cfg(any(test, feature = "test-support"))]
+use st0x_execution::HasZero;
 use st0x_execution::{
     AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, FractionalShares, Positive, Symbol,
 };
@@ -425,6 +427,31 @@ impl Ctx {
     pub async fn get_sqlite_pool(&self) -> Result<SqlitePool, sqlx::Error> {
         configure_sqlite_pool(&self.database_url).await
     }
+
+    /// Builds an Alpaca Market Data client from the stored credentials.
+    pub fn build_market_data(
+        &self,
+    ) -> Result<st0x_execution::AlpacaMarketData, st0x_execution::AlpacaMarketDataError> {
+        let base_url = match &self.alpaca.broker.mode {
+            Some(AlpacaBrokerApiMode::Production) => "https://data.alpaca.markets".to_owned(),
+            Some(_) => "https://data.sandbox.alpaca.markets".to_owned(),
+            None => {
+                tracing::warn!(
+                    "Alpaca mode not configured, defaulting to sandbox. \
+                     Set alpaca.mode in secrets to silence this warning."
+                );
+                "https://data.sandbox.alpaca.markets".to_owned()
+            }
+        };
+
+        let ctx = st0x_execution::AlpacaMarketDataCtx::new(
+            self.alpaca.broker.api_key.clone(),
+            self.alpaca.broker.api_secret.clone(),
+            base_url,
+        );
+
+        st0x_execution::AlpacaMarketData::new(&ctx)
+    }
 }
 
 /// Configures a SQLite connection pool with WAL mode and busy timeout.
@@ -436,6 +463,67 @@ async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sqlx::E
         .busy_timeout(std::time::Duration::from_secs(10));
 
     SqlitePool::connect_with(options).await
+}
+
+/// Test-only constructor for [`Ctx`], exposed behind `test-support`
+/// providing a stable construction API for the e2e test crate.
+#[cfg(any(test, feature = "test-support"))]
+#[bon::bon]
+impl Ctx {
+    #[builder]
+    pub fn for_test(
+        database_url: String,
+        ws_rpc_url: Url,
+        orderbook: Address,
+        usdc_address: Address,
+        deployment_block: u64,
+        excluded_owner: Address,
+        private_key: String,
+        equities: HashMap<Symbol, EquityTokenAddresses>,
+        #[builder(default = 50)] min_profit_margin_bps: u32,
+        #[builder(default = 5)] evaluation_interval_secs: u64,
+    ) -> Self {
+        Self {
+            database_url,
+            log_level: LogLevel::Debug,
+            evm: EvmCtx {
+                ws_rpc_url,
+                private_key,
+                orderbook,
+                usdc_address,
+                deployment_block,
+                excluded_owner,
+            },
+            order_taker: OrderTakerCtx {
+                min_profit_margin_bps,
+                max_position_per_symbol: FractionalShares::ZERO,
+                max_total_exposure_usdc: Usdc::ZERO,
+                max_gas_price_gwei: 100,
+                evaluation_interval_secs,
+            },
+            tokenization: TokenizationCtx {
+                alpaca_account_id: AlpacaAccountId::new(uuid::Uuid::nil()),
+                wallet_address: Address::ZERO,
+                redemption_wallet: Address::ZERO,
+            },
+            hold_pool: HoldPoolCtx {
+                retention_window_secs: 300,
+                max_pool_value_usdc: Usdc::ZERO,
+                max_per_symbol: FractionalShares::ZERO,
+            },
+            alpaca: AlpacaCtx {
+                broker: AlpacaBrokerApiCtx {
+                    api_key: "test_key".to_owned(),
+                    api_secret: "test_secret".to_owned(),
+                    account_id: AlpacaAccountId::new(uuid::Uuid::nil()),
+                    mode: None,
+                    asset_cache_ttl: std::time::Duration::from_secs(3600),
+                    time_in_force: st0x_execution::TimeInForce::default(),
+                },
+            },
+            equities,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/services/taker/src/lib.rs
+++ b/services/taker/src/lib.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use st0x_event_sorcery::{Projection, StoreBuilder};
+use st0x_execution::MarketDataProvider;
 use st0x_shared::bindings::{
     IOrderBookV6::{AddOrderV3, IOrderBookV6Instance, RemoveOrderV3, TakeOrderV3},
     MetaV1_2,
@@ -30,6 +31,7 @@ mod approval;
 mod classification;
 pub mod config;
 mod order_collector;
+mod profitability;
 mod tracked_order;
 
 #[cfg(test)]
@@ -54,7 +56,10 @@ pub fn setup_tracing(log_level: &LogLevel) {
 
 /// Main entry point for the taker bot.
 #[allow(clippy::cognitive_complexity)]
-pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
+pub async fn launch<M: MarketDataProvider + 'static>(
+    ctx: Ctx,
+    market_data: M,
+) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
     sqlx::migrate!().run(&pool).await?;
     info!("taker bot started, database migrated");
@@ -90,6 +95,13 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
 
     run_backfill(&provider, &processor, &pool, &ctx).await?;
 
+    // Spawn profitability evaluation loop as a supervised background task
+    let eval_projection = Arc::clone(&projection);
+    let eval_config = ctx.order_taker.clone();
+    let eval_handle = tokio::spawn(async move {
+        profitability::evaluation_loop(eval_projection, market_data, eval_config).await;
+    });
+
     info!(
         "Entering live event loop. Active orders: {}",
         count_active_orders(&projection).await
@@ -111,6 +123,7 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
         &mut take_stream,
         &mut meta_stream,
         &mut meta_cache,
+        eval_handle,
     )
     .await?;
 
@@ -127,7 +140,7 @@ pub async fn launch(ctx: Ctx) -> anyhow::Result<()> {
 /// `U256::MAX` placeholder, `RecordFill` duplicates will corrupt
 /// state. Fix by snapshotting the block first, backfilling to it,
 /// then subscribing from snapshot+1.
-#[allow(clippy::cognitive_complexity)]
+#[allow(clippy::cognitive_complexity, clippy::too_many_arguments)]
 async fn run_event_loop(
     processor: &EventProcessor,
     cursor: &BlockCursor<'_>,
@@ -140,9 +153,26 @@ async fn run_event_loop(
          ),
     meta_stream: &mut (impl StreamExt<Item = Log> + Unpin),
     meta_cache: &mut HashMap<B256, Bytes>,
+    mut eval_handle: tokio::task::JoinHandle<()>,
 ) -> anyhow::Result<()> {
     loop {
         tokio::select! {
+            result = &mut eval_handle => {
+                match result {
+                    Ok(()) => {
+                        error!("Profitability evaluation loop exited unexpectedly");
+                        return Err(anyhow::anyhow!(
+                            "Profitability evaluation loop exited unexpectedly"
+                        ));
+                    }
+                    Err(join_error) => {
+                        error!("Profitability evaluation loop panicked: {join_error}");
+                        return Err(anyhow::anyhow!(
+                            "Profitability evaluation loop panicked: {join_error}"
+                        ));
+                    }
+                }
+            }
             Some(log) = meta_stream.next() => {
                 if let Ok(decoded) = log.log_decode::<MetaV1_2>() {
                     let event = decoded.data();

--- a/services/taker/src/main.rs
+++ b/services/taker/src/main.rs
@@ -10,5 +10,7 @@ async fn main() -> anyhow::Result<()> {
 
     setup_tracing(&ctx.log_level);
 
-    launch(ctx).await
+    let market_data = ctx.build_market_data()?;
+
+    launch(ctx, market_data).await
 }

--- a/services/taker/src/profitability.rs
+++ b/services/taker/src/profitability.rs
@@ -1,0 +1,783 @@
+//! Profitability evaluation for tracked orders.
+//!
+//! Extracts IO ratios from classified Rainlang expressions, compares
+//! order prices against brokerage market prices, and determines whether
+//! taking an order is profitable after accounting for costs.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rain_math_float::{Float, FloatError};
+use tracing::{debug, error, info, warn};
+
+use st0x_event_sorcery::Projection;
+use st0x_execution::{MarketDataProvider, MarketQuote};
+use st0x_finance::Usdc;
+
+use crate::classification::strip_comments;
+use crate::config::OrderTakerCtx;
+use crate::tracked_order::{OrderType, Scenario, TrackedOrder};
+
+/// Parsed IO ratio from a Rainlang expression.
+///
+/// This is the raw value from the Rainlang expression's second literal.
+/// In Raindex, this represents "input tokens per output token" from
+/// the order owner's perspective:
+///
+/// - **Scenario A** (owner sells equity for USDC): `io_ratio` = USDC per
+///   wtToken (the owner's ask price). The bot's buy price IS the io_ratio.
+/// - **Scenario B** (owner buys equity with USDC): `io_ratio` = `inv(price)`
+///   = wtToken per USDC. The bot's sell price is `1/io_ratio`.
+///
+/// Both this code and the taker spec (`docs/taker-spec.md`) follow the
+/// actual Raindex contract semantics (input per output), matching how
+/// the hedge crate constructs expressions.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IoRatio(Float);
+
+impl IoRatio {
+    pub(crate) fn value(self) -> Float {
+        self.0
+    }
+}
+
+/// Snapshot of all inputs needed for a single profitability evaluation.
+///
+/// This is a pure-data struct — the evaluation function is side-effect-free
+/// and testable without async or external dependencies.
+#[derive(Debug)]
+pub(crate) struct EvaluationInput {
+    pub(crate) scenario: Scenario,
+    pub(crate) io_ratio: IoRatio,
+    pub(crate) quote: MarketQuote,
+    pub(crate) costs: EstimatedCosts,
+    pub(crate) min_margin_bps: u32,
+}
+
+/// Flat cost estimates for taking an order (MVP: config-driven, not dynamic).
+#[derive(Debug, Clone)]
+pub(crate) struct EstimatedCosts {
+    /// Gas cost for the `takeOrders4` transaction in USDC terms.
+    pub(crate) gas: Usdc,
+
+    /// Brokerage execution cost (commission + slippage) in USDC terms.
+    pub(crate) brokerage: Usdc,
+
+    /// Tokenization cost (wrap/unwrap gas) in USDC terms.
+    /// Zero if tokens are available in the hold pool.
+    pub(crate) tokenization: Usdc,
+}
+
+impl EstimatedCosts {
+    // TODO(Phase 2): Gas and tokenization are per-transaction costs, not
+    // per-unit. When non-zero costs are introduced, amortize them over the
+    // trade quantity rather than adding them directly to the per-unit threshold.
+    pub(crate) fn total(&self) -> Result<Usdc, FloatError> {
+        let sum = (self.gas.inner() + self.brokerage.inner())?;
+        let total = (sum + self.tokenization.inner())?;
+        Ok(Usdc::new(total))
+    }
+}
+
+/// Result of evaluating an order's profitability.
+#[derive(Debug)]
+pub(crate) enum ProfitabilityVerdict {
+    /// Taking this order is expected to be profitable.
+    Profitable { expected_profit: Usdc },
+
+    /// Taking this order would not be profitable.
+    Unprofitable { reason: UnprofitableReason },
+}
+
+/// Why an order is not profitable.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum UnprofitableReason {
+    /// The spread between order price and market price is less than
+    /// costs + minimum margin.
+    InsufficientMargin {
+        market_price: Usdc,
+        order_price: Usdc,
+        total_costs: Usdc,
+        min_margin: Usdc,
+    },
+}
+
+/// Evaluates whether taking an order is profitable.
+///
+/// Pure function: takes a snapshot of inputs, returns a verdict.
+/// All arithmetic uses checked Float operations via Usdc newtypes.
+pub(crate) fn evaluate_profitability(
+    input: &EvaluationInput,
+) -> Result<ProfitabilityVerdict, FloatError> {
+    let total_costs = input.costs.total()?;
+
+    match input.scenario {
+        Scenario::A => {
+            // Bot buys wtToken at order price, sells underlying at market.
+            // io_ratio = USDC per wtToken (the ask price). Bot pays this.
+            // Use BID price: bot sells underlying -> gets the bid.
+            let executable_price = Usdc::new(input.quote.bid_price);
+            let min_margin = compute_margin(executable_price, input.min_margin_bps)?;
+            let our_buy_price = Usdc::new(input.io_ratio.value());
+            let threshold =
+                Usdc::new(((our_buy_price.inner() + total_costs.inner())? + min_margin.inner())?);
+
+            if executable_price.inner().gt(threshold.inner())? {
+                let profit = Usdc::new((executable_price.inner() - threshold.inner())?);
+                Ok(ProfitabilityVerdict::Profitable {
+                    expected_profit: profit,
+                })
+            } else {
+                Ok(ProfitabilityVerdict::Unprofitable {
+                    reason: UnprofitableReason::InsufficientMargin {
+                        market_price: executable_price,
+                        order_price: our_buy_price,
+                        total_costs,
+                        min_margin,
+                    },
+                })
+            }
+        }
+        Scenario::B => {
+            // Bot buys underlying at market, sells wtToken at order price.
+            // io_ratio = inv(price) = wtToken per USDC. Bot sell price = 1/io_ratio.
+            // Use ASK price: bot buys underlying -> pays the ask.
+            let executable_price = Usdc::new(input.quote.ask_price);
+            let min_margin = compute_margin(executable_price, input.min_margin_bps)?;
+            let one = Float::from_fixed_decimal_lossy(alloy::primitives::U256::from(1), 0)?.0;
+            let our_sell_price = Usdc::new((one / input.io_ratio.value())?);
+            let threshold = Usdc::new(
+                ((executable_price.inner() + total_costs.inner())? + min_margin.inner())?,
+            );
+
+            if our_sell_price.inner().gt(threshold.inner())? {
+                let profit = Usdc::new((our_sell_price.inner() - threshold.inner())?);
+                Ok(ProfitabilityVerdict::Profitable {
+                    expected_profit: profit,
+                })
+            } else {
+                Ok(ProfitabilityVerdict::Unprofitable {
+                    reason: UnprofitableReason::InsufficientMargin {
+                        market_price: executable_price,
+                        order_price: our_sell_price,
+                        total_costs,
+                        min_margin,
+                    },
+                })
+            }
+        }
+    }
+}
+
+/// Computes the minimum profit margin in USDC terms from basis points.
+///
+/// `margin = market_price * min_margin_bps / 10_000`
+fn compute_margin(market_price: Usdc, bps: u32) -> Result<Usdc, FloatError> {
+    let bps_float = Float::from_fixed_decimal_lossy(alloy::primitives::U256::from(bps), 0)?.0;
+    let ten_thousand =
+        Float::from_fixed_decimal_lossy(alloy::primitives::U256::from(10_000u32), 0)?.0;
+    let ratio = (bps_float / ten_thousand)?;
+    let margin = (market_price.inner() * ratio)?;
+    Ok(Usdc::new(margin))
+}
+
+// ── IO Ratio extraction ────────────────────────────────────────────
+
+/// Errors from IO ratio extraction.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum IoRatioError {
+    #[error("no numeric literal found in calculate-io expression")]
+    NoNumericLiteral,
+
+    #[error("empty Rainlang expression")]
+    EmptyExpression,
+
+    #[error("failed to parse IO ratio literal '{literal}': {source}")]
+    ParseFailed {
+        literal: String,
+        source: Box<FloatError>,
+    },
+
+    #[error("unsupported order type for IO ratio extraction: {order_type:?}")]
+    UnsupportedOrderType { order_type: OrderType },
+}
+
+/// Extracts the IO ratio from a classified order.
+///
+/// Only `FixedPrice` orders have extractable IO ratios. Other types
+/// return `UnsupportedOrderType`.
+pub(crate) fn extract_io_ratio(order_type: &OrderType) -> Result<IoRatio, IoRatioError> {
+    match order_type {
+        OrderType::FixedPrice { rainlang } => extract_io_ratio_from_rainlang(rainlang),
+        other => Err(IoRatioError::UnsupportedOrderType {
+            order_type: other.clone(),
+        }),
+    }
+}
+
+/// Extracts the IO ratio from a Rainlang source string.
+///
+/// The Rainlang expression for a fixed-price order looks like:
+///   `_ _: 1000 185;:;`  or  `max-output: max-value(), io: 185;:;`
+///
+/// The IO ratio is the last numeric literal in the calculate-io source
+/// (the segment before the first `;`).
+fn extract_io_ratio_from_rainlang(rainlang: &str) -> Result<IoRatio, IoRatioError> {
+    let stripped = strip_comments(rainlang);
+
+    if stripped.trim().is_empty() {
+        return Err(IoRatioError::EmptyExpression);
+    }
+
+    // The calculate-io source is everything before the first `;`
+    let calculate_io = stripped.split(';').next().unwrap_or(&stripped);
+
+    // Tokenize: split on whitespace and commas, then filter out
+    // labels (tokens containing `:`) and known function calls
+    let last_literal = calculate_io
+        .split(|ch: char| ch.is_whitespace() || ch == ',')
+        .filter(|token| !token.is_empty())
+        .filter(|token| !token.contains(':'))
+        .filter(|token| *token != "max-value()")
+        .next_back()
+        .ok_or(IoRatioError::NoNumericLiteral)?;
+
+    debug!(literal = last_literal, "Parsing IO ratio literal");
+
+    let float_value =
+        Float::parse(last_literal.to_owned()).map_err(|source| IoRatioError::ParseFailed {
+            literal: last_literal.to_owned(),
+            source: Box::new(source),
+        })?;
+
+    Ok(IoRatio(float_value))
+}
+
+// ── Evaluation loop ────────────────────────────────────────────────
+
+/// Continuously evaluates all active tracked orders for profitability.
+///
+/// Runs every `evaluation_interval_secs`, loads all active orders from
+/// the projection, extracts IO ratios, fetches market quotes, and logs
+/// verdicts. Does NOT execute takes — this is a Phase 1 evaluation-only
+/// loop.
+#[allow(clippy::cognitive_complexity)]
+pub(crate) async fn evaluation_loop<M: MarketDataProvider>(
+    projection: Arc<Projection<TrackedOrder>>,
+    market_data: M,
+    config: OrderTakerCtx,
+) {
+    let interval = Duration::from_secs(config.evaluation_interval_secs);
+
+    loop {
+        tokio::time::sleep(interval).await;
+
+        let orders = match projection.load_all().await {
+            Ok(orders) => orders,
+            Err(error) => {
+                error!("Failed to load orders for evaluation: {error}");
+                continue;
+            }
+        };
+
+        let active_count = orders
+            .iter()
+            .filter(|(_, order)| matches!(order, TrackedOrder::Active { .. }))
+            .count();
+
+        if active_count == 0 {
+            debug!("No active orders to evaluate");
+            continue;
+        }
+
+        debug!(active_count, "Evaluating active orders");
+
+        // NOTE: Quotes are fetched serially per symbol. For large active-order
+        // sets this can stall a single evaluation pass beyond the configured
+        // interval. Acceptable for Phase 1; parallelize if scaling requires it.
+        for (order_hash, order) in &orders {
+            let TrackedOrder::Active {
+                symbol,
+                scenario,
+                order_type,
+                ..
+            } = order
+            else {
+                continue;
+            };
+
+            // TODO: Pyth oracle orders require reading the same onchain
+            // price feed to evaluate profitability. Deferred to a follow-up
+            // — for now they're logged as unevaluable.
+            let io_ratio = match extract_io_ratio(order_type) {
+                Ok(ratio) => ratio,
+                Err(IoRatioError::UnsupportedOrderType { .. }) => {
+                    debug!(%order_hash, %symbol, "Skipping non-evaluable order type");
+                    continue;
+                }
+                Err(error) => {
+                    warn!(%order_hash, %symbol, "Failed to extract IO ratio: {error}");
+                    continue;
+                }
+            };
+
+            let quote = match market_data.get_latest_quote(symbol).await {
+                Ok(quote) => quote,
+                Err(error) => {
+                    warn!(%order_hash, %symbol, "Failed to fetch market quote: {error}");
+                    continue;
+                }
+            };
+
+            // MVP: flat zero costs. Dynamic cost estimation is Phase 2.
+            let zero = match Float::zero() {
+                Ok(zero) => zero,
+                Err(error) => {
+                    error!("Float::zero() failed: {error}");
+                    continue;
+                }
+            };
+            let costs = EstimatedCosts {
+                gas: Usdc::new(zero),
+                brokerage: Usdc::new(zero),
+                tokenization: Usdc::new(zero),
+            };
+
+            let input = EvaluationInput {
+                scenario: *scenario,
+                io_ratio,
+                quote,
+                costs,
+                min_margin_bps: config.min_profit_margin_bps,
+            };
+
+            match evaluate_profitability(&input) {
+                Ok(ProfitabilityVerdict::Profitable { expected_profit }) => {
+                    info!(
+                        %order_hash, %symbol, ?scenario, %expected_profit,
+                        "Order is PROFITABLE"
+                    );
+                }
+                Ok(ProfitabilityVerdict::Unprofitable { reason }) => {
+                    debug!(
+                        %order_hash, %symbol, ?scenario, ?reason,
+                        "Order is not profitable"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        %order_hash, %symbol,
+                        "Profitability evaluation failed: {error}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+    use chrono::Utc;
+    use rain_math_float::Float;
+
+    use st0x_execution::{MarketQuote, Symbol};
+    use st0x_finance::Usdc;
+
+    use super::*;
+    use crate::tracked_order::Scenario;
+
+    fn usdc(value: u64) -> Usdc {
+        Usdc::new(
+            Float::from_fixed_decimal_lossy(U256::from(value), 0)
+                .unwrap()
+                .0,
+        )
+    }
+
+    fn usdc_cents(cents: u64) -> Usdc {
+        Usdc::new(
+            Float::from_fixed_decimal_lossy(U256::from(cents), 2)
+                .unwrap()
+                .0,
+        )
+    }
+
+    fn zero_costs() -> EstimatedCosts {
+        EstimatedCosts {
+            gas: usdc(0),
+            brokerage: usdc(0),
+            tokenization: usdc(0),
+        }
+    }
+
+    fn small_costs() -> EstimatedCosts {
+        EstimatedCosts {
+            gas: usdc_cents(10),
+            brokerage: usdc_cents(50),
+            tokenization: usdc_cents(20),
+        }
+    }
+
+    /// Creates a `MarketQuote` with the given bid and ask as whole-dollar values.
+    fn quote(bid: u64, ask: u64) -> MarketQuote {
+        MarketQuote {
+            symbol: Symbol::new("AAPL").unwrap(),
+            bid_price: float_from_u64(bid),
+            ask_price: float_from_u64(ask),
+            timestamp: Utc::now(),
+        }
+    }
+
+    fn float_from_u64(value: u64) -> Float {
+        Float::from_fixed_decimal_lossy(U256::from(value), 0)
+            .unwrap()
+            .0
+    }
+
+    // ── IO ratio extraction ──────────────────────────────────────
+
+    #[test]
+    fn extract_io_ratio_simple_expression() {
+        let order_type = OrderType::FixedPrice {
+            rainlang: "_ _: 1000 185;:;".to_owned(),
+        };
+        let ratio = extract_io_ratio(&order_type).unwrap();
+        let formatted = ratio.value().format().unwrap();
+        assert_eq!(formatted, "185");
+    }
+
+    #[test]
+    fn extract_io_ratio_named_outputs() {
+        let order_type = OrderType::FixedPrice {
+            rainlang: "max-output: max-value(), io: 185;:;".to_owned(),
+        };
+        let ratio = extract_io_ratio(&order_type).unwrap();
+        let formatted = ratio.value().format().unwrap();
+        assert_eq!(formatted, "185");
+    }
+
+    #[test]
+    fn extract_io_ratio_with_comments() {
+        let order_type = OrderType::FixedPrice {
+            rainlang: "/* price */ _ _: 1000 185;:;".to_owned(),
+        };
+        let ratio = extract_io_ratio(&order_type).unwrap();
+        let formatted = ratio.value().format().unwrap();
+        assert_eq!(formatted, "185");
+    }
+
+    #[test]
+    fn extract_io_ratio_decimal_value() {
+        let order_type = OrderType::FixedPrice {
+            rainlang: "_ _: 1000 0.005405405405;:;".to_owned(),
+        };
+        let ratio = extract_io_ratio(&order_type).unwrap();
+        // Just verify it parses without error — exact formatting
+        // depends on Float's internal representation
+        assert!(!ratio.value().is_zero().unwrap());
+    }
+
+    #[test]
+    fn extract_io_ratio_empty_expression_fails() {
+        let order_type = OrderType::FixedPrice {
+            rainlang: String::new(),
+        };
+        let result = extract_io_ratio(&order_type);
+        assert!(matches!(result.unwrap_err(), IoRatioError::EmptyExpression));
+    }
+
+    #[test]
+    fn extract_io_ratio_unsupported_order_type() {
+        let order_type = OrderType::PythOracle {
+            rainlang: "pyth-price(0xfeed)".to_owned(),
+        };
+        let result = extract_io_ratio(&order_type);
+        assert!(matches!(
+            result.unwrap_err(),
+            IoRatioError::UnsupportedOrderType { .. }
+        ));
+    }
+
+    #[test]
+    fn extract_io_ratio_unknown_order_type() {
+        let result = extract_io_ratio(&OrderType::Unknown);
+        assert!(matches!(
+            result.unwrap_err(),
+            IoRatioError::UnsupportedOrderType { .. }
+        ));
+    }
+
+    // ── Profitability evaluation ─────────────────────────────────
+
+    #[test]
+    fn scenario_a_profitable_when_market_exceeds_buy_price_plus_costs() {
+        // Scenario A: io_ratio = 185 (USDC per wtToken), market at $190
+        // Bot buy price = io_ratio = 185. Profit = 190 - 185 = $5.
+        let io_ratio = IoRatio(
+            Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0,
+        );
+        let input = EvaluationInput {
+            scenario: Scenario::A,
+            io_ratio,
+            quote: quote(190, 191),
+            costs: zero_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Profitable { .. }),
+            "Market $190 > order price $185 should be profitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_a_unprofitable_when_market_below_buy_price() {
+        // io_ratio = 185 (USDC per wtToken), market at $180
+        let io_ratio = IoRatio(
+            Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0,
+        );
+        let input = EvaluationInput {
+            scenario: Scenario::A,
+            io_ratio,
+            quote: quote(180, 181),
+            costs: zero_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Unprofitable { .. }),
+            "Market $180 < order price $185 should be unprofitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_a_costs_reduce_profitability() {
+        // io_ratio = 185, market = $186 (spread = $1)
+        // costs = $0.80, margin = 0 bps -> should still be profitable ($0.20 profit)
+        let io_ratio = IoRatio(
+            Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0,
+        );
+        let input = EvaluationInput {
+            scenario: Scenario::A,
+            io_ratio,
+            quote: quote(186, 187),
+            costs: small_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Profitable { .. }),
+            "$1 spread with $0.80 costs should be profitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_a_margin_requirement_makes_unprofitable() {
+        // io_ratio = 185, market = $186 (spread = $1)
+        // costs = $0, margin = 100 bps (1% of $186 = $1.86) -> unprofitable
+        let io_ratio = IoRatio(
+            Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0,
+        );
+        let input = EvaluationInput {
+            scenario: Scenario::A,
+            io_ratio,
+            quote: quote(186, 187),
+            costs: zero_costs(),
+            min_margin_bps: 100,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Unprofitable { .. }),
+            "$1 spread with 1% margin ($1.86) should be unprofitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_b_profitable_when_sell_price_exceeds_market_plus_costs() {
+        // Scenario B: io_ratio = wtAAPL per USDC. If owner wants to buy
+        // equity at $185, io_ratio = 1/185. Bot sell price = 1/(1/185) = 185.
+        // Market at $180: sell at $185, buy at $180, profit = $5.
+        //
+        // Actually for Scenario B with the corrected formula:
+        // Bot sell price = 1/io_ratio. If io_ratio = 0.005405... (1/185),
+        // then sell price = 185 USDC per wtAAPL.
+        let one_over_185 = {
+            let one = Float::from_fixed_decimal_lossy(U256::from(1u32), 0)
+                .unwrap()
+                .0;
+            let price = Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0;
+            (one / price).unwrap()
+        };
+        let io_ratio = IoRatio(one_over_185);
+
+        let input = EvaluationInput {
+            scenario: Scenario::B,
+            io_ratio,
+            quote: quote(179, 180),
+            costs: zero_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Profitable { .. }),
+            "Sell at $185, buy at ask $180 should be profitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_b_unprofitable_when_market_exceeds_sell_price() {
+        // io_ratio = 1/185, sell price = 185. Market at $190 -> unprofitable.
+        let one_over_185 = {
+            let one = Float::from_fixed_decimal_lossy(U256::from(1u32), 0)
+                .unwrap()
+                .0;
+            let price = Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0;
+            (one / price).unwrap()
+        };
+        let io_ratio = IoRatio(one_over_185);
+
+        let input = EvaluationInput {
+            scenario: Scenario::B,
+            io_ratio,
+            quote: quote(189, 190),
+            costs: zero_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Unprofitable { .. }),
+            "Sell at $185, buy at ask $190 should be unprofitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_b_costs_reduce_profitability() {
+        // io_ratio = 1/185, sell price = 185. Market ask = $184.
+        // Spread = $1, costs = $0.80, margin = 0 -> profitable ($0.20 profit)
+        let one_over_185 = {
+            let one = Float::from_fixed_decimal_lossy(U256::from(1u32), 0)
+                .unwrap()
+                .0;
+            let price = Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0;
+            (one / price).unwrap()
+        };
+        let io_ratio = IoRatio(one_over_185);
+
+        let input = EvaluationInput {
+            scenario: Scenario::B,
+            io_ratio,
+            quote: quote(183, 184),
+            costs: small_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Profitable { .. }),
+            "$1 spread with $0.80 costs should be profitable, got: {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_a_equal_price_is_unprofitable() {
+        // io_ratio = 185, market bid = $185 (exactly equal)
+        // With zero costs and zero margin, the threshold IS $185.
+        // The condition is `market > threshold` (strict), so equal = unprofitable.
+        let io_ratio = IoRatio(
+            Float::from_fixed_decimal_lossy(U256::from(185u32), 0)
+                .unwrap()
+                .0,
+        );
+        let input = EvaluationInput {
+            scenario: Scenario::A,
+            io_ratio,
+            quote: quote(185, 186),
+            costs: zero_costs(),
+            min_margin_bps: 0,
+        };
+
+        let verdict = evaluate_profitability(&input).unwrap();
+        assert!(
+            matches!(verdict, ProfitabilityVerdict::Unprofitable { .. }),
+            "Equal price should be unprofitable (strict >), got: {verdict:?}"
+        );
+    }
+
+    // ── Cost accounting ──────────────────────────────────────────
+
+    #[test]
+    fn estimated_costs_total_sums_all_components() {
+        let costs = small_costs();
+        let total = costs.total().unwrap();
+
+        // gas=0.10, brokerage=0.50, tokenization=0.20 -> total=0.80
+        let formatted = total.inner().format().unwrap();
+        assert!(
+            formatted.starts_with("0.8"),
+            "Expected total ~0.80, got {formatted}"
+        );
+    }
+
+    #[test]
+    fn estimated_costs_total_zero_when_all_zero() {
+        let costs = zero_costs();
+        let total = costs.total().unwrap();
+        assert!(
+            total.inner().is_zero().unwrap(),
+            "Zero costs should sum to zero"
+        );
+    }
+
+    #[test]
+    fn compute_margin_100_bps_of_200() {
+        // 100 bps of $200 = 1% * 200 = $2
+        let market_price = usdc(200);
+        let margin = super::compute_margin(market_price, 100).unwrap();
+        let formatted = margin.inner().format().unwrap();
+        assert_eq!(formatted, "2", "100 bps of $200 = $2");
+    }
+
+    #[test]
+    fn compute_margin_zero_bps() {
+        let market_price = usdc(200);
+        let margin = super::compute_margin(market_price, 0).unwrap();
+        assert!(
+            margin.inner().is_zero().unwrap(),
+            "0 bps margin should be zero"
+        );
+    }
+
+    #[test]
+    fn compute_margin_50_bps_of_185() {
+        // 50 bps of $185 = 0.5% * 185 = $0.925
+        let market_price = usdc(185);
+        let margin = super::compute_margin(market_price, 50).unwrap();
+        let formatted = margin.inner().format().unwrap();
+        assert!(
+            formatted.starts_with("0.925"),
+            "50 bps of $185 should be ~$0.925, got {formatted}"
+        );
+    }
+}

--- a/services/taker/tests/e2e/discovery.rs
+++ b/services/taker/tests/e2e/discovery.rs
@@ -1,0 +1,234 @@
+//! Phase 1 milestone: order discovery and classification end-to-end.
+//!
+//! Verifies the full pipeline: deploy an order on Anvil, start the taker
+//! bot, and assert that it discovers and classifies the order correctly.
+
+use alloy::primitives::{Bytes, U256, utils::parse_units};
+use alloy::providers::Provider;
+use std::collections::HashMap;
+use std::time::Duration;
+
+use st0x_execution::{AlpacaMarketDataMock, Symbol};
+use st0x_shared::EquityTokenAddresses;
+
+use crate::poll::{connect_db, fetch_all_events, poll_for_events, spawn_bot};
+use crate::test_infra::TakerTestInfra;
+
+/// Build a `Ctx` from the test infrastructure.
+fn build_ctx(
+    infra: &TakerTestInfra<impl Provider + Clone>,
+    deployment_block: u64,
+    excluded_owner: alloy::primitives::Address,
+) -> st0x_taker::Ctx {
+    let aapl = Symbol::new("AAPL").unwrap();
+    let mut equities = HashMap::new();
+    equities.insert(
+        aapl,
+        EquityTokenAddresses {
+            wrapped: infra.wt_aapl_addr,
+            unwrapped: infra.wt_aapl_addr,
+        },
+    );
+
+    let ws_url = infra
+        .rain
+        .chain
+        .ws_endpoint()
+        .expect("Anvil should provide WS endpoint");
+
+    let private_key = format!("{:x}", infra.rain.chain.owner_key);
+
+    st0x_taker::Ctx::for_test()
+        .database_url(infra.database_url())
+        .ws_rpc_url(ws_url)
+        .orderbook(infra.rain.orderbook)
+        .usdc_address(infra.usdc_addr)
+        .deployment_block(deployment_block)
+        .excluded_owner(excluded_owner)
+        .private_key(private_key)
+        .equities(equities)
+        .evaluation_interval_secs(1)
+        .call()
+}
+
+/// Smoke test: verify test infrastructure starts and can deploy orders.
+#[tokio::test]
+async fn test_infra_starts_and_deploys_order() {
+    let infra = TakerTestInfra::start().await.unwrap();
+
+    infra.rain.chain.provider.get_block_number().await.unwrap();
+
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 185;:;");
+
+    let result = infra
+        .rain
+        .add_order(
+            &expression,
+            Bytes::new(),
+            infra.usdc_addr,
+            infra.wt_aapl_addr,
+        )
+        .await
+        .unwrap();
+
+    assert!(result.block > 0);
+    assert!(!result.order_hash.is_zero());
+}
+
+/// Full pipeline: place a sell order on Anvil with metadata, start
+/// the taker bot, verify it discovers the order and classifies it
+/// as FixedPrice.
+#[tokio::test]
+async fn order_discovered_and_classified_via_bot() {
+    let infra = TakerTestInfra::start().await.unwrap();
+    // Place a fixed-price sell order with CBOR metadata so it gets
+    // classified as FixedPrice by the bot's classification pipeline.
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 185;:;");
+
+    let rainlang_source = "_ _: 1000 185;:;";
+    let meta = encode_rainlang_metadata(rainlang_source);
+
+    let add_result = infra
+        .rain
+        .add_order(&expression, meta, infra.usdc_addr, infra.wt_aapl_addr)
+        .await
+        .unwrap();
+
+    assert!(add_result.block > 0, "Order should be mined");
+
+    // Start the taker bot — it will backfill from deployment_block=0,
+    // discover the order, classify it, and begin the evaluation loop.
+    // The excluded_owner is NOT the Anvil owner, so the order should
+    // be tracked.
+    // Use a non-existent address as excluded_owner so orders from the
+    // Anvil owner ARE tracked.
+    let ctx = build_ctx(&infra, 0, alloy::primitives::Address::repeat_byte(0xFF));
+    let mut bot = spawn_bot(ctx, AlpacaMarketDataMock::new());
+
+    // Wait for the bot to discover and classify the order.
+    // The TrackedOrder aggregate emits a "Discovered" event.
+    poll_for_events(&mut bot, &infra.db_path, "TrackedOrderEvent::Discovered", 1).await;
+
+    // Verify the CQRS event store has exactly the expected events.
+    let pool = connect_db(&infra.db_path).await.unwrap();
+    let events = fetch_all_events(&pool).await.unwrap();
+
+    // Should have exactly 1 event: the Discover for our order
+    assert_eq!(
+        events.len(),
+        1,
+        "Expected exactly 1 event, got {}: {events:?}",
+        events.len()
+    );
+
+    let event = &events[0];
+    assert_eq!(event.aggregate_type, "TrackedOrder");
+    assert_eq!(event.event_type, "TrackedOrderEvent::Discovered");
+
+    // The aggregate_id should be the order hash (hex-encoded)
+    assert!(
+        !event.aggregate_id.is_empty(),
+        "aggregate_id should be the order hash"
+    );
+
+    // Verify the event payload contains expected classification data.
+    // The payload is the serialized TrackedOrderEvent::Discovered variant.
+    let payload = &event.payload;
+    let discovered = &payload["Discovered"];
+
+    assert_eq!(
+        discovered["scenario"].as_str().unwrap(),
+        "A",
+        "Owner outputs wtAAPL -> Scenario A"
+    );
+
+    assert_eq!(
+        discovered["symbol"].as_str().unwrap(),
+        "AAPL",
+        "Symbol should be AAPL"
+    );
+
+    // Classification should have produced FixedPrice with the Rainlang
+    // source from the metadata, NOT Unknown.
+    let order_type = &discovered["order_type"];
+    assert!(
+        order_type["FixedPrice"].is_object(),
+        "Expected FixedPrice classification, got: {order_type}"
+    );
+    assert_eq!(
+        order_type["FixedPrice"]["rainlang"].as_str().unwrap(),
+        rainlang_source,
+        "Rainlang source should match metadata"
+    );
+
+    assert_eq!(
+        discovered["discovered_block"].as_u64().unwrap(),
+        add_result.block,
+        "Discovered block should match the order's block"
+    );
+
+    pool.close().await;
+    bot.abort();
+}
+
+/// Places an order from the excluded owner address. The bot should
+/// NOT track it — no events should appear in the database.
+#[tokio::test]
+async fn excluded_owner_order_not_tracked() {
+    let infra = TakerTestInfra::start().await.unwrap();
+
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 185;:;");
+
+    infra
+        .rain
+        .add_order(
+            &expression,
+            Bytes::new(),
+            infra.usdc_addr,
+            infra.wt_aapl_addr,
+        )
+        .await
+        .unwrap();
+
+    // Use the Anvil owner as excluded_owner so their order gets filtered.
+    let ctx = build_ctx(&infra, 0, infra.rain.chain.owner);
+    let bot = spawn_bot(ctx, AlpacaMarketDataMock::new());
+
+    // Give the bot time to backfill and process. If the order were
+    // tracked, it would appear within a few seconds.
+    // NOTE: Sleep-based negative assertion is inherently racy. A
+    // deterministic approach (e.g., polling for backfill-complete)
+    // would be more reliable but adds complexity for Phase 1.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let pool = connect_db(&infra.db_path).await.unwrap();
+    let events = fetch_all_events(&pool).await.unwrap();
+
+    assert!(
+        events.is_empty(),
+        "Excluded owner's order should produce no events, got: {events:?}"
+    );
+
+    pool.close().await;
+    bot.abort();
+}
+
+/// Builds CBOR-encoded RainMetaDocumentV1 metadata from a Rainlang source.
+fn encode_rainlang_metadata(rainlang: &str) -> Bytes {
+    // RainMetaDocumentV1 magic prefix
+    let magic: [u8; 8] = [0xff, 0x0a, 0x89, 0xc6, 0x74, 0xee, 0x78, 0x74];
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&magic);
+
+    let map = ciborium::Value::Map(vec![(
+        ciborium::Value::Integer(0.into()),
+        ciborium::Value::Bytes(rainlang.as_bytes().to_vec()),
+    )]);
+    ciborium::into_writer(&map, &mut buf).unwrap();
+
+    Bytes::from(buf)
+}

--- a/services/taker/tests/e2e/main.rs
+++ b/services/taker/tests/e2e/main.rs
@@ -1,0 +1,12 @@
+//! E2E integration tests for the st0x-taker bot.
+//!
+//! Tests the full bot lifecycle: order discovery via Anvil events,
+//! classification, and profitability evaluation with mocked Alpaca
+//! market data.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod discovery;
+mod poll;
+mod profitability;
+mod test_infra;

--- a/services/taker/tests/e2e/poll.rs
+++ b/services/taker/tests/e2e/poll.rs
@@ -1,0 +1,110 @@
+//! Bot lifecycle helpers and event polling for e2e tests.
+
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnectOptions;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+use st0x_execution::MarketDataProvider;
+use st0x_taker::Ctx;
+
+/// Spawns the full taker bot as a background task.
+pub fn spawn_bot(
+    ctx: Ctx,
+    market_data: impl MarketDataProvider + 'static,
+) -> JoinHandle<anyhow::Result<()>> {
+    tokio::spawn(st0x_taker::launch(ctx, market_data))
+}
+
+pub const POLL_INTERVAL: Duration = Duration::from_millis(200);
+pub const DEFAULT_POLL_TIMEOUT_SECS: u64 = 30;
+
+/// Sleeps for [`POLL_INTERVAL`], panicking immediately if the bot task
+/// exits during the sleep.
+pub async fn sleep_or_crash(bot: &mut JoinHandle<anyhow::Result<()>>, context: &str) {
+    tokio::select! {
+        result = &mut *bot => {
+            match result {
+                Ok(Ok(())) => panic!("Bot exited cleanly while polling for: {context}"),
+                Ok(Err(error)) => panic!("Bot crashed while polling for: {context}: {error:#}"),
+                Err(join_error) => panic!("Bot panicked while polling for: {context}: {join_error}"),
+            }
+        }
+        () = tokio::time::sleep(POLL_INTERVAL) => {}
+    }
+}
+
+/// Polls the CQRS events table until at least `expected_count` events of
+/// the given `event_type` exist.
+pub async fn poll_for_events(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    event_type: &str,
+    expected_count: i64,
+) {
+    let connect_opts = SqliteConnectOptions::new().filename(db_path);
+    let timeout = Duration::from_secs(DEFAULT_POLL_TIMEOUT_SECS);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("{expected_count}x {event_type}");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect_with(connect_opts.clone()).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let query_result =
+            sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind(event_type)
+                .fetch_one(&pool)
+                .await;
+
+        pool.close().await;
+
+        match query_result {
+            Ok((count,)) if count >= expected_count => return,
+            Ok((count,)) => assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (found {count})",
+            ),
+            Err(query_error) => assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} \
+                 (query failed: {query_error})",
+            ),
+        }
+    }
+}
+
+/// Opens a SQLite connection to the test database.
+pub async fn connect_db(db_path: &std::path::Path) -> anyhow::Result<SqlitePool> {
+    let options = SqliteConnectOptions::new().filename(db_path);
+    Ok(SqlitePool::connect_with(options).await?)
+}
+
+/// Fetches all domain events ordered by insertion.
+#[derive(Debug, sqlx::FromRow)]
+pub struct StoredEvent {
+    pub aggregate_type: String,
+    pub aggregate_id: String,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+}
+
+pub async fn fetch_all_events(pool: &SqlitePool) -> anyhow::Result<Vec<StoredEvent>> {
+    let events: Vec<StoredEvent> = sqlx::query_as(
+        "SELECT aggregate_type, aggregate_id, event_type, payload \
+         FROM events \
+         WHERE aggregate_type != 'SchemaRegistry' \
+         ORDER BY rowid ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(events)
+}

--- a/services/taker/tests/e2e/profitability.rs
+++ b/services/taker/tests/e2e/profitability.rs
@@ -1,0 +1,178 @@
+//! Phase 1 milestone: profitability evaluation end-to-end.
+//!
+//! Deploys a FixedPrice order on Anvil, seeds mock market data with a
+//! known quote, starts the taker bot, and verifies the evaluation loop
+//! processes the order without crashing. The bot's evaluation interval
+//! is set to 1 second in test config, so waiting a few seconds after
+//! discovery proves the loop ran at least once.
+
+use alloy::primitives::{Bytes, U256, utils::parse_units};
+use rain_math_float::Float;
+use std::collections::HashMap;
+
+use st0x_execution::{AlpacaMarketDataMock, Symbol};
+use st0x_shared::EquityTokenAddresses;
+
+use crate::poll::{poll_for_events, spawn_bot};
+use crate::test_infra::TakerTestInfra;
+
+/// Builds CBOR-encoded RainMetaDocumentV1 metadata from a Rainlang source.
+fn encode_rainlang_metadata(rainlang: &str) -> Bytes {
+    let magic: [u8; 8] = [0xff, 0x0a, 0x89, 0xc6, 0x74, 0xee, 0x78, 0x74];
+
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&magic);
+
+    let map = ciborium::Value::Map(vec![(
+        ciborium::Value::Integer(0.into()),
+        ciborium::Value::Bytes(rainlang.as_bytes().to_vec()),
+    )]);
+    ciborium::into_writer(&map, &mut buf).unwrap();
+
+    Bytes::from(buf)
+}
+
+fn float_val(value: u32) -> Float {
+    Float::from_fixed_decimal_lossy(U256::from(value), 0)
+        .unwrap()
+        .0
+}
+
+/// Full pipeline: deploy a FixedPrice sell order, seed mock market data
+/// with a quote that makes the order profitable, start the bot, verify
+/// discovery, then verify the evaluation loop runs through at least one
+/// cycle without crashing.
+///
+/// Scenario A: owner sells wtAAPL for USDC at io_ratio=185 (USDC per wtAAPL).
+/// Market bid=$190 -> bot buy at $185, sell at $190 -> profitable.
+#[tokio::test]
+async fn profitable_order_evaluated_without_crash() {
+    let infra = TakerTestInfra::start().await.unwrap();
+
+    // Deploy a FixedPrice sell order with CBOR metadata
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 185;:;");
+    let rainlang_source = "_ _: 1000 185;:;";
+    let meta = encode_rainlang_metadata(rainlang_source);
+
+    infra
+        .rain
+        .add_order(&expression, meta, infra.usdc_addr, infra.wt_aapl_addr)
+        .await
+        .unwrap();
+
+    // Seed mock market data: bid=$190, ask=$191 -> Scenario A is profitable
+    let mock_market = AlpacaMarketDataMock::new();
+    let aapl = Symbol::new("AAPL").unwrap();
+    mock_market.set_quote(aapl.clone(), float_val(190), float_val(191));
+
+    let mut equities = HashMap::new();
+    equities.insert(
+        aapl,
+        EquityTokenAddresses {
+            wrapped: infra.wt_aapl_addr,
+            unwrapped: infra.wt_aapl_addr,
+        },
+    );
+
+    let ws_url = infra
+        .rain
+        .chain
+        .ws_endpoint()
+        .expect("Anvil should provide WS endpoint");
+    let private_key = format!("{:x}", infra.rain.chain.owner_key);
+
+    let ctx = st0x_taker::Ctx::for_test()
+        .database_url(infra.database_url())
+        .ws_rpc_url(ws_url)
+        .orderbook(infra.rain.orderbook)
+        .usdc_address(infra.usdc_addr)
+        .deployment_block(0)
+        .excluded_owner(alloy::primitives::Address::repeat_byte(0xFF))
+        .private_key(private_key)
+        .equities(equities)
+        .evaluation_interval_secs(1)
+        .call();
+
+    let mut bot = spawn_bot(ctx, mock_market);
+
+    // Wait for the bot to discover and classify the order
+    poll_for_events(&mut bot, &infra.db_path, "TrackedOrderEvent::Discovered", 1).await;
+
+    // The evaluation loop runs every 1 second. Wait for at least 2 cycles
+    // to prove the loop runs successfully with seeded quotes. If the
+    // evaluation panicked or errored fatally, the bot task would exit and
+    // the select! in sleep_or_crash would catch it.
+    for _ in 0..10 {
+        crate::poll::sleep_or_crash(&mut bot, "profitability evaluation cycle").await;
+    }
+
+    // Bot is still alive after multiple evaluation cycles — the eval loop
+    // processed the FixedPrice order with seeded market data successfully.
+    bot.abort();
+}
+
+/// Deploy an order where the market price makes it unprofitable, verify
+/// the evaluation loop still runs without crashing.
+///
+/// Scenario A: io_ratio=185, market bid=$180 -> unprofitable.
+#[tokio::test]
+async fn unprofitable_order_evaluated_without_crash() {
+    let infra = TakerTestInfra::start().await.unwrap();
+
+    let max_amount: U256 = parse_units("10", 18).unwrap().into();
+    let expression = format!("_ _: {max_amount} 185;:;");
+    let rainlang_source = "_ _: 1000 185;:;";
+    let meta = encode_rainlang_metadata(rainlang_source);
+
+    infra
+        .rain
+        .add_order(&expression, meta, infra.usdc_addr, infra.wt_aapl_addr)
+        .await
+        .unwrap();
+
+    // Seed mock market data: bid=$180, ask=$181 -> Scenario A is unprofitable
+    let mock_market = AlpacaMarketDataMock::new();
+    let aapl = Symbol::new("AAPL").unwrap();
+    mock_market.set_quote(aapl.clone(), float_val(180), float_val(181));
+
+    let mut equities = HashMap::new();
+    equities.insert(
+        aapl,
+        EquityTokenAddresses {
+            wrapped: infra.wt_aapl_addr,
+            unwrapped: infra.wt_aapl_addr,
+        },
+    );
+
+    let ws_url = infra
+        .rain
+        .chain
+        .ws_endpoint()
+        .expect("Anvil should provide WS endpoint");
+    let private_key = format!("{:x}", infra.rain.chain.owner_key);
+
+    let ctx = st0x_taker::Ctx::for_test()
+        .database_url(infra.database_url())
+        .ws_rpc_url(ws_url)
+        .orderbook(infra.rain.orderbook)
+        .usdc_address(infra.usdc_addr)
+        .deployment_block(0)
+        .excluded_owner(alloy::primitives::Address::repeat_byte(0xFF))
+        .private_key(private_key)
+        .equities(equities)
+        .evaluation_interval_secs(1)
+        .call();
+
+    let mut bot = spawn_bot(ctx, mock_market);
+
+    poll_for_events(&mut bot, &infra.db_path, "TrackedOrderEvent::Discovered", 1).await;
+
+    // Wait for evaluation cycles — unprofitable verdicts are debug-logged
+    // but should not crash the bot
+    for _ in 0..10 {
+        crate::poll::sleep_or_crash(&mut bot, "unprofitable evaluation cycle").await;
+    }
+
+    bot.abort();
+}

--- a/services/taker/tests/e2e/test_infra.rs
+++ b/services/taker/tests/e2e/test_infra.rs
@@ -1,0 +1,64 @@
+//! Test infrastructure for taker e2e tests.
+//!
+//! Provides [`TakerTestInfra`] which wires together an Anvil-based
+//! `RainOrderBook` and a temporary SQLite database for the taker bot.
+
+use std::path::PathBuf;
+
+use alloy::primitives::{Address, utils::parse_units};
+use alloy::providers::Provider;
+use tempfile::TempDir;
+
+use st0x_execution::Symbol;
+use st0x_shared::test_support::RainOrderBook;
+
+/// Assembled test environment for taker e2e tests.
+pub struct TakerTestInfra<P> {
+    /// Kept alive so the temp directory isn't deleted during the test.
+    _db_dir: TempDir,
+    pub db_path: PathBuf,
+    pub rain: RainOrderBook<P>,
+    pub usdc_addr: Address,
+    pub wt_aapl_addr: Address,
+}
+
+impl TakerTestInfra<()> {
+    pub async fn start() -> anyhow::Result<TakerTestInfra<impl Provider + Clone>> {
+        let db_dir = tempfile::tempdir()?;
+        let db_path = db_dir.path().join("e2e.sqlite");
+
+        let rain = RainOrderBook::start().await?;
+
+        let usdc_addr = rain
+            .deploy_erc20("USD Coin", "USDC", 6, parse_units("1000000", 6)?.into())
+            .await?;
+
+        let wt_aapl_addr = rain
+            .deploy_erc20(
+                "Wrapped AAPL",
+                "wtAAPL",
+                18,
+                parse_units("1000000", 18)?.into(),
+            )
+            .await?;
+
+        Ok(TakerTestInfra {
+            _db_dir: db_dir,
+            db_path,
+            rain,
+            usdc_addr,
+            wt_aapl_addr,
+        })
+    }
+}
+
+#[allow(dead_code)]
+impl<P> TakerTestInfra<P> {
+    pub fn aapl_symbol() -> Symbol {
+        Symbol::new("AAPL").unwrap()
+    }
+
+    pub fn database_url(&self) -> String {
+        format!("sqlite:{}?mode=rwc", self.db_path.display())
+    }
+}


### PR DESCRIPTION
## Motivation

Closes [RAI-10](https://linear.app/makeitrain/issue/RAI-10/phase-1-profitability-strategy).

The taker bot can discover and classify onchain orders but can't yet determine whether taking them is profitable. Without profitability evaluation, the bot has no way to distinguish actionable opportunities from unprofitable noise. This PR adds Phase 1 profitability evaluation — comparing onchain order prices against real-time Alpaca brokerage prices, accounting for costs and margin requirements — so the bot can identify opportunities worth taking. Phase 1 logs profitable verdicts without executing; actual `takeOrders4` execution is deferred to RAI-11.

## Solution

Three new components:

### 1. Alpaca Market Data client (`crates/execution/src/alpaca_market_data/`)

New module in the execution crate providing real-time bid/ask quotes via Alpaca's Market Data API (`data.alpaca.markets/v2/stocks/{symbol}/quotes/latest`). Uses the same API credentials as the existing Broker API with Basic auth, but a different base URL.

- `MarketDataProvider` trait with async `get_latest_quote()` — generic so tests can inject mocks
- `AlpacaMarketData` production HTTP client with `serde_json::Number` deserialization to avoid `f64` precision loss on financial data
- `AlpacaMarketDataMock` for testing (behind `mock` feature flag)
- `MarketQuote` type with `bid_price`, `ask_price`, and `mid_price()` helper, all using `Float` for precision-safe arithmetic

### 2. Profitability evaluation (`services/taker/src/profitability.rs`)

Pure evaluation logic with no side effects:

- **IO ratio extraction**: Parses the IO ratio from FixedPrice Rainlang expressions by stripping comments, splitting on `;`, tokenizing, and extracting the last numeric literal via `Float::parse()`. Pyth oracle orders are logged as unevaluable (deferred to follow-up).
- **Profitability formulas**: Uses bid/ask prices (not mid-price) for accurate executable pricing:
  - Scenario A (bot buys wtToken at order price, sells underlying at market): uses bid price since the bot is selling
  - Scenario B (bot buys underlying at market, sells wtToken at order price): uses ask price since the bot is buying
- **Cost model**: MVP uses flat zero costs; config-driven cost estimates (gas, brokerage, tokenization) are structurally supported via `EstimatedCosts` but deferred to Phase 2 when actual execution makes them relevant
- **Evaluation loop**: Supervised `tokio::spawn` task running every `evaluation_interval_secs`, loading all Active orders from the CQRS projection, evaluating each, and logging verdicts. The `JoinHandle` is monitored via `tokio::select!` in the main event loop — if the eval task panics or exits, the bot surfaces the error instead of silently losing profitability evaluation.

### 3. E2E test infrastructure (`services/taker/tests/e2e/`)

End-to-end test harness that boots a full taker bot against Anvil:

- `TakerTestInfra`: wires together `RainOrderBook` (Anvil + orderbook contract), mock ERC-20 tokens (USDC, wtAAPL), and a temporary SQLite database
- `spawn_bot()` / `poll_for_events()` / `sleep_or_crash()`: bot lifecycle helpers with deadline-based polling and crash detection
- Three tests: infra smoke test, full discovery+classification pipeline (deploy order with CBOR metadata, verify Discovered event with FixedPrice classification), and excluded-owner filtering (order from bot's own address is not tracked)

### Key design decisions

- **`launch()` is generic over `MarketDataProvider`**: The market data provider is injected into `launch()` rather than constructed internally. Production builds use `Ctx::build_market_data()` to construct `AlpacaMarketData` from Alpaca credentials; tests pass `AlpacaMarketDataMock`. This keeps the composition root in `main.rs` and makes the evaluation loop testable.
- **Bid/ask over mid-price**: Scenario A uses the bid (bot sells underlying) and Scenario B uses the ask (bot buys underlying) for realistic executable pricing rather than optimistic mid-price estimates.
- **`serde_json::Number` for quote deserialization**: Avoids `f64` precision loss on financial data by deserializing Alpaca quote prices as `serde_json::Number` and converting directly to `Float`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alpaca market-data integration with sandbox/production presets, live quote retrieval, mid-price calculation
  * In-memory mock market-data provider for deterministic local testing
  * Market-quote abstraction exposed for consumers

* **Enhancements**
  * Taker startup now accepts a market-data provider and runs a background profitability evaluation loop
  * Config test-builder for simplified test setup

* **Tests**
  * Extensive unit and end-to-end tests covering discovery, classification, pricing, profitability, and bot lifecycle
<!-- end of auto-generated comment: release notes by coderabbit.ai -->