### PR TITLE
fix: checkpoint backfill and clean up apalis jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ code, a regular shell is fine.
 
 The application uses TOML configuration files split into plaintext config and
 encrypted secrets. See `example.config.toml` and `example.secrets.toml` for all
-available options.
+available options. Operational intervals such as
+`apalis_finished_job_cleanup_interval_secs` must be explicitly configured and
+non-zero.
 
 Current broker support is limited to `alpaca-broker-api` and `dry-run`.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -170,6 +170,23 @@ historical events are processed before live events. The WebSocket subscription
 is established early, so no events are missed -- they buffer until the runtime
 starts.
 
+Historical backfill resumes from a persisted database checkpoint. The configured
+`deployment_block` is only the initial seed for the first startup or for an
+empty checkpoint; after a successful backfill, the service records the last
+processed block and the next startup begins at the following block. The
+checkpoint is updated only after the full backfill range succeeds, so a partial
+failure cannot skip unprocessed history.
+
+Completed apalis jobs are operational queue records, not audit history. The
+runtime periodically deletes terminal job rows and vacuums SQLite at the
+configured `apalis_finished_job_cleanup_interval_secs` cadence so the durable
+queue cannot grow without bound during normal operation or repeated restarts.
+The cadence must be explicitly configured and non-zero.
+
+Deployed systemd services must use bounded restart loops with a restart delay
+long enough to avoid runaway RPC consumption. After the restart limit is hit,
+the service stays stopped until an operator investigates.
+
 ##### Future: Lifecycle Workflows
 
 Business processes with multiple steps will be modeled as durable workflows via
@@ -2103,9 +2120,10 @@ sequenceDiagram
     end
 ```
 
-On startup, backfill pushes historical events as `AccountForDexTrade` jobs into
-the same queue. The worker starts after backfill completes, processing
-historical events before live events in FIFO order.
+On startup, backfill pushes historical events after the persisted backfill
+checkpoint as `AccountForDexTrade` jobs into the same queue. The worker starts
+after backfill completes, so historical jobs are enqueued before live events are
+processed. Successful backfill advances the checkpoint to the cutoff block.
 
 **Target Flow** (lifecycle workflows, future):
 

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -1,6 +1,7 @@
 server_port = 8001
 log_level = "debug"
 database_url = "sqlite:///mnt/data/st0x-hedge.db"
+apalis_finished_job_cleanup_interval_secs = 3600
 hyperdx.service_name = "st0x-liquidity"
 
 [broker]

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -1,6 +1,7 @@
 server_port = 8001
 log_level = "debug"
 database_url = "sqlite:///mnt/data/st0x-hedge.db"
+apalis_finished_job_cleanup_interval_secs = 3600
 hyperdx.service_name = "st0x-liquidity"
 
 [broker]

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -170,13 +170,23 @@ executor, CQRS frameworks, execution threshold, wallet polling config).
 ```
 Phase 1 (parallel):  connect_ws | setup_cqrs | setup_apalis_tables
 Phase 2 (parallel):  get_cutoff_block | seed_vaults | setup_rebalancing
