### PR TITLE
fix: track actual USDC settlement amounts in inventory

### DIFF
--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -489,6 +489,36 @@ where
         })
     }
 
+    /// Confirm an inflight transfer at the source venue and add the
+    /// actual settled amount at the destination venue.
+    ///
+    /// Unlike [`Self::transfer`] with [`TransferOp::Complete`], this allows
+    /// the amount leaving the source venue to differ from the amount credited
+    /// at the destination venue. USDC rebalancing needs this because bridge
+    /// fees and conversion slippage mean the settled amount can be smaller
+    /// than the amount that originally left the source venue.
+    pub(crate) fn settle_transfer(
+        from: Venue,
+        sent_amount: T,
+        received_amount: T,
+    ) -> Box<dyn FnOnce(Self) -> Result<Self, InventoryError<T>> + Send> {
+        Box::new(move |inventory| {
+            let source = inventory
+                .get_venue(from)
+                .unwrap_or_default()
+                .confirm_inflight(sent_amount)?;
+
+            let dest = match inventory.get_venue(from.other()) {
+                Some(balance) => balance.add_available(received_amount)?,
+                None => VenueBalance::new(received_amount, T::ZERO),
+            };
+
+            Ok(inventory
+                .set_venue(from, Some(source))
+                .set_venue(from.other(), Some(dest)))
+        })
+    }
+
     pub(crate) fn last_rebalancing(&self) -> Option<DateTime<Utc>> {
         self.last_rebalancing
     }
@@ -748,6 +778,15 @@ impl InventoryView {
         match venue {
             Venue::MarketMaking => self.usdc.onchain.map(VenueBalance::available),
             Venue::Hedging => self.usdc.offchain.map(VenueBalance::available),
+        }
+    }
+
+    /// Returns the USDC inflight balance at the given venue.
+    #[cfg(test)]
+    pub(crate) fn usdc_inflight(&self, venue: Venue) -> Option<Usdc> {
+        match venue {
+            Venue::MarketMaking => self.usdc.onchain.map(VenueBalance::inflight),
+            Venue::Hedging => self.usdc.offchain.map(VenueBalance::inflight),
         }
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -58,6 +58,16 @@ pub(crate) enum RebalancingTriggerError {
     },
     #[error("missing bridged amount for USDC rebalance {id} at deposit confirmation")]
     MissingUsdcBridgedAmount { id: UsdcRebalanceId },
+    #[error(
+        "settled USDC amount {settled_amount} exceeds initiated amount {initiated_amount} \
+         for rebalance {id} at {event}"
+    )]
+    SettledUsdcExceedsInitiatedAmount {
+        id: UsdcRebalanceId,
+        event: usdc::UsdcTrackingEvent,
+        initiated_amount: Usdc,
+        settled_amount: Usdc,
+    },
 }
 
 /// Why loading a token address from the vault registry failed.
