### PR TITLE
docs: staging smoke test spec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,5 +60,6 @@ changes the behavior. If you delete a feature, delete or revise the doc.
 | [how-to-add-new-asset.md](how-to-add-new-asset.md) | Procedure for onboarding a new tokenized equity                            |
 | [observability.md](observability.md)               | Tracing, metrics, logging conventions                                      |
 | [sqlx.md](sqlx.md)                                 | sqlx usage notes and pitfalls                                              |
+| [staging-smoke-tests.md](staging-smoke-tests.md)   | Proposed on-demand smoke test against live staging (not implemented yet)   |
 | [ttdd.md](ttdd.md)                                 | Type-driven TDD workflow                                                   |
 | [wrapper-nav-bump.md](wrapper-nav-bump.md)         | How the wtStock ERC-4626 wrapper NAV is bumped (bare ERC-20 transfer)      |

--- a/docs/staging-smoke-tests.md
+++ b/docs/staging-smoke-tests.md
@@ -49,10 +49,10 @@ The staging bot has two assets with `trading = "enabled"`:
 
 ### Broker
 
-- **Alpaca Broker API** in **sandbox mode**
-- The staging bot already uses sandbox credentials
-- Sandbox provides paper trading with real API behavior (rate limits, order
-  lifecycle, position tracking) but no real money
+- **Alpaca Broker API** in **production mode** (real money, real orders)
+- Staging uses the real Alpaca API -- not sandbox -- which is why we restrict
+  testing to low-value assets (RKLB, SGOV) and small amounts
+- All trades are real executions with real settlement
 
 ### CCTP
 
@@ -67,7 +67,7 @@ The staging bot has two assets with `trading = "enabled"`:
 | Component    | e2e (current)                        | Smoke test (proposed)                 |
 | ------------ | ------------------------------------ | ------------------------------------- |
 | Chains       | Local Anvil (fresh state)            | Base mainnet (persistent state)       |
-| Broker       | `AlpacaBrokerMock` (httpmock)        | Real Alpaca sandbox API               |
+| Broker       | `AlpacaBrokerMock` (httpmock)        | Real Alpaca production API            |
 | Tokenization | `AlpacaTokenizationMock`             | Real Alpaca tokenization API          |
 | CCTP         | `CctpAttestationMock` (local signer) | Real Circle attestation service       |
 | Contracts    | Freshly deployed per test            | Existing staging contracts            |
@@ -102,8 +102,8 @@ The smoke test observes the bot's behavior through:
 1. **Bot HTTP API** (`/health`, `/inventory`, dashboard WebSocket) -- confirms
    the bot is alive and processing
 2. **Onchain state** -- vault balances, token balances, transaction receipts
-3. **Alpaca sandbox API** -- broker positions, order history, account state
-   (using the same sandbox credentials)
+3. **Alpaca API** -- broker positions, order history, account state (using the
+   same production credentials as the staging bot)
 
 The smoke test does **not** read the bot's SQLite database directly (it runs on
 a remote server). All assertions use externally observable state.
@@ -353,13 +353,15 @@ Add a `nix run .#smoke-test` command that:
 
 - **Smoke wallet holds real assets** (small amounts on Base mainnet). Key must
   be encrypted at rest (agenix) and only decrypted on the staging server.
-- **Alpaca sandbox credentials** are already managed via agenix. The smoke test
-  reuses them read-only (observing positions/orders). It does **not** place
-  broker orders -- that's the bot's job.
-- **No production access**: the smoke test targets staging config only. A
-  runtime guard should reject `--config` paths not containing "staging".
-- **Rate limiting**: Alpaca sandbox has rate limits. The observation polling
-  should use 2-5s intervals, not 200ms like e2e tests.
+- **Alpaca production credentials** are already managed via agenix. The smoke
+  test reuses them read-only (observing positions/orders). It does **not** place
+  broker orders -- that's the bot's job. Since this is a real broker account,
+  the small trade sizes and low-value assets (RKLB, SGOV) are the primary risk
+  controls.
+- **No production bot interference**: the smoke test targets staging config
+  only. A runtime guard should reject `--config` paths not containing "staging".
+- **Rate limiting**: Alpaca production API has rate limits. The observation
+  polling should use 2-5s intervals, not 200ms like e2e tests.
 
 ## Open Questions
 

--- a/docs/staging-smoke-tests.md
+++ b/docs/staging-smoke-tests.md
@@ -240,57 +240,158 @@ for round in 1..=max_rounds:
 | `min_amount`     | 0.1 shares | `--min-amount`        |
 | `max_amount`     | 1.0 shares | `--max-amount`        |
 
-### Phase 3: Observation Window
+### Phase 3: Observation & Assertions
 
-After the trade phase, wait for the bot to finish processing:
+The smoke test connects to the bot's WebSocket (`/api/ws`) to observe its
+reaction in real time. On connect, the bot sends a `CurrentState` snapshot
+containing recent trades, inventory, positions, active transfers, and settings.
+After that, it streams events: `TradeFill`, `PositionUpdate`,
+`InventorySnapshot`, and `TransferUpdate`.
 
-1. **Wait for hedging**: poll Alpaca sandbox for new orders matching the trades
-   we generated. Timeout: 120 seconds (real broker fills take longer than
-   mocks).
-2. **Wait for rebalancing** (if triggered): monitor vault balances for
-   mint/redeem activity. Timeout: 10 minutes (tokenization + CCTP bridging can
-   take minutes).
+The smoke test correlates each onchain trade it placed with the bot's response.
 
-### Phase 4: Assertions
+#### 3a. Counter-Trading Assertions
 
-Assertions are **softer** than e2e tests because we don't control fill prices or
-timing:
+For **each trade the smoke test places onchain**, assert that the bot:
 
-| Assertion                   | e2e (strict)         | Smoke (relaxed)                   |
-| --------------------------- | -------------------- | --------------------------------- |
-| Hedge placed for each trade | Exact match          | Within 120s, correct direction    |
-| Fill price                  | Exact mock price     | Within 5% of market price         |
-| Position net-zero           | Exact zero           | Within threshold tolerance        |
-| Rebalancing triggered       | Exact event sequence | Vault balance moved toward target |
-| No bot crash                | Task panics          | Health endpoint still 200         |
+1. **Detects the onchain fill**: a `TradeFill` event with `venue: Raindex`
+   appears for the correct symbol and direction. The smoke test knows the
+   tx_hash it submitted, so it can match against the trade's `id`
+   (`tx_hash:log_index`). **Timeout: 60s** (block propagation + WebSocket
+   delivery).
 
-**Hard failures** (test fails immediately):
+2. **Places the opposite hedge on Alpaca**: a second `TradeFill` event with
+   `venue: Alpaca` appears for the same symbol with the **opposite direction**.
+   If the onchain trade was a SellEquity (user sold equity to bot), the bot
+   should buy on Alpaca. If BuyEquity, bot should sell on Alpaca. **Timeout:
+   120s** (real Alpaca order placement + fill).
 
-- Bot health check returns non-200
-- Smoke wallet runs out of funds mid-test
-- Trade revert on a vault that should have liquidity
-- No hedge activity after 120s for any trade
+3. **Position converges toward zero**: after the hedge fill, the
+   `PositionUpdate` for that symbol should show `net` within the configured
+   execution threshold of zero. The bot batches hedges by threshold, so `net`
+   won't be exactly zero after every single trade -- but it should never grow
+   unbounded. Assert: `|position.net| <= execution_threshold` after the hedge
+   fills.
 
-**Soft warnings** (logged, not failures):
+4. **Hedge direction is correct**: for every Alpaca `TradeFill`, verify the
+   direction is opposite to the accumulated net position. A positive net
+   (accumulated long) must produce a sell hedge; negative net must produce a buy
+   hedge.
 
-- Fill price deviation > 2%
-- Rebalancing not triggered (may be below threshold)
-- Hedge latency > 30s (slow but not broken)
+**Tracking state:** The smoke test maintains a local ledger:
 
-### Phase 5: Report
+```
+per_symbol:
+  onchain_trades: [(tx_hash, direction, shares, timestamp)]
+  alpaca_fills:   [(order_id, direction, shares, timestamp)]
+  position_net:   Float  (from PositionUpdate events)
+```
 
