### PR TITLE
fix: retry projection view updates on optimistic lock conflict

### DIFF
--- a/crates/event-sorcery/src/projection.rs
+++ b/crates/event-sorcery/src/projection.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::EventSourced;
 use crate::dependency::{Cons, Dependent, EntityList, Nil};
@@ -290,6 +290,45 @@ impl<Entity: EventSourced<Materialized = Table>> Projection<Entity> {
         Ok(())
     }
 
+    /// Rebuild a single view by deleting its row and replaying
+    /// all events from scratch via `catch_up`.
+    ///
+    /// Use as an escape hatch when a view becomes corrupted due
+    /// to lost updates.
+    pub async fn rebuild(&self, id: &Entity::Id) -> Result<(), ProjectionError<Entity>>
+    where
+        <Entity::Id as FromStr>::Err: Debug,
+    {
+        let (pool, table) = self.sqlite_backing()?;
+        let view_id = id.to_string();
+
+        info!(%view_id, %table, "Rebuilding view from event history");
+
+        sqlx::query(&format!("DELETE FROM {table} WHERE view_id = ?1"))
+            .bind(&view_id)
+            .execute(pool)
+            .await?;
+
+        self.catch_up().await
+    }
+
+    /// Rebuild all views by deleting every row and replaying
+    /// all events from scratch via `catch_up`.
+    pub async fn rebuild_all(&self) -> Result<(), ProjectionError<Entity>>
+    where
+        <Entity::Id as FromStr>::Err: Debug,
+    {
+        let (pool, table) = self.sqlite_backing()?;
+
+        info!(%table, "Rebuilding all views from event history");
+
+        sqlx::query(&format!("DELETE FROM {table}"))
+            .execute(pool)
+            .await?;
+
+        self.catch_up().await
+    }
+
     async fn replay_missed_events(
         &self,
         pool: &SqlitePool,
@@ -494,19 +533,40 @@ where
         let (id, event) = event.into_inner();
         let view_id = id.to_string();
 
-        let (mut lifecycle, context) = match self.repo.load_with_context(&view_id).await {
-            Ok(Some(pair)) => pair,
-            Ok(None) => (Lifecycle::default(), ViewContext::new(view_id.clone(), 0)),
-            Err(error) => {
-                warn!(%view_id, ?error, "Failed to load view for update");
-                return Ok(());
+        let max_retries = 3;
+
+        for attempt in 0..=max_retries {
+            let (mut lifecycle, context) = match self.repo.load_with_context(&view_id).await {
+                Ok(Some(pair)) => pair,
+                Ok(None) => (Lifecycle::default(), ViewContext::new(view_id.clone(), 0)),
+                Err(error) => {
+                    warn!(%view_id, ?error, "Failed to load view for update");
+                    return Ok(());
+                }
+            };
+
+            lifecycle.apply(event.clone());
+
+            match self.repo.update_view(lifecycle, context).await {
+                Ok(()) => return Ok(()),
+                Err(PersistenceError::OptimisticLockError) if attempt < max_retries => {
+                    warn!(
+                        %view_id, attempt = attempt + 1, max_retries,
+                        "Optimistic lock conflict, retrying view update"
+                    );
+                }
+                Err(PersistenceError::OptimisticLockError) => {
+                    error!(
+                        %view_id, max_retries,
+                        "View update lost: optimistic lock conflict persisted after all retries"
+                    );
+                    return Ok(());
+                }
+                Err(error) => {
+                    warn!(%view_id, ?error, "Failed to save view update");
+                    return Ok(());
+                }
             }
-        };
-
-        lifecycle.apply(event.clone());
-
-        if let Err(error) = self.repo.update_view(lifecycle, context).await {
-            warn!(%view_id, ?error, "Failed to save view update");
         }
 
         Ok(())
@@ -670,6 +730,149 @@ mod tests {
                 .insert(context.view_instance_id, view);
             Ok(())
         }
+    }
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use crate::dependency::OneOf;
+    use crate::reactor::Reactor;
+
+    /// In-memory view repository that returns `OptimisticLockError`
+    /// a configurable number of times before succeeding.
+    struct ConflictingRepo {
+        views: RwLock<HashMap<String, (Lifecycle<TestEntity>, i64)>>,
+        remaining_conflicts: AtomicU32,
+    }
+
+    impl ConflictingRepo {
+        fn new(conflicts: u32) -> Self {
+            Self {
+                views: RwLock::new(HashMap::new()),
+                remaining_conflicts: AtomicU32::new(conflicts),
+            }
+        }
+
+        fn with_entity(self, aggregate_id: &str, entity: TestEntity) -> Self {
+            let mut views = self.views.into_inner();
+            views.insert(aggregate_id.to_string(), (Lifecycle::Live(entity), 1));
+            Self {
+                views: RwLock::new(views),
+                ..self
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ViewRepository<Lifecycle<TestEntity>, Lifecycle<TestEntity>> for ConflictingRepo {
+        async fn load(
+            &self,
+            aggregate_id: &str,
+        ) -> Result<Option<Lifecycle<TestEntity>>, PersistenceError> {
+            Ok(self
+                .views
+                .read()
+                .await
+                .get(aggregate_id)
+                .map(|(lifecycle, _version)| lifecycle.clone()))
+        }
+
+        async fn load_with_context(
+            &self,
+            aggregate_id: &str,
+        ) -> Result<Option<(Lifecycle<TestEntity>, ViewContext)>, PersistenceError> {
+            let guard = self.views.read().await;
+            Ok(guard.get(aggregate_id).map(|(lifecycle, version)| {
+                let context = ViewContext::new(aggregate_id.to_string(), *version);
+                (lifecycle.clone(), context)
+            }))
+        }
+
+        async fn update_view(
+            &self,
+            view: Lifecycle<TestEntity>,
+            context: ViewContext,
+        ) -> Result<(), PersistenceError> {
+            let remaining = self.remaining_conflicts.load(Ordering::SeqCst);
+
+            if remaining > 0 {
+                self.remaining_conflicts
+                    .store(remaining - 1, Ordering::SeqCst);
+                return Err(PersistenceError::OptimisticLockError);
+            }
+
+            let new_version = context.version + 1;
+            self.views
+                .write()
+                .await
+                .insert(context.view_instance_id, (view, new_version));
+
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn react_retries_on_optimistic_lock_conflict() {
+        let entity = TestEntity {
+            name: "original".to_string(),
+        };
+        let repo = ConflictingRepo::new(2).with_entity("id-1", entity);
+        let projection = Projection::new(Arc::new(repo));
+
+        let event: OneOf<(String, TestEvent), Never> = OneOf::Here(("id-1".to_string(), TestEvent));
+
+        projection.react(event).await.unwrap();
+
+        // evolve clones the entity unchanged, but the update was persisted
+        let result = projection.load(&"id-1".to_string()).await.unwrap();
+        assert_eq!(
+            result,
+            Some(TestEntity {
+                name: "original".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn react_gives_up_after_max_retries() {
+        // 4 conflicts exceeds the max of 3 retries (attempts 0..=3)
+        let entity = TestEntity {
+            name: "original".to_string(),
+        };
+        let repo = Arc::new(ConflictingRepo::new(4).with_entity("id-1", entity.clone()));
+        let projection = Projection::new(Arc::clone(&repo));
+
+        let event: OneOf<(String, TestEvent), Never> = OneOf::Here(("id-1".to_string(), TestEvent));
+
+        // Should not panic -- react swallows the error
+        projection.react(event).await.unwrap();
+
+        // All 4 attempts were made (counter decremented from 4 to 0)
+        assert_eq!(repo.remaining_conflicts.load(Ordering::SeqCst), 0);
+
+        // View should still have the original entity (update never succeeded)
+        let result = projection.load(&"id-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(entity));
+    }
+
+    #[tokio::test]
+    async fn react_succeeds_without_conflict() {
+        let entity = TestEntity {
+            name: "original".to_string(),
+        };
+        let repo = ConflictingRepo::new(0).with_entity("id-1", entity);
+        let projection = Projection::new(Arc::new(repo));
+
+        let event: OneOf<(String, TestEvent), Never> = OneOf::Here(("id-1".to_string(), TestEvent));
+
+        projection.react(event).await.unwrap();
+
+        let result = projection.load(&"id-1".to_string()).await.unwrap();
+        assert_eq!(
+            result,
+            Some(TestEntity {
+                name: "original".to_string(),
+            })
+        );
     }
 
     #[tokio::test]
@@ -1028,5 +1231,54 @@ mod tests {
             matches!(error, ProjectionError::Serde { .. }),
             "expected Serde error, got: {error:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn rebuild_replays_all_events_from_scratch() {
+        let pool = setup_catch_up_db().await;
+
+        // Insert events and a corrupted view (value should be 2, not 99)
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+        insert_event(&pool, "counter-1", 2, &CounterEvent::Incremented).await;
+        insert_event(&pool, "counter-1", 3, &CounterEvent::Incremented).await;
+
+        insert_stale_view(&pool, "counter-1", 3, &Counter { value: 99 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        // catch_up would not fix this because version matches max_seq
+        projection.rebuild(&"counter-1".to_string()).await.unwrap();
+
+        let result = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result, Some(Counter { value: 2 }));
+    }
+
+    #[tokio::test]
+    async fn rebuild_all_replays_all_aggregates() {
+        let pool = setup_catch_up_db().await;
+
+        // Two aggregates with corrupted views
+        insert_event(&pool, "counter-1", 1, &CounterEvent::Created { initial: 0 }).await;
+        insert_event(&pool, "counter-1", 2, &CounterEvent::Incremented).await;
+        insert_event(
+            &pool,
+            "counter-2",
+            1,
+            &CounterEvent::Created { initial: 10 },
+        )
+        .await;
+
+        insert_stale_view(&pool, "counter-1", 2, &Counter { value: 99 }).await;
+        insert_stale_view(&pool, "counter-2", 1, &Counter { value: 99 }).await;
+
+        let projection = Projection::<Counter>::sqlite(pool);
+
+        projection.rebuild_all().await.unwrap();
+
+        let result1 = projection.load(&"counter-1".to_string()).await.unwrap();
+        assert_eq!(result1, Some(Counter { value: 1 }));
+
+        let result2 = projection.load(&"counter-2".to_string()).await.unwrap();
+        assert_eq!(result2, Some(Counter { value: 10 }));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,9 +23,13 @@ use st0x_execution::alpaca_broker_api::AlpacaLimitPrice;
 use st0x_execution::{AlpacaAccountId, Direction, FractionalShares, Positive, Symbol, TimeInForce};
 use st0x_finance::Usdc;
 
+use st0x_event_sorcery::Projection;
+
 use crate::config::{BrokerCtx, Ctx, Env};
-use crate::offchain_order::OrderPlacer;
+use crate::offchain_order::{OffchainOrder, OffchainOrderId, OrderPlacer};
+use crate::position::Position;
 use crate::symbol::cache::SymbolCache;
+use crate::vault_registry::VaultRegistry;
 
 /// Direction for transferring assets between trading venues.
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -43,6 +47,17 @@ pub enum ConvertDirection {
     ToUsd,
     /// Convert USD buying power to USDC (buy USDC/USD)
     ToUsdc,
+}
+
+/// Aggregate types that have materialized views.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum AggregateView {
+    /// Position aggregate (position_view)
+    Position,
+    /// Offchain order aggregate (offchain_order_view)
+    OffchainOrder,
+    /// Vault registry aggregate (vault_registry_view)
+    VaultRegistry,
 }
 
 /// CCTP chain identifier for specifying source chain.
@@ -422,6 +437,25 @@ pub enum Commands {
         #[arg(long = "yes")]
         yes: bool,
     },
+
+    /// Rebuild a materialized view by replaying all events from scratch
+    ///
+    /// Use as an escape hatch when a view becomes corrupted (e.g., due to
+    /// lost updates from optimistic lock conflicts). Deletes the view row(s)
+    /// and replays all events to reconstruct correct state.
+    RebuildView {
+        /// Aggregate type to rebuild (position, offchain-order, vault-registry)
+        #[arg(short = 'a', long = "aggregate")]
+        aggregate: AggregateView,
+        /// Specific aggregate ID to rebuild (e.g., AAPL for position).
+        /// Mutually exclusive with --all.
+        #[arg(long = "id", conflicts_with = "all", required_unless_present = "all")]
+        id: Option<String>,
+        /// Rebuild all views for the aggregate type.
+        /// Mutually exclusive with --id.
+        #[arg(long = "all", conflicts_with = "id", required_unless_present = "id")]
+        all: bool,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -566,6 +600,11 @@ enum SimpleCommand {
         to: Option<Address>,
         data: Option<String>,
         yes: bool,
+    },
+    RebuildView {
+        aggregate: AggregateView,
+        id: Option<String>,
+        all: bool,
     },
 }
 
@@ -746,6 +785,9 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         }),
         Commands::OrderStatus { order_id } => Ok(SimpleCommand::OrderStatus { order_id }),
         Commands::Submit { to, data, yes } => Ok(SimpleCommand::Submit { to, data, yes }),
+        Commands::RebuildView { aggregate, id, all } => {
+            Ok(SimpleCommand::RebuildView { aggregate, id, all })
+        }
     }
 }
 
@@ -887,7 +929,59 @@ async fn run_simple_command<W: Write>(
             };
             submit::submit_command(stdout, transactions, yes, ctx).await
         }
+        SimpleCommand::RebuildView { aggregate, id, all } => {
+            rebuild_view(stdout, pool, aggregate, id, all).await
+        }
     }
+}
+
+async fn rebuild_view<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    aggregate: AggregateView,
+    id: Option<String>,
+    all: bool,
+) -> anyhow::Result<()> {
+    match aggregate {
+        AggregateView::Position => {
+            let projection = Projection::<Position>::sqlite(pool.clone());
+
+            if let Some(raw_id) = id {
+                let symbol: Symbol = raw_id.parse()?;
+                projection.rebuild(&symbol).await?;
+                writeln!(stdout, "Rebuilt position view for {symbol}")?;
+            } else if all {
+                projection.rebuild_all().await?;
+                writeln!(stdout, "Rebuilt all position views")?;
+            }
+        }
+        AggregateView::OffchainOrder => {
+            let projection = Projection::<OffchainOrder>::sqlite(pool.clone());
+
+            if let Some(raw_id) = id {
+                let order_id: OffchainOrderId = raw_id.parse()?;
+                projection.rebuild(&order_id).await?;
+                writeln!(stdout, "Rebuilt offchain order view for {order_id}")?;
+            } else if all {
+                projection.rebuild_all().await?;
+                writeln!(stdout, "Rebuilt all offchain order views")?;
+            }
+        }
+        AggregateView::VaultRegistry => {
+            let projection = Projection::<VaultRegistry>::sqlite(pool.clone());
+
+            if let Some(raw_id) = id {
+                let registry_id = raw_id.parse()?;
+                projection.rebuild(&registry_id).await?;
+                writeln!(stdout, "Rebuilt vault registry view for {raw_id}")?;
+            } else if all {
+                projection.rebuild_all().await?;
+                writeln!(stdout, "Rebuilt all vault registry views")?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 async fn run_provider_command<W: Write>(

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -1380,7 +1380,10 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
 
     poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
 
-    // Snapshot counts before restart
+    bot.abort();
+    let _ = bot.await;
+
+    // Snapshot after shutdown so all in-flight view updates have settled
     let pool = connect_db(&infra.db_path).await?;
     let pre_onchain_events = count_events(&pool, "OnChainTrade").await?;
 
@@ -1389,9 +1392,6 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
         .await?
         .expect("Position should exist after first run");
     pool.close().await;
-
-    bot.abort();
-    let _ = bot.await;
 
     // Phase 2: restart bot with SAME deployment_block (re-backfills same events)
     let ctx2 = build_ctx()


### PR DESCRIPTION
## What

Closes [RAI-165](https://linear.app/makeitrain/issue/RAI-165/fix-projection-view-race-condition-causing-stale-pending-offchain-order-id)

- Add bounded retry logic (max 3 attempts) in `Projection::react` when `update_view` returns `OptimisticLockError`
- Add `Projection::rebuild` and `Projection::rebuild_all` methods to reconstruct views from event history
- Add CLI `rebuild-view` command as a manual escape hatch for corrupted views
- Fix flaky `duplicate_event_delivery` e2e test

## Why

- Race condition in `Projection::react`: when two `Store::send()` calls on the same aggregate dispatch concurrently, both load the same view version. The first save succeeds, the second gets `OptimisticLockError` which was silently swallowed — permanently losing the view update
- Observed in production: Position view's `pending_offchain_order_id` was never cleared despite `OffChainOrderFilled` being persisted, blocking all hedging for 10+ days (888 onchain trades missed)
- `catch_up` on restart couldn't fix this because it only replays events after the stored view version, and the corrupted view's version matched the latest event sequence

## How

### Retry logic (`Projection::react`)
- On `OptimisticLockError`, re-load the view (picking up the concurrent write), re-apply the event, and re-save
- Bounded retry loop: up to 3 retries (4 total attempts) to prevent infinite loops
- No backoff delay needed — by the time we receive `OptimisticLockError`, the conflicting write has already committed (SQLite serializes writes), so re-loading immediately picks up the new version
- `warn!` on each retry attempt, `error!` if all retries are exhausted (view update permanently lost)

### Rebuild methods (`Projection::rebuild` / `rebuild_all`)
- Delete the view row(s), then call `catch_up()` which handles missing rows by replaying from event 1
- Exposed via CLI: `cli rebuild-view --aggregate <position|offchain-order|vault-registry> --id <id>` or `--all`
- `--id` and `--all` are mutually exclusive and one is required — prevents accidentally rebuilding all views when `--id` is omitted

### Flaky test fix (`duplicate_event_delivery`)
- Moved position view snapshot from before `bot.abort()` to after shutdown, so in-flight reactor updates have settled before reading the view
- Verified stable over 10 consecutive runs

## Testing

- `react_retries_on_optimistic_lock_conflict` — `ConflictingRepo` mock that fails twice then succeeds, verifies view is persisted
- `react_gives_up_after_max_retries` — 4 conflicts exceeds max retries, verifies all attempts are made and view remains unchanged
- `react_succeeds_without_conflict` — baseline: no conflicts, view updated on first attempt
- `rebuild_replays_all_events_from_scratch` — corrupted view (value=99 vs correct=2), rebuild fixes it
- `rebuild_all_replays_all_aggregates` — two corrupted aggregates, both reconstructed correctly

## Anything else

- `ConflictingRepo` is a test-only in-memory `ViewRepository` implementation using `AtomicU32` to control how many `OptimisticLockError`s are returned before succeeding — reusable for future concurrency tests in event-sorcery