### PR TITLE
fix: job durability using apalis

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,69 @@
+# Feature Flags
+
+## Flag inventory
+
+| Flag                 | Purpose                             | Enabled by    |
+| -------------------- | ----------------------------------- | ------------- |
+| `test-support`       | Test infra visible to e2e tests     | dev-deps only |
+| `mock`               | Mock executor / EVM implementations | dev-deps only |
+| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets` |
+| `wallet-private-key` | Local signer wallet support         | `all-wallets` |
+| `all-wallets`        | All wallet backends                 | `default`     |
+
+## `test-support` vs `cfg(test)`
+
+- **`cfg(test)`** is true when compiling unit tests (`#[cfg(test)] mod tests`)
+  AND when compiling the lib for integration tests. It's set by the compiler,
+  not controllable per-crate.
+- **`feature = "test-support"`** is a cargo feature enabled only by
+  `[dev-dependencies]`. It gates types/methods that integration tests (`tests/`)
+  need but unit tests and production builds don't.
+
+### When to use which
+
+| Scenario                                  | Gate                                |
+| ----------------------------------------- | ----------------------------------- |
+| Unit test helper (same file, `mod tests`) | `#[cfg(test)]`                      |
+| Type/method used by e2e tests in `tests/` | `#[cfg(feature = "test-support")]`  |
+| Type that must exist in all builds but is | Always compiled; methods gated with |
+| only functional in tests                  | `#[cfg(feature = "test-support")]`  |
+
+### Common pitfall: dead code warnings
+
+A `pub` method gated on `cfg(any(test, feature = "test-support"))` will trigger
+`dead_code` warnings during `cargo test` if no unit test calls it — because
+`cfg(test)` makes it visible to the compiler but nothing in the lib crate
+references it. Fix: gate on `feature = "test-support"` only (not `test`). The
+method won't exist in unit test builds but will exist in e2e builds where
+dev-deps enable `test-support`.
+
+### Pattern: zero-size prod / functional test type
+
+When a type needs to exist in all builds (to avoid `#[cfg]` on every function
+parameter and call site) but only does real work in tests:
+
+```rust
+#[derive(Clone)]
+pub struct MyTestHook(
+    #[cfg(feature = "test-support")] Arc<AtomicBool>,
+    #[cfg(not(feature = "test-support"))] (),
+);
+
+impl MyTestHook {
+    pub fn new() -> Self { /* ... */ }
+
+    #[cfg(feature = "test-support")]
+    pub fn arm(&self) { /* ... */ }
+
+    fn check(&self) -> bool {
+        #[cfg(feature = "test-support")]
+        { self.0.swap(false, Ordering::SeqCst) }
+        #[cfg(not(feature = "test-support"))]
+        false
+    }
+}
+```
+
+The type compiles everywhere (zero-size in prod). Methods that only tests call
+are gated on `feature = "test-support"`. The `check` method always exists but
+returns `false` in prod (the compiler eliminates the branch).

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -134,11 +134,111 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use apalis::prelude::{Monitor, WorkerBuilder};
     use sqlx::SqlitePool;
 
     use super::*;
     use crate::conductor::setup_apalis_tables;
     use crate::test_utils::setup_test_db;
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct TestJob {
+        /// When true, `perform` always returns an error.
+        should_fail: bool,
+    }
+
+    struct TestCtx {
+        /// Counts how many jobs completed successfully.
+        success_count: AtomicUsize,
+        /// Counts how many jobs were attempted (including failures).
+        attempt_count: AtomicUsize,
+    }
+
+    impl Job<TestCtx> for TestJob {
+        type Error = TestJobError;
+
+        fn label(&self) -> Label {
+            Label::new(format!("test-job(should_fail={})", self.should_fail))
+        }
+
+        async fn perform(&self, ctx: &TestCtx) -> Result<(), Self::Error> {
+            ctx.attempt_count.fetch_add(1, Ordering::SeqCst);
+
+            if self.should_fail {
+                return Err(TestJobError);
+            }
+
+            ctx.success_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test job deliberately failed")]
+    struct TestJobError;
+
+    /// RAI-199 reproduction: a job that fails after all retries must halt
+    /// further job processing. Currently, the `work` handler swallows the
+    /// error and returns `()`, so apalis treats it as success and keeps
+    /// processing the queue.
+    ///
+    /// This test enqueues a failing job followed by a succeeding job, runs
+    /// them through a real apalis Monitor, and asserts that the succeeding
+    /// job was NOT processed. It FAILS with the current code because the
+    /// second job does get processed.
+    #[tokio::test]
+    async fn job_failure_after_retries_halts_processing() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&pool);
+
+        // Enqueue: failing job first, then a succeeding job.
+        queue.push(TestJob { should_fail: true }).await.unwrap();
+        queue.push(TestJob { should_fail: false }).await.unwrap();
+
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+            attempt_count: AtomicUsize::new(0),
+        });
+
+        let ctx_for_assert = ctx.clone();
+
+        // Run the apalis monitor with a single worker, giving it enough
+        // time to process both jobs.
+        let monitor_handle = tokio::spawn({
+            let monitor = Monitor::new().register(move |index| {
+                WorkerBuilder::new(format!("test-worker-{index}"))
+                    .backend(queue.clone().into_storage())
+                    .data(ctx.clone())
+                    .build(work::<TestCtx, TestJob>)
+            });
+
+            async move { monitor.run().await }
+        });
+
+        // Give the worker time to pick up and process both jobs.
+        // The failing job retries 3 times with exponential backoff
+        // (backon defaults: 1s, 2s, 4s), so we need enough time for
+        // retries plus processing the second job.
+        tokio::time::sleep(std::time::Duration::from_secs(12)).await;
+
+        monitor_handle.abort();
+
+        let successes = ctx_for_assert.success_count.load(Ordering::SeqCst);
+
+        // CORRECT BEHAVIOR: after the first job exhausts retries and fails,
+        // the worker should halt. The second job should NOT be processed.
+        assert_eq!(
+            successes, 0,
+            "The succeeding job should NOT have been processed after a \
+             prior job failed all retries, but it was. This means job \
+             failures are silently swallowed and processing continues \
+             with stale/incorrect state (RAI-199)."
+        );
+    }
 
     async fn insert_job(
         pool: &SqlitePool,


### PR DESCRIPTION
## What

Closes RAI-199. Adds a regression test that reproduces the bug where a job failing after all retries does not halt further job processing, and adds a feature flags reference document.

## Why

When a job exhausts its retries and fails, the `work` handler swallows the error and returns `()`, causing apalis to treat the failure as a success and continue processing the queue. This means subsequent jobs run against stale or incorrect state, which is unsafe behavior.

## How

A unit test (`job_failure_after_retries_halts_processing`) is added to `conductor/job.rs` that enqueues a deliberately failing job followed by a succeeding job, runs them through a real apalis `Monitor`, and asserts that the succeeding job is **not** processed after the first job exhausts its retries. The test is written to fail with the current implementation, documenting the expected correct behavior.

A `docs/feature-flags.md` document is also added to inventory all Cargo feature flags, clarify the distinction between `cfg(test)` and `feature = "test-support"`, and provide guidance on when to use each — including a pattern for zero-size production types that are only functional in test builds.

## Testing

The new `job_failure_after_retries_halts_processing` test directly reproduces the RAI-199 failure scenario using a real apalis monitor with a single worker. It enqueues a failing job and a succeeding job, waits long enough for retries and processing, then asserts zero successful completions.

## Anything else

The test currently **fails** intentionally — it documents the correct behavior that needs to be implemented to fix RAI-199. The retry backoff (1s, 2s, 4s) means the test requires a ~12 second sleep to allow all retries to complete before asserting.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/ST0x-Technology/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews