### PR TITLE
feat: add Orders tab to dashboard showing Raindex vault balances

### DIFF
--- a/dashboard/src/lib/components/orders-panel.svelte
+++ b/dashboard/src/lib/components/orders-panel.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import * as Card from '$lib/components/ui/card'
+  import { reactive } from '$lib/frp.svelte'
+  import { getApiBaseUrl } from '$lib/env'
+  /** The REST API proxies an on-chain query that can be slow. */
+  const ORDERS_TIMEOUT_MS = 30_000
+  import { formatDecimal, formatTimestamp } from '$lib/format'
+
+  type TokenRef = {
+    address: string
+    symbol: string
+    decimals: number
+  }
+
+  type OrderSummary = {
+    orderHash: string
+    owner: string
+    inputToken: TokenRef
+    outputToken: TokenRef
+    outputVaultBalance: string
+    ioRatio: string
+    createdAt: number
+    orderbookId: string
+  }
+
+  type OrdersListResponse = {
+    orders: OrderSummary[]
+    pagination: {
+      page: number
+      pageSize: number
+      totalOrders: number
+      totalPages: number
+      hasMore: boolean
+    }
+  }
+
+  type UnavailableResponse = {
+    unavailable: true
+    reason: string
+  }
+
+  type ApiResponse = OrdersListResponse | UnavailableResponse
+
+  const isUnavailable = (response: ApiResponse): response is UnavailableResponse =>
+    'unavailable' in response && response.unavailable
+
+  const CACHE_KEY = 'orders-panel-cache'
+
+  const loadCache = (): ApiResponse | null => {
+    try {
+      const raw = sessionStorage.getItem(CACHE_KEY)
+      return raw ? (JSON.parse(raw) as ApiResponse) : null
+    } catch {
+      return null
+    }
+  }
+
+  const saveCache = (response: ApiResponse) => {
+    try {
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify(response))
+    } catch { /* quota exceeded — not critical */ }
+  }
+
+  const data = reactive<ApiResponse | null>(loadCache())
+  const loading = reactive(false)
+  const error = reactive<string | null>(null)
+
+  const fetchOrders = async () => {
+    loading.update(() => true)
+    error.update(() => null)
+
+    try {
+      const baseUrl = getApiBaseUrl()
+      const response = await fetch(
+        `${baseUrl}/orders/raindex`,
+        { signal: AbortSignal.timeout(ORDERS_TIMEOUT_MS) },
+      )
+
+      if (!response.ok) {
+        error.update(() => `HTTP ${String(response.status)}`)
+        return
+      }
+
+      const result: unknown = await response.json()
+
+      if (typeof result === 'object' && result !== null && 'unavailable' in result) {
+        data.update(() => result as UnavailableResponse)
+        return
+      }
+
+      if (
+        typeof result !== 'object' ||
+        result === null ||
+        !('orders' in result) ||
+        !Array.isArray((result as OrdersListResponse).orders)
+      ) {
+        error.update(() => 'Unexpected response format from REST API')
+        return
+      }
+
+      const orders = result as OrdersListResponse
+      data.update(() => orders)
+      saveCache(orders)
+    } catch (fetchError) {
+      error.update(() =>
+        fetchError instanceof Error ? fetchError.message : 'Unknown error',
+      )
+    } finally {
+      loading.update(() => false)
+    }
+  }
+
+  onMount(() => {
+    void fetchOrders()
+  })
+
+
+</script>
+
+<Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-violet-500/50">
+  <Card.Header class="shrink-0 pb-2">
+    <Card.Title class="flex items-center justify-between">
+      <span class="flex items-center gap-1.5">
+        Raindex Orders
+        <span class="group relative cursor-help text-muted-foreground">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
+          <span class="pointer-events-none absolute left-0 top-full z-50 mt-1 hidden w-72 rounded bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg group-hover:block">
+            Active onchain orders on the Raindex orderbook owned by the bot wallet.
+            <strong>Output</strong> is the token the order offers (leaves the vault when taken).
+            <strong>Input</strong> is the token received in exchange.
+            <strong>Vault Balance</strong> is the output token amount currently available.
+            <strong>IO Ratio</strong> is the current price (output per input).
+          </span>
+        </span>
+      </span>
+
+      <div class="flex items-center gap-2">
+        {#if data.current && !isUnavailable(data.current)}
+          <span class="text-xs text-muted-foreground">
+            {data.current.orders.length} of {data.current.pagination.totalOrders}
+          </span>
+        {/if}
+
+        <button
+          class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+          onclick={() => { void fetchOrders() }}
+          disabled={loading.current}
+        >
+          {loading.current ? 'Loading...' : 'Refresh'}
+        </button>
+      </div>
+    </Card.Title>
+  </Card.Header>
+
+  <Card.Content class="relative min-h-0 flex-1 overflow-auto px-4 pt-0">
+    {#if error.current && data.current}
+      <div class="mb-2 rounded border border-destructive bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+        Refresh failed: {error.current}
+      </div>
+    {/if}
+
+    {#if error.current && !data.current}
+      <div class="flex h-full items-center justify-center text-destructive">
+        Failed to load orders: {error.current}
+      </div>
+    {:else if !data.current && loading.current}
+      <div class="flex h-full items-center justify-center text-muted-foreground">
+        Loading...
+      </div>
+    {:else if data.current && isUnavailable(data.current)}
+      <div class="flex h-full items-center justify-center text-muted-foreground">
+        {data.current.reason}
+      </div>
+    {:else if data.current && !isUnavailable(data.current)}
+      {#if data.current.orders.length === 0}
+        <div class="flex h-full items-center justify-center text-muted-foreground">
+          No active orders found for this owner.
+        </div>
+      {:else}
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b text-left text-xs text-muted-foreground">
+              <th class="pb-2 pr-4 font-medium">Output</th>
+              <th class="pb-2 pr-4 font-medium">Input</th>
+              <th class="pb-2 pr-4 text-right font-medium">Vault Balance</th>
+              <th class="pb-2 pr-4 text-right font-medium">IO Ratio</th>
+              <th class="pb-2 pr-4 font-medium">Order Hash</th>
+              <th class="pb-2 font-medium">Created</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {#each data.current.orders as order (order.orderHash)}
+              <tr class="border-b border-border/30 hover:bg-accent/30">
+                <td class="py-2 pr-4 font-medium">{order.outputToken.symbol}</td>
+
+                <td class="py-2 pr-4 font-medium">{order.inputToken.symbol}</td>
+
+                <td class="py-2 pr-4 text-right font-mono">
+                  {formatDecimal(order.outputVaultBalance)}
+                </td>
+
+                <td class="py-2 pr-4 text-right font-mono">
+                  {formatDecimal(order.ioRatio)}
+                </td>
+
+                <td class="py-2 pr-4">
+                  <span class="font-mono text-xs text-muted-foreground break-all">
+                    {order.orderHash}
+                  </span>
+                </td>
+
+                <td class="py-2 text-xs text-muted-foreground">
+                  {formatTimestamp(order.createdAt)}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    {:else}
+      <div class="flex h-full items-center justify-center text-muted-foreground">
+        No order data available.
+      </div>
+    {/if}
+  </Card.Content>
+</Card.Root>

--- a/dashboard/src/lib/format.test.ts
+++ b/dashboard/src/lib/format.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { formatBalance, formatDecimal, formatTimestamp } from './format'
+
+describe('formatBalance', () => {
+  it('returns "0" for empty string', () => {
+    expect(formatBalance('', 6)).toBe('0')
+  })
+
+  it('returns "0" for zero', () => {
+    expect(formatBalance('0', 18)).toBe('0')
+  })
+
+  it('formats a normal value with 6 decimals', () => {
+    expect(formatBalance('1500000', 6)).toBe('1.5')
+  })
+
+  it('formats a normal value with 18 decimals', () => {
+    expect(formatBalance('500000000000000000000', 18)).toBe('500')
+  })
+
+  it('handles values shorter than decimals', () => {
+    expect(formatBalance('500', 6)).toBe('0.0005')
+  })
+
+  it('handles decimals = 0', () => {
+    expect(formatBalance('12345', 0)).toBe('12345')
+  })
+
+  it('trims trailing zeros', () => {
+    expect(formatBalance('1000000', 6)).toBe('1')
+  })
+
+  it('preserves significant fractional digits', () => {
+    expect(formatBalance('1234567', 6)).toBe('1.234567')
+  })
+
+  it('handles large values', () => {
+    expect(formatBalance('100000000000000000000000', 18)).toBe('100000')
+  })
+})
+
+describe('formatDecimal', () => {
+  it('returns "0" for empty or zero', () => {
+    expect(formatDecimal('')).toBe('0')
+    expect(formatDecimal('0')).toBe('0')
+  })
+
+  it('returns non-numeric strings as-is', () => {
+    expect(formatDecimal('abc')).toBe('abc')
+  })
+
+  it('trims excessive decimals on values >= 1', () => {
+    expect(formatDecimal('1993.82413955615987854')).toBe('1993.82414')
+  })
+
+  it('trims trailing zeros', () => {
+    expect(formatDecimal('100.500000')).toBe('100.5')
+  })
+
+  it('handles integers', () => {
+    expect(formatDecimal('42')).toBe('42')
+  })
+
+  it('preserves significant digits for tiny values', () => {
+    expect(formatDecimal('0.00000000000010996')).toBe('1.0996e-13')
+  })
+
+  it('formats normal small values', () => {
+    expect(formatDecimal('0.123456789')).toBe('0.123457')
+  })
+
+  it('handles IO ratio style values', () => {
+    expect(formatDecimal('180.79830445')).toBe('180.798304')
+    expect(formatDecimal('0.5')).toBe('0.5')
+  })
+})
+
+describe('formatTimestamp', () => {
+  it('returns "-" for epoch 0', () => {
+    expect(formatTimestamp(0)).toBe('-')
+  })
+
+  it('formats a known epoch', () => {
+    expect(formatTimestamp(1718452800)).toBe('2024-06-15 12:00:00')
+  })
+})

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -1,0 +1,46 @@
+/// Converts a raw integer token amount string to a human-readable decimal.
+/// For example, formatBalance("1500000", 6) returns "1.5".
+export const formatBalance = (raw: string, decimals: number): string => {
+  if (!raw || raw === '0') return '0'
+
+  if (decimals === 0) return raw
+
+  const padded = raw.padStart(decimals + 1, '0')
+  const intPart = padded.slice(0, padded.length - decimals) || '0'
+  const fracPart = padded.slice(padded.length - decimals)
+
+  const trimmed = fracPart.replace(/0+$/, '')
+  return trimmed ? `${intPart}.${trimmed}` : intPart
+}
+
+/// Formats a decimal string for display by rounding to a sensible number
+/// of significant digits. Handles values the upstream API returns as
+/// pre-formatted decimals (e.g. "10.996", "1993.824…").
+///
+/// Rules:
+///  - Values >= 1: show up to 6 decimal places, trim trailing zeros.
+///  - Values < 1: preserve up to 6 significant digits after the leading zeros.
+///  - Non-numeric / empty: returned as-is.
+export const formatDecimal = (value: string): string => {
+  if (!value || value === '0') return '0'
+
+  const num = Number(value)
+  if (Number.isNaN(num)) return value
+
+  if (num === 0) return '0'
+
+  // For values >= 1, fixed 6 decimal places is plenty.
+  if (Math.abs(num) >= 1) {
+    return parseFloat(num.toFixed(6)).toString()
+  }
+
+  // For tiny values (< 1), toFixed(6) would round to "0.000000".
+  // Use toPrecision to keep 6 significant digits instead.
+  return parseFloat(num.toPrecision(6)).toString()
+}
+
+/// Formats a Unix epoch timestamp (seconds) to a UTC datetime string.
+export const formatTimestamp = (epoch: number): string => {
+  if (epoch === 0) return '-'
+  return new Date(epoch * 1000).toISOString().slice(0, 19).replace('T', ' ')
+}

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   import TradeHistoryPanel from '$lib/components/trade-history-panel.svelte'
   import TransferPanel from '$lib/components/transfer-panel.svelte'
   import LogPanel from '$lib/components/log-panel.svelte'
+  import OrdersPanel from '$lib/components/orders-panel.svelte'
   import { getWebSocketUrl } from '$lib/env'
   import { reactive } from '$lib/frp.svelte'
   import { createWebSocket, type WebSocketConnection } from '$lib/websocket'
@@ -43,7 +44,7 @@
     return () => { clearInterval(interval); }
   })
 
-  type Tab = 'dashboard' | 'logs'
+  type Tab = 'dashboard' | 'orders' | 'logs'
   type MobilePanel = 'inventory' | 'pending' | 'trades' | 'transfers'
 
   const activeTab = reactive<Tab>('dashboard')
@@ -80,6 +81,12 @@
       <button class={mobilePanelClass('transfers')} onclick={() => mobilePanel.update(() => 'transfers')}>Transfers</button>
     {/if}
     <button
+      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'orders' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => activeTab.update((tab) => tab === 'orders' ? 'dashboard' : 'orders')}
+    >
+      Orders
+    </button>
+    <button
       class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'logs' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
       onclick={() => activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs')}
     >
@@ -94,6 +101,13 @@
       onclick={() => activeTab.update(() => 'dashboard')}
     >
       Dashboard
+    </button>
+
+    <button
+      class={desktopTabClass(activeTab.current === 'orders')}
+      onclick={() => activeTab.update(() => 'orders')}
+    >
+      Orders
     </button>
 
     <button
@@ -131,6 +145,10 @@
         <TradeHistoryPanel />
         <TransferPanel />
       </div>
+    </main>
+  {:else if activeTab.current === 'orders'}
+    <main class="flex-1 overflow-hidden p-2 md:p-4">
+      <OrdersPanel />
     </main>
   {:else}
     <main class="flex-1 overflow-hidden p-2 md:p-4">

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -14,3 +14,6 @@ tokenized_equity_derivative = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 orderbook = "0x1111111111111111111111111111111111111111"
 order_owner = "0xcccccccccccccccccccccccccccccccccccccccc"
 deployment_block = 1
+
+[rest_api]
+url = "http://localhost:8099"

--- a/e2e/mock-rest-api.ts
+++ b/e2e/mock-rest-api.ts
@@ -1,0 +1,89 @@
+/// Mock st0x REST API for simulate mode.
+/// Returns fake Raindex order data so the Orders dashboard tab can be tested.
+
+const MOCK_ORDERS = {
+  orders: [
+    {
+      orderHash: "0xc24100a122c701de0627f745799829fdfc1cb85cab49d33dd06eb4be46852f94",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputToken: { address: "0xFF05E1bD696900dc6A52CA35Ca61Bb1024eDa8e2", symbol: "wtMSTR", decimals: 18 },
+      outputVaultBalance: "500000000000000000000",
+      ioRatio: "0.0027",
+      createdAt: 1718452800,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+    {
+      orderHash: "0xba760b0150cd36aad23755b230a47cc2a44975c83d1dc9f82645248fe1a32678",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0xFF05E1bD696900dc6A52CA35Ca61Bb1024eDa8e2", symbol: "wtMSTR", decimals: 18 },
+      outputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputVaultBalance: "15000000000",
+      ioRatio: "370.50",
+      createdAt: 1718452800,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+    {
+      orderHash: "0x97e83c4fbd18e6dd917385aabe5d051226dc62643bd689b6995668f124728296",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputToken: { address: "0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7", symbol: "wtNVDA", decimals: 18 },
+      outputVaultBalance: "3200000000000000000",
+      ioRatio: "0.0075",
+      createdAt: 1718539200,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+    {
+      orderHash: "0x572302e9377b43d44e897f1ba848066522952cea0a863017a9f5d6ce715b8e2d",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0xFb5B41acdbA20a3230F84BE995173CFb98b8D6E7", symbol: "wtNVDA", decimals: 18 },
+      outputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputVaultBalance: "8500000000",
+      ioRatio: "133.20",
+      createdAt: 1718539200,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+    {
+      orderHash: "0xabd966a604c6e67543cd27f79cb789e4cd057c02a779e496dace404a34a3c61b",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputToken: { address: "0x997baE3EC193a249596d3708C3fAB7C501Bb8a53", symbol: "wtAMZN", decimals: 18 },
+      outputVaultBalance: "1800000000000000000",
+      ioRatio: "0.0050",
+      createdAt: 1718625600,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+    {
+      orderHash: "0x54475d13b2783ba092b38dca9b09a4c96ade1d10aa94019c290aec7a3ca7376a",
+      owner: "0xcccccccccccccccccccccccccccccccccccccccc",
+      inputToken: { address: "0x997baE3EC193a249596d3708C3fAB7C501Bb8a53", symbol: "wtAMZN", decimals: 18 },
+      outputToken: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", symbol: "USDC", decimals: 6 },
+      outputVaultBalance: "5200000000",
+      ioRatio: "198.75",
+      createdAt: 1718625600,
+      orderbookId: "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+    },
+  ],
+  pagination: {
+    page: 1,
+    pageSize: 20,
+    totalOrders: 6,
+    totalPages: 1,
+    hasMore: false,
+  },
+};
+
+const server = Bun.serve({
+  port: 8099,
+  fetch(request: Request) {
+    const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/v1/orders/owner/")) {
+      return Response.json(MOCK_ORDERS);
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+});
+
+console.log(`Mock REST API listening on http://localhost:${server.port}`);

--- a/example.config.toml
+++ b/example.config.toml
@@ -56,3 +56,9 @@ rebalancing = "disabled"
 rebalancing = "enabled"
 # vault_id = "0xcd34"
 # operational_limit = 10000.0
+
+# Optional — enables the Orders dashboard tab by querying the st0x REST API.
+# When absent, the Orders tab shows "unavailable in simulate mode".
+# Credentials go in the secrets file under [rest_api].
+# [rest_api]
+# url = "https://api.example.com"

--- a/example.secrets.toml
+++ b/example.secrets.toml
@@ -20,3 +20,9 @@ private_key = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde
 # For kind = "turnkey" (in config), use instead:
 # [wallet]
 # api_private_key = "hex-encoded-p256-api-private-key"
+
+# Optional — REST API credentials for the Orders dashboard tab.
+# Only needed when [rest_api] is configured in the config file.
+# [rest_api]
+# key_id = "your-key-id"
+# key_secret = "your-key-secret"

--- a/flake.nix
+++ b/flake.nix
@@ -160,8 +160,10 @@
 
               dashboard = "cd dashboard && bun run dev";
 
+              mockApi = "bun run e2e/mock-rest-api.ts";
+
             in ''
-              exec mprocs "${backend}" "${dashboard}"
+              exec mprocs "${backend}" "${dashboard}" "${mockApi}"
             '';
           };
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,7 @@
 use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
+use rocket::response::content::RawJson;
 use rocket::serde::json::Json;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::{Route, State, get, routes};
@@ -703,8 +704,71 @@ async fn load_transfer_summary(
         .collect()
 }
 
+fn unavailable_json(reason: &str) -> RawJson<String> {
+    RawJson(
+        serde_json::json!({
+            "unavailable": true,
+            "reason": reason,
+        })
+        .to_string(),
+    )
+}
+
+/// Proxies the bot's active Raindex orders from the st0x REST API.
+/// When `[rest_api]` is not configured, returns an unavailable indicator
+/// so the dashboard can show a friendly message instead of an error.
+#[get("/orders/raindex")]
+#[allow(clippy::cognitive_complexity)]
+async fn raindex_orders(ctx: &State<Ctx>) -> RawJson<String> {
+    let Some(rest_api) = &ctx.rest_api else {
+        return unavailable_json("REST API not configured (simulate mode)");
+    };
+
+    let owner = ctx.order_owner();
+    let url = format!(
+        "{}/v1/orders/owner/{:#x}",
+        rest_api.url.trim_end_matches('/'),
+        owner
+    );
+
+    let mut request = rest_api.http_client.get(&url);
+
+    if let (Some(key_id), Some(key_secret)) = (&rest_api.key_id, &rest_api.key_secret) {
+        request = request.basic_auth(key_id, Some(key_secret));
+    }
+
+    let response = match request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            tracing::warn!(%error, %url, "Failed to reach st0x REST API");
+            return unavailable_json("REST API unreachable");
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        tracing::warn!(%status, %url, "st0x REST API returned error");
+        return unavailable_json("REST API returned an error");
+    }
+
+    match response.text().await {
+        Ok(body) => RawJson(body),
+        Err(error) => {
+            tracing::warn!(%error, "Failed to read st0x REST API response body");
+            unavailable_json("Failed to read REST API response")
+        }
+    }
+}
+
 pub(crate) fn routes() -> Vec<Route> {
-    routes![health, logs, pending_orders, trades, transfers_endpoint]
+    routes![
+        health,
+        logs,
+        pending_orders,
+        trades,
+        transfers_endpoint,
+        raindex_orders
+    ]
 }
 
 #[cfg(test)]
@@ -718,7 +782,7 @@ mod tests {
     #[test]
     fn test_num_of_routes() {
         let routes_list = routes();
-        assert_eq!(routes_list.len(), 5);
+        assert_eq!(routes_list.len(), 6);
     }
 
     #[tokio::test]
@@ -966,5 +1030,141 @@ mod tests {
         assert!(page2.has_more);
         assert_eq!(page2.entries[0]["message"], "trade 2");
         assert_eq!(page2.entries[1]["message"], "trade 1");
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_returns_unavailable_when_rest_api_not_configured() {
+        let ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        assert!(ctx.rest_api.is_none());
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/orders/raindex").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
+
+        assert_eq!(parsed["unavailable"], true);
+        assert_eq!(parsed["reason"], "REST API not configured (simulate mode)");
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_returns_unavailable_when_upstream_unreachable() {
+        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+            "http://127.0.0.1:1".to_string(),
+        ));
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/orders/raindex").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("response must be valid JSON even on error");
+
+        assert_eq!(parsed["unavailable"], true);
+        assert!(parsed["reason"].as_str().unwrap().contains("unreachable"),);
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_proxies_successful_upstream_response() {
+        let mock_server = httpmock::MockServer::start();
+        let upstream_body = serde_json::json!({
+            "orders": [{
+                "orderHash": "0xabcd",
+                "owner": "0x0000000000000000000000000000000000000000",
+                "inputToken": {"address": "0x1111", "symbol": "USDC", "decimals": 6},
+                "outputToken": {"address": "0x2222", "symbol": "wtTSLA", "decimals": 18},
+                "outputVaultBalance": "1000",
+                "ioRatio": "0.5",
+                "createdAt": 1_718_452_800,
+                "orderbookId": "0x3333"
+            }],
+            "pagination": {
+                "page": 1,
+                "pageSize": 20,
+                "totalOrders": 1,
+                "totalPages": 1,
+                "hasMore": false
+            }
+        });
+
+        let owner = alloy::primitives::Address::ZERO;
+        let expected_path = format!("/v1/orders/owner/{owner:#x}");
+
+        mock_server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(&expected_path);
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(upstream_body.clone());
+        });
+
+        let mut ctx = create_test_ctx_with_order_owner(owner);
+        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+            mock_server.base_url(),
+        ));
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/orders/raindex").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
+
+        assert_eq!(parsed["orders"][0]["orderHash"], "0xabcd");
+        assert_eq!(parsed["pagination"]["totalOrders"], 1);
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_returns_unavailable_on_upstream_500() {
+        let mock_server = httpmock::MockServer::start();
+        let owner = alloy::primitives::Address::ZERO;
+
+        mock_server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!("/v1/orders/owner/{owner:#x}"));
+            then.status(500).body("Internal Server Error");
+        });
+
+        let mut ctx = create_test_ctx_with_order_owner(owner);
+        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+            mock_server.base_url(),
+        ));
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/orders/raindex").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("response must be valid JSON on upstream error");
+
+        assert_eq!(parsed["unavailable"], true);
+        assert!(parsed["reason"].as_str().unwrap().contains("error"));
     }
 }

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -749,6 +749,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 
@@ -834,6 +835,7 @@ mod tests {
             wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
             execution_threshold: ExecutionThreshold::whole_share(),
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -282,6 +282,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1061,6 +1061,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -593,6 +593,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 
@@ -658,6 +659,7 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -681,6 +681,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -245,6 +245,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 
@@ -286,6 +287,7 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -169,6 +169,7 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,75 @@ struct Config {
     wallet: Option<toml::Value>,
     broker: Option<BrokerConfig>,
     assets: AssetsConfig,
+    rest_api: Option<RestApiUrlConfig>,
+}
+
+/// Plaintext REST API settings (URL only). Credentials live in secrets.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RestApiUrlConfig {
+    url: String,
+}
+
+/// Secret REST API credentials from the encrypted secrets TOML.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RestApiSecrets {
+    key_id: String,
+    key_secret: String,
+}
+
+/// Combined REST API runtime context assembled from config + secrets.
+/// When absent from config, features that depend on it (e.g., the Orders
+/// dashboard tab) are gracefully disabled.
+#[derive(Clone)]
+pub struct RestApiCtx {
+    pub(crate) url: String,
+    pub(crate) key_id: Option<String>,
+    pub(crate) key_secret: Option<String>,
+    pub(crate) http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for RestApiCtx {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RestApiCtx")
+            .field("url", &self.url)
+            .field("key_id", &self.key_id.as_deref().map(|_| "<redacted>"))
+            .field(
+                "key_secret",
+                &self.key_secret.as_deref().map(|_| "<redacted>"),
+            )
+            .field("http_client", &"reqwest::Client")
+            .finish()
+    }
+}
+
+impl RestApiCtx {
+    fn new(
+        url: String,
+        key_id: Option<String>,
+        key_secret: Option<String>,
+    ) -> Result<Self, reqwest::Error> {
+        let http_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
+
+        Ok(Self {
+            url,
+            key_id,
+            key_secret,
+            http_client,
+        })
+    }
+
+    /// Creates a REST API context without authentication. Used for testing
+    /// and environments where the API does not require credentials.
+    #[allow(clippy::expect_used)]
+    pub fn unauthenticated(url: String) -> Self {
+        Self::new(url, None, None)
+            .expect("reqwest client with default TLS should never fail to build")
+    }
 }
 
 /// Non-secret broker settings from the plaintext config TOML.