-Print a summary:
+After the trade phase ends and the observation window closes, assert:
+
+- Every onchain trade has a matching Alpaca fill (by symbol + opposite
+  direction)
+- `position.net` for each symbol is within threshold of zero
+- Total Alpaca fill shares approximately equal total onchain trade shares
+  (within Alpaca's 9-decimal truncation epsilon)
+
+#### 3b. Rebalancing Assertions (When Enabled)
+
+If rebalancing is enabled for the test assets, the smoke test additionally
+asserts that inventory stays balanced. The bot streams `InventorySnapshot`
+events containing per-symbol breakdowns:
+
+```
+SymbolInventory {
+  symbol, onchain_available, onchain_inflight,
+  offchain_available, offchain_inflight
+}
+```
+
+**Equity rebalancing assertions:**
+
+1. **Imbalance detection**: after sustained one-directional trading (e.g., many
+   SellEquity fills drain offchain inventory), the ratio
+   `onchain / (onchain + offchain)` should deviate beyond `target +/- deviation`
+   (default 0.5 +/- 0.2).
+
+2. **Transfer initiated**: a `TransferUpdate` event should appear with the
+   correct type:
+   - Too much offchain (ratio < 0.3) -> `Mint` transfer (Alpaca -> tokenize ->
+     wrap -> deposit into Raindex)
+   - Too much onchain (ratio > 0.7) -> `Redemption` transfer (Raindex -> unwrap
+     -> send to Alpaca redemption wallet)
+
+3. **Transfer completes**: the `TransferUpdate` should reach terminal state
+   (`Completed`). **Timeout: 10 minutes** (tokenization API + onchain
+   transactions).
+
+4. **Inventory converges**: after the transfer completes, the next
+   `InventorySnapshot` should show the ratio moved back toward the target (0.5).
+   Assert: `|ratio - target| < deviation` eventually.
+
+**USDC rebalancing assertions:**
+
+1. **Cash imbalance detection**: `UsdcInventory` ratio
+   `onchain / (onchain + offchain)` deviates beyond threshold.
+
+2. **Bridge initiated**: a `TransferUpdate` of type USDC bridge appears:
+   - Too much onchain -> `BaseToAlpaca` (withdraw from Raindex, CCTP bridge Base
+     -> Ethereum, deposit into Alpaca)
+   - Too much offchain -> `AlpacaToBase` (convert USD -> USDC on Alpaca,
+     withdraw, CCTP bridge Ethereum -> Base, deposit into Raindex)
+
+3. **Bridge completes**: transfer reaches `Completed`. **Timeout: 15 minutes**
+   (CCTP attestation ~40-70s + Alpaca withdrawal processing).
+
+4. **USDC inventory converges**: ratio moves back toward target.
+
+#### 3c. Invariant Assertions (Continuous)
+
+These are checked throughout the entire test, not just after trades:
+
+1. **Bot stays alive**: WebSocket connection remains open. If the connection
+   drops, attempt reconnect once. If it fails again, the test fails.
+
+2. **No stuck transfers**: any `TransferUpdate` that enters a non-terminal state
+   must reach a terminal state (`Completed` or `Failed`) within
+   `transfer_timeout_secs` (default 1800s / 30 min). A transfer stuck in
+   `Minting`, `Bridging`, etc. beyond this window is a hard failure.
+
+3. **No position blowup**: `|position.net|` for any symbol must never exceed a
+   safety bound (e.g., 50 shares). If the bot stops hedging, this catches it
+   before real exposure accumulates.
+
+4. **Inventory consistency**: `onchain_available` and `offchain_available` in
+   `InventorySnapshot` must never go negative.
+
+5. **Smoke wallet solvency**: before each trade, check the smoke wallet has
+   sufficient balance to take the order. If not, skip the round and log a
+   warning. If the wallet is empty for 5 consecutive rounds, fail (the
+   round-robin should keep it funded).
+
+### Phase 4: Report
+
+Print a summary after the observation window closes:
 
 ```
 Staging Smoke Test Report
 =========================
-Duration:        4m 12s
-Trades placed:   50 (25 RKLB, 25 SGOV)
-Trades filled:   48 (2 reverted - vault drain, refilled by rebalance)
-Hedges observed: 48/48
-Avg hedge delay:  8.3s
-Rebalances:      2 (1 equity mint, 1 USDC bridge)
-Bot status:      healthy
+Duration:           4m 12s
+Trades placed:      50 (25 RKLB, 25 SGOV)
+Trades filled:      48 (2 reverted - vault drain, refilled by rebalance)
+Hedges observed:    48/48
+Avg hedge latency:  8.3s
+Max hedge latency:  23.1s
+Position RKLB net:  0.00 (threshold: 1.0)
+Position SGOV net:  -0.12 (threshold: 1.0)
+Rebalances:         2 (1 equity mint, 1 USDC bridge)
+Transfers completed: 2/2
+Inventory RKLB:     52% onchain / 48% offchain (target: 50%)
+Inventory SGOV:     49% onchain / 51% offchain (target: 50%)
+USDC:               55% onchain / 45% offchain (target: 50%)
+Bot status:         healthy (WebSocket connected)
+Warnings:           1 (hedge latency > 30s on round 17)
 
 RESULT: PASS
 ```

--- a/docs/staging-smoke-tests.md
+++ b/docs/staging-smoke-tests.md
@@ -1,0 +1,375 @@
+# Staging Smoke Tests
+
+## Motivation
+
+The e2e test suite (`tests/e2e/`) validates the bot's logic using local Anvil
+chains and mock services. This gives us confidence that state machines, CQRS
+event flows, and business logic are correct -- but it says nothing about whether
+the bot works against **real infrastructure**: real RPC nodes, real Alpaca
+sandbox, real CCTP attestation, real Raindex orderbook.
+
+Staging smoke tests bridge that gap. They reuse the same simulation loop from
+`tests/e2e/full_system.rs::simulate` -- randomly generating trades, taking
+orders onchain, and asserting the bot counter-trades and rebalances -- but
+pointed at the live staging environment instead of mocks.
+
+## Goals
+
+1. **Validate integration**: real Alpaca sandbox, real Base RPC, real CCTP, real
+   Raindex orderbook
+2. **Catch deployment regressions**: config drift, secret rotation issues, RPC
+   provider changes, contract upgrades
+3. **Run on demand**: developer triggers the test manually (not CI), observes
+   via dashboard
+4. **Non-destructive**: uses small amounts, dedicated test wallet, does not
+   interfere with the running staging bot
+
+## Non-Goals
+
+- Replacing the existing e2e suite (that stays as-is for deterministic CI)
+- Automated scheduled execution (future work)
+- Production environment testing
+
+## Staging Environment
+
+### Assets Under Test
+
+The staging bot has two assets with `trading = "enabled"`:
+
+| Symbol   | Tokenized Equity                             | Vault Wrapper (ERC-4626)                     | Vault ID |
+| -------- | -------------------------------------------- | -------------------------------------------- | -------- |
+| **RKLB** | `0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b` | `0xf4f8c66085910d583c01f3b4e44bf731d4e2c565` | `0xfab`  |
+| **SGOV** | `0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612` | `0x78c31580c97101694c70022c83d570150c11e935` | --       |
+
+### Chain
+
+- **Base mainnet** (chain ID 8453, CCTP domain 6)
+- Orderbook: `0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D`
+- Order owner (bot wallet): `0xA9C16673F65AE808688cB18952AFE3d9658C808f`
+
+### Broker
+
+- **Alpaca Broker API** in **sandbox mode**
+- The staging bot already uses sandbox credentials
+- Sandbox provides paper trading with real API behavior (rate limits, order
+  lifecycle, position tracking) but no real money
+
+### CCTP
+
+- **Circle CCTP V2** on Base mainnet <-> Ethereum mainnet
+- Real attestation service at `https://iris-api.circle.com`
+- Real USDC bridging with ~0.01% fee per transfer
+
+## Architecture
+
+### What Changes vs. e2e Tests
+
+| Component    | e2e (current)                        | Smoke test (proposed)                 |
+| ------------ | ------------------------------------ | ------------------------------------- |
+| Chains       | Local Anvil (fresh state)            | Base mainnet (persistent state)       |
+| Broker       | `AlpacaBrokerMock` (httpmock)        | Real Alpaca sandbox API               |
+| Tokenization | `AlpacaTokenizationMock`             | Real Alpaca tokenization API          |
+| CCTP         | `CctpAttestationMock` (local signer) | Real Circle attestation service       |
+| Contracts    | Freshly deployed per test            | Existing staging contracts            |
+| Database     | Temp SQLite (deleted after)          | Staging bot's persistent SQLite       |
+| Bot instance | Spawned in-process                   | **Already running** on staging server |
+
+### What Gets Reused
+
+The smoke test **does not start the bot**. The bot is already running on
+staging. The smoke test only acts as an **external stimulus** -- a simulated
+user taking orders on the Raindex orderbook -- and then **observes** the bot's
+reaction.
+
+Reused from `tests/e2e/`:
+
+- **Trade simulation loop**: round-robin order taking with random amounts
+- **Polling infrastructure** (`poll.rs`): adapted to poll staging DB or bot's
+  HTTP API instead of local SQLite
+- **Assertion framework** (`assert.rs`): relaxed for non-deterministic fill
+  prices and timing
+
+Not reused (replaced by real infrastructure):
+
+- `TestInfra` (no mock setup needed)
+- `BaseChain` contract deployment (contracts already exist)
+- All mock servers
+
+### Observation Strategy
+
+The smoke test observes the bot's behavior through:
+
+1. **Bot HTTP API** (`/health`, `/inventory`, dashboard WebSocket) -- confirms
+   the bot is alive and processing
+2. **Onchain state** -- vault balances, token balances, transaction receipts
+3. **Alpaca sandbox API** -- broker positions, order history, account state
+   (using the same sandbox credentials)
+
+The smoke test does **not** read the bot's SQLite database directly (it runs on
+a remote server). All assertions use externally observable state.
+
+## Smoke Test Wallet
+
+### Dedicated Test Wallet
+
+The smoke test needs its own wallet to take orders on the Raindex orderbook.
+This wallet acts as the "user" counterparty to the bot's liquidity orders.
+
+**Requirements:**
+
+- Separate from the bot's Turnkey wallet
+  (`0xA9C16673F65AE808688cB18952AFE3d9658C808f`)
+- Holds USDC and wrapped equity tokens to take both buy and sell orders
+- Funded with small amounts (see "Amounts" below)
+
+**Key management options (choose one):**
+
+| Option                         | Pros                           | Cons                           |
+| ------------------------------ | ------------------------------ | ------------------------------ |
+| **Raw private key in env var** | Simple, CI-friendly            | Key in plaintext on runner     |
+| **Agenix-encrypted secret**    | Consistent with existing infra | Requires NixOS host to decrypt |
+| **Turnkey sub-wallet**         | Same security as bot wallet    | Overhead of Turnkey API calls  |
+
+**Recommendation:** Use a **raw private key** stored as an agenix-encrypted
+secret alongside the existing `st0x-hedge.toml.age`. The smoke test runs from
+the staging server (which already has agenix decryption), so the key is never in
+plaintext outside the server's tmpfs.
+
+```
+secret/smoke-test-wallet.age   # encrypted private key
+```
+
+Decrypt path: `/run/agenix/smoke-test-wallet` (same pattern as other secrets).
+
+### Why Not Reuse the Bot Wallet?
+
+The bot wallet is the Raindex order **owner**. Taking your own orders is a no-op
+in Raindex (you can't fill your own order). The smoke test must use a different
+address to act as a genuine counterparty.
+
+## Funding
+
+### Initial Funding (One-Time Setup)
+
+The smoke test wallet needs tokens to take orders in both directions:
+
+| Token                | Amount    | Purpose                                                  | Source                        |
+| -------------------- | --------- | -------------------------------------------------------- | ----------------------------- |
+| **USDC** (Base)      | 500 USDC  | Take SellEquity orders (user pays USDC, receives equity) | Bridge from Coinbase/exchange |
+| **wtRKLB** (wrapped) | 10 shares | Take BuyEquity orders (user sells equity, receives USDC) | Bot wallet transfers or mint  |
+| **wtSGOV** (wrapped) | 10 shares | Take BuyEquity orders for SGOV                           | Bot wallet transfers or mint  |
+| **ETH** (Base)       | 0.01 ETH  | Gas for onchain transactions                             | Bridge from Coinbase/exchange |
+
+**Why these amounts?** Small enough to be inconsequential if lost, large enough
+to run many rounds. At current prices (~$25/RKLB, ~$100/SGOV), the total
+exposure is roughly **$1,750** in equity + $500 USDC + negligible gas.
+
+### Per-Trade Amounts
+
+Each smoke test round takes a **small random amount** from the bot's Raindex
+orders:
+
+| Parameter      | Value         | Rationale                                      |
+| -------------- | ------------- | ---------------------------------------------- |
+| Min trade size | 0.1 shares    | Well above Alpaca's $1 minimum at these prices |
+| Max trade size | 1.0 shares    | Small enough to not drain vaults quickly       |
+| USDC per trade | ~$2.50 - $100 | Derived from share price * quantity            |
+
+At 1 trade every 5 seconds, a 10-minute session executes ~120 trades consuming
+at most ~120 shares total across both symbols. The bot's vault liquidity and
+rebalancing should keep up.
+
+### Refunding
+
+The smoke test wallet **naturally gets refunded** by the trading loop itself:
+
+- Taking a SellEquity order spends USDC but receives equity tokens
+- Taking a BuyEquity order spends equity tokens but receives USDC
+- Round-robin order taking keeps the wallet roughly balanced
+
+Over time, the wallet may drift due to price asymmetry. A simple CLI command
+should exist to top up the wallet when needed:
+
+```bash
+# Example: top up USDC from a faucet or team wallet
+cast send <USDC_ADDRESS> "transfer(address,uint256)" <SMOKE_WALLET> 500e6 \
+  --rpc-url $BASE_RPC --private-key $TEAM_WALLET_KEY
+```
+
+## Smoke Test Flow
+
+### Phase 1: Preflight Checks
+
+Before generating any trades, verify the environment is healthy:
+
+1. **Bot health**: `GET http://staging:8001/health` returns 200
+2. **Wallet funded**: smoke test wallet has sufficient USDC, wtRKLB, wtSGOV, and
+   ETH for gas
+3. **Raindex orders exist**: query orderbook for bot's active orders on RKLB and
+   SGOV -- at least one SellEquity and one BuyEquity per symbol
+4. **Broker reachable**: Alpaca sandbox API responds (using staging credentials)
+5. **Vault balances**: Raindex vaults have liquidity to fill trades
+
+If any check fails, the test aborts with a clear diagnostic message.
+
+### Phase 2: Trade Simulation (Configurable Duration)
+
+Core loop, directly adapted from `simulate()`:
+
+```
+for round in 1..=max_rounds:
+    sleep(trade_interval)
+
+    symbol, direction = round_robin([RKLB-Sell, RKLB-Buy, SGOV-Sell, SGOV-Buy])
+    amount = random(0.1, 1.0) shares
+
+    take_order(orderbook, order, amount, smoke_wallet)
+
+    if success:
+        record trade (symbol, direction, amount, tx_hash)
+    if revert:
+        log "vault drained, waiting for rebalance"
+```
+
+**Default parameters:**
+
+| Parameter        | Default    | Configurable via      |
+| ---------------- | ---------- | --------------------- |
+| `max_rounds`     | 50         | `--rounds` CLI flag   |
+| `trade_interval` | 5 seconds  | `--interval` CLI flag |
+| `min_amount`     | 0.1 shares | `--min-amount`        |
+| `max_amount`     | 1.0 shares | `--max-amount`        |
+
+### Phase 3: Observation Window
+
+After the trade phase, wait for the bot to finish processing:
+
+1. **Wait for hedging**: poll Alpaca sandbox for new orders matching the trades
+   we generated. Timeout: 120 seconds (real broker fills take longer than
+   mocks).
+2. **Wait for rebalancing** (if triggered): monitor vault balances for
+   mint/redeem activity. Timeout: 10 minutes (tokenization + CCTP bridging can
+   take minutes).
+
+### Phase 4: Assertions
+
+Assertions are **softer** than e2e tests because we don't control fill prices or
+timing:
+
+| Assertion                   | e2e (strict)         | Smoke (relaxed)                   |
+| --------------------------- | -------------------- | --------------------------------- |
+| Hedge placed for each trade | Exact match          | Within 120s, correct direction    |
+| Fill price                  | Exact mock price     | Within 5% of market price         |
+| Position net-zero           | Exact zero           | Within threshold tolerance        |
+| Rebalancing triggered       | Exact event sequence | Vault balance moved toward target |
+| No bot crash                | Task panics          | Health endpoint still 200         |
+
+**Hard failures** (test fails immediately):
+
+- Bot health check returns non-200
+- Smoke wallet runs out of funds mid-test
+- Trade revert on a vault that should have liquidity
+- No hedge activity after 120s for any trade
+
+**Soft warnings** (logged, not failures):
+
+- Fill price deviation > 2%
+- Rebalancing not triggered (may be below threshold)
+- Hedge latency > 30s (slow but not broken)
+
+### Phase 5: Report
+
+Print a summary:
+
+```
+Staging Smoke Test Report
+=========================
+Duration:        4m 12s
+Trades placed:   50 (25 RKLB, 25 SGOV)
+Trades filled:   48 (2 reverted - vault drain, refilled by rebalance)
+Hedges observed: 48/48
+Avg hedge delay:  8.3s
+Rebalances:      2 (1 equity mint, 1 USDC bridge)
+Bot status:      healthy
+
+RESULT: PASS
+```
+
+## Implementation Plan
+
+### Binary
+
+Add a new binary target `smoke` (alongside `server` and `cli`):
+
+```
+src/bin/smoke.rs
+```
+
+Or extend the existing CLI with a `smoke-test` subcommand:
+
+```bash
+cargo run --bin cli -- smoke-test \
+    --config config/staging/st0x-hedge.toml \
+    --secrets /run/agenix/st0x-hedge.toml \
+    --wallet-key /run/agenix/smoke-test-wallet \
+    --rounds 50 \
+    --interval 5
+```
+
+**Recommendation:** CLI subcommand. It reuses the existing config loading, RPC
+setup, and Alpaca client construction. No new binary needed.
+
+### Crate Dependencies
+
+The smoke test uses:
+
+- **Existing config/secrets loading** from `src/config.rs`
+- **Alloy provider** for onchain transactions (take orders)
+- **Alpaca client** for observing broker state (read-only)
+- **Raindex orderbook ABI** for `takeOrders` calls
+
+No new crate dependencies required.
+
+### Nix Integration
+
+Add a `nix run .#smoke-test` command that:
+
+1. Decrypts secrets via agenix
+2. Runs the CLI subcommand against staging
+3. Optionally opens the dashboard alongside (via mprocs, same as `simulate`)
+
+### Files to Create/Modify
+
+| File                           | Change                                        |
+| ------------------------------ | --------------------------------------------- |
+| `src/cli/smoke.rs`             | New: smoke test CLI subcommand                |
+| `src/cli/mod.rs`               | Modified: add `SmokeTest` variant to CLI enum |
+| `secret/smoke-test-wallet.age` | New: encrypted test wallet private key        |
+| `secret/secrets.nix`           | Modified: add smoke-test-wallet secret        |
+| `flake.nix`                    | Modified: add `smoke-test` app                |
+| `docs/staging-smoke-tests.md`  | This spec                                     |
+
+## Security Considerations
+
+- **Smoke wallet holds real assets** (small amounts on Base mainnet). Key must
+  be encrypted at rest (agenix) and only decrypted on the staging server.
+- **Alpaca sandbox credentials** are already managed via agenix. The smoke test
+  reuses them read-only (observing positions/orders). It does **not** place
+  broker orders -- that's the bot's job.
+- **No production access**: the smoke test targets staging config only. A
+  runtime guard should reject `--config` paths not containing "staging".
+- **Rate limiting**: Alpaca sandbox has rate limits. The observation polling
+  should use 2-5s intervals, not 200ms like e2e tests.
+
+## Open Questions
+
+1. **SGOV vault_id**: staging config has no `vault_id` for SGOV. Does the bot
+   discover it dynamically, or does it need to be added before smoke tests can
+   take SGOV orders?
+2. **Rebalancing disabled**: both assets have `rebalancing = "disabled"` in
+   staging. Should we enable it for smoke tests, or test hedging-only first?
+3. **Operational limits**: RKLB has a commented-out `operational_limit = 1`.
+   Should smoke tests respect this or use their own limits?
+4. **Dashboard access**: should the smoke test connect to the staging bot's
+   dashboard WebSocket for richer observation, or stick to Alpaca API + onchain
+   queries?

--- a/docs/staging-smoke-tests.md
+++ b/docs/staging-smoke-tests.md
@@ -6,7 +6,7 @@ The e2e test suite (`tests/e2e/`) validates the bot's logic using local Anvil
 chains and mock services. This gives us confidence that state machines, CQRS
 event flows, and business logic are correct -- but it says nothing about whether
 the bot works against **real infrastructure**: real RPC nodes, real Alpaca
-sandbox, real CCTP attestation, real Raindex orderbook.
+production APIs, real CCTP attestation, real Raindex orderbook.
 
 Staging smoke tests bridge that gap. They reuse the same simulation loop from
 `tests/e2e/full_system.rs::simulate` -- randomly generating trades, taking
@@ -15,14 +15,15 @@ pointed at the live staging environment instead of mocks.
 
 ## Goals
 
-1. **Validate integration**: real Alpaca sandbox, real Base RPC, real CCTP, real
-   Raindex orderbook
+1. **Validate integration**: real Alpaca production API, real Base RPC, real
+   CCTP, real Raindex orderbook
 2. **Catch deployment regressions**: config drift, secret rotation issues, RPC
    provider changes, contract upgrades
 3. **Run on demand**: developer triggers the test manually (not CI), observes
    via dashboard
-4. **Non-destructive**: uses small amounts, dedicated test wallet, does not
-   interfere with the running staging bot
+4. **Bounded impact**: runs against a dedicated broker account or during an
+   exclusive staging window, with a hard notional cap and post-test
+   reconciliation
 
 ## Non-Goals
 
@@ -34,24 +35,34 @@ pointed at the live staging environment instead of mocks.
 
 ### Assets Under Test
 
-The staging bot has two assets with `trading = "enabled"`:
+The smoke test derives its eligible symbols from the parsed staging config and
+only exercises assets with `trading = "enabled"`. The current config snapshot
+is:
 
-| Symbol   | Tokenized Equity                             | Vault Wrapper (ERC-4626)                     | Vault ID |
-| -------- | -------------------------------------------- | -------------------------------------------- | -------- |
-| **RKLB** | `0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b` | `0xf4f8c66085910d583c01f3b4e44bf731d4e2c565` | `0xfab`  |
-| **SGOV** | `0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612` | `0x78c31580c97101694c70022c83d570150c11e935` | --       |
+| Symbol   | Trading  | Rebalancing | Tokenized Equity                             | Vault Wrapper (ERC-4626)                     | Vault ID |
+| -------- | -------- | ----------- | -------------------------------------------- | -------------------------------------------- | -------- |
+| **RKLB** | enabled  | enabled     | `0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b` | `0xf4f8c66085910d583c01f3b4e44bf731d4e2c565` | `0xfab`  |
+| **SGOV** | disabled | disabled    | `0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612` | `0x78c31580c97101694c70022c83d570150c11e935` | `0xfab`  |
+
+SGOV is not currently eligible. Enabling it is a deployment/config change that
+must precede any SGOV smoke-test traffic.
 
 ### Chain
 
 - **Base mainnet** (chain ID 8453, CCTP domain 6)
 - Orderbook: `0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D`
-- Order owner (bot wallet): `0xA9C16673F65AE808688cB18952AFE3d9658C808f`
+- Inventory and order/vault owner: `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2`
+- Bot operator/signing wallet: `0x16ca08a5825612aAe805D172a81B1a52b43574bf`
 
 ### Broker
 
 - **Alpaca Broker API** in **production mode** (real money, real orders)
-- Staging uses the real Alpaca API -- not sandbox -- which is why we restrict
-  testing to low-value assets (RKLB, SGOV) and small amounts
+- Staging uses the real Alpaca API -- not sandbox. Small amounts alone do not
+  make these tests non-destructive: they can collide with concurrent staging
+  activity and leave residual positions
+- Use a dedicated broker account/subaccount. If that is unavailable, reserve an
+  exclusive test window, enforce a hard notional budget, and reconcile orders,
+  positions, and cash after the run
 - All trades are real executions with real settlement
 
 ### CCTP
@@ -102,8 +113,11 @@ The smoke test observes the bot's behavior through:
 1. **Bot HTTP API** (`/health`, `/inventory`, dashboard WebSocket) -- confirms
    the bot is alive and processing
 2. **Onchain state** -- vault balances, token balances, transaction receipts
-3. **Alpaca API** -- broker positions, order history, account state (using the
-   same production credentials as the staging bot)
+3. **Alpaca API** -- broker positions, order history, account state. Use a
+   separate observer credential without order-placement capability when Alpaca
+   exposes that permission boundary. Otherwise isolate the observer process and
+   dedicated staging account from other workloads rather than treating read-only
+   code paths as a credential boundary
 
 The smoke test does **not** read the bot's SQLite database directly (it runs on
 a remote server). All assertions use externally observable state.