@@ -561,7 +571,10 @@ impl RebalancingTrigger {
             other @ (RebalancingTriggerError::EquityTrigger(_)
             | RebalancingTriggerError::Float(_)
             | RebalancingTriggerError::MissingUsdcTrackingContext { .. }
-            | RebalancingTriggerError::MissingUsdcBridgedAmount { .. }) => return Err(other),
+            | RebalancingTriggerError::MissingUsdcBridgedAmount { .. }
+            | RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount { .. }) => {
+                return Err(other);
+            }
         };
 
         warn!(
@@ -3445,6 +3458,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn initiated_with_insufficient_balance_does_not_insert_tracking_context() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(100));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(1000)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, RebalancingTriggerError::Inventory(_)),
+            "initiated event should fail through inventory validation, got {error:?}"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking context should not be inserted when the initiation inventory update fails"
+        );
+    }
+
+    #[tokio::test]
     async fn deposit_confirmed_without_bridged_amount_returns_error_and_preserves_state() {
         let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
@@ -3493,6 +3531,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_failure_cancels_inflight_usdc_and_clears_tracking() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(1000)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_failed())
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress should clear after a terminal failure cancels inflight inventory"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking context should be removed after terminal failure cleanup succeeds"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(5000)),
+            "terminal failure should restore the full offchain USDC balance"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "terminal failure should clear offchain USDC inflight"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn conversion_failed_without_started_transfer_still_clears_in_progress() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_conversion_failed())
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "pre-withdrawal conversion failure should still clear usdc_in_progress"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "pre-withdrawal conversion failure should not leave tracking context behind"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(5000)),
+            "conversion failure before withdrawal should not change onchain USDC inventory"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(5000)),
+            "conversion failure before withdrawal should not change offchain USDC inventory"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
     async fn conversion_confirmed_without_tracking_returns_error_and_preserves_in_progress() {
         let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
@@ -3520,6 +3640,70 @@ mod tests {
             trigger.usdc_in_progress.load(Ordering::SeqCst),
             "usdc_in_progress should stay set when conversion settlement context is missing"
         );
+    }
+
+    #[tokio::test]
+    async fn conversion_confirmed_above_initiated_returns_error_and_preserves_state() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(1000)),
+            )
+            .await
+            .unwrap();
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(1001)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount {
+                id: error_id,
+                event: usdc::UsdcTrackingEvent::ConversionConfirmed,
+                initiated_amount,
+                settled_amount,
+            } if error_id == id
+                && initiated_amount == usdc(1000)
+                && settled_amount == usdc(1001)
+        ));
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress should stay set when settled amount validation fails"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking context should be retained after settled amount validation fails"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(4000)),
+            "initiated amount should remain deducted until a valid terminal event settles it"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(usdc(1000)),
+            "initiated amount should remain inflight when settled amount validation fails"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(5000)),
+            "invalid settlement must not credit the destination venue"
+        );
+        drop(inventory);
     }
 
     #[test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -36,7 +36,9 @@ use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintEvent,
 };
-use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent};
+use crate::usdc_rebalance::{
+    RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
+};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapper::Wrapper;
 