@@ -231,6 +300,7 @@ struct Secrets {
     #[serde(rename = "hyperdx")]
     telemetry: Option<TelemetrySecrets>,
     wallet: Option<toml::Value>,
+    rest_api: Option<RestApiSecrets>,
 }
 
 /// Broker type tag and all broker credentials.
@@ -279,6 +349,7 @@ pub struct Ctx {
     pub execution_threshold: ExecutionThreshold,
     pub(crate) assets: AssetsConfig,
     pub(crate) travel_rule: Option<TravelRuleConfig>,
+    pub(crate) rest_api: Option<RestApiCtx>,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -364,6 +435,7 @@ impl std::fmt::Debug for Ctx {
             .field("execution_threshold", &self.execution_threshold)
             .field("assets", &self.assets)
             .field("travel_rule_configured", &self.travel_rule.is_some())
+            .field("rest_api", &self.rest_api)
             .finish()
     }
 }
@@ -421,6 +493,7 @@ struct ValidatedParts {
     trading_mode: TradingMode,
     assets: AssetsConfig,
     travel_rule: Option<TravelRuleConfig>,
+    rest_api: Option<RestApiCtx>,
     /// Wallet construction inputs. `Some` when both config and secrets
     /// contain a `[wallet]` section and the required RPC URLs are present.
     /// The actual async wallet construction is deferred to `load_files`.
@@ -619,6 +692,21 @@ fn parse_and_validate(
         trading_mode,
         assets: config.assets,
         travel_rule,
+        rest_api: config
+            .rest_api
+            .map(|cfg| {
+                if secrets.rest_api.is_none() {
+                    warn!(
+                        "[rest_api] URL configured but no [rest_api] credentials in secrets -- \
+                         requests will be unauthenticated"
+                    );
+                }
+
+                let key_id = secrets.rest_api.as_ref().map(|s| s.key_id.clone());
+                let key_secret = secrets.rest_api.map(|s| s.key_secret);
+                RestApiCtx::new(cfg.url, key_id, key_secret).map_err(CtxError::RestApiClient)
+            })
+            .transpose()?,
         wallet_inputs,
     })
 }
