### PR TITLE
feat: skip # comment lines in cli submit input

### DIFF
--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -59,7 +59,7 @@ pub(crate) fn parse_stdin_lines(reader: impl BufRead) -> Result<Vec<Transaction>
         })?;
 
         let line = line.trim().to_string();
-        if line.is_empty() {
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
@@ -253,6 +253,38 @@ mod tests {
         let input = "\n0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913:0xaa\n\n";
         let txs = parse_stdin_lines(input.as_bytes()).unwrap();
         assert_eq!(txs.len(), 1);
+    }
+
+    #[test]
+    fn parse_skips_comment_lines() {
+        // Producers like `raindex strategy-builder` prefix each tx with a `#`
+        // comment describing what it does. Skip any line starting with `#`.
+        let input = "\
+            # approve WETH\n\
+            0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913:0xaabb\n\
+            # deploy order\n\
+            0x4200000000000000000000000000000000000006:0xccdd\n\
+            # emit metadata\n";
+        let txs = parse_stdin_lines(input.as_bytes()).unwrap();
+        assert_eq!(txs.len(), 2);
+        assert_eq!(txs[0].data, Bytes::from(vec![0xaa, 0xbb]));
+        assert_eq!(txs[1].data, Bytes::from(vec![0xcc, 0xdd]));
+    }
+
+    #[test]
+    fn parse_skips_indented_comment_lines() {
+        // Whitespace before `#` is also skipped (because we trim first).
+        let input =
+            "  # leading whitespace comment\n0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913:0xaa\n";
+        let txs = parse_stdin_lines(input.as_bytes()).unwrap();
+        assert_eq!(txs.len(), 1);
+    }
+
+    #[test]
+    fn parse_only_comments_returns_empty_input_error() {
+        let input = "# only a comment\n# another\n";
+        let result = parse_stdin_lines(input.as_bytes());
+        assert!(matches!(result, Err(SubmitError::EmptyInput)));
     }
 
     #[test]


### PR DESCRIPTION
Note: rainlanguage/raindex#2548 produces the labelled output format that produces the # comment lines this PR now skips.

## Motivation

`raindex strategy-builder` (rainlanguage/raindex#2548) now prefixes each transaction line on stdout with a `#` comment describing what the tx does:

```
# approve WETH
0x833589...:0x095ea7b3...
# deploy fixed-limit order
0xe522cB4a...:0xac9650d8...
# emit strategy metadata
0x59401C93...:0x37480e2a...
```

Piping this directly into `stox submit` currently fails because `parse_stdin_lines` treats a `#` line as a missing-separator parse error.

## Motivation (other side)

Same change is friendly to human operators who want to annotate a saved `deploy.calldata` file with comments.

## Solution

Skip any stdin line that starts with `#` (after trimming) in `parse_stdin_lines`, alongside the existing blank-line skip. Added unit tests for:

- `#`\-prefixed lines interleaved with transaction lines
- Indented `# ` comment lines (whitespace-then-hash)
- Input containing only comments (returns `EmptyInput`)

## Checks

- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input now supports comment lines (lines starting with `#`) for better organization and documentation.

* **Tests**
  * Extended test coverage for comment line handling and mixed input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->