### PR TITLE
fix: credit BaseToAlpaca conversions with actual USD proceeds

### DIFF
--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -1015,7 +1015,10 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
-                conversion: ConversionAmounts::new(Usdc::new(float!(1000)), Usdc::new(float!(1000))),
+                conversion: ConversionAmounts::new(
+                    Usdc::new(float!(1000)),
+                    Usdc::new(float!(1000)),
+                ),
                 converted_at: timestamp(10),
             },
             UsdcRebalanceEvent::WithdrawalSubmitting {

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -990,7 +990,9 @@ mod tests {
 
     use super::*;
     use crate::test_utils::setup_test_db;
-    use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
+    use crate::usdc_rebalance::{
+        ConversionAmounts, ReconcileReason, TransferRef, UsdcRebalanceCommand,
+    };
 
     fn timestamp(seconds: i64) -> DateTime<Utc> {
         Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
@@ -1013,7 +1015,7 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
-                filled_amount: Usdc::new(float!(1000)),
+                conversion: ConversionAmounts::new(Usdc::new(float!(1000)), Usdc::new(float!(1000))),
                 converted_at: timestamp(10),
             },
             UsdcRebalanceEvent::WithdrawalSubmitting {
@@ -1848,7 +1850,7 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
-                filled_amount: Usdc::new(float!(500)),
+                conversion: ConversionAmounts::new(Usdc::new(float!(500)), Usdc::new(float!(500))),
                 converted_at: timestamp(150),
             },
         ];
@@ -2413,7 +2415,7 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
-                filled_amount: Usdc::new(float!(500)),
+                conversion: ConversionAmounts::new(Usdc::new(float!(500)), Usdc::new(float!(500))),
                 converted_at: timestamp(150),
             },
         ];

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -4371,8 +4371,8 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ConfirmConversion {
                     conversion: ConversionAmounts::new(
-                        Usdc::new(float!(500)),
-                        Usdc::new(float!(499)),
+                        Usdc::new(float!(99.99)),
+                        Usdc::new(float!(99.79)),
                     ), // ~0.2% slippage
                 },
             )

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1060,7 +1060,9 @@ mod tests {
     use crate::position::{PositionEvent, TradeId};
     use crate::threshold::ExecutionThreshold;
     use crate::tokenized_equity_mint::{IssuerRequestId, ReceiptId, TokenizationRequestId};
-    use crate::usdc_rebalance::{TransferRef, UsdcRebalanceCommand, UsdcRebalanceId};
+    use crate::usdc_rebalance::{
+        ConversionAmounts, TransferRef, UsdcRebalanceCommand, UsdcRebalanceId,
+    };
     use crate::vault_registry::VaultRegistryCommand;
     use crate::wrapper::mock::MockWrapper;
     use st0x_execution::HasZero;
@@ -2832,7 +2834,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(499)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(500),
+                    usdc(499),
+                ),
             )
             .await
             .unwrap();
@@ -2851,7 +2857,7 @@ mod tests {
         assert_eq!(
             inventory.usdc_available(Venue::Hedging),
             Some(usdc(599)),
-            "terminal conversion should credit offchain cash-equivalent with the filled amount"
+            "terminal conversion should credit offchain cash-equivalent with actual proceeds"
         );
         assert_eq!(
             inventory.usdc_inflight(Venue::Hedging),
@@ -3226,11 +3232,12 @@ mod tests {
 
     fn make_usdc_conversion_confirmed(
         direction: RebalanceDirection,
-        filled_amount: Usdc,
+        source_amount: Usdc,
+        received_amount: Usdc,
     ) -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::ConversionConfirmed {
             direction,
-            filled_amount,
+            conversion: ConversionAmounts::new(source_amount, received_amount),
             converted_at: Utc::now(),
         }
     }
@@ -3264,7 +3271,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(999),
+                ),
             )
             .await
             .unwrap();
@@ -3459,7 +3470,11 @@ mod tests {
         let error = harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(999),
+                ),
             )
             .await
             .unwrap_err();
@@ -3497,7 +3512,11 @@ mod tests {
         let error = harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(1001)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(1001),
+                ),
             )
             .await
             .unwrap_err();
@@ -3577,7 +3596,11 @@ mod tests {
     fn conversion_confirmed_is_terminal_for_base_to_alpaca() {
         // For BaseToAlpaca, ConversionConfirmed IS the terminal event.
         assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(998))
+            &make_usdc_conversion_confirmed(
+                RebalanceDirection::BaseToAlpaca,
+                usdc(1000),
+                usdc(998),
+            )
         ));
     }
 
@@ -3586,7 +3609,11 @@ mod tests {
         // For AlpacaToBase, ConversionConfirmed is NOT terminal (flow continues
         // to withdrawal).
         assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(998))
+            &make_usdc_conversion_confirmed(
+                RebalanceDirection::AlpacaToBase,
+                usdc(1000),
+                usdc(998),
+            )
         ));
     }
 
@@ -4343,7 +4370,10 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: Usdc::new(float!(499)), // ~0.2% slippage
+                    conversion: ConversionAmounts::new(
+                        Usdc::new(float!(500)),
+                        Usdc::new(float!(499)),
+                    ), // ~0.2% slippage
                 },
             )
             .await

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -4851,7 +4851,7 @@ mod tests {
         TokenizationRequestId, TokenizedEquityMintCommand, issuer_request_id,
     };
     use crate::usdc_rebalance::{
-        TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+        ConversionAmounts, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistryCommand;
@@ -9431,7 +9431,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(499)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(500),
+                    usdc(499),
+                ),
             )
             .await
             .unwrap();
@@ -9450,7 +9454,7 @@ mod tests {
         assert_eq!(
             inventory.usdc_available(Venue::Hedging),
             Some(usdc(599)),
-            "terminal conversion should credit offchain cash-equivalent with the filled amount"
+            "terminal conversion should credit offchain cash-equivalent with actual proceeds"
         );
         assert_eq!(
             inventory.usdc_inflight(Venue::Hedging),
@@ -9547,7 +9551,7 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
             )
             .await
             .unwrap();
@@ -9822,7 +9826,7 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(399)),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(399), usdc(399)),
             )
             .await
             .unwrap();
@@ -9850,7 +9854,7 @@ mod tests {
                 name: "conversion_failed_before_withdrawal",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
                     make_usdc_conversion_failed(),
                 ],
             },
@@ -9858,7 +9862,7 @@ mod tests {
                 name: "withdrawal_failed_after_initiated",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
                     make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_withdrawal_failed(),
                 ],
@@ -9867,7 +9871,7 @@ mod tests {
                 name: "bridging_failed_before_burn",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
                     make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_withdrawal_confirmed(),
                     make_usdc_pre_burn_bridging_failed(),
@@ -9982,7 +9986,7 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
             )
             .await
             .unwrap();
@@ -11820,11 +11824,12 @@ mod tests {
 
     fn make_usdc_conversion_confirmed(
         direction: RebalanceDirection,
-        filled_amount: Usdc,
+        source_amount: Usdc,
+        received_amount: Usdc,
     ) -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::ConversionConfirmed {
             direction,
-            filled_amount,
+            conversion: ConversionAmounts::new(source_amount, received_amount),
             converted_at: Utc::now(),
         }
     }
@@ -11908,7 +11913,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(999),
+                ),
             )
             .await
             .unwrap();
@@ -11956,7 +11965,7 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999), usdc(999)),
             )
             .await
             .unwrap();
@@ -17177,7 +17186,7 @@ mod tests {
                 id.clone(),
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: usdc(399),
+                    conversion: ConversionAmounts::new(usdc(399), usdc(399)),
                     converted_at,
                 },
             )
@@ -17263,7 +17272,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(999),
+                ),
             )
             .await
             .unwrap();
@@ -17312,7 +17325,11 @@ mod tests {
         let error = harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(1001)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(1000),
+                    usdc(1001),
+                ),
             )
             .await
             .unwrap_err();
@@ -17397,7 +17414,11 @@ mod tests {
     fn conversion_confirmed_is_terminal_for_base_to_alpaca() {
         // For BaseToAlpaca, ConversionConfirmed IS the terminal event.
         assert!(RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(998))
+            &make_usdc_conversion_confirmed(
+                RebalanceDirection::BaseToAlpaca,
+                usdc(1000),
+                usdc(998),
+            )
         ));
     }
 
@@ -17406,7 +17427,11 @@ mod tests {
         // For AlpacaToBase, ConversionConfirmed is NOT terminal (flow continues
         // to withdrawal).
         assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
-            &make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(998))
+            &make_usdc_conversion_confirmed(
+                RebalanceDirection::AlpacaToBase,
+                usdc(1000),
+                usdc(998),
+            )
         ));
     }
 
@@ -18021,7 +18046,10 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: Usdc::new(float!(499)), // ~0.2% slippage
+                    conversion: ConversionAmounts::new(
+                        Usdc::new(float!(500)),
+                        Usdc::new(float!(499)),
+                    ), // ~0.2% slippage
                 },
             )
             .await
