### PR TITLE
refactor: rename *_cash fields to actual currency types (USDC/USD)

### DIFF
--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -156,8 +156,8 @@ pub enum AlpacaBrokerApiError {
         max_decimals: u8,
     },
 
-    #[error("Cash balance {} cannot be converted to cents", format_float_with_fallback(.0))]
-    CashBalanceConversion(Float),
+    #[error("USD balance {} cannot be converted to cents", format_float_with_fallback(.0))]
+    UsdBalanceConversion(Float),
 
     #[error("Cash balance {} has fractional cents after conversion", format_float_with_fallback(.0))]
     FractionalCents(Float),

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -81,13 +81,13 @@ pub(super) async fn fetch_inventory(
     let formatted = integer_cents
         .format_with_scientific(false)
         .map_err(AlpacaBrokerApiError::FloatConversion)?;
-    let cash_balance_cents: i64 = formatted
+    let usd_balance_cents: i64 = formatted
         .parse()
-        .map_err(|_| AlpacaBrokerApiError::CashBalanceConversion(account.cash))?;
+        .map_err(|_| AlpacaBrokerApiError::UsdBalanceConversion(account.cash))?;
 
     Ok(Inventory {
         positions: broker_positions,
-        cash_balance_cents,
+        usd_balance_cents,
     })
 }
 
@@ -198,7 +198,7 @@ mod tests {
         account_mock.assert();
 
         assert_eq!(state.positions.len(), 2);
-        assert_eq!(state.cash_balance_cents, 5_000_000);
+        assert_eq!(state.usd_balance_cents, 5_000_000);
 
         let aapl = state
             .positions
@@ -242,7 +242,7 @@ mod tests {
         account_mock.assert();
 
         assert!(state.positions.is_empty());
-        assert_eq!(state.cash_balance_cents, 10_000_000);
+        assert_eq!(state.usd_balance_cents, 10_000_000);
     }
 
     #[tokio::test]

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -347,7 +347,7 @@ pub struct EquityPosition {
 #[derive(Debug, Clone)]
 pub struct Inventory {
     pub positions: Vec<EquityPosition>,
-    pub cash_balance_cents: i64,
+    pub usd_balance_cents: i64,
 }
 
 /// Result of fetching inventory from an executor.

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -299,7 +299,7 @@ mod tests {
                 quantity: shares("100"),
                 market_value: Some(Float::parse("15000".to_string()).unwrap()),
             }],
-            cash_balance_cents: 5_000_000,
+            usd_balance_cents: 5_000_000,
         };
 
         let executor = MockExecutor::new().with_inventory(inventory.clone());
@@ -311,7 +311,7 @@ mod tests {
                 assert_eq!(fetched.positions.len(), 1);
                 assert_eq!(fetched.positions[0].symbol, Symbol::new("AAPL").unwrap());
                 assert_eq!(fetched.positions[0].quantity, shares("100"));
-                assert_eq!(fetched.cash_balance_cents, 5_000_000);
+                assert_eq!(fetched.usd_balance_cents, 5_000_000);
             }
             InventoryResult::Unimplemented => {
                 panic!("Expected Fetched, got Unimplemented")
@@ -333,7 +333,7 @@ mod tests {
     async fn with_inventory_preserves_other_settings() {
         let inventory = crate::Inventory {
             positions: vec![],
-            cash_balance_cents: 10_000,
+            usd_balance_cents: 10_000,
         };
 
         let executor = MockExecutor::new().with_inventory(inventory);

--- a/migrations/20260411002234_rename_cash_fields_to_usdc.sql
+++ b/migrations/20260411002234_rename_cash_fields_to_usdc.sql
@@ -1,0 +1,35 @@
+-- Rename *_cash event types and payload keys to reflect actual currency types
+-- (USDC/USD) instead of generic "cash".
+
+-- OnchainCash -> OnchainUsdc
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::OnchainUsdc',
+    payload = json_object('OnchainUsdc', json_extract(payload, '$.OnchainCash'))
+WHERE event_type = 'InventorySnapshotEvent::OnchainCash';
+
+-- OffchainCash -> OffchainUsd (also rename inner field cash_balance_cents -> usd_balance_cents)
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::OffchainUsd',
+    payload = json_object('OffchainUsd', json_object(
+        'usd_balance_cents', json_extract(payload, '$.OffchainCash.cash_balance_cents'),
+        'fetched_at', json_extract(payload, '$.OffchainCash.fetched_at')
+    ))
+WHERE event_type = 'InventorySnapshotEvent::OffchainCash';
+
+-- EthereumCash -> EthereumUsdc
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::EthereumUsdc',
+    payload = json_object('EthereumUsdc', json_extract(payload, '$.EthereumCash'))
+WHERE event_type = 'InventorySnapshotEvent::EthereumCash';
+
+-- BaseWalletCash -> BaseWalletUsdc
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::BaseWalletUsdc',
+    payload = json_object('BaseWalletUsdc', json_extract(payload, '$.BaseWalletCash'))
+WHERE event_type = 'InventorySnapshotEvent::BaseWalletCash';
+
+-- AlpacaWalletCash -> AlpacaWalletUsdc
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::AlpacaWalletUsdc',
+    payload = json_object('AlpacaWalletUsdc', json_extract(payload, '$.AlpacaWalletCash'))
+WHERE event_type = 'InventorySnapshotEvent::AlpacaWalletCash';

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -311,10 +311,10 @@ if [ -n "$onchain_equity_val" ]; then
   echo -e "    Equity: ${WHITE}$(trunc2 "$onchain_equity_val") RKLB${RESET}  ${DIM}($(fmt_ts "$onchain_equity_ts"))${RESET}"
 fi
 
-onchain_cash_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainCash.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
-onchain_cash_val=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainCash.usdc_balance') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
-if [ -n "$onchain_cash_val" ]; then
-  echo -e "    Cash:   ${WHITE}$(trunc2 "$onchain_cash_val") USDC${RESET}  ${DIM}($(fmt_ts "$onchain_cash_ts"))${RESET}"
+onchain_usdc_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainUsdc.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainUsdc' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+onchain_usdc_val=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OnchainUsdc.usdc_balance') FROM events WHERE event_type = 'InventorySnapshotEvent::OnchainUsdc' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$onchain_usdc_val" ]; then
+  echo -e "    USDC:   ${WHITE}$(trunc2 "$onchain_usdc_val") USDC${RESET}  ${DIM}($(fmt_ts "$onchain_usdc_ts"))${RESET}"
 fi
 
 echo -e "  ${YELLOW}Offchain:${RESET}"
@@ -325,10 +325,10 @@ if [ -n "$offchain_equity_val" ]; then
   echo -e "    Equity: ${WHITE}$(trunc2 "$offchain_equity_val") RKLB${RESET}  ${DIM}($(fmt_ts "$offchain_equity_ts"))${RESET}"
 fi
 
-offchain_cash_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OffchainCash.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
-offchain_cash_val=$($ssh_cmd "sqlite3 $db \"SELECT printf('%.2f', json_extract(payload, '\\\$.OffchainCash.cash_balance_cents') / 100.0) FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainCash' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
-if [ -n "$offchain_cash_val" ]; then
-  echo -e "    Cash:   ${WHITE}\$${offchain_cash_val}${RESET}  ${DIM}($(fmt_ts "$offchain_cash_ts"))${RESET}"
+offchain_usd_ts=$($ssh_cmd "sqlite3 $db \"SELECT json_extract(payload, '\\\$.OffchainUsd.fetched_at') FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainUsd' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+offchain_usd_val=$($ssh_cmd "sqlite3 $db \"SELECT printf('%.2f', json_extract(payload, '\\\$.OffchainUsd.usd_balance_cents') / 100.0) FROM events WHERE event_type = 'InventorySnapshotEvent::OffchainUsd' ORDER BY rowid DESC LIMIT 1;\"" 2>/dev/null || echo "")
+if [ -n "$offchain_usd_val" ]; then
+  echo -e "    USD:    ${WHITE}\$${offchain_usd_val}${RESET}  ${DIM}($(fmt_ts "$offchain_usd_ts"))${RESET}"
 fi
 
 # Recent onchain trades (from events table -- views are rebuilt only at startup)

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -156,7 +156,7 @@ where
         };
 
         self.poll_onchain_equity(snapshot_id, &registry).await?;
-        self.poll_onchain_cash(snapshot_id, &registry).await?;
+        self.poll_onchain_usdc(snapshot_id, &registry).await?;
 
         Ok(())
     }
@@ -221,7 +221,7 @@ where
         Ok(())
     }
 