@@ -117,9 +131,10 @@ This wallet acts as the "user" counterparty to the bot's liquidity orders.
 
 **Requirements:**
 
-- Separate from the bot's Turnkey wallet
-  (`0xA9C16673F65AE808688cB18952AFE3d9658C808f`)
-- Holds USDC and wrapped equity tokens to take both buy and sell orders
+- Separate from the bot's Turnkey operator wallet
+  (`0x16ca08a5825612aAe805D172a81B1a52b43574bf`)
+- Holds USDC and the wrapped equity token for every eligible symbol to take both
+  buy and sell orders
 - Funded with small amounts (see "Amounts" below)
 
 **Key management options (choose one):**
@@ -143,9 +158,11 @@ Decrypt path: `/run/agenix/smoke-test-wallet` (same pattern as other secrets).
 
 ### Why Not Reuse the Bot Wallet?
 
-The bot wallet is the Raindex order **owner**. Taking your own orders is a no-op
-in Raindex (you can't fill your own order). The smoke test must use a different
-address to act as a genuine counterparty.
+Managed staging orders are owned by the inventory contract, but the bot's
+Turnkey wallet is its privileged operator and uses its own nonce stream and
+balances for production operations. Reusing it would couple test submissions to
+bot transactions and put operational funds and permissions in the test process.
+The smoke test therefore uses a separate address as the counterparty.
 
 ## Funding
 
@@ -157,44 +174,46 @@ The smoke test wallet needs tokens to take orders in both directions:
 | -------------------- | --------- | -------------------------------------------------------- | ----------------------------- |
 | **USDC** (Base)      | 500 USDC  | Take SellEquity orders (user pays USDC, receives equity) | Bridge from Coinbase/exchange |
 | **wtRKLB** (wrapped) | 10 shares | Take BuyEquity orders (user sells equity, receives USDC) | Bot wallet transfers or mint  |
-| **wtSGOV** (wrapped) | 10 shares | Take BuyEquity orders for SGOV                           | Bot wallet transfers or mint  |
 | **ETH** (Base)       | 0.01 ETH  | Gas for onchain transactions                             | Bridge from Coinbase/exchange |
 
-**Why these amounts?** Small enough to be inconsequential if lost, large enough
-to run many rounds. At current prices (~$25/RKLB, ~$100/SGOV), the total
-exposure is roughly **$1,750** in equity + $500 USDC + negligible gas.
+These are initial funding targets, not an authorization to consume the full
+balance. Before each run, query live marks and compute the USD value of all
+funded assets. The required `--max-notional-usd` argument is an absolute cap on
+the test's gross real-money exposure; preflight fails if the starting inventory,
+configured trade range, or requested rounds can exceed it. If additional symbols
+become eligible, add their wrapped-token reserves to the funding plan before
+enabling their test cases.
 
 ### Per-Trade Amounts
 
-Each smoke test round takes a **small random amount** from the bot's Raindex
-orders:
+Each smoke test round takes a random amount admitted by live prices, the
+remaining notional budget, and direction-specific reserves:
 
-| Parameter      | Value         | Rationale                                      |
-| -------------- | ------------- | ---------------------------------------------- |
-| Min trade size | 0.1 shares    | Well above Alpaca's $1 minimum at these prices |
-| Max trade size | 1.0 shares    | Small enough to not drain vaults quickly       |
-| USDC per trade | ~$2.50 - $100 | Derived from share price * quantity            |
+| Parameter      | Example value | Admission rule                                     |
+| -------------- | ------------- | -------------------------------------------------- |
+| Min trade size | 0.1 shares    | Meets the broker minimum at the current live mark  |
+| Max trade size | 1.0 shares    | Fits the remaining USD cap and directional reserve |
+| USDC per trade | Dynamic       | Live order quote plus the configured safety buffer |
 
-At 1 trade every 5 seconds, a 10-minute session executes ~120 trades consuming
-at most ~120 shares total across both symbols. The bot's vault liquidity and
-rebalancing should keep up.
+Preflight calculates separate reserves for every symbol and direction:
+`SellEquity` consumes smoke-wallet USDC, while `BuyEquity` consumes that
+symbol's wrapped shares. Requested rounds, trade sizes, and direction mix are
+accepted only when the worst-case sequence fits all reserves and the absolute
+USD cap. A later round repeats the check against current balances and live marks
+before submitting.
 
 ### Refunding
 
-The smoke test wallet **naturally gets refunded** by the trading loop itself:
+The trading loop redistributes the smoke wallet's inventory:
 
 - Taking a SellEquity order spends USDC but receives equity tokens
 - Taking a BuyEquity order spends equity tokens but receives USDC
-- Round-robin order taking keeps the wallet roughly balanced
+- Round-robin order taking may reduce drift, but does not guarantee balance
 
-Over time, the wallet may drift due to price asymmetry. A simple CLI command
-should exist to top up the wallet when needed:
-
-```bash
-# Example: top up USDC from a faucet or team wallet
-cast send <USDC_ADDRESS> "transfer(address,uint256)" <SMOKE_WALLET> 500e6 \
-  --rpc-url $BASE_RPC --private-key $TEAM_WALLET_KEY
-```
+Every run therefore ends with reconciliation against the pre-test wallet and
+broker snapshots. Top-ups use the dedicated funding signer/service or a
+supported secret-input mechanism; private keys must never be expanded into
+process arguments, logs, or shell history.
 
 ## Smoke Test Flow
 
@@ -203,12 +222,18 @@ cast send <USDC_ADDRESS> "transfer(address,uint256)" <SMOKE_WALLET> 500e6 \
 Before generating any trades, verify the environment is healthy:
 
 1. **Bot health**: `GET http://staging:8001/health` returns 200
-2. **Wallet funded**: smoke test wallet has sufficient USDC, wtRKLB, wtSGOV, and
-   ETH for gas
-3. **Raindex orders exist**: query orderbook for bot's active orders on RKLB and
-   SGOV -- at least one SellEquity and one BuyEquity per symbol
-4. **Broker reachable**: Alpaca sandbox API responds (using staging credentials)
+2. **Wallet funded**: smoke test wallet has sufficient USDC, each eligible
+   symbol's wrapped token, and ETH for gas
+3. **Raindex orders exist**: query the orderbook for the inventory owner's
+   active orders -- at least one SellEquity and one BuyEquity for every eligible
+   symbol
+4. **Broker identity and access**: read-only calls to the Alpaca production API
+   verify credentials, account state, limits, current order access, and the
+   exact expected staging account ID. Abort if the endpoint or account identity
+   differs from the staging configuration
 5. **Vault balances**: Raindex vaults have liquidity to fill trades
+6. **Exposure budget**: live marks, per-symbol/per-direction reserves, requested
+   rounds, and trade-size bounds fit the required absolute USD cap
 
 If any check fails, the test aborts with a clear diagnostic message.
 
@@ -220,16 +245,29 @@ Core loop, directly adapted from `simulate()`:
 for round in 1..=max_rounds:
     sleep(trade_interval)
 
-    symbol, direction = round_robin([RKLB-Sell, RKLB-Buy, SGOV-Sell, SGOV-Buy])
+    symbol, direction = round_robin(eligible_symbol_direction_pairs)
     amount = random(0.1, 1.0) shares
 
-    take_order(orderbook, order, amount, smoke_wallet)
+    sender_nonce = reserve_nonce(smoke_wallet)
+    tx_hash = submit_take_order(orderbook, order, amount, sender_nonce)
+    persist pending trade (symbol, direction, amount, sender_nonce, tx_hash)
 
-    if success:
-        record trade (symbol, direction, amount, tx_hash)
-    if revert:
+    receipt = poll_receipt_or_replacement(sender_nonce, tx_hash)
+    if receipt.success:
+        record confirmed trade (symbol, direction, amount, receipt.tx_hash)
+    if receipt.revert:
+        record terminal revert
         log "vault drained, waiting for rebalance"
+    if receipt.unknown:
+        record unknown outcome
+        stop new submissions and reconcile the nonce before continuing
 ```
+
+Persist the transaction hash immediately after broadcast. A timeout, dropped RPC
+response, replacement, or nonce mismatch is neither success nor revert. The test
+must recover the submitted/replacement transaction by sender and nonce, poll its
+receipt, and leave the result `unknown` while inconclusive. It never blindly
+retries `take_order` while a prior outcome may still land.
 
 **Default parameters:**
 
@@ -239,58 +277,182 @@ for round in 1..=max_rounds:
 | `trade_interval` | 5 seconds  | `--interval` CLI flag |
 | `min_amount`     | 0.1 shares | `--min-amount`        |
 | `max_amount`     | 1.0 shares | `--max-amount`        |
+| `max_notional`   | Required   | `--max-notional-usd`  |
 
-### Phase 3: Observation Window
+### Phase 3: Observation & Assertions
 
-After the trade phase, wait for the bot to finish processing:
+The smoke test connects to the bot's WebSocket (`/api/ws`) to observe its
+reaction in real time. The JSON envelope uses a lower-snake-case `type` and
+camel-case payload fields. On connect, the bot sends `type: "current_state"`
+containing recent trades, inventory, positions, active transfers, and settings.
+After that, it streams `trade_fill`, `position_update`, `inventory_snapshot`,
+and `transfer_update`. Rust names such as `CurrentState` and `InventorySnapshot`
+below are conceptual types; assertions use the serialized JSON names (for
+example, `perSymbol` and `onchainAvailable`).
 
-1. **Wait for hedging**: poll Alpaca sandbox for new orders matching the trades
-   we generated. Timeout: 120 seconds (real broker fills take longer than
-   mocks).
-2. **Wait for rebalancing** (if triggered): monitor vault balances for
-   mint/redeem activity. Timeout: 10 minutes (tokenization + CCTP bridging can
-   take minutes).
+The smoke test correlates confirmed onchain trades with the bot's aggregate
+per-symbol response.
 
-### Phase 4: Assertions
+#### 3a. Counter-Trading Assertions
 
-Assertions are **softer** than e2e tests because we don't control fill prices or
-timing:
+Track every confirmed onchain trade, then assert:
 
-| Assertion                   | e2e (strict)         | Smoke (relaxed)                   |
-| --------------------------- | -------------------- | --------------------------------- |
-| Hedge placed for each trade | Exact match          | Within 120s, correct direction    |
-| Fill price                  | Exact mock price     | Within 5% of market price         |
-| Position net-zero           | Exact zero           | Within threshold tolerance        |
-| Rebalancing triggered       | Exact event sequence | Vault balance moved toward target |
-| No bot crash                | Task panics          | Health endpoint still 200         |
+1. **Detects the onchain fill**: a `trade_fill` event with `venue: Raindex`
+   appears for the correct symbol and direction. The smoke test knows the
+   tx_hash it submitted, so it can match against the trade's `id`
+   (`tx_hash:log_index`). **Timeout: 60s** (block propagation + WebSocket
+   delivery).
 
-**Hard failures** (test fails immediately):
+2. **Hedges threshold-crossing exposure on Alpaca**: when accumulated exposure
+   crosses its execution threshold, one or more `trade_fill` events with
+   `venue: Alpaca` cover that per-symbol batch. A single broker fill may cover
+   several onchain trades. `SellEquity` means the bot's order sold equity to the
+   taker, so the bot buys on Alpaca; `BuyEquity` means the bot bought equity
+   from the taker, so it sells on Alpaca. **Timeout: 120s** after the threshold
+   is crossed.
 
-- Bot health check returns non-200
-- Smoke wallet runs out of funds mid-test
-- Trade revert on a vault that should have liquidity
-- No hedge activity after 120s for any trade
+3. **Position converges toward zero**: after the hedge fill, the
+   `position_update` for that symbol should show `net` below the configured
+   shares or dollar-value execution threshold. The bot batches hedges by
+   threshold, so `net` won't be exactly zero after every single trade -- but it
+   should never grow unbounded.
 
-**Soft warnings** (logged, not failures):
+4. **Hedge direction is correct**: for every Alpaca `trade_fill`, verify the
+   direction is opposite to the accumulated net position. A positive net
+   (accumulated long) must produce a sell hedge; negative net must produce a buy
+   hedge.
 
-- Fill price deviation > 2%
-- Rebalancing not triggered (may be below threshold)
-- Hedge latency > 30s (slow but not broken)
+**Tracking state:** The smoke test maintains a local ledger:
 
-### Phase 5: Report
+```
+per_symbol:
+  onchain_trades: [(tx_hash, direction, shares, timestamp)]
+  alpaca_fills:   [(order_id, direction, shares, timestamp)]
+  uncovered_signed_shares: Float
+  position_net:   Float  (from position_update events)
+```
 
-Print a summary:
+Each onchain fill updates `uncovered_signed_shares`. When a broker fill arrives,
+the ledger consumes exposure from that per-symbol accumulator in FIFO order,
+allowing a many-to-one hedge relationship. It never assigns one broker fill to
+exactly one onchain transaction.
+
+After the trade phase ends and the observation window closes, assert:
+
+- Every threshold-crossing batch has sufficient opposite-direction Alpaca fill
+  volume
+- `position.net` for each symbol is below its configured shares or dollar-value
+  threshold
+- Covered onchain shares equal opposite-direction Alpaca fill shares within
+  Alpaca's 9-decimal truncation epsilon after wrapped amounts are converted to
+  underlying shares; any unmatched residual is below the execution threshold
+
+#### 3b. Rebalancing Assertions (When Enabled)
+
+If rebalancing is enabled for the test assets, the smoke test additionally
+asserts that inventory stays balanced. The bot streams `inventory_snapshot`
+events containing `perSymbol` entries:
+
+```
+{
+  symbol, onchainAvailable, onchainInflight,
+  offchainAvailable, offchainInflight
+}
+```
+
+**Equity rebalancing assertions:**
+
+1. **Imbalance detection**: after sustained one-directional trading (e.g., many
+   SellEquity fills drain offchain inventory), the ratio
+   `onchain / (onchain + offchain)` should deviate beyond `target +/- deviation`
+   (default 0.5 +/- 0.2). If the denominator is zero, mark this ratio check
+   inconclusive and do not divide; normal validation resumes when either balance
+   is nonzero.
+
+2. **Transfer initiated**: a `transfer_update` event should appear with the
+   correct type:
+   - Too much offchain (ratio < 0.3) -> `Mint` transfer (Alpaca -> tokenize ->
+     wrap -> deposit into Raindex)
+   - Too much onchain (ratio > 0.7) -> `Redemption` transfer (Raindex -> unwrap
+     -> send to Alpaca redemption wallet)
+
+3. **Transfer completes**: the `transfer_update` should reach terminal state
+   (`Completed`). **Timeout: 10 minutes** (tokenization API + onchain
+   transactions).
+
+4. **Inventory converges**: after the transfer completes, the next
+   `inventory_snapshot` should show the ratio moved back toward the target
+   (0.5). Assert `|ratio - target| < deviation` eventually when the denominator
+   is nonzero; otherwise mark the check inconclusive.
+
+**USDC rebalancing assertions:**
+
+1. **Cash imbalance detection**: `UsdcInventory` ratio
+   `onchain / (onchain + offchain)` deviates beyond threshold. A zero
+   denominator is inconclusive rather than a ratio failure.
+
+2. **Bridge initiated**: a `transfer_update` of type USDC bridge appears:
+   - Too much onchain -> `BaseToAlpaca` (withdraw from Raindex, CCTP bridge Base
+     -> Ethereum, deposit into Alpaca)
+   - Too much offchain -> `AlpacaToBase` (convert USD -> USDC on Alpaca,
+     withdraw, CCTP bridge Ethereum -> Base, deposit into Raindex)
+
+3. **Bridge completes**: transfer reaches `Completed`. **Timeout: 15 minutes**
+   (CCTP attestation ~40-70s + Alpaca withdrawal processing).
+
+4. **USDC inventory converges**: ratio moves back toward target.
+
+#### 3c. Invariant Assertions (Continuous)
+
+These are checked throughout the entire test, not just after trades:
+
+1. **Bot stays alive**: WebSocket connection remains open. If the connection
+   drops, attempt reconnect once. Before resuming assertions, reload all
+   submitted transaction receipts, Alpaca order history, and the latest
+   `current_state` dashboard snapshot. Deduplicate the recovered and streamed
+   records by stable trade ID, broker order ID, transfer ID, or transaction
+   hash. If reconciliation or the second connection fails, the test fails.
+
+2. **No stuck transfers**: any `transfer_update` that enters a non-terminal
+   state must reach a terminal state (`Completed` or `Failed`) within
+   `transfer_timeout_secs` (default 1800s / 30 min). A transfer stuck in
+   `Minting`, `Bridging`, etc. beyond this window is a hard failure.
+
+3. **No position blowup**: the live-mark USD value of `|position.net|` for any
+   symbol must never exceed its directional reserve or the remaining absolute
+   USD cap. If the bot stops hedging, this catches it before the authorized real
+   exposure is exceeded.
+
+4. **Inventory consistency**: `onchainAvailable` and `offchainAvailable` in
+   `inventory_snapshot` must never go negative.
+
+5. **Smoke wallet solvency**: before each trade, check the smoke wallet has
+   sufficient balance to take the order. If not, skip the round and log a
+   warning. If the wallet is empty for 5 consecutive rounds, fail (the
+   round-robin should keep it funded).
+
+### Phase 4: Report
+
+Print a summary after the observation window closes:
 
 ```
 Staging Smoke Test Report
 =========================
-Duration:        4m 12s
-Trades placed:   50 (25 RKLB, 25 SGOV)
-Trades filled:   48 (2 reverted - vault drain, refilled by rebalance)
-Hedges observed: 48/48
-Avg hedge delay:  8.3s
-Rebalances:      2 (1 equity mint, 1 USDC bridge)
-Bot status:      healthy
+Duration:           4m 12s
+Trades placed:      50 (50 RKLB)
+Trades filled:      48 (2 reverted - vault drain, refilled by rebalance)
+Onchain fills seen:  48/48
+Hedge batches:       12
+Covered shares:      47.8/48.0 (0.2 residual < 1.0 threshold)
+Avg hedge latency:  8.3s
+Max hedge latency:  23.1s
+Position RKLB net:  0.00 (threshold: 1.0)
+Rebalances:         1 (equity mint; USDC rebalancing disabled)
+Transfers completed: 1/1
+Inventory RKLB:     52% onchain / 48% offchain (target: 50%)
+USDC:               55% onchain / 45% offchain (target: 50%)
+Bot status:         healthy (WebSocket connected)
+Warnings:           1 (hedge latency > 30s on round 17)
 
 RESULT: PASS
 ```
@@ -312,6 +474,8 @@ cargo run --bin cli -- smoke-test \
     --config config/staging/st0x-hedge.toml \
     --secrets /run/agenix/st0x-hedge.toml \
     --wallet-key /run/agenix/smoke-test-wallet \
+    --expected-broker-account-id <staging-account-id> \
+    --max-notional-usd <required-cap> \
     --rounds 50 \
     --interval 5
 ```
@@ -323,7 +487,8 @@ setup, and Alpaca client construction. No new binary needed.
 
 The smoke test uses:
 
-- **Existing config/secrets loading** from `src/config.rs`
+- **Existing config/secrets loading** from the `st0x-config` crate
+  (`crates/config/`)
 - **Alloy provider** for onchain transactions (take orders)
 - **Alpaca client** for observing broker state (read-only)
 - **Raindex orderbook ABI** for `takeOrders` calls
@@ -332,11 +497,15 @@ No new crate dependencies required.
 
 ### Nix Integration
 
-Add a `nix run .#smoke-test` command that:
+The implementation PR must export a `packages.smokeTest` flake output before
+operators use the planned `nix run .#smokeTest` command. That output will:
 
-1. Decrypts secrets via agenix
-2. Runs the CLI subcommand against staging
-3. Optionally opens the dashboard alongside (via mprocs, same as `simulate`)
+1. Decrypt secrets via agenix
+2. Run the CLI subcommand against staging
+3. Optionally open the dashboard alongside (via mprocs, same as `simulate`)
+
+The command is not available in the current flake; documenting it here defines
+the required implementation output rather than a command that works today.
 
 ### Files to Create/Modify
 
@@ -346,32 +515,37 @@ Add a `nix run .#smoke-test` command that:
 | `src/cli/mod.rs`               | Modified: add `SmokeTest` variant to CLI enum |
 | `secret/smoke-test-wallet.age` | New: encrypted test wallet private key        |
 | `secret/secrets.nix`           | Modified: add smoke-test-wallet secret        |
-| `flake.nix`                    | Modified: add `smoke-test` app                |
+| `flake.nix`                    | Modified: add `smokeTest` package             |
 | `docs/staging-smoke-tests.md`  | This spec                                     |
 
 ## Security Considerations
 
 - **Smoke wallet holds real assets** (small amounts on Base mainnet). Key must
   be encrypted at rest (agenix) and only decrypted on the staging server.
-- **Alpaca production credentials** are already managed via agenix. The smoke
-  test reuses them read-only (observing positions/orders). It does **not** place
-  broker orders -- that's the bot's job. Since this is a real broker account,
-  the small trade sizes and low-value assets (RKLB, SGOV) are the primary risk
-  controls.
-- **No production bot interference**: the smoke test targets staging config
-  only. A runtime guard should reject `--config` paths not containing "staging".
+- **Alpaca production credentials** are managed via agenix. Prefer a separate
+  observer credential without order-placement capability. If Alpaca cannot
+  enforce that permission boundary, isolate the observer process and dedicated
+  staging account. The smoke test does **not** place broker orders -- that is
+  the bot's job.
+- **Explicit staging identity**: before loading a signing key or submitting a
+  transaction, parse the configuration and require
+  `telemetry.environment = "staging"`, Base chain ID 8453, the expected
+  orderbook, inventory/vault-owner addresses, production broker endpoint, and
+  exact staging broker account ID. A path substring is not an identity check.
+  Reject any mismatch before signing or sending.
+- **Bounded real exposure**: low-value assets and small nominal trade sizes do
+  not make production-API executions non-destructive. A dedicated account or
+  exclusive window, the required absolute USD cap, directional reserves, and
+  post-test reconciliation are all mandatory.
 - **Rate limiting**: Alpaca production API has rate limits. The observation
   polling should use 2-5s intervals, not 200ms like e2e tests.
 
 ## Open Questions
 
-1. **SGOV vault_id**: staging config has no `vault_id` for SGOV. Does the bot
-   discover it dynamically, or does it need to be added before smoke tests can
-   take SGOV orders?
-2. **Rebalancing disabled**: both assets have `rebalancing = "disabled"` in
-   staging. Should we enable it for smoke tests, or test hedging-only first?
-3. **Operational limits**: RKLB has a commented-out `operational_limit = 1`.
+1. **Broker isolation**: can Alpaca provide a dedicated staging subaccount and
+   observer-only credential, or must runs reserve an exclusive window?
+2. **Operational limits**: RKLB has a commented-out `operational_limit = 1`.
    Should smoke tests respect this or use their own limits?
-4. **Dashboard access**: should the smoke test connect to the staging bot's
+3. **Dashboard access**: should the smoke test connect to the staging bot's
    dashboard WebSocket for richer observation, or stick to Alpaca API + onchain
    queries?

--- a/docs/staging-smoke-tests.md
+++ b/docs/staging-smoke-tests.md
@@ -1,473 +1,497 @@
 # Staging Smoke Tests
 
+**Status: proposed, not implemented.** Nothing in this document runs today.
+There is no `smoke-test` subcommand, no smoke-test wallet secret, and no
+`smokeTest` flake output. This is the design we agreed on, kept next to the code
+so the implementer does not have to reconstruct it. Every fact about the current
+system below was read out of the repo at the time of writing. When the feature
+lands, rewrite this file as a runbook and drop this status block.
+
 ## Motivation
 
-The e2e test suite (`tests/e2e/`) validates the bot's logic using local Anvil
-chains and mock services. This gives us confidence that state machines, CQRS
-event flows, and business logic are correct -- but it says nothing about whether
-the bot works against **real infrastructure**: real RPC nodes, real Alpaca
-production APIs, real CCTP attestation, real Raindex orderbook.
+The e2e suite in `tests/e2e/` runs the whole bot against local Anvil chains and
+mock services. It proves the state machines, the CQRS flows, and the business
+logic are correct. It proves nothing about real infrastructure.
 
-Staging smoke tests bridge that gap. They reuse the same simulation loop from
-`tests/e2e/full_system.rs::simulate` -- randomly generating trades, taking
-orders onchain, and asserting the bot counter-trades and rebalances -- but
-pointed at the live staging environment instead of mocks.
+These are the things it cannot catch:
+
+- config drift between the repo and the deployed `st0x-hedge.toml`
+- secret rotation that breaks Alpaca or Turnkey auth
+- an RPC provider that answers differently from Anvil
+- a contract upgrade that changes an ABI we depend on
+- real Circle attestation latency and failure modes
+
+A staging smoke test covers that gap. It takes real orders on the staging
+Raindex orderbook and then checks that the running staging bot reacts correctly.
 
 ## Goals
 
-1. **Validate integration**: real Alpaca production API, real Base RPC, real
-   CCTP, real Raindex orderbook
-2. **Catch deployment regressions**: config drift, secret rotation issues, RPC
-   provider changes, contract upgrades
-3. **Run on demand**: developer triggers the test manually (not CI), observes
-   via dashboard
-4. **Bounded impact**: runs against a dedicated broker account or during an
-   exclusive staging window, with a hard notional cap and post-test
-   reconciliation
+1. Prove the deployed bot works against real infrastructure: real Alpaca, real
+   Base RPC, real Circle attestation, and the real Raindex orderbook.
+2. Catch deployment regressions that CI cannot see.
+3. Run on demand. A developer starts it and watches the dashboard.
+4. Stay inside a hard, explicit money cap.
 
-## Non-Goals
+## Non-goals
 
-- Replacing the existing e2e suite (that stays as-is for deterministic CI)
-- Automated scheduled execution (future work)
-- Production environment testing
+- Replacing the e2e suite. That stays as the deterministic CI gate.
+- Scheduled or automated runs. Later, if the on-demand version proves stable.
+- Production. Never point this at prod.
 
-## Staging Environment
+## Staging today
 
-### Assets Under Test
+Read from `config/staging/st0x-hedge.toml`. Check the file before a run, because
+these values change.
 
-The smoke test derives its eligible symbols from the parsed staging config and
-only exercises assets with `trading = "enabled"`. The current config snapshot
-is:
+### Settlement model
 
-| Symbol   | Trading  | Rebalancing | Tokenized Equity                             | Vault Wrapper (ERC-4626)                     | Vault ID |
-| -------- | -------- | ----------- | -------------------------------------------- | -------------------------------------------- | -------- |
-| **RKLB** | enabled  | enabled     | `0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b` | `0xf4f8c66085910d583c01f3b4e44bf731d4e2c565` | `0xfab`  |
-| **SGOV** | disabled | disabled    | `0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612` | `0x78c31580c97101694c70022c83d570150c11e935` | `0xfab`  |
+Staging runs **managed inventory** since PR #1072:
 
-SGOV is not currently eligible. Enabling it is a deployment/config change that
-must precede any SGOV smoke-test traffic.
+| Key                      | Value                                        |
+| ------------------------ | -------------------------------------------- |
+| `inventory_mode`         | `managed`                                    |
+| `inventory`              | `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2` |
+| `vault_owner`            | `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2` |
+| `orderbook`              | `0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D` |
+| Bot wallet (Turnkey)     | `0x16ca08a5825612aAe805D172a81B1a52b43574bf` |
+| `required_confirmations` | 3                                            |
+| `ingestion_cutoff`       | `safe`                                       |
 
-### Chain
+The orders and the vaults belong to the shared `RaindexInventory` contract, not
+to the bot wallet. The bot wallet only operates that contract through
+`OPERATOR_ROLE`. Startup fails closed if the role is missing, so a bot that is
+up has the role.
 
-- **Base mainnet** (chain ID 8453, CCTP domain 6)
-- Orderbook: `0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D`
-- Inventory and order/vault owner: `0x5FE36e6b6c320f8FD0B6109B2315253387DbdeF2`
-- Bot operator/signing wallet: `0x16ca08a5825612aAe805D172a81B1a52b43574bf`
+### Assets
+
+The staging config registers about 35 equities for parity with prod. Only one is
+tradable:
+
+| Symbol     | Trading  | Rebalancing | Extended hours | Vault ID |
+| ---------- | -------- | ----------- | -------------- | -------- |
+| RKLB       | enabled  | enabled     | enabled        | `0xfab`  |
+| all others | disabled | disabled    | disabled       | `0xfab`  |
+
+So today the smoke test is an RKLB test. Derive the symbol list from the parsed
+config and take only symbols with `trading = "enabled"`. Do not hardcode RKLB.
+Enabling a second symbol is a config change and a deploy, and it must happen
+before that symbol gets smoke-test traffic.
+
+SGOV now has a `vault_id`, which it did not have when this spec was first
+written. It is still `trading = "disabled"`.
+
+### Rebalancing
+
+| Setting                   | Value        |
+| ------------------------- | ------------ |
+| Equity target / deviation | 0.5 / 0.2    |
+| Equity rebalancing (RKLB) | enabled      |
+| USDC rebalancing          | **disabled** |
+| `transfer_timeout_secs`   | 1800         |
+| `freeze_check`            | disabled     |
+
+USDC rebalancing is off in two places. `[rebalancing]` sets `usdc.mode` to
+`disabled`, and `[assets.cash]` sets `rebalancing` to `disabled`. The USDC
+assertions in this document therefore cannot run today. Keep them, but skip them
+unless the parsed config says USDC rebalancing is enabled. Never assert a bridge
+that config has switched off.
+
+`freeze_check = "disabled"` means the dividend freeze gate will not block a mint
+or a redemption on staging. Worth knowing so a rebalancing result is not
+misread.
 
 ### Broker
 
-- **Alpaca Broker API** in **production mode** (real money, real orders)
-- Staging uses the real Alpaca API -- not sandbox. Small amounts alone do not
-  make these tests non-destructive: they can collide with concurrent staging
-  activity and leave residual positions
-- Use a dedicated broker account/subaccount. If that is unavailable, reserve an
-  exclusive test window, enforce a hard notional budget, and reconcile orders,
-  positions, and cash after the run
-- All trades are real executions with real settlement
+Alpaca Broker API in **production mode**. Real money, real orders, real
+settlement. Staging does not use the sandbox.
 
-### CCTP
+Small trade sizes do not make this safe on their own. A run can collide with
+other staging activity and leave positions behind. Use a dedicated account, or
+reserve an exclusive window, cap the notional, and reconcile afterwards.
 
-- **Circle CCTP V2** on Base mainnet <-> Ethereum mainnet
-- Real attestation service at `https://iris-api.circle.com`
-- Real USDC bridging with ~0.01% fee per transfer
+### Hedging threshold
 
-## Architecture
+The execution threshold is **not** a config value. It comes from the executor
+kind in `crates/config/src/loader.rs`:
 
-### What Changes vs. e2e Tests
+- Alpaca executor: dollar-value threshold of **$2** (`ALPACA_MIN_DOLLARS`)
+- Dry-run executor: a share threshold
 
-| Component    | e2e (current)                        | Smoke test (proposed)                 |
-| ------------ | ------------------------------------ | ------------------------------------- |
-| Chains       | Local Anvil (fresh state)            | Base mainnet (persistent state)       |
-| Broker       | `AlpacaBrokerMock` (httpmock)        | Real Alpaca production API            |
-| Tokenization | `AlpacaTokenizationMock`             | Real Alpaca tokenization API          |
-| CCTP         | `CctpAttestationMock` (local signer) | Real Circle attestation service       |
-| Contracts    | Freshly deployed per test            | Existing staging contracts            |
-| Database     | Temp SQLite (deleted after)          | Staging bot's persistent SQLite       |
-| Bot instance | Spawned in-process                   | **Already running** on staging server |
+RKLB trades far above $2, so nearly every single onchain fill crosses the
+threshold by itself. Expect roughly one broker order per onchain trade, not a
+batch of many. Assertions must still allow batching, because the bot is free to
+cover several fills with one order.
 
-### What Gets Reused
+### Extended hours
 
-The smoke test **does not start the bot**. The bot is already running on
-staging. The smoke test only acts as an **external stimulus** -- a simulated
-user taking orders on the Raindex orderbook -- and then **observes** the bot's
-reaction.
+RKLB has `extended_hours_counter_trading = "enabled"`. This changes the hedge
+path outside regular market hours:
 
-Reused from `tests/e2e/`:
+- The counter-trade goes out as a **limit** order, priced off the last trade
+  plus `counter_trade_slippage_bps` (100 bps on staging).
+- `CheckPositions` cancels and reprices an unfilled extended-hours order after
+  `extended_hours_reprice_timeout_secs` (300s).
+- Inside `extended_hours_close_flatten_window_secs` (900s) before the extended
+  close, it flattens instead.
 
-- **Trade simulation loop**: round-robin order taking with random amounts
-- **Polling infrastructure** (`poll.rs`): adapted to poll staging DB or bot's
-  HTTP API instead of local SQLite
-- **Assertion framework** (`assert.rs`): relaxed for non-deterministic fill
-  prices and timing
+A single fixed hedge timeout is wrong. The assertion window must depend on the
+session:
 
-Not reused (replaced by real infrastructure):
+| Session        | Expected hedge behavior      | Suggested timeout           |
+| -------------- | ---------------------------- | --------------------------- |
+| Regular hours  | market order, fills fast     | 120s                        |
+| Extended hours | limit order, may reprice     | 2 reprice cycles, so ~660s  |
+| Closed         | no hedge until the next open | assert deferral, not a fill |
 
-- `TestInfra` (no mock setup needed)
-- `BaseChain` contract deployment (contracts already exist)
-- All mock servers
+Running inside regular hours is the simplest option and gives the tightest
+assertions. Say so in the report if the run crossed a session boundary.
 
-### Observation Strategy
+### Chain and CCTP
 
-The smoke test observes the bot's behavior through:
+- Base mainnet, chain ID 8453, CCTP domain 6.
+- Circle CCTP V2 between Base and Ethereum, real attestation service.
+- CCTP only comes into play if someone enables USDC rebalancing for a run. It is
+  disabled today.
 
-1. **Bot HTTP API** (`/health`, `/inventory`, dashboard WebSocket) -- confirms
-   the bot is alive and processing
-2. **Onchain state** -- vault balances, token balances, transaction receipts
-3. **Alpaca API** -- broker positions, order history, account state. Use a
-   separate observer credential without order-placement capability when Alpaca
-   exposes that permission boundary. Otherwise isolate the observer process and
-   dedicated staging account from other workloads rather than treating read-only
-   code paths as a credential boundary
+## What we can reuse, and what we cannot
 
-The smoke test does **not** read the bot's SQLite database directly (it runs on
-a remote server). All assertions use externally observable state.
+The earlier version of this spec said the smoke test reuses the simulation loop
+from `tests/e2e/full_system.rs::simulate`, plus `poll.rs` and `assert.rs`. That
+is not possible. `tests/e2e/` is a separate integration-test binary with its own
+`main.rs`. A binary under `src/` cannot import it. `TestInfra` and `BaseChain`
+live there too.
 
