### PR TITLE
feat: enable SGOV as second staging asset

### DIFF
--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -33,6 +33,12 @@ vault_id = "0xfab"
 tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
 tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
 
+[assets.equities.SGOV]
+trading = "enabled"
+rebalancing = "disabled"
+tokenized_equity = "0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612"
+tokenized_equity_derivative = "0x78c31580c97101694c70022c83d570150c11e935"
+
 [assets.equities.SPYM]
 trading = "disabled"
 rebalancing = "disabled"


### PR DESCRIPTION
## What

Enables SGOV (iShares 0-3 Month Treasury Bond ETF) as a second trading-enabled
asset in the staging environment alongside RKLB.

## Why

We need to test the hedge bot with two assets trading in parallel to validate
multi-asset behavior before expanding to more symbols in production.

## How

Added `[assets.equities.SGOV]` section to `config/staging/st0x-hedge.toml` with
`trading = "enabled"`, `rebalancing = "disabled"`, and the tSGOV/wtSGOV token
addresses from the st0x.registry.

## Testing

Config-only change — no new tests needed.

## Anything else

Token addresses sourced from commit `7f7d862` in `ST0x-Technology/st0x.registry`
("add tIBHG, tSGOV"):
- tSGOV: `0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612`
- wtSGOV: `0x78c31580c97101694c70022c83d570150c11e935`

A DCA order still needs to be deployed on Raindex for SGOV before it can
actually trade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for SGOV asset trading in the staging environment with trading enabled and rebalancing disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->