-    async fn poll_onchain_cash(
+    async fn poll_onchain_usdc(
         &self,
         snapshot_id: &InventorySnapshotId,
         registry: &VaultRegistry,
@@ -242,7 +242,7 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OnchainCash { usdc_balance },
+                InventorySnapshotCommand::OnchainUsdc { usdc_balance },
             )
             .await?;
 
@@ -258,10 +258,10 @@ where
             return Ok(());
         };
 
-        self.poll_ethereum_cash(snapshot_id, &wallets.ethereum)
+        self.poll_ethereum_usdc(snapshot_id, &wallets.ethereum)
             .await?;
 
-        self.poll_base_wallet_cash(snapshot_id, &wallets.base)
+        self.poll_base_wallet_usdc(snapshot_id, &wallets.base)
             .await?;
 
         let balances = self
@@ -298,14 +298,14 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::AlpacaWalletCash { usdc_balance },
+                InventorySnapshotCommand::AlpacaWalletUsdc { usdc_balance },
             )
             .await?;
 
         Ok(())
     }
 
-    async fn poll_ethereum_cash(
+    async fn poll_ethereum_usdc(
         &self,
         snapshot_id: &InventorySnapshotId,
         wallet: &Arc<dyn Wallet<Provider = RootProvider>>,
@@ -324,14 +324,14 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::EthereumCash { usdc_balance },
+                InventorySnapshotCommand::EthereumUsdc { usdc_balance },
             )
             .await?;
 
         Ok(())
     }
 
-    async fn poll_base_wallet_cash(
+    async fn poll_base_wallet_usdc(
         &self,
         snapshot_id: &InventorySnapshotId,
         wallet: &Arc<dyn Wallet<Provider = RootProvider>>,
@@ -350,7 +350,7 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::BaseWalletCash { usdc_balance },
+                InventorySnapshotCommand::BaseWalletUsdc { usdc_balance },
             )
             .await?;
 
@@ -412,8 +412,8 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OffchainCash {
-                    cash_balance_cents: inventory.cash_balance_cents,
+                InventorySnapshotCommand::OffchainUsd {
+                    usd_balance_cents: inventory.usd_balance_cents,
                 },
             )
             .await?;
@@ -717,7 +717,7 @@ mod tests {
                     market_value: Some(float!(20000)),
                 },
             ],
-            cash_balance_cents: 10_000_000,
+            usd_balance_cents: 10_000_000,
         };
         let executor = MockExecutor::new().with_inventory(inventory.clone());
 
@@ -757,7 +757,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_emits_offchain_cash_command_with_executor_cash_balance() {
+    async fn poll_and_record_emits_offchain_usd_command_with_executor_usd_balance() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -765,7 +765,7 @@ mod tests {
 
         let inventory = Inventory {
             positions: vec![],
-            cash_balance_cents: 25_000_000, // $250,000.00
+            usd_balance_cents: 25_000_000, // $250,000.00
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -783,19 +783,19 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let offchain_cash_event = events
+        let offchain_usd_event = events
             .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::OffchainCash { .. }))
-            .expect("Expected OffchainCash event to be emitted");
+            .find(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }))
+            .expect("Expected OffchainUsd event to be emitted");
 
-        let InventorySnapshotEvent::OffchainCash {
-            cash_balance_cents, ..
-        } = offchain_cash_event
+        let InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents, ..
+        } = offchain_usd_event
         else {
-            panic!("Expected OffchainCash event, got {offchain_cash_event:?}");
+            panic!("Expected OffchainUsd event, got {offchain_usd_event:?}");
         };
         assert_eq!(
-            *cash_balance_cents, 25_000_000,
+            *usd_balance_cents, 25_000_000,
             "Cash balance mismatch: expected $250,000.00"
         );
     }
@@ -809,7 +809,7 @@ mod tests {
 
         let inventory = Inventory {
             positions: vec![],
-            cash_balance_cents: 5_000_000,
+            usd_balance_cents: 5_000_000,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -867,17 +867,17 @@ mod tests {
         let has_offchain_equity = events
             .iter()
             .any(|event| matches!(event, InventorySnapshotEvent::OffchainEquity { .. }));
-        let has_offchain_cash = events
+        let has_offchain_usd = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::OffchainCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }));
 
         assert!(
             !has_offchain_equity,
             "Should NOT emit OffchainEquity when executor returns Unimplemented"
         );
         assert!(
-            !has_offchain_cash,
-            "Should NOT emit OffchainCash when executor returns Unimplemented"
+            !has_offchain_usd,
+            "Should NOT emit OffchainUsd when executor returns Unimplemented"
         );
         assert!(
             logs_contain(
@@ -888,7 +888,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_handles_negative_cash_balance() {
+    async fn poll_and_record_handles_negative_usd_balance() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -901,7 +901,7 @@ mod tests {
                 quantity: test_shares(1000),
                 market_value: Some(float!(150000)),
             }],
-            cash_balance_cents: -5_000_000, // -$50,000 (margin debt)
+            usd_balance_cents: -5_000_000, // -$50,000 (margin debt)
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -919,19 +919,19 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let offchain_cash_event = events
+        let offchain_usd_event = events
             .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::OffchainCash { .. }))
-            .expect("Expected OffchainCash event");
+            .find(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. }))
+            .expect("Expected OffchainUsd event");
 
-        let InventorySnapshotEvent::OffchainCash {
-            cash_balance_cents, ..
-        } = offchain_cash_event
+        let InventorySnapshotEvent::OffchainUsd {
+            usd_balance_cents, ..
+        } = offchain_usd_event
         else {
-            panic!("Expected OffchainCash event, got {offchain_cash_event:?}");
+            panic!("Expected OffchainUsd event, got {offchain_usd_event:?}");
         };
         assert_eq!(
-            *cash_balance_cents, -5_000_000,
+            *usd_balance_cents, -5_000_000,
             "Should preserve negative cash balance"
         );
     }
@@ -950,7 +950,7 @@ mod tests {
                 quantity: fractional_qty,
                 market_value: Some(float!(1851.75)),
             }],
