### PR TITLE
Optimize CI cache setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,32 +21,38 @@ jobs:
         include:
           - name: check
             cache_target: check
-            command: nix develop -c cargo check --workspace
+            needs_database: false
+            command: nix develop -c env SQLX_OFFLINE=true cargo check --workspace
           - name: test 1 of 4
             cache_target: test
+            needs_database: true
             command: >
               nix develop -c cargo nextest run --workspace --all-features
               --profile ci --partition hash:1/4
           - name: test 2 of 4
             cache_target: test
+            needs_database: true
             command: >
               nix develop -c cargo nextest run --workspace --all-features
               --profile ci --partition hash:2/4
           - name: test 3 of 4
             cache_target: test
+            needs_database: true
             command: >
               nix develop -c cargo nextest run --workspace --all-features
               --profile ci --partition hash:3/4
           - name: test 4 of 4
             cache_target: test
+            needs_database: true
             command: >
               nix develop -c cargo nextest run --workspace --all-features
               --profile ci --partition hash:4/4
           - name: clippy
             cache_target: clippy
+            needs_database: false
             command: >
-              nix develop -c cargo clippy --workspace --all-targets
-              --all-features
+              nix develop -c env SQLX_OFFLINE=true cargo clippy --workspace
+              --all-targets --all-features
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_TARGET_DIR: target/${{ matrix.cache_target }}
@@ -115,6 +121,7 @@ jobs:
             cargo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_target }}-
 
       - name: Setup database
+        if: matrix.needs_database
         run: nix develop -c sqlx db reset -y
 
       - name: ${{ matrix.name }}
@@ -173,6 +180,8 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Cache Solidity artifacts
         id: cache-sol
@@ -237,6 +246,8 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: pre-commit hooks
         run: nix develop -c pre-commit run --all-files


### PR DESCRIPTION
## What

Tighten the CI workflow as a small timing experiment:

- add Magic Nix Cache to the dashboard and hooks jobs
- skip SQLite reset for backend check/clippy jobs
- run backend check/clippy with `SQLX_OFFLINE=true`
- leave test jobs on the existing database reset path

## Why

Recent CI runs are faster after the Blacksmith migration, but timing still varies. The linked slow run spent most of its time in dashboard Nix/Bun setup, and warmed backend runs still spend roughly 2m40s per backend matrix job resetting SQLite before validation starts.

## How

The backend matrix now declares whether each entry needs a database. Test partitions keep `needs_database: true`; check and clippy use SQLx offline metadata instead. Dashboard and hooks now use the same Magic Nix Cache action already used by backend jobs.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yaml"); puts "yaml ok"'`
- `git --no-pager diff --check`
- `nix develop -c env SQLX_OFFLINE=true cargo check --workspace`
- `nix develop -c pre-commit run --files .github/workflows/ci.yaml`

## Screenshots

N/A

## Anything else

This is intentionally incremental so we can compare CI timing on Blacksmith runners before making larger workflow restructuring changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve build efficiency with conditional database setup and enhanced caching across jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->