### PR TITLE
Resume interrupted tokenization aggregates after restart

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -34,7 +34,9 @@ use crate::bindings::IOrderBookV6::{self, IOrderBookV6Instance};
 use crate::conductor::job::cleanup_finished_jobs;
 use crate::config::{AssetsConfig, BrokerCtx, Ctx, CtxError};
 use crate::dashboard::Broadcaster;
-use crate::equity_redemption::symbols_with_stuck_redemptions;
+use crate::equity_redemption::{
+    EquityRedemption, interrupted_redemption_ids, symbols_with_stuck_redemptions,
+};
 use crate::inventory::{
     BroadcastingInventory, Inventory, InventoryPollingService, InventoryProjection,
     InventorySnapshot, Venue,
@@ -53,7 +55,7 @@ use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
-use crate::rebalancing::equity::EquityTransferServices;
+use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingCtx, RebalancingTrigger,
     RebalancingTriggerConfig,
@@ -62,6 +64,7 @@ use crate::symbol::cache::SymbolCache;
 use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
 use crate::tokenization::alpaca::AlpacaTokenizationService;
+use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{DexTradeAccountingJobQueue, TradeAccountingError};
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
@@ -199,8 +202,6 @@ impl Conductor {
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())
             .await?;
-
-        recover_stuck_redemptions(&pool, &inventory).await?;
 
         let (vault_registry, vault_registry_projection) =
             StoreBuilder::<VaultRegistry>::new(pool.clone())
@@ -578,15 +579,34 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             market_maker_wallet,
             deps.inventory.clone(),
             operation_sender,
-            wrapper,
+            wrapper.clone(),
         ));
 
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_trigger, broadcaster);
+        let manifest = QueryManifest::new(rebalancing_trigger.clone(), broadcaster);
 
         let built = manifest
             .build(deps.pool.clone(), equity_transfer_services)
             .await?;
+
+        let recovery_transfer = CrossVenueEquityTransfer::new(
+            raindex_service.clone(),
+            tokenizer.clone(),
+            wrapper.clone(),
+            market_maker_wallet,
+            built.mint.clone(),
+            built.redemption.clone(),
+        );
+
+        recover_interrupted_tokenization_aggregates(
+            &deps.pool,
+            &rebalancing_trigger,
+            deps.inventory.as_ref(),
+            &recovery_transfer,
+            built.mint.clone(),
+            built.redemption.clone(),
+        )
+        .await?;
 
         let frameworks = RebalancingCqrsFrameworks {
             mint: built.mint,
@@ -669,6 +689,62 @@ async fn recover_stuck_redemptions(
         stuck = ?stuck_redemptions,
         "Recovered inflight from event history"
     );
+
+    Ok(())
+}
+
+async fn recover_interrupted_tokenization_aggregates(
+    pool: &SqlitePool,
+    rebalancing_trigger: &RebalancingTrigger,
+    inventory: &BroadcastingInventory,
+    transfer: &CrossVenueEquityTransfer,
+    mint_store: Arc<Store<TokenizedEquityMint>>,
+    redemption_store: Arc<Store<EquityRedemption>>,
+) -> anyhow::Result<()> {
+    let interrupted_mints = interrupted_mint_ids(pool).await?;
+    let interrupted_redemptions = interrupted_redemption_ids(pool).await?;
+
+    for mint_id in &interrupted_mints {
+        let Some(mint) = mint_store.load(mint_id).await? else {
+            return Err(anyhow::anyhow!(
+                "Interrupted mint aggregate {mint_id} missing from store"
+            ));
+        };
+
+        rebalancing_trigger
+            .recover_mint_state(mint_id, &mint)
+            .await?;
+    }
+
+    for redemption_id in &interrupted_redemptions {
+        let Some(redemption) = redemption_store.load(redemption_id).await? else {
+            return Err(anyhow::anyhow!(
+                "Interrupted redemption aggregate {redemption_id} missing from store"
+            ));
+        };
+
+        rebalancing_trigger
+            .recover_redemption_state(redemption_id, &redemption)
+            .await?;
+    }
+
+    recover_stuck_redemptions(pool, inventory).await?;
+
+    for mint_id in &interrupted_mints {
+        transfer.resume_mint(mint_id).await?;
+    }
+
+    for redemption_id in &interrupted_redemptions {
+        transfer.resume_redemption(redemption_id).await?;
+    }
+
+    if !interrupted_mints.is_empty() || !interrupted_redemptions.is_empty() {
+        info!(
+            mint_count = interrupted_mints.len(),
+            redemption_count = interrupted_redemptions.len(),
+            "Recovered interrupted tokenization aggregates"
+        );
+    }
 
     Ok(())
 }

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -1129,7 +1129,7 @@ pub(crate) async fn symbols_with_stuck_redemptions(
 /// until the SQL is updated.
 ///
 /// Queries the event store directly so the result is durable across
-/// restarts — no runtime state required.
+/// restarts -- no runtime state required.
 pub(crate) async fn symbols_with_active_transfers(
     pool: &SqlitePool,
 ) -> Result<HashSet<Symbol>, sqlx::Error> {
@@ -1178,6 +1178,38 @@ pub(crate) async fn symbols_with_active_transfers(
                 .ok()
         })
         .collect())
