### PR TITLE
ci: move CI to Blacksmith 4-vCPU runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,15 +9,39 @@ permissions:
   contents: read
 
 jobs:
-  backend:
+  backend-validation:
+    name: backend ${{ matrix.name }}
     concurrency:
-      group: ${{ github.ref }}-backend
+      group: ${{ github.ref }}-backend-${{ matrix.name }}
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: check
+            command: nix develop -c cargo check --workspace
+          - name: test 1 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:1/4
+          - name: test 2 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:2/4
+          - name: test 3 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:3/4
+          - name: test 4 of 4
+            command: >
+              nix develop -c cargo nextest run --workspace --all-features
+              --profile ci --partition hash:4/4
+          - name: clippy
+            command: >
+              nix develop -c cargo clippy --workspace --all-targets
+              --all-features -- -D clippy::all -D warnings
     steps:
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
-
       - uses: actions/checkout@v4
 
       - name: Compute submodule cache key
@@ -64,24 +88,27 @@ jobs:
       - name: Setup database
         run: nix develop -c sqlx db reset -y
 
-      - name: Validate standalone build
-        run: nix develop -c cargo check --workspace
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
 
-      - name: Test
+  backend:
+    name: backend
+    needs: backend-validation
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check backend validation
         run: |
-          nix develop -c cargo nextest run \
-            --workspace --all-features --profile ci
-
-      - name: Clippy
-        run: |
-          nix develop -c cargo clippy \
-            --workspace --all-targets --all-features
+          if [ "${{ needs.backend-validation.result }}" != "success" ]; then
+            echo "backend validation failed"
+            exit 1
+          fi
 
   dashboard:
     concurrency:
       group: ${{ github.ref }}-dashboard
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -136,7 +163,7 @@ jobs:
     concurrency:
       group: ${{ github.ref }}-flake
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What

Supersedes the runner-only slice of #591.

Move the CI workflow onto Blacksmith 4-vCPU runners:

- Split backend validation into a `backend-validation` matrix for `cargo check`, four `nextest` shards, and `clippy`.
- Keep a tiny `backend` aggregate job so the existing backend gate still reflects all backend validation jobs.
- Move the dashboard and hooks jobs to `blacksmith-4vcpu-ubuntu-2404`.

## Why

This is the clean base for the Blacksmith CI stack. It isolates the runner migration and backend parallelization from the explicit cache optimizations in the next PR, so CI timing and review are easier to reason about.

## How

- Backend validation now runs as independent matrix jobs on Blacksmith.
- The aggregate `backend` job checks the matrix result and preserves the expected required-check surface.
- Dashboard and hooks use the same Blacksmith 4-vCPU runner class.

## Testing

- `git diff --check master...blacksmith-other-workflows`
- Ruby `YAML.load_file` for `.github/workflows/ci.yaml`, `deploy-prod.yaml`, `deploy-staging.yaml`, and `rekey.yaml`
- Commit hook: `yamlfmt` passed

## Screenshots

N/A

## Anything else

Stack order:

1. #596 - CI Blacksmith 4-vCPU runner baseline
2. #597 - CI cache optimizations
3. #598 - remaining workflow migration and caches

`actionlint` was not available on the host or in `nix develop`, so validation is limited to YAML parsing and formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend validation and testing infrastructure with optimized build processes and updated system runners for enhanced efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->