### PR TITLE
Benchmark Blacksmith 4-vCPU without extra caches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,15 +9,39 @@ permissions:
   contents: read
 
 jobs:
-  backend:
+  backend-validation:
+    name: backend ${{ matrix.name }}
     concurrency:
-      group: ${{ github.ref }}-backend
+      group: ${{ github.ref }}-backend-${{ matrix.name }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: check
+            command: nix develop -c cargo check --workspace
+          - name: test 1 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:1/4
+          - name: test 2 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:2/4
+          - name: test 3 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:3/4
+          - name: test 4 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:4/4
+          - name: clippy
+            command: >
+              nix develop -c cargo clippy --workspace --all-targets
+              --all-features -- -D clippy::all -D warnings
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-
       - uses: actions/checkout@v4
 
       - name: Compute submodule cache key
@@ -64,25 +88,27 @@ jobs:
       - name: Setup database
         run: nix develop -c sqlx db reset -y
 
-      - name: Validate standalone build
-        run: nix develop -c cargo check --workspace
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
 
-      - name: Test
+  backend:
+    name: backend
+    needs: backend-validation
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check backend validation
         run: |
-          nix develop -c cargo nextest run \
-            --workspace --all-features --profile ci
-
-      - name: Clippy
-        run: |
-          nix develop -c cargo clippy \
-            --workspace --all-targets --all-features \
-            -- -D clippy::all -D warnings
+          if [ "${{ needs.backend-validation.result }}" != "success" ]; then
+            echo "backend validation failed"
+            exit 1
+          fi
 
   dashboard:
     concurrency:
       group: ${{ github.ref }}-dashboard
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -137,7 +163,7 @@ jobs:
     concurrency:
       group: ${{ github.ref }}-flake
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Move CI jobs to Blacksmith 4-vCPU runners.
- Split backend validation into parallel cargo check, four nextest shards, and clippy jobs.
- Keep a tiny backend aggregate job so the backend gate still reflects all backend validation jobs.
- Do not add the extra cache changes from PR #590: no Cargo target cache, no Solidity artifact cache, and no hooks submodule-cache rewrite.

## Why

This is a benchmark comparator for PR #590. It measures Blacksmith 4-vCPU runner behavior and backend parallelization without the extra explicit cache additions, so we can compare:

- baseline GitHub-hosted CI
- Blacksmith 4-vCPU without extra caches
- Blacksmith 4-vCPU with explicit cache additions

## Result

Latest successful run: https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/24709810993

- Full CI wall time: about 17m25s from run creation, about 17m17s from first job start.
- Backend gate: about 14m46s from shard start to aggregate backend pass.
- Dashboard: 17m17s.
- Hooks: 13m29s.

For comparison, PR #590 with the explicit cache additions on 4-vCPU completed full CI in about 8m32s, with backend at about 8m24s from first job start.

## Validation

- git diff --check
- YAML parsed locally with Ruby YAML.load_file
- Commit hook: yamlfmt passed
- CI passed on the benchmark run