+}
+
+/// Returns redemption aggregate IDs whose latest event is non-terminal and
+/// should be resumed after restart.
+pub(crate) async fn interrupted_redemption_ids(
+    pool: &SqlitePool,
+) -> Result<Vec<RedemptionAggregateId>, sqlx::Error> {
+    let rows: Vec<String> = sqlx::query_scalar(
+        "WITH latest AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'EquityRedemption' \
+             GROUP BY aggregate_id \
+         ) \
+         SELECT latest.aggregate_id \
+         FROM events last_ev \
+         INNER JOIN latest \
+             ON last_ev.aggregate_id = latest.aggregate_id \
+            AND last_ev.sequence = latest.max_seq \
+         WHERE last_ev.aggregate_type = 'EquityRedemption' \
+           AND last_ev.event_type IN ( \
+               'EquityRedemptionEvent::WithdrawnFromRaindex', \
+               'EquityRedemptionEvent::TokensUnwrapped', \
+               'EquityRedemptionEvent::TokensSent', \
+               'EquityRedemptionEvent::Detected' \
+           ) \
+         ORDER BY latest.aggregate_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(RedemptionAggregateId::new).collect())
 }
 
 fn parse_stuck_symbol(aggregate_id: &str, raw: Option<String>) -> Option<Symbol> {
@@ -2048,6 +2080,48 @@ mod tests {
             "Recovered quantity should be 10, got {:?}",
             result[&aapl]
         );
+    }
+
+    #[tokio::test]
+    async fn interrupted_redemption_ids_returns_only_non_terminal_redemptions() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        insert_event(
+            &pool,
+            "resume-me",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "resume-me",
+            1,
+            "EquityRedemptionEvent::TokensSent",
+            r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000001","redemption_tx":"0x0000000000000000000000000000000000000000000000000000000000000002","sent_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        insert_event(
+            &pool,
+            "completed",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("TSLA"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "completed",
+            1,
+            "EquityRedemptionEvent::Completed",
+            r#"{"Completed":{"completed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = interrupted_redemption_ids(&pool).await.unwrap();
+        assert_eq!(result, vec![RedemptionAggregateId::new("resume-me")]);
     }
 
     #[tokio::test]

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -199,6 +199,171 @@ impl CrossVenueEquityTransfer {
         }
     }
 
+    async fn load_mint_entity(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+    ) -> Result<TokenizedEquityMint, MintError> {
+        self.mint_store
+            .load(issuer_request_id)
+            .await?
+            .ok_or_else(|| MintError::EntityNotFound {
+                issuer_request_id: issuer_request_id.clone(),
+                expected_state: "active mint state",
+            })
+    }
+
+    async fn finalize_received_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        tokens_received: TokensReceivedData,
+    ) -> Result<(), MintError> {
+        self.verify_received_mint(&tokens_received).await?;
+
+        let (wrapped_token, wrapped_shares) = self
+            .wrap_received_mint(issuer_request_id, &tokens_received)
+            .await?;
+
+        self.deposit_wrapped_mint(
+            issuer_request_id,
+            &tokens_received.symbol,
+            wrapped_token,
+            wrapped_shares,
+        )
+        .await
+    }
+
+    async fn deposit_wrapped_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        wrapped_token: Address,
+        wrapped_shares: U256,
+    ) -> Result<(), MintError> {
+        let vault_id = self.raindex.lookup_vault_id(wrapped_token).await?;
+        let vault_deposit_tx_hash = self
+            .raindex
+            .deposit(
+                wrapped_token,
+                vault_id,
+                wrapped_shares,
+                TOKENIZED_EQUITY_DECIMALS,
+            )
+            .await?;
+
+        self.mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::DepositToVault {
+                    vault_deposit_tx_hash,
+                },
+            )
+            .await?;
+
+        info!(%symbol, %vault_deposit_tx_hash, "Mint workflow completed");
+        Ok(())
+    }
+
+    async fn verify_received_mint(
+        &self,
+        tokens_received: &TokensReceivedData,
+    ) -> Result<(), MintError> {
+        info!(
+            shares_minted = %tokens_received.shares_minted,
+            tx_hash = %tokens_received.tx_hash,
+            "Tokens received, verifying onchain"
+        );
+
+        let unwrapped_token = self.wrapper.lookup_underlying(&tokens_received.symbol)?;
+        self.tokenizer
+            .verify_mint_tx(
+                tokens_received.tx_hash,
+                unwrapped_token,
+                tokens_received.wallet,
+                tokens_received.shares_minted,
+            )
+            .await
+            .inspect_err(|error| {
+                warn!(%error, "Onchain mint verification failed");
+            })?;
+
+        Ok(())
+    }
+
+    async fn wrap_received_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        tokens_received: &TokensReceivedData,
+    ) -> Result<(Address, U256), MintError> {
+        info!("Onchain verification passed, wrapping into ERC-4626 shares");
+
+        let wrapped_token = self.wrapper.lookup_derivative(&tokens_received.symbol)?;
+        let (wrap_tx_hash, wrapped_shares) = self
+            .wrapper
+            .to_wrapped(wrapped_token, tokens_received.shares_minted, self.wallet)
+            .await?;
+
+        self.mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash,
+                    wrapped_shares,
+                },
+            )
+            .await?;
+
+        info!(%wrap_tx_hash, %wrapped_shares, "Tokens wrapped, depositing to Raindex vault");
+        Ok((wrapped_token, wrapped_shares))
+    }
+
+    pub(crate) async fn resume_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+    ) -> Result<(), MintError> {
+        loop {
+            match self.load_mint_entity(issuer_request_id).await? {
+                TokenizedEquityMint::MintAccepted { .. } => {
+                    info!(%issuer_request_id, "Resuming accepted mint");
+                    self.mint_store
+                        .send(issuer_request_id, TokenizedEquityMintCommand::Poll)
+                        .await?;
+                }
+                TokenizedEquityMint::TokensReceived { .. } => {
+                    info!(%issuer_request_id, "Resuming received mint");
+                    let tokens_received = self.load_tokens_received(issuer_request_id).await?;
+                    return self
+                        .finalize_received_mint(issuer_request_id, tokens_received)
+                        .await;
+                }
+                TokenizedEquityMint::TokensWrapped {
+                    symbol,
+                    wrapped_shares,
+                    ..
+                } => {
+                    info!(%issuer_request_id, "Resuming wrapped mint");
+                    let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
+                    return self
+                        .deposit_wrapped_mint(
+                            issuer_request_id,
+                            &symbol,
+                            wrapped_token,
+                            wrapped_shares,
+                        )
+                        .await;
+                }
+                TokenizedEquityMint::DepositedIntoRaindex { .. }
+                | TokenizedEquityMint::Failed { .. } => return Ok(()),
+                entity @ TokenizedEquityMint::MintRequested { .. } => {
+                    return Err(MintError::UnexpectedState {
+                        issuer_request_id: issuer_request_id.clone(),
+                        expected_state: "MintAccepted, TokensReceived, or TokensWrapped",
+                        entity: Box::new(entity),
+                    });
+                }
+            }
+        }
+    }
+
     /// Sends the Redeem command to withdraw from Raindex vault.
     async fn withdraw_from_raindex(
         &self,
@@ -351,6 +516,126 @@ impl CrossVenueEquityTransfer {
             }
         }
     }