-## Smoke Test Wallet
+This is not a big loss. The loop itself is about 40 lines: sleep, pick the next
+(order, symbol, direction) tuple round-robin, pick a random size, take the
+order, and log the result. Copying the shape is fine. The value is in the
+assertions, and those have to be written against real infrastructure anyway.
 
-### Dedicated Test Wallet
+What the smoke test **can** use, because it lives in the production crates:
 
-The smoke test needs its own wallet to take orders on the Raindex orderbook.
-This wallet acts as the "user" counterparty to the bot's liquidity orders.
+| Piece                     | Where                                   |
+| ------------------------- | --------------------------------------- |
+| Orderbook bindings        | `src/bindings.rs`, `IRaindexV6`         |
+| Take-order call           | `takeOrders4` with `TakeOrdersConfigV5` |
+| Config and secret loading | `st0x-config`                           |
+| Wallet and provider       | `st0x-evm`                              |
+| WebSocket message types   | `st0x-dto`, the `Statement` enum        |
 
-**Requirements:**
+If we later want the real `poll.rs` and `assert.rs` helpers in both places, they
+must move into a crate behind the `test-support` feature. That is a separate
+piece of work. Do not block the smoke test on it.
 
-- Separate from the bot's Turnkey operator wallet
-  (`0x16ca08a5825612aAe805D172a81B1a52b43574bf`)
-- Holds USDC and the wrapped equity token for every eligible symbol to take both
-  buy and sell orders
-- Funded with small amounts (see "Amounts" below)
+## Observation surface
 
