### PR TITLE
fix status command

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -51,8 +51,8 @@ case "$env" in
     order_owner="0x386c24644e532387b03c1992ca83542492a3ac32"
     ;;
   staging)
-    subgraph="${STAGING_SUBGRAPH:?Set STAGING_SUBGRAPH env var for staging status}"
-    order_owner="${STAGING_ORDER_OWNER:?Set STAGING_ORDER_OWNER env var for staging status}"
+    subgraph="https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn"
+    order_owner="0x386c24644e532387b03c1992ca83542492a3ac32"
     ;;
   *)
     echo "ERROR: unknown environment '$env'" >&2


### PR DESCRIPTION
## What

Closes [RAI-167](https://linear.app/makeitrain/issue/RAI-167/fix-prod-dashboard-nix-command)

- Hardcodes the staging subgraph URL and order owner address in `scripts/status.sh`

## Why

- The staging `status.sh` path required setting `STAGING_SUBGRAPH` and `STAGING_ORDER_OWNER` env vars to run, but the values are the same as prod — no reason to gate behind env vars
- This was causing the status command to fail when run without the env vars set

## How

- Replaced `${STAGING_SUBGRAPH:?...}` and `${STAGING_ORDER_OWNER:?...}` with the same hardcoded values used in the prod case

## Testing

- Manual verification of `status.sh` against staging

## Anything else

- The staging subgraph and order owner currently match prod — when a dedicated staging environment is set up (RAI-122), these values will need updating