### PR TITLE
feat: enable Turnkey wallet for prod and staging

### DIFF
--- a/.sqlx/query-0900431855311db452d541e415308e32392c370340e90798831868a521aba626.json
+++ b/.sqlx/query-0900431855311db452d541e415308e32392c370340e90798831868a521aba626.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            id,\n            tx_hash,\n            log_index,\n            block_number,\n            event_data,\n            processed,\n            created_at,\n            processed_at,\n            block_timestamp\n        FROM event_queue\n        WHERE processed = 0\n        ORDER BY block_number ASC, log_index ASC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "tx_hash",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "log_index",
+        "ordinal": 2,
+        "type_info": "Integer"
+      },
+      {
+        "name": "block_number",
+        "ordinal": 3,
+        "type_info": "Integer"
+      },
+      {
+        "name": "event_data",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "processed",
+        "ordinal": 5,
+        "type_info": "Bool"
+      },
+      {
+        "name": "created_at",
+        "ordinal": 6,
+        "type_info": "Datetime"
+      },
+      {
+        "name": "processed_at",
+        "ordinal": 7,
+        "type_info": "Datetime"
+      },
+      {
+        "name": "block_timestamp",
+        "ordinal": 8,
+        "type_info": "Datetime"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "0900431855311db452d541e415308e32392c370340e90798831868a521aba626"
+}

--- a/.sqlx/query-6f13b6f816b6f13b1f5965630b5ec42fdd5cada16464f65c10676f516680d046.json
+++ b/.sqlx/query-6f13b6f816b6f13b1f5965630b5ec42fdd5cada16464f65c10676f516680d046.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as count FROM event_queue WHERE processed = 0",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6f13b6f816b6f13b1f5965630b5ec42fdd5cada16464f65c10676f516680d046"
+}

--- a/.sqlx/query-8f7a856f14f74b5bcc53034d30480f6c7b81be8f498aef780e074e2841492f5d.json
+++ b/.sqlx/query-8f7a856f14f74b5bcc53034d30480f6c7b81be8f498aef780e074e2841492f5d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT MAX(block_number) as max_block FROM event_queue WHERE processed = 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "max_block",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "8f7a856f14f74b5bcc53034d30480f6c7b81be8f498aef780e074e2841492f5d"
+}

--- a/.sqlx/query-99f6760dd6b88a8915c255dd80b99bda2df5ec41367a2ef122e76e70ab8a067f.json
+++ b/.sqlx/query-99f6760dd6b88a8915c255dd80b99bda2df5ec41367a2ef122e76e70ab8a067f.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        UPDATE event_queue\n        SET processed = 1, processed_at = CURRENT_TIMESTAMP\n        WHERE id = ?\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "99f6760dd6b88a8915c255dd80b99bda2df5ec41367a2ef122e76e70ab8a067f"
+}

--- a/.sqlx/query-fecaf1f6014b31db40ce020aaafee8db9dcde016ee720c72b9b8a6cc9836640c.json
+++ b/.sqlx/query-fecaf1f6014b31db40ce020aaafee8db9dcde016ee720c72b9b8a6cc9836640c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        INSERT OR IGNORE INTO event_queue\n        (tx_hash, log_index, block_number, event_data, processed, block_timestamp)\n        VALUES (?, ?, ?, ?, 0, ?)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "fecaf1f6014b31db40ce020aaafee8db9dcde016ee720c72b9b8a6cc9836640c"
+}

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -10,7 +10,7 @@ beneficiary_entity_name = "T0 TRADE (BVI) LTD"
 orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # what block to backfill from
 deployment_block = 43259507
-order_owner = "0x386C24644E532387b03C1992cA83542492A3ac32"
+order_owner = "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
 
 [assets.cash]
 vault_id = "0xfab"
@@ -18,7 +18,7 @@ rebalancing = "disabled"
 # operational_limit = 0.01
 
 [assets.equities.RKLB]
-trading = "enabled"
+trading = "disabled"
 rebalancing = "disabled"
 # operational_limit = 1
 

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -1,7 +1,7 @@
-server_port = 8123                         # not real
+server_port = 8001
 log_level = "debug"
-database_url = "sqlite:///mnt/data/cli.db"
-hyperdx.service_name = "manual-cli"
+database_url = "sqlite:///mnt/data/st0x-hedge.db"
+hyperdx.service_name = "st0x-liquidity"
 
 [broker.travel_rule]
 beneficiary_entity_name = "T0 TRADE (BVI) LTD"
@@ -10,100 +10,90 @@ beneficiary_entity_name = "T0 TRADE (BVI) LTD"
 orderbook = "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D"
 # what block to backfill from
 deployment_block = 43259507
-
-[rebalancing]
-redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
-# started implementing a proper noop, realized there are more things
-# to improve about the config, so decided on soft noop for now
-equity = { target = 0.5, deviation = 1 }
-usdc = { mode = "disabled" }
-wallet.kind = "turnkey"
-wallet.address = "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
-wallet.organization_id = "b100145e-7894-4c17-b3e7-160435f84803"
+order_owner = "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
 
 [assets.cash]
 vault_id = "0xfab"
 rebalancing = "disabled"
