### PR TITLE
fix: harden Alpaca tokenization polling against malformed request history

### DIFF
--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -510,8 +510,10 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             let tokenization_request: TokenizationRequest = serde_json::from_str(&body)
                 .inspect_err(|error| {
                     error!(
-                        body = %body,
+                        body_len = body.len(),
                         error = %error,
+                        symbol = %request.underlying_symbol,
+                        issuer_request_id = %request.issuer_request_id.0,
                         "Failed to deserialize tokenization response"
                     );
                 })?;
@@ -536,12 +538,18 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         params: ListRequestsParams,
     ) -> Result<Vec<TokenizationRequest>, AlpacaTokenizationError> {
         let body = self.fetch_requests_body(&params).await?;
-        trace!(body = %body, "List requests response body");
+        trace!(
+            body_len = body.len(),
+            "List requests response body received"
+        );
 
         let requests = parse_request_list(&body).inspect_err(|error| {
             error!(
-                body = %body,
+                body_len = body.len(),
                 error = %error,
+                request_type = ?params.request_type,
+                status = ?params.status,
+                underlying_symbol = ?params.underlying_symbol,
                 "Failed to deserialize list requests response"
             );
         })?;
@@ -579,7 +587,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         })
         .inspect_err(|error| {
             error!(
-                body = %body,
+                body_len = body.len(),
                 error = %error,
                 request_id = %id.0,
                 "Failed to scan list requests response for tokenization request"
@@ -656,7 +664,7 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         })
         .inspect_err(|error| {
             error!(
-                body = %body,
+                body_len = body.len(),
                 error = %error,
                 tx_hash = %expected_tx_hash,
                 "Failed to scan list requests response for redemption request"


### PR DESCRIPTION
## Motivation

Closes [RAI-24](https://linear.app/makeitrain/issue/RAI-24/alpaca-tokenization-polling-fails-to-deserialize-list-requests).
Closes #528.

The `alpaca-tokenize` CLI flow could fail after a mint request was accepted by
Alpaca. The failure happened during the follow-up polling step, where we fetched
Alpaca's request history and attempted to deserialize the full response into
typed `TokenizationRequest` values.

In practice, a malformed historical entry could poison the entire response and
cause polling to fail before we ever reached the request we actually cared
about. The original "response too large" diagnosis appears to have been
incomplete; the more actionable failure mode is that unrelated bad history
entries can break the whole decode.

## Solution

- split request-history fetching into a shared `fetch_requests_body()` helper
  and a query builder for the list endpoint
- change `get_request()` and `find_redemption_by_tx()` to scan the raw JSON list
  and only deserialize the matching entry instead of eagerly decoding the entire
  history
- make `list_requests()` resilient to malformed historical entries by skipping
  invalid rows and logging a warning instead of failing the whole command
- add regression coverage for:
  - polling a target request with malformed unrelated history entries
  - finding a redemption request by tx hash with malformed unrelated history
  - listing requests when one malformed entry is present
- add the missing `Display` impl for `TokenizationRequestStatus` needed by the
  refactored query builder

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gracefully skip malformed tokenization entries when listing or searching, improving robustness.
  * Avoid full deserialization of large lists when locating a single entry; only the matched item is parsed.
  * Use raw response body text for clearer API error messages on non-success responses.

* **Behavior Changes**
  * Standardized tokenization request status text to lowercase (e.g., "pending", "completed", "rejected").
  * Case-insensitive transaction-hash matching for redemption lookups.

* **Tests**
  * Added tests covering malformed-entry handling, uppercase tx_hash matching, and large mixed-history polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->