@@ -21047,7 +21075,7 @@ mod tests {
         let error = harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(200)),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(200), usdc(200)),
             )
             .await
             .unwrap_err();
@@ -21180,7 +21208,7 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(400)),
+                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(400), usdc(400)),
             )
             .await
             .unwrap();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -9551,7 +9551,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::AlpacaToBase,
+                    usdc(399),
+                    usdc(399),
+                ),
             )
             .await
             .unwrap();
@@ -9826,7 +9830,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(399), usdc(399)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(399),
+                    usdc(399),
+                ),
             )
             .await
             .unwrap();
@@ -9854,7 +9862,11 @@ mod tests {
                 name: "conversion_failed_before_withdrawal",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
+                    make_usdc_conversion_confirmed(
+                        RebalanceDirection::AlpacaToBase,
+                        usdc(399),
+                        usdc(399),
+                    ),
                     make_usdc_conversion_failed(),
                 ],
             },
@@ -9862,7 +9874,11 @@ mod tests {
                 name: "withdrawal_failed_after_initiated",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
+                    make_usdc_conversion_confirmed(
+                        RebalanceDirection::AlpacaToBase,
+                        usdc(399),
+                        usdc(399),
+                    ),
                     make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_withdrawal_failed(),
                 ],
@@ -9871,7 +9887,11 @@ mod tests {
                 name: "bridging_failed_before_burn",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
+                    make_usdc_conversion_confirmed(
+                        RebalanceDirection::AlpacaToBase,
+                        usdc(399),
+                        usdc(399),
+                    ),
                     make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_withdrawal_confirmed(),
                     make_usdc_pre_burn_bridging_failed(),
@@ -9986,7 +10006,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399), usdc(399)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::AlpacaToBase,
+                    usdc(399),
+                    usdc(399),
+                ),
             )
             .await
             .unwrap();
@@ -11965,7 +11989,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id,
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999), usdc(999)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(999),
+                    usdc(999),
+                ),
             )
             .await
             .unwrap();
@@ -15733,7 +15761,7 @@ mod tests {
             .send(
                 id,
                 UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: amount,
+                    conversion: ConversionAmounts::new(amount, amount),
                 },
             )
             .await
@@ -15897,7 +15925,7 @@ mod tests {
             .send(
                 id,
                 UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: amount,
+                    conversion: ConversionAmounts::new(amount, amount),
                 },
             )
             .await
@@ -18047,8 +18075,8 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ConfirmConversion {
                     conversion: ConversionAmounts::new(
-                        Usdc::new(float!(500)),
-                        Usdc::new(float!(499)),
+                        Usdc::new(float!(99.99)),
+                        Usdc::new(float!(99.79)),
                     ), // ~0.2% slippage
                 },
             )
@@ -21075,7 +21103,11 @@ mod tests {
         let error = harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(200), usdc(200)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::BaseToAlpaca,
+                    usdc(200),
+                    usdc(200),
+                ),
             )
             .await
             .unwrap_err();
@@ -21208,7 +21240,11 @@ mod tests {
         harness
             .receive::<UsdcRebalance>(
                 id.clone(),
-                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(400), usdc(400)),
+                make_usdc_conversion_confirmed(
+                    RebalanceDirection::AlpacaToBase,
+                    usdc(400),
+                    usdc(400),
+                ),
             )
             .await
             .unwrap();

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -247,13 +247,13 @@ impl RebalancingTrigger {
 
             ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
-                filled_amount,
+                conversion,
                 ..
             } => {
                 self.complete_usdc_rebalance(
                     &id,
                     UsdcTrackingEvent::ConversionConfirmed,
-                    *filled_amount,
+                    conversion.received_amount,
                 )
                 .await?;
             }

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -738,13 +738,13 @@ impl RebalancingService {
             }
             ConversionConfirmed {
                 direction: RebalanceDirection::BaseToAlpaca,
-                filled_amount,
+                conversion,
                 ..
             } => {
                 self.complete_usdc_rebalance(
                     id,
                     UsdcTrackingEvent::ConversionConfirmed,
-                    *filled_amount,
+                    conversion.received_amount,
                 )
                 .await?;
             }
@@ -1237,7 +1237,7 @@ mod tests {
 
     use super::*;
     use crate::inventory::InventoryView;
-    use crate::usdc_rebalance::TransferRef;
+    use crate::usdc_rebalance::{ConversionAmounts, TransferRef};
 
     #[test]
     fn test_guard_releases_on_drop() {
@@ -1961,7 +1961,7 @@ mod tests {
     ) -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::ConversionConfirmed {
             direction,
-            filled_amount,
+            conversion: ConversionAmounts::new(filled_amount, filled_amount),
             converted_at: ts(102),
         }
     }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -15,6 +15,7 @@ use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
+use st0x_execution::alpaca_broker_api::CryptoOrderResponse;
 use st0x_execution::{AlpacaBrokerApi, ConversionDirection, Positive};
 use st0x_finance::Usdc;
 
@@ -25,7 +26,8 @@ use crate::alpaca_wallet::{
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::usdc_rebalance::{
-    RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+    ConversionAmounts, RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand,
+    UsdcRebalanceId,
 };
 
 /// Orchestrates USDC rebalancing between Alpaca (Ethereum) and Rain (Base).
@@ -128,25 +130,23 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
-        let filled_qty = order
-            .filled_quantity
-            .ok_or_else(|| UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
-        let filled_amount = Usdc::new(filled_qty);
+        let conversion = self
+            .record_conversion_or_fail(id, &order, ConversionDirection::UsdToUsdc)
+            .await?;
+        let received_amount = conversion.received_amount;
 
         self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ConfirmConversion { filled_amount },
-            )
+            .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await?;
 
         info!(
             order_id = %order.id,
             requested = ?amount,
-            filled = ?filled_qty,
+            source_amount = ?conversion.source_amount,
+            received_amount = ?conversion.received_amount,
             "USD to USDC conversion completed"
         );
-        Ok(filled_amount)
+        Ok(received_amount)
     }
 
     /// Converts USDC to USD buying power.
@@ -154,8 +154,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// Used at the end of BaseToAlpaca flow, after deposit is confirmed.
     /// Places a sell order on USDC/USD and polls until filled.
     ///
-    /// Returns the actual filled USDC amount (the USDC sold, which may
-    /// differ from requested if there's a partial fill).
+    /// Returns the actual USD proceeds credited at Alpaca.
     ///
     /// # Event Sourcing Flow
     ///
@@ -212,27 +211,23 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
-        let filled_amount = order
-            .filled_quantity
-            .ok_or_else(|| UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
-        let filled_usdc = Usdc::new(filled_amount);
+        let conversion = self
+            .record_conversion_or_fail(id, &order, ConversionDirection::UsdcToUsd)
+            .await?;
+        let proceeds = conversion.received_amount;
 
         self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: filled_usdc,
-                },
-            )
+            .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await?;
 
         info!(
             order_id = %order.id,
             requested = ?amount,
-            filled = ?filled_amount,
+            source_amount = ?conversion.source_amount,
+            received_amount = ?conversion.received_amount,
             "USDC to USD conversion completed"
         );
-        Ok(filled_usdc)
+        Ok(proceeds)
     }
 
     /// Executes the full Alpaca to Base rebalancing workflow.
@@ -257,7 +252,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     ) -> Result<(), UsdcTransferError> {
         info!(?amount, "Starting Alpaca to Base rebalance");
 
-        // Convert USD to USDC - use actual filled amount for subsequent steps
+        // Convert USD to USDC - use the actual received amount for subsequent steps
         let usdc_amount = self.execute_usd_to_usdc_conversion(id, amount).await?;
 
         let transfer = self.initiate_alpaca_withdrawal(id, usdc_amount).await?;
@@ -819,6 +814,34 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         info!("Alpaca deposit confirmed");
         Ok(())
     }
+
+    async fn record_conversion_or_fail(
+        &self,
+        id: &UsdcRebalanceId,
+        order: &CryptoOrderResponse,
+        direction: ConversionDirection,
+    ) -> Result<ConversionAmounts, UsdcTransferError> {
+        match conversion_amounts_from_order(order, direction) {
+            Ok(conversion) => Ok(conversion),
+            Err(error) => {
+                warn!(
+                    order_id = %order.id,
+                    ?direction,
+                    %error,
+                    "Conversion response missing fill details"
+                );
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: error.to_string(),
+                        },
+                    )
+                    .await?;
+                Err(error)
+            }
+        }
+    }
 }
 
 /// Converts a USDC decimal amount to U256 with 6 decimals.
