### PR TITLE
fix: job durability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ the limit:
 - [docs/float.md](docs/float.md) - Float type, precision-safe financial
   arithmetic, Solidity-backed operations for guaranteed compatibility with smart
   contracts
+- [docs/feature-flags.md](docs/feature-flags.md) - Cargo feature flags,
+  `test-support` vs `cfg(test)`, common pitfalls with dead code warnings
 
 **Update at the end:**
 
@@ -41,6 +43,11 @@ the limit:
 - **ROADMAP.md** — mark completed issues, link PRs. When a PR is chained
   (depends on a parent PR), mark both as done in the roadmap so it's up to date
   by the time they merge.
+- **`docs/`** — when research or trial-and-error reveals non-obvious patterns,
+  pitfalls, or framework behavior, document it in the relevant `docs/` file (or
+  create a new one). Future agents and developers should not have to rediscover
+  the same things. Prioritize documenting: framework-specific idioms,
+  integration gotchas, and "X doesn't work because Y" findings.
 
 ## Ownership Principles
 

--- a/dashboard/src/lib/components/log-panel.svelte
+++ b/dashboard/src/lib/components/log-panel.svelte
@@ -258,14 +258,14 @@
   }
 
   const getMessage = (entry: LogEntry): string => {
-    return entry.fields?.message ?? JSON.stringify(entry)
+    return entry.fields.message
   }
 
   const getTarget = (entry: LogEntry): string => {
     const spans = entry.spans?.map(span => span.name).join(' > ')
     if (spans) return `${entry.target}::${spans}`
     if (entry.span) return `${entry.target}::${entry.span.name}`
-    return entry.target ?? ''
+    return entry.target
   }
 </script>
 

--- a/dashboard/src/lib/components/settings-bar.svelte
+++ b/dashboard/src/lib/components/settings-bar.svelte
@@ -67,7 +67,7 @@
   <dialog
     bind:this={dialogEl}
     class="w-full max-w-md rounded-lg border bg-card p-6 text-foreground shadow-lg backdrop:bg-black/50"
-    onclick={(event) => { if (event.target === dialogEl) dialogEl?.close() }}
+    onclick={(event) => { if (event.target === dialogEl) dialogEl.close() }}
   >
     <div class="mb-4 flex items-center justify-between">
       <h3 class="text-sm font-semibold text-foreground">Configuration</h3>

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -88,7 +88,7 @@
     </button>
     <button
       class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'logs' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs')}
