### PR TITLE
fix: job durability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ the limit:
 - [docs/float.md](docs/float.md) - Float type, precision-safe financial
   arithmetic, Solidity-backed operations for guaranteed compatibility with smart
   contracts
+- [docs/feature-flags.md](docs/feature-flags.md) - Cargo feature flags,
+  `test-support` vs `cfg(test)`, common pitfalls with dead code warnings
 
 **Update at the end:**
 
@@ -41,6 +43,11 @@ the limit:
 - **ROADMAP.md** — mark completed issues, link PRs. When a PR is chained
   (depends on a parent PR), mark both as done in the roadmap so it's up to date
   by the time they merge.
+- **`docs/`** — when research or trial-and-error reveals non-obvious patterns,
+  pitfalls, or framework behavior, document it in the relevant `docs/` file (or
+  create a new one). Future agents and developers should not have to rediscover
+  the same things. Prioritize documenting: framework-specific idioms,
+  integration gotchas, and "X doesn't work because Y" findings.
 
 ## Ownership Principles
 

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -96,35 +96,77 @@ logging.
 ### work
 
 Generic apalis handler that bridges `Job` implementations with apalis's
-function-based worker API:
+function-based worker API. Returns `Result<(), JobError>` so apalis can
+distinguish success from failure.
 
 ```rust
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
-where
-    Ctx: Send + Sync + 'static,
-    J: Job<Ctx>,
-{
-    // Retries with exponential backoff, then logs on final failure.
+pub(crate) async fn work<Ctx, J>(
+    job: J, ctx: Data<Arc<Ctx>>,
+) -> Result<(), JobError> {
+    let label = job.label();
+    info!(%label, "Processing job");
+    job.perform(&ctx).await.map_err(|source| JobError::Failed { source: Box::new(source) })
 }
 ```
 
-### Wiring a job into apalis
+### Worker middleware stack
+
+Apalis workers use a Tower middleware stack configured on `WorkerBuilder`. The
+layers are applied in order — outermost first:
 
 ```
 WorkerBuilder::new(name)
-    .backend(job_queue)       // SqliteStorage<MyJob, ...>
-    .data(ctx)                // Arc<MyCtx>
+    .backend(job_queue)
+    .data(ctx)
+    .concurrency(1)                          // sequential processing
+    .retry(RetryPolicy::retries(3))          // 1 initial + 3 retries = 4 attempts
+    .break_circuit_with(fail_stop_config)    // halt on terminal failure
+    .on_event(|ctx, event| { ... })          // observability + lifecycle
     .build(work::<MyCtx, MyJob>)
 ```
 
-The apalis `Monitor` wraps workers and restarts them on failure:
+**Layer roles:**
+
+- **`.concurrency(1)`** — serializes job processing. Without it,
+  `CallAllUnordered` processes jobs in parallel and a failing job can't prevent
+  the next job from starting.
+- **`.retry(RetryPolicy::retries(3))`** — retries failed jobs (replaces backon
+  in the handler). `retries(3)` = 4 total attempts. Instant by default; use
+  `.with_backoff()` for delays.
+- **`.break_circuit_with(config)`** — opens the circuit after
+  `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
+  block new job pickup. Use `failure_threshold(1)` + very long
+  `recovery_timeout` for fail-stop.
+- **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
+  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
+  calling `ctx.stop()` on terminal failure. The circuit breaker alone only
+  pauses the worker (`Poll::Pending`); `ctx.stop()` is needed to actually make
+  the worker exit.
+
+### Error propagation: handler failure -> bot shutdown
+
+1. `work()` returns `Err` -> retry layer retries
+2. Retries exhaust -> error reaches circuit breaker -> circuit opens
+3. Error becomes `Ok(Event::Error)` in apalis `poll_tasks`
+4. `on_event` catches `Event::Error`, calls `ctx.stop()`
+5. Worker exits cleanly (`Ok(())`)
+6. `Monitor::should_restart` returns `false` -> monitor exits
+7. Monitor task propagates error to conductor -> bot shuts down
+
+**Critical:** the monitor `tokio::spawn` task must return `Result`, not swallow
+errors. Without this, the conductor never sees the failure.
+
+### Monitor configuration
 
 ```
 Monitor::new()