+
+    async fn load_redemption_entity(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<EquityRedemption, RedemptionError> {
+        self.redemption_store
+            .load(aggregate_id)
+            .await?
+            .ok_or_else(|| RedemptionError::EntityNotFound {
+                aggregate_id: aggregate_id.clone(),
+            })
+    }
+
+    pub(crate) async fn resume_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<(), RedemptionError> {
+        loop {
+            match self.load_redemption_entity(aggregate_id).await? {
+                EquityRedemption::WithdrawnFromRaindex { .. } => {
+                    self.resume_withdrawn_redemption(aggregate_id).await?;
+                }
+                EquityRedemption::TokensUnwrapped { .. } => {
+                    self.resume_unwrapped_redemption(aggregate_id).await?;
+                }
+                EquityRedemption::TokensSent { redemption_tx, .. } => {
+                    self.resume_sent_redemption(aggregate_id, &redemption_tx)
+                        .await?;
+                }
+                EquityRedemption::Pending {
+                    tokenization_request_id,
+                    ..
+                } => {
+                    return self
+                        .resume_pending_redemption(aggregate_id, &tokenization_request_id)
+                        .await;
+                }
+                EquityRedemption::Completed { .. } | EquityRedemption::Failed { .. } => {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    async fn resume_withdrawn_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<(), RedemptionError> {
+        info!(%aggregate_id, "Resuming withdrawn redemption");
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::UnwrapTokens)
+            .await?;
+        Ok(())
+    }
+
+    async fn resume_unwrapped_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<(), RedemptionError> {
+        info!(%aggregate_id, "Resuming unwrapped redemption");
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::SendTokens)
+            .await?;
+        Ok(())
+    }
+
+    async fn resume_sent_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        redemption_tx: &TxHash,
+    ) -> Result<(), RedemptionError> {
+        info!(%aggregate_id, "Resuming sent redemption");
+        match self.poll_detection(aggregate_id, redemption_tx).await {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                self.ignore_redemption_error_if_terminal(aggregate_id, error)
+                    .await
+            }
+        }
+    }
+
+    async fn resume_pending_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        tokenization_request_id: &TokenizationRequestId,
+    ) -> Result<(), RedemptionError> {
+        info!(%aggregate_id, "Resuming detected redemption");
+        match self
+            .poll_completion(aggregate_id, tokenization_request_id)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.ignore_redemption_error_if_terminal(aggregate_id, error)
+                    .await
+            }
+        }
+    }
+
+    async fn ignore_redemption_error_if_terminal(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        error: RedemptionError,
+    ) -> Result<(), RedemptionError> {
+        if self.redemption_is_terminal(aggregate_id).await? {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+
+    async fn redemption_is_terminal(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+    ) -> Result<bool, RedemptionError> {
+        Ok(matches!(
+            self.load_redemption_entity(aggregate_id).await?,
+            EquityRedemption::Completed { .. } | EquityRedemption::Failed { .. }
+        ))
+    }
 }
 
 /// Hedging -> Market-Making: tokenize equity on Alpaca and deposit into
@@ -386,68 +671,8 @@ impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTra
             .await?;
 
         let tokens_received = self.load_tokens_received(&issuer_request_id).await?;
-
-        info!(
-            shares_minted = %tokens_received.shares_minted,
-            tx_hash = %tokens_received.tx_hash,
-            "Tokens received, verifying onchain"
-        );
-
-        let unwrapped_token = self.wrapper.lookup_underlying(&tokens_received.symbol)?;
-        self.tokenizer
-            .verify_mint_tx(
-                tokens_received.tx_hash,
-                unwrapped_token,
-                tokens_received.wallet,
-                tokens_received.shares_minted,
-            )
+        self.finalize_received_mint(&issuer_request_id, tokens_received)
             .await
-            .inspect_err(|error| {
-                warn!(%error, "Onchain mint verification failed");
-            })?;
-
-        info!("Onchain verification passed, wrapping into ERC-4626 shares");
-
-        let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
-        let (wrap_tx_hash, wrapped_shares) = self
-            .wrapper
-            .to_wrapped(wrapped_token, tokens_received.shares_minted, self.wallet)
-            .await?;
-
-        self.mint_store
-            .send(
-                &issuer_request_id,
-                TokenizedEquityMintCommand::WrapTokens {
-                    wrap_tx_hash,
-                    wrapped_shares,
-                },
-            )
-            .await?;
-
-        info!(%wrap_tx_hash, %wrapped_shares, "Tokens wrapped, depositing to Raindex vault");
-
-        let vault_id = self.raindex.lookup_vault_id(wrapped_token).await?;
-        let vault_deposit_tx_hash = self
-            .raindex
-            .deposit(
-                wrapped_token,
-                vault_id,
-                wrapped_shares,
-                TOKENIZED_EQUITY_DECIMALS,
-            )
-            .await?;
-
-        self.mint_store
-            .send(
-                &issuer_request_id,
-                TokenizedEquityMintCommand::DepositToVault {
-                    vault_deposit_tx_hash,
-                },
-            )
-            .await?;
-
-        info!(%vault_deposit_tx_hash, "Mint workflow completed");
-        Ok(())
     }
 }
 