@@ -49,6 +51,13 @@ pub(crate) enum RebalancingTriggerError {
     EquityTrigger(#[from] equity::EquityTriggerError),
     #[error("float arithmetic error: {0}")]
     Float(#[from] rain_math_float::FloatError),
+    #[error("missing USDC tracking context for rebalance {id} at {event}")]
+    MissingUsdcTrackingContext {
+        id: UsdcRebalanceId,
+        event: usdc::UsdcTrackingEvent,
+    },
+    #[error("missing bridged amount for USDC rebalance {id} at deposit confirmation")]
+    MissingUsdcBridgedAmount { id: UsdcRebalanceId },
 }
 
 /// Why loading a token address from the vault registry failed.
@@ -430,6 +439,9 @@ pub(crate) struct RebalancingTrigger {
     /// Tracks symbol/quantity for in-flight redemptions. The initial
     /// `WithdrawnFromRaindex` event carries this data; follow-up events don't.
     redemption_tracking: Arc<RwLock<HashMap<RedemptionAggregateId, (Symbol, FractionalShares)>>>,
+    /// Tracks USDC rebalance lifecycle data needed to settle inventory on
+    /// terminal events with the actual amount received.
+    usdc_tracking: Arc<RwLock<HashMap<UsdcRebalanceId, usdc::UsdcRebalanceTracking>>>,
 }
 
 impl RebalancingTrigger {
@@ -454,6 +466,7 @@ impl RebalancingTrigger {
             wrapper,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
+            usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -546,7 +559,9 @@ impl RebalancingTrigger {
         let inventory_error = match error {
             RebalancingTriggerError::Inventory(inventory_error) => inventory_error,
             other @ (RebalancingTriggerError::EquityTrigger(_)
-            | RebalancingTriggerError::Float(_)) => return Err(other),
+            | RebalancingTriggerError::Float(_)
+            | RebalancingTriggerError::MissingUsdcTrackingContext { .. }
+            | RebalancingTriggerError::MissingUsdcBridgedAmount { .. }) => return Err(other),
         };
 
         warn!(
@@ -762,30 +777,7 @@ impl Reactor for RebalancingTrigger {
             })
             .on(|id, event| async move { self.on_mint(id, event).await })
             .on(|id, event| async move { self.on_redemption(id, event).await })
-            .on(|_id, event| async move {
-                if let UsdcRebalanceEvent::Initiated {
-                    direction, amount, ..
-                } = &event
-                {
-                    let venue = match direction {
-                        RebalanceDirection::AlpacaToBase => Venue::Hedging,
-                        RebalanceDirection::BaseToAlpaca => Venue::MarketMaking,
-                    };
-                    let update = Inventory::transfer(venue, TransferOp::Start, *amount);
-
-                    let mut inventory = self.inventory.write().await;
-                    *inventory = inventory.clone().update_usdc(update, Utc::now())?;
-                }
-
-                if Self::is_terminal_usdc_rebalance_event(&event) {
-                    self.clear_usdc_in_progress();
-                    debug!("Cleared USDC in-progress flag after rebalance terminal event");
-
-                    self.check_and_trigger_usdc().await;
-                }
-
-                Ok::<(), RebalancingTriggerError>(())
-            })
+            .on(|id, event| async move { self.on_usdc_rebalance(id, event).await })
             .on_with_fallback(
                 |_id, event| async move { self.on_snapshot(event).await },
                 |error, _id, event| async move { self.on_snapshot_recovery(error, event).await },
@@ -1230,6 +1222,7 @@ mod tests {
     use crate::usdc_rebalance::{TransferRef, UsdcRebalanceCommand, UsdcRebalanceId};
     use crate::vault_registry::VaultRegistryCommand;
     use crate::wrapper::mock::MockWrapper;
+    use st0x_execution::HasZero;
     use st0x_float_macro::float;
 
     fn test_config() -> RebalancingTriggerConfig {
@@ -2971,6 +2964,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn base_to_alpaca_terminal_conversion_settles_usdc_inventory() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(500)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id,
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(499)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(400)),
+            "terminal conversion should remove the full initiated amount from onchain available"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(Usdc::ZERO),
+            "terminal conversion should clear onchain USDC inflight"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(599)),
+            "terminal conversion should credit offchain cash-equivalent with the filled amount"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "terminal conversion should not leave offchain USDC inflight behind"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_terminal_deposit_uses_bridged_amount_for_inventory() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(500)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_bridged_with_amounts(usdc(499), usdc(1)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id,
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(400)),
+            "terminal deposit should remove the full initiated amount from offchain available"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "terminal deposit should clear offchain USDC inflight"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(599)),
+            "terminal deposit should credit onchain available with the bridged amount after fees"
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(Usdc::ZERO),
+            "terminal deposit should not leave onchain USDC inflight behind"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
     async fn snapshot_onchain_cash_via_reactor_updates_usdc_balance() {
         // Start with 500 onchain, 500 offchain = balanced
         let inventory = InventoryView::default().with_usdc(usdc(500), usdc(500));
@@ -3240,10 +3337,17 @@ mod tests {
     }
 
     fn make_usdc_bridged() -> UsdcRebalanceEvent {
+        make_usdc_bridged_with_amounts(Usdc::new(float!(99.99)), Usdc::new(float!(0.01)))
+    }
+
+    fn make_usdc_bridged_with_amounts(
+        amount_received: Usdc,
+        fee_collected: Usdc,
+    ) -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::Bridged {
             mint_tx_hash: TxHash::random(),
-            amount_received: Usdc::new(float!(99.99)),
-            fee_collected: Usdc::new(float!(0.01)),
+            amount_received,
+            fee_collected,
             minted_at: Utc::now(),
         }
     }
@@ -3292,20 +3396,130 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_rebalance_completion_clears_in_progress_flag() {
-        let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
 
         // Mark USDC as in-progress.
         trigger.usdc_in_progress.store(true, Ordering::SeqCst);
         assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
 
-        // DepositConfirmed for AlpacaToBase is terminal.
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
-            &make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase)
-        ));
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(1000)),
+            )
+            .await
+            .unwrap();
 
