### PR TITLE
feat: failure injector

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,69 @@
+# Feature Flags
+
+## Flag inventory
+
+| Flag                 | Purpose                             | Enabled by    |
+| -------------------- | ----------------------------------- | ------------- |
+| `test-support`       | Test infra visible to e2e tests     | dev-deps only |
+| `mock`               | Mock executor / EVM implementations | dev-deps only |
+| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets` |
+| `wallet-private-key` | Local signer wallet support         | `all-wallets` |
+| `all-wallets`        | All wallet backends                 | `default`     |
+
+## `test-support` vs `cfg(test)`
+
+- **`cfg(test)`** is true when compiling unit tests (`#[cfg(test)] mod tests`)
+  AND when compiling the lib for integration tests. It's set by the compiler,
+  not controllable per-crate.
+- **`feature = "test-support"`** is a cargo feature enabled only by
+  `[dev-dependencies]`. It gates types/methods that integration tests (`tests/`)
+  need but unit tests and production builds don't.
+
+### When to use which
+
+| Scenario                                  | Gate                                |
+| ----------------------------------------- | ----------------------------------- |
+| Unit test helper (same file, `mod tests`) | `#[cfg(test)]`                      |
+| Type/method used by e2e tests in `tests/` | `#[cfg(feature = "test-support")]`  |
+| Type that must exist in all builds but is | Always compiled; methods gated with |
+| only functional in tests                  | `#[cfg(feature = "test-support")]`  |
+
+### Common pitfall: dead code warnings
+
+A `pub` method gated on `cfg(any(test, feature = "test-support"))` will trigger
+`dead_code` warnings during `cargo test` if no unit test calls it — because
+`cfg(test)` makes it visible to the compiler but nothing in the lib crate
+references it. Fix: gate on `feature = "test-support"` only (not `test`). The
+method won't exist in unit test builds but will exist in e2e builds where
+dev-deps enable `test-support`.
+
+### Pattern: zero-size prod / functional test type
+
+When a type needs to exist in all builds (to avoid `#[cfg]` on every function
+parameter and call site) but only does real work in tests:
+
+```rust
+#[derive(Clone)]
+pub struct MyTestHook(
+    #[cfg(feature = "test-support")] Arc<AtomicBool>,
+    #[cfg(not(feature = "test-support"))] (),
+);
+
+impl MyTestHook {
+    pub fn new() -> Self { /* ... */ }
+
+    #[cfg(feature = "test-support")]
+    pub fn arm(&self) { /* ... */ }
+
+    fn check(&self) -> bool {
+        #[cfg(feature = "test-support")]
+        { self.0.swap(false, Ordering::SeqCst) }
+        #[cfg(not(feature = "test-support"))]
+        false
+    }
+}
+```
+
+The type compiles everywhere (zero-size in prod). Methods that only tests call
+are gated on `feature = "test-support"`. The `check` method always exists but
+returns `false` in prod (the compiler eliminates the branch).

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -749,6 +749,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -834,6 +836,8 @@ mod tests {
             wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
             execution_threshold: ExecutionThreshold::whole_share(),
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -282,6 +282,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1061,6 +1061,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -593,6 +593,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -658,6 +660,8 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -681,6 +681,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -245,6 +245,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -286,6 +288,8 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -169,6 +169,8 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -307,6 +307,8 @@ impl Conductor {
             poll_notify: Arc::new(tokio::sync::Notify::new()),
             wallet_polling,
             tokenizer,
+            #[cfg(feature = "test-support")]
+            failure_injector: ctx.failure_injector.clone(),
         };
 
         let mut conductor = builder::spawn()

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -12,6 +12,8 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 
+#[cfg(feature = "test-support")]
+use super::job::FailureInjector;
 use super::job::work;
 use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
 use super::monitor::positions::PositionMonitor;
@@ -55,6 +57,8 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) poll_notify: Arc<tokio::sync::Notify>,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
+    #[cfg(feature = "test-support")]
+    pub(crate) failure_injector: FailureInjector,
 }
 
 /// Wires all runtime components and returns a running [`Conductor`].
@@ -165,6 +169,11 @@ where
         .build()
         .run();
 
