### PR TITLE
feat: enable counter trading for 8 prod assets

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -42,19 +42,19 @@ tokenized_equity = "0x8fdf41116f755771bfe0747d5f8c3711d5debfbb"
 tokenized_equity_derivative = "0x31c2c14134e6e3b7ef9478297f199331133fc2d8"
 
 [assets.equities.TSLA]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x4e169cd2ab4f82640a8c65c68fed55863866fdb0"
 tokenized_equity_derivative = "0x219a8d384a10bf19b9f24cb5cc53f79dd0e5a03d"
 
 [assets.equities.AMZN]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x466cb2e46fa1afc0ab5e22274b34d0391db18efd"
 tokenized_equity_derivative = "0x997bae3ec193a249596d3708c3fab7c501bb8a53"
 
 [assets.equities.NVDA]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x7271a3c91bb6070ed09333b84a815949d4f16d14"
 tokenized_equity_derivative = "0xfb5b41acdba20a3230f84be995173cfb98b8d6e7"
@@ -72,7 +72,7 @@ tokenized_equity = "0x4a9a9fc94a507559481270d0bff3315ab92fcefa"
 tokenized_equity_derivative = "0x849e389982209f901b7b9ffca57ae4c9eeb11c0d"
 
 [assets.equities.IAU]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x9a507314ea2a6c5686c0d07bfecb764dcf324dff"
 tokenized_equity_derivative = "0x1e46d7efef64a833afb1cd49299a7ad5b439f4d8"
@@ -84,25 +84,25 @@ tokenized_equity = "0x626757e6f50675d17fcad312e82f989ae7a23d38"
 tokenized_equity_derivative = "0x5cda0e1ca4ce2af96315f7f8963c85399c172204"
 
 [assets.equities.SIVR]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x58ce5024b89b4f73c27814c0f0abbea331c99be8"
 tokenized_equity_derivative = "0xeb7f3e4093c9d68253b6104fbbff561f3ec0442f"
 
 [assets.equities.CRCL]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x38eb797892ed71da69bdc27a456a7c83ff813b52"
 tokenized_equity_derivative = "0x8afba81dec38de0a18e2df5e1967a7493651eebf"
 
 [assets.equities.PPLT]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0x1f17523b147ccc2a2328c0f014f6d49c479ea063"
 tokenized_equity_derivative = "0x82f5baee1076334357a34a19e04f7c282d51ce47"
 
 [assets.equities.BMNR]
-trading = "disabled"
+trading = "enabled"
 rebalancing = "disabled"
 tokenized_equity = "0xfbde45df60249203b12148452fc77c3b5f811eb2"
 tokenized_equity_derivative = "0x02512ec661f0ba89c275ea105e31bad6fcfcf319"


### PR DESCRIPTION
## What

Closes [RAI-171](https://linear.app/makeitrain/issue/RAI-171/enable-all-needed-assets-on-prod-for-hedging)

Enable counter trading for 8 assets in the production config.

## Why

These assets are ready for hedged trading in production. Enabling counter trading allows the system to execute offsetting broker trades when onchain order events occur, reducing directional exposure.

## How

Set `trading = "enabled"` in `config/prod/st0x-hedge.toml` for:

- **TSLA**, **AMZN**, **NVDA** — large-cap equities
- **IAU**, **SIVR**, **PPLT** — precious metal ETFs
- **CRCL**, **BMNR** — additional equities

The remaining 5 assets (RKLB, SPYM, MSTR, QSEP, COIN) stay with `trading = "disabled"`.

## Testing

No new tests — config-only change. The existing pre-deploy config validation (`af4f2b58`) will catch any parse errors at deploy time.

## Anything else

Rebalancing remains disabled for all assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trading is now enabled for TSLA, AMZN, NVDA, IAU, SIVR, CRCL, PPLT, and BMNR equities.
  * Rebalancing for these equities remains disabled; existing tokenized asset configurations are unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->