-            cash_balance_cents: 1_000_000,
+            usd_balance_cents: 1_000_000,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -993,7 +993,7 @@ mod tests {
 
         let inventory = Inventory {
             positions: vec![],
-            cash_balance_cents: 10_000,
+            usd_balance_cents: 10_000,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1108,17 +1108,17 @@ mod tests {
         let has_onchain_equity = events
             .iter()
             .any(|event| matches!(event, InventorySnapshotEvent::OnchainEquity { .. }));
-        let has_onchain_cash = events
+        let has_onchain_usdc = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::OnchainCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::OnchainUsdc { .. }));
 
         assert!(
             !has_onchain_equity,
             "Should NOT emit OnchainEquity when VaultRegistry not initialized"
         );
         assert!(
-            !has_onchain_cash,
-            "Should NOT emit OnchainCash when VaultRegistry not initialized"
+            !has_onchain_usdc,
+            "Should NOT emit OnchainUsdc when VaultRegistry not initialized"
         );
         assert!(
             logs_contain("Vault registry not initialized, skipping onchain polling"),
@@ -1171,7 +1171,7 @@ mod tests {
 
     #[tracing_test::traced_test]
     #[tokio::test]
-    async fn poll_and_record_skips_onchain_cash_when_no_usdc_vault_discovered() {
+    async fn poll_and_record_skips_onchain_usdc_when_no_usdc_vault_discovered() {
         let pool = setup_test_db().await;
         let (orderbook, order_owner) = test_addresses();
 
@@ -1206,13 +1206,13 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let has_onchain_cash = events
+        let has_onchain_usdc = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::OnchainCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::OnchainUsdc { .. }));
 
         assert!(
-            !has_onchain_cash,
-            "Should NOT emit OnchainCash when no USDC vault discovered"
+            !has_onchain_usdc,
+            "Should NOT emit OnchainUsdc when no USDC vault discovered"
         );
         assert!(
             logs_contain("No USDC vault discovered, skipping onchain cash polling"),
@@ -1335,7 +1335,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_emits_ethereum_cash_when_wallet_provided() {
+    async fn poll_and_record_emits_ethereum_usdc_when_wallet_provided() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1367,20 +1367,20 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let ethereum_cash_event = events
+        let ethereum_usdc_event = events
             .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::EthereumCash { .. }))
-            .expect("Expected EthereumCash event to be emitted");
+            .find(|event| matches!(event, InventorySnapshotEvent::EthereumUsdc { .. }))
+            .expect("Expected EthereumUsdc event to be emitted");
 
-        let InventorySnapshotEvent::EthereumCash { usdc_balance, .. } = ethereum_cash_event else {
-            panic!("Expected EthereumCash event, got {ethereum_cash_event:?}");
+        let InventorySnapshotEvent::EthereumUsdc { usdc_balance, .. } = ethereum_usdc_event else {
+            panic!("Expected EthereumUsdc event, got {ethereum_usdc_event:?}");
         };
         let expected = u256_to_usdc(raw_usdc).unwrap();
         assert_eq!(*usdc_balance, expected, "USDC balance mismatch");
     }
 
     #[tokio::test]
-    async fn poll_and_record_emits_base_wallet_cash_when_wallet_provided() {
+    async fn poll_and_record_emits_base_wallet_usdc_when_wallet_provided() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1412,21 +1412,21 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let base_wallet_cash_event = events
+        let base_wallet_usdc_event = events
             .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::BaseWalletCash { .. }))
-            .expect("Expected BaseWalletCash event to be emitted");
+            .find(|event| matches!(event, InventorySnapshotEvent::BaseWalletUsdc { .. }))
+            .expect("Expected BaseWalletUsdc event to be emitted");
 
-        let InventorySnapshotEvent::BaseWalletCash { usdc_balance, .. } = base_wallet_cash_event
+        let InventorySnapshotEvent::BaseWalletUsdc { usdc_balance, .. } = base_wallet_usdc_event
         else {
-            panic!("Expected BaseWalletCash event, got {base_wallet_cash_event:?}");
+            panic!("Expected BaseWalletUsdc event, got {base_wallet_usdc_event:?}");
         };
         let expected = u256_to_usdc(raw_usdc).unwrap();
         assert_eq!(*usdc_balance, expected, "USDC balance mismatch");
     }
 
     #[tokio::test]
-    async fn poll_and_record_emits_alpaca_wallet_cash_when_wallet_provided() {
+    async fn poll_and_record_emits_alpaca_wallet_usdc_when_wallet_provided() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1465,15 +1465,15 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let alpaca_wallet_cash_event = events
+        let alpaca_wallet_usdc_event = events
             .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletCash { .. }))
-            .expect("Expected AlpacaWalletCash event to be emitted");
+            .find(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }))
+            .expect("Expected AlpacaWalletUsdc event to be emitted");
 
-        let InventorySnapshotEvent::AlpacaWalletCash { usdc_balance, .. } =
-            alpaca_wallet_cash_event
+        let InventorySnapshotEvent::AlpacaWalletUsdc { usdc_balance, .. } =
+            alpaca_wallet_usdc_event
         else {
-            panic!("Expected AlpacaWalletCash event, got {alpaca_wallet_cash_event:?}");
+            panic!("Expected AlpacaWalletUsdc event, got {alpaca_wallet_usdc_event:?}");
         };
         assert!(usdc_balance.inner().eq(float!(1250.75)).unwrap());
         wallets_mock.assert();
@@ -1481,7 +1481,7 @@ mod tests {
 
     #[tracing_test::traced_test]
     #[tokio::test]
-    async fn poll_and_record_skips_alpaca_wallet_cash_when_no_wallet() {
+    async fn poll_and_record_skips_alpaca_wallet_usdc_when_no_wallet() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1501,13 +1501,13 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let has_alpaca_wallet_cash = events
+        let has_alpaca_wallet_usdc = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }));
 
         assert!(
-            !has_alpaca_wallet_cash,
-            "Should NOT emit AlpacaWalletCash when no Alpaca wallet configured"
+            !has_alpaca_wallet_usdc,
+            "Should NOT emit AlpacaWalletUsdc when no Alpaca wallet configured"
         );
         assert!(logs_contain(
             "No wallet polling configured, skipping wallet balance polling"
@@ -1555,7 +1555,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_skips_unchanged_alpaca_wallet_cash_snapshot() {
+    async fn poll_and_record_skips_unchanged_alpaca_wallet_usdc_snapshot() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1595,21 +1595,21 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let alpaca_wallet_cash_event_count = events
+        let alpaca_wallet_usdc_event_count = events
             .iter()
-            .filter(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletCash { .. }))
+            .filter(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }))
             .count();
 
         assert_eq!(
-            alpaca_wallet_cash_event_count, 1,
-            "Should not emit a second AlpacaWalletCash event when the balance is unchanged"
+            alpaca_wallet_usdc_event_count, 1,
+            "Should not emit a second AlpacaWalletUsdc event when the balance is unchanged"
         );
         wallets_mock.assert_calls(2);
     }
 
     #[tracing_test::traced_test]
     #[tokio::test]