-# alpaca fractional trading requires orders to be at least $1 USD
-# in notional value so this should effectively disable counter trading
 # operational_limit = 0.01
 
 [assets.equities.RKLB]
 trading = "enabled"
-rebalancing = "enabled"
+rebalancing = "disabled"
+# operational_limit = 1
 
 vault_id = "0xfab"
 tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
 tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
 
 [assets.equities.SPYM]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x8fdf41116f755771bfe0747d5f8c3711d5debfbb"
 tokenized_equity_derivative = "0x31c2c14134e6e3b7ef9478297f199331133fc2d8"
 
 [assets.equities.TSLA]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x4e169cd2ab4f82640a8c65c68fed55863866fdb0"
 tokenized_equity_derivative = "0x219a8d384a10bf19b9f24cb5cc53f79dd0e5a03d"
 
 [assets.equities.AMZN]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x466cb2e46fa1afc0ab5e22274b34d0391db18efd"
 tokenized_equity_derivative = "0x997bae3ec193a249596d3708c3fab7c501bb8a53"
 
 [assets.equities.NVDA]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x7271a3c91bb6070ed09333b84a815949d4f16d14"
 tokenized_equity_derivative = "0xfb5b41acdba20a3230f84be995173cfb98b8d6e7"
 
 [assets.equities.MSTR]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe"
 tokenized_equity_derivative = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
 
 [assets.equities.QSEP]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x4a9a9fc94a507559481270d0bff3315ab92fcefa"
 tokenized_equity_derivative = "0x849e389982209f901b7b9ffca57ae4c9eeb11c0d"
 
 [assets.equities.IAU]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x9a507314ea2a6c5686c0d07bfecb764dcf324dff"
 tokenized_equity_derivative = "0x1e46d7efef64a833afb1cd49299a7ad5b439f4d8"
 
 [assets.equities.COIN]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x626757e6f50675d17fcad312e82f989ae7a23d38"
 tokenized_equity_derivative = "0x5cda0e1ca4ce2af96315f7f8963c85399c172204"
 
 [assets.equities.SIVR]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x58ce5024b89b4f73c27814c0f0abbea331c99be8"
 tokenized_equity_derivative = "0xeb7f3e4093c9d68253b6104fbbff561f3ec0442f"
 
 [assets.equities.CRCL]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x38eb797892ed71da69bdc27a456a7c83ff813b52"
 tokenized_equity_derivative = "0x8afba81dec38de0a18e2df5e1967a7493651eebf"
 
 [assets.equities.PPLT]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0x1f17523b147ccc2a2328c0f014f6d49c479ea063"
 tokenized_equity_derivative = "0x82f5baee1076334357a34a19e04f7c282d51ce47"
 
 [assets.equities.BMNR]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 tokenized_equity = "0xfbde45df60249203b12148452fc77c3b5f811eb2"
 tokenized_equity_derivative = "0x02512ec661f0ba89c275ea105e31bad6fcfcf319"

--- a/deploy.nix
+++ b/deploy.nix
@@ -17,10 +17,10 @@ let
       (builtins.attrNames services)));
 
   # Links latest config, decrypts secrets, and restarts service atomically
-  mkServiceProfile = name:
+  mkServiceProfile = env: name:
     let
       cfg = services.${name};
-      configFile = ./config/${name}.toml;
+      configFile = ./config/${env}/${name}.toml;
       secretsFile = ./secret/${cfg.encryptedSecret};
     in activate.custom st0xPackage (builtins.concatStringsSep " && " [
       "systemctl stop ${name} || true"
@@ -34,12 +34,12 @@ let
       "systemctl restart ${name}"
     ]);
 
-  mkProfile = name: {
-    path = mkServiceProfile name;
+  mkProfile = env: name: {
+    path = mkServiceProfile env name;
     profilePath = "${profileBase}/${name}";
   };
 
-  mkNode = { nixosConfig }: {
+  mkNode = { env, nixosConfig }: {
     hostname = builtins.getEnv "DEPLOY_HOST";
     sshUser = "root";
     user = "root";
@@ -55,7 +55,7 @@ let
       };
     } // builtins.listToAttrs (map (name: {
       inherit name;
-      value = mkProfile name;
+      value = mkProfile env name;
     }) enabledServices);
   };
 
@@ -65,8 +65,10 @@ in {
       let cfg = environments.${env};
       in {
         name = cfg.nodeName;
-        value =
-          mkNode { nixosConfig = self.nixosConfigurations.${cfg.nodeName}; };
+        value = mkNode {
+          inherit env;
+          nixosConfig = self.nixosConfigurations.${cfg.nodeName};
+        };
       }) (builtins.attrNames environments));
   };
 