@@ -551,6 +776,81 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_mint_from_accepted_completes_workflow() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = IssuerRequestId::new("ISS-RESUME");
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer.resume_mint(&id).await.unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "Expected deposited mint after resume, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_redemption_from_tokens_sent_completes_workflow() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = RedemptionAggregateId::new("redemption-resume");
+        let symbol = Symbol::new("TEST").unwrap();
+        let (token, _vault_id) = transfer.raindex.lookup_vault_info(&symbol).await.unwrap();
+        let amount = FractionalShares::new(float!(50))
+            .to_u256_18_decimals()
+            .unwrap();
+
+        transfer
+            .withdraw_from_raindex(
+                &id,
+                &symbol,
+                FractionalShares::new(float!(50)),
+                token,
+                amount,
+            )
+            .await
+            .unwrap();
+        transfer.unwrap_and_send(&id).await.unwrap();
+
+        transfer.resume_redemption(&id).await.unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "Expected completed redemption after resume, got: {entity:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1540,9 +1540,139 @@ impl RebalancingTrigger {
         guard.remove(symbol);
     }
 
+    fn mark_equity_in_progress(&self, symbol: &Symbol) {
+        let mut guard = match self.equity_in_progress.write() {
+            Ok(guard) => guard,
+            Err(poison) => poison.into_inner(),
+        };
+        guard.insert(symbol.clone());
+    }
+
     /// Clears the in-progress flag for USDC rebalancing.
     pub(crate) fn clear_usdc_in_progress(&self) {
         self.usdc_in_progress.store(false, Ordering::SeqCst);
+    }
+
+    pub(crate) async fn recover_mint_state(
+        &self,
+        id: &IssuerRequestId,
+        entity: &TokenizedEquityMint,
+    ) -> Result<(), RebalancingTriggerError> {
+        use TokenizedEquityMint::*;
+
+        match entity {
+            MintRequested {
+                symbol, quantity, ..
+            }
+            | MintAccepted {
+                symbol, quantity, ..
+            }
+            | TokensReceived {
+                symbol, quantity, ..
+            }
+            | TokensWrapped {
+                symbol, quantity, ..
+            } => {
+                let quantity = FractionalShares::new(*quantity);
+
+                let (stage, last_progress_at) = match entity {
+                    MintRequested { requested_at, .. } => {
+                        (MintTrackingStage::Requested, *requested_at)
+                    }
+                    MintAccepted { accepted_at, .. } => (MintTrackingStage::Accepted, *accepted_at),
+                    TokensReceived { received_at, .. } => {
+                        (MintTrackingStage::TokensReceived, *received_at)
+                    }
+                    TokensWrapped { wrapped_at, .. } => {
+                        (MintTrackingStage::TokensWrapped, *wrapped_at)
+                    }
+                    _ => unreachable!(),
+                };
+
+                self.mint_tracking.write().await.insert(
+                    id.clone(),
+                    MintTracking {
+                        symbol: symbol.clone(),
+                        quantity,
+                        stage,
+                        last_progress_at,
+                    },
+                );
+                self.mark_equity_in_progress(symbol);
+
+                if matches!(entity, MintAccepted { .. }) {
+                    let mut inventory = self.inventory.write().await;
+                    *inventory = inventory.clone().update_equity(
+                        symbol,
+                        Inventory::set_inflight(Venue::Hedging, quantity),
+                        Utc::now(),
+                    )?;
+                }
+            }
+            DepositedIntoRaindex { .. } | Failed { .. } => {}
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn recover_redemption_state(
+        &self,
+        id: &RedemptionAggregateId,
+        entity: &EquityRedemption,
+    ) -> Result<(), RebalancingTriggerError> {
+        use EquityRedemption::*;
+
+        match entity {
+            WithdrawnFromRaindex {
+                symbol, quantity, ..
+            }
+            | TokensUnwrapped {
+                symbol, quantity, ..
+            }
+            | TokensSent {
+                symbol, quantity, ..
+            }
+            | Pending {
+                symbol, quantity, ..
+            } => {
+                let quantity = FractionalShares::new(*quantity);
+
+                let (stage, last_progress_at) = match entity {
+                    WithdrawnFromRaindex { withdrawn_at, .. } => {
+                        (RedemptionTrackingStage::WithdrawnFromRaindex, *withdrawn_at)
+                    }
+                    TokensUnwrapped { unwrapped_at, .. } => {
+                        (RedemptionTrackingStage::TokensUnwrapped, *unwrapped_at)
+                    }
+                    TokensSent { sent_at, .. } => (RedemptionTrackingStage::TokensSent, *sent_at),
+                    Pending { detected_at, .. } => {
+                        (RedemptionTrackingStage::Detected, *detected_at)
+                    }
+                    _ => unreachable!(),
+                };
+
+                self.redemption_tracking.write().await.insert(
+                    id.clone(),
+                    RedemptionTracking {
+                        symbol: symbol.clone(),
+                        quantity,
+                        stage,
+                        last_progress_at,
+                    },
+                );
+                self.mark_equity_in_progress(symbol);
+
+                let mut inventory = self.inventory.write().await;
+                *inventory = inventory.clone().update_equity(
+                    symbol,
+                    Inventory::set_inflight(Venue::MarketMaking, quantity),
+                    Utc::now(),
+                )?;
+            }
+            Completed { .. } | Failed { .. } => {}
+        }
+
+        Ok(())
     }
 
     async fn on_mint(
@@ -1788,6 +1918,93 @@ mod tests {
             )),
             receiver,
         )
+    }
+
+    #[tokio::test]
+    async fn recover_mint_state_restores_tracking_and_inflight() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-recovery");
+        let accepted_at = Utc::now();
+
+        trigger
+            .recover_mint_state(
+                &mint_id,
+                &TokenizedEquityMint::MintAccepted {
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    issuer_request_id: mint_id.clone(),
+                    tokenization_request_id: TokenizationRequestId("TOK-1".to_string()),
+                    requested_at: Utc::now(),
+                    accepted_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+
+        let tracking = trigger
+            .mint_tracking
+            .read()
+            .await
+            .get(&mint_id)
+            .cloned()
+            .unwrap();
+        assert_eq!(tracking.symbol, symbol);
+        assert_eq!(tracking.quantity, FractionalShares::new(float!(10)));
+        assert_eq!(tracking.stage, MintTrackingStage::Accepted);
+        assert_eq!(tracking.last_progress_at, accepted_at);
+
+        let inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_inflight(&symbol, Venue::Hedging)
+        };
+        assert_eq!(inflight, Some(FractionalShares::new(float!(10))));
+    }
+
+    #[tokio::test]
+    async fn recover_redemption_state_restores_tracking_and_inflight() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-recovery");
+        let detected_at = Utc::now();
+
+        trigger
+            .recover_redemption_state(
+                &redemption_id,
+                &EquityRedemption::Pending {
+                    symbol: symbol.clone(),
+                    quantity: float!(12),
+                    redemption_tx: TxHash::random(),
+                    tokenization_request_id: TokenizationRequestId("TOK-2".to_string()),
+                    sent_at: Utc::now(),
+                    detected_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
+
+        let tracking = trigger
+            .redemption_tracking
+            .read()
+            .await
+            .get(&redemption_id)
+            .cloned()
+            .unwrap();
+        assert_eq!(tracking.symbol, symbol);
+        assert_eq!(tracking.quantity, FractionalShares::new(float!(12)));
+        assert_eq!(tracking.stage, RedemptionTrackingStage::Detected);
+        assert_eq!(tracking.last_progress_at, detected_at);
+
+        let inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_inflight(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(inflight, Some(FractionalShares::new(float!(12))));
     }
 
     /// Mirrors the production wiring where [`InventoryProjection`] writes

--- a/src/tokenization/mock_api.rs
+++ b/src/tokenization/mock_api.rs
@@ -247,6 +247,12 @@ impl AlpacaTokenizationMock {
         lock(&self.state).redemption_outcome = outcome;
     }
 
+    /// Configures how many poll cycles a request stays pending before it can
+    /// complete or reject.
+    pub fn set_polls_until_complete(&self, polls_until_complete: usize) {
+        lock(&self.state).polls_until_complete = polls_until_complete;
+    }
+
     /// Injects a pending tokenization request with an arbitrary wallet
     /// address. Used to simulate requests from other conductors sharing
     /// the same Alpaca account.

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -43,6 +43,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
 use std::str::FromStr;
 use tracing::warn;
 
@@ -908,6 +909,38 @@ impl TokenizedEquityMint {
         }
     }
 }