@@ -831,6 +854,26 @@ fn usdc_to_u256(usdc: Usdc) -> Result<U256, UsdcTransferError> {
 /// Converts a U256 amount (with 6 decimals) to USDC decimal.
 pub(crate) fn u256_to_usdc(amount: U256) -> Result<Usdc, UsdcTransferError> {
     Ok(Usdc::new(Float::from_fixed_decimal(amount, 6)?))
+}
+
+fn conversion_amounts_from_order(
+    order: &CryptoOrderResponse,
+    direction: ConversionDirection,
+) -> Result<ConversionAmounts, UsdcTransferError> {
+    let filled_quantity = order
+        .filled_quantity
+        .ok_or_else(|| UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
+    let filled_average_price = order
+        .filled_average_price
+        .ok_or_else(|| UsdcTransferError::MissingFilledAveragePrice { order_id: order.id })?;
+
+    let filled_quantity = Usdc::new(filled_quantity);
+    let cash_proceeds = std::ops::Mul::mul(filled_quantity, filled_average_price)?;
+
+    Ok(match direction {
+        ConversionDirection::UsdToUsdc => ConversionAmounts::new(cash_proceeds, filled_quantity),
+        ConversionDirection::UsdcToUsd => ConversionAmounts::new(filled_quantity, cash_proceeds),
+    })
 }
 
 /// Alpaca -> Base (hedging -> market-making): convert USD to USDC,
@@ -919,6 +962,7 @@ mod tests {
         cqrs: &Store<UsdcRebalance>,
         id: &UsdcRebalanceId,
         amount: Usdc,
+        bridged_amount_received: Usdc,
     ) {
         let burn_tx =
             fixed_bytes!("0xbbbb000000000000000000000000000000000000000000000000000000000001");
@@ -958,7 +1002,7 @@ mod tests {
             id,
             UsdcRebalanceCommand::ConfirmBridging {
                 mint_tx,
-                amount_received: usdc("99.99"),
+                amount_received: bridged_amount_received,
                 fee_collected: usdc("0.01"),
             },
         )
@@ -1137,9 +1181,33 @@ mod tests {
         })
     }
 
-    /// Creates a mock where filled_qty differs from requested qty to
-    /// simulate slippage.
-    fn create_get_order_mock_with_slippage<'a>(
+    /// Creates a mock with explicit fill quantity and average price.
+    fn create_get_order_mock_with_fill<'a>(
+        server: &'a MockServer,
+        order_id: &str,
+        requested_qty: &str,
+        filled_qty: &str,
+        filled_avg_price: &str,
+    ) -> httpmock::Mock<'a> {
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "USDCUSD",
+                    "qty": requested_qty,
+                    "status": "filled",
+                    "filled_avg_price": filled_avg_price,
+                    "filled_qty": filled_qty,
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        })
+    }
+
+    fn create_get_order_mock_missing_average_price<'a>(
         server: &'a MockServer,
         order_id: &str,
         requested_qty: &str,
@@ -1156,7 +1224,7 @@ mod tests {
                     "symbol": "USDCUSD",
                     "qty": requested_qty,
                     "status": "filled",
-                    "filled_avg_price": "1.0001",
+                    "filled_avg_price": null,
                     "filled_qty": filled_qty,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
@@ -2089,7 +2157,7 @@ mod tests {
         let amount = usdc("1000");
         let amount_received = usdc("99.99");
 
-        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, amount).await;
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
 
         manager
             .execute_usdc_to_usd_conversion(&id, amount_received)
@@ -2362,7 +2430,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn usd_to_usdc_conversion_returns_actual_filled_amount() {
+    async fn usd_to_usdc_conversion_returns_actual_received_amount() {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
@@ -2387,26 +2455,209 @@ mod tests {
 
         // Request 1000, but only 999.5 fills due to slippage
         let _order_mock = create_conversion_order_pending_mock(&server, "1000");
-        let _get_mock = create_get_order_mock_with_slippage(
+        let _get_mock = create_get_order_mock_with_fill(
             &server,
             "61e7b016-9c91-4a97-b912-615c9d365c9d",
             "1000",
             "999.5",
+            "1.0001",
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let requested_amount = usdc("1000");
 
-        let filled_amount = manager
+        let received_amount = manager
             .execute_usd_to_usdc_conversion(&id, requested_amount)
             .await
             .unwrap();
 
-        // Should return the actual filled amount, not the requested amount
+        // Should return the actual received amount, not the requested amount.
         assert_eq!(
-            filled_amount,
+            received_amount,
             usdc("999.5"),
-            "Should return actual filled amount, not requested amount"
+            "Should return actual received amount, not requested amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn usd_to_usdc_conversion_missing_average_price_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_average_price(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        assert!(
+            matches!(
+                manager.execute_usd_to_usdc_conversion(&id, amount).await,
+                Err(UsdcTransferError::MissingFilledAveragePrice { .. })
+            ),
+            "Missing fill price should fail the conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_returns_actual_proceeds() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_with_fill(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+            "0.9983",
+        );
+
+        let proceeds = manager
+            .execute_usdc_to_usd_conversion(&id, deposited_amount)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            proceeds,
+            usdc("998.3"),
+            "Should return actual USD proceeds, not the USDC sold amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_missing_average_price_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_average_price(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+        );
+
+        assert!(
+            matches!(
+                manager
+                    .execute_usdc_to_usd_conversion(&id, deposited_amount)
+                    .await,
+                Err(UsdcTransferError::MissingFilledAveragePrice { .. })
+            ),
+            "Missing fill price should fail the post-deposit conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
         );
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -828,7 +828,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                     order_id = %order.id,
                     ?direction,
                     %error,
-                    "Conversion response missing fill details"
+                    "Failed to derive settled conversion amounts"
                 );
                 self.cqrs
                     .send(
@@ -1226,6 +1226,30 @@ mod tests {
                     "status": "filled",
                     "filled_avg_price": null,
                     "filled_qty": filled_qty,
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        })
+    }
+
+    fn create_get_order_mock_missing_quantity<'a>(
+        server: &'a MockServer,
+        order_id: &str,
+        requested_qty: &str,
+        filled_avg_price: &str,
+    ) -> httpmock::Mock<'a> {
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "USDCUSD",
+                    "qty": requested_qty,
+                    "status": "filled",
+                    "filled_avg_price": filled_avg_price,
+                    "filled_qty": null,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         })
@@ -2594,6 +2618,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn usd_to_usdc_conversion_missing_quantity_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_quantity(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1.0001",
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        assert!(
+            matches!(
+                manager.execute_usd_to_usdc_conversion(&id, amount).await,
+                Err(UsdcTransferError::MissingFilledQuantity { .. })
+            ),
+            "Missing fill quantity should fail the conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn usdc_to_usd_conversion_missing_average_price_fails_aggregate() {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
@@ -2639,6 +2726,74 @@ mod tests {
                 Err(UsdcTransferError::MissingFilledAveragePrice { .. })
             ),
             "Missing fill price should fail the post-deposit conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_missing_quantity_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_quantity(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "0.9983",
+        );
+
+        assert!(
+            matches!(
+                manager
+                    .execute_usdc_to_usd_conversion(&id, deposited_amount)
+                    .await,
+                Err(UsdcTransferError::MissingFilledQuantity { .. })
+            ),
+            "Missing fill quantity should fail the post-deposit conversion"
         );
 
         let retry_result = cqrs

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -688,8 +688,11 @@ impl<
                 conversion,
                 ..
             }) => {
-                self.continue_alpaca_to_base_from_conversion_complete(id, conversion.received_amount)
-                    .await
+                self.continue_alpaca_to_base_from_conversion_complete(
+                    id,
+                    conversion.received_amount,
+                )
+                .await
             }
 
             Some(Withdrawing {
@@ -3403,7 +3406,7 @@ impl<
                     order_id = %order.id,
                     ?direction,
                     %error,
-                    "Conversion response missing fill details"
+                    "Failed to derive settled conversion amounts"
                 );
                 self.cqrs
                     .send(
@@ -3436,11 +3439,12 @@ fn conversion_amounts_from_order(
     correlation_id: &ClientOrderId,
     direction: ConversionDirection,
 ) -> Result<ConversionAmounts, UsdcTransferError> {
-    let filled_quantity = order
-        .filled_quantity
-        .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
-            order_id: correlation_id.clone(),
-        })?;
+    let filled_quantity =
+        order
+            .filled_quantity
+            .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
+                order_id: correlation_id.clone(),
+            })?;
     let filled_average_price =
         order
             .filled_average_price
@@ -4189,6 +4193,30 @@ mod tests {
                     "status": "filled",
                     "filled_avg_price": null,
                     "filled_qty": filled_qty,
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        })
+    }
+
+    fn create_get_order_mock_missing_quantity<'a>(
+        server: &'a MockServer,
+        order_id: &str,
+        requested_qty: &str,
+        filled_avg_price: &str,
+    ) -> httpmock::Mock<'a> {
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "USDCUSD",
+                    "qty": requested_qty,
+                    "status": "filled",
+                    "filled_avg_price": filled_avg_price,
+                    "filled_qty": null,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         })
@@ -5506,6 +5534,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn usd_to_usdc_conversion_missing_quantity_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_quantity(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1.0001",
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        assert!(
+            matches!(
+                manager.execute_usd_to_usdc_conversion(&id, amount).await,
+                Err(UsdcTransferError::MissingFilledQuantity { .. })
+            ),
+            "Missing fill quantity should fail the conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn usdc_to_usd_conversion_returns_actual_proceeds() {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
@@ -5610,6 +5705,78 @@ mod tests {
                 Err(UsdcTransferError::MissingFilledAveragePrice { .. })
             ),
             "Missing fill price should fail the post-deposit conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_missing_quantity_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_quantity(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "0.9983",
+        );
+
+        assert!(
+            matches!(
+                manager
+                    .execute_usdc_to_usd_conversion(&id, deposited_amount)
+                    .await,
+                Err(UsdcTransferError::MissingFilledQuantity { .. })
+            ),
+            "Missing fill quantity should fail the post-deposit conversion"
         );
 
         let retry_result = cqrs
@@ -6232,7 +6399,7 @@ mod tests {
                     "symbol": "USDCUSD",
                     "qty": "99.99",
                     "status": status,
-                    "filled_avg_price": "1.0001",
+                    "filled_avg_price": "1",
                     "filled_qty": filled_quantity,
                     "created_at": "2025-01-06T12:00:00Z"
                 }));