-**Key management options (choose one):**
+The smoke test never reads the bot's SQLite file. That file is on the staging
+server. Everything is observed from outside.
 
-| Option                         | Pros                           | Cons                           |
-| ------------------------------ | ------------------------------ | ------------------------------ |
-| **Raw private key in env var** | Simple, CI-friendly            | Key in plaintext on runner     |
-| **Agenix-encrypted secret**    | Consistent with existing infra | Requires NixOS host to decrypt |
-| **Turnkey sub-wallet**         | Same security as bot wallet    | Overhead of Turnkey API calls  |
+Staging is on the RAIN tailnet. The host is
+`st0x-liquidity-staging.tail6094d7.ts.net`, and the API port is 8001.
 
-**Recommendation:** Use a **raw private key** stored as an agenix-encrypted
-secret alongside the existing `st0x-hedge.toml.age`. The smoke test runs from
-the staging server (which already has agenix decryption), so the key is never in
-plaintext outside the server's tmpfs.
+### HTTP endpoints that exist
 
-```
-secret/smoke-test-wallet.age   # encrypted private key
-```
+Read from `src/api.rs`. There is **no** `/inventory` endpoint. An earlier
+version of this spec claimed one.
 
-Decrypt path: `/run/agenix/smoke-test-wallet` (same pattern as other secrets).
+| Endpoint                     | Use in the smoke test                        |
+| ---------------------------- | -------------------------------------------- |
+| `GET /health`                | preflight liveness, and the continuous check |
+| `GET /orders/raindex`        | preflight: the orders we are about to take   |
+| `GET /trades`                | recovery after a WebSocket drop              |
+| `GET /transfers`             | recovery, and the final transfer count       |
+| `GET /transfers/interrupted` | preflight: refuse to start with stuck work   |
+| `GET /pnl`                   | the cost-inclusive number for the report     |
+| `GET /orders/pending`        | preflight: no open broker orders left over   |
 