-        // Simulate what dispatch does - clear in-progress on terminal.
-        trigger.clear_usdc_in_progress();
+        harness
+            .receive::<UsdcRebalance>(
+                id,
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+            )
+            .await
+            .unwrap();
+
         assert!(!trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn bridged_without_initiated_returns_tracking_error() {
+        let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let error = harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridged())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingTriggerError::MissingUsdcTrackingContext {
+                id: error_id,
+                event: usdc::UsdcTrackingEvent::Bridged,
+            } if error_id == id
+        ));
+    }
+
+    #[tokio::test]
+    async fn deposit_confirmed_without_bridged_amount_returns_error_and_preserves_state() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(1000)),
+            )
+            .await
+            .unwrap();
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingTriggerError::MissingUsdcBridgedAmount { id: error_id }
+                if error_id == id
+        ));
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress should stay set when terminal settlement context is missing"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking context should be retained after a terminal settlement failure"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(usdc(1000)),
+            "offchain USDC inflight should remain until settlement succeeds"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn conversion_confirmed_without_tracking_returns_error_and_preserves_in_progress() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingTriggerError::MissingUsdcTrackingContext {
+                id: error_id,
+                event: usdc::UsdcTrackingEvent::ConversionConfirmed,
+            } if error_id == id
+        ));
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "usdc_in_progress should stay set when conversion settlement context is missing"
+        );
     }
 
     #[test]
@@ -3969,6 +4183,19 @@ mod tests {
                     amount: Usdc::new(float!(1000)),
                     withdrawal_ref: TransferRef::OnchainTx(tx_hash),
                     initiated_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        trigger_harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: TxHash::random(),
+                    amount_received: Usdc::new(float!(999)),
+                    fee_collected: Usdc::new(float!(1)),
+                    minted_at: chrono::Utc::now(),
                 },
             )
             .await

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -216,15 +216,18 @@ impl RebalancingTrigger {
                 self.complete_alpaca_to_base_deposit(&id).await?;
             }
 
+            WithdrawalFailed { .. }
+            | BridgingFailed { .. }
+            | DepositFailed { .. }
+            | ConversionFailed { .. } => {
+                self.cancel_tracked_usdc_rebalance(&id).await?;
+            }
+
             WithdrawalConfirmed { .. }
             | BridgingInitiated { .. }
             | BridgeAttestationReceived { .. }
             | DepositInitiated { .. }
             | ConversionInitiated { .. }
-            | WithdrawalFailed { .. }
-            | BridgingFailed { .. }
-            | DepositFailed { .. }
-            | ConversionFailed { .. }
             | DepositConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
                 ..
@@ -259,14 +262,14 @@ impl RebalancingTrigger {
         };
         let update = Inventory::transfer(tracking.source_venue(), TransferOp::Start, amount);
 
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory.clone().update_usdc(update, Utc::now())?;
+        drop(inventory);
+
         self.usdc_tracking
             .write()
             .await
             .insert(id.clone(), tracking);
-
-        let mut inventory = self.inventory.write().await;
-        *inventory = inventory.clone().update_usdc(update, Utc::now())?;
-        drop(inventory);
 
         Ok(())
     }
@@ -315,6 +318,34 @@ impl RebalancingTrigger {
             .await
     }
 
