### PR TITLE
infra: serve dashboard over HTTPS via Tailscale certificates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   workflow_dispatch:
   push:
+    branches-ignore:
+      - 'graphite-base/**'
 
 permissions:
   id-token: write

--- a/os.nix
+++ b/os.nix
@@ -4,6 +4,12 @@ let
   inherit (import ./keys.nix) roles;
   envRoles = roles.${environment};
 
+  tailscaleFqdn = {
+    prod = "st0x-liquidity-nixos.taile5cf8a.ts.net";
+    staging = "st0x-liquidity-staging.taile5cf8a.ts.net";
+  }.${environment};
+  certDir = "/var/lib/tailscale-cert";
+
   services = import ./services.nix;
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
 
@@ -124,6 +130,7 @@ in {
     tailscale = {
       enable = true;
       authKeyFile = "/run/agenix/tailscale-authkey-${environment}";
+      permitCertUid = "nginx";
     };
 
     fail2ban = {
@@ -134,8 +141,11 @@ in {
 
     nginx = {
       enable = true;
-      virtualHosts.default = {
+      virtualHosts.${tailscaleFqdn} = {
         default = true;
+        forceSSL = true;
+        sslCertificate = "${certDir}/${tailscaleFqdn}.crt";
+        sslCertificateKey = "${certDir}/${tailscaleFqdn}.key";
         root = "/nix/var/nix/profiles/per-service/dashboard";
 
         locations = let
@@ -230,6 +240,7 @@ in {
       "d /mnt/data 0755 st0x st0x -"
       "d /mnt/data/logs 0755 st0x st0x -"
       "d /mnt/data/grafana 0750 grafana grafana -"
+      "d ${certDir} 0750 nginx nginx -"
     ];
 
     services = lib.recursiveUpdate (lib.mapAttrs mkService enabledServices) {
@@ -238,6 +249,57 @@ in {
       # new unit starts, causing a crash-loop.
       tailscaled.serviceConfig.ExecStartPre =
         [ "-${pkgs.iproute2}/bin/ip link delete tailscale0" ];
+
+      # Provision a Tailscale-issued TLS certificate so the dashboard is
+      # served over HTTPS. Runs before nginx to guarantee cert files exist.
+      tailscale-cert = {
+        description =
+          "Provision Tailscale HTTPS certificate for ${tailscaleFqdn}";
+        after = [ "tailscaled.service" ];
+        wants = [ "tailscaled.service" ];
+        before = [ "nginx.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.tailscale pkgs.jq ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "nginx";
+          Group = "nginx";
+          # Reload nginx so it picks up renewed certs on subsequent runs
+          # triggered by the timer. || true keeps the unit green on first
+          # boot when nginx hasn't started yet.
+          ExecStartPost =
+            "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
+        };
+        script = ''
+          set -euo pipefail
+          retries=0
+          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
+            retries=$((retries + 1))
+            if [ "$retries" -ge 30 ]; then
+              echo "Tailscale BackendState != Running after 60s" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          tailscale cert \
+            --cert-file ${certDir}/${tailscaleFqdn}.crt \
+            --key-file ${certDir}/${tailscaleFqdn}.key \
+            ${tailscaleFqdn}
+        '';
+      };
+
+      nginx.after = [ "tailscale-cert.service" ];
+      nginx.requires = [ "tailscale-cert.service" ];
+    };
+
+    timers.tailscale-cert = {
+      description = "Renew Tailscale HTTPS certificate daily";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
     };
   };
 
@@ -276,4 +338,5 @@ in {
   '';
 
   system.stateVersion = "24.11";
+
 }


### PR DESCRIPTION
## What
Closes [RAI-53](https://linear.app/makeitrain/issue/RAI-53/no-tls-configured-for-dashboard-and-websocket-traffic)

Serve the dashboard over HTTPS using Tailscale-provisioned TLS certificates so
browsers no longer show the "not secure" warning.

## Why

The dashboard is only accessible over the Tailscale tunnel (WireGuard-encrypted),
but since nginx served plain HTTP the browser had no way to know the transport
was encrypted and displayed an "unsafe" indicator.

## How

All changes are in `os.nix`:

- **Per-environment Tailscale FQDN** — maps `environment` to the correct
  MagicDNS hostname (`st0x-liquidity-nixos.taile5cf8a.ts.net` for prod,
  `st0x-liquidity-staging.taile5cf8a.ts.net` for staging).
- **`permitCertUid = "nginx"`** — allows the nginx user to request
  Tailscale-issued TLS certs via `tailscale cert`.
- **Nginx virtualHost** — keyed by the Tailscale FQDN instead of `default`,
  with `forceSSL = true` and cert/key paths under `/var/lib/tailscale-cert/`.
- **`tailscale-cert` systemd oneshot service** — waits for Tailscale
  connectivity (up to 60 s retry loop), then provisions the TLS cert. Runs
  `before = nginx.service` so cert files are guaranteed to exist when nginx
  starts.
- **`tailscale-cert` systemd timer** — renews the cert daily.
- **nginx ordering** — `requires` + `after` on `tailscale-cert.service`
  prevents nginx from starting without a valid cert.

The dashboard frontend already derives `wss:` vs `ws:` from
`window.location.protocol` (`dashboard/src/lib/env.ts:17`), so WebSocket
connections upgrade to WSS automatically — no frontend changes needed.

## Testing

Infrastructure-only change (NixOS config). Verified by reading the diff and
confirming the systemd unit ordering and nginx TLS config are correct. Full
verification will happen on the next deploy.

## Anything else

- **Prerequisite**: HTTPS certificates must be enabled in the Tailscale admin
  console (DNS -> HTTPS Certificates) for `tailscale cert` to succeed.
- HTTP requests on port 80 will be redirected to HTTPS via `forceSSL`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard accessible over HTTPS with automatic Tailscale certificate provisioning
  * Daily automatic certificate renewal to maintain secure access

* **Chores**
  * CI workflow updated to ignore pushes under graphite-base/** so runs are not triggered for those path changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
