### PR TITLE
feat: run multiple simulations side by side

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -18,6 +18,7 @@
         "@sveltejs/kit": "^2.49.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tailwindcss/vite": "^4.1.17",
+        "@types/node": "^25.6.0",
         "@typescript-eslint/eslint-plugin": "^8.49.0",
         "@typescript-eslint/parser": "^8.49.0",
         "bits-ui": "^2.11.0",
@@ -244,6 +245,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.49.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.49.0", "@typescript-eslint/type-utils": "8.49.0", "@typescript-eslint/utils": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.49.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A=="],
 
@@ -590,6 +593,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 

--- a/dashboard/bun.nix
+++ b/dashboard/bun.nix
@@ -441,6 +441,10 @@
     url = "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz";
     hash = "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==";
   };
+  "@types/node@25.6.0" = fetchurl {
+    url = "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz";
+    hash = "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==";
+  };
   "@typescript-eslint/eslint-plugin@8.49.0" = fetchurl {
     url = "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz";
     hash = "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==";
@@ -1156,6 +1160,10 @@
   "typescript@5.9.3" = fetchurl {
     url = "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz";
     hash = "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==";
+  };
+  "undici-types@7.19.2" = fetchurl {
+    url = "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz";
+    hash = "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==";
   };
   "uri-js@4.4.1" = fetchurl {
     url = "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz";

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -27,6 +27,7 @@
     "@sveltejs/kit": "^2.49.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tailwindcss/vite": "^4.1.17",
+    "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "bits-ui": "^2.11.0",

--- a/dashboard/src/lib/components/header-bar.svelte
+++ b/dashboard/src/lib/components/header-bar.svelte
@@ -2,9 +2,44 @@
   import { onMount } from 'svelte'
   import { Badge } from '$lib/components/ui/badge'
   import type { ConnectionState } from '$lib/websocket'
-  import { getApiBaseUrl } from '$lib/env'
+  import {
+    getApiBaseUrl,
+    getSimulateRev,
+    getSimulateBackendPort,
+    getSimulateSourceId,
+  } from '$lib/env'
   import { formatUtcClock, FETCH_TIMEOUT_MS } from '$lib/time'
   import { reactive } from '$lib/frp.svelte'
+
+  const simulateRev = getSimulateRev()
+  const simulateBackendPort = getSimulateBackendPort()
+  const simulateSourceId = getSimulateSourceId()
+
+  const simulateLabel = simulateRev
+    ? `simulate · ${simulateRev}${
+        simulateBackendPort ? `:${simulateBackendPort}` : ''
+      }${simulateSourceId ? ` · ${simulateSourceId}` : ''}`
+    : null
+
+  const pageTitle = simulateLabel
+    ? `${simulateLabel} · st0x.liquidity`
+    : 'st0x.liquidity'
+
+  const hashString = (input: string): number => {
+    let hash = 0
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash * 31 + input.charCodeAt(i)) | 0
+    }
+    return hash
+  }
+
+  const simulateHue = simulateSourceId !== null
+    ? Math.abs(hashString(simulateSourceId)) % 360
+    : null
+
+  const simulateBackground = simulateHue !== null
+    ? `hsl(${String(simulateHue)} 70% 35%)`
+    : null
 
   type Props = {
     connectionStatus: ConnectionState
@@ -78,9 +113,24 @@
   )
 </script>
 
-<header class="shrink-0 border-b bg-card px-2 py-2 shadow-sm md:px-4 md:py-3">
+<svelte:head>
+  <title>{pageTitle}</title>
+</svelte:head>
+
+<header
+  class="shrink-0 border-b bg-card px-2 py-2 shadow-sm md:px-4 md:py-3"
+  style:background-color={simulateBackground}
+  style:color={simulateBackground !== null ? 'white' : null}
+>
   <div class="flex items-center justify-between gap-2">