+      onclick={() => { activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs'); }}
     >
       Logs
     </button>
@@ -98,7 +98,7 @@
   <nav class="hidden shrink-0 gap-1 border-b bg-card/50 px-4 md:flex">
     <button
       class={desktopTabClass(activeTab.current === 'dashboard')}
-      onclick={() => activeTab.update(() => 'dashboard')}
+      onclick={() => { activeTab.update(() => 'dashboard'); }}
     >
       Dashboard
     </button>
@@ -112,7 +112,7 @@
 
     <button
       class={desktopTabClass(activeTab.current === 'logs')}
-      onclick={() => activeTab.update(() => 'logs')}
+      onclick={() => { activeTab.update(() => 'logs'); }}
     >
       Logs
     </button>

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -96,35 +96,77 @@ logging.
 ### work
 
 Generic apalis handler that bridges `Job` implementations with apalis's
-function-based worker API:
+function-based worker API. Returns `Result<(), JobError>` so apalis can
+distinguish success from failure.
 
 ```rust
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
-where
-    Ctx: Send + Sync + 'static,
-    J: Job<Ctx>,
-{
-    // Retries with exponential backoff, then logs on final failure.
+pub(crate) async fn work<Ctx, J>(
+    job: J, ctx: Data<Arc<Ctx>>,
+) -> Result<(), JobError> {
+    let label = job.label();
+    info!(%label, "Processing job");
+    job.perform(&ctx).await.map_err(|source| JobError::Failed { source: Box::new(source) })
 }
 ```
 
-### Wiring a job into apalis
+### Worker middleware stack
+
+Apalis workers use a Tower middleware stack configured on `WorkerBuilder`. The
+layers are applied in order — outermost first:
 
 ```
 WorkerBuilder::new(name)
-    .backend(job_queue)       // SqliteStorage<MyJob, ...>
-    .data(ctx)                // Arc<MyCtx>
+    .backend(job_queue)
+    .data(ctx)
+    .concurrency(1)                          // sequential processing
+    .retry(RetryPolicy::retries(3))          // 1 initial + 3 retries = 4 attempts
+    .break_circuit_with(fail_stop_config)    // halt on terminal failure
+    .on_event(|ctx, event| { ... })          // observability + lifecycle
     .build(work::<MyCtx, MyJob>)
 ```
 
-The apalis `Monitor` wraps workers and restarts them on failure:
+**Layer roles:**
+
+- **`.concurrency(1)`** — serializes job processing. Without it,
+  `CallAllUnordered` processes jobs in parallel and a failing job can't prevent
+  the next job from starting.
+- **`.retry(RetryPolicy::retries(3))`** — retries failed jobs (replaces backon
+  in the handler). `retries(3)` = 4 total attempts. Instant by default; use
+  `.with_backoff()` for delays.
+- **`.break_circuit_with(config)`** — opens the circuit after
+  `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
+  block new job pickup. Use `failure_threshold(1)` + very long
+  `recovery_timeout` for fail-stop.
+- **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
+  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
+  calling `ctx.stop()` on terminal failure. The circuit breaker alone only
+  pauses the worker (`Poll::Pending`); `ctx.stop()` is needed to actually make
+  the worker exit.
+
+### Error propagation: handler failure -> bot shutdown
+
+1. `work()` returns `Err` -> retry layer retries
+2. Retries exhaust -> error reaches circuit breaker -> circuit opens
+3. Error becomes `Ok(Event::Error)` in apalis `poll_tasks`
+4. `on_event` catches `Event::Error`, calls `ctx.stop()`
+5. Worker exits cleanly (`Ok(())`)
+6. `Monitor::should_restart` returns `false` -> monitor exits
+7. Monitor task propagates error to conductor -> bot shuts down
+
+**Critical:** the monitor `tokio::spawn` task must return `Result`, not swallow
+errors. Without this, the conductor never sees the failure.
+
+### Monitor configuration
 
 ```
 Monitor::new()
-    .should_restart(|_ctx, _error, _attempt| true)
+    .should_restart(|_ctx, _error, _attempt| false)
     .register(|index| { /* WorkerBuilder as above */ })
     .run().await
 ```
+
+`should_restart(false)` — terminal job failure is fail-stop. The worker must not
+restart and process the next job with stale state.
 
 ### AccountForDexTrade
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,69 @@
+# Feature Flags
+
+## Flag inventory
+
+| Flag                 | Purpose                             | Enabled by    |
+| -------------------- | ----------------------------------- | ------------- |
+| `test-support`       | Test infra visible to e2e tests     | dev-deps only |
+| `mock`               | Mock executor / EVM implementations | dev-deps only |
+| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets` |
+| `wallet-private-key` | Local signer wallet support         | `all-wallets` |
+| `all-wallets`        | All wallet backends                 | `default`     |
+
+## `test-support` vs `cfg(test)`
+
+- **`cfg(test)`** is true when compiling unit tests (`#[cfg(test)] mod tests`)
+  AND when compiling the lib for integration tests. It's set by the compiler,
+  not controllable per-crate.
+- **`feature = "test-support"`** is a cargo feature enabled only by
+  `[dev-dependencies]`. It gates types/methods that integration tests (`tests/`)
+  need but unit tests and production builds don't.
+
+### When to use which
+
+| Scenario                                  | Gate                                |
+| ----------------------------------------- | ----------------------------------- |
+| Unit test helper (same file, `mod tests`) | `#[cfg(test)]`                      |
+| Type/method used by e2e tests in `tests/` | `#[cfg(feature = "test-support")]`  |
+| Type that must exist in all builds but is | Always compiled; methods gated with |
+| only functional in tests                  | `#[cfg(feature = "test-support")]`  |
+
+### Common pitfall: dead code warnings
+
+A `pub` method gated on `cfg(any(test, feature = "test-support"))` will trigger
+`dead_code` warnings during `cargo test` if no unit test calls it — because
+`cfg(test)` makes it visible to the compiler but nothing in the lib crate
+references it. Fix: gate on `feature = "test-support"` only (not `test`). The
+method won't exist in unit test builds but will exist in e2e builds where
+dev-deps enable `test-support`.
+
+### Pattern: zero-size prod / functional test type
+
+When a type needs to exist in all builds (to avoid `#[cfg]` on every function
+parameter and call site) but only does real work in tests:
+
+```rust
+#[derive(Clone)]
+pub struct MyTestHook(
+    #[cfg(feature = "test-support")] Arc<AtomicBool>,
+    #[cfg(not(feature = "test-support"))] (),
+);
+
+impl MyTestHook {
+    pub fn new() -> Self { /* ... */ }
+
+    #[cfg(feature = "test-support")]
+    pub fn arm(&self) { /* ... */ }
+
+    fn check(&self) -> bool {
+        #[cfg(feature = "test-support")]
+        { self.0.swap(false, Ordering::SeqCst) }
+        #[cfg(not(feature = "test-support"))]
+        false
+    }
+}
+```
+
+The type compiles everywhere (zero-size in prod). Methods that only tests call
+are gated on `feature = "test-support"`. The `check` method always exists but
+returns `false` in prod (the compiler eliminates the branch).

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -2,22 +2,25 @@
 
 ## Flag inventory
 
-| Flag                 | Purpose                             | Enabled by    |
-| -------------------- | ----------------------------------- | ------------- |
-| `test-support`       | Test infra visible to e2e tests     | dev-deps only |
-| `mock`               | Mock executor / EVM implementations | dev-deps only |
-| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets` |
-| `wallet-private-key` | Local signer wallet support         | `all-wallets` |
-| `all-wallets`        | All wallet backends                 | `default`     |
+| Flag                 | Purpose                             | Enabled by                  |
+| -------------------- | ----------------------------------- | --------------------------- |
+| `test-support`       | Test infra visible to e2e tests     | explicit feature enablement |
+| `mock`               | Mock executor / EVM implementations | dev-deps only               |
+| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets`               |
+| `wallet-private-key` | Local signer wallet support         | `all-wallets`               |
+| `all-wallets`        | All wallet backends                 | `default`                   |
 
 ## `test-support` vs `cfg(test)`
 
-- **`cfg(test)`** is true when compiling unit tests (`#[cfg(test)] mod tests`)
-  AND when compiling the lib for integration tests. It's set by the compiler,
-  not controllable per-crate.
-- **`feature = "test-support"`** is a cargo feature enabled only by
-  `[dev-dependencies]`. It gates types/methods that integration tests (`tests/`)
-  need but unit tests and production builds don't.
+- **`cfg(test)`** is true only for the crate currently being compiled for its
+  own unit tests (for example `#[cfg(test)] mod tests`). It is not set when that
+  crate is compiled as a dependency of an integration test or another target. It
+  is set by the compiler, not by Cargo feature selection.
+- **`feature = "test-support"`** is a normal Cargo feature. Declaring a crate in
+  `[dev-dependencies]` does not automatically enable that feature. If code in
+  `tests/` or another build target needs feature-gated APIs, the feature must be
+  enabled explicitly via `--features`, a dependency feature list, or normal
+  feature unification during the test build.
 
 ### When to use which
 
@@ -31,11 +34,14 @@
 ### Common pitfall: dead code warnings
 
 A `pub` method gated on `cfg(any(test, feature = "test-support"))` will trigger
-`dead_code` warnings during `cargo test` if no unit test calls it — because
-`cfg(test)` makes it visible to the compiler but nothing in the lib crate
-references it. Fix: gate on `feature = "test-support"` only (not `test`). The
-method won't exist in unit test builds but will exist in e2e builds where
-dev-deps enable `test-support`.
+`dead_code` warnings during unit-test builds if no unit test calls it, because
+`cfg(test)` makes it visible to that crate's test build. If the API exists only
+for integration tests or external test harnesses, prefer
+`#[cfg(feature = "test-support")]` so it is compiled only when the feature is
+actually enabled. If unit tests also need it,
+`cfg(any(test, feature =
+"test-support"))` is correct, but the method still
+needs real callers in unit-test builds.
 
 ### Pattern: zero-size prod / functional test type
 
@@ -64,6 +70,12 @@ impl MyTestHook {
 }
 ```
 
-The type compiles everywhere (zero-size in prod). Methods that only tests call
-are gated on `feature = "test-support"`. The `check` method always exists but
-returns `false` in prod (the compiler eliminates the branch).
+The type compiles everywhere (zero-size in prod). Methods that only integration
+tests or feature-enabled test builds call are gated on
+`feature =
+"test-support"`. The `check` method always exists but returns `false`
+in prod (the compiler eliminates the branch). If unit tests in the same crate
+also need test-only helpers, gate those helpers with
+`cfg(any(test, feature =
+"test-support"))` instead of assuming `cfg(test)` will
+propagate through dependency builds.

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -754,8 +754,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 
@@ -845,8 +849,12 @@ mod tests {
             redemption_wallet: Some(Address::ZERO),
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -749,8 +749,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 
@@ -835,8 +840,13 @@ mod tests {
             wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
             execution_threshold: ExecutionThreshold::whole_share(),
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -282,8 +282,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -287,8 +287,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1098,8 +1098,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1093,8 +1093,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -603,8 +603,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 
@@ -674,8 +678,12 @@ mod tests {
             redemption_wallet: Some(Address::ZERO),
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -598,8 +598,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 
@@ -664,8 +669,13 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -686,8 +686,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -681,8 +681,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -250,8 +250,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 
@@ -297,8 +301,12 @@ mod tests {
             redemption_wallet: Some(Address::ZERO),
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -245,8 +245,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 
@@ -287,8 +292,13 @@ mod tests {
                 cash,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -169,8 +169,13 @@ mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -174,8 +174,12 @@ mod tests {
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
+<<<<<<< HEAD
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -15,7 +15,7 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use task_supervisor::SupervisorHandle;
+use task_supervisor::{SupervisorError, SupervisorHandle};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tokio::task::{JoinError, JoinHandle};
 use tokio::time::MissedTickBehavior;
@@ -103,7 +103,7 @@ pub(crate) struct Conductor {
     /// Manages long-running tasks (order fill monitor) with automatic restart.
     supervisor: SupervisorHandle,
     /// Runs the apalis job queue workers that process trade accounting jobs.
-    monitor: JoinHandle<()>,
+    monitor: JoinHandle<Result<(), MonitorTaskError>>,
     /// Periodic executor upkeep (e.g. Schwab token refresh). Absent when
     /// the executor requires no background maintenance.
     executor_maintenance: Option<JoinHandle<()>>,
@@ -112,8 +112,41 @@ pub(crate) struct Conductor {
     /// Polls wallet balances and onchain state on a timer. Absent when
     /// rebalancing (and therefore wallet context) is not configured.
     inventory_poller: Option<JoinHandle<()>>,
+    /// Polls pending offchain orders until they reach a terminal state.
+    order_poller_handle: JoinHandle<()>,
     /// Periodically removes terminal rows from the persistent job queue.
     job_cleanup: JoinHandle<()>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MonitorTaskError {
+    #[error("Apalis worker failed after retries")]
+    TerminalJobFailure,
+
+    #[error("Apalis monitor exited unexpectedly")]
+    UnexpectedExit,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ConductorExitError {
+    #[error(transparent)]
+    Supervisor(#[from] SupervisorError),
+
+    #[error(transparent)]
+    Join(#[from] JoinError),
+
+    #[error(transparent)]
+    Monitor(#[from] MonitorTaskError),
+
+    #[error("{task} failed")]
+    TaskFailed {
+        task: &'static str,
+        #[source]
+        source: JoinError,
+    },
+
+    #[error("{task} exited unexpectedly")]
+    UnexpectedTaskExit { task: &'static str },
 }
 
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
@@ -309,7 +342,7 @@ impl Conductor {
             poll_notify: Arc::new(tokio::sync::Notify::new()),
             wallet_polling,
             tokenizer,
-            #[cfg(feature = "test-support")]
+            #[cfg(any(test, feature = "test-support"))]
             failure_injector: ctx.failure_injector.clone(),
         };
 
@@ -333,12 +366,14 @@ impl Conductor {
 impl Conductor {
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
         let exit = tokio::select! {
-            result = self.supervisor.wait() => ConductorExit::Supervisor(result.map_err(anyhow::Error::new)),
+            result = self.supervisor.wait() => ConductorExit::Supervisor(result),
             result = &mut self.monitor => ConductorExit::Monitor(result),
+            result = &mut self.order_poller_handle => ConductorExit::OrderPoller(result),
             result = &mut self.job_cleanup => ConductorExit::JobCleanup(result),
         };
 
-        handle_conductor_exit(exit)
+        handle_conductor_exit(exit)?;
+        Ok(())
     }
 
     pub(crate) fn abort_all(&self) {
@@ -354,6 +389,7 @@ impl Conductor {
         if let Some(ref handle) = self.inventory_poller {
             handle.abort();
         }
+        self.order_poller_handle.abort();
         if let Some(ref handle) = self.executor_maintenance {
             handle.abort();
         }
@@ -362,35 +398,56 @@ impl Conductor {
 }
 
 enum ConductorExit {
-    Supervisor(anyhow::Result<()>),
-    Monitor(Result<(), JoinError>),
+    Supervisor(Result<(), SupervisorError>),
+    Monitor(Result<Result<(), MonitorTaskError>, JoinError>),
+    OrderPoller(Result<(), JoinError>),
     JobCleanup(Result<(), JoinError>),
 }
 
-fn handle_conductor_exit(exit: ConductorExit) -> anyhow::Result<()> {
+fn handle_conductor_exit(exit: ConductorExit) -> Result<(), ConductorExitError> {
     match exit {
-        ConductorExit::Supervisor(result) => {
-            result?;
-            info!("Supervisor exited");
-        }
-        ConductorExit::Monitor(result) => {
-            handle_task_exit(result, "Apalis monitor")?;
-            info!("Apalis monitor exited");
-        }
-        ConductorExit::JobCleanup(result) => {
-            handle_required_background_task_exit(result, "Job cleanup")?;
-            info!("Job cleanup exited");
-        }
+        ConductorExit::Supervisor(result) => handle_supervisor_exit(result),
+        ConductorExit::Monitor(join_result) => handle_monitor_exit(join_result),
+        ConductorExit::OrderPoller(result) => handle_required_task_exit(result, "Order poller"),
+        ConductorExit::JobCleanup(result) => handle_required_task_exit(result, "Job cleanup"),
     }
+}
 
+fn handle_supervisor_exit(result: Result<(), SupervisorError>) -> Result<(), ConductorExitError> {
+    result?;
+    info!("Supervisor exited");
     Ok(())
 }
 
-fn handle_task_exit(result: Result<(), JoinError>, task: &'static str) -> anyhow::Result<()> {
+fn handle_monitor_exit(
+    join_result: Result<Result<(), MonitorTaskError>, JoinError>,
+) -> Result<(), ConductorExitError> {
+    let inner = join_result?;
+    inner?;
+    info!("Apalis monitor exited");
+    Ok(())
+}
+
+fn handle_required_task_exit(
+    result: Result<(), JoinError>,
+    task: &'static str,
+) -> Result<(), ConductorExitError> {
+    handle_required_background_task_exit(result, task)?;
+    info!("{task} exited");
+    Ok(())
+}
+
+fn handle_task_exit(
+    result: Result<(), JoinError>,
+    task: &'static str,
+) -> Result<(), ConductorExitError> {
     if let Err(join_error) = result
         && !join_error.is_cancelled()
     {
-        return Err(anyhow::Error::new(join_error).context(format!("{task} failed")));
+        return Err(ConductorExitError::TaskFailed {
+            task,
+            source: join_error,
+        });
     }
 
     Ok(())
@@ -399,9 +456,9 @@ fn handle_task_exit(result: Result<(), JoinError>, task: &'static str) -> anyhow
 fn handle_required_background_task_exit(
     result: Result<(), JoinError>,
     task: &'static str,
-) -> anyhow::Result<()> {
+) -> Result<(), ConductorExitError> {
     match result {
-        Ok(()) => Err(anyhow::anyhow!("{task} exited unexpectedly")),
+        Ok(()) => Err(ConductorExitError::UnexpectedTaskExit { task }),
         Err(join_error) => handle_task_exit(Err(join_error), task),
     }
 }
@@ -1654,7 +1711,8 @@ mod tests {
 
     fn conductor_with_job_cleanup(job_cleanup: JoinHandle<()>) -> Conductor {
         let supervisor = SupervisorBuilder::default().build().run();
-        let monitor = tokio::spawn(pending::<()>());
+        let monitor = tokio::spawn(pending::<Result<(), MonitorTaskError>>());
+        let order_poller_handle = tokio::spawn(pending::<()>());
 
         Conductor {
             supervisor,
@@ -1662,6 +1720,7 @@ mod tests {
             executor_maintenance: None,
             rebalancer: None,
             inventory_poller: None,
+            order_poller_handle,
             job_cleanup,
         }
     }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -309,6 +309,8 @@ impl Conductor {
             poll_notify: Arc::new(tokio::sync::Notify::new()),
             wallet_polling,
             tokenizer,
+            #[cfg(feature = "test-support")]
+            failure_injector: ctx.failure_injector.clone(),
         };
 
         let mut conductor = builder::spawn()

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -12,6 +12,8 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 
+#[cfg(feature = "test-support")]
+use super::job::FailureInjector;
 use super::job::work;
 use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
 use super::monitor::positions::PositionMonitor;
@@ -55,6 +57,8 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) poll_notify: Arc<tokio::sync::Notify>,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
+    #[cfg(feature = "test-support")]
+    pub(crate) failure_injector: FailureInjector,
 }
 
 /// Wires all runtime components and returns a running [`Conductor`].
@@ -165,6 +169,11 @@ where
         .build()
         .run();
 
+    #[cfg(feature = "test-support")]
+    let failure_injector = context.failure_injector;
+    #[cfg(feature = "test-support")]
+    let failure_injector_for_hedge = failure_injector.clone();
+
     let monitor = tokio::spawn(async move {
         let apalis_monitor = Monitor::new()
             .should_restart(|_ctx, _error, attempt| {
@@ -172,16 +181,24 @@ where
                 true
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("order-fill-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
-                    .data(accountant_ctx.clone())
-                    .build(work::<AccountantCtx<Prov, Exec>, _>)
+                    .data(accountant_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder.data(failure_injector.clone());
+
+                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("hedge-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
                     .backend(hedge_queue.clone().into_storage())
-                    .data(hedge_ctx.clone())
-                    .build(work::<HedgeCtx, _>)
+                    .data(hedge_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder.data(failure_injector_for_hedge.clone());
+
+                builder.build(work::<HedgeCtx, _>)
             });
 
         tokio::select! {

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1,9 +1,15 @@
 //! Constructs a fully-wired [`Conductor`] instance from its dependencies.
 
 use alloy::providers::Provider;
+use apalis::layers::WorkerBuilderExt;
+use apalis::layers::retry::RetryPolicy;
 use apalis::prelude::{Monitor, WorkerBuilder};
+use apalis_core::worker::event::Event;
+use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+use apalis_core::worker::ext::event_listener::EventListenerExt;
 use sqlx::SqlitePool;
 use std::sync::Arc;
+use std::time::Duration;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -12,12 +18,12 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
 use super::job::FailureInjector;
 use super::job::work;
 use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
 use super::monitor::positions::PositionMonitor;
-use super::{Conductor, spawn_inventory_poller, spawn_order_poller};
+use super::{Conductor, MonitorTaskError, spawn_inventory_poller, spawn_order_poller};
 use crate::config::Ctx;
 use crate::inventory::{InventoryPollingService, InventorySnapshot, WalletPollingCtx};
 use crate::offchain_order::OffchainOrder;
@@ -57,7 +63,7 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) poll_notify: Arc<tokio::sync::Notify>,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
 }
 
@@ -169,46 +175,82 @@ where
         .build()
         .run();
 
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     let failure_injector = context.failure_injector;
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     let failure_injector_for_hedge = failure_injector.clone();
+    let failure_notify = Arc::new(tokio::sync::Notify::new());
+    let failure_notify_for_hedge = failure_notify.clone();
 
-    let monitor = tokio::spawn(async move {
+    let fail_stop = CircuitBreakerConfig::default()
+        .with_failure_threshold(1)
+        .with_recovery_timeout(Duration::from_secs(u64::MAX));
+    let fail_stop_for_hedge = fail_stop.clone();
+
+    let monitor: JoinHandle<Result<(), MonitorTaskError>> = tokio::spawn(async move {
+        let failure_notify_for_accountant = failure_notify.clone();
+        let failure_notify_for_select = failure_notify.clone();
         let apalis_monitor = Monitor::new()
-            .should_restart(|_ctx, _error, attempt| {
-                info!(attempt, "Restarting worker");
-                true
-            })
+            .should_restart(|_ctx, _error, _attempt| false)
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
                     .data(accountant_ctx.clone());
 
-                #[cfg(feature = "test-support")]
+                #[cfg(any(test, feature = "test-support"))]
                 let builder = builder.data(failure_injector.clone());
 
-                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3))
+                    .break_circuit_with(fail_stop.clone())
+                    .on_event({
+                        let failure_notify = failure_notify_for_accountant.clone();
+                        move |ctx, event| {
+                            if let Event::Error(err) = event {
+                                error!(%err, worker = %ctx.name(), "Job failed after retries");
+                                failure_notify.notify_waiters();
+                                let _ = ctx.stop();
+                            }
+                        }
+                    })
+                    .build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
                     .backend(hedge_queue.clone().into_storage())
                     .data(hedge_ctx.clone());
 
-                #[cfg(feature = "test-support")]
+                #[cfg(any(test, feature = "test-support"))]
                 let builder = builder.data(failure_injector_for_hedge.clone());
 
-                builder.build(work::<HedgeCtx, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3))
+                    .break_circuit_with(fail_stop_for_hedge.clone())
+                    .on_event({
+                        let failure_notify = failure_notify_for_hedge.clone();
+                        move |ctx, event| {
+                            if let Event::Error(err) = event {
+                                error!(%err, worker = %ctx.name(), "Job failed after retries");
+                                failure_notify.notify_waiters();
+                                let _ = ctx.stop();
+                            }
+                        }
+                    })
+                    .build(work::<HedgeCtx, _>)
             });
 
         tokio::select! {
+            () = failure_notify_for_select.notified() => Err(MonitorTaskError::TerminalJobFailure),
             result = apalis_monitor.run() => {
-                if let Err(monitor_error) = result {
-                    error!(%monitor_error, "Apalis monitor exited with error");
+                match result {
+                    Ok(()) => Err(MonitorTaskError::UnexpectedExit),
+                    Err(error) => {
+                        error!(?error, "Apalis monitor exited");
+                        Err(MonitorTaskError::UnexpectedExit)
+                    }
                 }
-            }
-            _ = order_poller_handle => {
-                error!("Order poller exited unexpectedly");
             }
         }
     });
@@ -219,6 +261,7 @@ where
         executor_maintenance,
         rebalancer,
         inventory_poller,
+        order_poller_handle,
         job_cleanup,
     }
 }

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -13,6 +13,8 @@ use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
+#[cfg(feature = "test-support")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{error, info, warn};
 
 type Storage<Task> = SqliteStorage<
@@ -84,16 +86,61 @@ impl fmt::Display for Label {
     }
 }
 
-/// Generic apalis handler that bridges [`Job`] implementations
-/// with apalis's function-based worker API.
+/// Allows e2e tests to force the next job to fail terminally.
+/// Decorates `Job::perform` — when armed, returns `Err` without
+/// calling the job. When not armed, delegates transparently.
+#[cfg(feature = "test-support")]
+#[derive(Clone)]
+pub struct FailureInjector(Arc<AtomicBool>);
+
+#[cfg(feature = "test-support")]
+impl FailureInjector {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn arm(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    fn is_armed(&self) -> bool {
+        self.0.swap(false, Ordering::SeqCst)
+    }
+}
+
+/// Generic apalis handler — test-support build.
 ///
-/// Register with apalis via:
-/// ```text
-/// WorkerBuilder::new(name)
-///     .backend(storage)
-///     .data(ctx)
-///     .build(work::<MyCtx, MyJob>)
-/// ```
+/// Accepts a [`FailureInjector`] via apalis `Data`. When armed,
+/// the job fails without calling `perform`.
+#[cfg(feature = "test-support")]
+pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>, injector: Data<FailureInjector>)
+where
+    Ctx: Send + Sync + 'static,
+    J: Job<Ctx> + Sync,
+{
+    if injector.is_armed() {
+        error!(label = %job.label(), "Injected terminal failure (test)");
+        return;
+    }
+
+    const MAX_RETRIES: usize = 3;
+    let label = job.label();
+    info!(%label, max_retries = MAX_RETRIES, "Starting job");
+
+    let result = (|| job.perform(&ctx))
+        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
+        .notify(|error, duration| {
+            warn!(%label, %error, ?duration, "Retrying job after transient failure");
+        })
+        .await;
+
+    if let Err(error) = result {
+        error!(%label, %error, "Job failed after retries");
+    }
+}
+
+/// Generic apalis handler — production build.
+#[cfg(not(feature = "test-support"))]
 pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
 where
     Ctx: Send + Sync + 'static,
@@ -139,6 +186,40 @@ mod tests {
     use super::*;
     use crate::conductor::setup_apalis_tables;
     use crate::test_utils::setup_test_db;
+
+    #[test]
+    fn failure_injector_not_armed_by_default() {
+        let injector = FailureInjector::new();
+        assert!(!injector.is_armed());
+    }
+
+    #[test]
+    fn failure_injector_arm_then_check_auto_disarms() {
+        let injector = FailureInjector::new();
+
+        injector.arm();
+        assert!(injector.is_armed());
+        assert!(
+            !injector.is_armed(),
+            "second check should be false (auto-disarmed)"
+        );
+    }
+
+    #[test]
+    fn failure_injector_shared_across_clones() {
+        let injector = FailureInjector::new();
+        let clone = injector.clone();
+
+        injector.arm();
+        assert!(
+            clone.is_armed(),
+            "arming original should be visible from clone"
+        );
+        assert!(
+            !injector.is_armed(),
+            "should be disarmed after clone consumed it"
+        );
+    }
 
     async fn insert_job(
         pool: &SqlitePool,

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -181,6 +181,9 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use apalis::prelude::{Monitor, WorkerBuilder};
     use sqlx::SqlitePool;
 
     use super::*;
@@ -218,6 +221,79 @@ mod tests {
         assert!(
             !injector.is_armed(),
             "should be disarmed after clone consumed it"
+        );
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct TestJob {
+        should_fail: bool,
+    }
+
+    struct TestCtx {
+        success_count: AtomicUsize,
+    }
+
+    impl Job<TestCtx> for TestJob {
+        type Error = TestJobError;
+
+        fn label(&self) -> Label {
+            Label::new(format!("test-job(should_fail={})", self.should_fail))
+        }
+
+        async fn perform(&self, ctx: &TestCtx) -> Result<(), Self::Error> {
+            if self.should_fail {
+                return Err(TestJobError);
+            }
+
+            ctx.success_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test job deliberately failed")]
+    struct TestJobError;
+
+    /// RAI-199: a job that fails after all retries must halt further
+    /// processing. Currently `work()` swallows the error and the worker
+    /// picks up the next job with stale state.
+    ///
+    /// FAILS with current code — the second job runs.
+    #[tokio::test]
+    async fn job_failure_after_retries_halts_processing() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&pool);
+        queue.push(TestJob { should_fail: true }).await.unwrap();
+        queue.push(TestJob { should_fail: false }).await.unwrap();
+
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+        });
+        let ctx_for_assert = ctx.clone();
+
+        let monitor_handle = tokio::spawn({
+            let monitor = Monitor::new().register(move |index| {
+                WorkerBuilder::new(format!("test-worker-{index}"))
+                    .backend(queue.clone().into_storage())
+                    .data(ctx.clone())
+                    .data(FailureInjector::new())
+                    .build(work::<TestCtx, TestJob>)
+            });
+
+            async move { monitor.run().await }
+        });
+
+        // backon default: 1s + 2s + 4s retries, plus time for second job
+        tokio::time::sleep(std::time::Duration::from_secs(12)).await;
+        monitor_handle.abort();
+
+        assert_eq!(
+            ctx_for_assert.success_count.load(Ordering::SeqCst),
+            0,
+            "The second job should NOT have been processed after a prior \
+             job failed all retries (RAI-199)."
         );
     }
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -7,15 +7,14 @@
 
 use apalis::prelude::{Data, Status, TaskSink};
 use apalis_sqlite::SqliteStorage;
-use backon::{ExponentialBuilder, Retryable};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
-#[cfg(feature = "test-support")]
-use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::{error, info, warn};
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::Mutex;
+use tracing::{error, info};
 
 type Storage<Task> = SqliteStorage<
     Task,
@@ -72,6 +71,7 @@ where
 }
 
 /// Human-readable identifier for an enqueued job, used in structured logging.
+#[derive(Debug)]
 pub(crate) struct Label(String);
 
 impl Label {
@@ -86,80 +86,121 @@ impl fmt::Display for Label {
     }
 }
 
+/// Job execution error. Wraps the concrete `Job::Error` type at
+/// the `work()` boundary where the handler is generic over job types.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum JobError {
+    #[error("{label}: {source}")]
+    Failed {
+        label: Label,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[error("injected terminal job failure")]
+    Injected,
+}
+
 /// Allows e2e tests to force the next job to fail terminally.
-/// Decorates `Job::perform` — when armed, returns `Err` without
+/// Decorates `Job::perform` -- when armed, returns `Err` without
 /// calling the job. When not armed, delegates transparently.
-#[cfg(feature = "test-support")]
-#[derive(Clone)]
-pub struct FailureInjector(Arc<AtomicBool>);
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Clone, Default)]
+pub struct FailureInjector(Arc<Mutex<InjectionState>>);
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Default)]
+enum InjectionState {
+    #[default]
+    Idle,
+    Armed,
+    Targeted(String),
+}
+
+#[cfg(any(test, feature = "test-support"))]
 impl FailureInjector {
-    pub fn new() -> Self {
-        Self(Arc::new(AtomicBool::new(false)))
-    }
-
     pub fn arm(&self) {
-        self.0.store(true, Ordering::SeqCst);
+        *self.lock_state() = InjectionState::Armed;
     }
 
+    #[cfg(test)]
     fn is_armed(&self) -> bool {
-        self.0.swap(false, Ordering::SeqCst)
+        let state = &mut *self.lock_state();
+        let was_armed = matches!(state, InjectionState::Armed);
+
+        if was_armed {
+            *state = InjectionState::Idle;
+        }
+
+        was_armed
+    }
+
+    fn should_inject(&self, label: &Label) -> bool {
+        let state = &mut *self.lock_state();
+
+        match state {
+            InjectionState::Idle => false,
+            InjectionState::Armed => {
+                *state = InjectionState::Targeted(label.to_string());
+                true
+            }
+            InjectionState::Targeted(target_label) => target_label == &label.to_string(),
+        }
+    }
+
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, InjectionState> {
+        match self.0.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    async fn perform<Ctx, J: Job<Ctx> + Sync>(&self, job: &J, ctx: &Ctx) -> Result<(), JobError>
+    where
+        Ctx: Send + Sync + 'static,
+    {
+        let label = job.label();
+
+        if self.should_inject(&label) {
+            return Err(JobError::Injected);
+        }
+
+        info!(%label, "Processing job");
+        job.perform(ctx).await.map_err(|source| JobError::Failed {
+            label,
+            source: Box::new(source),
+        })
     }
 }
 
-/// Generic apalis handler — test-support build.
-///
-/// Accepts a [`FailureInjector`] via apalis `Data`. When armed,
-/// the job fails without calling `perform`.
-#[cfg(feature = "test-support")]
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>, injector: Data<FailureInjector>)
+/// Generic apalis handler -- test-support build.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) async fn work<Ctx, J>(
+    job: J,
+    ctx: Data<Arc<Ctx>>,
+    injector: Data<FailureInjector>,
+) -> Result<(), JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
 {
-    if injector.is_armed() {
-        error!(label = %job.label(), "Injected terminal failure (test)");
-        return;
-    }
-
-    const MAX_RETRIES: usize = 3;
-    let label = job.label();
-    info!(%label, max_retries = MAX_RETRIES, "Starting job");
-
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
+    injector.perform(&job, &ctx).await
 }
 
