### PR TITLE
Fix stale view bug

### DIFF
--- a/crates/event-sorcery/src/projection.rs
+++ b/crates/event-sorcery/src/projection.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::EventSourced;
 use crate::dependency::{Cons, Dependent, EntityList, Nil};
@@ -70,6 +70,22 @@ pub enum ProjectionError<Entity: EventSourced> {
         column: Column,
         table: String,
         row_count: i64,
+    },
+    #[error("serde failed for aggregate '{aggregate_id}': {source}")]
+    Serde {
+        aggregate_id: String,
+        source: serde_json::Error,
+    },
+    #[error(
+        "event sequence gap for aggregate '{aggregate_id}': \
+         expected {expected} events after version {view_version}, \
+         found {actual}"
+    )]
+    EventSequenceGap {
+        aggregate_id: String,
+        view_version: i64,
+        expected: i64,
+        actual: usize,
     },
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
@@ -224,6 +240,137 @@ impl<Entity: EventSourced<Materialized = Table>> Projection<Entity> {
             sqlx::query_as(&query).bind(value).fetch_all(pool).await?;
 
         Ok(Self::parse_rows(rows))
+    }
+
+    /// Replays any events the view missed due to a crash between
+    /// event persistence and view update.
+    ///
+    /// For each view row, compares its `version` against the max
+    /// event `sequence` for that aggregate. If behind, fetches the
+    /// missed events and applies them incrementally.
+    ///
+    /// On a normal startup (no crash), this is a cheap version
+    /// comparison query with no replay.
+    pub async fn catch_up(&self) -> Result<(), ProjectionError<Entity>> {
+        let (pool, table) = self.sqlite_backing()?;
+        let aggregate_type = <Lifecycle<Entity> as Aggregate>::aggregate_type();
+
+        // Drive from events table (LEFT JOIN) so we also detect aggregates
+        // with persisted events but no view row (crash before initial view write).
+        // view_version is NULL when the view row is missing.
+        let stale_aggregates: Vec<(String, Option<i64>, i64)> = sqlx::query_as(&format!(
+            "SELECT e.aggregate_id, v.version, e.max_seq \
+             FROM ( \
+                 SELECT aggregate_id, MAX(sequence) as max_seq \
+                 FROM events \
+                 WHERE aggregate_type = ?1 \
+                 GROUP BY aggregate_id \
+             ) e \
+             LEFT JOIN {table} v ON v.view_id = e.aggregate_id \
+             WHERE v.version IS NULL OR e.max_seq > v.version"
+        ))
+        .bind(&aggregate_type)
+        .fetch_all(pool)
+        .await?;
+
+        for (aggregate_id, view_version, max_seq) in &stale_aggregates {
+            let view_version = view_version.unwrap_or(0);
+
+            self.replay_missed_events(
+                pool,
+                table,
+                &aggregate_type,
+                aggregate_id,
+                view_version,
+                *max_seq,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn replay_missed_events(
+        &self,
+        pool: &SqlitePool,
+        table: &str,
+        aggregate_type: &str,
+        view_id: &str,
+        view_version: i64,
+        max_seq: i64,
+    ) -> Result<(), ProjectionError<Entity>> {
+        let behind = max_seq - view_version;
+
+        info!(
+            %view_id, %view_version, %max_seq, %behind, %aggregate_type,
+            "View is behind, replaying missed events"
+        );
+
+        let mut lifecycle = match self.repo.load_with_context(view_id).await? {
+            Some((lifecycle, _context)) => lifecycle,
+            // No view row exists -- start from scratch
+            None => Lifecycle::default(),
+        };
+
+        let missed_payloads: Vec<(String,)> = sqlx::query_as(
+            "SELECT payload FROM events \
+             WHERE aggregate_type = ?1 \
+               AND aggregate_id = ?2 \
+               AND sequence > ?3 \
+             ORDER BY sequence ASC",
+        )
+        .bind(aggregate_type)
+        .bind(view_id)
+        .bind(view_version)
+        .fetch_all(pool)
+        .await?;
+
+        let actual = missed_payloads.len();
+        // behind is always positive (SQL WHERE max_seq > version), safe to compare
+        if !usize::try_from(behind).is_ok_and(|expected| actual == expected) {
+            return Err(ProjectionError::EventSequenceGap {
+                aggregate_id: view_id.to_string(),
+                view_version,
+                expected: behind,
+                actual,
+            });
+        }
+
+        for (payload_json,) in &missed_payloads {
+            let event: Entity::Event = serde_json::from_str(payload_json).map_err(|source| {
+                ProjectionError::<Entity>::Serde {
+                    aggregate_id: view_id.to_string(),
+                    source,
+                }
+            })?;
+
+            lifecycle.apply(event);
+        }
+
+        let payload = serde_json::to_string(&lifecycle).map_err(|source| ProjectionError::<
+            Entity,
+        >::Serde {
+            aggregate_id: view_id.to_string(),
+            source,
+        })?;
+
+        // Write directly with version = max_seq, bypassing the view repo's
+        // optimistic lock (which expects version + 1 increments). This is
+        // safe because catch_up runs once at startup before the main loop.
+        sqlx::query(&format!(
+            "INSERT INTO {table} (view_id, version, payload) \
+             VALUES (?1, ?2, ?3) \
+             ON CONFLICT(view_id) DO UPDATE SET version = ?2, payload = ?3"
+        ))
+        .bind(view_id)
+        .bind(max_seq)
+        .bind(&payload)
+        .execute(pool)
+        .await?;
+
+        info!(%view_id, %behind, "View caught up successfully");
+
+        Ok(())
     }
 
     fn sqlite_backing(&self) -> Result<(&SqlitePool, &str), ProjectionError<Entity>> {
@@ -577,5 +724,309 @@ mod tests {
             ProjectionError::Lifecycle(boxed)
                 if matches!(*boxed, LifecycleError::EventCantOriginate { .. })
         ));
+    }
+
+    // -- catch_up tests --
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct Counter {
+        value: i64,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    enum CounterEvent {
+        Created { initial: i64 },
+        Incremented,
+    }
+
+    impl DomainEvent for CounterEvent {
+        fn event_type(&self) -> String {
+            match self {
+                Self::Created { .. } => "CounterEvent::Created".to_string(),
+                Self::Incremented => "CounterEvent::Incremented".to_string(),
+            }
+        }
+
+        fn event_version(&self) -> String {
+            "1.0".to_string()
+        }
+    }
+
+    #[async_trait]
+    impl EventSourced for Counter {
+        type Id = String;
+        type Event = CounterEvent;
+        type Command = ();
+        type Error = Never;
+        type Services = ();
+        type Materialized = Table;
+
+        const AGGREGATE_TYPE: &'static str = "Counter";
+        const PROJECTION: Table = Table("counter_view");
+        const SCHEMA_VERSION: u64 = 1;
+
+        fn originate(event: &CounterEvent) -> Option<Self> {
+            match event {
+                CounterEvent::Created { initial } => Some(Self { value: *initial }),
+                CounterEvent::Incremented => None,
+            }
+        }
+
+        fn evolve(entity: &Self, event: &CounterEvent) -> Result<Option<Self>, Never> {
+            match event {
+                CounterEvent::Created { .. } => Ok(None),
+                CounterEvent::Incremented => Ok(Some(Self {
+                    value: entity.value + 1,
+                })),
+            }
+        }
+
+        async fn initialize(_command: (), _services: &()) -> Result<Vec<CounterEvent>, Never> {
+            Ok(vec![])
+        }
+
+        async fn transition(
+            &self,
+            _command: (),
+            _services: &(),
+        ) -> Result<Vec<CounterEvent>, Never> {
+            Ok(vec![])
+        }
+    }
+
+    async fn setup_catch_up_db() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+
+        sqlx::query(
+            "CREATE TABLE events ( \
+                 aggregate_type TEXT NOT NULL, \
+                 aggregate_id TEXT NOT NULL, \
+                 sequence BIGINT NOT NULL, \
+                 event_type TEXT NOT NULL, \
+                 event_version TEXT NOT NULL, \
+                 payload TEXT NOT NULL, \
+                 metadata TEXT NOT NULL, \
+                 PRIMARY KEY (aggregate_type, aggregate_id, sequence) \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "CREATE TABLE counter_view ( \
+                 view_id TEXT NOT NULL PRIMARY KEY, \
+                 version BIGINT NOT NULL, \
+                 payload TEXT NOT NULL \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Also need schema_registry for Projection::sqlite
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS schema_registry ( \
+                 aggregate_type TEXT NOT NULL PRIMARY KEY, \
+                 version BIGINT NOT NULL \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        pool
+    }
+
+    async fn insert_event(
+        pool: &SqlitePool,
+        aggregate_id: &str,
+        sequence: i64,
+        event: &CounterEvent,
+    ) {
+        let payload = serde_json::to_string(event).unwrap();
+        let event_type = DomainEvent::event_type(event);
+
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES (?1, ?2, ?3, ?4, '1.0', ?5, '{}')",
+        )
+        .bind("Counter")
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(&event_type)
+        .bind(&payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_stale_view(pool: &SqlitePool, view_id: &str, version: i64, counter: &Counter) {
+        let lifecycle = Lifecycle::Live(counter.clone());
+        let payload = serde_json::to_string(&lifecycle).unwrap();
+
+        sqlx::query("INSERT INTO counter_view (view_id, version, payload) VALUES (?1, ?2, ?3)")
+            .bind(view_id)
+            .bind(version)
+            .bind(&payload)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn catch_up_replays_missed_events() {
+        let pool = setup_catch_up_db().await;
+
+        // Insert 3 events: Created(0), Incremented, Incremented
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+        insert_event(&pool, "counter-1", 2, &CounterEvent::Incremented).await;
+        insert_event(&pool, "counter-1", 3, &CounterEvent::Incremented).await;
+
+        // View is stale at version 1 (only saw Created)
+        insert_stale_view(&pool, "counter-1", 1, &Counter { value: 0 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        projection.catch_up().await.unwrap();
+
+        let result = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(Counter { value: 2 }));
+    }
+
+    #[tokio::test]
+    async fn catch_up_skips_up_to_date_views() {
+        let pool = setup_catch_up_db().await;
+
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 5 }).await;
+
+        // View is up to date at version 1
+        insert_stale_view(&pool, "counter-1", 1, &Counter { value: 5 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        projection.catch_up().await.unwrap();
+
+        let result = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(Counter { value: 5 }));
+    }
+
+    #[tokio::test]
+    async fn catch_up_with_no_events_is_noop() {
+        let pool = setup_catch_up_db().await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        projection.catch_up().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn catch_up_is_idempotent() {
+        let pool = setup_catch_up_db().await;
+
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+        insert_event(&pool, "counter-1", 2, &CounterEvent::Incremented).await;
+        insert_event(&pool, "counter-1", 3, &CounterEvent::Incremented).await;
+
+        insert_stale_view(&pool, "counter-1", 1, &Counter { value: 0 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool.clone());
+
+        projection.catch_up().await.unwrap();
+        projection.catch_up().await.unwrap();
+
+        let result = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(Counter { value: 2 }));
+
+        // Verify version is correct (should be 3, matching max event sequence)
+        let (version,): (i64,) =
+            sqlx::query_as("SELECT version FROM counter_view WHERE view_id = 'counter-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        assert_eq!(version, 3);
+    }
+
+    #[tokio::test]
+    async fn catch_up_rebuilds_missing_view_row() {
+        let pool = setup_catch_up_db().await;
+
+        // Events exist but no view row (crash before initial view write)
+        insert_event(
+            &pool,
+            "counter-1",
+            1,
+            &CounterEvent::Created { initial: 10 },
+        )
+        .await;
+        insert_event(&pool, "counter-1", 2, &CounterEvent::Incremented).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        projection.catch_up().await.unwrap();
+
+        let result = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(Counter { value: 11 }));
+    }
+
+    #[tokio::test]
+    async fn catch_up_detects_sequence_gap() {
+        let pool = setup_catch_up_db().await;
+
+        // Insert events with a gap: seq 1 and seq 3 (missing seq 2)
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+        insert_event(&pool, "counter-1", 3, &CounterEvent::Incremented).await;
+
+        // View at version 1 expects 2 missed events (3 - 1), but only 1 exists
+        insert_stale_view(&pool, "counter-1", 1, &Counter { value: 0 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        let error = projection.catch_up().await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                ProjectionError::EventSequenceGap {
+                    expected: 2,
+                    actual: 1,
+                    ..
+                }
+            ),
+            "expected EventSequenceGap, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn catch_up_fails_on_malformed_payload() {
+        let pool = setup_catch_up_db().await;
+
+        // Insert a valid first event, then a malformed payload at seq 2
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES (?1, ?2, ?3, ?4, '1.0', ?5, '{}')",
+        )
+        .bind("Counter")
+        .bind("counter-1")
+        .bind(2_i64)
+        .bind("CounterEvent::Incremented")
+        .bind("not valid json {{{")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        insert_stale_view(&pool, "counter-1", 1, &Counter { value: 0 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        let error = projection.catch_up().await.unwrap_err();
+        assert!(
+            matches!(error, ProjectionError::Serde { .. }),
+            "expected Serde error, got: {error:?}"
+        );
     }
 }

--- a/crates/event-sorcery/src/schema_registry.rs
+++ b/crates/event-sorcery/src/schema_registry.rs
@@ -15,6 +15,7 @@
 
 use async_trait::async_trait;
 use cqrs_es::AggregateError;
+use cqrs_es::persist::PersistenceError;
 use serde::{Deserialize, Serialize};
 use sqlite_es::SqliteCqrs;
 use sqlx::SqlitePool;
@@ -206,6 +207,8 @@ pub enum ReconcileError {
     Json(#[from] serde_json::Error),
     #[error(transparent)]
     Aggregate(#[from] AggregateError<LifecycleError<SchemaRegistry>>),
+    #[error(transparent)]
+    Persistence(#[from] PersistenceError),
 }
 
 impl From<Never> for ReconcileError {

--- a/crates/event-sorcery/src/wire.rs
+++ b/crates/event-sorcery/src/wire.rs
@@ -36,12 +36,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use cqrs_es::Query;
+use cqrs_es::persist::PersistenceError;
 use sqlx::SqlitePool;
 
 use crate::Nil;
 use crate::dependency::HasEntity;
 use crate::lifecycle::{Lifecycle, ReactorBridge};
-use crate::projection::{Projection, Table};
+use crate::projection::{Projection, ProjectionError, Table};
 use crate::reactor::Reactor;
 use crate::schema_registry::{ReconcileError, Reconciler};
 use crate::{EventSourced, Store};
@@ -109,6 +110,19 @@ where
             .await?;
 
         let projection = Arc::new(Projection::sqlite(self.pool.clone()));
+
+        // Replay any events the view missed due to a crash between
+        // event persistence and view update. Runs before registering
+        // the projection as a reactor so no concurrent writes can
+        // interfere.
+        projection.catch_up().await.map_err(|error| match error {
+            ProjectionError::Sqlx(sqlx_error) => ReconcileError::from(sqlx_error),
+            ProjectionError::Persistence(persistence_error) => {
+                ReconcileError::from(persistence_error)
+            }
+            other => ReconcileError::Persistence(PersistenceError::UnknownError(Box::new(other))),
+        })?;
+
         self.queries.push(Box::new(ReactorBridge {
             reactor: projection.clone(),
         }));

--- a/src/conductor/mod.rs
+++ b/src/conductor/mod.rs
@@ -53,7 +53,7 @@ use crate::queue::{
 use crate::rebalancing::equity::EquityTransferServices;
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingCtx, RebalancingTrigger,
-    RebalancingTriggerConfig,
+    RebalancingTriggerConfig, TriggeredOperation,
 };
 use crate::symbol::cache::SymbolCache;
 use crate::symbol::lock::get_symbol_lock;
@@ -224,7 +224,7 @@ impl Conductor {
             ) = if let Some(rebalancing_ctx) = rebalancing {
                 let ethereum_wallet = rebalancing_ctx.ethereum_wallet().clone();
                 let base_wallet = rebalancing_ctx.base_wallet().clone();
-                let infra = spawn_rebalancing_infrastructure(
+                let components = build_rebalancing_infrastructure(
                     rebalancing_ctx,
                     ethereum_wallet.clone(),
                     base_wallet.clone(),
@@ -239,17 +239,20 @@ impl Conductor {
                 )
                 .await?;
 
+                let rebalancer = components.spawner.spawn();
+
                 (
-                    infra.position,
-                    infra.position_projection,
-                    infra.snapshot,
-                    Some(infra.rebalancer),
+                    components.position,
+                    components.position_projection,
+                    components.snapshot,
+                    Some(rebalancer),
                     Some(ethereum_wallet),
                     Some(base_wallet),
-                    Some(infra.alpaca_wallet),
+                    Some(components.alpaca_wallet),
                 )
             } else {
                 let (position, position_projection) = build_position_cqrs(&pool).await?;
+
                 let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
                     .build(())
                     .await?;
@@ -372,12 +375,36 @@ impl Conductor {
     }
 }
 
-struct RebalancingInfrastructure {
+/// Built rebalancing components, ready for spawning.
+/// Catch-up has already been performed by `StoreBuilder::build()`.
+/// No background tasks are running yet.
+struct RebalancingComponents<Chain: Wallet> {
     position: Arc<Store<Position>>,
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
-    rebalancer: JoinHandle<()>,
     alpaca_wallet: Arc<AlpacaWalletService>,
+    spawner: RebalancerSpawner<Chain>,
+}
+
+/// Deferred spawner for the rebalancer task.
+/// Call [`spawn`](Self::spawn) to start the background task.
+struct RebalancerSpawner<Chain: Wallet> {
+    services: RebalancerServices<Chain>,
+    usdc_vault_id: RaindexVaultId,
+    market_maker_wallet: Address,
+    operation_receiver: mpsc::Receiver<TriggeredOperation>,
+    frameworks: RebalancingCqrsFrameworks,
+}
+
+impl<Chain: Wallet + Clone> RebalancerSpawner<Chain> {
+    fn spawn(self) -> JoinHandle<()> {
+        self.services.spawn(
+            self.usdc_vault_id,
+            self.market_maker_wallet,
+            self.operation_receiver,
+            self.frameworks,
+        )
+    }
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -455,13 +482,13 @@ async fn seed_vault_registry_from_config(
     Ok(())
 }
 
-fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
+fn build_rebalancing_infrastructure<Chain: Wallet + Clone>(
     rebalancing_ctx: RebalancingCtx,
     ethereum_wallet: Chain,
     base_wallet: Chain,
     deps: RebalancingDeps,
 ) -> std::pin::Pin<
-    Box<dyn std::future::Future<Output = anyhow::Result<RebalancingInfrastructure>> + Send>,
+    Box<dyn std::future::Future<Output = anyhow::Result<RebalancingComponents<Chain>>> + Send>,
 > {
     Box::pin(async move {
         info!("Initializing rebalancing infrastructure");
@@ -565,19 +592,18 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .and_then(|cash| cash.vault_id)
             .ok_or(CtxError::MissingCashVaultId)?;
 
-        let handle = services.spawn(
-            RaindexVaultId(usdc_vault_id),
-            market_maker_wallet,
-            operation_receiver,
-            frameworks,
-        );
-
-        Ok(RebalancingInfrastructure {
+        Ok(RebalancingComponents {
             position: built.position,
             position_projection: built.position_projection,
             snapshot: built.snapshot,
-            rebalancer: handle,
             alpaca_wallet,
+            spawner: RebalancerSpawner {
+                services,
+                usdc_vault_id: RaindexVaultId(usdc_vault_id),
+                market_maker_wallet,
+                operation_receiver,
+                frameworks,
+            },
         })
     })
 }


### PR DESCRIPTION
## Summary

- **Fix stale CQRS view bug**: Add `catch_up()` to `Projection` that detects views whose `version` is behind the max event `sequence` and replays missed events incrementally. This fixes a production issue where the `position_view` had a stale `pending_offchain_order_id` after a server restart, blocking all hedging since Mar 27.
- **Automatic catch-up**: `StoreBuilder::build()` calls `catch_up()` before registering the projection as a reactor, so every projected entity gets catch-up for free — no manual wiring needed.
- **Refactor rebalancing startup**: Split `spawn_rebalancing_infrastructure` into build + spawn phases so all view catch-ups complete before any background tasks start.

## Root Cause

The `cqrs-es` framework persists events and dispatches view updates non-atomically. A crash between event persistence and view update left `OffChainOrderFilled` (seq 20) persisted but the view not updated. This caused `is_ready_for_execution()` to silently return `None` for all subsequent trades.

## Changes

**`crates/event-sorcery/src/projection.rs`**
- `catch_up()` — queries for stale views via LEFT JOIN from events table (also detects missing view rows where events exist but no view was ever written)
- `replay_missed_events()` — loads view, fetches missed event payloads, applies via `Lifecycle::apply()`, writes corrected version via UPSERT
- `Serde` variant added to `ProjectionError`
- 5 tests: replays missed events, skips up-to-date, empty noop, idempotent, rebuilds missing view row

**`crates/event-sorcery/src/wire.rs`**
- `StoreBuilder::build()` calls `projection.catch_up()` automatically before registering the reactor — every projected entity gets catch-up without manual calls

**`crates/event-sorcery/src/schema_registry.rs`**
- `Persistence` variant added to `ReconcileError` to propagate catch-up errors

**`src/conductor/mod.rs`**
- `build_rebalancing_infrastructure` (was `spawn_rebalancing_infrastructure`) — returns `RebalancingComponents` without spawning background tasks
- `RebalancerSpawner` — deferred spawner, called after all projections are caught up
- No manual `catch_up()` calls — handled automatically by `StoreBuilder::build()`

## Test plan

- [x] `cargo nextest run -p st0x-event-sorcery` — 54 tests pass
- [x] `cargo nextest run --workspace --all-features` — 1659 tests pass
- [x] `cargo clippy --workspace --all-targets --all-features` — clean
- [ ] Deploy to production, verify hedging resumes on next market open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projection catch-up: detect and replay missing events to synchronize stale or absent materialized views before registration.

* **Improvements**
  * Surface serialization failures and event-sequence gaps with clearer error variants.
  * Reconciliation now surfaces persistence-layer failures more directly.
  * Projections are registered only after a successful catch-up pass.
  * Deferred background rebalancer startup for safer ordering.

* **Tests**
  * Added tests for catch-up behavior, idempotency, rebuilds, gap detection, and malformed payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->