### PR TITLE
feat: show deployed commit and config in status commands

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -8,6 +8,8 @@ let
   st0xPackage = self.packages.${system}.st0x-liquidity;
   dashboardPackage = self.packages.${system}.st0x-dashboard;
 
+  gitRev = self.rev or self.dirtyRev or "unknown";
+
   rage = "/run/current-system/sw/bin/rage";
   hostKey = "/etc/ssh/ssh_host_ed25519_key";
 
@@ -30,6 +32,7 @@ let
       "${rage} -d -i ${hostKey} ${secretsFile} > ${cfg.decryptedSecretPath}"
       "chown root:st0x ${cfg.decryptedSecretPath}"
       "chmod 0640 ${cfg.decryptedSecretPath}"
+      "echo '${gitRev}' > /run/st0x/${name}.git-rev"
       "touch ${cfg.markerFile}"
       "systemctl restart ${name}"
     ]);

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -80,6 +80,62 @@ echo -e "${BOLD}${WHITE}══════════════════�
 echo -e "  ${status_color}${status_icon} Bot is ${BOLD}${status}${RESET}"
 echo -e "${BOLD}${WHITE}══════════════════════════════════════${RESET}"
 
+# Deployed version
+echo ""
+echo -e "${BOLD}${CYAN}▸ Deployed Version${RESET}"
+git_rev=$($ssh_cmd "cat /run/st0x/st0x-hedge.git-rev 2>/dev/null" || echo "")
+if [ -n "$git_rev" ] && [ "$git_rev" != "unknown" ]; then
+  short_rev="${git_rev:0:8}"
+  echo -e "  ${DIM}Commit:${RESET}   ${WHITE}${short_rev}${RESET}  ${DIM}(${git_rev})${RESET}"
+  echo -e "  ${DIM}GitHub:${RESET}   https://github.com/ST0x-Technology/st0x.liquidity/commit/${git_rev}"
+else
+  echo -e "  ${DIM}Commit:${RESET}   ${YELLOW}unknown${RESET} ${DIM}(pre-tracking deployment)${RESET}"
+fi
+deploy_ts=$($ssh_cmd "stat -c '%y' /nix/var/nix/profiles/per-service/st0x-hedge 2>/dev/null" | cut -d. -f1 || echo "")
+if [ -n "$deploy_ts" ]; then
+  echo -e "  ${DIM}Deployed:${RESET} ${deploy_ts} UTC"
+fi
+
+# Active config summary
+echo ""
+echo -e "${BOLD}${CYAN}▸ Active Config${RESET}"
+config=$($ssh_cmd "cat /run/st0x/st0x-hedge.config 2>/dev/null" || echo "")
+if [ -n "$config" ]; then
+  # Operational settings
+  log_level=$(echo "$config" | grep -E '^log_level' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  deployment_block=$(echo "$config" | grep -E '^deployment_block' | head -1 | sed 's/.*= *//')
+  order_owner=$(echo "$config" | grep -E '^order_owner' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  orderbook=$(echo "$config" | grep -E '^orderbook' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+
+  [ -n "$log_level" ] && echo -e "  ${DIM}Log level:${RESET}        ${WHITE}${log_level}${RESET}"
+  [ -n "$deployment_block" ] && echo -e "  ${DIM}Deployment block:${RESET} ${WHITE}${deployment_block}${RESET}"
+  [ -n "$orderbook" ] && echo -e "  ${DIM}Orderbook:${RESET}        ${WHITE}${orderbook}${RESET}"
+  [ -n "$order_owner" ] && echo -e "  ${DIM}Order owner:${RESET}      ${WHITE}${order_owner}${RESET}"
+
+  # Asset trading status
+  echo ""
+  echo -e "  ${DIM}Assets:${RESET}"
+  # Parse each equity section: extract symbol, trading, and rebalancing status
+  echo "$config" | awk '
+    /^\[assets\.equities\.[A-Z]/ {
+      gsub(/\[assets\.equities\./, ""); gsub(/\]/, "");
+      symbol = $0; trading = ""; rebalancing = ""
+      in_equity = 1; next
+    }
+    /^\[/ { in_equity = 0; next }
+    !in_equity { next }
+    /^trading/ { gsub(/.*= *"?/, ""); gsub(/"/, ""); trading = $0 }
+    /^rebalancing/ {
+      gsub(/.*= *"?/, ""); gsub(/"/, ""); rebalancing = $0
+      color_t = (trading == "enabled") ? "\033[32m" : "\033[2m"
+      color_r = (rebalancing == "enabled") ? "\033[32m" : "\033[2m"
+      printf "    %-6s  trade: %s%-8s\033[0m  rebalance: %s%-8s\033[0m\n", symbol, color_t, trading, color_r, rebalancing
+    }
+  '
+else
+  echo -e "  ${DIM}(no config found)${RESET}"
+fi
+
 # Last boot time
 echo ""
 echo -e "${BOLD}${CYAN}▸ Last Started${RESET}"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -51,8 +51,8 @@ case "$env" in
     order_owner="0x386c24644e532387b03c1992ca83542492a3ac32"
     ;;
   staging)
-    subgraph="${STAGING_SUBGRAPH:?Set STAGING_SUBGRAPH env var for staging status}"
-    order_owner="${STAGING_ORDER_OWNER:?Set STAGING_ORDER_OWNER env var for staging status}"
+    subgraph="https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/2026-02-05-c4ef/gn"
+    order_owner="0x386c24644e532387b03c1992ca83542492a3ac32"
     ;;
   *)
     echo "ERROR: unknown environment '$env'" >&2
@@ -86,14 +86,21 @@ echo -e "${BOLD}${CYAN}▸ Deployed Version${RESET}"
 git_rev=$($ssh_cmd "cat /run/st0x/st0x-hedge.git-rev 2>/dev/null" || echo "")
 if [ -n "$git_rev" ] && [ "$git_rev" != "unknown" ]; then
   short_rev="${git_rev:0:8}"
-  echo -e "  ${DIM}Commit:${RESET}   ${WHITE}${short_rev}${RESET}  ${DIM}(${git_rev})${RESET}"
-  echo -e "  ${DIM}GitHub:${RESET}   https://github.com/ST0x-Technology/st0x.liquidity/commit/${git_rev}"
+  if [[ "$git_rev" =~ ^[0-9a-f]{7,40}$ ]]; then
+    echo -e "  ${DIM}Commit:${RESET}   ${WHITE}${short_rev}${RESET}  ${DIM}(${git_rev})${RESET}"
+    echo -e "  ${DIM}GitHub:${RESET}   https://github.com/ST0x-Technology/st0x.liquidity/commit/${git_rev}"
+  else
+    echo -e "  ${DIM}Commit:${RESET}   ${WHITE}${short_rev}${RESET}  ${YELLOW}[dirty]${RESET} ${DIM}(${git_rev})${RESET}"
+  fi
 else
   echo -e "  ${DIM}Commit:${RESET}   ${YELLOW}unknown${RESET} ${DIM}(pre-tracking deployment)${RESET}"
 fi
-deploy_ts=$($ssh_cmd "stat -c '%y' /nix/var/nix/profiles/per-service/st0x-hedge 2>/dev/null" | cut -d. -f1 || echo "")
-if [ -n "$deploy_ts" ]; then
-  echo -e "  ${DIM}Deployed:${RESET} ${deploy_ts} UTC"
+deploy_epoch=$($ssh_cmd "stat -c '%Y' /nix/var/nix/profiles/per-service/st0x-hedge 2>/dev/null" || echo "")
+if [ -n "$deploy_epoch" ]; then
+  deploy_ts=$(date -u -d "@$deploy_epoch" '+%b %d, %Y %H:%M UTC' 2>/dev/null \
+    || date -u -r "$deploy_epoch" '+%b %d, %Y %H:%M UTC' 2>/dev/null \
+    || echo "$deploy_epoch")
+  echo -e "  ${DIM}Deployed:${RESET} ${deploy_ts}"
 fi
 
 # Active config summary
@@ -102,10 +109,11 @@ echo -e "${BOLD}${CYAN}▸ Active Config${RESET}"
 config=$($ssh_cmd "cat /run/st0x/st0x-hedge.config 2>/dev/null" || echo "")
 if [ -n "$config" ]; then
   # Operational settings
-  log_level=$(echo "$config" | grep -E '^log_level' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
-  deployment_block=$(echo "$config" | grep -E '^deployment_block' | head -1 | sed 's/.*= *//')
-  order_owner=$(echo "$config" | grep -E '^order_owner' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
-  orderbook=$(echo "$config" | grep -E '^orderbook' | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  log_level=$(echo "$config" | { grep -E '^log_level' || true; } | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  deployment_block=$(echo "$config" | { grep -E '^deployment_block' || true; } | head -1 | sed 's/.*= *//')
+  config_order_owner=$(echo "$config" | { grep -E '^order_owner' || true; } | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  orderbook=$(echo "$config" | { grep -E '^orderbook' || true; } | head -1 | sed 's/.*= *"*\([^"]*\)"*/\1/')
+  [ -n "$config_order_owner" ] && order_owner="$config_order_owner"
 
   [ -n "$log_level" ] && echo -e "  ${DIM}Log level:${RESET}        ${WHITE}${log_level}${RESET}"
   [ -n "$deployment_block" ] && echo -e "  ${DIM}Deployment block:${RESET} ${WHITE}${deployment_block}${RESET}"


### PR DESCRIPTION
## What

Closes [RAI-152](https://linear.app/makeitrain/issue/RAI-152/create-simple-way-to-get-prod-bot-status) (extends)

- Show the deployed git commit hash (short + full) with a clickable GitHub link in `prod-status` / `staging-status`
- Show the deploy timestamp derived from the Nix profile
- Display the active plaintext config (log level, deployment block, orderbook, order owner, per-asset trading/rebalancing status)
- Write the git revision to `/run/st0x/st0x-hedge.git-rev` during deploy activation
- Hardcode staging subgraph URL and order owner (previously required env vars)

## Why

- No way to tell what code is running on prod/staging without SSHing in and inspecting Nix store paths manually
- When debugging production issues, the first question is always "what commit is deployed?" — this makes it instantly visible
- Seeing the active config alongside service status avoids a separate SSH-and-cat step
- Staging status required setting `STAGING_SUBGRAPH` and `STAGING_ORDER_OWNER` env vars, which was unnecessary friction since these values are stable

## How

### Deploy-time git rev tracking (`deploy.nix`)
- Extract `self.rev` (or `self.dirtyRev`, or `"unknown"`) from the flake at eval time
- Write it to `/run/st0x/${name}.git-rev` during the service activation script, alongside the existing config/secret setup

### Status script additions (`scripts/status.sh`)
- **Deployed Version** section: reads `/run/st0x/st0x-hedge.git-rev`, shows short hash + full hash + clickable GitHub commit URL + deploy timestamp from the Nix profile (`stat -c '%y'`)
- **Active Config** section: reads `/run/st0x/st0x-hedge.config` and extracts key operational settings (log level, deployment block, orderbook, order owner) plus per-asset trading/rebalancing status using awk parsing
- Hardcode staging subgraph and order_owner instead of requiring env vars
- Gracefully handles pre-tracking deployments by showing "unknown (pre-tracking deployment)"

### Example output
```
▸ Deployed Version
  Commit:   dd5942f7  (dd5942f79fd5633570d89493f545d474f7403428)
  GitHub:   https://github.com/ST0x-Technology/st0x.liquidity/commit/dd5942f7...
  Deployed: 2026-04-10 19:43:07 UTC

▸ Active Config
  Log level:        info
  Deployment block: 12345
  Orderbook:        0xabc...
  Order owner:      0xdef...

  Assets:
    AAPL    trade: enabled   rebalance: enabled
    TSLA    trade: enabled   rebalance: disabled
```

## Testing

- Nix flake evaluates successfully (`nix eval .#packages.aarch64-darwin --apply 'x: builtins.attrNames x'`)
- Shell script passes shellcheck (via pre-commit hook)
- Deployments before this change will show "unknown (pre-tracking deployment)" gracefully

## Anything else

- Only 2 files changed, 63 lines added — minimal surface area
- Stacked on `04-10-fix-deploy-workflows` which fixes the deploy workflow failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status output now displays deployed version information, including git revision and deployment timestamp
  * Configuration details now visible in status output, including log level, deployment block, and symbol-specific trading/rebalancing status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->