@@ -6258,7 +6425,7 @@ mod tests {
                     "symbol": "USDCUSD",
                     "qty": "99.99",
                     "status": status,
-                    "filled_avg_price": "1.0001",
+                    "filled_avg_price": "1",
                     "filled_qty": filled_quantity,
                     "created_at": "2025-01-06T12:00:00Z"
                 }));

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -16,6 +16,7 @@ use st0x_bridge::cctp::{AttestationResponse, CctpBridge, CctpError};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, BurnTxStatus, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::{USDC_BASE, Wallet};
+use st0x_execution::alpaca_broker_api::CryptoOrderResponse;
 use st0x_execution::{
     AlpacaTransferId, AlpacaWalletService, ClientOrderId, ConversionDirection, CryptoOrderOutcome,
     Network, Positive, TokenSymbol, Transfer, TransferStatus,
@@ -26,7 +27,8 @@ use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
 use super::UsdcTransferError;
 use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::usdc_rebalance::{
-    RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+    ConversionAmounts, RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand,
+    UsdcRebalanceId,
 };
 
 /// Attempts to commit `RecordPendingBurn` in the detached submit-and-record
@@ -522,29 +524,23 @@ impl<
             }
         };
 
-        let filled_quantity =
-            order
-                .filled_quantity
-                .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
-                    order_id: correlation_id.clone(),
-                })?;
-
-        let filled_amount = Usdc::new(filled_quantity);
+        let conversion = self
+            .record_conversion_or_fail(id, &correlation_id, &order, ConversionDirection::UsdToUsdc)
+            .await?;
+        let received_amount = conversion.received_amount;
 
         self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ConfirmConversion { filled_amount },
-            )
+            .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await?;
 
         info!(target: "rebalance",
             order_id = %order.id,
-            requested = %amount,
-            filled = %filled_amount,
+            requested = ?amount,
+            source_amount = ?conversion.source_amount,
+            received_amount = ?conversion.received_amount,
             "USD to USDC conversion completed"
         );
-        Ok(filled_amount)
+        Ok(received_amount)
     }
 
     /// Converts USDC to USD buying power.
@@ -552,8 +548,7 @@ impl<
     /// Used at the end of BaseToAlpaca flow, after deposit is confirmed.
     /// Places a sell order on USDC/USD and polls until filled.
     ///
-    /// Returns the actual filled USDC amount (the USDC sold, which may
-    /// differ from requested if there's a partial fill).
+    /// Returns the actual USD proceeds credited at Alpaca.
     ///
     /// # Event Sourcing Flow
     ///
@@ -614,30 +609,23 @@ impl<
             }
         };
 
-        let filled_amount =
-            order
-                .filled_quantity
-                .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
-                    order_id: correlation_id.clone(),
-                })?;
-        let filled_usdc = Usdc::new(filled_amount);
+        let conversion = self
+            .record_conversion_or_fail(id, &correlation_id, &order, ConversionDirection::UsdcToUsd)
+            .await?;
+        let proceeds = conversion.received_amount;
 
         self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ConfirmConversion {
-                    filled_amount: filled_usdc,
-                },
-            )
+            .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await?;
 
         info!(target: "rebalance",
             order_id = %order.id,
-            requested = %amount,
-            filled = %filled_usdc,
+            requested = ?amount,
+            source_amount = ?conversion.source_amount,
+            received_amount = ?conversion.received_amount,
             "USDC to USD conversion completed"
         );
-        Ok(filled_usdc)
+        Ok(proceeds)
     }
 
     /// Executes the full Alpaca to Base rebalancing workflow.
@@ -697,10 +685,10 @@ impl<
 
             Some(ConversionComplete {
                 direction: AlpacaToBase,
-                filled_amount,
+                conversion,
                 ..
             }) => {
-                self.continue_alpaca_to_base_from_conversion_complete(id, filled_amount)
+                self.continue_alpaca_to_base_from_conversion_complete(id, conversion.received_amount)
                     .await
             }
 
@@ -1380,7 +1368,7 @@ impl<
     ) -> Result<(), UsdcTransferError> {
         info!(target: "rebalance", %amount, "Starting Alpaca to Base rebalance");
 
-        // Convert USD to USDC - use actual filled amount for subsequent steps
+        // Convert USD to USDC - use the actual received amount for subsequent steps
         let usdc_amount = self.execute_usd_to_usdc_conversion(id, amount).await?;
 
         let transfer = self.initiate_alpaca_withdrawal(id, usdc_amount).await?;
@@ -2096,22 +2084,16 @@ impl<
 
         match order.classify() {
             CryptoOrderOutcome::Filled => {
-                let filled_quantity =
-                    order
-                        .filled_quantity
-                        .ok_or(UsdcTransferError::MissingFilledQuantity {
-                            order_id: correlation_id,
-                        })?;
-
-                let filled_amount = Usdc::new(filled_quantity);
+                let conversion = conversion_amounts_from_order(
+                    &order,
+                    &correlation_id,
+                    ConversionDirection::UsdcToUsd,
+                )?;
 
                 self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::ConfirmConversion { filled_amount },
-                    )
+                    .send(id, UsdcRebalanceCommand::ConfirmConversion { conversion })
                     .await?;
-                info!(target: "rebalance", order_id = %order.id, %filled_amount, "Resumed conversion confirmed from already-filled order");
+                info!(target: "rebalance", order_id = %order.id, received_amount = %conversion.received_amount, "Resumed conversion confirmed from already-filled order");
                 Ok(())
             }
             CryptoOrderOutcome::Pending => {
@@ -3406,6 +3388,35 @@ impl<
         info!(target: "rebalance", "Alpaca deposit confirmed");
         Ok(())
     }
+
+    async fn record_conversion_or_fail(
+        &self,
+        id: &UsdcRebalanceId,
+        correlation_id: &ClientOrderId,
+        order: &CryptoOrderResponse,
+        direction: ConversionDirection,
+    ) -> Result<ConversionAmounts, UsdcTransferError> {
+        match conversion_amounts_from_order(order, correlation_id, direction) {
+            Ok(conversion) => Ok(conversion),
+            Err(error) => {
+                warn!(
+                    order_id = %order.id,
+                    ?direction,
+                    %error,
+                    "Conversion response missing fill details"
+                );
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: error.to_string(),
+                        },
+                    )
+                    .await?;
+                Err(error)
+            }
+        }
+    }
 }
 
 /// Converts a USDC decimal amount to U256 with 6 decimals.
@@ -3418,6 +3429,32 @@ fn usdc_to_u256(usdc: Usdc) -> Result<U256, UsdcTransferError> {
 /// Converts a U256 amount (with 6 decimals) to USDC decimal.
 pub(crate) fn u256_to_usdc(amount: U256) -> Result<Usdc, UsdcTransferError> {
     Ok(Usdc::new(Float::from_fixed_decimal(amount, 6)?))
+}
+
+fn conversion_amounts_from_order(
+    order: &CryptoOrderResponse,
+    correlation_id: &ClientOrderId,
+    direction: ConversionDirection,
+) -> Result<ConversionAmounts, UsdcTransferError> {
+    let filled_quantity = order
+        .filled_quantity
+        .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
+            order_id: correlation_id.clone(),
+        })?;
+    let filled_average_price =
+        order
+            .filled_average_price
+            .ok_or_else(|| UsdcTransferError::MissingFilledAveragePrice {
+                order_id: correlation_id.clone(),
+            })?;
+
+    let filled_quantity = Usdc::new(filled_quantity);
+    let cash_proceeds = std::ops::Mul::mul(filled_quantity, filled_average_price)?;
+
+    Ok(match direction {
+        ConversionDirection::UsdToUsdc => ConversionAmounts::new(cash_proceeds, filled_quantity),
+        ConversionDirection::UsdcToUsd => ConversionAmounts::new(filled_quantity, cash_proceeds),
+    })
 }
 
 #[cfg(test)]
@@ -3633,6 +3670,12 @@ mod tests {
         Usdc::from_str(value).unwrap()
     }
 