-Phase 3 (sequential): backfill historical events to job queue
+Phase 3 (sequential): backfill checkpoint gap to job queue
 Phase 4:              builder::spawn() starts the runtime
 ```
 
 The trade accounting worker starts only after backfill completes. The WS
 subscription is established in phase 1, so no events are missed -- they buffer
 until the monitor starts.
+
+Backfill reads the last successful checkpoint from SQLite. The configured
+`deployment_block` seeds only the first run; subsequent runs start at
+`checkpoint + 1`. The checkpoint advances only after the full requested range
+has been enqueued successfully.
+
+The conductor also runs periodic cleanup for terminal apalis jobs at the
+configured `apalis_finished_job_cleanup_interval_secs` cadence. Those rows are
+queue bookkeeping, while trade history lives in CQRS events and projections. The
+cadence is required config and must be non-zero.
 
 ## Error handling in jobs
 

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -1,6 +1,7 @@
 server_port = 8001
 log_level = "info"
 database_url = ":memory:"
+apalis_finished_job_cleanup_interval_secs = 3600
 hyperdx.service_name = "st0x-hedge-e2e"
 
 [assets.equities.EXAMPLE]

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,6 +1,7 @@
 server_port = 8080
 log_level = "debug"
 database_url = ":memory:"
+apalis_finished_job_cleanup_interval_secs = 3600
 hyperdx.service_name = "st0x-hedge"
 
 # Travel Rule info for Alpaca whitelist creation (required since 2026-03-27).

--- a/migrations/20260421082832_backfill_checkpoint.sql
+++ b/migrations/20260421082832_backfill_checkpoint.sql
@@ -1,0 +1,5 @@
+CREATE TABLE backfill_checkpoints (
+    orderbook TEXT PRIMARY KEY,
+    last_processed_block INTEGER NOT NULL CHECK (last_processed_block >= 0),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);

--- a/os.nix
+++ b/os.nix
@@ -30,6 +30,8 @@ let
 
     unitConfig = {
       "X-OnlyManualStart" = true;
+      StartLimitBurst = 10;
+      StartLimitIntervalSec = 300;
 
       # Marker file created ONLY by service profile activation.
       # Guarantees service is SKIPPED (not failed) during system activation.
@@ -47,7 +49,7 @@ let
         cfg.decryptedSecretPath
       ];
       Restart = "always";
-      RestartSec = 5;
+      RestartSec = 30;
     };
   };
 

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -735,6 +735,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -799,6 +800,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::AlpacaBrokerApi(AlpacaBrokerApiCtx {
                 api_key: "test-key".to_string(),
                 api_secret: "test-secret".to_string(),

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -268,6 +268,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1047,6 +1047,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -1248,6 +1249,7 @@ mod tests {
             &config_path,
             r#"
                 database_url = ":memory:"
+                apalis_finished_job_cleanup_interval_secs = 3600
 
                 [assets.equities]
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -579,6 +579,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -632,6 +633,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::AlpacaBrokerApi(alpaca_broker_auth),
             telemetry: None,
             trading_mode: TradingMode::Rebalancing(Box::new(

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -667,6 +667,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -231,6 +231,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {
@@ -260,6 +261,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Rebalancing(Box::new(

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -155,6 +155,7 @@ mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone {

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use task_supervisor::SupervisorHandle;
 use tokio::sync::{Mutex, broadcast, mpsc};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, warn};
 
 use st0x_dto::Statement;
@@ -30,6 +31,7 @@ use st0x_execution::{
 
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::bindings::IOrderBookV6::{self, IOrderBookV6Instance};
+use crate::conductor::job::cleanup_finished_jobs;
 use crate::config::{AssetsConfig, BrokerCtx, Ctx, CtxError};
 use crate::dashboard::Broadcaster;
 use crate::equity_redemption::symbols_with_stuck_redemptions;
@@ -107,6 +109,8 @@ pub(crate) struct Conductor {
     /// Polls wallet balances and onchain state on a timer. Absent when
     /// rebalancing (and therefore wallet context) is not configured.
     inventory_poller: Option<JoinHandle<()>>,
+    /// Periodically removes terminal rows from the persistent job queue.
+    job_cleanup: JoinHandle<()>,
 }
 
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
@@ -185,6 +189,7 @@ impl Conductor {
         backfill_events(
             &provider,
             &ctx.evm,
+            &pool,
             cutoff_block,
             get_backfill_retry_strat(),
             job_queue.clone(),
@@ -286,6 +291,10 @@ impl Conductor {
         };
 
         let hedge_queue = crate::conductor::job::JobQueue::new(&pool);
+        let job_cleanup = spawn_finished_job_cleanup(
+            pool.clone(),
+            Duration::from_secs(ctx.apalis_finished_job_cleanup_interval_secs),
+        );
 
         let conductor_ctx = builder::ConductorCtx {
             ctx: ctx.clone(),
@@ -307,6 +316,7 @@ impl Conductor {
             .dex_streams(dex_streams)
             .maybe_executor_maintenance(executor_maintenance)
             .maybe_rebalancer(rebalancer)
+            .job_cleanup(job_cleanup)
             .call();
 
         info!("Conductor running");
@@ -318,22 +328,13 @@ impl Conductor {
 
 impl Conductor {
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
-        tokio::select! {
-            result = self.supervisor.wait() => {
-                result?;
-                info!("Supervisor exited");
-            }
-            result = &mut self.monitor => {
-                if let Err(join_error) = result
-                    && !join_error.is_cancelled()
-                {
-                    return Err(anyhow::anyhow!("Apalis monitor failed: {join_error}"));
-                }
-                info!("Apalis monitor exited");
-            }
-        }
+        let exit = tokio::select! {
+            result = self.supervisor.wait() => ConductorExit::Supervisor(result.map_err(anyhow::Error::new)),
+            result = &mut self.monitor => ConductorExit::Monitor(result),
+            result = &mut self.job_cleanup => ConductorExit::JobCleanup(result),
+        };
 
-        Ok(())
+        handle_conductor_exit(exit)
     }
 
     pub(crate) fn abort_all(&self) {
@@ -352,7 +353,73 @@ impl Conductor {
         if let Some(ref handle) = self.executor_maintenance {
             handle.abort();
         }
+        self.job_cleanup.abort();
     }
+}
+
+enum ConductorExit {
+    Supervisor(anyhow::Result<()>),
+    Monitor(Result<(), JoinError>),
+    JobCleanup(Result<(), JoinError>),
+}
+
+fn handle_conductor_exit(exit: ConductorExit) -> anyhow::Result<()> {
+    match exit {
+        ConductorExit::Supervisor(result) => {
+            result?;
+            info!("Supervisor exited");
+        }
+        ConductorExit::Monitor(result) => {
+            handle_task_exit(result, "Apalis monitor")?;
+            info!("Apalis monitor exited");
+        }
+        ConductorExit::JobCleanup(result) => {
+            handle_required_background_task_exit(result, "Job cleanup")?;
+            info!("Job cleanup exited");
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_task_exit(result: Result<(), JoinError>, task: &'static str) -> anyhow::Result<()> {
+    if let Err(join_error) = result
+        && !join_error.is_cancelled()
+    {
+        return Err(anyhow::Error::new(join_error).context(format!("{task} failed")));
+    }
+
+    Ok(())
+}
+
+fn handle_required_background_task_exit(
+    result: Result<(), JoinError>,
+    task: &'static str,
+) -> anyhow::Result<()> {
+    match result {
+        Ok(()) => Err(anyhow::anyhow!("{task} exited unexpectedly")),
+        Err(join_error) => handle_task_exit(Err(join_error), task),
+    }
+}
+
+fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(cleanup_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            interval.tick().await;
+
+            match cleanup_finished_jobs(&pool).await {
+                Ok(deleted) => {
+                    debug!(deleted, "Cleaned up finished job queue rows");
+                }
+                Err(error) => {
+                    error!(%error, "Failed to clean up finished job queue rows");
+                }
+            }
+        }
+    })
 }
 
 struct RebalancingInfrastructure {
@@ -1464,10 +1531,14 @@ mod tests {
     use alloy::primitives::{Address, B256, TxHash, U256, address, bytes, fixed_bytes};
     use alloy::providers::ProviderBuilder;
     use alloy::providers::mock::Asserter;
+    use apalis::prelude::Status;
     use rain_math_float::Float;
+    use sqlx::SqlitePool;
     use std::collections::HashSet;
+    use std::future::pending;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use task_supervisor::SupervisorBuilder;
     use tokio::sync::broadcast;
 
     use st0x_dto::Statement;
@@ -1477,6 +1548,7 @@ mod tests {
         MockExecutor, Positive, Symbol,
     };
     use st0x_finance::{Usd, Usdc};
+    use st0x_float_macro::float;
 
     use super::*;
     use crate::bindings::IOrderBookV6::{
@@ -1495,10 +1567,113 @@ mod tests {
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::wrapper::mock::MockWrapper;
     use crate::wrapper::{RATIO_ONE, UnderlyingPerWrapped};
-    use st0x_float_macro::float;
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()
+    }
+
+    fn conductor_with_job_cleanup(job_cleanup: JoinHandle<()>) -> Conductor {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let monitor = tokio::spawn(pending::<()>());
+
+        Conductor {
+            supervisor,
+            monitor,
+            executor_maintenance: None,
+            rebalancer: None,
+            inventory_poller: None,
+            job_cleanup,
+        }
+    }
+
+    async fn insert_finished_job(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO Jobs \
+             (job, id, job_type, status, attempts, max_attempts, run_at, priority) \
+             VALUES (?, ?, 'test', ?, 1, 25, 0, 0)",
+        )
+        .bind(vec![0_u8])
+        .bind(id)
+        .bind(Status::Done.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn job_count(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    async fn wait_for_job_count(pool: &SqlitePool, expected_count: i64) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let count = job_count(pool).await;
+                if count == expected_count {
+                    return;
+                }
+
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_for_completion_reports_unexpected_job_cleanup_exit() {
+        let job_cleanup = tokio::spawn(async {});
+        let mut conductor = conductor_with_job_cleanup(job_cleanup);
+
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        conductor.abort_all();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Job cleanup exited unexpectedly"),
+            "expected unexpected job cleanup exit, got: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_completion_reports_job_cleanup_failure() {
+        let job_cleanup = tokio::spawn(async {
+            panic!("job cleanup failure for test");
+        });
+        let mut conductor = conductor_with_job_cleanup(job_cleanup);
+
+        let error = conductor.wait_for_completion().await.unwrap_err();
+        conductor.abort_all();
+
+        assert!(
+            error.to_string().contains("Job cleanup failed"),
+            "expected job cleanup failure context, got: {error:#}"
+        );
+        assert!(
+            error.source().is_some(),
+            "expected preserved JoinError source"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_finished_job_cleanup_runs_until_aborted() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+        insert_finished_job(&pool, "done").await;
+
+        let handle = spawn_finished_job_cleanup(pool.clone(), Duration::from_secs(60));
+
+        wait_for_job_count(&pool, 0).await;
+        handle.abort();
+        let join_error = handle.await.unwrap_err();
+
+        assert!(
+            join_error.is_cancelled(),
+            "expected cleanup task to be cancelled, got: {join_error}"
+        );
     }
 
     #[test]

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -64,6 +64,7 @@ pub(crate) fn spawn<Prov, Exec>(
     job_queue: DexTradeAccountingJobQueue,
     hedge_queue: HedgeJobQueue,
     dex_streams: DexEventStreams,
+    job_cleanup: JoinHandle<()>,
     executor_maintenance: Option<JoinHandle<()>>,
     rebalancer: Option<JoinHandle<()>>,
 ) -> Conductor
@@ -201,6 +202,7 @@ where
         executor_maintenance,
         rebalancer,
         inventory_poller,
+        job_cleanup,
     }
 }
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -5,7 +5,7 @@
 //! `SqliteStorage`; the generic [`work`] handler deserializes
 //! it and calls [`Job::perform`] with the shared context.
 
-use apalis::prelude::{Data, TaskSink};
+use apalis::prelude::{Data, Status, TaskSink};
 use apalis_sqlite::SqliteStorage;
 use backon::{ExponentialBuilder, Retryable};
 use serde::Serialize;
@@ -112,5 +112,107 @@ where
 
     if let Err(error) = result {
         error!(%label, %error, "Job failed after retries");
+    }
+}
+
+pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let deleted = sqlx::query(
+        "DELETE FROM Jobs \
+         WHERE status = ? \
+         OR status = ? \
+         OR (status = ? AND max_attempts <= attempts)",
+    )
+    .bind(Status::Done.to_string())
+    .bind(Status::Killed.to_string())
+    .bind(Status::Failed.to_string())
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::SqlitePool;
+
+    use super::*;
+    use crate::conductor::setup_apalis_tables;
+    use crate::test_utils::setup_test_db;
+
+    async fn insert_job(
+        pool: &SqlitePool,
+        id: &str,
+        status: Status,
+        attempts: i64,
+        max_attempts: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO Jobs \
+             (job, id, job_type, status, attempts, max_attempts, run_at, priority) \
+             VALUES (?, ?, 'test', ?, ?, ?, 0, 0)",
+        )
+        .bind(vec![0_u8])
+        .bind(id)
+        .bind(status.to_string())
+        .bind(attempts)
+        .bind(max_attempts)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn job_ids(pool: &SqlitePool) -> Vec<String> {
+        sqlx::query_scalar::<_, String>("SELECT id FROM Jobs ORDER BY id")
+            .fetch_all(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn cleanup_finished_jobs_deletes_terminal_rows() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        insert_job(&pool, "done", Status::Done, 1, 25).await;
+        insert_job(&pool, "killed", Status::Killed, 1, 25).await;
+        insert_job(&pool, "failed-terminal", Status::Failed, 25, 25).await;
+        insert_job(&pool, "failed-retryable", Status::Failed, 3, 25).await;
+        insert_job(&pool, "pending", Status::Pending, 0, 25).await;
+        insert_job(&pool, "running", Status::Running, 1, 25).await;
+
+        let deleted = cleanup_finished_jobs(&pool).await.unwrap();
+
+        assert_eq!(deleted, 3);
+        assert_eq!(
+            job_ids(&pool).await,
+            vec![
+                "failed-retryable".to_string(),
+                "pending".to_string(),
+                "running".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_finished_jobs_keeps_non_terminal_rows() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        insert_job(&pool, "failed-retryable", Status::Failed, 3, 25).await;
+        insert_job(&pool, "pending", Status::Pending, 0, 25).await;
+        insert_job(&pool, "running", Status::Running, 1, 25).await;
+
+        let deleted = cleanup_finished_jobs(&pool).await.unwrap();
+
+        assert_eq!(deleted, 0);
+        assert_eq!(
+            job_ids(&pool).await,
+            vec![
+                "failed-retryable".to_string(),
+                "pending".to_string(),
+                "running".to_string()
+            ]
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,7 @@ struct Config {
     order_polling_max_jitter: Option<u64>,
     position_check_interval: Option<u64>,
     inventory_poll_interval: Option<u64>,
+    apalis_finished_job_cleanup_interval_secs: u64,
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetryConfig>,
     rebalancing: Option<RebalancingConfig>,
@@ -268,6 +269,7 @@ pub struct Ctx {
     pub(crate) order_polling_max_jitter: u64,
     pub(crate) position_check_interval: u64,
     pub(crate) inventory_poll_interval: u64,
+    pub(crate) apalis_finished_job_cleanup_interval_secs: u64,
     pub(crate) broker: BrokerCtx,
     pub telemetry: Option<TelemetryCtx>,
     pub trading_mode: TradingMode,
@@ -348,6 +350,10 @@ impl std::fmt::Debug for Ctx {
             .field("order_polling_max_jitter", &self.order_polling_max_jitter)
             .field("position_check_interval", &self.position_check_interval)
             .field("inventory_poll_interval", &self.inventory_poll_interval)
+            .field(
+                "apalis_finished_job_cleanup_interval_secs",
+                &self.apalis_finished_job_cleanup_interval_secs,
+            )
             .field("broker", &self.broker)
             .field("telemetry", &self.telemetry)
             .field("trading_mode", &self.trading_mode)
@@ -404,6 +410,7 @@ struct ValidatedParts {
     order_polling_max_jitter: u64,
     position_check_interval: u64,
     inventory_poll_interval: u64,
+    apalis_finished_job_cleanup_interval_secs: u64,
     broker: BrokerCtx,
     telemetry: Option<TelemetryCtx>,
     execution_threshold: ExecutionThreshold,
@@ -563,6 +570,14 @@ fn parse_and_validate(
         });
     }
 
+    let apalis_finished_job_cleanup_interval_secs =
+        config.apalis_finished_job_cleanup_interval_secs;
+    if apalis_finished_job_cleanup_interval_secs == 0 {
+        return Err(CtxError::ZeroPollingInterval {
+            field: "apalis_finished_job_cleanup_interval_secs",
+        });
+    }
+
     let travel_rule = config
         .broker
         .as_ref()
@@ -592,6 +607,7 @@ fn parse_and_validate(
         order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
         position_check_interval,
         inventory_poll_interval,
+        apalis_finished_job_cleanup_interval_secs,
         broker,
         telemetry,
         execution_threshold,
@@ -643,6 +659,8 @@ impl Ctx {
             order_polling_max_jitter: parts.order_polling_max_jitter,
             position_check_interval: parts.position_check_interval,
             inventory_poll_interval: parts.inventory_poll_interval,
+            apalis_finished_job_cleanup_interval_secs: parts
+                .apalis_finished_job_cleanup_interval_secs,
             broker: parts.broker,
             telemetry: parts.telemetry,
             trading_mode: parts.trading_mode,
@@ -671,7 +689,6 @@ impl Ctx {
                 path: secrets_path.to_path_buf(),
                 source,
             })?;
-
         parse_and_validate(&config_str, config_path, &secrets_str, secrets_path)?;
         Ok(())
     }
@@ -761,6 +778,7 @@ impl Ctx {
         wallet: Option<crate::wallet::OnchainWalletCtx>,
         assets: AssetsConfig,
         #[builder(default = 2)] inventory_poll_interval: u64,
+        #[builder(default = 3600)] apalis_finished_job_cleanup_interval_secs: u64,
         #[builder(default = 0)] server_port: u16,
         execution_threshold_override: Option<ExecutionThreshold>,
         travel_rule: Option<TravelRuleConfig>,
@@ -787,6 +805,7 @@ impl Ctx {
             order_polling_max_jitter: 0,
             position_check_interval: 2,
             inventory_poll_interval,
+            apalis_finished_job_cleanup_interval_secs,
             broker,
             telemetry: None,
             trading_mode,
@@ -958,11 +977,11 @@ pub(crate) mod tests {
     use tempfile::NamedTempFile;
 
     use st0x_execution::{MockExecutor, MockExecutorCtx, TryIntoExecutor};
+    use st0x_float_macro::float;
 
     use super::*;
     use crate::onchain::EvmCtx;
     use crate::threshold::ExecutionThreshold;
-    use st0x_float_macro::float;
 
     fn toml_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
@@ -984,6 +1003,7 @@ pub(crate) mod tests {
             order_polling_max_jitter: 5,
             position_check_interval: 60,
             inventory_poll_interval: 60,
+            apalis_finished_job_cleanup_interval_secs: 3600,
             broker: BrokerCtx::DryRun,
             telemetry: None,
             trading_mode: TradingMode::Standalone { order_owner },
@@ -1002,6 +1022,7 @@ pub(crate) mod tests {
         file.write_all(
             br#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1020,6 +1041,7 @@ pub(crate) mod tests {
         file.write_all(
             br#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1039,6 +1061,7 @@ pub(crate) mod tests {
         toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1060,6 +1083,7 @@ pub(crate) mod tests {
         toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1171,6 +1195,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1207,6 +1232,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1244,6 +1270,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1278,6 +1305,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1333,6 +1361,69 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn apalis_finished_job_cleanup_interval_is_required() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CtxError::ConfigToml { .. }),
+            "expected config parse failure for missing cleanup interval, got: {error:#}"
+        );
+
+        let source = std::error::Error::source(&error).unwrap();
+        let source_display = source.to_string();
+        assert!(
+            source_display.contains("apalis_finished_job_cleanup_interval_secs"),
+            "expected parse error to mention cleanup interval field, got: {source_display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apalis_finished_job_cleanup_interval_must_be_non_zero() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 0
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+            order_owner = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            deployment_block = 1
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                CtxError::ZeroPollingInterval {
+                    field: "apalis_finished_job_cleanup_interval_secs"
+                }
+            ),
+            "expected ZeroPollingInterval for cleanup interval, got: {error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn rebalancing_with_low_cash_operational_limit_fails() {
         let secrets = toml_file(
             r#"
@@ -1356,6 +1447,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1407,6 +1499,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
             log_level = "warn"
             server_port = 9090
             order_polling_interval = 30
@@ -1458,6 +1551,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1540,6 +1634,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities.EXAMPLE]
             tokenized_equity = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1611,6 +1706,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1650,6 +1746,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1709,6 +1806,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1759,6 +1857,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1813,6 +1912,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1858,6 +1958,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -1950,6 +2051,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -2075,6 +2177,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -2256,6 +2359,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
             bogus_field = "should fail"
 
             [raindex]
@@ -2280,6 +2384,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets]
             bogus_field = "should fail"
@@ -2308,6 +2413,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities.AAPL]
             tokenized_equity = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -2338,6 +2444,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.cash]
             rebalancing = "disabled"
@@ -2421,6 +2528,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
             bogus_field = "should fail"
 
             [raindex]
@@ -3157,6 +3265,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -3201,6 +3310,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -3276,6 +3386,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -3336,6 +3447,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
 
@@ -3368,6 +3480,7 @@ pub(crate) mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            apalis_finished_job_cleanup_interval_secs = 3600
             position_check_interval = 0
 
             [assets.equities]

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -2,10 +2,8 @@
 //!
 //! Scans past blocks for `ClearV3` and `TakeOrderV3` events and pushes them
 //! into the apalis job queue for processing, ensuring no trades are missed
-//! after downtime.
-//!
-//! Always backfills from `deployment_block` — the CQRS pipeline rejects
-//! duplicate fills via aggregate idempotency, so re-pushing is safe.
+//! after downtime. A persisted checkpoint records the last block that was
+//! fully enqueued.
 
 use alloy::providers::Provider;
 use alloy::rpc::types::Filter;
@@ -13,6 +11,7 @@ use alloy::sol_types::SolEvent;
 use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
 use futures_util::future;
 use itertools::Itertools;
+use sqlx::SqlitePool;
 use std::time::Duration;
 use tracing::{debug, info, trace, warn};
 
@@ -36,24 +35,27 @@ pub(crate) fn get_backfill_retry_strat() -> ExponentialBuilder {
 }
 
 #[tracing::instrument(
-    skip(provider, evm_ctx, retry_strategy, job_queue),
+    skip(provider, evm_ctx, pool, retry_strategy, job_queue),
     fields(end_block),
     level = tracing::Level::INFO,
 )]
 pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     provider: &P,
     evm_ctx: &EvmCtx,
+    pool: &SqlitePool,
     end_block: u64,
     retry_strategy: B,
     job_queue: DexTradeAccountingJobQueue,
 ) -> Result<(), OnChainError> {
-    let start_block = evm_ctx.deployment_block;
+    let start_block = backfill_start_block(pool, evm_ctx).await?;
 
     if start_block > end_block {
         info!(
             "Already caught up to block {}, skipping backfill",
             end_block
         );
+
+        save_backfill_checkpoint(pool, evm_ctx, end_block).await?;
         return Ok(());
     }
 
@@ -89,6 +91,57 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
         .sum::<usize>();
 
     info!("Backfill completed: {total_enqueued} events enqueued");
+
+    save_backfill_checkpoint(pool, evm_ctx, end_block).await?;
+
+    Ok(())
+}
+
+async fn backfill_start_block(pool: &SqlitePool, evm_ctx: &EvmCtx) -> Result<u64, OnChainError> {
+    load_backfill_checkpoint(pool, evm_ctx)
+        .await?
+        .map_or(Ok(evm_ctx.deployment_block), |last_processed_block| {
+            Ok((last_processed_block + 1).max(evm_ctx.deployment_block))
+        })
+}
+
+async fn load_backfill_checkpoint(
+    pool: &SqlitePool,
+    evm_ctx: &EvmCtx,
+) -> Result<Option<u64>, OnChainError> {
+    let row = sqlx::query_as::<_, (i64,)>(
+        "SELECT last_processed_block FROM backfill_checkpoints WHERE orderbook = ?",
+    )
+    .bind(evm_ctx.orderbook.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(|(last_processed_block,)| u64::try_from(last_processed_block))
+        .transpose()
+        .map_err(OnChainError::IntConversion)
+}
+
+async fn save_backfill_checkpoint(
+    pool: &SqlitePool,
+    evm_ctx: &EvmCtx,
+    last_processed_block: u64,
+) -> Result<(), OnChainError> {
+    let last_processed_block = i64::try_from(last_processed_block)?;
+
+    sqlx::query(
+        "INSERT INTO backfill_checkpoints (orderbook, last_processed_block) \
+         VALUES (?, ?) \
+         ON CONFLICT(orderbook) DO UPDATE SET \
+         last_processed_block = MAX( \
+             excluded.last_processed_block, \
+             backfill_checkpoints.last_processed_block \
+         ), \
+         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+    )
+    .bind(evm_ctx.orderbook.to_string())
+    .bind(last_processed_block)
+    .execute(pool)
+    .await?;
 
     Ok(())
 }
@@ -241,6 +294,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_backfill_start_block_uses_deployment_block_without_checkpoint() {
+        let pool = setup_test_db().await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 50,
+        };
+
+        let start_block = backfill_start_block(&pool, &evm_ctx).await.unwrap();
+
+        assert_eq!(start_block, 50);
+    }
+
+    #[tokio::test]
+    async fn test_backfill_start_block_resumes_after_checkpoint() {
+        let pool = setup_test_db().await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 50,
+        };
+
+        save_backfill_checkpoint(&pool, &evm_ctx, 80).await.unwrap();
+
+        let start_block = backfill_start_block(&pool, &evm_ctx).await.unwrap();
+
+        assert_eq!(start_block, 81);
+    }
+
+    #[tokio::test]
+    async fn test_backfill_start_block_respects_deployment_block_floor() {
+        let pool = setup_test_db().await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 50,
+        };
+
+        save_backfill_checkpoint(&pool, &evm_ctx, 20).await.unwrap();
+
+        let start_block = backfill_start_block(&pool, &evm_ctx).await.unwrap();
+
+        assert_eq!(start_block, 50);
+    }
+
+    #[tokio::test]
     async fn test_backfill_events_empty_results() {
         let pool = setup_test_db().await;
         let job_queue = setup_job_queue(&pool).await;
@@ -256,11 +355,111 @@ mod tests {
             deployment_block: 1,
         };
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            Some(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backfill_events_skips_when_checkpoint_is_caught_up() {
+        let pool = setup_test_db().await;
+        let job_queue = setup_job_queue(&pool).await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+        };
+
+        save_backfill_checkpoint(&pool, &evm_ctx, 100)
             .await
             .unwrap();
 
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
         assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            Some(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backfill_events_skip_preserves_newer_checkpoint() {
+        let pool = setup_test_db().await;
+        let job_queue = setup_job_queue(&pool).await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+        };
+
+        save_backfill_checkpoint(&pool, &evm_ctx, 100)
+            .await
+            .unwrap();
+
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            99,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            Some(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_save_backfill_checkpoint_is_monotonic() {
+        let pool = setup_test_db().await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+        };
+
+        save_backfill_checkpoint(&pool, &evm_ctx, 100)
+            .await
+            .unwrap();
+        save_backfill_checkpoint(&pool, &evm_ctx, 80).await.unwrap();
+
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            Some(100)
+        );
     }
 
     #[test]
@@ -408,9 +607,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 1);
     }
@@ -466,9 +672,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 1);
     }
@@ -555,9 +768,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 2);
     }
@@ -584,10 +804,21 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let result =
-            backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue).await;
+        let result = backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await;
 
         assert!(matches!(result.unwrap_err(), OnChainError::RpcTransport(_)));
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -606,9 +837,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 0);
     }
@@ -696,9 +934,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 2);
     }
@@ -725,9 +970,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 2500, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            2500,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 0);
     }
@@ -757,6 +1009,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            &pool,
             1900,
             get_backfill_retry_strat(),
             job_queue,
@@ -830,6 +1083,7 @@ mod tests {
         backfill_events(
             &provider,
             &evm_ctx,
+            &pool,
             3000,
             get_backfill_retry_strat(),
             job_queue,
@@ -881,9 +1135,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         // Both events should be enqueued (filtering happens during processing, not backfill)
         assert_eq!(job_count(&pool).await, 2);
@@ -951,9 +1212,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 2);
     }
@@ -1024,6 +1292,10 @@ mod tests {
         .await;
 
         assert!(matches!(result.unwrap_err(), OnChainError::RpcTransport(_)));
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -1054,10 +1326,21 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let result =
-            backfill_events(&provider, &evm_ctx, 25000, test_retry_strategy(), job_queue).await;
+        let result = backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            25000,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await;
 
         assert!(matches!(result.unwrap_err(), OnChainError::RpcTransport(_)));
+        assert_eq!(
+            load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
@@ -1095,9 +1378,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         // Corrupted logs are silently ignored during backfill
         assert_eq!(job_count(&pool).await, 0);
@@ -1119,9 +1409,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 42, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            42,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 0);
     }
@@ -1297,9 +1594,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 3000, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            3000,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 1);
     }
@@ -1357,9 +1661,16 @@ mod tests {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 50, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            50,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 0);
     }
@@ -1456,9 +1767,16 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        backfill_events(&provider, &evm_ctx, 100, test_retry_strategy(), job_queue)
-            .await
-            .unwrap();
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(job_count(&pool).await, 0);
     }


### PR DESCRIPTION
## What

[RAI-220](https://linear.app/makeitrain/issue/RAI-220/checkpoint-backfill-progress-clean-up-apalis-jobs-and-rate-limit)

Closes RAI-220

Persist historical backfill progress, periodically clean up terminal apalis job rows, and
bound service restart loops so crashes do not cause repeated full backfills or unbounded
SQLite growth.

## Why

The conductor always backfilled from `deployment_block` on startup. After a crash or
restart, that meant the service re-scanned the same historical range and re-enqueued
already-seen work, relying on downstream idempotency to absorb duplicates.

Apalis job rows are queue bookkeeping, not audit history. Leaving completed, killed, or
terminally failed rows around lets the queue table grow without bound during normal
operation and repeated restarts.

The deployed service also used an aggressive `Restart=always` loop with a short delay
and no explicit burst limit, which can amplify startup failures into repeated RPC
consumption.

## How

- **Backfill checkpoints** (`src/onchain/backfill.rs`, migration) — added
  `backfill_checkpoints` keyed by orderbook. Backfill now resumes from
  `checkpoint + 1`, falls back to `deployment_block` only when no checkpoint exists,
  and advances the checkpoint only after the full requested range is enqueued
  successfully.
- **Apalis job cleanup** (`src/conductor/job.rs`, `src/conductor.rs`) — added cleanup
  for terminal job rows (`Done`, `Killed`, and exhausted `Failed`) followed by SQLite
  `VACUUM`.
- **Explicit cleanup cadence config** (`src/config.rs`, repo TOMLs) — added required
  `apalis_finished_job_cleanup_interval_secs`. Missing config fails TOML parsing;
  zero fails startup validation. No production default or fallback is used.
- **Conductor lifecycle wiring** (`src/conductor.rs`, `src/conductor/builder.rs`) — the
  cleanup task is spawned with the configured interval, included in
  `wait_for_completion`, and aborted with the rest of the conductor.
- **Deployment restart limits** (`os.nix`) — increased restart delay to 30s and added
  systemd start-limit settings to stop runaway restart loops.
- **Docs/spec** (`SPEC.md`, `docs/conductor.md`, `README.md`) — documented
  checkpointing, cleanup behavior, and the required cleanup interval config.

## Testing

Added coverage for:
- Backfill start block selection with and without checkpoints.
- Checkpoint persistence after successful backfill.
- No checkpoint advancement after partial batch failure.
- Skipping backfill when the checkpoint is already caught up.
- Terminal apalis job cleanup SQL behavior.
- Required/non-zero `apalis_finished_job_cleanup_interval_secs` config validation.
- Cleanup task spawn, abort, completion selection, and failure propagation through
  conductor lifecycle.

Validation run:

- `nix develop -c cargo check --workspace`
- `nix develop -c cargo nextest run --workspace --all-features`
  - 1616 passed, 3 skipped; nextest reported 1 leaky existing `rain-math-float` test
    and exited successfully.
- `nix develop -c cargo clippy --workspace --all-targets --all-features`
- `nix develop -c cargo fmt`
- `git --no-pager diff --check`

## Screenshots

N/A

## Anything else

This intentionally makes `apalis_finished_job_cleanup_interval_secs` required config.
Checked-in config files were updated, but any external operator config must add the
field before deploying this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backfill now resumes from persisted checkpoints instead of always starting from deployment block, preventing reprocessing of historical data.
  * Automatic periodic cleanup of finished jobs to manage queue storage.

* **Configuration**
  * New required configuration parameter: `apalis_finished_job_cleanup_interval_secs` (must be set to a non-zero value).

* **Documentation**
  * Updated operational constraints and startup sequencing documentation.

* **Infrastructure**
  * Enhanced systemd service restart rate limiting and increased restart delay for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->