### PR TITLE
repro: silent event processing after failure

### DIFF
--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -181,6 +181,9 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use apalis::prelude::{Monitor, WorkerBuilder};
     use sqlx::SqlitePool;
 
     use super::*;
@@ -218,6 +221,79 @@ mod tests {
         assert!(
             !injector.is_armed(),
             "should be disarmed after clone consumed it"
+        );
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct TestJob {
+        should_fail: bool,
+    }
+
+    struct TestCtx {
+        success_count: AtomicUsize,
+    }
+
+    impl Job<TestCtx> for TestJob {
+        type Error = TestJobError;
+
+        fn label(&self) -> Label {
+            Label::new(format!("test-job(should_fail={})", self.should_fail))
+        }
+
+        async fn perform(&self, ctx: &TestCtx) -> Result<(), Self::Error> {
+            if self.should_fail {
+                return Err(TestJobError);
+            }
+
+            ctx.success_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test job deliberately failed")]
+    struct TestJobError;
+
+    /// RAI-199: a job that fails after all retries must halt further
+    /// processing. Currently `work()` swallows the error and the worker
+    /// picks up the next job with stale state.
+    ///
+    /// FAILS with current code — the second job runs.
+    #[tokio::test]
+    async fn job_failure_after_retries_halts_processing() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&pool);
+        queue.push(TestJob { should_fail: true }).await.unwrap();
+        queue.push(TestJob { should_fail: false }).await.unwrap();
+
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+        });
+        let ctx_for_assert = ctx.clone();
+
+        let monitor_handle = tokio::spawn({
+            let monitor = Monitor::new().register(move |index| {
+                WorkerBuilder::new(format!("test-worker-{index}"))
+                    .backend(queue.clone().into_storage())
+                    .data(ctx.clone())
+                    .data(FailureInjector::new())
+                    .build(work::<TestCtx, TestJob>)
+            });
+
+            async move { monitor.run().await }
+        });
+
+        // backon default: 1s + 2s + 4s retries, plus time for second job
+        tokio::time::sleep(std::time::Duration::from_secs(12)).await;
+        monitor_handle.abort();
+
+        assert_eq!(
+            ctx_for_assert.success_count.load(Ordering::SeqCst),
+            0,
+            "The second job should NOT have been processed after a prior \
+             job failed all retries (RAI-199)."
         );
     }
 

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -14,6 +14,8 @@ use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
 
+use st0x_hedge::FailureInjector;
+
 use self::assertions::*;
 use crate::poll::poll_for_all_jobs_done;
 
@@ -1446,5 +1448,85 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
 
     pool.close().await;
     bot2.abort();
+    Ok(())
+}
+
+/// RAI-199: when a job fails terminally, the bot must halt — not
+/// silently continue processing subsequent events with stale state.
+///
+/// FAILS with current code — the bot keeps running after the injected
+/// failure.
+#[test_log::test(tokio::test)]
+async fn job_failure_halts_bot() -> anyhow::Result<()> {
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let mut ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+
+    let injector = FailureInjector::new();
+    ctx.failure_injector = injector.clone();
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // First trade processes normally
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    // Snapshot event count before the injected failure
+    let pool = connect_db(&infra.db_path).await?;
+    let events_before = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    // Arm the injector, then submit a second trade
+    injector.arm();
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // The bot should exit — the injected failure should halt processing
+    let bot_exited = tokio::time::timeout(Duration::from_secs(30), &mut bot).await;
+
+    assert!(
+        bot_exited.is_ok(),
+        "Bot should have exited after terminal job failure, but it kept running"
+    );
+
+    // The second trade's onchain event should NOT have been processed
+    let pool = connect_db(&infra.db_path).await?;
+    let events_after = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    assert_eq!(
+        events_before, events_after,
+        "No new OnChainTrade events should be persisted after terminal failure"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## What

Proves validity of RAI-199 (fix is the next pr up in the stack). Adds failing tests that document the bug where a job that exhausts all retries does not halt further processing — the worker silently continues picking up subsequent jobs with stale state.

## Why

When a job fails terminally (after all retries are exhausted), the bot should stop. Currently `work()` swallows the error, allowing the worker to continue processing the next job. This can lead to incorrect state being carried forward and subsequent events being processed when they should not be.

## How

A `FailureInjector` is introduced to allow tests to arm an injected failure at a precise point in execution. Two tests are added that are explicitly expected to fail with the current implementation:

- A unit-level test (`job_failure_after_retries_halts_processing`) that enqueues a failing job followed by a succeeding job and asserts the second job is never executed.
- An end-to-end test (`job_failure_halts_bot`) that submits a first trade normally, arms the injector, submits a second trade, and then asserts the bot exits and no additional on-chain events are persisted.

Both tests are marked as failing under current code and serve as the regression specification for the fix.

## Testing

Two new tests cover the failure-halts-processing contract:

- `conductor::job::tests::job_failure_after_retries_halts_processing` — unit test using `Monitor`/`WorkerBuilder` with a `TestJob` that can be configured to fail. Uses `backon` default retry delays (1s + 2s + 4s) with a 12-second observation window.
- `tests::e2e::hedging::job_failure_halts_bot` — end-to-end test using `FailureInjector` to trigger a terminal failure mid-run and asserting the bot process exits within 30 seconds with no additional `OnChainTrade` events persisted.

## Anything else

These tests are intentionally written to fail against the current implementation. The actual fix to `work()` (or the surrounding error-handling logic) is a follow-up and should make both tests pass.