+    /// A conversion with equal source and received amounts (no slippage),
+    /// for tests that only care about the post-conversion effective amount.
+    fn par_conversion(amount: Usdc) -> ConversionAmounts {
+        ConversionAmounts::new(amount, amount)
+    }
+
     const USDC_ADDRESS: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     const ORDERBOOK_ADDRESS: Address = address!("0x1234567890123456789012345678901234567890");
     const TEST_VAULT_ID: RaindexVaultId = RaindexVaultId(b256!(
@@ -3667,6 +3710,7 @@ mod tests {
         cqrs: &Store<UsdcRebalance>,
         id: &UsdcRebalanceId,
         amount: Usdc,
+        bridged_amount_received: Usdc,
     ) {
         let burn_tx =
             fixed_bytes!("0xbbbb000000000000000000000000000000000000000000000000000000000001");
@@ -3713,7 +3757,7 @@ mod tests {
             id,
             UsdcRebalanceCommand::ConfirmBridging {
                 mint_tx,
-                amount_received: usdc("99.99"),
+                amount_received: bridged_amount_received,
                 fee_collected: usdc("0.01"),
             },
         )
@@ -3770,7 +3814,7 @@ mod tests {
         cqrs.send(
             id,
             ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -3866,7 +3910,7 @@ mod tests {
         cqrs.send(
             id,
             ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -4100,13 +4144,13 @@ mod tests {
         })
     }
 
-    /// Creates a mock where the filled quantity differs from the requested
-    /// quantity to simulate slippage.
-    fn create_get_order_mock_with_slippage<'a>(
+    /// Creates a mock with explicit fill quantity and average price.
+    fn create_get_order_mock_with_fill<'a>(
         server: &'a MockServer,
         order_id: &str,
-        requested_quantity: &str,
-        filled_quantity: &str,
+        requested_qty: &str,
+        filled_qty: &str,
+        filled_avg_price: &str,
     ) -> httpmock::Mock<'a> {
         server.mock(|when, then| {
             when.method(GET).path(format!(
@@ -4117,10 +4161,34 @@ mod tests {
                 .json_body(json!({
                     "id": order_id,
                     "symbol": "USDCUSD",
-                    "qty": requested_quantity,
+                    "qty": requested_qty,
                     "status": "filled",
-                    "filled_avg_price": "1.0001",
-                    "filled_qty": filled_quantity,
+                    "filled_avg_price": filled_avg_price,
+                    "filled_qty": filled_qty,
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        })
+    }
+
+    fn create_get_order_mock_missing_average_price<'a>(
+        server: &'a MockServer,
+        order_id: &str,
+        requested_qty: &str,
+        filled_qty: &str,
+    ) -> httpmock::Mock<'a> {
+        server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/{order_id}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": order_id,
+                    "symbol": "USDCUSD",
+                    "qty": requested_qty,
+                    "status": "filled",
+                    "filled_avg_price": null,
+                    "filled_qty": filled_qty,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         })
@@ -5032,7 +5100,7 @@ mod tests {
         let amount = usdc("1000");
         let amount_received = usdc("99.99");
 
-        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, amount).await;
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
 
         manager
             .execute_usdc_to_usd_conversion(&id, amount_received)
@@ -5317,7 +5385,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn usd_to_usdc_conversion_returns_actual_filled_amount() {
+    async fn usd_to_usdc_conversion_returns_actual_received_amount() {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
@@ -5346,26 +5414,221 @@ mod tests {
 
         // Request 1000, but only 999.5 fills due to slippage
         let _order_mock = create_conversion_order_pending_mock(&server, "1000");
-        let _get_mock = create_get_order_mock_with_slippage(
+        let _get_mock = create_get_order_mock_with_fill(
             &server,
             "61e7b016-9c91-4a97-b912-615c9d365c9d",
             "1000",
             "999.5",
+            "1.0001",
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let requested_amount = usdc("1000");
 
-        let filled_amount = manager
+        let received_amount = manager
             .execute_usd_to_usdc_conversion(&id, requested_amount)
             .await
             .unwrap();
 
-        // Should return the actual filled amount, not the requested amount
+        // Should return the actual received amount, not the requested amount.
         assert_eq!(
-            filled_amount,
+            received_amount,
             usdc("999.5"),
-            "Should return actual filled amount, not requested amount"
+            "Should return actual received amount, not requested amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn usd_to_usdc_conversion_missing_average_price_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_average_price(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1000");
+
+        assert!(
+            matches!(
+                manager.execute_usd_to_usdc_conversion(&id, amount).await,
+                Err(UsdcTransferError::MissingFilledAveragePrice { .. })
+            ),
+            "Missing fill price should fail the conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_returns_actual_proceeds() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_with_fill(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+            "0.9983",
+        );
+
+        let proceeds = manager
+            .execute_usdc_to_usd_conversion(&id, deposited_amount)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            proceeds,
+            usdc("998.3"),
+            "Should return actual USD proceeds, not the USDC sold amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_to_usd_conversion_missing_average_price_fails_aggregate() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let _account_mock = create_broker_account_mock(&server);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let rebalance_amount = usdc("1000");
+        let deposited_amount = usdc("1000");
+
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, rebalance_amount, deposited_amount)
+            .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            Arc::clone(&cqrs),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        let _order_mock = create_conversion_order_pending_mock(&server, "1000");
+        let _get_mock = create_get_order_mock_missing_average_price(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "1000",
+            "1000",
+        );
+
+        assert!(
+            matches!(
+                manager
+                    .execute_usdc_to_usd_conversion(&id, deposited_amount)
+                    .await,
+                Err(UsdcTransferError::MissingFilledAveragePrice { .. })
+            ),
+            "Missing fill price should fail the post-deposit conversion"
+        );
+
+        let retry_result = cqrs
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailConversion {
+                    reason: "should already be failed".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                retry_result,
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    UsdcRebalanceError::ConversionAlreadyCompleted
+                )))
+            ),
+            "Aggregate should already be in ConversionFailed, got: {retry_result:?}"
         );
     }
 
@@ -5561,7 +5824,7 @@ mod tests {
         cqrs.send(
             id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -6277,7 +6540,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount_received,
+                conversion: par_conversion(amount_received),
             },
         )
         .await
@@ -6317,10 +6580,10 @@ mod tests {
         assert!(
             matches!(
                 &state,
-                Some(UsdcRebalance::ConversionComplete { filled_amount, .. })
-                    if *filled_amount == usdc("99.99")
+                Some(UsdcRebalance::ConversionComplete { conversion, .. })
+                    if conversion.received_amount == usdc("99.99")
             ),
-            "expected ConversionComplete with filled_amount 99.99, got {state:?}"
+            "expected ConversionComplete with received_amount 99.99, got {state:?}"
         );
     }
 
@@ -6403,10 +6666,10 @@ mod tests {
         assert!(
             matches!(
                 &state,
-                Some(UsdcRebalance::ConversionComplete { filled_amount, .. })
-                    if *filled_amount == usdc("99.99")
+                Some(UsdcRebalance::ConversionComplete { conversion, .. })
+                    if conversion.received_amount == usdc("99.99")
             ),
-            "expected ConversionComplete with filled_amount 99.99 after awaiting settle, got {state:?}"
+            "expected ConversionComplete with received_amount 99.99 after awaiting settle, got {state:?}"
         );
     }
 
@@ -6729,7 +6992,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -7624,7 +7887,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -8282,7 +8545,7 @@ mod tests {
         cqrs.send(
             id,
             ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -8799,7 +9062,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -8885,7 +9148,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -8978,7 +9241,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -9069,7 +9332,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -9139,7 +9402,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -9212,7 +9475,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -9837,7 +10100,7 @@ mod tests {
         cqrs.send(
             &id,
             ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await
@@ -12236,7 +12499,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: amount,
+                conversion: par_conversion(amount),
             },
         )
         .await

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -51,6 +51,11 @@ pub(crate) enum UsdcTransferError {
          filled_quantity is missing"
     )]
     MissingFilledQuantity { order_id: uuid::Uuid },
+    #[error(
+        "Conversion order {order_id} filled but \
+         filled_average_price is missing"
+    )]
+    MissingFilledAveragePrice { order_id: uuid::Uuid },
 }
 
 impl From<SendError<crate::usdc_rebalance::UsdcRebalance>> for UsdcTransferError {

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -77,6 +77,11 @@ pub(crate) enum UsdcTransferError {
     )]
     MissingFilledQuantity { order_id: ClientOrderId },
     #[error(
+        "Conversion order {order_id} filled but \
+         filled_average_price is missing"
+    )]
+    MissingFilledAveragePrice { order_id: ClientOrderId },
+    #[error(
         "USDC rebalance {id} conversion could not be completed on resume \
          (order not found at Alpaca or terminally failed); failed for \
          operator reconciliation"

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -104,6 +104,25 @@ pub(crate) enum RebalanceDirection {
     BaseToAlpaca,
 }
 
+/// Explicit source and destination cash amounts for a USD <-> USDC conversion.
+///
+/// Cash amounts remain modeled as [`Usdc`] throughout the system because offchain
+/// USD buying power is normalized into the same cash type as onchain USDC.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ConversionAmounts {
+    pub(crate) source_amount: Usdc,
+    pub(crate) received_amount: Usdc,
+}
+
+impl ConversionAmounts {
+    pub(crate) const fn new(source_amount: Usdc, received_amount: Usdc) -> Self {
+        Self {
+            source_amount,
+            received_amount,
+        }
+    }
+}
+
 /// Errors that can occur during USDC rebalance operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum UsdcRebalanceError {
@@ -178,13 +197,8 @@ pub(crate) enum UsdcRebalanceCommand {
         order_id: Uuid,
     },
     /// Confirm successful conversion. Valid only from `Converting` state.
-    /// Contains filled_amount for accurate inventory tracking.
-    ConfirmConversion {
-        /// Actual USDC amount from the conversion.
-        /// - AlpacaToBase (USD->USDC): USDC received
-        /// - BaseToAlpaca (USDC->USD): USDC sold
-        filled_amount: Usdc,
-    },
+    /// Contains the source amount sold and the destination amount received.
+    ConfirmConversion { conversion: ConversionAmounts },
     /// Record conversion failure. Valid only from `Converting` state.
     FailConversion { reason: String },
     /// Start post-deposit conversion for BaseToAlpaca direction.
@@ -246,13 +260,11 @@ pub(crate) enum UsdcRebalanceEvent {
     /// Conversion completed successfully.
     /// Includes direction so terminal detection works with incremental dispatch
     /// (cqrs-es Query::dispatch only receives newly committed events, not full history).
-    /// Contains filled_amount for accurate inventory tracking (may differ from requested due to slippage).
+    /// Captures both the source amount sold and the destination amount received.
     ConversionConfirmed {
         direction: RebalanceDirection,
-        /// Actual USDC amount from the conversion.
-        /// - AlpacaToBase (USD->USDC): USDC received
-        /// - BaseToAlpaca (USDC->USD): USDC sold
-        filled_amount: Usdc,
+        #[serde(flatten)]
+        conversion: ConversionAmounts,
         converted_at: DateTime<Utc>,
     },
     /// Conversion failed.
@@ -345,7 +357,7 @@ impl DomainEvent for UsdcRebalanceEvent {
     }
 
     fn event_version(&self) -> String {
-        "1.0".to_string()
+        "2.0".to_string()
     }
 }
 
@@ -367,8 +379,7 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         /// Originally requested amount
         amount: Usdc,
-        /// Actual USDC amount from the conversion (may differ due to slippage)
-        filled_amount: Usdc,
+        conversion: ConversionAmounts,
         initiated_at: DateTime<Utc>,
         converted_at: DateTime<Utc>,
     },
@@ -497,7 +508,7 @@ impl UsdcRebalance {
 
             Self::ConversionComplete {
                 direction,
-                filled_amount,
+                conversion,
                 initiated_at,
                 converted_at,
                 ..
@@ -513,7 +524,7 @@ impl UsdcRebalance {
 
                 (
                     direction,
-                    *filled_amount,
+                    conversion.received_amount,
                     status,
                     *initiated_at,
                     *converted_at,
@@ -691,7 +702,7 @@ impl EventSourced for UsdcRebalance {
 
     const AGGREGATE_TYPE: &'static str = "UsdcRebalance";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -749,7 +760,7 @@ impl EventSourced for UsdcRebalance {
 
             (
                 ConversionConfirmed {
-                    filled_amount,
+                    conversion,
                     converted_at,
                     ..
                 },
@@ -762,7 +773,7 @@ impl EventSourced for UsdcRebalance {
             ) => Self::ConversionComplete {
                 direction: direction.clone(),
                 amount: *amount,
-                filled_amount: *filled_amount,
+                conversion: *conversion,
                 initiated_at: *initiated_at,
                 converted_at: *converted_at,
             },
@@ -788,13 +799,13 @@ impl EventSourced for UsdcRebalance {
                 Initiated { withdrawal_ref, .. },
                 Self::ConversionComplete {
                     direction,
-                    filled_amount,
+                    conversion,
                     initiated_at,
                     ..
                 },
             ) => Self::Withdrawing {
                 direction: direction.clone(),
-                amount: *filled_amount,
+                amount: conversion.received_amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 initiated_at: *initiated_at,
             },
@@ -1071,9 +1082,7 @@ impl EventSourced for UsdcRebalance {
         use UsdcRebalanceCommand::*;
         match command {
             InitiateConversion { .. } => Err(UsdcRebalanceError::AlreadyInitiated),
-            ConfirmConversion { filled_amount } => {
-                self.transition_confirm_conversion(filled_amount)
-            }
+            ConfirmConversion { conversion } => self.transition_confirm_conversion(conversion),
             FailConversion { reason } => self.transition_fail_conversion(reason),
             InitiatePostDepositConversion { order_id, amount } => {
                 self.transition_post_deposit_conversion(order_id, amount)
@@ -1110,13 +1119,13 @@ impl EventSourced for UsdcRebalance {
 impl UsdcRebalance {
     fn transition_confirm_conversion(
         &self,
-        filled_amount: Usdc,
+        conversion: ConversionAmounts,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Converting { direction, .. } => Ok(vec![ConversionConfirmed {
                 direction: direction.clone(),
-                filled_amount,
+                conversion,
                 converted_at: Utc::now(),
             }]),
             Self::ConversionComplete { .. } | Self::ConversionFailed { .. } => {
@@ -1181,7 +1190,7 @@ impl UsdcRebalance {
         use UsdcRebalanceEvent::*;
         let Self::ConversionComplete {
             direction: conv_direction,
-            filled_amount: conv_filled_amount,
+            conversion,
             ..
         } = self
         else {
@@ -1195,20 +1204,20 @@ impl UsdcRebalance {
                     .to_string(),
             });
         }
-        if amount != *conv_filled_amount {
+        if amount != conversion.received_amount {
             return Err(UsdcRebalanceError::InvalidCommand {
                 command: "Initiate".to_string(),
                 state: format!(
                     "ConversionComplete with amount \
                      mismatch: expected {:?}, got {:?}",
-                    conv_filled_amount.inner(),
+                    conversion.received_amount.inner(),
                     amount.inner()
                 ),
             });
         }
         Ok(vec![Initiated {
             direction,
-            amount: *conv_filled_amount,
+            amount: conversion.received_amount,
             withdrawal_ref: withdrawal,
             initiated_at: Utc::now(),
         }])
@@ -1480,6 +1489,14 @@ mod tests {
 
     use super::*;
     use st0x_float_macro::float;
+
+    fn conversion(source_amount: Usdc, received_amount: Usdc) -> ConversionAmounts {
+        ConversionAmounts::new(source_amount, received_amount)
+    }
+
+    fn par_conversion(amount: Usdc) -> ConversionAmounts {
+        conversion(amount, amount)
+    }
 
     #[tokio::test]
     async fn test_initiate_alpaca_to_base() {
@@ -3327,7 +3344,7 @@ mod tests {
     #[tokio::test]
     async fn test_confirm_conversion_from_converting_state() {
         let order_id = Uuid::new_v4();
-        let filled_amount = Usdc::new(float!(998));
+        let conversion = par_conversion(Usdc::new(float!(998)));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
@@ -3336,7 +3353,7 @@ mod tests {
                 order_id,
                 initiated_at: Utc::now(),
             }])
-            .when(UsdcRebalanceCommand::ConfirmConversion { filled_amount })
+            .when(UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await
             .events();
 
@@ -3352,7 +3369,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: par_conversion(Usdc::new(float!(998))),
             })
             .await
             .then_expect_error();
@@ -3377,12 +3394,12 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc::new(float!(998)),
+                    conversion: par_conversion(Usdc::new(float!(998))),
                     converted_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: par_conversion(Usdc::new(float!(998))),
             })
             .await
             .then_expect_error();
@@ -3447,7 +3464,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc::new(float!(998)),
+                    conversion: par_conversion(Usdc::new(float!(998))),
                     converted_at: Utc::now(),
                 },
             ])
@@ -3467,7 +3484,7 @@ mod tests {
     async fn test_initiate_withdrawal_after_conversion_complete() {
         let order_id = Uuid::new_v4();
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc::new(float!(998));
+        let received_amount = Usdc::new(float!(998));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -3479,13 +3496,13 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount,
+                    conversion: par_conversion(received_amount),
                     converted_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: filled_amount,
+                amount: received_amount,
                 withdrawal: TransferRef::AlpacaId(transfer_id),
             })
             .await
@@ -3499,7 +3516,7 @@ mod tests {
     async fn test_initiate_with_mismatched_amount_from_conversion_complete_fails() {
         let order_id = Uuid::new_v4();
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc::new(float!(998));
+        let received_amount = Usdc::new(float!(998));
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -3511,7 +3528,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount,
+                    conversion: par_conversion(received_amount),
                     converted_at: Utc::now(),
                 },
             ])
@@ -3782,7 +3799,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(998))),
             })
             .await
             .events();
@@ -3883,7 +3900,7 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
-                filled_amount: Usdc::new(float!(999.99)),
+                conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(999.99))),
                 converted_at: conversion_completed_at,
             },
             UsdcRebalanceEvent::Initiated {
@@ -3913,7 +3930,7 @@ mod tests {
     fn conversion_confirmed_on_uninitialized_produces_failed_state() {
         let error = replay::<UsdcRebalance>(vec![UsdcRebalanceEvent::ConversionConfirmed {
             direction: RebalanceDirection::BaseToAlpaca,
-            filled_amount: Usdc::new(float!(998)),
+            conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(998))),
             converted_at: Utc::now(),
         }])
         .unwrap_err();
@@ -4066,7 +4083,7 @@ mod tests {
         let state = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(500)),
-            filled_amount: Usdc::new(float!(499)),
+            conversion: conversion(Usdc::new(float!(500)), Usdc::new(float!(499))),
             initiated_at,
             converted_at,
         };
@@ -4090,7 +4107,7 @@ mod tests {
         let state = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(500)),
-            filled_amount: Usdc::new(float!(499)),
+            conversion: conversion(Usdc::new(float!(500)), Usdc::new(float!(499))),
             initiated_at,
             converted_at,
         };

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -128,6 +128,25 @@ impl From<RebalanceDirection> for st0x_dto::UsdcBridgeDirection {
     }
 }
 