-### Why Not Reuse the Bot Wallet?
+### WebSocket
 
-Managed staging orders are owned by the inventory contract, but the bot's
-Turnkey wallet is its privileged operator and uses its own nonce stream and
-balances for production operations. Reusing it would couple test submissions to
-bot transactions and put operational funds and permissions in the test process.
-The smoke test therefore uses a separate address as the counterparty.
+`ws://<host>:8001/api/ws?trade_protocol=terminal_outcomes_v2`
 
-## Funding
+**Pin the protocol version.** The default is `legacy_fills`, and it drops every
+failed and cancelled counter-trade. Those are exactly the events a smoke test
+exists to catch. The three versions, from `src/dashboard/mod.rs`:
 
-### Initial Funding (One-Time Setup)
+| Version                  | Trade statement | Outcomes delivered            |
+| ------------------------ | --------------- | ----------------------------- |
+| `legacy_fills` (default) | `trade_fill`    | filled only                   |
+| `terminal_outcomes_v1`   | `trade_update`  | filled, failed                |
+| `terminal_outcomes_v2`   | `trade_update`  | filled, failed, and cancelled |
 
-The smoke test wallet needs tokens to take orders in both directions:
+The envelope is a serde tag-and-content union, so the payload sits under `data`,
+not at the top level:
 
-| Token                | Amount    | Purpose                                                  | Source                        |
-| -------------------- | --------- | -------------------------------------------------------- | ----------------------------- |
-| **USDC** (Base)      | 500 USDC  | Take SellEquity orders (user pays USDC, receives equity) | Bridge from Coinbase/exchange |
-| **wtRKLB** (wrapped) | 10 shares | Take BuyEquity orders (user sells equity, receives USDC) | Bot wallet transfers or mint  |
-| **ETH** (Base)       | 0.01 ETH  | Gas for onchain transactions                             | Bridge from Coinbase/exchange |
-
-These are initial funding targets, not an authorization to consume the full
-balance. Before each run, query live marks and compute the USD value of all
-funded assets. The required `--max-notional-usd` argument is an absolute cap on
-the test's gross real-money exposure; preflight fails if the starting inventory,
-configured trade range, or requested rounds can exceed it. If additional symbols
-become eligible, add their wrapped-token reserves to the funding plan before
-enabling their test cases.
-
-### Per-Trade Amounts
-
-Each smoke test round takes a random amount admitted by live prices, the
-remaining notional budget, and direction-specific reserves:
-
-| Parameter      | Example value | Admission rule                                     |
-| -------------- | ------------- | -------------------------------------------------- |
-| Min trade size | 0.1 shares    | Meets the broker minimum at the current live mark  |
-| Max trade size | 1.0 shares    | Fits the remaining USD cap and directional reserve |
-| USDC per trade | Dynamic       | Live order quote plus the configured safety buffer |
-
-Preflight calculates separate reserves for every symbol and direction:
-`SellEquity` consumes smoke-wallet USDC, while `BuyEquity` consumes that
-symbol's wrapped shares. Requested rounds, trade sizes, and direction mix are
-accepted only when the worst-case sequence fits all reserves and the absolute
-USD cap. A later round repeats the check against current balances and live marks
-before submitting.
-
-### Refunding
-
-The trading loop redistributes the smoke wallet's inventory:
-
-- Taking a SellEquity order spends USDC but receives equity tokens
-- Taking a BuyEquity order spends equity tokens but receives USDC
-- Round-robin order taking may reduce drift, but does not guarantee balance
-
-Every run therefore ends with reconciliation against the pre-test wallet and
-broker snapshots. Top-ups use the dedicated funding signer/service or a
-supported secret-input mechanism; private keys must never be expanded into
-process arguments, logs, or shell history.
-
-## Smoke Test Flow
-
-### Phase 1: Preflight Checks
-
-Before generating any trades, verify the environment is healthy:
-
-1. **Bot health**: `GET http://staging:8001/health` returns 200
-2. **Wallet funded**: smoke test wallet has sufficient USDC, each eligible
-   symbol's wrapped token, and ETH for gas
-3. **Raindex orders exist**: query the orderbook for the inventory owner's
-   active orders -- at least one SellEquity and one BuyEquity for every eligible
-   symbol
-4. **Broker identity and access**: read-only calls to the Alpaca production API
-   verify credentials, account state, limits, current order access, and the
-   exact expected staging account ID. Abort if the endpoint or account identity
-   differs from the staging configuration
-5. **Vault balances**: Raindex vaults have liquidity to fill trades
-6. **Exposure budget**: live marks, per-symbol/per-direction reserves, requested
-   rounds, and trade-size bounds fit the required absolute USD cap
-
-If any check fails, the test aborts with a clear diagnostic message.
-
-### Phase 2: Trade Simulation (Configurable Duration)
-
-Core loop, directly adapted from `simulate()`:
-
-```
-for round in 1..=max_rounds:
-    sleep(trade_interval)
-
-    symbol, direction = round_robin(eligible_symbol_direction_pairs)
-    amount = random(0.1, 1.0) shares
-
-    sender_nonce = reserve_nonce(smoke_wallet)
-    tx_hash = submit_take_order(orderbook, order, amount, sender_nonce)
-    persist pending trade (symbol, direction, amount, sender_nonce, tx_hash)
-
-    receipt = poll_receipt_or_replacement(sender_nonce, tx_hash)
-    if receipt.success:
-        record confirmed trade (symbol, direction, amount, receipt.tx_hash)
-    if receipt.revert:
-        record terminal revert
-        log "vault drained, waiting for rebalance"
-    if receipt.unknown:
-        record unknown outcome
-        stop new submissions and reconcile the nonce before continuing
+```json
+{ "type": "trade_update", "data": { "...": "..." } }
 ```
 
-Persist the transaction hash immediately after broadcast. A timeout, dropped RPC
-response, replacement, or nonce mismatch is neither success nor revert. The test
-must recover the submitted/replacement transaction by sender and nonce, poll its
-receipt, and leave the result `unknown` while inconclusive. It never blindly
-retries `take_order` while a prior outcome may still land.
+Statement types, from `crates/dto/src/statement.rs`: `current_state`,
+`trade_update`, `trade_fill`, `position_update`, `inventory_snapshot`, and
+`transfer_update`. On connect the bot sends `current_state` first. Payload
+fields are camelCase.
 
-**Default parameters:**
+Shapes worth writing down, because they are easy to get wrong:
 
-| Parameter        | Default    | Configurable via      |
-| ---------------- | ---------- | --------------------- |
-| `max_rounds`     | 50         | `--rounds` CLI flag   |
-| `trade_interval` | 5 seconds  | `--interval` CLI flag |
-| `min_amount`     | 0.1 shares | `--min-amount`        |
-| `max_amount`     | 1.0 shares | `--max-amount`        |
-| `max_notional`   | Required   | `--max-notional-usd`  |
+- `trade_update` carries `id`, `occurredAt`, `venue`, `direction`, `symbol`,
+  `shares`, and `outcome`. `outcome` is tagged by `status`: `filled`, `failed`,
+  or `cancelled`. The non-filled variants carry `acceptedShares`,
+  `filledShares`, `remainingShares`, and `excessShares`.
+- `inventory_snapshot` nests one level deeper than you expect:
+  `data.inventory.perSymbol[]` and `data.inventory.usdc`, plus `data.fetchedAt`.
+  Each `perSymbol` entry has `onchainAvailable`, `onchainInflight`,
+  `offchainAvailable`, `offchainInflight`, and `inflightEquity`.
+- `transfer_update` is tagged by `kind`: `equity_mint`, `equity_redemption`, or
+  `usdc_bridge`. Each has its own `status` union. Terminal statuses are
+  `completed`, `failed`, and **`reconciled`**. An earlier version of this spec
+  missed `reconciled` and would have hung waiting on a transfer that an operator
+  had already closed out.
 
-### Phase 3: Observation & Assertions
+Non-terminal statuses, so the stuck-transfer check knows what it is waiting on:
 
-The smoke test connects to the bot's WebSocket (`/api/ws`) to observe its
-reaction in real time. The JSON envelope uses a lower-snake-case `type` and
-camel-case payload fields. On connect, the bot sends `type: "current_state"`
-containing recent trades, inventory, positions, active transfers, and settings.
-After that, it streams `trade_fill`, `position_update`, `inventory_snapshot`,
-and `transfer_update`. Rust names such as `CurrentState` and `InventorySnapshot`
-below are conceptual types; assertions use the serialized JSON names (for
-example, `perSymbol` and `onchainAvailable`).
+| Kind                | Non-terminal statuses                                  |
+| ------------------- | ------------------------------------------------------ |
+| `equity_mint`       | minting, wrapping, depositing                          |
+| `equity_redemption` | withdrawing, unwrapping, sending, pending_confirmation |
+| `usdc_bridge`       | converting, withdrawing, bridging, depositing          |
 
-The smoke test correlates confirmed onchain trades with the bot's aggregate
-per-symbol response.
+## Smoke test wallet
 
-#### 3a. Counter-Trading Assertions
+The test needs its own wallet to take orders. It is the counterparty to the
+bot's liquidity.
 
-Track every confirmed onchain trade, then assert:
+It must be separate from the bot's Turnkey wallet. Two reasons. The bot wallet
+holds operational funds and `OPERATOR_ROLE`, and sharing it puts both in the
+test process. It also shares a nonce stream, so test submissions would race the
+bot's own transactions.
 
-1. **Detects the onchain fill**: a `trade_fill` event with `venue: Raindex`
-   appears for the correct symbol and direction. The smoke test knows the
-   tx_hash it submitted, so it can match against the trade's `id`
-   (`tx_hash:log_index`). **Timeout: 60s** (block propagation + WebSocket
-   delivery).
-
-2. **Hedges threshold-crossing exposure on Alpaca**: when accumulated exposure
-   crosses its execution threshold, one or more `trade_fill` events with
-   `venue: Alpaca` cover that per-symbol batch. A single broker fill may cover
-   several onchain trades. `SellEquity` means the bot's order sold equity to the
-   taker, so the bot buys on Alpaca; `BuyEquity` means the bot bought equity
-   from the taker, so it sells on Alpaca. **Timeout: 120s** after the threshold
-   is crossed.
-
-3. **Position converges toward zero**: after the hedge fill, the
-   `position_update` for that symbol should show `net` below the configured
-   shares or dollar-value execution threshold. The bot batches hedges by
-   threshold, so `net` won't be exactly zero after every single trade -- but it
-   should never grow unbounded.
-
-4. **Hedge direction is correct**: for every Alpaca `trade_fill`, verify the
-   direction is opposite to the accumulated net position. A positive net
-   (accumulated long) must produce a sell hedge; negative net must produce a buy
-   hedge.
-
-**Tracking state:** The smoke test maintains a local ledger:
+Key handling: a raw private key stored as an agenix secret, next to
+`st0x-hedge.toml.age`.
 
 ```
