### PR TITLE
Merge to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,7 +155,7 @@ jobs:
         run: nix develop -c pre-commit run --all-files
 
   deploy:
-    if: github.ref == 'refs/heads/prod'
+    if: github.ref == 'refs/heads/master'
     needs: [backend, dashboard, hooks]
     concurrency:
       group: deploy


### PR DESCRIPTION
## Motivation

The deploy workflow in CI was configured to trigger on pushes to the `prod` branch, but the team is consolidating to use `master` as the primary deployment branch. This change ensures auto-deployments fire when changes land on `master`, aligning CI with the current branching strategy.

## Solution

Update the deploy job's `if` condition in `.github/workflows/ci.yaml` from `refs/heads/prod` to `refs/heads/master`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow trigger to run from a different repository branch, changing when automated deployments are initiated so releases are deployed based on the updated branch workflow and release cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->