+
+/// Returns mint aggregate IDs whose latest event is non-terminal and should be
+/// resumed after restart.
+pub(crate) async fn interrupted_mint_ids(
+    pool: &SqlitePool,
+) -> Result<Vec<IssuerRequestId>, sqlx::Error> {
+    let rows: Vec<String> = sqlx::query_scalar(
+        "WITH latest AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'TokenizedEquityMint' \
+             GROUP BY aggregate_id \
+         ) \
+         SELECT latest.aggregate_id \
+         FROM events last_ev \
+         INNER JOIN latest \
+             ON last_ev.aggregate_id = latest.aggregate_id \
+            AND last_ev.sequence = latest.max_seq \
+         WHERE last_ev.aggregate_type = 'TokenizedEquityMint' \
+           AND last_ev.event_type IN ( \
+               'TokenizedEquityMintEvent::MintAccepted', \
+               'TokenizedEquityMintEvent::TokensReceived', \
+               'TokenizedEquityMintEvent::TokensWrapped' \
+           ) \
+         ORDER BY latest.aggregate_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(IssuerRequestId::new).collect())
+}
+
 /// Our tokenized equity tokens use 18 decimals.
 pub(crate) const TOKENIZED_EQUITY_DECIMALS: u8 = 18;
 
@@ -1362,6 +1395,7 @@ impl EventSourced for TokenizedEquityMint {
 
 #[cfg(test)]
 mod tests {
+    use sqlx::SqlitePool;
     use std::sync::Arc;
 
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore};
@@ -1430,6 +1464,34 @@ mod tests {
             vault_deposit_tx_hash: TxHash::random(),
             deposited_at: Utc::now(),
         }
+    }
+
+    async fn insert_event(
+        pool: &SqlitePool,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES (?, ?, ?, ?, '1.0', ?, '{}')",
+        )
+        .bind("TokenizedEquityMint")
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn mint_requested_payload(symbol: &str) -> String {
+        format!(
+            r#"{{"MintRequested":{{"symbol":"{symbol}","quantity":"10","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}}}"#
+        )
     }
 
     #[tokio::test]
@@ -1967,6 +2029,48 @@ mod tests {
             matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
             "Expected DepositedIntoRaindex, got: {entity:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn interrupted_mint_ids_returns_only_non_terminal_mints() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        insert_event(
+            &pool,
+            "mint-accepted",
+            0,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "mint-accepted",
+            1,
+            "TokenizedEquityMintEvent::MintAccepted",
+            r#"{"MintAccepted":{"issuer_request_id":"ISS001","tokenization_request_id":"TOK001","accepted_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        insert_event(
+            &pool,
+            "mint-deposited",
+            0,
+            "TokenizedEquityMintEvent::MintRequested",
+            &mint_requested_payload("TSLA"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "mint-deposited",
+            1,
+            "TokenizedEquityMintEvent::DepositedIntoRaindex",
+            r#"{"DepositedIntoRaindex":{"vault_deposit_tx_hash":"0x0000000000000000000000000000000000000000000000000000000000000002","deposited_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = interrupted_mint_ids(&pool).await.unwrap();
+        assert_eq!(result, vec![IssuerRequestId::new("mint-accepted")]);
     }
 
     #[test]

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -28,12 +28,38 @@ pub(crate) mod assertions;
 
 use std::collections::HashMap;
 
-use st0x_execution::SharesBlockchain;
+use st0x_execution::{FractionalShares, SharesBlockchain};
 use st0x_hedge::OperationMode;
 
 use self::assertions::*;
 
+use crate::assert::assert_single_clean_aggregate;
 use st0x_float_macro::float;
+
+fn aggregate_id_for_event(events: &[crate::assert::StoredEvent], event_type: &str) -> String {
+    events
+        .iter()
+        .find(|event| event.event_type == event_type)
+        .unwrap_or_else(|| panic!("Missing event type {event_type}"))
+        .aggregate_id
+        .clone()
+}
+
+fn count_tokenization_requests(
+    requests: &[st0x_hedge::mock_api::MockTokenizationRequestSnapshot],
+    request_type: TokenizationRequestType,
+    symbol: &str,
+    status: st0x_hedge::mock_api::TokenizationStatus,
+) -> usize {
+    requests
+        .iter()
+        .filter(|request| {
+            request.request_type == request_type
+                && request.symbol == symbol
+                && request.status == status
+        })
+        .count()
+}
 
 /// Control test: direct high-precision sell-side Raindex prices should not
 /// break equity rebalancing. This avoids buy-side reciprocal math and verifies
@@ -1223,44 +1249,41 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
         ],
     );
 
