### PR TITLE
feat: add prod ops commands and deploy access

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,23 @@
-<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->
+## What
 
-## Motivation
+<!-- Link relevant issues first, then describe what this PR does. -->
 
-<!--
-Explain the context and why you're making that change. What is the problem
-you're trying to solve? In some cases there is not a problem and this can be
-thought of as being the motivation for your change.
--->
+## Why
 
-## Solution
+<!-- Why is this change needed? -->
 
-<!--
-Summarize the solution and provide any necessary context needed to understand
-the code change.
--->
+## How
 
-## Checks
+<!-- How does it work? Summarize the approach and any key design decisions. -->
 
-<!-- It's important you've done these, or your PR will not be considered for review -->
+## Testing
 
-By submitting this for review, I'm confirming I've done the following:
+<!-- How was this tested? What test coverage was added? -->
 
-- [ ] added comprehensive test coverage for any changes in logic
-- [ ] made this PR as small as possible
-- [ ] linked any relevant issues or PRs
-- [ ] included screenshots (if this involves a change to the dashboard)
+## Screenshots
+
+<!-- If applicable, add screenshots or recordings. -->
+
+## Anything else
+
+<!-- Any additional context, trade-offs, or follow-up work. -->

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -1,0 +1,49 @@
+name: Rekey Terraform Secrets
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tf-rekey:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Rekey terraform secrets
+        run: nix develop -c tf-rekey
+
+      - name: Commit and push rekeyed secrets
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add infra/*.age
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: rekey terraform secrets"
+            git push
+          fi
+
+      - name: Cleanup SSH
+        if: always()
+        run: rm -rf ~/.ssh/id_ed25519

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ out/
 cache/
 .tmp/
 .bacon-locations
+claude-local-ctx/

--- a/and
+++ b/and
@@ -1,0 +1,4 @@
+Error: No matching keys found
+
+[ Did rage not do what you expected? Could an error be more useful? ]
+[ Tell us: https://str4d.xyz/rage/report                            ]

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,61 @@
             '';
           };
 
+          prodStatus = pkgs.writeShellApplication {
+            name = "prod-status";
+            runtimeInputs = infraPkgs.sshBuildInputs
+              ++ [ pkgs.openssh pkgs.curl pkgs.jq ];
+            text = ''
+              ${infraPkgs.resolveHost}
+              export identity host_ip
+              exec bash scripts/prod-status.sh "$@"
+            '';
+          };
+
+          botStart = pkgs.writeShellApplication {
+            name = "bot-start";
+            runtimeInputs = infraPkgs.sshBuildInputs ++ [ pkgs.openssh ];
+            text = ''
+              ${infraPkgs.resolveHost}
+              echo "Starting st0x-hedge on prod..."
+              ssh -i "$identity" "root@$host_ip" "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl start st0x-hedge"
+              ssh -i "$identity" "root@$host_ip" systemctl is-active st0x-hedge
+            '';
+          };
+
+          botStop = pkgs.writeShellApplication {
+            name = "bot-stop";
+            runtimeInputs = infraPkgs.sshBuildInputs ++ [ pkgs.openssh ];
+            text = ''
+              ${infraPkgs.resolveHost}
+              echo "Stopping st0x-hedge on prod..."
+              ssh -i "$identity" "root@$host_ip" "systemctl stop st0x-hedge && rm -f /run/st0x/st0x-hedge.ready"
+              echo "Stopped."
+            '';
+          };
+
+          botRestart = pkgs.writeShellApplication {
+            name = "bot-restart";
+            runtimeInputs = infraPkgs.sshBuildInputs ++ [ pkgs.openssh ];
+            text = ''
+              ${infraPkgs.resolveHost}
+              echo "Restarting st0x-hedge on prod..."
+              ssh -i "$identity" "root@$host_ip" "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl restart st0x-hedge"
+              ssh -i "$identity" "root@$host_ip" systemctl is-active st0x-hedge
+            '';
+          };
+
+          prodDashboard = pkgs.writeShellApplication {
+            name = "prod-dashboard";
+            runtimeInputs = infraPkgs.sshBuildInputs
+              ++ [ pkgs.openssh pkgs.bun ];
+            text = ''
+              ${infraPkgs.resolveHost}
+              export identity host_ip
+              exec bash scripts/prod-dashboard.sh "$@"
+            '';
+          };
+
         };
 
         formatter = pkgs.nixfmt-classic;
@@ -221,6 +276,11 @@
               packages.deployNixos
               packages.deployService
               packages.deployAll
+              packages.prodStatus
+              packages.prodDashboard
+              packages.botStart
+              packages.botStop
+              packages.botRestart
             ] ++ rainix.devShells.${system}.default.buildInputs;
         };
       });

--- a/keys.nix
+++ b/keys.nix
@@ -30,7 +30,7 @@ rec {
     # this is for both accessing terraform secrets and encrypted state
     # but the only reason you need one without the other is because ssh
     # requires decoding terraform state just to get the host ip address
-    infra = [ st0x-op ci ];
+    infra = [ st0x-op ci juan ];
 
     # this role was meant to be for the ability to ssh into the machine
     # but in the future we should restrict what that exactly means in

--- a/scripts/prod-dashboard.sh
+++ b/scripts/prod-dashboard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Opens an SSH tunnel to prod and starts the dashboard dev server.
+# Called by the nix `prod-dashboard` wrapper which sets $identity and $host_ip.
+# shellcheck disable=SC2154  # identity and host_ip are exported by the nix wrapper
+
+set -euo pipefail
+
+local_port="${1:-8001}"
+ctl_socket="/tmp/prod-dashboard-ssh-$$"
+
+cleanup() {
+  echo ""
+  echo "Closing SSH tunnel..."
+  ssh -i "$identity" -S "$ctl_socket" -O exit "root@$host_ip" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Opening SSH tunnel: localhost:$local_port -> prod:8001"
+ssh -i "$identity" -f -N -M -S "$ctl_socket" \
+  -L "$local_port:localhost:8001" "root@$host_ip"
+
+echo "Starting dashboard at http://localhost:5173"
+echo "WebSocket proxied to ws://localhost:$local_port/api/ws"
+echo ""
+
+cd dashboard
+bun install --frozen-lockfile
+PUBLIC_ALPACA_WS_URL="ws://localhost:$local_port/api/ws" bun run dev

--- a/scripts/prod-status.sh
+++ b/scripts/prod-status.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Prod status dump: fetches bot status, Raindex orders, DB, and logs.
+# Called by the nix `prod-status` wrapper which sets $identity and $host_ip.
+# shellcheck disable=SC2154  # identity and host_ip are exported by the nix wrapper
+
+set -euo pipefail
+
+# --- Colors ---
+BOLD='\033[1m'
+DIM='\033[2m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+WHITE='\033[1;37m'
+RESET='\033[0m'
+
+# Format ISO timestamps like "2026-03-30T18:16:50.908685705Z" or
+# "2026-03-27T19:24:39+00:00" into "Mar 30, 2026 18:16 UTC"
+fmt_ts() {
+  local ts="$1"
+  ts=$(echo "$ts" | sed -E 's/\.[0-9]+(Z|[+-])/\1/')
+  if date -d "$ts" '+%b %d, %Y %H:%M UTC' 2>/dev/null; then
+    return
+  fi
+  local cleaned
+  cleaned=$(echo "$ts" | sed -E 's/Z$/+0000/; s/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+  date -j -f '%Y-%m-%dT%H:%M:%S%z' "$cleaned" '+%b %d, %Y %H:%M UTC' 2>/dev/null || echo "$1"
+}
+
+# Truncate a decimal string to 2 places
+trunc2() {
+  local val="$1"
+  if [[ "$val" == *"."* ]]; then
+    # integer part + first 2 decimal digits
+    echo "$val" | sed -E 's/(\.[0-9]{2})[0-9]*/\1/'
+  else
+    echo "$val"
+  fi
+}
+
+ssh_cmd="ssh -i $identity root@$host_ip"
+db="/mnt/data/st0x-hedge.db"
+subgraph="https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn"
+order_owner="0x386c24644e532387b03c1992ca83542492a3ac32"
+
+# Check service status
+if $ssh_cmd systemctl is-active --quiet st0x-hedge; then
+  status="running"
+  status_color="$GREEN"
+  status_icon="●"
+else
+  status="stopped"
+  status_color="$RED"
+  status_icon="○"
+fi
+
+timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+out_dir="./claude-local-ctx/${timestamp}-${status}"
+mkdir -p "$out_dir"
+
+echo ""
+echo -e "${BOLD}${WHITE}══════════════════════════════════════${RESET}"
+echo -e "  ${status_color}${status_icon} Bot is ${BOLD}${status}${RESET}"
+echo -e "${BOLD}${WHITE}══════════════════════════════════════${RESET}"
+
+# Last boot time
+echo ""
+echo -e "${BOLD}${CYAN}▸ Last Started${RESET}"
+boot_line=$($ssh_cmd "journalctl -u st0x-hedge --no-pager -o short-iso \
+  | grep -E '(Started st0x|Initializing.*executor)' \
+  | tail -1" 2>/dev/null || echo "")
+if [ -n "$boot_line" ]; then
+  boot_ts=$(echo "$boot_line" | grep -oE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[^ ]*')
+  if [ -n "$boot_ts" ]; then
+    echo -e "  $(fmt_ts "$boot_ts")"
+  else
+    echo -e "  ${DIM}(could not determine)${RESET}"
+  fi
+else
+  echo -e "  ${DIM}(could not determine)${RESET}"
+fi
+
+# Raindex open orders for this owner
+echo ""
+echo -e "${BOLD}${CYAN}▸ Raindex Open Orders${RESET}"
+orders_json=$(curl -s -X POST "$subgraph" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\": \"{ orders(where: { owner: \\\"$order_owner\\\", active: true }, orderBy: timestampAdded, orderDirection: desc) { orderHash active timestampAdded inputs { token { symbol decimals } balance vaultId } outputs { token { symbol decimals } balance vaultId } trades(first: 5, orderBy: timestamp, orderDirection: desc) { timestamp inputVaultBalanceChange { amount vault { token { symbol decimals } } } outputVaultBalanceChange { amount vault { token { symbol decimals } } } } } }\"}")
+
+echo "$orders_json" | jq '.' > "$out_dir/raindex-orders.json"
+
+# Extract unique Rain Float hex values from balance/amount fields
+hex_values=$(echo "$orders_json" | jq -r '
+  [.data.orders[]
+    | .inputs[].balance, .outputs[].balance,
+      .trades[]?.inputVaultBalanceChange.amount,
+      .trades[]?.outputVaultBalanceChange.amount
+  ] | unique | .[]
+')
+
+# Batch decode all hex values in a single invocation
+dec_values=$(echo "$hex_values" | cargo run --quiet --bin decode-floats)
+
+# Replace hex values in the JSON with decoded decimals
+patched_json="$orders_json"
+while IFS= read -r hex && IFS= read -r dec <&3; do
+  patched_json="${patched_json//\"$hex\"/\"$dec\"}"
+done <<< "$hex_values" 3<<< "$dec_values"
+
+echo "$patched_json" | jq '.' > "$out_dir/raindex-orders-decoded.json"
+
+num_orders=$(echo "$patched_json" | jq '.data.orders | length')
+echo -e "  Active orders: ${WHITE}${num_orders}${RESET}"
+echo ""
+
+echo "$patched_json" | jq -r '
+  def trunc2:
+    tostring | capture("^(?<i>[^.]*)\\.(?<d>..)") // {i: tostring, d: ""} |
+    if .d == "" then .i else "\(.i).\(.d)" end;
+
+  .data.orders[] |
+  "  \u001b[1;37m\(.orderHash[0:18])...\u001b[0m" +
+  "  \u001b[2mAdded \(.timestampAdded | tonumber | strftime("%b %d, %Y %H:%M UTC"))\u001b[0m" +
+  "\n    \u001b[2m├\u001b[0m In:   " +
+  (.inputs | map("\(.token.symbol) \(.balance | trunc2)") | join(", ")) +
+  "\n    \u001b[2m├\u001b[0m Out:  " +
+  (.outputs | map("\(.token.symbol) \(.balance | trunc2)") | join(", ")) +
+  "\n    \u001b[2m└\u001b[0m Trades: \(.trades | length) recent" +
+  "\n"
+'
+
+# Fetch full trade history for each order from subgraph
+echo -e "${BOLD}${CYAN}▸ Fetching Full Trade History${RESET}"
+order_hashes=$(echo "$orders_json" | jq -r '.data.orders[].orderHash')
+
+all_trade_hexes=""
+for order_hash in $order_hashes; do
+  short_hash="${order_hash:0:18}"
+  echo -e "  ${DIM}Fetching trades for ${short_hash}...${RESET}"
+  page=0
+  page_size=100
+  trades_file="$out_dir/trades_$short_hash.json"
+  echo '[]' > "$trades_file"
+
+  while true; do
+    skip=$((page * page_size))
+    page_json=$(curl -s -X POST "$subgraph" \
+      -H "Content-Type: application/json" \
+      -d "{\"query\": \"{ trades(first: $page_size, skip: $skip, orderBy: timestamp, orderDirection: desc, where: { order_: { orderHash: \\\"$order_hash\\\" } }) { timestamp inputVaultBalanceChange { amount vault { token { symbol } } } outputVaultBalanceChange { amount vault { token { symbol } } } tradeEvent { transaction { id blockNumber } } } }\"}")
+
+    count=$(echo "$page_json" | jq '.data.trades | length')
+    if [ "$count" -eq 0 ]; then
+      break
+    fi
+
+    # Append page to trades file
+    merged=$(jq -s '.[0] + .[1]' "$trades_file" <(echo "$page_json" | jq '.data.trades'))
+    echo "$merged" > "$trades_file"
+
+    if [ "$count" -lt "$page_size" ]; then
+      break
+    fi
+    page=$((page + 1))
+  done
+
+  total=$(jq 'length' "$trades_file")
+  echo -e "  ${DIM}Found ${total} trades${RESET}"
+
+  # Collect hex values for batch decoding
+  file_hexes=$(jq -r '.[].inputVaultBalanceChange.amount, .[].outputVaultBalanceChange.amount' "$trades_file")
+  all_trade_hexes="$all_trade_hexes"$'\n'"$file_hexes"
+done
+
+# Batch decode all trade hex values
+unique_hexes=$(echo "$all_trade_hexes" | sort -u | grep -v '^$')
+if [ -n "$unique_hexes" ]; then
+  decoded_hexes=$(echo "$unique_hexes" | cargo run --quiet --bin decode-floats)
+
+  # Build CSV for each order's trades
+  for order_hash in $order_hashes; do
+    short_hash="${order_hash:0:18}"
+    trades_file="$out_dir/trades_$short_hash.json"
+    csv_file="$out_dir/trades_$short_hash.csv"
+
+    # Replace hex amounts with decoded values in the JSON
+    patched_trades=$(cat "$trades_file")
+    while IFS= read -r hex && IFS= read -r dec <&3; do
+      patched_trades="${patched_trades//\"$hex\"/\"$dec\"}"
+    done <<< "$unique_hexes" 3<<< "$decoded_hexes"
+
+    # Write decoded JSON
+    echo "$patched_trades" | jq '.' > "$trades_file"
+
+    # Write CSV
+    echo "timestamp,datetime,block_number,tx_hash,input_symbol,input_amount,output_symbol,output_amount" > "$csv_file"
+    echo "$patched_trades" | jq -r '.[] |
+      [
+        .timestamp,
+        (.timestamp | tonumber | strftime("%Y-%m-%d %H:%M:%S")),
+        .tradeEvent.transaction.blockNumber,
+        .tradeEvent.transaction.id,
+        .inputVaultBalanceChange.vault.token.symbol,
+        .inputVaultBalanceChange.amount,
+        .outputVaultBalanceChange.vault.token.symbol,
+        .outputVaultBalanceChange.amount
+      ] | @csv
+    ' >> "$csv_file"
+
+    echo -e "  ${DIM}Wrote ${csv_file}${RESET}"
+  done
+fi
+echo ""
+
+# RKLB position (from events, views are empty when bot is stopped)
+echo -e "${BOLD}${CYAN}▸ RKLB Position${RESET}"
+pos_data=$($ssh_cmd "sqlite3 -json $db \"SELECT symbol, net_position, last_updated FROM position_view WHERE symbol LIKE '%RKLB%';\"" 2>/dev/null || echo "[]")
+echo "$pos_data" | jq -r '
+  .[] |
+  "  \(.symbol)  net: \(.net_position | tostring | capture("^(?<i>[^.]*)\\.(?<d>..)") // {i: (.net_position | tostring), d: ""} | if .d == "" then .i else "\(.i).\(.d)" end)"
+' 2>/dev/null || echo -e "  ${DIM}(no position data)${RESET}"
+
+# Inventory balance (latest snapshots from events table)
+echo ""
+echo -e "${BOLD}${CYAN}▸ Inventory Balance${RESET}"
+echo -e "  ${YELLOW}Onchain:${RESET}"
+
+onchain_equity_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainEquity.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainEquity' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+onchain_equity_val=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainEquity.balances.RKLB') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainEquity' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$onchain_equity_val" ]; then
+  echo -e "    Equity: ${WHITE}$(trunc2 "$onchain_equity_val") RKLB${RESET}  ${DIM}($(fmt_ts "$onchain_equity_ts"))${RESET}"
+fi
+
+onchain_cash_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainCash.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+onchain_cash_val=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainCash.usdc_balance') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$onchain_cash_val" ]; then
+  echo -e "    Cash:   ${WHITE}$(trunc2 "$onchain_cash_val") USDC${RESET}  ${DIM}($(fmt_ts "$onchain_cash_ts"))${RESET}"
+fi
+
+echo -e "  ${YELLOW}Offchain:${RESET}"
+
+offchain_equity_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OffchainEquity.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainEquity' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+offchain_equity_val=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OffchainEquity.positions.RKLB') FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainEquity' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$offchain_equity_val" ]; then
+  echo -e "    Equity: ${WHITE}$(trunc2 "$offchain_equity_val") RKLB${RESET}  ${DIM}($(fmt_ts "$offchain_equity_ts"))${RESET}"
+fi
+
+offchain_cash_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OffchainCash.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+offchain_cash_val=$($ssh_cmd "sqlite3 $db \"SELECT printf('%.2f', json_extract(payload, '\\\$.OffchainCash.cash_balance_cents') / 100.0) FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$offchain_cash_val" ]; then
+  echo -e "    Cash:   ${WHITE}\$${offchain_cash_val}${RESET}  ${DIM}($(fmt_ts "$offchain_cash_ts"))${RESET}"
+fi
+
+# Recent onchain trades (from events table -- views are rebuilt only at startup)
+echo ""
+echo -e "${BOLD}${CYAN}▸ Recent Onchain Trades${RESET}"
+echo -e "  ${DIM}TIME              SIDE  AMOUNT    PRICE     TOTAL      SYMBOL${RESET}"
+echo -e "  ${DIM}────────────────  ────  ────────  ────────  ─────────  ──────${RESET}"
+$ssh_cmd "sqlite3 -json $db \"SELECT json_extract(payload, '\\\$.Filled.symbol') AS symbol, json_extract(payload, '\\\$.Filled.direction') AS direction, printf('%.2f', json_extract(payload, '\\\$.Filled.amount')) AS amount, printf('%.2f', json_extract(payload, '\\\$.Filled.price_usdc')) AS price, json_extract(payload, '\\\$.Filled.block_timestamp') AS time FROM events WHERE event_type = 'OnChainTradeEvent::Filled' ORDER BY json_extract(payload, '\\\$.Filled.block_timestamp') DESC LIMIT 20;\"" | jq -r '
+  def pad(n): tostring | if length < n then . + (" " * (n - length)) else . end;
+  def fmt_short_date:
+    split("T") | .[0] as $d | .[1] | split(":") | "\(.[0]):\(.[1])" as $t |
+    ($d | split("-")) as $parts |
+    "\($parts[1])/\($parts[2]) \($t)";
+  .[] |
+  (.amount | tonumber) as $amt | (.price | tonumber) as $prc |
+  ($amt * $prc * 100 | round / 100 | tostring) as $total_raw |
+  (if ($total_raw | contains(".")) then
+    ($total_raw | split(".") | "\(.[0]).\(.[1] | .[:2] | if length < 2 then . + "0" else . end)")
+  else
+    ($total_raw + ".00")
+  end) as $total |
+  "  \(.time | fmt_short_date | pad(16))  \(if .direction == "Buy" then "\u001b[32mBUY \u001b[0m" else "\u001b[31mSELL\u001b[0m" end)  \(.amount | pad(8))  $\(.price | pad(8))  $\($total | pad(9))  \(.symbol)"
+'
+
+# Recent offchain orders (formatted)
+echo ""
+echo -e "${BOLD}${CYAN}▸ Recent Offchain Orders${RESET}"
+$ssh_cmd "sqlite3 -json $db 'SELECT view_id, status, payload FROM offchain_order_view ORDER BY view_id DESC LIMIT 20;'" | jq -r '
+  def color_status:
+    if . == "Filled" then "\u001b[32m"
+    elif . == "Failed" then "\u001b[31m"
+    elif . == "Submitted" then "\u001b[33m"
+    elif . == "Pending" then "\u001b[34m"
+    else "\u001b[2m"
+    end;
+
+  def fmt_short_date:
+    split("T") | .[0] as $d | .[1] | split(":") | "\(.[0]):\(.[1])" as $t |
+    ($d | split("-")) as $parts |
+    "\($parts[1])/\($parts[2]) \($t)";
+
+  .[] |
+  .status as $status |
+  (.payload | fromjson) as $p |
+  if $status == "Filled" then
+    $p.Live.Filled |
+    "  \(.filled_at // .placed_at | fmt_short_date)  \($status | color_status)[\($status)]\u001b[0m  \(.direction) \(.shares) \(.symbol) @ \(.price)"
+  elif $status == "Failed" then
+    $p.Live.Failed |
+    "  \(.failed_at // .placed_at | fmt_short_date)  \($status | color_status)[\($status)]\u001b[0m  \(.direction) \(.shares) \(.symbol) \u001b[2m\(.error | split("{")[0])\u001b[0m"
+  elif $status == "Submitted" then
+    $p.Live.Submitted |
+    "  \(.submitted_at // .placed_at | fmt_short_date)  \($status | color_status)[\($status)]\u001b[0m  \(.direction) \(.shares) \(.symbol)"
+  elif $status == "Pending" then
+    $p.Live.Pending |
+    "  \(.placed_at | fmt_short_date)  \($status | color_status)[\($status)]\u001b[0m  \(.direction) \(.shares) \(.symbol)"
+  else
+    "  \($status | color_status)[\($status)]\u001b[0m \(.view_id)"
+  end
+'
+
+# Fetch full logs
+echo ""
+echo -e "${DIM}Saving full data to ${out_dir} ...${RESET}"
+$ssh_cmd "journalctl -u st0x-hedge --no-pager" > "$out_dir/logs.txt"
+
+# Fetch DB dump
+scp -i "$identity" "root@$host_ip:$db" "$out_dir/st0x-hedge.db"
+
+echo ""
+echo -e "${BOLD}${WHITE}══════════════════════════════════════${RESET}"
+echo -e "  ${status_color}${status_icon} Bot is ${BOLD}${status}${RESET}"
+echo -e "${BOLD}${WHITE}──────────────────────────────────────${RESET}"
+echo -e "  ${DIM}Logs:${RESET}   $out_dir/logs.txt"
+echo -e "  ${DIM}DB:${RESET}     $out_dir/st0x-hedge.db"
+echo -e "  ${DIM}Orders:${RESET} $out_dir/raindex-orders-decoded.json"
+echo -e "  ${DIM}Trades:${RESET} $out_dir/trades_*.csv"
+echo -e "${BOLD}${WHITE}══════════════════════════════════════${RESET}"

--- a/services.nix
+++ b/services.nix
@@ -9,6 +9,6 @@ let
     markerFile = "/run/st0x/${name}.ready";
   };
 in builtins.mapAttrs (name: attrs: attrs // paths name) {
-  st0x-hedge.enabled = false;
+  st0x-hedge.enabled = true;
   st0x-hedge.bin = "server";
 }

--- a/src/bin/decode-floats.rs
+++ b/src/bin/decode-floats.rs
@@ -1,0 +1,38 @@
+//! Decodes Rain Float hex values from stdin to human-readable decimals.
+//!
+//! Reads one hex string per line from stdin and writes the decoded
+//! decimal value to stdout. Non-hex lines are passed through unchanged.
+//!
+//! Used by `prod-status` to decode Raindex subgraph vault balances.
+
+use std::io::{BufRead, Write};
+
+use rain_math_float::Float;
+use st0x_float_serde::format_float_with_fallback;
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(error) => {
+                eprintln!("read error: {error}");
+                std::process::exit(1);
+            }
+        };
+
+        let trimmed = line.trim();
+
+        let decoded = match Float::from_hex(trimmed) {
+            Ok(float) => format_float_with_fallback(&float),
+            Err(_) => line,
+        };
+
+        if writeln!(out, "{decoded}").is_err() {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## What

Closes [RAI-152](https://linear.app/makeitrain/issue/RAI-152/create-simple-way-to-get-prod-bot-status)

- Add nix devShell commands for prod operations (`prod-status`, `bot-start`, `bot-stop`, `bot-restart`, `prod-dashboard`)
- Enable the bot's systemd service (`services.nix`)
- Grant deploy access to Juan (`keys.nix`)
- Add CI workflow for rekeying terraform secrets (`.github/workflows/rekey.yaml`)
- Add `decode-floats` Rust binary for decoding Rain Float hex values
- Update PR template to What/Why/How/Testing/Screenshots/Anything else

## Why

- No quick way to check prod bot status, grab logs, or get a DB dump for debugging — requires manual SSH each time
- Only CI could deploy — no dev had local deploy access because the `infra` role didn't include any dev keys
- No way to rekey secrets without the `st0x-op` key — this is needed to grant new roles

## How

**Prod ops commands** (nix devShell):
- `prod-status` — SSHs to prod, checks systemd status, queries Raindex subgraph for open orders and full trade history, decodes Rain Float hex values, fetches position/inventory/trades from SQLite, downloads logs and DB to `./claude-local-ctx/<datetime>-<status>/`. Colored output with column-aligned tables and human-readable timestamps.
- `bot-start` / `bot-stop` / `bot-restart` — systemctl wrappers that handle the `ConditionPathExists` marker file.
- `prod-dashboard` — SSH tunnel to prod WebSocket + local dashboard dev server.

**`decode-floats` binary** — reads Rain Float hex strings from stdin, writes decoded decimals to stdout. Used by `prod-status` for batch decoding Raindex vault balances.

**Infrastructure changes:**
- `services.nix`: `enabled = true` — creates the systemd unit on deploy (service still doesn't auto-start due to `wantedBy = []`).
- `keys.nix`: added `juan` to `infra` role for local deploy access.
- `.github/workflows/rekey.yaml`: workflow dispatch job that runs `tf-rekey` with the CI key and commits re-encrypted `.age` files. Required after changing key roles.

**Other:**
- `claude-local-ctx/` added to `.gitignore`

## Testing

Operational shell scripts and a thin stdin/stdout binary — no application logic tests added. `prod-status` tested manually against prod.

## Screenshots
<img width="1300" height="2668" alt="Ghostty 2026-04-03 17 06 48" src="https://github.com/user-attachments/assets/0eaebaaa-4f3f-41d5-90ee-effdb033ecd3" />


## Anything else

After merging, trigger the "Rekey Terraform Secrets" workflow from Actions to re-encrypt the terraform `.age` files with Juan's key. Until then, `deploy-all` from Juan's machine won't work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added production status monitoring command with detailed service and order reporting
  * Added production dashboard command with SSH tunneling capabilities

* **Chores**
  * Improved PR contribution template with clearer guidance structure
  * Enabled production hedge service
  * Expanded GitHub Actions automation capabilities
  * Updated infrastructure access permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->