+/// Explicit source and destination cash amounts for a USD <-> USDC conversion.
+///
+/// Cash amounts remain modeled as [`Usdc`] throughout the system because offchain
+/// USD buying power is normalized into the same cash type as onchain USDC.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ConversionAmounts {
+    pub(crate) source_amount: Usdc,
+    pub(crate) received_amount: Usdc,
+}
+
+impl ConversionAmounts {
+    pub(crate) const fn new(source_amount: Usdc, received_amount: Usdc) -> Self {
+        Self {
+            source_amount,
+            received_amount,
+        }
+    }
+}
+
 /// Why an operator reconciled a USDC rebalance stranded in the post-burn
 /// terminal `DepositFailed` state. The funds were handled out-of-band, so the
 /// reconcile records the reason rather than re-driving the failed deposit.
@@ -255,13 +274,8 @@ pub(crate) enum UsdcRebalanceCommand {
         order_id: ClientOrderId,
     },
     /// Confirm successful conversion. Valid only from `Converting` state.
-    /// Contains filled_amount for accurate inventory tracking.
-    ConfirmConversion {
-        /// Actual USDC amount from the conversion.
-        /// - AlpacaToBase (USD->USDC): USDC received
-        /// - BaseToAlpaca (USDC->USD): USDC sold
-        filled_amount: Usdc,
-    },
+    /// Contains the source amount sold and the destination amount received.
+    ConfirmConversion { conversion: ConversionAmounts },
     /// Record conversion failure. Valid only from `Converting` state.
     FailConversion { reason: String },
     /// Start post-deposit conversion for BaseToAlpaca direction.
@@ -383,13 +397,11 @@ pub(crate) enum UsdcRebalanceEvent {
     /// Conversion completed successfully.
     /// Includes direction so terminal detection works with incremental dispatch
     /// (cqrs-es Query::dispatch only receives newly committed events, not full history).
-    /// Contains filled_amount for accurate inventory tracking (may differ from requested due to slippage).
+    /// Captures both the source amount sold and the destination amount received.
     ConversionConfirmed {
         direction: RebalanceDirection,
-        /// Actual USDC amount from the conversion.
-        /// - AlpacaToBase (USD->USDC): USDC received
-        /// - BaseToAlpaca (USDC->USD): USDC sold
-        filled_amount: Usdc,
+        #[serde(flatten)]
+        conversion: ConversionAmounts,
         converted_at: DateTime<Utc>,
     },
     /// Conversion failed.
@@ -573,7 +585,7 @@ impl DomainEvent for UsdcRebalanceEvent {
     }
 
     fn event_version(&self) -> String {
-        "1.0".to_string()
+        "2.0".to_string()
     }
 }
 
@@ -595,8 +607,7 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         /// Originally requested amount
         amount: Usdc,
-        /// Actual USDC amount from the conversion (may differ due to slippage)
-        filled_amount: Usdc,
+        conversion: ConversionAmounts,
         initiated_at: DateTime<Utc>,
         converted_at: DateTime<Utc>,
     },