-/// Generic apalis handler — production build.
+/// Generic apalis handler -- production build.
 #[cfg(not(feature = "test-support"))]
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
+pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>) -> Result<(), JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
 {
-    const MAX_RETRIES: usize = 3;
     let label = job.label();
-    info!(%label, max_retries = MAX_RETRIES, "Starting job");
-
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
+    info!(%label, "Processing job");
+    job.perform(&ctx).await.map_err(|source| JobError::Failed {
+        label,
+        source: Box::new(source),
+    })
 }
 
 pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
@@ -181,10 +222,15 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+    use apalis::layers::WorkerBuilderExt;
+    use apalis::layers::retry::RetryPolicy;
     use apalis::prelude::{Monitor, WorkerBuilder};
+    use apalis_core::worker::event::Event;
+    use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+    use apalis_core::worker::ext::event_listener::EventListenerExt;
     use sqlx::SqlitePool;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use super::*;
     use crate::conductor::setup_apalis_tables;
@@ -192,13 +238,13 @@ mod tests {
 
     #[test]
     fn failure_injector_not_armed_by_default() {
-        let injector = FailureInjector::new();
+        let injector = FailureInjector::default();
         assert!(!injector.is_armed());
     }
 
     #[test]
     fn failure_injector_arm_then_check_auto_disarms() {
-        let injector = FailureInjector::new();
+        let injector = FailureInjector::default();
 
         injector.arm();
         assert!(injector.is_armed());
@@ -210,7 +256,7 @@ mod tests {
 
     #[test]
     fn failure_injector_shared_across_clones() {
-        let injector = FailureInjector::new();
+        let injector = FailureInjector::default();
         let clone = injector.clone();
 
         injector.arm();
@@ -254,11 +300,8 @@ mod tests {
     #[error("test job deliberately failed")]
     struct TestJobError;
 
-    /// RAI-199: a job that fails after all retries must halt further
-    /// processing. Currently `work()` swallows the error and the worker
-    /// picks up the next job with stale state.
-    ///
-    /// FAILS with current code — the second job runs.
+    /// A job that fails after all retries must halt further processing --
+    /// the worker must not pick up the next job with stale state.
     #[tokio::test]
     async fn job_failure_after_retries_halts_processing() {
         let pool = setup_test_db().await;
@@ -274,26 +317,44 @@ mod tests {
         let ctx_for_assert = ctx.clone();
 
         let monitor_handle = tokio::spawn({
-            let monitor = Monitor::new().register(move |index| {
-                WorkerBuilder::new(format!("test-worker-{index}"))
-                    .backend(queue.clone().into_storage())
-                    .data(ctx.clone())
-                    .data(FailureInjector::new())
-                    .build(work::<TestCtx, TestJob>)
-            });
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    let fail_stop = CircuitBreakerConfig::default()
+                        .with_failure_threshold(1)
+                        .with_recovery_timeout(Duration::from_secs(u64::MAX));
+
+                    WorkerBuilder::new(format!("test-worker-{index}"))
+                        .backend(queue.clone().into_storage())
+                        .data(ctx.clone())
+                        .data(FailureInjector::default())
+                        .concurrency(1)
+                        .retry(RetryPolicy::retries(3))
+                        .break_circuit_with(fail_stop)
+                        .on_event(|ctx, event| {
+                            if let Event::Error(_) = event {
+                                let _ = ctx.stop();
+                            }
+                        })
+                        .build(work::<TestCtx, TestJob>)
+                });
 
             async move { monitor.run().await }
         });
 
-        // backon default: 1s + 2s + 4s retries, plus time for second job
-        tokio::time::sleep(std::time::Duration::from_secs(12)).await;
-        monitor_handle.abort();
+        // RetryPolicy retries instantly, so the monitor should exit
+        // quickly once the failing job exhausts retries.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), monitor_handle).await;
+        assert!(
+            result.is_ok(),
+            "Monitor should have exited after terminal job failure"
+        );
 
         assert_eq!(
             ctx_for_assert.success_count.load(Ordering::SeqCst),
             0,
             "The second job should NOT have been processed after a prior \
-             job failed all retries (RAI-199)."
+             job failed all retries."
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -362,10 +362,15 @@ pub struct Ctx {
     pub execution_threshold: ExecutionThreshold,
     pub(crate) assets: AssetsConfig,
     pub(crate) travel_rule: Option<TravelRuleConfig>,
+<<<<<<< HEAD
     pub(crate) rest_api: Option<RestApiCtx>,
     /// Alpaca redemption wallet from `[tokenization]`.
     /// `Some` when the config includes a `[tokenization]` section.
     pub(crate) redemption_wallet: Option<Address>,
+=======
+    #[cfg(feature = "test-support")]
+    pub failure_injector: crate::conductor::job::FailureInjector,
+>>>>>>> 304ecf3d1 (feat: failure injector)
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -787,8 +792,13 @@ impl Ctx {
             execution_threshold: parts.execution_threshold,
             assets: parts.assets,
             travel_rule: parts.travel_rule,
+<<<<<<< HEAD
             rest_api: parts.rest_api,
             redemption_wallet: parts.redemption_wallet,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         })
     }
 
@@ -946,8 +956,13 @@ impl Ctx {
             execution_threshold,
             assets,
             travel_rule,
+<<<<<<< HEAD
             rest_api,
             redemption_wallet,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         })
     }
 }
@@ -1159,8 +1174,13 @@ pub(crate) mod tests {
                 cash: None,
             },
             travel_rule: None,
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
+=======
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
+>>>>>>> 304ecf3d1 (feat: failure injector)
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,12 +363,16 @@ pub struct Ctx {
     pub(crate) assets: AssetsConfig,
     pub(crate) travel_rule: Option<TravelRuleConfig>,
 <<<<<<< HEAD
+<<<<<<< HEAD
     pub(crate) rest_api: Option<RestApiCtx>,
     /// Alpaca redemption wallet from `[tokenization]`.
     /// `Some` when the config includes a `[tokenization]` section.
     pub(crate) redemption_wallet: Option<Address>,
 =======
     #[cfg(feature = "test-support")]
+=======
+    #[cfg(any(test, feature = "test-support"))]
+>>>>>>> 0a7bd6f84 (feat: job durability)
     pub failure_injector: crate::conductor::job::FailureInjector,
 >>>>>>> 304ecf3d1 (feat: failure injector)
 }
@@ -456,9 +460,13 @@ impl std::fmt::Debug for Ctx {
             .field("execution_threshold", &self.execution_threshold)
             .field("assets", &self.assets)
             .field("travel_rule_configured", &self.travel_rule.is_some())
+<<<<<<< HEAD
             .field("redemption_wallet", &self.redemption_wallet)
             .field("rest_api", &self.rest_api)
             .finish()
+=======
+            .finish_non_exhaustive()
+>>>>>>> 0a7bd6f84 (feat: job durability)
     }
 }
 
@@ -793,12 +801,17 @@ impl Ctx {
             assets: parts.assets,
             travel_rule: parts.travel_rule,
 <<<<<<< HEAD
+<<<<<<< HEAD
             rest_api: parts.rest_api,
             redemption_wallet: parts.redemption_wallet,
 =======
             #[cfg(feature = "test-support")]
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         })
     }
 