+    #[cfg(feature = "test-support")]
+    let failure_injector = context.failure_injector;
+    #[cfg(feature = "test-support")]
+    let failure_injector_for_hedge = failure_injector.clone();
+
     let monitor = tokio::spawn(async move {
         let apalis_monitor = Monitor::new()
             .should_restart(|_ctx, _error, attempt| {
@@ -172,16 +181,24 @@ where
                 true
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("order-fill-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
-                    .data(accountant_ctx.clone())
-                    .build(work::<AccountantCtx<Prov, Exec>, _>)
+                    .data(accountant_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder.data(failure_injector.clone());
+
+                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("hedge-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
                     .backend(hedge_queue.clone().into_storage())
-                    .data(hedge_ctx.clone())
-                    .build(work::<HedgeCtx, _>)
+                    .data(hedge_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder.data(failure_injector_for_hedge.clone());
+
+                builder.build(work::<HedgeCtx, _>)
             });
 
         tokio::select! {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -13,6 +13,8 @@ use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
+#[cfg(feature = "test-support")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{error, info, warn};
 
 type Storage<Task> = SqliteStorage<
@@ -84,16 +86,61 @@ impl fmt::Display for Label {
     }
 }
 
-/// Generic apalis handler that bridges [`Job`] implementations
-/// with apalis's function-based worker API.
+/// Allows e2e tests to force the next job to fail terminally.
+/// Decorates `Job::perform` — when armed, returns `Err` without
+/// calling the job. When not armed, delegates transparently.
+#[cfg(feature = "test-support")]
+#[derive(Clone)]
+pub struct FailureInjector(Arc<AtomicBool>);
+
+#[cfg(feature = "test-support")]
+impl FailureInjector {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn arm(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    fn is_armed(&self) -> bool {
+        self.0.swap(false, Ordering::SeqCst)
+    }
+}
+
+/// Generic apalis handler — test-support build.
 ///
-/// Register with apalis via:
-/// ```text
-/// WorkerBuilder::new(name)
-///     .backend(storage)
-///     .data(ctx)
-///     .build(work::<MyCtx, MyJob>)
-/// ```
+/// Accepts a [`FailureInjector`] via apalis `Data`. When armed,
+/// the job fails without calling `perform`.
+#[cfg(feature = "test-support")]
+pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>, injector: Data<FailureInjector>)
+where
+    Ctx: Send + Sync + 'static,
+    J: Job<Ctx> + Sync,
+{
+    if injector.is_armed() {
+        error!(label = %job.label(), "Injected terminal failure (test)");
+        return;
+    }
+
+    const MAX_RETRIES: usize = 3;
+    let label = job.label();
+    info!(%label, max_retries = MAX_RETRIES, "Starting job");
+
+    let result = (|| job.perform(&ctx))
+        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
+        .notify(|error, duration| {
+            warn!(%label, %error, ?duration, "Retrying job after transient failure");
+        })
+        .await;
+
+    if let Err(error) = result {
+        error!(%label, %error, "Job failed after retries");
+    }
+}
+
+/// Generic apalis handler — production build.
+#[cfg(not(feature = "test-support"))]
 pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
 where
     Ctx: Send + Sync + 'static,
@@ -139,6 +186,40 @@ mod tests {
     use super::*;
     use crate::conductor::setup_apalis_tables;
     use crate::test_utils::setup_test_db;
+
+    #[test]
+    fn failure_injector_not_armed_by_default() {
+        let injector = FailureInjector::new();
+        assert!(!injector.is_armed());
+    }
+
+    #[test]
+    fn failure_injector_arm_then_check_auto_disarms() {
+        let injector = FailureInjector::new();
+
+        injector.arm();
+        assert!(injector.is_armed());
+        assert!(
+            !injector.is_armed(),
+            "second check should be false (auto-disarmed)"
+        );
+    }
+
+    #[test]
+    fn failure_injector_shared_across_clones() {
+        let injector = FailureInjector::new();
+        let clone = injector.clone();
+
+        injector.arm();
+        assert!(
+            clone.is_armed(),
+            "arming original should be visible from clone"
+        );
+        assert!(
+            !injector.is_armed(),
+            "should be disarmed after clone consumed it"
+        );
+    }
 
     async fn insert_job(
         pool: &SqlitePool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,6 +279,8 @@ pub struct Ctx {
     pub execution_threshold: ExecutionThreshold,
     pub(crate) assets: AssetsConfig,
     pub(crate) travel_rule: Option<TravelRuleConfig>,
+    #[cfg(feature = "test-support")]
+    pub failure_injector: crate::conductor::job::FailureInjector,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -674,6 +676,8 @@ impl Ctx {
             execution_threshold: parts.execution_threshold,
             assets: parts.assets,
             travel_rule: parts.travel_rule,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 
@@ -820,6 +824,8 @@ impl Ctx {
             execution_threshold,
             assets,
             travel_rule,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 }
@@ -1022,6 +1028,8 @@ pub(crate) mod tests {
                 cash: None,
             },
             travel_rule: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ mod wrapper;
 
 pub use telemetry::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
 
+#[cfg(feature = "test-support")]
+pub use conductor::job::FailureInjector;
 #[cfg(any(test, feature = "test-support"))]
 pub use config::TradingMode;
 #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
## What

Adds a `FailureInjector` mechanism that allows e2e tests to force the next conductor job to fail terminally, and introduces a `docs/feature-flags.md` reference document covering the project's Cargo feature flag conventions.

## Why

E2e tests need a way to simulate terminal job failures in the conductor's apalis worker pipeline without modifying production logic. Previously there was no hook to trigger this path from outside the process. The feature flags doc was also missing, leaving no canonical reference for when to use `cfg(test)` vs `feature = "test-support"` and how to structure types that must compile in all builds but only do real work in tests.

## How

`FailureInjector` is a cheaply cloneable `Arc<AtomicBool>` wrapper. When armed via `arm()`, the next call to `is_armed()` returns `true` and atomically resets the flag (one-shot, auto-disarming). It is gated entirely behind `feature = "test-support"` so it compiles to nothing in production.

In the `test-support` build, the apalis `work` handler gains an additional `Data<FailureInjector>` parameter. When the injector is armed, the handler logs a terminal failure and returns early without calling `Job::perform`. The production build retains the original single-parameter signature with no overhead.

`FailureInjector` is threaded through `Ctx`, `ConductorCtx`, and both worker registrations (order-fill and hedge workers) under `#[cfg(feature = "test-support")]` guards, keeping all call sites clean in production builds.

The feature flags doc covers the full flag inventory, the distinction between `cfg(test)` and `feature = "test-support"`, common dead-code warning pitfalls, and the zero-size-in-prod / functional-in-test struct pattern.

## Testing

Three unit tests cover the core `FailureInjector` invariants:
- Not armed by default.
- Arming then checking auto-disarms (second check returns `false`).
- Arming on one clone is visible from another clone, and is consumed exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added feature flags reference guide describing available Cargo build configurations and their behavior.

* **Tests**
  * Extended test contexts across CLI and conductor modules to support failure injection during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->