-    .should_restart(|_ctx, _error, _attempt| true)
+    .should_restart(|_ctx, _error, _attempt| false)
     .register(|index| { /* WorkerBuilder as above */ })
     .run().await
 ```
+
+`should_restart(false)` — terminal job failure is fail-stop. The worker must not
+restart and process the next job with stale state.
 
 ### AccountForDexTrade
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -100,7 +100,7 @@ pub(crate) struct Conductor {
     /// Manages long-running tasks (order fill monitor) with automatic restart.
     supervisor: SupervisorHandle,
     /// Runs the apalis job queue workers that process trade accounting jobs.
-    monitor: JoinHandle<()>,
+    monitor: JoinHandle<anyhow::Result<()>>,
     /// Periodic executor upkeep (e.g. Schwab token refresh). Absent when
     /// the executor requires no background maintenance.
     executor_maintenance: Option<JoinHandle<()>>,
@@ -361,7 +361,7 @@ impl Conductor {
 
 enum ConductorExit {
     Supervisor(anyhow::Result<()>),
-    Monitor(Result<(), JoinError>),
+    Monitor(Result<anyhow::Result<()>, JoinError>),
     JobCleanup(Result<(), JoinError>),
 }
 
@@ -371,8 +371,9 @@ fn handle_conductor_exit(exit: ConductorExit) -> anyhow::Result<()> {
             result?;
             info!("Supervisor exited");
         }
-        ConductorExit::Monitor(result) => {
-            handle_task_exit(result, "Apalis monitor")?;
+        ConductorExit::Monitor(join_result) => {
+            let inner = join_result.map_err(|error| anyhow::anyhow!(error))?;
+            inner?;
             info!("Apalis monitor exited");
         }
         ConductorExit::JobCleanup(result) => {
@@ -1576,7 +1577,7 @@ mod tests {
 
     fn conductor_with_job_cleanup(job_cleanup: JoinHandle<()>) -> Conductor {
         let supervisor = SupervisorBuilder::default().build().run();
-        let monitor = tokio::spawn(pending::<()>());
+        let monitor = tokio::spawn(pending::<anyhow::Result<()>>());
 
         Conductor {
             supervisor,

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1,7 +1,14 @@
 //! Constructs a fully-wired [`Conductor`] instance from its dependencies.
 
+use std::time::Duration;
+
 use alloy::providers::Provider;
+use apalis::layers::WorkerBuilderExt;
+use apalis::layers::retry::RetryPolicy;
 use apalis::prelude::{Monitor, WorkerBuilder};
+use apalis_core::worker::event::Event;
+use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+use apalis_core::worker::ext::event_listener::EventListenerExt;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
@@ -174,12 +181,14 @@ where
     #[cfg(feature = "test-support")]
     let failure_injector_for_hedge = failure_injector.clone();
 
-    let monitor = tokio::spawn(async move {
+    let fail_stop = CircuitBreakerConfig::default()
+        .with_failure_threshold(1)
+        .with_recovery_timeout(Duration::from_secs(u64::MAX));
+    let fail_stop_for_hedge = fail_stop.clone();
+
+    let monitor: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
         let apalis_monitor = Monitor::new()
-            .should_restart(|_ctx, _error, attempt| {
-                info!(attempt, "Restarting worker");
-                true
-            })
+            .should_restart(|_ctx, _error, _attempt| false)
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
@@ -188,7 +197,17 @@ where
                 #[cfg(feature = "test-support")]
                 let builder = builder.data(failure_injector.clone());
 
-                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3))
+                    .break_circuit_with(fail_stop.clone())
+                    .on_event(|ctx, event| {
+                        if let Event::Error(err) = event {
+                            error!(%err, worker = %ctx.name(), "Job failed after retries");
+                            let _ = ctx.stop();
+                        }
+                    })
+                    .build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
@@ -198,17 +217,25 @@ where
                 #[cfg(feature = "test-support")]
                 let builder = builder.data(failure_injector_for_hedge.clone());
 
-                builder.build(work::<HedgeCtx, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3))
+                    .break_circuit_with(fail_stop_for_hedge.clone())
+                    .on_event(|ctx, event| {
+                        if let Event::Error(err) = event {
+                            error!(%err, worker = %ctx.name(), "Job failed after retries");
+                            let _ = ctx.stop();
+                        }
+                    })
+                    .build(work::<HedgeCtx, _>)
             });
 
         tokio::select! {
             result = apalis_monitor.run() => {
-                if let Err(monitor_error) = result {
-                    error!(%monitor_error, "Apalis monitor exited with error");
-                }
+                result.map_err(|error| anyhow::anyhow!(error))
             }
             _ = order_poller_handle => {
-                error!("Order poller exited unexpectedly");
+                Err(anyhow::anyhow!("Order poller exited unexpectedly"))
             }
         }
     });

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -7,7 +7,6 @@
 
 use apalis::prelude::{Data, Status, TaskSink};
 use apalis_sqlite::SqliteStorage;
-use backon::{ExponentialBuilder, Retryable};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
@@ -15,7 +14,7 @@ use std::fmt;
 use std::sync::Arc;
 #[cfg(feature = "test-support")]
 use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 type Storage<Task> = SqliteStorage<
     Task,
@@ -86,6 +85,21 @@ impl fmt::Display for Label {
     }
 }
 
+/// Job execution error. Wraps the concrete `Job::Error` type at
+/// the `work()` boundary where the handler is generic over job types.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum JobError {
+    #[error("{source}")]
+    Failed {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[cfg(feature = "test-support")]
+    #[error("injected terminal job failure")]
+    Injected,
+}
+
 /// Allows e2e tests to force the next job to fail terminally.
 /// Decorates `Job::perform` — when armed, returns `Err` without
 /// calling the job. When not armed, delegates transparently.
@@ -94,9 +108,16 @@ impl fmt::Display for Label {
 pub struct FailureInjector(Arc<AtomicBool>);
 
 #[cfg(feature = "test-support")]
+impl Default for FailureInjector {
+    fn default() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+}
+
+#[cfg(feature = "test-support")]
 impl FailureInjector {
     pub fn new() -> Self {
-        Self(Arc::new(AtomicBool::new(false)))
+        Self::default()
     }
 
     pub fn arm(&self) {
@@ -106,60 +127,49 @@ impl FailureInjector {
     fn is_armed(&self) -> bool {
         self.0.swap(false, Ordering::SeqCst)
     }
+
+    async fn perform<Ctx, J: Job<Ctx> + Sync>(&self, job: &J, ctx: &Ctx) -> Result<(), JobError>
+    where
+        Ctx: Send + Sync + 'static,
+    {
+        if self.is_armed() {
+            return Err(JobError::Injected);
+        }
+
+        let label = job.label();
+        info!(%label, "Processing job");
+        job.perform(ctx).await.map_err(|source| JobError::Failed {
+            source: Box::new(source),
+        })
+    }
 }
 
 /// Generic apalis handler — test-support build.
-///
-/// Accepts a [`FailureInjector`] via apalis `Data`. When armed,
-/// the job fails without calling `perform`.
 #[cfg(feature = "test-support")]
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>, injector: Data<FailureInjector>)
+pub(crate) async fn work<Ctx, J>(
+    job: J,
+    ctx: Data<Arc<Ctx>>,
+    injector: Data<FailureInjector>,
+) -> Result<(), JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
 {
-    if injector.is_armed() {
-        error!(label = %job.label(), "Injected terminal failure (test)");
-        return;
-    }
-
-    const MAX_RETRIES: usize = 3;
-    let label = job.label();
-    info!(%label, max_retries = MAX_RETRIES, "Starting job");
-
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
+    injector.perform(&job, &ctx).await
 }
 
 /// Generic apalis handler — production build.
 #[cfg(not(feature = "test-support"))]
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
+pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>) -> Result<(), JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
 {
-    const MAX_RETRIES: usize = 3;
     let label = job.label();
-    info!(%label, max_retries = MAX_RETRIES, "Starting job");
-
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
+    info!(%label, "Processing job");
+    job.perform(&ctx).await.map_err(|source| JobError::Failed {
+        source: Box::new(source),
+    })
 }
 
 pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
@@ -182,8 +192,14 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
+    use apalis::layers::WorkerBuilderExt;
+    use apalis::layers::retry::RetryPolicy;
     use apalis::prelude::{Monitor, WorkerBuilder};
+    use apalis_core::worker::event::Event;
+    use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+    use apalis_core::worker::ext::event_listener::EventListenerExt;
     use sqlx::SqlitePool;
 
     use super::*;
@@ -274,20 +290,38 @@ mod tests {
         let ctx_for_assert = ctx.clone();
 
         let monitor_handle = tokio::spawn({
-            let monitor = Monitor::new().register(move |index| {
-                WorkerBuilder::new(format!("test-worker-{index}"))
-                    .backend(queue.clone().into_storage())
-                    .data(ctx.clone())
-                    .data(FailureInjector::new())
-                    .build(work::<TestCtx, TestJob>)
-            });
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    let fail_stop = CircuitBreakerConfig::default()
+                        .with_failure_threshold(1)
+                        .with_recovery_timeout(Duration::from_secs(u64::MAX));
+
+                    WorkerBuilder::new(format!("test-worker-{index}"))
+                        .backend(queue.clone().into_storage())
+                        .data(ctx.clone())
+                        .data(FailureInjector::new())
+                        .concurrency(1)
+                        .retry(RetryPolicy::retries(3))
+                        .break_circuit_with(fail_stop)
+                        .on_event(|ctx, event| {
+                            if let Event::Error(_) = event {
+                                let _ = ctx.stop();
+                            }
+                        })
+                        .build(work::<TestCtx, TestJob>)
+                });
 
             async move { monitor.run().await }
         });
 
-        // backon default: 1s + 2s + 4s retries, plus time for second job
-        tokio::time::sleep(std::time::Duration::from_secs(12)).await;
-        monitor_handle.abort();
+        // RetryPolicy retries instantly, so the monitor should exit
+        // quickly once the failing job exhausts retries.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), monitor_handle).await;
+        assert!(
+            result.is_ok(),
+            "Monitor should have exited after terminal job failure"
+        );
 
         assert_eq!(
             ctx_for_assert.success_count.load(Ordering::SeqCst),

--- a/src/config.rs
+++ b/src/config.rs
@@ -366,7 +366,7 @@ impl std::fmt::Debug for Ctx {
             .field("execution_threshold", &self.execution_threshold)
             .field("assets", &self.assets)
             .field("travel_rule_configured", &self.travel_rule.is_some())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
## What

Replaces the `backon`-based retry loop inside the `work()` handler with apalis Tower middleware layers (`.retry()`, `.break_circuit_with()`, `.on_event()`), and propagates job failures all the way up to the conductor so a terminal job failure causes a clean bot shutdown.

## Why

The previous implementation swallowed errors inside `work()` — failures were logged but never surfaced to the conductor. The monitor task returned `JoinHandle<()>`, so even if a job failed fatally, the conductor had no way to observe it and the bot would continue running in a broken state. Retries were also handled manually with `backon`, duplicating logic that apalis's middleware stack already provides.

## How

**Retry and circuit-breaker middleware:**
- `.concurrency(1)` serializes job processing so a failing job blocks the next one from starting.
- `.retry(RetryPolicy::retries(3))` replaces the `backon` loop — 4 total attempts, instant retries by default.
- `.break_circuit_with(CircuitBreakerConfig)` opens the circuit after 1 failure, with a near-infinite recovery timeout, making it effectively fail-stop.
- `.on_event()` catches `Event::Error` (after retries are exhausted) and calls `ctx.stop()` to actually exit the worker. The circuit breaker alone only pauses pickup via `Poll::Pending`; `ctx.stop()` is required to make the worker exit.

**Error propagation:**
- `work()` now returns `Result<(), JobError>` instead of `()`, so apalis can distinguish success from failure.
- The monitor `tokio::spawn` task is typed as `JoinHandle<anyhow::Result<()>>` and the `tokio::select!` arms return `Result` rather than logging and discarding errors.
- `handle_conductor_exit` unwraps both the `JoinError` and the inner `anyhow::Result`, so a terminal job failure propagates to the conductor and triggers shutdown.
- `Monitor::should_restart` is set to `false` — after a terminal failure the worker must not restart and process the next job with stale state.

**`JobError` type:** A new `JobError` enum wraps the concrete `Job::Error` at the `work()` boundary where the handler is generic. The `test-support` variant (`JobError::Injected`) is used by `FailureInjector`.

**`FailureInjector` refactor:** The injected-failure path is moved into a `FailureInjector::perform()` method, eliminating the duplicated `work()` body between `cfg(feature = "test-support")` and production builds.

## Testing

The existing job worker integration test is updated to mirror the production middleware stack (`.concurrency(1)`, `.retry()`, `.break_circuit_with()`, `.on_event()`). The test now asserts that the monitor exits within 5 seconds after a terminal job failure, replacing the previous 12-second sleep + `abort()` approach. This validates the full failure-propagation path: `work()` error → retry exhaustion → circuit open → `ctx.stop()` → monitor exit.

## Anything else

- `docs/conductor.md` is expanded with a detailed breakdown of the Tower middleware stack, the error-propagation chain, and the reasoning behind each layer's role.
- `docs/feature-flags.md` is added to the `AGENTS.md` reading list.
- `AGENTS.md` now instructs agents to document non-obvious patterns and pitfalls in `docs/` rather than leaving future contributors to rediscover them.
- `Ctx::fmt` uses `finish_non_exhaustive()` to avoid future debug-output breakage when new fields are added.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews