### PR TITLE
fix(flake): use ref syntax for bun2nix pin so Lix accepts it

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,6 +44,7 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "2.0.8",
         "repo": "bun2nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     ragenix.url = "github:yaxitech/ragenix";
     deploy-rs.url = "github:serokell/deploy-rs";
 
-    bun2nix.url = "github:nix-community/bun2nix?tag=2.0.8";
+    bun2nix.url = "github:nix-community/bun2nix/2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
 
     crane.url = "github:ipetkov/crane";


### PR DESCRIPTION
## What

Pin bun2nix flake input to version 2.0.8 using a more explicit reference format.

## Why

The previous URL format using `?tag=2.0.8` was inconsistent with standard Nix flake reference syntax and could potentially cause issues with flake resolution.

## How

Changed the bun2nix URL from `github:nix-community/bun2nix?tag=2.0.8` to `github:nix-community/bun2nix/2.0.8` and added an explicit `ref` field in the flake.lock to ensure the version is properly pinned.

## Testing

Verified that the flake resolves correctly with the new reference format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bun2nix dependency reference to a more explicit version-style declaration for consistency and reliability.
  * No functional or public-facing behavior changes are included; this is a low-risk infrastructure update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->