### PR TITLE
Reduce deploy cache upload cleanup

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -74,6 +74,8 @@ jobs:
             fallback = true
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -61,6 +61,8 @@ jobs:
             fallback = true
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -49,6 +49,8 @@ jobs:
             fallback = true
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        with:
+          use-gha-cache: false
 
       - name: Setup SSH key
         run: |


### PR DESCRIPTION
## What

Disable GitHub Actions cache uploads for Magic Nix Cache in operational workflows:

- `.github/workflows/deploy-prod.yaml`
- `.github/workflows/deploy-staging.yaml`
- `.github/workflows/rekey.yaml`

## Why

Recent deploy runs after the Blacksmith migration still spend a noticeable amount of time after the deploy step finishes. The run data showed Magic Nix Cache post-job cleanup taking about 3m12s on production deploy run `24867618939` and about 6m53s on staging deploy run `24857730808`.

These workflows should consume caches, not pay the upload cost for populating GitHub Actions cache at the end of deploy/rekey jobs.

## How

Set `use-gha-cache: false` on `DeterminateSystems/magic-nix-cache-action@main` for deploy and rekey workflows. The action still runs as the local Nix cache proxy with the configured upstream cache, but it skips uploading build results into GitHub Actions cache during post-job cleanup.

## Testing

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml ok"' .github/workflows/deploy-prod.yaml .github/workflows/deploy-staging.yaml .github/workflows/rekey.yaml`
- `git --no-pager diff --check`
- `nix develop -c pre-commit run --files .github/workflows/deploy-prod.yaml .github/workflows/deploy-staging.yaml .github/workflows/rekey.yaml`

## Screenshots

N/A

## Anything else

Stacked on #599.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->