+    async fn cancel_tracked_usdc_rebalance(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<(), RebalancingTriggerError> {
+        let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
+            debug!(
+                id = %id,
+                "Terminal failure event had no USDC tracking context to cancel"
+            );
+            return Ok(());
+        };
+
+        let source_venue = tracking.source_venue();
+        let initiated_amount = tracking.initiated_amount;
+        let now = Utc::now();
+        let update = Box::new(move |inventory| {
+            let cancelled =
+                Inventory::transfer(source_venue, TransferOp::Cancel, initiated_amount)(inventory)?;
+            Inventory::with_last_rebalancing(now)(cancelled)
+        });
+
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory.clone().update_usdc(update, now)?;
+        drop(inventory);
+
+        Ok(())
+    }
+
     async fn complete_usdc_rebalance(
         &self,
         id: &UsdcRebalanceId,
@@ -331,6 +362,23 @@ impl RebalancingTrigger {
 
         let source_venue = tracking.source_venue();
         let initiated_amount = tracking.initiated_amount;
+
+        if settled_amount.gt(&initiated_amount)? {
+            warn!(
+                id = %id,
+                ?event,
+                ?initiated_amount,
+                ?settled_amount,
+                "Settled USDC amount exceeds initiated amount"
+            );
+            return Err(RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount {
+                id: id.clone(),
+                event,
+                initiated_amount,
+                settled_amount,
+            });
+        }
+
         let now = Utc::now();
         let update = Box::new(move |inventory| {
             let settled =

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -4,13 +4,51 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use chrono::Utc;
+
 use st0x_float_macro::float;
 use tracing::{debug, trace, warn};
 
 use st0x_finance::Usdc;
 
-use super::TriggeredOperation;
-use crate::inventory::{BroadcastingInventory, Imbalance, ImbalanceThreshold};
+use super::{RebalancingTrigger, RebalancingTriggerError, TriggeredOperation};
+use crate::inventory::{
+    BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
+};
+use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent, UsdcRebalanceId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UsdcTrackingEvent {
+    Bridged,
+    DepositConfirmed,
+    ConversionConfirmed,
+}
+
+impl std::fmt::Display for UsdcTrackingEvent {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bridged => write!(formatter, "Bridged"),
+            Self::DepositConfirmed => write!(formatter, "DepositConfirmed"),
+            Self::ConversionConfirmed => write!(formatter, "ConversionConfirmed"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct UsdcRebalanceTracking {
+    direction: RebalanceDirection,
+    initiated_amount: Usdc,
+    bridged_amount_received: Option<Usdc>,
+}
+
+impl UsdcRebalanceTracking {
+    fn source_venue(&self) -> Venue {
+        match self.direction {
+            RebalanceDirection::AlpacaToBase => Venue::Hedging,
+            RebalanceDirection::BaseToAlpaca => Venue::MarketMaking,
+        }
+    }
+}
 
 /// Minimum USDC amount for Alpaca withdrawals.
 /// Alpaca requires $50 USD minimum, but due to USDC/USD spread (~17bps observed in live tests),
@@ -133,6 +171,180 @@ fn cap_usdc(amount: Usdc, usdc_limit: Option<Usdc>) -> Usdc {
         cap
     } else {
         amount
+    }
+}
+
+impl RebalancingTrigger {
+    pub(super) async fn on_usdc_rebalance(
+        &self,
+        id: UsdcRebalanceId,
+        event: UsdcRebalanceEvent,
+    ) -> Result<(), RebalancingTriggerError> {
+        use UsdcRebalanceEvent::*;
+
+        match &event {
+            Initiated {
+                direction, amount, ..
+            } => {
+                self.track_initiated_usdc_rebalance(&id, direction, *amount)
+                    .await?;
+            }
+
+            Bridged {
+                amount_received, ..
+            } => {
+                self.track_bridged_amount(&id, *amount_received).await?;
+            }
+
+            ConversionConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                filled_amount,
+                ..
+            } => {
+                self.complete_usdc_rebalance(
+                    &id,
+                    UsdcTrackingEvent::ConversionConfirmed,
+                    *filled_amount,
+                )
+                .await?;
+            }
+
+            DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            } => {
+                self.complete_alpaca_to_base_deposit(&id).await?;
+            }
+
+            WithdrawalConfirmed { .. }
+            | BridgingInitiated { .. }
+            | BridgeAttestationReceived { .. }
+            | DepositInitiated { .. }
+            | ConversionInitiated { .. }
+            | WithdrawalFailed { .. }
+            | BridgingFailed { .. }
+            | DepositFailed { .. }
+            | ConversionFailed { .. }
+            | DepositConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
+            | ConversionConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            } => {}
+        }
+
+        if Self::is_terminal_usdc_rebalance_event(&event) {
+            self.usdc_tracking.write().await.remove(&id);
+            self.clear_usdc_in_progress();
+            debug!("Cleared USDC in-progress flag after rebalance terminal event");
+
+            self.check_and_trigger_usdc().await;
+        }
+
+        Ok(())
+    }
+
+    async fn track_initiated_usdc_rebalance(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: &RebalanceDirection,
+        amount: Usdc,
+    ) -> Result<(), RebalancingTriggerError> {
+        let tracking = UsdcRebalanceTracking {
+            direction: direction.clone(),
+            initiated_amount: amount,
+            bridged_amount_received: None,
+        };
+        let update = Inventory::transfer(tracking.source_venue(), TransferOp::Start, amount);
+
+        self.usdc_tracking
+            .write()
+            .await
+            .insert(id.clone(), tracking);
+
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory.clone().update_usdc(update, Utc::now())?;
+        drop(inventory);
+
+        Ok(())
+    }
+
+    async fn track_bridged_amount(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+    ) -> Result<(), RebalancingTriggerError> {
+        let mut tracking = self.usdc_tracking.write().await;
+        let Some(existing) = tracking.get_mut(id) else {
+            warn!(id = %id, "Bridged event missing USDC tracking context");
+            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+                id: id.clone(),
+                event: UsdcTrackingEvent::Bridged,
+            });
+        };
+
+        existing.bridged_amount_received = Some(amount_received);
+        drop(tracking);
+
+        Ok(())
+    }
+
+    async fn complete_alpaca_to_base_deposit(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<(), RebalancingTriggerError> {
+        let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
+            warn!(id = %id, "DepositConfirmed event missing USDC tracking context");
+            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+                id: id.clone(),
+                event: UsdcTrackingEvent::DepositConfirmed,
+            });
+        };
+
+        let Some(amount_received) = tracking.bridged_amount_received else {
+            warn!(
+                id = %id,
+                "DepositConfirmed event missing bridged amount for USDC rebalance"
+            );
+            return Err(RebalancingTriggerError::MissingUsdcBridgedAmount { id: id.clone() });
+        };
+
+        self.complete_usdc_rebalance(id, UsdcTrackingEvent::DepositConfirmed, amount_received)
+            .await
+    }
+
+    async fn complete_usdc_rebalance(
+        &self,
+        id: &UsdcRebalanceId,
+        event: UsdcTrackingEvent,
+        settled_amount: Usdc,
+    ) -> Result<(), RebalancingTriggerError> {
+        let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
+            warn!(id = %id, "Terminal success event missing USDC tracking context");
+            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+                id: id.clone(),
+                event,
+            });
+        };
+
+        let source_venue = tracking.source_venue();
+        let initiated_amount = tracking.initiated_amount;
+        let now = Utc::now();
+        let update = Box::new(move |inventory| {
+            let settled =
+                Inventory::settle_transfer(source_venue, initiated_amount, settled_amount)(
+                    inventory,
+                )?;
+            Inventory::with_last_rebalancing(now)(settled)
+        });
+
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory.clone().update_usdc(update, now)?;
+        drop(inventory);
+
+        Ok(())
     }
 }
 

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -73,7 +73,7 @@ use st0x_finance::{Id, Usdc};
 use crate::alpaca_wallet::AlpacaTransferId;
 
 /// Unique identifier for a USDC rebalance operation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub(crate) struct UsdcRebalanceId(pub(crate) Uuid);
 
 impl Display for UsdcRebalanceId {


### PR DESCRIPTION
## Motivation

Closes #240.
Closes [RAI-43](https://linear.app/makeitrain/issue/RAI-43/conversion-slippage-not-tracked-causing-inventory-drift).

USDC rebalancing was assuming that the amount leaving the source venue always
matched the amount credited at the destination venue.

That breaks in two real paths:

- `BaseToAlpaca`: Alpaca USDC -> USD conversion can settle below the initiated
  amount because of slippage
- `AlpacaToBase`: CCTP bridging can settle below the initiated amount because of
  bridge fees

As a result, the inventory view could silently drift after a rebalance
completed, even though the aggregate had already recorded the actual settled
amounts.

## Solution

- add `Inventory::settle_transfer` so inventory can confirm the full sent amount
  at the source venue while crediting the actual received amount at the
  destination venue
- track per-rebalance USDC settlement context in the rebalancing trigger so
  terminal events can settle inventory using the real received amount
- use `ConversionConfirmed.filled_amount` as the terminal settled amount for
  `BaseToAlpaca`
- use `Bridged.amount_received` as the settled amount that gets applied on
  terminal `DepositConfirmed` for `AlpacaToBase`
- add trigger-level regression tests covering both settlement paths
- derive `Hash` for `UsdcRebalanceId` so the trigger can track in-flight
  rebalances by aggregate ID

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to the dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USDC rebalances now track lifecycle state and settle using actual confirmed amounts, allowing sent and received amounts to differ.

* **Bug Fixes**
  * Improved handling of terminal rebalance events, validation of settled amounts, and robust initialization when counter-venue balance state is missing.
  * Terminal failures now properly cancel inflight and clear tracking.

* **Tests**
  * Expanded tests for settlement flows, error cases, tracking preservation/cleanup, and inflight reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->