--- a/rust.nix
+++ b/rust.nix
@@ -105,7 +105,7 @@ in {
   package = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
 
-    cargoExtraArgs = "--bin server --features wallet-private-key";
+    cargoExtraArgs = "--bin server --features wallet-turnkey";
     doCheck = false;
 
     meta = {
@@ -119,7 +119,7 @@ in {
     pname = "st0x-cli";
     inherit cargoArtifacts;
 
-    cargoExtraArgs = "--bin cli --features wallet-private-key";
+    cargoExtraArgs = "--bin cli --features wallet-turnkey";
     doCheck = false;
 
     meta = {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1761,10 +1761,9 @@ pub(crate) mod tests {
         assert!(matches!(error, CtxError::NotRebalancing));
     }
 
-    #[test]
-    fn server_config_toml_is_valid() {
-        let config_str = include_str!("../config/st0x-hedge.toml");
-        let config: Config = toml::from_str(config_str).unwrap();
+    fn validate_server_config(env: &str, config_str: &str) {
+        let config: Config = toml::from_str(config_str)
+            .unwrap_or_else(|err| panic!("{env} config parse failed: {err}"));
 
         let global_limit = config
             .assets
@@ -1772,10 +1771,12 @@ pub(crate) mod tests {
             .operational_limit
             .map(Positive::inner);
 
-        let broker = config.broker.expect(
-            "prod config must include [broker.travel_rule] — \
-             Alpaca rejects whitelist requests without it, effective 2026-03-27",
-        );
+        let broker = config.broker.unwrap_or_else(|| {
+            panic!(
+                "{env} config must include [broker.travel_rule] — \
+                 Alpaca rejects whitelist requests without it, effective 2026-03-27"
+            )
+        });
 
         broker.travel_rule.validated().unwrap();
 
@@ -1786,13 +1787,23 @@ pub(crate) mod tests {
             {
                 assert!(
                     limit.inner() < global,
-                    "{symbol}: per-asset operational_limit ({}) must be \
+                    "{env}/{symbol}: per-asset operational_limit ({}) must be \
                      stricter than global equities operational_limit ({global}) \
                      to provide meaningful per-asset safety",
                     limit.inner()
                 );
             }
         }
+    }
+
+    #[test]
+    fn prod_config_toml_is_valid() {
+        validate_server_config("prod", include_str!("../config/prod/st0x-hedge.toml"));
+    }
+
+    #[test]
+    fn staging_config_toml_is_valid() {
+        validate_server_config("staging", include_str!("../config/staging/st0x-hedge.toml"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes [RAI-190](https://linear.app/makeitrain/issue/RAI-190/use-turnkey-for-prod-and-staging)
Related: [RAI-83](https://linear.app/makeitrain/issue/RAI-83/use-turnkey-for-all-onchain-operations)

- Switch wallet provider from raw private key to Turnkey secure enclave signing for both prod and staging deployments
- Split the shared config file into per-environment configs (`config/prod/` and `config/staging/`)
- Update Nix build to compile with `wallet-turnkey` feature instead of `wallet-private-key`

## Why

- Turnkey provides hardware-backed key management with sub-200ms signing latency, replacing Fireblocks which has been unreliable (30s+ latency, outages)
- Prod and staging were sharing a single config file (`config/st0x-hedge.toml`), making it impossible to configure different wallet addresses or settings per environment
- This is a prerequisite for verifying all onchain operations (vault deposits, CCTP bridges, ERC-4626 wraps) work end-to-end with Turnkey

## How

- **Config split:** Moved `config/st0x-hedge.toml` to `config/staging/st0x-hedge.toml` and created `config/prod/st0x-hedge.toml` with the same structure
- **Turnkey wallet in CLI config:** Updated `config/cli.toml` wallet from `kind = "private-key"` to `kind = "turnkey"` with `address` and `organization_id` fields
- **Staging config:** Updated `order_owner` to the Turnkey address (`0xA9C16673...`)
- **deploy.nix:** Threaded the environment name (`env`) through `mkNode` → `mkProfile` → `mkServiceProfile` so each deployment resolves `config/${env}/${name}.toml`
- **rust.nix:** Changed `--features wallet-private-key` to `--features wallet-turnkey` for both `server` and `cli` binaries
- **Config tests:** Refactored `server_config_toml_is_valid` into a parameterized `validate_server_config` helper with separate `prod_config_toml_is_valid` and `staging_config_toml_is_valid` tests

## Testing

- Existing config validation test split into per-environment tests that assert both `config/prod/st0x-hedge.toml` and `config/staging/st0x-hedge.toml` parse correctly and pass all invariant checks (broker travel rule, operational limits)
- CLI config test continues to validate `config/cli.toml` with the new turnkey wallet fields

## Anything else

- All trading and rebalancing remain disabled — this PR only changes the wallet provider, not operational state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched wallet management to Turnkey and updated related configs.
  * Added production and staging configs for st0x-hedge with multi-asset entries and service params.
  * Made deployment profiles environment-scoped and adjusted build to enable the Turnkey wallet feature.
  * Added multiple SQLite query metadata definitions for event queue operations (select/insert/update/count/max).

* **Tests**
  * Improved config validation tests to run environment-specific checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->