-    async fn poll_and_record_skips_ethereum_cash_when_no_wallet() {
+    async fn poll_and_record_skips_ethereum_usdc_when_no_wallet() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1631,13 +1631,13 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let has_ethereum_cash = events
+        let has_ethereum_usdc = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::EthereumCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::EthereumUsdc { .. }));
 
         assert!(
-            !has_ethereum_cash,
-            "Should NOT emit EthereumCash when no Ethereum wallet configured"
+            !has_ethereum_usdc,
+            "Should NOT emit EthereumUsdc when no Ethereum wallet configured"
         );
         assert!(
             logs_contain("No wallet polling configured, skipping wallet balance polling"),
@@ -1647,7 +1647,7 @@ mod tests {
 
     #[tracing_test::traced_test]
     #[tokio::test]
-    async fn poll_and_record_skips_base_wallet_cash_when_no_wallet() {
+    async fn poll_and_record_skips_base_wallet_usdc_when_no_wallet() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -1669,13 +1669,13 @@ mod tests {
         service.poll_and_record().await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let has_base_wallet_cash = events
+        let has_base_wallet_usdc = events
             .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::BaseWalletCash { .. }));
+            .any(|event| matches!(event, InventorySnapshotEvent::BaseWalletUsdc { .. }));
 
         assert!(
-            !has_base_wallet_cash,
-            "Should NOT emit BaseWalletCash when no Base wallet configured"
+            !has_base_wallet_usdc,
+            "Should NOT emit BaseWalletUsdc when no Base wallet configured"
         );
         assert!(
             logs_contain("No wallet polling configured, skipping wallet balance polling"),

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -68,17 +68,17 @@ pub(crate) struct InventorySnapshot {
     /// Latest onchain equity balances by symbol
     pub(crate) onchain_equity: BTreeMap<Symbol, FractionalShares>,
     /// Latest onchain USDC balance
-    pub(crate) onchain_cash: Option<Usdc>,
+    pub(crate) onchain_usdc: Option<Usdc>,
     /// Latest offchain equity positions by symbol
     pub(crate) offchain_equity: BTreeMap<Symbol, FractionalShares>,
-    /// Latest offchain cash balance in cents
-    pub(crate) offchain_cash_cents: Option<i64>,
+    /// Latest offchain USD balance in cents
+    pub(crate) offchain_usd_cents: Option<i64>,
     /// Latest Ethereum wallet USDC balance
-    pub(crate) ethereum_cash: Option<Usdc>,
+    pub(crate) ethereum_usdc: Option<Usdc>,
     /// Latest Base wallet USDC balance (outside Raindex vaults)
     pub(crate) base_wallet_usdc: Option<Usdc>,
     /// Latest USDC balance in Alpaca's crypto wallet
-    pub(crate) alpaca_wallet_cash: Option<Usdc>,
+    pub(crate) alpaca_wallet_usdc: Option<Usdc>,
     /// Latest Base wallet unwrapped equity token balances
     pub(crate) base_wallet_unwrapped_equity: BTreeMap<Symbol, FractionalShares>,
     /// Latest Base wallet wrapped equity token balances
@@ -102,19 +102,19 @@ impl EventSourced for InventorySnapshot {
 
     const AGGREGATE_TYPE: &'static str = "InventorySnapshot";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         let mut snapshot = Self {
             onchain_equity: BTreeMap::new(),
-            onchain_cash: None,
+            onchain_usdc: None,
             offchain_equity: BTreeMap::new(),
-            offchain_cash_cents: None,
-            ethereum_cash: None,
+            offchain_usd_cents: None,
+            ethereum_usdc: None,
             base_wallet_usdc: None,
             inflight_mints: BTreeMap::new(),
             inflight_redemptions: BTreeMap::new(),
-            alpaca_wallet_cash: None,
+            alpaca_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
             base_wallet_wrapped_equity: BTreeMap::new(),
             last_updated: event.timestamp(),
@@ -140,7 +140,7 @@ impl EventSourced for InventorySnapshot {
                 balances,
                 fetched_at: now,
             },
-            OnchainCash { usdc_balance } => InventorySnapshotEvent::OnchainCash {
+            OnchainUsdc { usdc_balance } => InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at: now,
             },
@@ -148,15 +148,15 @@ impl EventSourced for InventorySnapshot {
                 positions,
                 fetched_at: now,
             },
-            OffchainCash { cash_balance_cents } => InventorySnapshotEvent::OffchainCash {
-                cash_balance_cents,
+            OffchainUsd { usd_balance_cents } => InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents,
                 fetched_at: now,
             },
-            EthereumCash { usdc_balance } => InventorySnapshotEvent::EthereumCash {
+            EthereumUsdc { usdc_balance } => InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance,
                 fetched_at: now,
             },
-            BaseWalletCash { usdc_balance } => InventorySnapshotEvent::BaseWalletCash {
+            BaseWalletUsdc { usdc_balance } => InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance,
                 fetched_at: now,
             },
@@ -165,7 +165,7 @@ impl EventSourced for InventorySnapshot {
                 redemptions,
                 fetched_at: now,
             },
-            AlpacaWalletCash { usdc_balance } => InventorySnapshotEvent::AlpacaWalletCash {
+            AlpacaWalletUsdc { usdc_balance } => InventorySnapshotEvent::AlpacaWalletUsdc {
                 usdc_balance,
                 fetched_at: now,
             },
@@ -197,7 +197,7 @@ impl EventSourced for InventorySnapshot {
                 balances,
                 fetched_at: now,
             }]),
-            OnchainCash { usdc_balance } => Ok(vec![InventorySnapshotEvent::OnchainCash {
+            OnchainUsdc { usdc_balance } => Ok(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at: now,
             }]),
@@ -205,24 +205,24 @@ impl EventSourced for InventorySnapshot {
                 positions,
                 fetched_at: now,
             }]),
-            OffchainCash { cash_balance_cents } => Ok(vec![InventorySnapshotEvent::OffchainCash {
-                cash_balance_cents,
+            OffchainUsd { usd_balance_cents } => Ok(vec![InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents,
                 fetched_at: now,
             }]),
-            EthereumCash { usdc_balance } => {
-                if self.ethereum_cash == Some(usdc_balance) {
+            EthereumUsdc { usdc_balance } => {
+                if self.ethereum_usdc == Some(usdc_balance) {
                     return Ok(vec![]);
                 }
-                Ok(vec![InventorySnapshotEvent::EthereumCash {
+                Ok(vec![InventorySnapshotEvent::EthereumUsdc {
                     usdc_balance,
                     fetched_at: now,
                 }])
             }
-            BaseWalletCash { usdc_balance } => {
+            BaseWalletUsdc { usdc_balance } => {
                 if self.base_wallet_usdc == Some(usdc_balance) {
                     return Ok(vec![]);
                 }
-                Ok(vec![InventorySnapshotEvent::BaseWalletCash {
+                Ok(vec![InventorySnapshotEvent::BaseWalletUsdc {
                     usdc_balance,
                     fetched_at: now,
                 }])
@@ -237,11 +237,11 @@ impl EventSourced for InventorySnapshot {
                     fetched_at: now,
                 }])
             }
-            AlpacaWalletCash { usdc_balance } => {
-                if self.alpaca_wallet_cash == Some(usdc_balance) {
+            AlpacaWalletUsdc { usdc_balance } => {
+                if self.alpaca_wallet_usdc == Some(usdc_balance) {
                     return Ok(vec![]);
                 }
-                Ok(vec![InventorySnapshotEvent::AlpacaWalletCash {
+                Ok(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
                     usdc_balance,
                     fetched_at: now,
                 }])
@@ -276,21 +276,21 @@ impl InventorySnapshot {
             InventorySnapshotEvent::OnchainEquity { balances, .. } => {
                 self.onchain_equity = balances.clone();
             }
-            InventorySnapshotEvent::OnchainCash { usdc_balance, .. } => {
-                self.onchain_cash = Some(*usdc_balance);
+            InventorySnapshotEvent::OnchainUsdc { usdc_balance, .. } => {
+                self.onchain_usdc = Some(*usdc_balance);
             }
             InventorySnapshotEvent::OffchainEquity { positions, .. } => {
                 self.offchain_equity = positions.clone();
             }
-            InventorySnapshotEvent::OffchainCash {
-                cash_balance_cents, ..
+            InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents, ..
             } => {
-                self.offchain_cash_cents = Some(*cash_balance_cents);
+                self.offchain_usd_cents = Some(*usd_balance_cents);
             }
-            InventorySnapshotEvent::EthereumCash { usdc_balance, .. } => {
-                self.ethereum_cash = Some(*usdc_balance);
+            InventorySnapshotEvent::EthereumUsdc { usdc_balance, .. } => {
+                self.ethereum_usdc = Some(*usdc_balance);
             }
-            InventorySnapshotEvent::BaseWalletCash { usdc_balance, .. } => {
+            InventorySnapshotEvent::BaseWalletUsdc { usdc_balance, .. } => {
                 self.base_wallet_usdc = Some(*usdc_balance);
             }
             InventorySnapshotEvent::InflightEquity {
@@ -299,8 +299,8 @@ impl InventorySnapshot {
                 self.inflight_mints = mints.clone();
                 self.inflight_redemptions = redemptions.clone();
             }
-            InventorySnapshotEvent::AlpacaWalletCash { usdc_balance, .. } => {
-                self.alpaca_wallet_cash = Some(*usdc_balance);
+            InventorySnapshotEvent::AlpacaWalletUsdc { usdc_balance, .. } => {
+                self.alpaca_wallet_usdc = Some(*usdc_balance);
             }
             InventorySnapshotEvent::BaseWalletUnwrappedEquity { balances, .. } => {
                 self.base_wallet_unwrapped_equity = balances.clone();
@@ -317,22 +317,22 @@ pub(crate) enum InventorySnapshotCommand {
     OnchainEquity {
         balances: BTreeMap<Symbol, FractionalShares>,
     },
-    OnchainCash {
+    OnchainUsdc {
         usdc_balance: Usdc,
     },
     OffchainEquity {
         positions: BTreeMap<Symbol, FractionalShares>,
     },
-    OffchainCash {
-        cash_balance_cents: i64,
+    OffchainUsd {
+        usd_balance_cents: i64,
     },
-    EthereumCash {
+    EthereumUsdc {
         usdc_balance: Usdc,
     },
-    BaseWalletCash {
+    BaseWalletUsdc {
         usdc_balance: Usdc,
     },
-    AlpacaWalletCash {
+    AlpacaWalletUsdc {
         usdc_balance: Usdc,
     },
     BaseWalletUnwrappedEquity {
@@ -357,7 +357,8 @@ pub(crate) enum InventorySnapshotEvent {
         balances: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
     },
-    OnchainCash {
+    #[serde(alias = "OnchainCash")]
+    OnchainUsdc {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
     },
@@ -365,15 +366,19 @@ pub(crate) enum InventorySnapshotEvent {
         positions: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
     },
-    OffchainCash {
-        cash_balance_cents: i64,
+    #[serde(alias = "OffchainCash")]
+    OffchainUsd {
+        #[serde(alias = "cash_balance_cents")]
+        usd_balance_cents: i64,
         fetched_at: DateTime<Utc>,
     },
-    EthereumCash {
+    #[serde(alias = "EthereumCash")]
+    EthereumUsdc {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
     },
-    BaseWalletCash {
+    #[serde(alias = "BaseWalletCash")]
+    BaseWalletUsdc {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
     },
@@ -384,7 +389,8 @@ pub(crate) enum InventorySnapshotEvent {
         redemptions: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
     },
-    AlpacaWalletCash {
+    #[serde(alias = "AlpacaWalletCash")]
+    AlpacaWalletUsdc {
         usdc_balance: Usdc,
         fetched_at: DateTime<Utc>,
     },
@@ -402,12 +408,12 @@ impl InventorySnapshotEvent {
     pub(crate) fn timestamp(&self) -> DateTime<Utc> {
         match self {
             Self::OnchainEquity { fetched_at, .. }
-            | Self::OnchainCash { fetched_at, .. }
+            | Self::OnchainUsdc { fetched_at, .. }
             | Self::OffchainEquity { fetched_at, .. }
-            | Self::OffchainCash { fetched_at, .. }
-            | Self::EthereumCash { fetched_at, .. }
-            | Self::BaseWalletCash { fetched_at, .. }
-            | Self::AlpacaWalletCash { fetched_at, .. }
+            | Self::OffchainUsd { fetched_at, .. }
+            | Self::EthereumUsdc { fetched_at, .. }
+            | Self::BaseWalletUsdc { fetched_at, .. }
+            | Self::AlpacaWalletUsdc { fetched_at, .. }
             | Self::BaseWalletUnwrappedEquity { fetched_at, .. }
             | Self::BaseWalletWrappedEquity { fetched_at, .. }
             | Self::InflightEquity { fetched_at, .. } => *fetched_at,
@@ -419,12 +425,12 @@ impl DomainEvent for InventorySnapshotEvent {
     fn event_type(&self) -> String {
         match self {
             Self::OnchainEquity { .. } => "InventorySnapshotEvent::OnchainEquity".to_string(),
-            Self::OnchainCash { .. } => "InventorySnapshotEvent::OnchainCash".to_string(),
+            Self::OnchainUsdc { .. } => "InventorySnapshotEvent::OnchainUsdc".to_string(),
             Self::OffchainEquity { .. } => "InventorySnapshotEvent::OffchainEquity".to_string(),
-            Self::OffchainCash { .. } => "InventorySnapshotEvent::OffchainCash".to_string(),
-            Self::EthereumCash { .. } => "InventorySnapshotEvent::EthereumCash".to_string(),
-            Self::BaseWalletCash { .. } => "InventorySnapshotEvent::BaseWalletCash".to_string(),
-            Self::AlpacaWalletCash { .. } => "InventorySnapshotEvent::AlpacaWalletCash".to_string(),
+            Self::OffchainUsd { .. } => "InventorySnapshotEvent::OffchainUsd".to_string(),
+            Self::EthereumUsdc { .. } => "InventorySnapshotEvent::EthereumUsdc".to_string(),
+            Self::BaseWalletUsdc { .. } => "InventorySnapshotEvent::BaseWalletUsdc".to_string(),
+            Self::AlpacaWalletUsdc { .. } => "InventorySnapshotEvent::AlpacaWalletUsdc".to_string(),
             Self::BaseWalletUnwrappedEquity { .. } => {
                 "InventorySnapshotEvent::BaseWalletUnwrappedEquity".to_string()
             }
@@ -527,7 +533,7 @@ mod tests {
         balances.insert(test_symbol("AAPL"), test_shares(100));
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::OnchainCash {
+            .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
             }])
@@ -550,24 +556,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_onchain_cash_emits_event() {
+    async fn record_onchain_usdc_emits_event() {
         let usdc_balance = Usdc::from_str("10000.50").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::OnchainCash { usdc_balance })
+            .when(InventorySnapshotCommand::OnchainUsdc { usdc_balance })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
         match &events[0] {
-            InventorySnapshotEvent::OnchainCash {
+            InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: event_balance,
                 ..
             } => {
                 assert_eq!(*event_balance, usdc_balance);
             }
-            _ => panic!("Expected OnchainCash event"),
+            _ => panic!("Expected OnchainUsdc event"),
         }
     }
 
@@ -597,24 +603,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn record_offchain_cash_emits_event() {
-        let cash_balance_cents = 50_000_000; // $500,000.00
+    async fn record_offchain_usd_emits_event() {
+        let usd_balance_cents = 50_000_000; // $500,000.00
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::OffchainCash { cash_balance_cents })
+            .when(InventorySnapshotCommand::OffchainUsd { usd_balance_cents })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
         match &events[0] {
-            InventorySnapshotEvent::OffchainCash {
-                cash_balance_cents: event_cents,
+            InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents: event_cents,
                 ..
             } => {
-                assert_eq!(*event_cents, cash_balance_cents);
+                assert_eq!(*event_cents, usd_balance_cents);
             }
-            _ => panic!("Expected OffchainCash event"),
+            _ => panic!("Expected OffchainUsd event"),
         }
     }
 
@@ -630,7 +636,7 @@ mod tests {
                 balances: balances.clone(),
                 fetched_at: Utc::now(),
             },
-            InventorySnapshotEvent::OnchainCash {
+            InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: usdc,
                 fetched_at: Utc::now(),
             },
@@ -639,7 +645,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(snapshot.onchain_equity, balances);
-        assert_eq!(snapshot.onchain_cash, Some(usdc));
+        assert_eq!(snapshot.onchain_usdc, Some(usdc));
     }
 
     #[test]
@@ -668,62 +674,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ethereum_cash_command_initializes_aggregate() {
+    async fn ethereum_usdc_command_initializes_aggregate() {
         let usdc_balance = Usdc::from_str("5000.50").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::EthereumCash { usdc_balance })
+            .when(InventorySnapshotCommand::EthereumUsdc { usdc_balance })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
         match &events[0] {
-            InventorySnapshotEvent::EthereumCash {
+            InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance: event_balance,
                 ..
             } => {
                 assert_eq!(*event_balance, usdc_balance);
             }
-            _ => panic!("Expected EthereumCash event"),
+            _ => panic!("Expected EthereumUsdc event"),
         }
     }
 
     #[tokio::test]
-    async fn ethereum_cash_command_emits_event_on_existing_aggregate() {
+    async fn ethereum_usdc_command_emits_event_on_existing_aggregate() {
         let usdc_balance = Usdc::from_str("2500").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::OnchainCash {
+            .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::EthereumCash { usdc_balance })
+            .when(InventorySnapshotCommand::EthereumUsdc { usdc_balance })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
         match &events[0] {
-            InventorySnapshotEvent::EthereumCash {
+            InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance: event_balance,
                 ..
             } => {
                 assert_eq!(*event_balance, usdc_balance);
             }
-            _ => panic!("Expected EthereumCash event"),
+            _ => panic!("Expected EthereumUsdc event"),
         }
     }
 
     #[tokio::test]
-    async fn ethereum_cash_command_skips_event_when_unchanged() {
+    async fn ethereum_usdc_command_skips_event_when_unchanged() {
         let usdc_balance = Usdc::from_str("5000").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::EthereumCash {
+            .given(vec![InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::EthereumCash { usdc_balance })
+            .when(InventorySnapshotCommand::EthereumUsdc { usdc_balance })
             .await
             .events();
 
@@ -734,77 +740,77 @@ mod tests {
     }
 
     #[test]
-    fn apply_event_updates_ethereum_cash() {
+    fn apply_event_updates_ethereum_usdc() {
         let usdc = Usdc::from_str("7500").unwrap();
 
-        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::EthereumCash {
+        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::EthereumUsdc {
             usdc_balance: usdc,
             fetched_at: Utc::now(),
         }])
         .unwrap()
         .unwrap();
 
-        assert_eq!(snapshot.ethereum_cash, Some(usdc));
+        assert_eq!(snapshot.ethereum_usdc, Some(usdc));
     }
 
     #[tokio::test]
-    async fn base_wallet_cash_initializes_on_first_command() {
+    async fn base_wallet_usdc_initializes_on_first_command() {
         let usdc_balance = Usdc::from_str("500").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::BaseWalletCash { usdc_balance })
+            .when(InventorySnapshotCommand::BaseWalletUsdc { usdc_balance })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::BaseWalletCash {
+        let InventorySnapshotEvent::BaseWalletUsdc {
             usdc_balance: event_balance,
             ..
         } = &events[0]
         else {
-            panic!("Expected BaseWalletCash event, got {:?}", events[0]);
+            panic!("Expected BaseWalletUsdc event, got {:?}", events[0]);
         };
         assert_eq!(*event_balance, usdc_balance);
     }
 
     #[tokio::test]
-    async fn base_wallet_cash_emits_on_change() {
+    async fn base_wallet_usdc_emits_on_change() {
         let old_balance = Usdc::from_str("500").unwrap();
         let new_balance = Usdc::from_str("750").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::BaseWalletCash {
+            .given(vec![InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance: old_balance,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::BaseWalletCash {
+            .when(InventorySnapshotCommand::BaseWalletUsdc {
                 usdc_balance: new_balance,
             })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::BaseWalletCash {
+        let InventorySnapshotEvent::BaseWalletUsdc {
             usdc_balance: event_balance,
             ..
         } = &events[0]
         else {
-            panic!("Expected BaseWalletCash event, got {:?}", events[0]);
+            panic!("Expected BaseWalletUsdc event, got {:?}", events[0]);
         };
         assert_eq!(*event_balance, new_balance);
     }
 
     #[tokio::test]
-    async fn base_wallet_cash_skips_when_unchanged() {
+    async fn base_wallet_usdc_skips_when_unchanged() {
         let balance = Usdc::from_str("500").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::BaseWalletCash {
+            .given(vec![InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance: balance,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::BaseWalletCash {
+            .when(InventorySnapshotCommand::BaseWalletUsdc {
                 usdc_balance: balance,
             })
             .await
@@ -817,7 +823,7 @@ mod tests {
     fn apply_event_updates_base_wallet_usdc() {
         let usdc = Usdc::from_str("1234.56").unwrap();
 
-        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::BaseWalletCash {
+        let snapshot = replay::<InventorySnapshot>(vec![InventorySnapshotEvent::BaseWalletUsdc {
             usdc_balance: usdc,
             fetched_at: Utc::now(),
         }])
@@ -828,63 +834,63 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn alpaca_wallet_cash_initializes_on_first_command() {
+    async fn alpaca_wallet_usdc_initializes_on_first_command() {
         let usdc_balance = Usdc::from_str("750").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
-            .when(InventorySnapshotCommand::AlpacaWalletCash { usdc_balance })
+            .when(InventorySnapshotCommand::AlpacaWalletUsdc { usdc_balance })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::AlpacaWalletCash {
+        let InventorySnapshotEvent::AlpacaWalletUsdc {
             usdc_balance: event_balance,
             ..
         } = &events[0]
         else {
-            panic!("Expected AlpacaWalletCash event, got {:?}", events[0]);
+            panic!("Expected AlpacaWalletUsdc event, got {:?}", events[0]);
         };
         assert_eq!(*event_balance, usdc_balance);
     }
 
     #[tokio::test]
-    async fn alpaca_wallet_cash_emits_on_change() {
+    async fn alpaca_wallet_usdc_emits_on_change() {
         let old_balance = Usdc::from_str("750").unwrap();
         let new_balance = Usdc::from_str("0").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::AlpacaWalletCash {
+            .given(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
                 usdc_balance: old_balance,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::AlpacaWalletCash {
+            .when(InventorySnapshotCommand::AlpacaWalletUsdc {
                 usdc_balance: new_balance,
             })
             .await
             .events();
 
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::AlpacaWalletCash {
+        let InventorySnapshotEvent::AlpacaWalletUsdc {
             usdc_balance: event_balance,
             ..
         } = &events[0]
         else {
-            panic!("Expected AlpacaWalletCash event, got {:?}", events[0]);
+            panic!("Expected AlpacaWalletUsdc event, got {:?}", events[0]);
         };
         assert_eq!(*event_balance, new_balance);
     }
 
     #[tokio::test]
-    async fn alpaca_wallet_cash_skips_when_unchanged() {
+    async fn alpaca_wallet_usdc_skips_when_unchanged() {
         let balance = Usdc::from_str("750").unwrap();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::AlpacaWalletCash {
+            .given(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
                 usdc_balance: balance,
                 fetched_at: Utc::now(),
             }])
-            .when(InventorySnapshotCommand::AlpacaWalletCash {
+            .when(InventorySnapshotCommand::AlpacaWalletUsdc {
                 usdc_balance: balance,
             })
             .await
@@ -894,18 +900,18 @@ mod tests {
     }
 
     #[test]
-    fn apply_event_updates_alpaca_wallet_cash() {
+    fn apply_event_updates_alpaca_wallet_usdc() {
         let usdc = Usdc::from_str("987.65").unwrap();
 
         let snapshot =
-            replay::<InventorySnapshot>(vec![InventorySnapshotEvent::AlpacaWalletCash {
+            replay::<InventorySnapshot>(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
                 usdc_balance: usdc,
                 fetched_at: Utc::now(),
             }])
             .unwrap()
             .unwrap();
 
-        assert_eq!(snapshot.alpaca_wallet_cash, Some(usdc));
+        assert_eq!(snapshot.alpaca_wallet_usdc, Some(usdc));
     }
 
     #[tokio::test]
@@ -1308,7 +1314,7 @@ mod tests {
         let before = Utc::now();
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::OnchainCash {
+            .given(vec![InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: Usdc::from_str("1000").unwrap(),
                 fetched_at: Utc::now(),
             }])

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -27,8 +27,8 @@ pub(crate) enum InventoryViewError {
     Equity(#[from] InventoryError<FractionalShares>),
     #[error(transparent)]
     Usdc(#[from] InventoryError<Usdc>),
-    #[error("failed to convert cash balance cents {0} to USDC")]
-    CashBalanceConversion(i64),
+    #[error("failed to convert USD balance cents {0} to USDC")]
+    UsdBalanceConversion(i64),
 }
 
 /// Why an equity imbalance check failed.

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -507,7 +507,7 @@ impl RebalancingTrigger {
                     },
                 ),
 
-                OnchainCash { usdc_balance, .. } => inventory.clone().update_usdc(
+                OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
                     Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
                     now,
                 ),
@@ -523,21 +523,20 @@ impl RebalancingTrigger {
                     },
                 ),
 
-                OffchainCash {
-                    cash_balance_cents, ..
+                OffchainUsd {
+                    usd_balance_cents, ..
                 } => {
-                    let usdc = Usdc::from_cents(*cash_balance_cents).ok_or(
-                        InventoryViewError::CashBalanceConversion(*cash_balance_cents),
-                    )?;
+                    let usdc = Usdc::from_cents(*usd_balance_cents)
+                        .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                     inventory.clone().update_usdc(
                         Inventory::on_snapshot(Venue::Hedging, usdc, fetched_at),
                         now,
                     )
                 }
 
-                EthereumCash { .. }
-                | BaseWalletCash { .. }
-                | AlpacaWalletCash { .. }
+                EthereumUsdc { .. }
+                | BaseWalletUsdc { .. }
+                | AlpacaWalletUsdc { .. }
                 | BaseWalletUnwrappedEquity { .. }
                 | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
 
@@ -607,7 +606,7 @@ impl RebalancingTrigger {
                     })
             }
 
-            OnchainCash { usdc_balance, .. } => inventory.clone().update_usdc(
+            OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
                 Inventory::force_on_snapshot(
                     Venue::MarketMaking,
                     *usdc_balance,
@@ -632,21 +631,20 @@ impl RebalancingTrigger {
                     })
             }
 
-            OffchainCash {
-                cash_balance_cents, ..
+            OffchainUsd {
+                usd_balance_cents, ..
             } => {
-                let usdc = Usdc::from_cents(*cash_balance_cents).ok_or(
-                    InventoryViewError::CashBalanceConversion(*cash_balance_cents),
-                )?;
+                let usdc = Usdc::from_cents(*usd_balance_cents)
+                    .ok_or(InventoryViewError::UsdBalanceConversion(*usd_balance_cents))?;
                 inventory.clone().update_usdc(
                     Inventory::force_on_snapshot(Venue::Hedging, usdc, recovery_reason),
                     now,
                 )
             }
 
-            EthereumCash { .. }
-            | BaseWalletCash { .. }
-            | AlpacaWalletCash { .. }
+            EthereumUsdc { .. }
+            | BaseWalletUsdc { .. }
+            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
 
@@ -687,12 +685,12 @@ impl RebalancingTrigger {
                     self.check_and_trigger_equity(symbol).await?;
                 }
             }
-            OnchainCash { .. } | OffchainCash { .. } => {
+            OnchainUsdc { .. } | OffchainUsd { .. } => {
                 self.check_and_trigger_usdc().await;
             }
-            EthereumCash { .. }
-            | BaseWalletCash { .. }
-            | AlpacaWalletCash { .. }
+            EthereumUsdc { .. }
+            | BaseWalletUsdc { .. }
+            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. }
             // Inflight snapshots don't trigger rebalancing -- they indicate
@@ -3081,7 +3079,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_onchain_cash_via_reactor_updates_usdc_balance() {
+    async fn snapshot_onchain_usdc_via_reactor_updates_usdc_balance() {
         // Start with 500 onchain, 500 offchain = balanced
         let inventory = InventoryView::default().with_usdc(usdc(500), usdc(500));
 
@@ -3105,7 +3103,7 @@ mod tests {
         harness
             .receive::<InventorySnapshot>(
                 id.clone(),
-                InventorySnapshotEvent::OnchainCash {
+                InventorySnapshotEvent::OnchainUsdc {
                     usdc_balance: usdc(900),
                     fetched_at: Utc::now(),
                 },
@@ -3128,7 +3126,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn snapshot_offchain_cash_via_reactor_updates_usdc_balance() {
+    async fn snapshot_offchain_usd_via_reactor_updates_usdc_balance() {
         // Start with 900 onchain, 100 offchain = 90% ratio -> TooMuchOnchain
         let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
 
@@ -3154,8 +3152,8 @@ mod tests {
         harness
             .receive::<InventorySnapshot>(
                 id.clone(),
-                InventorySnapshotEvent::OffchainCash {
-                    cash_balance_cents: 90000,
+                InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents: 90000,
                     fetched_at: Utc::now(),
                 },
             )

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -357,12 +357,12 @@ async fn assert_inventory_snapshots(
 
     if assert_cash {
         assert!(
-            event_types.contains(&"InventorySnapshotEvent::OnchainCash"),
-            "Missing OnchainCash event, got types: {event_types:?}"
+            event_types.contains(&"InventorySnapshotEvent::OnchainUsdc"),
+            "Missing OnchainUsdc event, got types: {event_types:?}"
         );
         assert!(
-            event_types.contains(&"InventorySnapshotEvent::OffchainCash"),
-            "Missing OffchainCash event, got types: {event_types:?}"
+            event_types.contains(&"InventorySnapshotEvent::OffchainUsd"),
+            "Missing OffchainUsd event, got types: {event_types:?}"
         );
     }
 
@@ -412,17 +412,17 @@ async fn assert_inventory_snapshots(
     }
 
     if assert_cash {
-        let last_onchain_cash = events
+        let last_onchain_usdc = events
             .iter()
             .rev()
-            .find(|ev| ev.event_type == "InventorySnapshotEvent::OnchainCash")
-            .ok_or_else(|| anyhow::anyhow!("Missing OnchainCash event"))?;
-        let usdc_balance_str = last_onchain_cash
+            .find(|ev| ev.event_type == "InventorySnapshotEvent::OnchainUsdc")
+            .ok_or_else(|| anyhow::anyhow!("Missing OnchainUsdc event"))?;
+        let usdc_balance_str = last_onchain_usdc
             .payload
-            .get("OnchainCash")
+            .get("OnchainUsdc")
             .and_then(|val| val.get("usdc_balance"))
             .and_then(|val| val.as_str())
-            .ok_or_else(|| anyhow::anyhow!("OnchainCash payload missing usdc_balance"))?;
+            .ok_or_else(|| anyhow::anyhow!("OnchainUsdc payload missing usdc_balance"))?;
         let _usdc_balance = Float::parse(usdc_balance_str.to_string())
             .unwrap_or_else(|err| panic!("Failed to parse onchain USDC balance: {err:?}"));
     }
@@ -1276,62 +1276,62 @@ async fn assert_usdc_rebalancing_onchain_state<P: Provider>(
     Ok(())
 }
 
-/// Asserts that at least one `EthereumCash` inventory snapshot was emitted.
-pub(crate) async fn assert_ethereum_cash_event_exists(
+/// Asserts that at least one `EthereumUsdc` inventory snapshot was emitted.
+pub(crate) async fn assert_ethereum_usdc_event_exists(
     db_path: &std::path::Path,
 ) -> anyhow::Result<()> {
     let pool = connect_db(db_path).await?;
     let events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
 
-    let has_ethereum_cash = events
+    let has_ethereum_usdc = events
         .iter()
-        .any(|event| event.event_type == "InventorySnapshotEvent::EthereumCash");
+        .any(|event| event.event_type == "InventorySnapshotEvent::EthereumUsdc");
     assert!(
-        has_ethereum_cash,
-        "Expected EthereumCash snapshot from Ethereum wallet polling"
+        has_ethereum_usdc,
+        "Expected EthereumUsdc snapshot from Ethereum wallet polling"
     );
 
     pool.close().await;
     Ok(())
 }
 
-pub(crate) async fn assert_base_wallet_cash_event_exists(
+pub(crate) async fn assert_base_wallet_usdc_event_exists(
     db_path: &std::path::Path,
 ) -> anyhow::Result<()> {
     let pool = connect_db(db_path).await?;
     let events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
 
-    let has_base_wallet_cash = events
+    let has_base_wallet_usdc = events
         .iter()
-        .any(|event| event.event_type == "InventorySnapshotEvent::BaseWalletCash");
+        .any(|event| event.event_type == "InventorySnapshotEvent::BaseWalletUsdc");
     assert!(
-        has_base_wallet_cash,
-        "Expected BaseWalletCash snapshot from Base wallet polling"
+        has_base_wallet_usdc,
+        "Expected BaseWalletUsdc snapshot from Base wallet polling"
     );
 
     pool.close().await;
     Ok(())
 }
 
-pub(crate) async fn assert_alpaca_wallet_cash_event(
+pub(crate) async fn assert_alpaca_wallet_usdc_event(
     db_path: &std::path::Path,
     expected_balance: Float,
 ) -> anyhow::Result<()> {
     let pool = connect_db(db_path).await?;
     let events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
 
-    let alpaca_wallet_cash = events
+    let alpaca_wallet_usdc = events
         .iter()
         .rev()
-        .find(|event| event.event_type == "InventorySnapshotEvent::AlpacaWalletCash")
-        .ok_or_else(|| anyhow::anyhow!("Missing AlpacaWalletCash event"))?;
+        .find(|event| event.event_type == "InventorySnapshotEvent::AlpacaWalletUsdc")
+        .ok_or_else(|| anyhow::anyhow!("Missing AlpacaWalletUsdc event"))?;
 
-    let balance_str = alpaca_wallet_cash
+    let balance_str = alpaca_wallet_usdc
         .payload
-        .get("AlpacaWalletCash")
+        .get("AlpacaWalletUsdc")
         .and_then(|value| value.get("usdc_balance"))
         .and_then(|value| value.as_str())
-        .ok_or_else(|| anyhow::anyhow!("AlpacaWalletCash payload missing usdc_balance"))?;
+        .ok_or_else(|| anyhow::anyhow!("AlpacaWalletUsdc payload missing usdc_balance"))?;
     let balance = Float::parse(balance_str.to_string())
         .unwrap_or_else(|error| panic!("Failed to parse Alpaca wallet USDC balance: {error}"));
 

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -792,9 +792,9 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
         .call()
         .await?;
 
-    assert_ethereum_cash_event_exists(&infra.db_path).await?;
-    assert_base_wallet_cash_event_exists(&infra.db_path).await?;
-    assert_alpaca_wallet_cash_event(&infra.db_path, expected_alpaca_wallet_balance).await?;
+    assert_ethereum_usdc_event_exists(&infra.db_path).await?;
+    assert_base_wallet_usdc_event_exists(&infra.db_path).await?;
+    assert_alpaca_wallet_usdc_event(&infra.db_path, expected_alpaca_wallet_balance).await?;
 
     bot.abort();
     Ok(())


### PR DESCRIPTION
## What

Closes [RAI-101](https://linear.app/makeitrain/issue/RAI-101/rename-cash-fields-in-inventorysnapshot-and-related-types)
Closes [#464](https://github.com/ST0x-Technology/st0x.liquidity/issues/464)

Renames all misleading `*_cash` fields in `InventorySnapshot` and related types to reflect the actual currency being tracked — USDC for onchain balances, USD for the offchain broker balance.

**Renamed fields/variants:**

| Old | New | Rationale |
|-----|-----|-----------|
| `onchain_cash` | `onchain_usdc` | Tracks USDC in Raindex vaults |
| `offchain_cash_cents` | `offchain_usd_cents` | Tracks USD cash from broker (not USDC) |
| `ethereum_cash` | `ethereum_usdc` | Tracks USDC in Ethereum wallet |
| `alpaca_wallet_cash` | `alpaca_wallet_usdc` | Tracks USDC in Alpaca's crypto wallet |
| `OnchainCash` | `OnchainUsdc` | Command/Event variant |
| `OffchainCash` | `OffchainUsd` | Command/Event variant |
| `EthereumCash` | `EthereumUsdc` | Command/Event variant |
| `BaseWalletCash` | `BaseWalletUsdc` | Command/Event variant |
| `AlpacaWalletCash` | `AlpacaWalletUsdc` | Command/Event variant |
| `cash_balance_cents` | `usd_balance_cents` | Execution crate `Inventory` struct field |
| `CashBalanceConversion` | `UsdBalanceConversion` | Error variants (view.rs + alpaca_broker_api) |

## Why

- The `*_cash` naming was ambiguous — "cash" doesn't distinguish between onchain USDC stablecoin and offchain USD fiat
- The distinction matters: `offchain_cash_cents` tracks USD from the broker while `onchain_cash` tracks USDC in vaults — these are fundamentally different currencies
- Aligns naming with the rest of the codebase which already uses `usdc` (e.g., `base_wallet_usdc` was already correctly named)

## How

- **Pure rename refactor** across 12 files — no logic changes
- **DB migration** updates existing `event_type` strings and payload JSON keys in the events table so old records match the new naming
- **Serde aliases** (`#[serde(alias = "OnchainCash")]`) on renamed event variants ensure backwards-compatible deserialization as a safety net
- **SCHEMA_VERSION** bumped from 2 to 3
- `scripts/status.sh` updated to query with new event type strings and payload keys

## Testing

- All 1713 existing tests pass unchanged (test names updated to match)
- No new tests needed — this is a mechanical rename with no behavior change
- E2e assertion helpers renamed to match new event type strings

## Screenshots

N/A

## Anything else

- Alpaca API's own `cash` field in their JSON response is **not** renamed — that's their external API, not our domain concept
- Config-level `cash_*` fields (e.g., `cash_ratio`) are **not** in scope — those refer to a different concept (cash allocation ratios)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed inventory balance fields and event types from generic "cash" terminology to currency-specific "USDC" and "USD" labels for clearer balance tracking.
  * Updated status display to show "USDC" and "USD" instead of "Cash".
  * Added database migration for existing event records with backward-compatible serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->