+    // The number of mint aggregates is timing-sensitive because later fills
+    // can legitimately trigger a follow-up mint after the first cycle
+    // completes. Assert on the inflight snapshots instead: the foreign
+    // wallet's 1000-share request must never appear in our conductor's
+    // polled inflight state.
     let snapshot_events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
-    let inflight_events: Vec<_> = snapshot_events
+    let foreign_request_quantity = FractionalShares::new(float!("1000"));
+    let observed_inflight_mints: Vec<FractionalShares> = snapshot_events
         .iter()
         .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .filter_map(|event| {
+            event
+                .payload
+                .get("InflightEquity")?
+                .get("mints")?
+                .get("AAPL")?
+                .as_str()
+        })
+        .map(|quantity| {
+            quantity
+                .parse::<FractionalShares>()
+                .unwrap_or_else(|error| {
+                    panic!("Failed to parse InflightEquity AAPL quantity '{quantity}': {error:?}")
+                })
+        })
         .collect();
 
-    assert!(
-        !inflight_events.is_empty(),
-        "Expected InflightEquity polling events while the mint was pending"
-    );
-
-    let mut saw_aapl_inflight = false;
-
-    for inflight_event in inflight_events {
-        let Some(quantity_value) = inflight_event
-            .payload
-            .get("InflightEquity")
-            .and_then(|inner| inner.get("mints"))
-            .and_then(|mints| mints.get("AAPL"))
-            .and_then(serde_json::Value::as_str)
-        else {
-            continue;
-        };
-
-        saw_aapl_inflight = true;
-
-        let quantity = float!(quantity_value);
-        assert!(
-            quantity.lt(float!(1000))?,
-            "Foreign wallet pending mint should be filtered out of inflight polling, \
-             got AAPL mint quantity {quantity_value} in payload {}",
-            inflight_event.payload,
-        );
-    }
-
-    assert!(
-        saw_aapl_inflight,
-        "Expected at least one InflightEquity snapshot containing the bot's own AAPL mint"
+    assert_eq!(
+        observed_inflight_mints
+            .iter()
+            .filter(|quantity| **quantity >= foreign_request_quantity)
+            .count(),
+        0,
+        "Foreign wallet request should never appear in inflight polling: \
+         {observed_inflight_mints:?}",
     );
 
     // Verify the foreign request still exists in the mock but was not
@@ -1390,6 +1413,404 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
 
     pool.close().await;
     bot.abort();
+    Ok(())
+}
+
+/// A mint accepted before shutdown must resume and complete after restart.
+#[test_log::test(tokio::test)]
+async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
+    let onchain_price = float!(150.00);
+    let broker_fill_price = float!(148.00);
+    let amount_per_trade = float!(7.5);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    infra.tokenization_service.set_polls_until_complete(4);
+
+    let wrapped_token = infra.equity_addresses[0].1;
+    let unwrapped_token = infra.equity_addresses[0].2;
+
+    let balance_skew: U256 = parse_units("1", 18)?.into();
+    crate::base_chain::IERC20::new(unwrapped_token, &infra.base_chain.provider)
+        .transfer(infra.base_chain.taker, balance_skew)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let mut prepared_orders = Vec::new();
+    for _ in 0..3 {
+        prepared_orders.push(
+            infra
+                .base_chain
+                .setup_order()
+                .symbol("AAPL")
+                .amount(amount_per_trade)
+                .price(onchain_price)
+                .direction(TakeDirection::SellEquity)
+                .call()
+                .await?,
+        );
+    }
+
+    let owner_unwrapped_balance_before_takes =
+        crate::base_chain::IERC20::new(unwrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+    let owner_wrapped_balance_before_takes =
+        crate::base_chain::IERC20::new(wrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+    let owner_unwrapped_shares_before_takes =
+        st0x_execution::FractionalShares::from_u256_18_decimals(
+            owner_unwrapped_balance_before_takes,
+        )?;
+    let owner_wrapped_shares_before_takes =
+        st0x_execution::FractionalShares::from_u256_18_decimals(
+            owner_wrapped_balance_before_takes,
+        )?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared_orders[0].input_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared_orders[0].output_vault_id)]);
+
+    let ctx1 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+    let mut bot1 = spawn_bot(ctx1);
+
+    assert_initial_base_wallet_unwrapped_and_wrapped_equity_snapshot(
+        &mut bot1,
+        &infra.db_path,
+        "AAPL",
+        owner_unwrapped_shares_before_takes,
+        owner_wrapped_shares_before_takes,
+    )
+    .await?;
+
+    let mut take_results = Vec::new();
+    for prepared in &prepared_orders {
+        take_results.push(infra.base_chain.take_prepared_order(prepared).await?);
+    }
+
+    poll_for_events_with_timeout(
+        &mut bot1,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAccepted",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let mint_events_before_restart = fetch_events_by_type(&pool, "TokenizedEquityMint").await?;
+    let resumed_aggregate_id = aggregate_id_for_event(
+        &mint_events_before_restart,
+        "TokenizedEquityMintEvent::MintAccepted",
+    );
+    pool.close().await;
+
+    let requests_before_restart = infra.tokenization_service.tokenization_requests();
+    let pending_mints_before_restart = count_tokenization_requests(
+        &requests_before_restart,
+        TokenizationRequestType::Mint,
+        "AAPL",
+        st0x_hedge::mock_api::TokenizationStatus::Pending,
+    );
+    assert!(
+        pending_mints_before_restart >= 1,
+        "Expected the mint request to still be pending before restart"
+    );
+
+    bot1.abort();
+    let _ = bot1.await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let ctx2 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let mint_events_after_restart = fetch_events_by_type(&pool, "TokenizedEquityMint").await?;
+    assert_single_clean_aggregate(&mint_events_after_restart, &["Failed", "Rejected"]);
+    assert_event_subsequence(
+        &mint_events_after_restart,
+        &[
+            "TokenizedEquityMintEvent::MintRequested",
+            "TokenizedEquityMintEvent::MintAccepted",
+            "TokenizedEquityMintEvent::TokensReceived",
+            "TokenizedEquityMintEvent::TokensWrapped",
+            "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        ],
+    );
+    assert_eq!(
+        aggregate_id_for_event(
+            &mint_events_after_restart,
+            "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        ),
+        resumed_aggregate_id,
+        "Expected the interrupted mint aggregate to complete after restart",
+    );
+    pool.close().await;
+
+    let requests_after_restart = infra.tokenization_service.tokenization_requests();
+    let completed_mints_after_restart = count_tokenization_requests(
+        &requests_after_restart,
+        TokenizationRequestType::Mint,
+        "AAPL",
+        st0x_hedge::mock_api::TokenizationStatus::Completed,
+    );
+    assert!(
+        completed_mints_after_restart >= 1,
+        "Expected a completed mint request after restart"
+    );
+
+    let expected_positions = [ExpectedPosition::builder()
+        .symbol("AAPL")
+        .amount(float!(22.5))
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(float!(22.5))
+        .expected_net(float!(0))
+        .build()];
+
+    assert_equity_rebalancing_flow()
+        .expected_positions(&expected_positions)
+        .take_results(&take_results)
+        .provider(&infra.base_chain.provider)
+        .orderbook(infra.base_chain.orderbook)
+        .owner(infra.base_chain.owner)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .rebalance_type(EquityRebalanceType::Mint {
+            symbol: "AAPL",
+            tokenization: &infra.tokenization_service,
+        })
+        .call()
+        .await?;
+
+    bot2.abort();
+    Ok(())
+}
+
+/// A redemption detected before shutdown must resume and complete after restart.
+#[test_log::test(tokio::test)]
+async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
+    let onchain_price = float!(112.50);
+    let broker_fill_price = float!(113.60);
+    let trade_amount = float!(12.5);
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!("20"))],
+    )
+    .await?;
+    infra.tokenization_service.set_polls_until_complete(4);
+
+    let prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(trade_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::BuyEquity)
+        .call()
+        .await?;
+
+    let vault_addr = infra.equity_addresses[0].1;
+    let underlying_addr = infra.equity_addresses[0].2;
+    let redemption_wallet_balance_before =
+        crate::base_chain::IERC20::new(underlying_addr, &infra.base_chain.provider)
+            .balanceOf(REDEMPTION_WALLET)
+            .call()
+            .await?;
+    let equity_vault_id = prepared.input_vault_id;
+    let extra_equity: U256 = parse_units("20", 18)?.into();
+    infra
+        .base_chain
+        .deposit_into_raindex_vault(vault_addr, equity_vault_id, extra_equity, 18)
+        .await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared.output_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared.input_vault_id)]);
+
+    let ctx1 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+    let mut bot1 = spawn_bot(ctx1);
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    let take_result = infra.base_chain.take_prepared_order(&prepared).await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    poll_for_events_with_timeout(
+        &mut bot1,
+        &infra.db_path,
+        "EquityRedemptionEvent::Detected",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let redemption_events_before_restart = fetch_events_by_type(&pool, "EquityRedemption").await?;
+    let resumed_aggregate_id = aggregate_id_for_event(
+        &redemption_events_before_restart,
+        "EquityRedemptionEvent::Detected",
+    );
+    pool.close().await;
+
+    let requests_before_restart = infra.tokenization_service.tokenization_requests();
+    let pending_redemptions_before_restart = count_tokenization_requests(
+        &requests_before_restart,
+        TokenizationRequestType::Redeem,
+        "AAPL",
+        st0x_hedge::mock_api::TokenizationStatus::Pending,
+    );
+    assert!(
+        pending_redemptions_before_restart >= 1,
+        "Expected the redemption request to still be pending before restart"
+    );
+
+    bot1.abort();
+    let _ = bot1.await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let ctx2 = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "EquityRedemptionEvent::Completed",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let redemption_events_after_restart = fetch_events_by_type(&pool, "EquityRedemption").await?;
+    assert_single_clean_aggregate(&redemption_events_after_restart, &["Failed", "Rejected"]);
+    assert_event_subsequence(
+        &redemption_events_after_restart,
+        &[
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            "EquityRedemptionEvent::TokensUnwrapped",
+            "EquityRedemptionEvent::TokensSent",
+            "EquityRedemptionEvent::Detected",
+            "EquityRedemptionEvent::Completed",
+        ],
+    );
+    assert_eq!(
+        aggregate_id_for_event(
+            &redemption_events_after_restart,
+            "EquityRedemptionEvent::Completed",
+        ),
+        resumed_aggregate_id,
+        "Expected the interrupted redemption aggregate to complete after restart",
+    );
+    pool.close().await;
+
+    let requests_after_restart = infra.tokenization_service.tokenization_requests();
+    let completed_redemptions_after_restart = count_tokenization_requests(
+        &requests_after_restart,
+        TokenizationRequestType::Redeem,
+        "AAPL",
+        st0x_hedge::mock_api::TokenizationStatus::Completed,
+    );
+    assert!(
+        completed_redemptions_after_restart >= 1,
+        "Expected a completed redemption request after restart"
+    );
+
+    let expected_positions = [ExpectedPosition::builder()
+        .symbol("AAPL")
+        .amount(trade_amount)
+        .direction(TakeDirection::BuyEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(12.5))
+        .expected_accumulated_short(float!(0))
+        .expected_net(float!(0))
+        .build()];
+
+    let redemption_wallet_balance_after =
+        crate::base_chain::IERC20::new(underlying_addr, &infra.base_chain.provider)
+            .balanceOf(REDEMPTION_WALLET)
+            .call()
+            .await?;
+
+    assert_equity_rebalancing_flow()
+        .expected_positions(&expected_positions)
+        .take_results(&[take_result])
+        .provider(&infra.base_chain.provider)
+        .orderbook(infra.base_chain.orderbook)
+        .owner(infra.base_chain.owner)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .rebalance_type(EquityRebalanceType::Redeem {
+            symbol: "AAPL",
+            tokenization: &infra.tokenization_service,
+            redemption_wallet_balance_before,
+            redemption_wallet_balance_after,
+        })
+        .call()
+        .await?;
+
+    bot2.abort();
     Ok(())
 }
 