@@ -957,12 +970,17 @@ impl Ctx {
             assets,
             travel_rule,
 <<<<<<< HEAD
+<<<<<<< HEAD
             rest_api,
             redemption_wallet,
 =======
             #[cfg(feature = "test-support")]
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         })
     }
 }
@@ -1175,12 +1193,17 @@ pub(crate) mod tests {
             },
             travel_rule: None,
 <<<<<<< HEAD
+<<<<<<< HEAD
             rest_api: None,
             redemption_wallet: None,
 =======
             #[cfg(feature = "test-support")]
             failure_injector: crate::conductor::job::FailureInjector::new(),
 >>>>>>> 304ecf3d1 (feat: failure injector)
+=======
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector: crate::conductor::job::FailureInjector::default(),
+>>>>>>> 0a7bd6f84 (feat: job durability)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ mod wrapper;
 
 pub use telemetry::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
 
+#[cfg(feature = "test-support")]
+pub use conductor::job::FailureInjector;
 #[cfg(any(test, feature = "test-support"))]
 pub use config::TradingMode;
 #[cfg(any(test, feature = "test-support"))]

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod assertions;
 use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
-
+#[cfg(feature = "test-support")]
 use st0x_hedge::FailureInjector;
 
 use self::assertions::*;
@@ -1451,11 +1451,9 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// RAI-199: when a job fails terminally, the bot must halt — not
-/// silently continue processing subsequent events with stale state.
-///
-/// FAILS with current code — the bot keeps running after the injected
-/// failure.
+/// When a job fails terminally, the bot must halt -- not silently
+/// continue processing subsequent events with stale state.
+#[cfg(feature = "test-support")]
 #[test_log::test(tokio::test)]
 async fn job_failure_halts_bot() -> anyhow::Result<()> {
     let onchain_price = float!(155.00);
@@ -1473,7 +1471,7 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
         .assets(infra.assets_config())
         .call()?;
 
-    let injector = FailureInjector::new();
+    let injector = FailureInjector::default();
     ctx.failure_injector = injector.clone();
     let mut bot = spawn_bot(ctx);
 
@@ -1511,11 +1509,14 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
         .await?;
 
     // The bot should exit — the injected failure should halt processing
-    let bot_exited = tokio::time::timeout(Duration::from_secs(30), &mut bot).await;
+    let join_result = tokio::time::timeout(Duration::from_secs(30), &mut bot)
+        .await
+        .unwrap();
+    let inner_result = join_result.expect("Bot task should fail, not panic");
 
     assert!(
-        bot_exited.is_ok(),
-        "Bot should have exited after terminal job failure, but it kept running"
+        inner_result.is_err(),
+        "Bot should fail after terminal job failure, not keep running or exit successfully"
     );
 
     // The second trade's onchain event should NOT have been processed

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -14,6 +14,8 @@ use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
 
+use st0x_hedge::FailureInjector;
+
 use self::assertions::*;
 use crate::poll::poll_for_all_jobs_done;
 
@@ -1446,5 +1448,85 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
 
     pool.close().await;
     bot2.abort();
+    Ok(())
+}
+
+/// RAI-199: when a job fails terminally, the bot must halt — not
+/// silently continue processing subsequent events with stale state.
+///
+/// FAILS with current code — the bot keeps running after the injected
+/// failure.
+#[test_log::test(tokio::test)]
+async fn job_failure_halts_bot() -> anyhow::Result<()> {
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let mut ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+
+    let injector = FailureInjector::new();
+    ctx.failure_injector = injector.clone();
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // First trade processes normally
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    // Snapshot event count before the injected failure
+    let pool = connect_db(&infra.db_path).await?;
+    let events_before = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    // Arm the injector, then submit a second trade
+    injector.arm();
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // The bot should exit — the injected failure should halt processing
+    let bot_exited = tokio::time::timeout(Duration::from_secs(30), &mut bot).await;
+
+    assert!(
+        bot_exited.is_ok(),
+        "Bot should have exited after terminal job failure, but it kept running"
+    );
+
+    // The second trade's onchain event should NOT have been processed
+    let pool = connect_db(&infra.db_path).await?;
+    let events_after = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    assert_eq!(
+        events_before, events_after,
+        "No new OnChainTrade events should be persisted after terminal failure"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## What

Closes RAI-199. When a job fails terminally (exhausts all retries), the bot must halt rather than silently continue processing subsequent jobs with stale state.

## Why

Previously, `work()` swallowed job errors and the apalis monitor was configured to restart workers on failure. This meant a terminally failing job would not prevent the next job from being picked up and processed — a correctness hazard where subsequent jobs run against state that was never properly updated by the failed job.

## How

**Fail-stop worker pipeline:**

- `work()` now returns `Result<(), JobError>` so apalis can distinguish success from failure.
- Workers are configured with a Tower middleware stack: `.concurrency(1)` (sequential), `.retry(RetryPolicy::retries(3))` (4 total attempts), `.break_circuit_with(fail_stop)` (circuit opens after 1 failure with an effectively infinite recovery timeout), and `.on_event()` (calls `ctx.stop()` on `Event::Error` so the worker actually exits rather than just pausing).
- `Monitor::should_restart` is set to `false` — a terminal failure is fail-stop and the worker must not restart.
- The monitor `tokio::spawn` task now returns `anyhow::Result<()>` so the conductor sees the failure and shuts down the bot.

**`FailureInjector` for e2e testing:**

A `FailureInjector` (gated on `feature = "test-support"`) is threaded through `Ctx`, `ConductorCtx`, and the apalis worker `Data`. When armed, it intercepts the next `Job::perform` call and returns `Err` without invoking the job. It auto-disarms after firing (one-shot). This allows e2e tests to force a terminal job failure without mocking the entire job implementation.

**`backon` retry removed** from `work()` — retries are now handled entirely by the apalis `RetryPolicy` layer, which integrates correctly with the circuit breaker.

## Testing

- Unit tests for `FailureInjector`: not-armed by default, arm/auto-disarm, shared state across clones.
- Unit test `job_failure_after_retries_halts_processing`: spins up a real apalis monitor with the full middleware stack, enqueues a failing job followed by a succeeding job, and asserts the monitor exits and the second job is never processed.
- E2e test `job_failure_halts_bot`: runs a full bot, processes one trade normally, arms the injector, submits a second trade, and asserts the bot exits within 30 seconds and no new `OnChainTrade` events are persisted.

## Anything else

`docs/feature-flags.md` is added to document the `test-support` vs `cfg(test)` distinction, the dead-code warning pitfall, and the zero-size-in-prod pattern used by `FailureInjector`. `docs/conductor.md` is updated to reflect the new worker middleware stack, error propagation path, and monitor configuration.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented terminal job failure handling with graceful worker shutdown.

* **Bug Fixes**
  * Improved log message and target field handling in dashboard components.
  * Enhanced dialog and button click handlers for consistency.

* **Documentation**
  * Added comprehensive Cargo feature flags guidance.
  * Updated conductor worker middleware documentation with failure handling details.
  * Expanded development workflow documentation with behavior discovery requirements.

* **Tests**
  * Added end-to-end test validating failure behavior and bot shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->