### PR TITLE
fix: include cutoff block in backfill to prevent data loss

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -156,17 +156,19 @@ impl Conductor {
         // Phase 2: determine cutoff block from WS subscription
         let cutoff_block = get_cutoff_block(&mut clear_stream, &mut take_stream, &provider).await?;
 
-        // Phase 3: backfill historical events to the job queue
-        if let Some(end_block) = cutoff_block.checked_sub(1) {
-            backfill_events(
-                &provider,
-                &ctx.evm,
-                end_block,
-                get_backfill_retry_strat(),
-                job_queue.clone(),
-            )
-            .await?;
-        }
+        // Phase 3: backfill historical events to the job queue.
+        // Backfill includes the cutoff block because `get_cutoff_block`
+        // consumed one stream item to learn the block number — that event
+        // would otherwise be lost. Duplicate events from the overlap are
+        // harmless: OnChainTrade aggregates deduplicate by (tx_hash, log_index).
+        backfill_events(
+            &provider,
+            &ctx.evm,
+            cutoff_block,
+            get_backfill_retry_strat(),
+            job_queue.clone(),
+        )
+        .await?;
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())


### PR DESCRIPTION
## What

Closes [RAI-196](https://linear.app/makeitrain/issue/RAI-196/block-n-lost-between-backfill-and-live-stream)

Fixes a bug where events in the cutoff block are silently dropped during the backfill-to-live-stream handoff in `Conductor::run`.

## Why

- `get_cutoff_block` **consumes** one event from the WS stream to learn the current block number `n`
- Backfill then ran up to block `n-1` (`cutoff_block.checked_sub(1)`)
- The live stream resumes at block `n+1` (since the event at `n` was already consumed)
- **Block `n` is never processed by either path** — any order fills in that block are silently lost, causing missed hedges and stale position data

## How

- Remove the `checked_sub(1)` and pass `cutoff_block` directly to `backfill_events` so backfill includes block `n`
- The consumed stream event and the backfilled events from block `n` may overlap, but this is harmless — `OnChainTrade` aggregates already deduplicate by `(tx_hash, log_index)`, logging "Trade already processed (duplicate event), skipping"
- `backfill_events` already handles `start_block > end_block` gracefully (skips with a log), so no guard needed

## Testing

- All 32 conductor tests pass
- The existing `test_get_cutoff_block_with_timeout` test verifies the timeout fallback path
- The deduplication path is covered by existing `OnChainTrade` aggregate tests

## Screenshots

N/A

## Anything else

- The issue suggested three possible fixes: (1) backfill through block `n` inclusive, (2) use `provider.get_block_number()` instead of consuming the stream, (3) redesign with simultaneous backfill + WS dedup. Option 1 was chosen as the simplest correct fix — it's a one-line change with no architectural risk
- The timeout path (`provider.get_block_number()`) was already correct — no stream event is consumed, so no gap exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event backfilling during startup to include the cutoff block, ensuring complete and uninterrupted historical event recovery during system initialization without gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->