-    <h1 class="text-sm font-semibold md:text-lg">st0x.liquidity</h1>
+    <h1 class="text-sm font-semibold md:text-lg">
+      st0x.liquidity
+      {#if simulateLabel}
+        <Badge variant="outline" class="ml-2 font-mono text-xs">
+          {simulateLabel}
+        </Badge>
+      {/if}
+    </h1>
 
     <div class="flex items-center gap-2 md:gap-4">
       <span class="font-mono text-xs text-muted-foreground">

--- a/dashboard/src/lib/env.test.ts
+++ b/dashboard/src/lib/env.test.ts
@@ -54,6 +54,41 @@ describe('getWebSocketUrl', () => {
 
     expect(getWebSocketUrl()).toBe('wss://trimmed.example.com/ws')
   })
+
+  it('uses default port 8001 in local dev when PUBLIC_BACKEND_PORT is unset', () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '5173',
+          host: 'localhost:5173',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    expect(getWebSocketUrl()).toBe('ws://localhost:8001/api/ws')
+  })
+
+  it('honors PUBLIC_BACKEND_PORT in local dev for concurrent simulate instances', () => {
+    mockEnv.current = { PUBLIC_BACKEND_PORT: '8002' }
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '5174',
+          host: 'localhost:5174',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    expect(getWebSocketUrl()).toBe('ws://localhost:8002/api/ws')
+  })
 })
 
 describe('getExplorerTxUrl', () => {

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -1,7 +1,12 @@
 import { browser } from '$app/environment'
 import { env } from '$env/dynamic/public'
 
-const LOCAL_DEV_PORT = 8001
+const DEFAULT_LOCAL_DEV_PORT = '8001'
+
+const localDevPort = (): string => {
+  const configured = env['PUBLIC_BACKEND_PORT']?.trim()
+  return configured !== undefined && configured !== '' ? configured : DEFAULT_LOCAL_DEV_PORT
+}
 
 const isLocalDev = (): boolean => {
   if (!browser) return true
@@ -11,7 +16,7 @@ const isLocalDev = (): boolean => {
 
 const getDefaultWsUrl = (): string => {
   if (isLocalDev()) {
-    return `ws://localhost:${String(LOCAL_DEV_PORT)}/api/ws`
+    return `ws://localhost:${localDevPort()}/api/ws`
   }
 
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -25,6 +30,21 @@ export const getWebSocketUrl = (): string => {
 }
 
 export const getApiBaseUrl = (): string => window.location.origin
+
+export const getSimulateRev = (): string | null => {
+  const val = env['PUBLIC_SIMULATE_REV']?.trim()
+  return val !== undefined && val !== '' ? val : null
+}
+
+export const getSimulateBackendPort = (): string | null => {
+  const val = env['PUBLIC_BACKEND_PORT']?.trim()
+  return val !== undefined && val !== '' ? val : null
+}
+
+export const getSimulateSourceId = (): string | null => {
+  const val = env['PUBLIC_SIMULATE_SOURCE_ID']?.trim()
+  return val !== undefined && val !== '' ? val : null
+}
 
 export const getExplorerTxUrl = (txHash: string): string => {
   const envKey = 'PUBLIC_EXPLORER_URL'

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -2,15 +2,18 @@ import tailwindcss from '@tailwindcss/vite'
 import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig } from 'vite'
 
+const backendPort = process.env['BACKEND_PORT'] ?? '8001'
+const backendUrl = `http://localhost:${backendPort}`
+
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
   server: {
     proxy: {
-      '/logs': 'http://localhost:8001',
-      '/health': 'http://localhost:8001',
-      '/orders': 'http://localhost:8001',
-      '/trades': 'http://localhost:8001',
-      '/transfers': 'http://localhost:8001',
+      '/logs': backendUrl,
+      '/health': backendUrl,
+      '/orders': backendUrl,
+      '/trades': backendUrl,
+      '/transfers': backendUrl,
     }
   }
 })

--- a/e2e/mock-rest-api.ts
+++ b/e2e/mock-rest-api.ts
@@ -73,8 +73,19 @@ const MOCK_ORDERS = {
   },
 };
 
+const rawPort = process.env["MOCK_REST_API_PORT"];
+if (rawPort === undefined) {
+  throw new Error("MOCK_REST_API_PORT must be set");
+}
+const port = Number(rawPort);
+if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+  throw new Error(
+    `MOCK_REST_API_PORT must be a valid u16 port number, got: ${rawPort}`,
+  );
+}
+
 const server = Bun.serve({
-  port: 8099,
+  port,
   fetch(request: Request) {
     const url = new URL(request.url);
 

--- a/flake.nix
+++ b/flake.nix
@@ -250,7 +250,12 @@
             };
 
             # Mock infra + bot + dashboard + continuous user trades.
-            # Run with `nix run .#simulate`, press `q` to exit
+            #
+            # Run with `nix run .#simulate`, press `q` to exit. Picks the
+            # lowest port offset whose bot/vite/mock-api ports are all
+            # free, so multiple instances can run side-by-side without
+            # collisions. The dashboard auto-opens in the browser on
+            # start.
             simulate = pkgs.writeShellApplication {
               name = "simulate";
               runtimeInputs = [
@@ -259,18 +264,50 @@
                 pkgs.cargo-nextest
                 rainix.rust-toolchain.${system}
               ];
-              text =
-                let
-                  backend = "cargo nextest run --test e2e -E 'test(=full_system::simulate)' --run-ignored ignored-only --no-capture";
+              text = ''
+                                port_free() {
+                                  ! (echo >"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+                                }
 
-                  dashboard = "cd dashboard && bun run dev";
+                                offset=0
+                                max_offset=9
+                                while (( offset <= max_offset )); do
+                                  bot_port=$((8001 + offset))
+                                  vite_port=$((5173 + offset))
+                                  mock_api_port=$((8099 + offset))
+                                  if port_free "$bot_port" \
+                                    && port_free "$vite_port" \
+                                    && port_free "$mock_api_port"; then
+                                    break
+                                  fi
+                                  offset=$((offset + 1))
+                                done
 
-                  mockApi = "bun run e2e/mock-rest-api.ts";
+                                if (( offset > max_offset )); then
+                                  echo "simulate: no free port offset in [0..$max_offset]" >&2
+                                  exit 1
+                                fi
 
-                in
-                ''
-                  exec mprocs "${backend}" "${dashboard}" "${mockApi}"
-                '';
+                                echo "simulate: offset=$offset (bot=$bot_port \
+                vite=$vite_port mock_api=$mock_api_port)"
+
+                                backend="SIMULATE_BOT_PORT=$bot_port \
+                                  cargo nextest run --test e2e \
+                                  -E 'test(=full_system::simulate)' \
+                                  --run-ignored ignored-only --no-capture"
+
+                                dashboard="cd dashboard && \
+                                  BACKEND_PORT=$bot_port \
+                                  PUBLIC_BACKEND_PORT=$bot_port \
+                                  PUBLIC_SIMULATE_REV=${self.shortRev or self.dirtyShortRev or "unknown"} \
+                                  PUBLIC_SIMULATE_SOURCE_ID=${builtins.substring 0 8 (baseNameOf self.outPath)} \
+                                  bun run dev --port=$vite_port --strictPort --open"
+
+                                mockApi="MOCK_REST_API_PORT=$mock_api_port \
+                                  bun run e2e/mock-rest-api.ts"
+
+                                exec mprocs "$backend" "$dashboard" "$mockApi"
+              '';
             };
 
             # Sandbox-runnable test for scripts/patch-rain-math-float.nu so

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -67,6 +67,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
     cctp: CctpOverrides,
     rest_api_url: Option<&str>,
     cash_reserved: Option<Positive<Usd>>,
+    server_port: u16,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -143,7 +144,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
             }),
         })
         .inventory_poll_interval(15)
-        .server_port(8001)
+        .server_port(server_port)
         .maybe_rest_api(
             rest_api_url
                 .map(|url| st0x_hedge::config::RestApiCtx::unauthenticated(url.to_string())),
@@ -273,6 +274,7 @@ async fn full_system() -> anyhow::Result<()> {
         .equity_vault_ids(&equity_vault_ids)
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
+        .server_port(8001)
         .call()?;
 
     let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
@@ -462,14 +464,20 @@ async fn full_system() -> anyhow::Result<()> {
 #[ignore = "infinite simulation -- run via nix run .#simulate"]
 #[allow(clippy::too_many_lines)]
 async fn simulate() -> anyhow::Result<()> {
-    let log_dir = std::path::PathBuf::from("/tmp/st0x-simulate-logs");
+    let server_port: u16 = std::env::var("SIMULATE_BOT_PORT")
+        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate`)")
+        .parse()
+        .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
+
+    let log_dir = std::path::PathBuf::from(format!("/tmp/st0x-simulate-logs-{server_port}"));
     std::fs::create_dir_all(&log_dir)?;
     let _log_guard = crate::test_infra::init_tracing_with_log_dir(&log_dir);
 
     let aapl_broker_price = float!(150.25);
     let tsla_broker_price = float!(245.00);
 
-    let db_path = std::path::PathBuf::from("/tmp/st0x-liquidity-simulate.sqlite");
+    let db_path =
+        std::path::PathBuf::from(format!("/tmp/st0x-liquidity-simulate-{server_port}.sqlite"));
     let _ = std::fs::remove_file(&db_path);
     let _ = std::fs::remove_file(db_path.with_extension("sqlite-shm"));
     let _ = std::fs::remove_file(db_path.with_extension("sqlite-wal"));
@@ -568,13 +576,14 @@ async fn simulate() -> anyhow::Result<()> {
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
         .cash_reserved(Positive::new(Usd::new(float!(50000)))?)
+        .server_port(server_port)
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
 
     debug!("Starting bot");
     let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
 
-    poll_for_ready(&mut bot, 8001).await;
+    poll_for_ready(&mut bot, server_port).await;
     info!("Bot ready. Starting continuous trade simulation.");
 
     let orders = [


### PR DESCRIPTION
## What

Adds support for running multiple `simulate` instances concurrently without port conflicts. The `simulate` Nix app now automatically detects a free port offset (checking bot, Vite dev server, and mock REST API ports together) and launches all three processes on that offset. The dashboard displays a badge and page title indicating the git revision and backend port when running in simulate mode.

## Why

Previously, all simulate processes were hardcoded to fixed ports (8001, 5173, 8099), making it impossible to run more than one instance at a time. Supporting concurrent instances is useful for comparing behavior across different revisions or configurations side-by-side.

## How

- The `simulate` shell script probes port offsets 0–9 and picks the first where all three ports (bot, Vite, mock API) are free, then passes the resolved ports via environment variables (`SIMULATE_BOT_PORT`, `BACKEND_PORT`, `PUBLIC_BACKEND_PORT`, `MOCK_REST_API_PORT`).
- `MOCK_REST_API_PORT` is now required via environment variable rather than hardcoded; the mock API server validates and uses it at startup.
- `SIMULATE_BOT_PORT` is read in the `simulate` test to configure the bot's HTTP server port, and per-instance paths are used for the SQLite database and log directory.
- `PUBLIC_SIMULATE_REV` (set to the flake's short git rev) and `PUBLIC_BACKEND_PORT` are exposed to the dashboard, which renders them as a badge in the header and sets the page title accordingly.
- `vite.config.ts` reads `BACKEND_PORT` to configure the dev server proxy, and `@types/node` is added as a dev dependency to support `process.env` access in the Vite config.
- The Vite dev server is launched with `--open` to auto-open the browser on start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard header shows simulation metadata (rev, backend port, source ID) with a visual badge and updates the page title.

* **Improvements**
  * Dev tooling now uses environment-driven ports and auto-selects collision-free offsets so multiple local instances can run concurrently.
  * Dev server proxies and the mock API honor configured ports and validate them.

* **Tests**
  * Added tests for WebSocket URL generation with custom backend port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/604)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->