@@ -674,6 +762,7 @@ impl Ctx {
             execution_threshold: parts.execution_threshold,
             assets: parts.assets,
             travel_rule: parts.travel_rule,
+            rest_api: parts.rest_api,
         })
     }
 
@@ -788,6 +877,7 @@ impl Ctx {
         #[builder(default = 0)] server_port: u16,
         execution_threshold_override: Option<ExecutionThreshold>,
         travel_rule: Option<TravelRuleConfig>,
+        rest_api: Option<RestApiCtx>,
     ) -> Result<Self, CtxError> {
         let execution_threshold = match execution_threshold_override {
             Some(threshold) => threshold,
@@ -820,6 +910,7 @@ impl Ctx {
             execution_threshold,
             assets,
             travel_rule,
+            rest_api,
         })
     }
 }
@@ -828,6 +919,8 @@ impl Ctx {
 pub enum CtxError {
     #[error(transparent)]
     Rebalancing(Box<RebalancingCtxError>),
+    #[error("failed to build REST API HTTP client")]
+    RestApiClient(#[source] reqwest::Error),
     #[error("ORDER_OWNER required when rebalancing is disabled")]
     MissingOrderOwner,
     #[error("failed to read config file {path}")]
@@ -952,6 +1045,7 @@ impl CtxError {
             Self::Wallet(_) => "wallet construction error",
             Self::WalletMissingRpcUrl { .. } => "wallet missing RPC URL",
             Self::WalletSecretsMissing => "wallet secrets missing",
+            Self::RestApiClient(_) => "failed to build REST API HTTP client",
         }
     }
 }
@@ -1022,6 +1116,7 @@ pub(crate) mod tests {
                 cash: None,
             },
             travel_rule: None,
+            rest_api: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ async fn run_conductor_session(
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
 ) -> anyhow::Result<()> {
-    let result = dispatch_to_executor(ctx, pool, event_sender, inventory).await;
+    let result = Box::pin(dispatch_to_executor(ctx, pool, event_sender, inventory)).await;
 
     match result {
         Ok(()) => {

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -64,6 +64,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
     equity_vault_ids: &HashMap<String, B256>,
     cash_vault_id: B256,
     cctp: CctpOverrides,
+    rest_api_url: Option<&str>,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -140,6 +141,10 @@ fn build_full_system_ctx<P: Provider + Clone>(
         })
         .inventory_poll_interval(15)
         .server_port(8001)
+        .maybe_rest_api(
+            rest_api_url
+                .map(|url| st0x_hedge::config::RestApiCtx::unauthenticated(url.to_string())),
+        )
         .call()
         .map_err(Into::into)
 }
@@ -558,6 +563,7 @@ async fn simulate() -> anyhow::Result<()> {
         .equity_vault_ids(&equity_vault_ids)
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
+        .rest_api_url("http://localhost:8099")
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
 


### PR DESCRIPTION
## What
Closed [RAI-226](https://linear.app/makeitrain/issue/RAI-226/dashboard-orders-tab-showing-raindex-vault-balances) 

Add a new top-level "Orders" tab to the dashboard that displays Raindex vault
registry data (vault IDs, token addresses, onchain balances, provenance) for
all registered equity vaults and the USDC vault.

## Why

The dashboard's inventory panel shows aggregated onchain balances but provides
no visibility into the individual Raindex vaults backing those balances. Operators
need to see which vaults are registered, their IDs (for manual operations like
deposits/withdrawals), and how each vault was discovered (config-seeded vs
onchain trade discovery).

## How

**Backend — `src/api.rs`**:
- New `GET /vaults` endpoint that constructs a `Projection<VaultRegistry>` from
  the SQLite pool, loads the registry for the configured orderbook/owner, and
  merges vault metadata with latest onchain balances from `DashboardState.inventory`.
- Response types: `VaultsResponse` containing `Vec<EquityVaultEntry>` (symbol,
  token address, vault ID, onchain balance, provenance) and
  `Option<UsdcVaultEntry>`.
- Route count test updated from 5 to 6.

**Frontend — `dashboard/src/lib/components/orders-panel.svelte`** (new):
- Self-contained component that fetches `GET /vaults` on mount with a manual
  Refresh button.
- Renders a table with USDC vault first, then equity vaults sorted by token
  address. Addresses and vault IDs are truncated with full values on hover.
  Provenance shown as color-coded badges (blue = seeded, green = discovered).

**Frontend — `dashboard/src/routes/+page.svelte`**:
- Extended `Tab` union type to `'dashboard' | 'orders' | 'logs'`.
- Added "Orders" button to both mobile and desktop nav bars, positioned between
  Dashboard and Logs.
- Conditional rendering for the Orders panel.

**Infra — `os.nix`**:
- Added `/vaults` to the nginx reverse proxy location rules.

## Testing

Route count test updated (`test_num_of_routes` asserts 6). No new integration
tests — the endpoint reads from existing projections and the vault registry
aggregate has extensive test coverage.

## Anything else

- Vault balances will only populate for vaults that have been seeded via config
  (`vault_id` field in `[assets.equities.<SYMBOL>]`) or discovered from onchain
  trade events. Assets without a configured `vault_id` and no prior trades will
  show as absent from the list.
- This is stacked on #601 (dashboard HTTPS via Tailscale certificates).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Orders dashboard tab displaying active orders with token symbols, vault balance, IO ratio, order hash, and creation timestamp
  * Added refresh button to fetch latest order data on demand
  * Displays loading, error, and empty states appropriately

<!-- end of auto-generated comment: release notes by coderabbit.ai -->