### PR DESCRIPTION
## What

- Closes [RAI-115](https://linear.app/makeitrain/issue/RAI-115/resume-interrupted-tokenization-aggregates-after-restart)
- Resume non-terminal mint and redemption aggregates during conductor startup
- Restore trigger-side tracking and inflight inventory for interrupted tokenization before rebalancing resumes
- Add end-to-end restart coverage for interrupted mint and redemption flows
- Add a test-only tokenization mock control for holding requests pending long enough to exercise restart recovery deterministically

## Why

When the bot crashes mid-tokenization, the aggregate state is still in the event store, but the in-memory workflow state is gone. On restart, the reactor only sees new events, so interrupted mints and redemptions can remain stuck mid-lifecycle with inflight state never cleared.

That leaves the symbol blocked indefinitely until manual intervention. The correct fix is to discover interrupted aggregates at startup, restore the trigger state they depend on, and resume the real workflow from persisted aggregate state.

## How

- Query the event store for `TokenizedEquityMint` and `EquityRedemption` aggregates whose latest event is non-terminal
- During rebalancing startup:
  - load those aggregates from the CQRS stores
  - repopulate `mint_tracking` / `redemption_tracking`
  - restore the relevant `equity_in_progress` guards
  - restore inflight inventory for interrupted tokenization
- Resume mint workflows from persisted states:
  - `MintAccepted` -> poll Alpaca
  - `TokensReceived` -> verify, wrap, deposit
  - `TokensWrapped` -> deposit
- Resume redemption workflows from persisted states:
  - `WithdrawnFromRaindex` -> unwrap
  - `TokensUnwrapped` -> send
  - `TokensSent` -> poll detection
  - `Pending` -> poll completion
- Add focused tests for interrupted aggregate discovery and trigger-state recovery
- Add restart e2e coverage that shuts the bot down after a non-terminal mint/redemption event and verifies the same aggregate completes after restart

## Testing

- `nix develop -c cargo check --workspace`
- `nix develop -c cargo nextest run --workspace --all-features`
- `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `nix develop -c cargo fmt`

Added/updated coverage for:

- interrupted mint aggregate discovery
- interrupted redemption aggregate discovery
- trigger recovery for restored mint/redemption state
- resume-from-accepted mint workflow
- resume-from-sent redemption workflow
- restart recovery e2e for interrupted mint
- restart recovery e2e for interrupted redemption

## Screenshots

- None

## Anything else

- The documented `nix build --impure .#st0x-clippy` target was not available in this Darwin environment, so the CI-equivalent `nix develop -c cargo clippy ...` command was used for verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded and hardened recovery so interrupted equity mint and redemption operations are detected and resumed after restart.

* **New Features**
  * Added resume flows and helpers to continue in-progress mint/redemption work and DB queries to locate interrupted aggregates.
  * Added a test-only setter to control mock tokenization completion timing.

* **Tests**
  * New unit and end-to-end tests validating recovery, inflight tracking, and successful completion after restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->