-per_symbol:
-  onchain_trades: [(tx_hash, direction, shares, timestamp)]
-  alpaca_fills:   [(order_id, direction, shares, timestamp)]
-  uncovered_signed_shares: Float
-  position_net:   Float  (from position_update events)
+secret/smoke-test-wallet.age
 ```
 
-Each onchain fill updates `uncovered_signed_shares`. When a broker fill arrives,
-the ledger consumes exposure from that per-symbol accumulator in FIFO order,
-allowing a many-to-one hedge relationship. It never assigns one broker fill to
-exactly one onchain transaction.
+It decrypts to `/run/agenix/smoke-test-wallet` on the staging server, the same
+pattern as the other secrets. The test runs from that server, so the key is
+never in plaintext anywhere else. A key never goes into a process argument, a
+log line, or shell history.
 
-After the trade phase ends and the observation window closes, assert:
+## Funding and the money cap
 
-- Every threshold-crossing batch has sufficient opposite-direction Alpaca fill
+### Initial funding
+
+| Token        | Amount    | Why                       |
+| ------------ | --------- | ------------------------- |
+| USDC on Base | 500       | to take SellEquity orders |
+| wtRKLB       | 10 shares | to take BuyEquity orders  |
+| ETH on Base  | 0.01      | gas                       |
+
+These are funding targets, not permission to spend the lot.
+
+### The cap
+
+`--max-notional-usd` is required. It is an absolute ceiling on gross real-money
+exposure for the run. Preflight computes the worst-case sequence from the live
+marks, the requested rounds, the size bounds, and the direction mix. If that
+worst case can exceed the cap, preflight fails and the run does not start.
+
+Each direction consumes a different reserve:
+
+- SellEquity spends the wallet's USDC and returns wrapped shares.
+- BuyEquity spends wrapped shares and returns USDC.
+
+Round-robin reduces the drift but does not remove it. Check the reserves again
+against live balances before every round, not only at the start.
+
+### Sizing
+
+| Parameter      | Default    | Rule                                           |
+| -------------- | ---------- | ---------------------------------------------- |
+| Min trade size | 0.1 shares | must clear the broker minimum at the live mark |
+| Max trade size | 1.0 shares | must fit the remaining cap and the reserve     |
+
+If `operational_limit` is ever set for the symbol, keep the max trade size below
+it. See the open questions.
+
+### After the run
+
+Reconcile against the pre-run snapshots of the wallet and the broker account.
+Top-ups go through the funding signer, never through a key on the command line.
+
+## Flow
+
+### Phase 1: preflight
+
+Abort with a clear message on any failure. Nothing is signed before all of these
+pass.
+
+1. `GET /health` returns 200.
+2. Parsed config says `telemetry.environment = "staging"`, chain ID 8453, and
+   the expected orderbook, inventory, and `vault_owner` addresses. A path that
+   contains the word "staging" is not an identity check.
+3. The broker account ID matches the expected staging account exactly, and the
+   endpoint is the expected one.
+4. `GET /orders/raindex` shows at least one SellEquity order and one BuyEquity
+   order for every eligible symbol.
+5. The vaults behind those orders hold enough to fill the planned sizes.
+6. The smoke wallet holds enough USDC, wrapped shares, and ETH.
+7. `GET /transfers/interrupted` is empty, and `GET /orders/pending` has no
+   leftover broker orders. Starting on top of stuck work makes every later
+   assertion meaningless.
+8. The worst-case exposure fits `--max-notional-usd`.
+9. Record the market session. It selects the hedge timeouts.
+
+### Phase 2: take orders
+
+```
+for round in 1..=rounds:
+    sleep(interval)
+
+    symbol, direction = round_robin(eligible pairs)
+    amount           = random(min_amount, max_amount)
+
+    nonce   = reserve_nonce(smoke_wallet)
+    tx_hash = takeOrders4(orderbook, order, amount, nonce)
+    persist (symbol, direction, amount, nonce, tx_hash)   # before waiting
+
+    receipt = poll_receipt_or_replacement(nonce, tx_hash)
+    match receipt:
+        success -> record a confirmed trade
+        revert  -> record a terminal revert; the vault is drained, wait for a
+                   rebalance
+        unknown -> record unknown, stop submitting, and reconcile the nonce
+```
+
+Persist the transaction hash right after broadcast. A timeout, a dropped RPC
+response, a replacement, or a nonce mismatch is neither success nor failure.
+Recover the transaction by sender and nonce, then poll its receipt. Leave the
+result `unknown` while it is undecided. Never resubmit `takeOrders4` while an
+earlier attempt can still land.
+
+Defaults:
+
+| Parameter    | Default    | Flag                 |
+| ------------ | ---------- | -------------------- |
+| rounds       | 50         | `--rounds`           |
+| interval     | 5s         | `--interval`         |
+| min amount   | 0.1 shares | `--min-amount`       |
+| max amount   | 1.0 shares | `--max-amount`       |
+| max notional | required   | `--max-notional-usd` |
+
+### Phase 3: assertions
+
+Keep a local ledger per symbol:
+
+```
+onchain_trades:          [(tx_hash, direction, shares, at)]
+broker_trades:           [(id, direction, shares, outcome, at)]
+uncovered_signed_shares: Float
+position_net:            Float   # from position_update
+```
+
+#### 3a. Hedging
+
+1. **The fill is detected.** A `trade_update` with `venue: raindex` appears for
+   the symbol and direction. Match it on `id`, which is `tx_hash:log_index`, so
+   the test can tie it to its own submission. Timeout 60s.
+
+2. **The exposure is hedged.** One or more `trade_update` events with
+   `venue: alpaca` cover the exposure. Direction is inverted: a SellEquity fill
+   means the bot sold equity onchain, so it buys on Alpaca. A BuyEquity fill
+   means it bought onchain, so it sells. Timeout depends on the session, per the
+   table above.
+
+3. **Failed and cancelled hedges are reported, not ignored.** With
+   `terminal_outcomes_v2` a hedge can arrive as `failed` or `cancelled`. That is
+   a finding. Record it, keep the uncovered exposure on the books, and fail the
+   run if the exposure never gets covered inside the window.
+
+4. **Coverage is consumed FIFO.** One broker order may cover several onchain
+   fills. Never map one broker order to exactly one transaction.
+
+5. **The position stays bounded.** `position_update.net` should sit under the $2
+   dollar-value threshold once the bot has caught up. It will not be zero after
+   every trade. It must never grow without bound.
+
+At the end of the observation window:
+
+- every batch that crossed the threshold has enough opposite-direction broker
   volume
-- `position.net` for each symbol is below its configured shares or dollar-value
-  threshold
-- Covered onchain shares equal opposite-direction Alpaca fill shares within
-  Alpaca's 9-decimal truncation epsilon after wrapped amounts are converted to
-  underlying shares; any unmatched residual is below the execution threshold
+- covered onchain shares equal opposite-direction broker shares, within Alpaca's
+  9-decimal truncation, after converting wrapped amounts to underlying shares
+- any residual is below the threshold
 
-#### 3b. Rebalancing Assertions (When Enabled)
+#### 3b. Equity rebalancing
 
-If rebalancing is enabled for the test assets, the smoke test additionally
-asserts that inventory stays balanced. The bot streams `inventory_snapshot`
-events containing `perSymbol` entries:
+Only run this when the parsed config says rebalancing is enabled for the symbol.
+On staging that is RKLB.
 
-```
-{
-  symbol, onchainAvailable, onchainInflight,
-  offchainAvailable, offchainInflight
-}
-```
+1. **The imbalance appears.** After sustained one-directional trading, the ratio
+   `onchain / (onchain + offchain)` moves outside `0.5 +/- 0.2`. If the
+   denominator is zero, mark the check inconclusive. Do not divide.
+2. **A transfer starts.** A `transfer_update` appears with the right kind. Too
+   much offchain gives `equity_mint`. Too much onchain gives
+   `equity_redemption`.
+3. **The transfer finishes.** It reaches `completed`. Treat `reconciled` as a
+   finding, not a pass: an operator closed it out by hand. Timeout 10 minutes.
+4. **The ratio recovers.** A later `inventory_snapshot` moves back toward 0.5.
 
-**Equity rebalancing assertions:**
+#### 3c. USDC rebalancing
 
-1. **Imbalance detection**: after sustained one-directional trading (e.g., many
-   SellEquity fills drain offchain inventory), the ratio
-   `onchain / (onchain + offchain)` should deviate beyond `target +/- deviation`
-   (default 0.5 +/- 0.2). If the denominator is zero, mark this ratio check
-   inconclusive and do not divide; normal validation resumes when either balance
-   is nonzero.
+Skipped while USDC rebalancing is disabled. When it is on:
 
-2. **Transfer initiated**: a `transfer_update` event should appear with the
-   correct type:
-   - Too much offchain (ratio < 0.3) -> `Mint` transfer (Alpaca -> tokenize ->
-     wrap -> deposit into Raindex)
-   - Too much onchain (ratio > 0.7) -> `Redemption` transfer (Raindex -> unwrap
-     -> send to Alpaca redemption wallet)
+1. The `usdc` ratio moves outside its threshold.
+2. A `usdc_bridge` transfer starts. Too much onchain gives `base_to_alpaca`. Too
+   much offchain gives `alpaca_to_base`.
+3. It reaches `completed`. Timeout 15 minutes, which covers attestation plus
+   Alpaca withdrawal processing.
+4. The ratio recovers.
 
-3. **Transfer completes**: the `transfer_update` should reach terminal state
-   (`Completed`). **Timeout: 10 minutes** (tokenization API + onchain
-   transactions).
+#### 3d. Continuous invariants
 
-4. **Inventory converges**: after the transfer completes, the next
-   `inventory_snapshot` should show the ratio moved back toward the target
-   (0.5). Assert `|ratio - target| < deviation` eventually when the denominator
-   is nonzero; otherwise mark the check inconclusive.
+1. **The bot stays alive.** The WebSocket stays open. On a drop, reconnect once.
+   Before resuming, reload `GET /trades`, `GET /transfers`, and the fresh
+   `current_state`, then deduplicate against the streamed records by trade ID,
+   broker order ID, transfer ID, or transaction hash. A second failure fails the
+   run.
+2. **No stuck transfers.** Any transfer that goes non-terminal must reach
+   `completed`, `failed`, or `reconciled` inside `transfer_timeout_secs`
+   (1800s). Past that is a hard failure.
+3. **No exposure blowup.** The USD value of `|position.net|` never exceeds the
+   directional reserve or the remaining cap.
+4. **No negative inventory.** `onchainAvailable` and `offchainAvailable` never
+   go below zero.
+5. **The wallet stays solvent.** Check before each round. Skip the round and
+   warn if it cannot fund the trade. Fail after 5 consecutive skips.
 
-**USDC rebalancing assertions:**
-
-1. **Cash imbalance detection**: `UsdcInventory` ratio
-   `onchain / (onchain + offchain)` deviates beyond threshold. A zero
-   denominator is inconclusive rather than a ratio failure.
-
-2. **Bridge initiated**: a `transfer_update` of type USDC bridge appears:
-   - Too much onchain -> `BaseToAlpaca` (withdraw from Raindex, CCTP bridge Base
-     -> Ethereum, deposit into Alpaca)
-   - Too much offchain -> `AlpacaToBase` (convert USD -> USDC on Alpaca,
-     withdraw, CCTP bridge Ethereum -> Base, deposit into Raindex)
-
-3. **Bridge completes**: transfer reaches `Completed`. **Timeout: 15 minutes**
-   (CCTP attestation ~40-70s + Alpaca withdrawal processing).
-
-4. **USDC inventory converges**: ratio moves back toward target.
-
-#### 3c. Invariant Assertions (Continuous)
-
-These are checked throughout the entire test, not just after trades:
-
-1. **Bot stays alive**: WebSocket connection remains open. If the connection
-   drops, attempt reconnect once. Before resuming assertions, reload all
-   submitted transaction receipts, Alpaca order history, and the latest
-   `current_state` dashboard snapshot. Deduplicate the recovered and streamed
-   records by stable trade ID, broker order ID, transfer ID, or transaction
-   hash. If reconciliation or the second connection fails, the test fails.
-
-2. **No stuck transfers**: any `transfer_update` that enters a non-terminal
-   state must reach a terminal state (`Completed` or `Failed`) within
-   `transfer_timeout_secs` (default 1800s / 30 min). A transfer stuck in
-   `Minting`, `Bridging`, etc. beyond this window is a hard failure.
-
-3. **No position blowup**: the live-mark USD value of `|position.net|` for any
-   symbol must never exceed its directional reserve or the remaining absolute
-   USD cap. If the bot stops hedging, this catches it before the authorized real
-   exposure is exceeded.
-
-4. **Inventory consistency**: `onchainAvailable` and `offchainAvailable` in
-   `inventory_snapshot` must never go negative.
-
-5. **Smoke wallet solvency**: before each trade, check the smoke wallet has
-   sufficient balance to take the order. If not, skip the round and log a
-   warning. If the wallet is empty for 5 consecutive rounds, fail (the
-   round-robin should keep it funded).
-
-### Phase 4: Report
-
-Print a summary after the observation window closes:
+### Phase 4: report
 
 ```
 Staging Smoke Test Report
 =========================
