### PR TITLE
fix: fall back to scientific notation for Floats with extreme exponents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6892,6 +6892,7 @@ dependencies = [
 name = "st0x-float-serde"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "rain-math-float",
  "serde",
  "serde_json",

--- a/crates/float-serde/Cargo.toml
+++ b/crates/float-serde/Cargo.toml
@@ -12,3 +12,6 @@ serde_json.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+alloy.workspace = true

--- a/crates/float-serde/src/lib.rs
+++ b/crates/float-serde/src/lib.rs
@@ -7,12 +7,23 @@ use rain_math_float::Float;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Borrow;
 
+/// Format a Float as a decimal string, falling back to scientific
+/// notation when the exponent exceeds the non-scientific formatter's
+/// range.
+///
+/// Rain Float's `format_with_scientific(false)` rejects exponents
+/// below -76. Rather than losing data, we fall back to scientific
+/// notation (e.g., `"1.23e-5"`), which the parser handles natively.
+pub fn format_float(value: &Float) -> Result<String, rain_math_float::FloatError> {
+    value
+        .format_with_scientific(false)
+        .or_else(|_| value.format_with_scientific(true))
+}
+
 /// Format a Float value as a decimal string for display/logging purposes.
 /// Falls back to debug representation on error.
 pub fn format_float_with_fallback(value: &Float) -> String {
-    value
-        .format_with_scientific(false)
-        .unwrap_or_else(|_| format!("{value:?}"))
+    format_float(value).unwrap_or_else(|_| format!("{value:?}"))
 }
 
 /// Wrapper for formatting a `Float` as decimal in `Debug` output.
@@ -60,9 +71,7 @@ pub fn serialize_float_as_string<S>(value: &Float, serializer: S) -> Result<S::O
 where
     S: Serializer,
 {
-    let formatted = value
-        .format_with_scientific(false)
-        .map_err(serde::ser::Error::custom)?;
+    let formatted = format_float(value).map_err(serde::ser::Error::custom)?;
     serializer.serialize_str(&formatted)
 }
 
@@ -292,6 +301,173 @@ mod tests {
         let parsed: WithOptionalSerdeModule =
             serde_json::from_value(json!({"value": null})).unwrap();
         assert!(parsed.value.is_none());
+    }
+
+    /// Construct a Float from raw coefficient and exponent by packing
+    /// them into the B256 layout: upper 32 bits = exponent (int32),
+    /// lower 224 bits = coefficient (int224).
+    fn pack_raw(coefficient: i64, exponent: i32) -> Float {
+        use alloy::primitives::B256;
+
+        let mut bytes = [0u8; 32];
+
+        // Exponent in the top 4 bytes (big-endian).
+        bytes[..4].copy_from_slice(&exponent.to_be_bytes());
+
+        // Coefficient in the lower 28 bytes (big-endian, sign-extended).
+        let coeff_bytes = coefficient.to_be_bytes();
+        let fill = if coefficient < 0 { 0xFF } else { 0x00 };
+        bytes[4..24].fill(fill);
+        bytes[24..32].copy_from_slice(&coeff_bytes);
+
+        Float::from_raw(B256::from(bytes))
+    }
+
+    #[test]
+    fn serialize_float_with_extreme_exponent_uses_scientific_fallback() {
+        // Construct a Float with exponent -77, which exceeds the
+        // non-scientific formatter's -76 limit. This reproduces the
+        // crash from RAI-218: accumulated Float arithmetic can produce
+        // such exponents through catastrophic cancellation.
+        let float = pack_raw(9_999_999_910_959_448, -77);
+
+        // Non-scientific formatting should fail for this exponent.
+        assert!(
+            float.format_with_scientific(false).is_err(),
+            "Expected non-scientific format to fail for exponent -77"
+        );
+
+        // But our format_float should succeed via scientific fallback.
+        let formatted = format_float(&float).unwrap();
+        assert!(
+            !formatted.is_empty(),
+            "format_float should produce output for exponent -77"
+        );
+
+        // The formatted string should roundtrip through parse.
+        let roundtripped = Float::parse(formatted.clone()).unwrap();
+        assert!(
+            roundtripped.eq(float).unwrap(),
+            "Roundtrip failed: formatted as '{formatted}', parsed back to different value"
+        );
+    }
+
+    #[test]
+    fn serialize_float_with_extreme_exponent_roundtrips_through_serde() {
+        let float = pack_raw(9_999_999_910_959_448, -77);
+
+        let payload = SerializeFloat { value: float };
+        let json = serde_json::to_value(payload).unwrap();
+
+        // Should serialize without error (previously panicked).
+        let serialized = json["value"].as_str().unwrap();
+        assert!(!serialized.is_empty());
+
+        // Should deserialize back to the same value.
+        let parsed: DeserializeFloat = serde_json::from_value(json).unwrap();
+        assert!(
+            parsed.value.eq(float).unwrap(),
+            "Serde roundtrip failed for Float with exponent -77"
+        );
+    }
+
+    /// Proves the upstream Rain Float bug: adding two values whose
+    /// magnitudes nearly cancel produces a Float that the non-scientific
+    /// formatter cannot handle (UnformatableExponent).
+    ///
+    /// These are the exact values from the production crash (staging
+    /// logs, event 605 applied to position view version 604):
+    ///   net position = -0.09999999910959448  (17 decimal places)
+    ///   hedge fill   =  0.099999999          (9 decimal places)
+    ///   sum          = -0.00000000010959448  (~-1.1e-10)
+    ///
+    /// Both inputs format fine individually. Their sum is a valid tiny
+    /// number, but its internal Float representation has exponent -77
+    /// because `add` inflates both inputs via `maximizeFull` (adding
+    /// trailing zeros), and after cancellation `packLossy` doesn't
+    /// strip them.
+    #[test]
+    fn addition_of_near_cancelling_values_produces_unformattable_float() {
+        let net_position = Float::parse("-0.09999999910959448".to_string()).unwrap();
+        let hedge_fill = Float::parse("0.099999999".to_string()).unwrap();
+
+        // Both inputs format fine individually.
+        net_position.format_with_scientific(false).unwrap();
+        hedge_fill.format_with_scientific(false).unwrap();
+
+        // Their sum is a valid, tiny number (~-1.1e-10).
+        let result = (net_position + hedge_fill).unwrap();
+
+        // Scientific notation works — the value is real and finite.
+        let scientific = result.format_with_scientific(true).unwrap();
+        assert!(
+            !scientific.is_empty(),
+            "Scientific format should work for the sum"
+        );
+
+        // But non-scientific formatting crashes — this is the upstream bug.
+        assert!(
+            result.format_with_scientific(false).is_err(),
+            "Expected non-scientific format to fail for near-cancellation \
+             result. Rain Float's add produces exponent -77 from \
+             maximizeFull trailing zeros that packLossy doesn't strip. \
+             Scientific result: {scientific}"
+        );
+
+        // Our format_float works around this via scientific fallback.
+        let formatted = format_float(&result).unwrap();
+        let roundtripped = Float::parse(formatted.clone()).unwrap();
+        assert!(
+            roundtripped.eq(result).unwrap(),
+            "Roundtrip failed: '{formatted}'"
+        );
+    }
+
+    /// Verify that smaller numbers produce even worse exponents after
+    /// near-cancellation. If 0.0999... → exponent -77, then 0.00999...
+    /// should → -78 and 0.000999... → -79, since maximizeFull inflates
+    /// by more powers of 10 for smaller starting coefficients.
+    #[test]
+    fn smaller_magnitudes_produce_worse_exponents() {
+        // Each pair: a negative value and a slightly smaller positive value,
+        // so their sum is a tiny residual that triggers the formatter bug.
+
+        // ~0.01 magnitude: expect exponent -78
+        let hundredths = (Float::parse("-0.0099999991".to_string()).unwrap()
+            + Float::parse("0.009999999".to_string()).unwrap())
+        .unwrap();
+        assert!(
+            hundredths.format_with_scientific(false).is_err(),
+            "Expected exponent -78 to fail non-scientific format. \
+             Scientific: {}",
+            hundredths.format_with_scientific(true).unwrap()
+        );
+
+        // ~0.001 magnitude: expect exponent -79
+        let thousandths = (Float::parse("-0.00099999991".to_string()).unwrap()
+            + Float::parse("0.0009999999".to_string()).unwrap())
+        .unwrap();
+        assert!(
+            thousandths.format_with_scientific(false).is_err(),
+            "Expected exponent -79 to fail non-scientific format. \
+             Scientific: {}",
+            thousandths.format_with_scientific(true).unwrap()
+        );
+
+        // All should work with our format_float fallback.
+        format_float(&hundredths).unwrap();
+        format_float(&thousandths).unwrap();
+    }
+
+    #[test]
+    fn serialize_normal_float_still_uses_decimal_format() {
+        // Normal values should still produce clean decimal strings,
+        // not scientific notation.
+        let formatted = format_float(&Float::parse("72.5".to_string()).unwrap()).unwrap();
+        assert_eq!(formatted, "72.5");
+
+        let formatted = format_float(&Float::parse("0.1".to_string()).unwrap()).unwrap();
+        assert_eq!(formatted, "0.1");
     }
 
     #[test]


### PR DESCRIPTION
## What

[RAI-218](https://linear.app/makeitrain/issue/RAI-218/fix-float-serialization-crash-from-unformatableexponent-in-cqrs-replay)

Fix a crash-loop caused by Rain Float's non-scientific decimal formatter rejecting Floats with exponents < -76, which the library's own arithmetic produces through normal add/sub operations.

## Why

The staging bot crash-loops on startup during CQRS event replay. After accumulating 605 position events (324 onchain trades + 11 offchain fills), Float subtraction of nearly-equal values produces a result with exponent -77. The non-scientific formatter (`format_with_scientific(false)`) rejects this with `UnformatableExponent`, crashing during Position view re-serialization.

This is an upstream limitation in Rain Float — the arithmetic and formatter disagree on valid exponent ranges. Tracked upstream as [RAI-219](https://linear.app/makeitrain/issue/RAI-219/upstream-rain-float-formatter-rejects-exponents-produced-by-its-own).

## How

- **`format_float()`** (`crates/float-serde/src/lib.rs`) — new function that tries `format_with_scientific(false)` first, falls back to `format_with_scientific(true)` when the exponent exceeds the formatter's range. Scientific notation (e.g., `"9.999e-62"`) is valid input for `Float::parse`, so roundtrips are preserved.
- **`serialize_float_as_string()`** and **`format_float_with_fallback()`** — both now delegate to `format_float()` instead of calling the non-scientific formatter directly.

## Testing

3 new tests:
- `serialize_float_with_extreme_exponent_uses_scientific_fallback` — verifies a Float with exponent -77 formats successfully and roundtrips through `Float::parse`
- `serialize_float_with_extreme_exponent_roundtrips_through_serde` — verifies the full serde serialize/deserialize roundtrip
- `serialize_normal_float_still_uses_decimal_format` — verifies normal values like `72.5` and `0.1` still produce clean decimal strings (no unnecessary scientific notation)

Full workspace: 1644 tests passed.

## Screenshots

N/A

## Anything else

- Normal values still serialize as decimal strings (`"72.5"`, `"0.1"`) — scientific notation is only used when the non-scientific formatter would crash.
- The root cause is in the Rain Float library: `add`/`sub` call `maximizeFull` which pushes coefficients to ~76 digits with very negative exponents. After catastrophic cancellation, the small result inherits the large negative exponent. `packLossy` stores it as-is (small coefficient fits in int224), but the non-scientific formatter can't render exponents below -76.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved floating-point serialization to gracefully fall back to scientific notation for extreme or unrepresentable values, preventing serialization failures.

* **Tests**
  * Added extensive tests covering extreme-exponent and near-cancellation cases and full serialization/deserialization roundtrips to prevent regressions.

* **Chores**
  * Added a development-only workspace dependency to support testing and development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->