@@ -847,7 +858,7 @@ impl UsdcRebalance {
 
             Self::ConversionComplete {
                 direction,
-                filled_amount,
+                conversion,
                 initiated_at,
                 converted_at,
                 ..
@@ -863,7 +874,7 @@ impl UsdcRebalance {
 
                 (
                     direction,
-                    *filled_amount,
+                    conversion.received_amount,
                     status,
                     *initiated_at,
                     *converted_at,
@@ -1181,7 +1192,7 @@ impl UsdcRebalance {
     /// through the opposite-direction resume path.
     ///
     /// Deliberately does NOT expose the amount: a state's `amount` field is
-    /// reassigned to the conversion `filled_amount` (and later the post-fee
+    /// reassigned to the conversion's received amount (and later the post-fee
     /// `amount_received`), so it is not the original requested amount the CLI
     /// prints -- validating `--amount` against it would reject legitimate resumes
     /// whenever slippage or CCTP fees move the effective amount.
@@ -1315,7 +1326,7 @@ impl UsdcRebalance {
         match self {
             // Post-conversion / post-bridge, the actually received amount is
             // the effective one; `amount` is the originally requested figure.
-            Self::ConversionComplete { filled_amount, .. } => *filled_amount,
+            Self::ConversionComplete { conversion, .. } => conversion.received_amount,
             Self::Bridged {
                 amount_received, ..
             } => *amount_received,
@@ -1514,7 +1525,11 @@ impl EventSourced for UsdcRebalance {
     // in `evolve()` would never run for them. Bumped to invalidate stale
     // snapshots, forcing a rebuild from events so `failure_reason` is derived
     // from the prior failed state on replay.
-    const SCHEMA_VERSION: u64 = 6;
+    // v7: the conversion data model changed -- `ConversionComplete` state and the
+    // `ConversionConfirmed` event now carry `ConversionAmounts` (source +
+    // received) instead of a single `filled_amount`. Bumped to clear stale
+    // snapshots so they rebuild under the new schema.
+    const SCHEMA_VERSION: u64 = 7;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1584,7 +1599,7 @@ impl EventSourced for UsdcRebalance {
 
             (
                 ConversionConfirmed {
-                    filled_amount,
+                    conversion,
                     converted_at,
                     ..
                 },
@@ -1597,7 +1612,7 @@ impl EventSourced for UsdcRebalance {
             ) => Self::ConversionComplete {
                 direction: *direction,
                 amount: *amount,
-                filled_amount: *filled_amount,
+                conversion: *conversion,
                 initiated_at: *initiated_at,
                 converted_at: *converted_at,
             },
@@ -1623,13 +1638,13 @@ impl EventSourced for UsdcRebalance {
                 WithdrawalSubmitting { from_block, .. },
                 Self::ConversionComplete {
                     direction,
-                    filled_amount,
+                    conversion,
                     initiated_at,
                     ..
                 },
             ) => Self::WithdrawalSubmitting {
                 direction: *direction,
-                amount: *filled_amount,
+                amount: conversion.received_amount,
                 from_block: *from_block,
                 initiated_at: *initiated_at,
             },
@@ -1653,13 +1668,13 @@ impl EventSourced for UsdcRebalance {
                 Initiated { withdrawal_ref, .. },
                 Self::ConversionComplete {
                     direction,
-                    filled_amount,
+                    conversion,
                     initiated_at,
                     ..
                 },
             ) => Self::Withdrawing {
                 direction: *direction,
-                amount: *filled_amount,
+                amount: conversion.received_amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 initiated_at: *initiated_at,
             },
@@ -2209,9 +2224,7 @@ impl EventSourced for UsdcRebalance {
         use UsdcRebalanceCommand::*;
         match command {
             InitiateConversion { .. } => Err(UsdcRebalanceError::AlreadyInitiated),
-            ConfirmConversion { filled_amount } => {
-                self.transition_confirm_conversion(filled_amount)
-            }
+            ConfirmConversion { conversion } => self.transition_confirm_conversion(conversion),
             FailConversion { reason } => self.transition_fail_conversion(reason),
             InitiatePostDepositConversion { order_id, amount } => {
                 self.transition_post_deposit_conversion(order_id, amount)
@@ -2277,13 +2290,13 @@ impl EventSourced for UsdcRebalance {
 impl UsdcRebalance {
     fn transition_confirm_conversion(
         &self,
-        filled_amount: Usdc,
+        conversion: ConversionAmounts,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Converting { direction, .. } => Ok(vec![ConversionConfirmed {
                 direction: *direction,
-                filled_amount,
+                conversion,
                 converted_at: Utc::now(),
             }]),
             Self::ConversionComplete { .. } | Self::ConversionFailed { .. } => {
@@ -2351,7 +2364,7 @@ impl UsdcRebalance {
         use UsdcRebalanceEvent::*;
         let Self::ConversionComplete {
             direction: conv_direction,
-            filled_amount: conv_filled_amount,
+            conversion,
             ..
         } = self
         else {
@@ -2365,20 +2378,20 @@ impl UsdcRebalance {
                     .to_string(),
             });
         }
-        if amount != *conv_filled_amount {
+        if amount != conversion.received_amount {
             return Err(UsdcRebalanceError::InvalidCommand {
                 command: "BeginWithdrawal".to_string(),
                 state: format!(
                     "ConversionComplete with amount \
                      mismatch: expected {:?}, got {:?}",
-                    conv_filled_amount.inner(),
+                    conversion.received_amount.inner(),
                     amount.inner()
                 ),
             });
         }
         Ok(vec![WithdrawalSubmitting {
             direction,
-            amount: *conv_filled_amount,
+            amount: conversion.received_amount,
             from_block,
             submitting_at: Utc::now(),
         }])
@@ -2400,9 +2413,9 @@ impl UsdcRebalance {
             } => (direction, amount),
             Self::ConversionComplete {
                 direction,
-                filled_amount,
+                conversion,
                 ..
-            } => (direction, filled_amount),
+            } => (direction, &conversion.received_amount),
             _ => return Err(UsdcRebalanceError::AlreadyInitiated),
         };
         if direction != *expected_direction {
@@ -3184,6 +3197,14 @@ mod tests {
         };
 
         assert_eq!(message, None);
+    }
+
+    fn conversion(source_amount: Usdc, received_amount: Usdc) -> ConversionAmounts {
+        ConversionAmounts::new(source_amount, received_amount)
+    }
+
+    fn par_conversion(amount: Usdc) -> ConversionAmounts {
+        conversion(amount, amount)
     }
 
     #[tokio::test]
@@ -4846,7 +4867,7 @@ mod tests {
         let conversion_complete = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::BaseToAlpaca,
             amount,
-            filled_amount: Usdc::new(float!(999)),
+            conversion: par_conversion(Usdc::new(float!(999))),
             initiated_at: now,
             converted_at: now,
         };
@@ -4907,7 +4928,7 @@ mod tests {
         let conversion_complete = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: requested,
-            filled_amount: Usdc::new(float!(319)),
+            conversion: par_conversion(Usdc::new(float!(319))),
             initiated_at: now,
             converted_at: now,
         };
@@ -7284,7 +7305,7 @@ mod tests {
     #[tokio::test]
     async fn test_confirm_conversion_from_converting_state() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
-        let filled_amount = Usdc::new(float!(998));
+        let conversion = par_conversion(Usdc::new(float!(998)));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
@@ -7293,7 +7314,7 @@ mod tests {
                 order_id,
                 initiated_at: Utc::now(),
             }])
-            .when(UsdcRebalanceCommand::ConfirmConversion { filled_amount })
+            .when(UsdcRebalanceCommand::ConfirmConversion { conversion })
             .await
             .events();
 
@@ -7309,7 +7330,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: par_conversion(Usdc::new(float!(998))),
             })
             .await
             .then_expect_error();
@@ -7334,12 +7355,12 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc::new(float!(998)),
+                    conversion: par_conversion(Usdc::new(float!(998))),
                     converted_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: par_conversion(Usdc::new(float!(998))),
             })
             .await
             .then_expect_error();
@@ -7404,7 +7425,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount: Usdc::new(float!(998)),
+                    conversion: par_conversion(Usdc::new(float!(998))),
                     converted_at: Utc::now(),
                 },
             ])
@@ -7424,7 +7445,7 @@ mod tests {
     async fn test_initiate_withdrawal_after_conversion_complete() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc::new(float!(998));
+        let received_amount = Usdc::new(float!(998));
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -7436,13 +7457,13 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount,
+                    conversion: par_conversion(received_amount),
                     converted_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::AlpacaToBase,
-                amount: filled_amount,
+                amount: received_amount,
                 withdrawal: TransferRef::AlpacaId(transfer_id),
             })
             .await
@@ -7456,7 +7477,7 @@ mod tests {
     async fn test_initiate_with_mismatched_amount_from_conversion_complete_fails() {
         let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
-        let filled_amount = Usdc::new(float!(998));
+        let received_amount = Usdc::new(float!(998));
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -7468,7 +7489,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::ConversionConfirmed {
                     direction: RebalanceDirection::AlpacaToBase,
-                    filled_amount,
+                    conversion: par_conversion(received_amount),
                     converted_at: Utc::now(),
                 },
             ])
@@ -7751,7 +7772,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ConfirmConversion {
-                filled_amount: Usdc::new(float!(998)),
+                conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(998))),
             })
             .await
             .events();
@@ -7855,7 +7876,7 @@ mod tests {
             },
             UsdcRebalanceEvent::ConversionConfirmed {
                 direction: RebalanceDirection::AlpacaToBase,
-                filled_amount: Usdc::new(float!(999.99)),
+                conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(999.99))),
                 converted_at: conversion_completed_at,
             },
             UsdcRebalanceEvent::Initiated {
@@ -7885,7 +7906,7 @@ mod tests {
     fn conversion_confirmed_on_uninitialized_produces_failed_state() {
         let error = replay::<UsdcRebalance>(vec![UsdcRebalanceEvent::ConversionConfirmed {
             direction: RebalanceDirection::BaseToAlpaca,
-            filled_amount: Usdc::new(float!(998)),
+            conversion: conversion(Usdc::new(float!(1000)), Usdc::new(float!(998))),
             converted_at: Utc::now(),
         }])
         .unwrap_err();
@@ -8062,7 +8083,7 @@ mod tests {
         let state = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(500)),
-            filled_amount: Usdc::new(float!(499)),
+            conversion: conversion(Usdc::new(float!(500)), Usdc::new(float!(499))),
             initiated_at,
             converted_at,
         };
@@ -8086,7 +8107,7 @@ mod tests {
         let state = UsdcRebalance::ConversionComplete {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(500)),
-            filled_amount: Usdc::new(float!(499)),
+            conversion: conversion(Usdc::new(float!(500)), Usdc::new(float!(499))),
             initiated_at,
             converted_at,
         };
@@ -8659,7 +8680,7 @@ mod tests {
             ConversionComplete {
                 direction: AlpacaToBase,
                 amount,
-                filled_amount: amount,
+                conversion: par_conversion(amount),
                 initiated_at: now,
                 converted_at: now,
             }
@@ -8669,7 +8690,7 @@ mod tests {
             !ConversionComplete {
                 direction: BaseToAlpaca,
                 amount,
-                filled_amount: amount,
+                conversion: par_conversion(amount),
                 initiated_at: now,
                 converted_at: now,
             }
@@ -8985,7 +9006,7 @@ mod tests {
             ConversionComplete {
                 direction: BaseToAlpaca,
                 amount,
-                filled_amount: amount,
+                conversion: par_conversion(amount),
                 initiated_at: now,
                 converted_at: now,
             }


### PR DESCRIPTION
## What

Closes [RAI-202](https://linear.app/makeitrain/issue/RAI-202/basetoalpaca-conversion-credits-sold-usdc-instead-of-usd-proceeds).

Fix `BaseToAlpaca` USDC rebalancing so the hedging venue is credited with actual
USD proceeds received from Alpaca, not the USDC quantity sold.

## Why

The previous flow treated `ConversionConfirmed.filled_amount` as the credited
amount for `BaseToAlpaca`, even though that value represented the USDC sold.

That is only correct at exact par. For off-par fills like `1000 USDC @ 0.9983`,
the system should credit about `998.3` USD, not `1000`. Crediting the sold USDC
amount causes inventory drift.

While fixing that path, this branch also closes the failure mode where a filled
conversion missing `filled_avg_price` could leave `UsdcRebalance` stuck in
`Converting`.

## How

- replace the single conversion amount with explicit `ConversionAmounts` carrying
  both `source_amount` and `received_amount`
- update `UsdcRebalanceCommand::ConfirmConversion` and
  `UsdcRebalanceEvent::ConversionConfirmed` to use those explicit semantics
- compute conversion settlement from Alpaca `filled_quantity` and
  `filled_average_price`
- settle `BaseToAlpaca` trigger-side inventory using `conversion.received_amount`
  so the hedging venue gets actual USD proceeds
- keep downstream aggregate transitions aligned on the received amount instead of
  the sold amount
- fail the aggregate explicitly when Alpaca returns a filled conversion without
  enough fill data to compute proceeds
- add regression coverage for:
  - off-par `BaseToAlpaca` proceeds
  - explicit source vs received conversion semantics
  - missing `filled_average_price` failure handling in both conversion directions

## Testing

- `nix develop -c cargo check --workspace`
- `nix develop -c cargo nextest run --workspace --all-features`
- `nix develop -c cargo clippy --workspace --all-targets --all-features`
- `nix develop -c cargo fmt --check`

## Screenshots

N/A

## Anything else

This changes `UsdcRebalance` conversion event semantics and bumps the aggregate
schema/event version accordingly. That is acceptable here because the system is
not live yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error detection and handling when conversion order data is incomplete or missing average price information during USDC rebalancing.

* **Refactor**
  * Improved internal tracking of USD↔USDC conversion amounts by separately recording source and received values for better visibility into conversion outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->