-Duration:           4m 12s
-Trades placed:      50 (50 RKLB)
-Trades filled:      48 (2 reverted - vault drain, refilled by rebalance)
-Onchain fills seen:  48/48
-Hedge batches:       12
-Covered shares:      47.8/48.0 (0.2 residual < 1.0 threshold)
-Avg hedge latency:  8.3s
-Max hedge latency:  23.1s
-Position RKLB net:  0.00 (threshold: 1.0)
-Rebalances:         1 (equity mint; USDC rebalancing disabled)
-Transfers completed: 1/1
-Inventory RKLB:     52% onchain / 48% offchain (target: 50%)
-USDC:               55% onchain / 45% offchain (target: 50%)
-Bot status:         healthy (WebSocket connected)
-Warnings:           1 (hedge latency > 30s on round 17)
+Session:             regular hours
+Duration:            4m 12s
+Orders taken:        50 RKLB (48 confirmed, 2 reverted on a drained vault)
+Fills detected:      48/48
+Broker orders:       46 filled, 1 cancelled, 0 failed
+Covered shares:      47.8/48.0 (0.2 residual, under the $2 threshold)
+Hedge latency:       8.3s avg, 23.1s max
+Position RKLB net:   0.00
+Rebalances:          1 equity mint (USDC rebalancing disabled by config)
+Transfers:           1/1 completed
+Inventory RKLB:      52% onchain / 48% offchain (target 50%)
+Realized PnL:        from GET /pnl over the run window
+Warnings:            1 (hedge latency over 30s on round 17)
 
 RESULT: PASS
 ```
 
-## Implementation Plan
+Pull the PnL number from `GET /pnl` rather than computing it in the test. That
+endpoint already nets out observed costs.
 
-### Binary
+## Implementation plan
 
-Add a new binary target `smoke` (alongside `server` and `cli`):
-
-```
-src/bin/smoke.rs
-```
-
-Or extend the existing CLI with a `smoke-test` subcommand:
+A subcommand on the existing CLI, not a new binary. It reuses config loading,
+secret loading, provider setup, and the Alpaca client.
 
 ```bash
 cargo run --bin cli -- smoke-test \
@@ -475,77 +499,59 @@ cargo run --bin cli -- smoke-test \
     --secrets /run/agenix/st0x-hedge.toml \
     --wallet-key /run/agenix/smoke-test-wallet \
     --expected-broker-account-id <staging-account-id> \
-    --max-notional-usd <required-cap> \
+    --max-notional-usd <required> \
     --rounds 50 \
     --interval 5
 ```
 
-**Recommendation:** CLI subcommand. It reuses the existing config loading, RPC
-setup, and Alpaca client construction. No new binary needed.
+Files:
 
-### Crate Dependencies
+| File                           | Change                                    |
+| ------------------------------ | ----------------------------------------- |
+| `src/cli/smoke.rs`             | new: the subcommand                       |
+| `src/cli/mod.rs`               | add the `SmokeTest` variant to `Commands` |
+| `secret/smoke-test-wallet.age` | new: the encrypted key                    |
+| `secret/secrets.nix`           | declare the new secret                    |
+| `flake.nix`                    | new `smokeTest` package                   |
+| `docs/staging-smoke-tests.md`  | rewrite as a runbook once it works        |
 
-The smoke test uses:
+No new crate dependencies.
 
-- **Existing config/secrets loading** from the `st0x-config` crate
-  (`crates/config/`)
-- **Alloy provider** for onchain transactions (take orders)
-- **Alpaca client** for observing broker state (read-only)
-- **Raindex orderbook ABI** for `takeOrders` calls
+The `smokeTest` flake output has to exist before anyone can run it with
+`nix run`. It decrypts the secrets through agenix, runs the subcommand, and can
+pair the dashboard alongside it with mprocs, the same way `mkSimulation` does
+for the `simulate` targets.
 
-No new crate dependencies required.
+## Security
 
-### Nix Integration
+- The smoke wallet holds real assets on Base mainnet. The key is encrypted at
+  rest and is only decrypted on the staging server.
+- The test does not place broker orders. That is the bot's job. Use an
+  observer-only Alpaca credential if Alpaca can express that boundary. If it
+  cannot, isolate the process and the account instead. Read-only code is not a
+  credential boundary.
+- Identity is checked before anything is signed: environment, chain ID,
+  orderbook, inventory, `vault_owner`, broker endpoint, and broker account ID. A
+  mismatch aborts.
+- Low prices and small sizes do not make production executions harmless. The
+  dedicated account, the cap, the reserves, and the reconciliation are all
+  required.
+- Alpaca production rate limits apply. Poll every 2 to 5 seconds, not every
+  200ms like the e2e tests do.
 
-The implementation PR must export a `packages.smokeTest` flake output before
-operators use the planned `nix run .#smokeTest` command. That output will:
+## Open questions
 
-1. Decrypt secrets via agenix
-2. Run the CLI subcommand against staging
-3. Optionally open the dashboard alongside (via mprocs, same as `simulate`)
-
-The command is not available in the current flake; documenting it here defines
-the required implementation output rather than a command that works today.
-
-### Files to Create/Modify
-
-| File                           | Change                                        |
-| ------------------------------ | --------------------------------------------- |
-| `src/cli/smoke.rs`             | New: smoke test CLI subcommand                |
-| `src/cli/mod.rs`               | Modified: add `SmokeTest` variant to CLI enum |
-| `secret/smoke-test-wallet.age` | New: encrypted test wallet private key        |
-| `secret/secrets.nix`           | Modified: add smoke-test-wallet secret        |
-| `flake.nix`                    | Modified: add `smokeTest` package             |
-| `docs/staging-smoke-tests.md`  | This spec                                     |
-
-## Security Considerations
-
-- **Smoke wallet holds real assets** (small amounts on Base mainnet). Key must
-  be encrypted at rest (agenix) and only decrypted on the staging server.
-- **Alpaca production credentials** are managed via agenix. Prefer a separate
-  observer credential without order-placement capability. If Alpaca cannot
-  enforce that permission boundary, isolate the observer process and dedicated
-  staging account. The smoke test does **not** place broker orders -- that is
-  the bot's job.
-- **Explicit staging identity**: before loading a signing key or submitting a
-  transaction, parse the configuration and require
-  `telemetry.environment = "staging"`, Base chain ID 8453, the expected
-  orderbook, inventory/vault-owner addresses, production broker endpoint, and
-  exact staging broker account ID. A path substring is not an identity check.
-  Reject any mismatch before signing or sending.
-- **Bounded real exposure**: low-value assets and small nominal trade sizes do
-  not make production-API executions non-destructive. A dedicated account or
-  exclusive window, the required absolute USD cap, directional reserves, and
-  post-test reconciliation are all mandatory.
-- **Rate limiting**: Alpaca production API has rate limits. The observation
-  polling should use 2-5s intervals, not 200ms like e2e tests.
-
-## Open Questions
-
-1. **Broker isolation**: can Alpaca provide a dedicated staging subaccount and
-   observer-only credential, or must runs reserve an exclusive window?
-2. **Operational limits**: RKLB has a commented-out `operational_limit = 1`.
-   Should smoke tests respect this or use their own limits?
-3. **Dashboard access**: should the smoke test connect to the staging bot's
-   dashboard WebSocket for richer observation, or stick to Alpaca API + onchain
-   queries?
+1. **Broker isolation.** Can we get a dedicated staging subaccount and an
+   observer-only credential? If not, every run needs an exclusive window, which
+   makes this much harder to use.
+2. **`operational_limit`.** It is commented out for RKLB today. It caps the
+   bot's own counter-trade size, so it is not a smoke-test knob. If someone sets
+   it, the bot under-hedges on purpose and the position will not converge. Do we
+   keep max trade size under the limit, or fold the limit into the assertion?
+   Keeping sizes under it is simpler.
+3. **Session policy.** Do we require regular hours for a run, or support the
+   extended-hours timeouts from day one? Regular hours only is less code and
+   gives sharper assertions.
+4. **Shared test helpers.** Worth moving `poll.rs` and `assert.rs` into a crate
+   behind `test-support` so both the e2e suite and the smoke test use them? Not
+   a blocker either way.


### PR DESCRIPTION
## Summary

Spec for running the `simulate` test loop against the live staging environment instead of local Anvil + mocks. The core simulation loop (random order taking, round-robin across RKLB/SGOV, assertion of counter-trades and rebalancing) is reused directly from the e2e suite — only the infrastructure layer underneath changes.

Key decisions covered:
- **Dedicated smoke test wallet** (separate from bot's Turnkey wallet) with agenix-encrypted private key
- **Small funding**: ~$2,250 total (500 USDC + 10 shares each of wtRKLB/wtSGOV + gas)
- **External observation only**: smoke test doesn't touch bot's DB — asserts via onchain state + Alpaca API
- **Relaxed assertions**: fill prices within tolerance, timing windows widened for real network latency
- **CLI subcommand**: `cargo run --bin cli -- smoke-test` reusing existing config/secret loading

## Open questions

1. SGOV has no `vault_id` in staging config — is it discovered dynamically?
2. Rebalancing is disabled for both assets — test hedging-only first, or enable?
3. Should smoke tests connect to staging dashboard WebSocket for richer observation?

## Test plan

- [ ] Review spec for completeness and accuracy
- [ ] Validate staging contract addresses are current
- [ ] Decide on open questions before implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running on-demand smoke tests against the live staging environment.
  * Documented preflight checks, trade simulation, hedging and rebalancing validation, transfer monitoring, inventory consistency, and solvency checks.
  * Added requirements for test wallet funding, secure key management, reporting, and operational safeguards.
  * Included implementation planning details and open operational questions for staging validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->