### PR TITLE
feat: support multiple vaults per asset in VaultRegistry

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2000,8 +2000,9 @@ The reconciliation system closes this gap by periodically fetching actual
 balances and emitting them as events the system can react to:
 
 - **VaultRegistry** (CQRS aggregate): Auto-discovers Raindex vaults from
-  ClearV3/TakeOrderV3 trade events. Tracks equity vaults (per token address) and
-  a single USDC vault per orderbook/owner pair.
+  ClearV3/TakeOrderV3 trade events. Tracks multiple equity vaults per token
+  address and multiple USDC vaults per orderbook/owner pair. Inventory polling
+  sums balances across all vaults for each asset.
 - **InventorySnapshot** (CQRS aggregate): Records point-in-time snapshots of
   actual balances fetched from onchain vaults and the offchain broker.
 - **InventoryPollingService**: Periodically polls actual balances from both

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -61,7 +61,8 @@ rebalancing = "disabled"
 # - rebalancing: whether automatic equity rebalancing is active.
 # - tokenized_equity: unwrapped tTOKEN contract address on Base.
 # - tokenized_equity_derivative: wrapped wtTOKEN contract address on Base.
-# - vault_id: Raindex vault ID (required when rebalancing is enabled).
+# - vault_ids: Raindex vault ID(s) — single string or array of strings.
+#   (alias: vault_id for backward compat. Required when rebalancing is enabled.)
 
 [assets.equities.RKLB]
 trading = "disabled"

--- a/example.config.toml
+++ b/example.config.toml
@@ -56,12 +56,14 @@ tokenized_equity = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 tokenized_equity_derivative = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 trading = "enabled"
 rebalancing = "disabled"
-# vault_id = "0xab12"
+# Single vault: vault_ids = "0xab12"
+# Multiple vaults: vault_ids = ["0xab12", "0xcd34"]
 # operational_limit = 100.0
 
 [assets.cash]
 rebalancing = "enabled"
-# vault_id = "0xcd34"
+# Single vault: vault_ids = "0xcd34"
+# Multiple vaults: vault_ids = ["0xcd34", "0xef56"]
 # operational_limit = 10000.0
 
 # Optional — enables the Orders dashboard tab by querying the st0x REST API.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -290,7 +290,7 @@ pub enum Commands {
     /// Withdraw USDC from the configured Raindex cash vault
     ///
     /// This preserves the existing USDC-specific operator flow by resolving
-    /// `assets.cash.vault_id` from config and forwarding into the generic
+    /// `assets.cash.vault_ids` from config and forwarding into the generic
     /// vault withdrawal implementation.
     VaultWithdrawUsdc {
         /// Amount of USDC to withdraw

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -171,14 +171,25 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
 
     let wallet_ctx = ctx.wallet()?;
 
-    let usdc_vault_id = ctx
-        .assets
-        .cash
-        .as_ref()
-        .and_then(|cash| cash.vault_id)
-        .ok_or_else(|| anyhow::anyhow!("assets.cash.vault_id is required but not configured"))?;
+    let cash =
+        ctx.assets.cash.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("assets.cash.vault_ids is required but not configured")
+        })?;
+
+    let usdc_vault_id =
+        cash.vault_ids.first().copied().ok_or_else(|| {
+            anyhow::anyhow!("assets.cash.vault_ids is required but not configured")
+        })?;
 
     writeln!(stdout, "   Vault ID: {usdc_vault_id}")?;
+
+    if cash.vault_ids.len() > 1 {
+        writeln!(
+            stdout,
+            "   Warning: {} USDC vaults configured, using the first one",
+            cash.vault_ids.len()
+        )?;
+    }
     let owner = wallet_ctx.base_wallet().address();
 
     let broker_mode = if alpaca_auth.is_sandbox() {
@@ -748,9 +759,9 @@ mod tests {
     async fn test_transfer_usdc_requires_wallet_config() {
         let mut ctx = create_alpaca_ctx_without_rebalancing();
         ctx.assets.cash = Some(CashAssetConfig {
-            vault_id: Some(b256!(
+            vault_ids: vec![b256!(
                 "0x00000000000000000000000000000000000000000000000000000000000000ab"
-            )),
+            )],
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
         });
@@ -866,7 +877,7 @@ mod tests {
 
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("assets.cash.vault_id is required"),
+            err_msg.contains("assets.cash.vault_ids is required"),
             "Expected vault_id error, got: {err_msg}"
         );
     }
@@ -874,7 +885,7 @@ mod tests {
     #[tokio::test]
     async fn test_transfer_usdc_requires_vault_id_when_vault_id_is_none() {
         let ctx = create_alpaca_ctx_with_rebalancing(Some(CashAssetConfig {
-            vault_id: None,
+            vault_ids: Vec::new(),
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
         }));
@@ -893,7 +904,7 @@ mod tests {
 
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("assets.cash.vault_id is required"),
+            err_msg.contains("assets.cash.vault_ids is required"),
             "Expected vault_id error, got: {err_msg}"
         );
     }
@@ -902,7 +913,7 @@ mod tests {
     async fn test_transfer_usdc_writes_vault_id_to_stdout() {
         let vault_id = b256!("0x00000000000000000000000000000000000000000000000000000000000000ab");
         let ctx = create_alpaca_ctx_with_rebalancing(Some(CashAssetConfig {
-            vault_id: Some(vault_id),
+            vault_ids: vec![vault_id],
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
         }));

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -178,12 +178,23 @@ pub(super) async fn vault_withdraw_usdc_command<Writer: Write>(
 ) -> anyhow::Result<()> {
     ctx.wallet()?;
 
-    let vault_id = ctx
-        .assets
-        .cash
-        .as_ref()
-        .and_then(|cash| cash.vault_id)
-        .ok_or_else(|| anyhow::anyhow!("assets.cash.vault_id is required but not configured"))?;
+    let cash =
+        ctx.assets.cash.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("assets.cash.vault_ids is required but not configured")
+        })?;
+
+    let vault_id =
+        cash.vault_ids.first().copied().ok_or_else(|| {
+            anyhow::anyhow!("assets.cash.vault_ids is required but not configured")
+        })?;
+
+    if cash.vault_ids.len() > 1 {
+        writeln!(
+            stdout,
+            "Warning: {} USDC vaults configured, using the first one: {vault_id}",
+            cash.vault_ids.len()
+        )?;
+    }
 
     let withdraw = Withdraw {
         amount: amount.into(),
@@ -525,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn withdraw_usdc_fails_when_cash_vault_id_missing() {
         let ctx = create_ctx_with_rebalancing(Some(CashAssetConfig {
-            vault_id: None,
+            vault_ids: Vec::new(),
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
         }));
@@ -543,7 +554,7 @@ mod tests {
         .to_string();
 
         assert!(
-            err_msg.contains("assets.cash.vault_id is required but not configured"),
+            err_msg.contains("assets.cash.vault_ids is required but not configured"),
             "Expected vault_id missing error, got: {err_msg}"
         );
     }
@@ -586,7 +597,7 @@ mod tests {
         .to_string();
 
         assert!(
-            err_msg.contains("assets.cash.vault_id is required but not configured"),
+            err_msg.contains("assets.cash.vault_ids is required but not configured"),
             "Expected vault_id missing error, got: {err_msg}"
         );
     }
@@ -594,7 +605,7 @@ mod tests {
     #[tokio::test]
     async fn withdraw_usdc_passes_cash_vault_lookup_when_vault_id_configured() {
         let ctx = create_ctx_with_rebalancing(Some(CashAssetConfig {
-            vault_id: Some(TEST_VAULT_ID),
+            vault_ids: vec![TEST_VAULT_ID],
             rebalancing: OperationMode::Enabled,
             operational_limit: None,
         }));

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -452,10 +452,10 @@ async fn seed_vault_registry_from_config(
     vault_registry: &Store<VaultRegistry>,
     ctx: &Ctx,
 ) -> anyhow::Result<()> {
-    // Pre-flight validation: ensure every rebalancing-enabled equity has a
-    // vault_id before performing any writes to the vault registry.
+    // Pre-flight validation: ensure every rebalancing-enabled equity has at
+    // least one vault_id before performing any writes to the vault registry.
     for (symbol, equity_config) in &ctx.assets.equities.symbols {
-        if equity_config.vault_id.is_none() && ctx.is_rebalancing_enabled(symbol) {
+        if equity_config.vault_ids.is_empty() && ctx.is_rebalancing_enabled(symbol) {
             return Err(CtxError::MissingEquityVaultId {
                 symbol: symbol.clone(),
             }
@@ -469,40 +469,40 @@ async fn seed_vault_registry_from_config(
     };
 
     for (symbol, equity_config) in &ctx.assets.equities.symbols {
-        let Some(vault_id) = equity_config.vault_id else {
-            continue;
-        };
+        for vault_id in &equity_config.vault_ids {
+            debug!(
+                %symbol,
+                %vault_id,
+                token = %equity_config.tokenized_equity_derivative,
+                "Seeding equity vault from config"
+            );
 
-        debug!(
-            %symbol,
-            %vault_id,
-            token = %equity_config.tokenized_equity_derivative,
-            "Seeding equity vault from config"
-        );
-
-        vault_registry
-            .send(
-                &vault_registry_id,
-                VaultRegistryCommand::SeedEquityVaultFromConfig {
-                    token: equity_config.tokenized_equity_derivative,
-                    vault_id,
-                    symbol: symbol.clone(),
-                },
-            )
-            .await?;
+            vault_registry
+                .send(
+                    &vault_registry_id,
+                    VaultRegistryCommand::SeedEquityVaultFromConfig {
+                        token: equity_config.tokenized_equity_derivative,
+                        vault_id: *vault_id,
+                        symbol: symbol.clone(),
+                    },
+                )
+                .await?;
+        }
     }
 
-    if let Some(cash) = &ctx.assets.cash
-        && let Some(vault_id) = cash.vault_id
-    {
-        info!(%vault_id, "Seeding USDC vault from config");
+    if let Some(cash) = &ctx.assets.cash {
+        for vault_id in &cash.vault_ids {
+            info!(%vault_id, "Seeding USDC vault from config");
 
-        vault_registry
-            .send(
-                &vault_registry_id,
-                VaultRegistryCommand::SeedUsdcVaultFromConfig { vault_id },
-            )
-            .await?;
+            vault_registry
+                .send(
+                    &vault_registry_id,
+                    VaultRegistryCommand::SeedUsdcVaultFromConfig {
+                        vault_id: *vault_id,
+                    },
+                )
+                .await?;
+        }
     }
 
     Ok(())
@@ -640,7 +640,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .assets
             .cash
             .as_ref()
-            .and_then(|cash| cash.vault_id)
+            .and_then(|cash| cash.vault_ids.first().copied())
             .ok_or(CtxError::MissingCashVaultId)?;
 
         let handle = services.spawn(
@@ -1788,7 +1788,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: aapl_token,
                 tokenized_equity_derivative: Address::random(),
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Enabled,
                 rebalancing: OperationMode::Disabled,
                 operational_limit: None,
@@ -1799,7 +1799,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: tsla_token,
                 tokenized_equity_derivative: Address::random(),
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
@@ -1810,7 +1810,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: spym_token,
                 tokenized_equity_derivative: Address::random(),
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Disabled,
                 operational_limit: None,
@@ -1860,7 +1860,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::random(),
                 tokenized_equity_derivative: aapl_wrapped_token,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Enabled,
                 rebalancing: OperationMode::Disabled,
                 operational_limit: None,
@@ -1871,7 +1871,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::random(),
                 tokenized_equity_derivative: tsla_wrapped_token,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
@@ -1882,7 +1882,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::random(),
                 tokenized_equity_derivative: spym_wrapped_token,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Disabled,
                 operational_limit: None,
@@ -2115,7 +2115,7 @@ mod tests {
             .expect("VaultRegistry should exist after discovery");
 
         assert!(
-            registry.usdc_vault.is_some(),
+            !registry.usdc_vaults.is_empty(),
             "Expected USDC vault to be discovered"
         );
     }
@@ -2164,7 +2164,7 @@ mod tests {
             .expect("VaultRegistry should exist after discovery");
 
         assert!(
-            registry.usdc_vault.is_some(),
+            !registry.usdc_vaults.is_empty(),
             "Expected USDC vault to be discovered from take order"
         );
         assert!(
@@ -2242,6 +2242,7 @@ mod tests {
         let has_goog_vault = registry
             .equity_vaults
             .values()
+            .flat_map(|vaults| vaults.values())
             .any(|vault| vault.symbol == goog_symbol);
 
         assert!(
@@ -2250,6 +2251,7 @@ mod tests {
             registry
                 .equity_vaults
                 .values()
+                .flat_map(|vaults| vaults.values())
                 .map(|vault| &vault.symbol)
                 .collect::<Vec<_>>()
         );
@@ -3761,9 +3763,9 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::ZERO,
                 tokenized_equity_derivative: Address::ZERO,
-                vault_id: Some(fixed_bytes!(
+                vault_ids: vec![fixed_bytes!(
                     "0x0000000000000000000000000000000000000000000000000000000000000001"
-                )),
+                )],
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
@@ -3775,7 +3777,7 @@ mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::ZERO,
                 tokenized_equity_derivative: Address::ZERO,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,8 +62,12 @@ pub enum OperationMode {
 pub struct EquityAssetConfig {
     pub tokenized_equity: Address,
     pub tokenized_equity_derivative: Address,
-    #[serde(default, deserialize_with = "deserialize_padded_b256")]
-    pub vault_id: Option<B256>,
+    #[serde(
+        default,
+        alias = "vault_id",
+        deserialize_with = "deserialize_vault_ids"
+    )]
+    pub vault_ids: Vec<B256>,
     pub trading: OperationMode,
     pub rebalancing: OperationMode,
     pub operational_limit: Option<Positive<FractionalShares>>,
@@ -73,8 +77,12 @@ pub struct EquityAssetConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CashAssetConfig {
-    #[serde(default, deserialize_with = "deserialize_padded_b256")]
-    pub vault_id: Option<B256>,
+    #[serde(
+        default,
+        alias = "vault_id",
+        deserialize_with = "deserialize_vault_ids"
+    )]
+    pub vault_ids: Vec<B256>,
     pub rebalancing: OperationMode,
     pub operational_limit: Option<Positive<Usdc>>,
 }
@@ -100,37 +108,55 @@ pub struct AssetsConfig {
     pub cash: Option<CashAssetConfig>,
 }
 
-/// Deserializes a hex string (possibly short, e.g. `"0xfab"`) into a
-/// left-padded `B256`. Missing values deserialize as `None`.
-fn deserialize_padded_b256<'de, D>(deserializer: D) -> Result<Option<B256>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let Some(hex_str) = Option::<String>::deserialize(deserializer)? else {
-        return Ok(None);
-    };
-
+/// Parses a hex string (possibly short, e.g. `"0xfab"`) into a
+/// left-padded `B256`.
+fn parse_padded_b256(hex_str: &str) -> Result<B256, String> {
     let stripped = hex_str
         .strip_prefix("0x")
         .or_else(|| hex_str.strip_prefix("0X"))
-        .unwrap_or(&hex_str);
+        .unwrap_or(hex_str);
 
     if stripped.len() > 64 {
-        return Err(serde::de::Error::custom(format!(
-            "hex string too long for B256: {stripped}"
-        )));
+        return Err(format!("hex string too long for B256: {stripped}"));
     }
 
     if stripped.is_empty() {
-        return Err(serde::de::Error::custom("empty hex string for B256"));
+        return Err("empty hex string for B256".to_string());
     }
 
     let padded = format!("{stripped:0>64}");
-    padded
-        .parse::<B256>()
-        .map(Some)
-        .map_err(serde::de::Error::custom)
+    padded.parse::<B256>().map_err(|err| err.to_string())
 }
+
+/// Deserializes vault IDs from either a single hex string or an array of hex
+/// strings. Each value is left-padded to a full `B256`.
+///
+/// Accepts both `vault_id = "0xfab"` (single) and
+/// `vault_ids = ["0xfab", "0xfab2"]` (multiple) in TOML.
+fn deserialize_vault_ids<'de, D>(deserializer: D) -> Result<Vec<B256>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    let raw = OneOrMany::deserialize(deserializer)?;
+
+    let hex_strings = match raw {
+        OneOrMany::One(single) => vec![single],
+        OneOrMany::Many(many) => many,
+    };
+
+    hex_strings
+        .into_iter()
+        .map(|hex_str| parse_padded_b256(&hex_str).map_err(serde::de::Error::custom))
+        .collect()
+}
+
 /// Non-secret settings deserialized from the plaintext config TOML.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1030,12 +1056,12 @@ pub enum CtxError {
     )]
     CashOperationalLimitBelowMinimumWithdrawal { configured: Usdc, minimum: Usdc },
     #[error(
-        "assets.cash.vault_id is required for rebalancing \
+        "assets.cash.vault_ids is required for rebalancing \
          but not configured"
     )]
     MissingCashVaultId,
     #[error(
-        "assets.equities.{symbol}.vault_id is required when \
+        "assets.equities.{symbol}.vault_ids is required when \
          rebalancing is enabled but not configured"
     )]
     MissingEquityVaultId { symbol: Symbol },
@@ -1080,8 +1106,8 @@ impl CtxError {
             Self::CashOperationalLimitBelowMinimumWithdrawal { .. } => {
                 "cash operational limit below minimum withdrawal"
             }
-            Self::MissingCashVaultId => "missing cash vault_id",
-            Self::MissingEquityVaultId { .. } => "missing equity vault_id",
+            Self::MissingCashVaultId => "missing cash vault_ids",
+            Self::MissingEquityVaultId { .. } => "missing equity vault_ids",
             Self::ZeroPollingInterval { .. } => "zero polling interval",
             Self::FloatComparison(_) => "float comparison failed",
             Self::InvalidTravelRule { .. } => "invalid travel rule config",
@@ -2837,12 +2863,12 @@ pub(crate) mod tests {
         );
         assert_eq!(rklb.trading, OperationMode::Disabled);
         assert_eq!(rklb.rebalancing, OperationMode::Enabled);
-        assert!(rklb.vault_id.is_some());
+        assert_eq!(rklb.vault_ids.len(), 1);
         assert!(rklb.operational_limit.is_some());
 
         let cash = config.cash.unwrap();
         assert_eq!(cash.rebalancing, OperationMode::Disabled);
-        assert!(cash.vault_id.is_some());
+        assert_eq!(cash.vault_ids.len(), 1);
     }
 
     #[test]
@@ -2861,7 +2887,32 @@ pub(crate) mod tests {
         let expected: B256 = "0000000000000000000000000000000000000000000000000000000000000fab"
             .parse()
             .unwrap();
-        assert_eq!(rklb.vault_id.unwrap(), expected);
+        assert_eq!(rklb.vault_ids[0], expected);
+    }
+
+    #[test]
+    fn vault_ids_array_parses_multiple_values() {
+        let toml_str = r#"
+            [equities.RKLB]
+            tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
+            tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
+            vault_ids = ["0xfab", "0xfab2"]
+            trading = "disabled"
+            rebalancing = "enabled"
+        "#;
+
+        let config: AssetsConfig = toml::from_str(toml_str).unwrap();
+        let rklb = &config.equities.symbols[&Symbol::new("RKLB").unwrap()];
+        assert_eq!(rklb.vault_ids.len(), 2);
+
+        let expected_1: B256 = "0000000000000000000000000000000000000000000000000000000000000fab"
+            .parse()
+            .unwrap();
+        let expected_2: B256 = "000000000000000000000000000000000000000000000000000000000000fab2"
+            .parse()
+            .unwrap();
+        assert_eq!(rklb.vault_ids[0], expected_1);
+        assert_eq!(rklb.vault_ids[1], expected_2);
     }
 
     #[test]
@@ -2934,7 +2985,7 @@ pub(crate) mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::ZERO,
                 tokenized_equity_derivative: Address::ZERO,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
@@ -2980,7 +3031,7 @@ pub(crate) mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::ZERO,
                 tokenized_equity_derivative: Address::ZERO,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
@@ -3029,7 +3080,7 @@ pub(crate) mod tests {
             EquityAssetConfig {
                 tokenized_equity: Address::ZERO,
                 tokenized_equity_derivative: Address::ZERO,
-                vault_id: None,
+                vault_ids: Vec::new(),
                 trading: OperationMode::Disabled,
                 rebalancing: OperationMode::Disabled,
                 operational_limit: None,
@@ -3079,49 +3130,25 @@ pub(crate) mod tests {
             /// zero-filled on the left to 64 chars.
             #[test]
             fn padded_b256_roundtrip(hex_digits in arb_hex_digits()) {
-                let toml_str = format!(
-                    r#"vault_id = "0x{hex_digits}""#,
-                );
-
-                #[derive(Deserialize)]
-                #[serde(rename_all = "snake_case")]
-                struct Wrapper {
-                    #[serde(deserialize_with = "deserialize_padded_b256")]
-                    vault_id: Option<B256>,
-                }
-
-                let wrapper: Wrapper = toml::from_str(&toml_str).unwrap();
-                let parsed = wrapper.vault_id.unwrap();
+                let hex_str = format!("0x{hex_digits}");
+                let parsed = parse_padded_b256(&hex_str).unwrap();
 
                 let expected_hex = format!("{hex_digits:0>64}");
                 let expected: B256 = expected_hex.parse().unwrap();
                 prop_assert_eq!(parsed, expected);
             }
 
-            /// Invalid hex characters must produce a deserialization error.
+            /// Invalid hex characters must produce a parse error.
             #[test]
             fn padded_b256_rejects_invalid_hex(
                 bad_char in "[g-zG-Z!@#$%^&*]",
                 prefix in arb_hex_digits(),
             ) {
-                let hex_str = format!("{prefix}{bad_char}");
-                let toml_str = format!(
-                    r#"vault_id = "0x{hex_str}""#,
-                );
-
-                #[derive(Debug, Deserialize)]
-                #[serde(rename_all = "snake_case")]
-                struct Wrapper {
-                    #[serde(deserialize_with = "deserialize_padded_b256")]
-                    vault_id: Option<B256>,
-                }
-
-                let result = toml::from_str::<Wrapper>(&toml_str);
+                let hex_str = format!("0x{prefix}{bad_char}");
+                let result = parse_padded_b256(&hex_str);
                 prop_assert!(
                     result.is_err(),
-                    "Expected error for invalid hex '{hex_str}', got {result:?}. \
-                     Parsed vault_id: {:?}",
-                    result.as_ref().ok().map(|w| w.vault_id),
+                    "Expected error for invalid hex '{hex_str}', got {result:?}",
                 );
             }
 
@@ -3222,7 +3249,7 @@ pub(crate) mod tests {
 
             let config: CashAssetConfig = toml::from_str(toml_str).unwrap();
             assert_eq!(config.rebalancing, OperationMode::Disabled);
-            assert!(config.vault_id.is_some());
+            assert_eq!(config.vault_ids.len(), 1);
         }
 
         #[test]
@@ -3253,17 +3280,7 @@ pub(crate) mod tests {
 
         #[test]
         fn padded_b256_rejects_empty_hex() {
-            let toml_str = r#"vault_id = "0x""#;
-
-            #[derive(Debug, Deserialize)]
-            #[serde(rename_all = "snake_case")]
-            struct Wrapper {
-                #[serde(deserialize_with = "deserialize_padded_b256")]
-                #[allow(dead_code)]
-                vault_id: Option<B256>,
-            }
-
-            let result = toml::from_str::<Wrapper>(toml_str);
+            let result = parse_padded_b256("0x");
             assert!(
                 result.is_err(),
                 "Expected error for empty hex string, got {result:?}"
@@ -3273,17 +3290,8 @@ pub(crate) mod tests {
         #[test]
         fn padded_b256_rejects_too_long_hex() {
             let long_hex = "a".repeat(65);
-            let toml_str = format!(r#"vault_id = "0x{long_hex}""#);
-
-            #[derive(Debug, Deserialize)]
-            #[serde(rename_all = "snake_case")]
-            struct Wrapper {
-                #[serde(deserialize_with = "deserialize_padded_b256")]
-                #[allow(dead_code)]
-                vault_id: Option<B256>,
-            }
-
-            let result = toml::from_str::<Wrapper>(&toml_str);
+            let hex_str = format!("0x{long_hex}");
+            let result = parse_padded_b256(&hex_str);
             assert!(
                 result.is_err(),
                 "Expected error for too-long hex string, got {result:?}"

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -2007,7 +2007,7 @@ async fn operational_limits_dollar_cap_constrains_counter_trades_across_cycles()
                 EquityAssetConfig {
                     tokenized_equity: Address::ZERO,
                     tokenized_equity_derivative: Address::ZERO,
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Disabled,
                     operational_limit: Some(
@@ -2195,7 +2195,7 @@ async fn operational_limits_shares_cap_constrains_counter_trades_with_failure_an
                 EquityAssetConfig {
                     tokenized_equity: Address::ZERO,
                     tokenized_equity_derivative: Address::ZERO,
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Disabled,
                     operational_limit: Some(

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -129,7 +129,7 @@ fn test_trigger_config() -> RebalancingTriggerConfig {
                     EquityAssetConfig {
                         tokenized_equity: Address::ZERO,
                         tokenized_equity_derivative: Address::ZERO,
-                        vault_id: None,
+                        vault_ids: Vec::new(),
                         trading: OperationMode::Disabled,
                         rebalancing: OperationMode::Enabled,
                         operational_limit: None,
@@ -137,7 +137,7 @@ fn test_trigger_config() -> RebalancingTriggerConfig {
                 )]),
             },
             cash: Some(CashAssetConfig {
-                vault_id: None,
+                vault_ids: Vec::new(),
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
             }),
@@ -1276,7 +1276,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let assets = AssetsConfig {
         equities: EquitiesConfig::default(),
         cash: Some(CashAssetConfig {
-            vault_id: None,
+            vault_ids: Vec::new(),
             rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc::new(float!(100))).unwrap()),
         }),
@@ -1407,7 +1407,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     let assets = AssetsConfig {
         equities: EquitiesConfig::default(),
         cash: Some(CashAssetConfig {
-            vault_id: None,
+            vault_ids: Vec::new(),
             rebalancing: OperationMode::Enabled,
             operational_limit: Some(Positive::new(Usdc::new(float!(100))).unwrap()),
         }),
@@ -1527,7 +1527,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),
@@ -1587,7 +1587,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -184,18 +184,37 @@ where
 
         let expected_tokens: Vec<_> = registry.equity_vaults.keys().copied().collect();
 
-        let balance_futures = registry.equity_vaults.values().map(|vault| async {
-            self.raindex_service
-                .get_equity_balance::<OpenChainErrorRegistry>(
-                    self.order_owner,
-                    vault.token,
-                    RaindexVaultId(vault.vault_id),
-                )
-                .await
-                .map(|balance| (vault.token, vault.symbol.clone(), balance))
-        });
+        // Fetch all vault balances in parallel across all tokens and vault IDs,
+        // then sum per-token to get the total balance for each asset.
+        let per_token_futures = registry
+            .equity_vaults
+            .iter()
+            .filter_map(|(token, vaults_for_token)| {
+                let first_vault = vaults_for_token.values().next()?;
+                let symbol = first_vault.symbol.clone();
+                Some((*token, symbol, vaults_for_token))
+            })
+            .map(|(token, symbol, vaults_for_token)| async move {
+                let vault_futures = vaults_for_token.values().map(|vault| {
+                    self.raindex_service
+                        .get_equity_balance::<OpenChainErrorRegistry>(
+                            self.order_owner,
+                            vault.token,
+                            RaindexVaultId(vault.vault_id),
+                        )
+                });
 
-        let results = try_join_all(balance_futures).await?;
+                let vault_balances = try_join_all(vault_futures).await?;
+
+                let total = vault_balances[1..]
+                    .iter()
+                    .copied()
+                    .try_fold(vault_balances[0], |acc, balance| acc + balance)?;
+
+                Ok::<_, InventoryPollingError<Exe::Error>>((token, symbol, total))
+            });
+
+        let results = try_join_all(per_token_futures).await?;
 
         let balances: BTreeMap<_, _> = results
             .iter()
@@ -226,18 +245,25 @@ where
         snapshot_id: &InventorySnapshotId,
         registry: &VaultRegistry,
     ) -> Result<(), InventoryPollingError<Exe::Error>> {
-        let Some(usdc_vault) = &registry.usdc_vault else {
-            debug!(target: "inventory", "No USDC vault discovered, skipping onchain cash polling");
+        if registry.usdc_vaults.is_empty() {
+            debug!(target: "inventory", "No USDC vaults discovered, skipping onchain cash polling");
             return Ok(());
-        };
+        }
 
-        let usdc_balance = self
-            .raindex_service
-            .get_usdc_balance::<OpenChainErrorRegistry>(
-                self.order_owner,
-                RaindexVaultId(usdc_vault.vault_id),
-            )
-            .await?;
+        let balance_futures = registry.usdc_vaults.values().map(|vault| {
+            self.raindex_service
+                .get_usdc_balance::<OpenChainErrorRegistry>(
+                    self.order_owner,
+                    RaindexVaultId(vault.vault_id),
+                )
+        });
+
+        let vault_balances = try_join_all(balance_futures).await?;
+
+        let usdc_balance = vault_balances[1..]
+            .iter()
+            .copied()
+            .try_fold(vault_balances[0], |acc, balance| acc + balance)?;
 
         self.snapshot
             .send(
@@ -1233,7 +1259,7 @@ mod tests {
             "Should NOT emit OnchainUsdc when no USDC vault discovered"
         );
         assert!(
-            logs_contain("No USDC vault discovered, skipping onchain cash polling"),
+            logs_contain("No USDC vaults discovered, skipping onchain cash polling"),
             "Should log debug message explaining why cash polling was skipped"
         );
     }

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -555,7 +555,7 @@ mod tests {
                     EquityAssetConfig {
                         tokenized_equity: Address::ZERO,
                         tokenized_equity_derivative: Address::ZERO,
-                        vault_id: None,
+                        vault_ids: Vec::new(),
                         trading: OperationMode::Enabled,
                         rebalancing: OperationMode::Disabled,
                         operational_limit: Some(

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -327,7 +327,7 @@ impl<W: Wallet> Raindex for RaindexService<W> {
     async fn lookup_vault_id(&self, token: Address) -> Result<RaindexVaultId, RaindexError> {
         let registry = self.load_registry().await?;
         registry
-            .vault_id_by_token(token)
+            .primary_vault_id_by_token(token)
             .map(RaindexVaultId)
             .ok_or(RaindexError::VaultNotFound(token))
     }
@@ -341,7 +341,7 @@ impl<W: Wallet> Raindex for RaindexService<W> {
             .token_by_symbol(symbol)
             .ok_or_else(|| RaindexError::TokenNotFound(symbol.clone()))?;
         let vault_id = registry
-            .vault_id_by_token(token)
+            .primary_vault_id_by_token(token)
             .ok_or(RaindexError::VaultNotFound(token))?;
         Ok((token, RaindexVaultId(vault_id)))
     }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1888,7 +1888,7 @@ mod tests {
             assets: AssetsConfig {
                 equities: EquitiesConfig::default(),
                 cash: Some(CashAssetConfig {
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
                 }),

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -77,7 +77,7 @@ impl EventSourced for VaultRegistry {
 
     const AGGREGATE_TYPE: &'static str = "VaultRegistry";
     const PROJECTION: Table = Table("vault_registry_view");
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         let mut registry = Self::empty(event.timestamp());
@@ -107,17 +107,15 @@ impl EventSourced for VaultRegistry {
             VaultRegistryCommand::SeedEquityVaultFromConfig {
                 token, vault_id, ..
             } => {
-                if let Some(existing) = self.equity_vaults.get(token)
-                    && existing.vault_id == *vault_id
+                if let Some(vaults_for_token) = self.equity_vaults.get(token)
+                    && vaults_for_token.contains_key(vault_id)
                 {
                     return Ok(vec![]);
                 }
             }
 
             VaultRegistryCommand::SeedUsdcVaultFromConfig { vault_id } => {
-                if let Some(ref existing) = self.usdc_vault
-                    && existing.vault_id == *vault_id
-                {
+                if self.usdc_vaults.contains_key(vault_id) {
                     return Ok(vec![]);
                 }
             }
@@ -131,12 +129,26 @@ impl EventSourced for VaultRegistry {
 }
 
 /// Registry state tracking all discovered vaults for an orderbook/owner pair.
+///
+/// Supports multiple vaults per asset. Equity vaults are grouped by token
+/// address, with each token mapping to a set of vaults keyed by vault ID.
+/// Multiple USDC vaults are supported, keyed by vault ID.
+///
+/// Each asset also tracks a **primary** vault ID — the first vault seeded
+/// from config (or the first discovered, if none was configured). The
+/// primary vault is used for single-vault operations like deposits and
+/// withdrawals, preserving operator intent from config ordering.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct VaultRegistry {
-    /// Equity vaults, keyed by token address
-    pub(crate) equity_vaults: BTreeMap<Address, EquityVault>,
-    /// USDC vault (at most one per owner)
-    pub(crate) usdc_vault: Option<UsdcVault>,
+    /// Equity vaults, grouped by token address then keyed by vault ID.
+    pub(crate) equity_vaults: BTreeMap<Address, BTreeMap<B256, EquityVault>>,
+    /// USDC vaults, keyed by vault ID.
+    pub(crate) usdc_vaults: BTreeMap<B256, UsdcVault>,
+    /// Primary equity vault per token — the first config-seeded or discovered
+    /// vault ID for each token. Used by deposit/withdraw operations.
+    primary_equity_vault: BTreeMap<Address, B256>,
+    /// Primary USDC vault — the first config-seeded or discovered vault ID.
+    primary_usdc_vault: Option<B256>,
     pub(crate) last_updated: DateTime<Utc>,
 }
 
@@ -173,21 +185,47 @@ pub(crate) struct UsdcVault {
 impl VaultRegistry {
     pub(crate) fn token_by_symbol(&self, symbol: &Symbol) -> Option<Address> {
         self.equity_vaults
-            .values()
-            .find(|vault| vault.symbol == *symbol)
-            .map(|vault| vault.token)
+            .iter()
+            .find(|(_, vaults)| vaults.values().any(|vault| vault.symbol == *symbol))
+            .map(|(token, _)| *token)
     }
 
-    pub(crate) fn vault_id_by_token(&self, token: Address) -> Option<B256> {
-        self.equity_vaults.get(&token).map(|v| v.vault_id)
+    /// Returns the primary vault ID for a token — the first config-seeded
+    /// or discovered vault, preserving operator intent from config ordering.
+    pub(crate) fn primary_vault_id_by_token(&self, token: Address) -> Option<B256> {
+        self.primary_equity_vault.get(&token).copied()
+    }
+
+    /// Returns all vault IDs registered for a token.
+    #[cfg(test)]
+    fn all_vault_ids_by_token(&self, token: Address) -> Vec<B256> {
+        self.equity_vaults
+            .get(&token)
+            .map(|vaults| vaults.keys().copied().collect())
+            .unwrap_or_default()
+    }
+
+    /// Returns the primary USDC vault ID.
+    #[cfg(test)]
+    fn primary_usdc_vault_id(&self) -> Option<B256> {
+        self.primary_usdc_vault
     }
 
     fn empty(timestamp: DateTime<Utc>) -> Self {
         Self {
             equity_vaults: BTreeMap::new(),
-            usdc_vault: None,
+            usdc_vaults: BTreeMap::new(),
+            primary_equity_vault: BTreeMap::new(),
+            primary_usdc_vault: None,
             last_updated: timestamp,
         }
+    }
+
+    fn insert_equity_vault(&mut self, token: Address, vault_id: B256, vault: EquityVault) {
+        self.equity_vaults
+            .entry(token)
+            .or_default()
+            .insert(vault_id, vault);
     }
 
     fn apply_event(&mut self, event: &VaultRegistryEvent) {
@@ -201,8 +239,11 @@ impl VaultRegistry {
                 discovered_at,
                 symbol,
             } => {
-                self.equity_vaults.insert(
+                self.primary_equity_vault.entry(*token).or_insert(*vault_id);
+
+                self.insert_equity_vault(
                     *token,
+                    *vault_id,
                     EquityVault {
                         token: *token,
                         vault_id: *vault_id,
@@ -220,13 +261,18 @@ impl VaultRegistry {
                 discovered_in,
                 discovered_at,
             } => {
-                self.usdc_vault = Some(UsdcVault {
-                    vault_id: *vault_id,
-                    provenance: VaultProvenance::Discovered {
-                        tx_hash: *discovered_in,
-                        discovered_at: *discovered_at,
+                self.primary_usdc_vault.get_or_insert(*vault_id);
+
+                self.usdc_vaults.insert(
+                    *vault_id,
+                    UsdcVault {
+                        vault_id: *vault_id,
+                        provenance: VaultProvenance::Discovered {
+                            tx_hash: *discovered_in,
+                            discovered_at: *discovered_at,
+                        },
                     },
-                });
+                );
             }
 
             VaultRegistryEvent::EquityVaultSeededFromConfig {
@@ -235,8 +281,11 @@ impl VaultRegistry {
                 seeded_at,
                 symbol,
             } => {
-                self.equity_vaults.insert(
+                self.primary_equity_vault.entry(*token).or_insert(*vault_id);
+
+                self.insert_equity_vault(
                     *token,
+                    *vault_id,
                     EquityVault {
                         token: *token,
                         vault_id: *vault_id,
@@ -252,12 +301,17 @@ impl VaultRegistry {
                 vault_id,
                 seeded_at,
             } => {
-                self.usdc_vault = Some(UsdcVault {
-                    vault_id: *vault_id,
-                    provenance: VaultProvenance::Seeded {
-                        seeded_at: *seeded_at,
+                self.primary_usdc_vault.get_or_insert(*vault_id);
+
+                self.usdc_vaults.insert(
+                    *vault_id,
+                    UsdcVault {
+                        vault_id: *vault_id,
+                        provenance: VaultProvenance::Seeded {
+                            seeded_at: *seeded_at,
+                        },
                     },
-                });
+                );
             }
         }
     }
@@ -529,8 +583,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rediscovering_vault_updates_it() {
-        let new_vault_id =
+    async fn discovering_new_vault_id_for_same_token_adds_it() {
+        let second_vault_id =
             b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
         let new_tx_hash =
             b256!("0x2222222222222222222222222222222222222222222222222222222222222222");
@@ -545,19 +599,113 @@ mod tests {
             }])
             .when(VaultRegistryCommand::DiscoverEquityVault {
                 token: TEST_TOKEN,
-                vault_id: new_vault_id,
+                vault_id: second_vault_id,
                 discovered_in: new_tx_hash,
                 symbol: test_symbol(),
             })
             .await
             .events();
 
-        assert_eq!(events.len(), 1, "Should emit event to update vault");
+        assert_eq!(events.len(), 1, "Should emit event for new vault ID");
         assert!(matches!(
             &events[0],
             VaultRegistryEvent::EquityVaultDiscovered { vault_id, .. }
-            if *vault_id == new_vault_id
+            if *vault_id == second_vault_id
         ));
+    }
+
+    #[test]
+    fn multiple_vaults_per_token_are_tracked() {
+        let vault_id_2 =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+
+        let registry = replay::<VaultRegistry>(vec![
+            VaultRegistryEvent::EquityVaultDiscovered {
+                token: TEST_TOKEN,
+                vault_id: TEST_VAULT_ID,
+                discovered_in: TEST_TX_HASH,
+                discovered_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+            VaultRegistryEvent::EquityVaultDiscovered {
+                token: TEST_TOKEN,
+                vault_id: vault_id_2,
+                discovered_in: TEST_TX_HASH,
+                discovered_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        // One token entry with two vaults
+        assert_eq!(registry.equity_vaults.len(), 1);
+        let vaults = &registry.equity_vaults[&TEST_TOKEN];
+        assert_eq!(vaults.len(), 2);
+        assert!(vaults.contains_key(&TEST_VAULT_ID));
+        assert!(vaults.contains_key(&vault_id_2));
+
+        let all_ids = registry.all_vault_ids_by_token(TEST_TOKEN);
+        assert_eq!(all_ids.len(), 2);
+    }
+
+    #[test]
+    fn primary_vault_preserves_config_order_not_btreemap_order() {
+        // The second vault has a SMALLER B256 value than the first. Without
+        // primary tracking, BTreeMap ordering would return the second one.
+        let large_vault_id =
+            b256!("0x00000000000000000000000000000000000000000000000000000000000000ff");
+        let small_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let registry = replay::<VaultRegistry>(vec![
+            VaultRegistryEvent::EquityVaultSeededFromConfig {
+                token: TEST_TOKEN,
+                vault_id: large_vault_id,
+                seeded_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+            VaultRegistryEvent::EquityVaultSeededFromConfig {
+                token: TEST_TOKEN,
+                vault_id: small_vault_id,
+                seeded_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        // Primary should be the FIRST seeded vault (large), not the
+        // BTreeMap-ordered smallest (small).
+        assert_eq!(
+            registry.primary_vault_id_by_token(TEST_TOKEN),
+            Some(large_vault_id),
+            "Primary vault must preserve config order, not BTreeMap key order"
+        );
+    }
+
+    #[test]
+    fn multiple_usdc_vaults_are_tracked() {
+        let vault_id_2 =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+
+        let registry = replay::<VaultRegistry>(vec![
+            VaultRegistryEvent::UsdcVaultDiscovered {
+                vault_id: TEST_VAULT_ID,
+                discovered_in: TEST_TX_HASH,
+                discovered_at: Utc::now(),
+            },
+            VaultRegistryEvent::UsdcVaultDiscovered {
+                vault_id: vault_id_2,
+                discovered_in: TEST_TX_HASH,
+                discovered_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(registry.usdc_vaults.len(), 2);
+        assert_eq!(registry.primary_usdc_vault_id(), Some(TEST_VAULT_ID));
     }
 
     #[test]
@@ -581,7 +729,7 @@ mod tests {
 
         assert_eq!(registry.equity_vaults.len(), 1);
         assert!(registry.equity_vaults.contains_key(&TEST_TOKEN));
-        assert!(registry.usdc_vault.is_some());
+        assert!(!registry.usdc_vaults.is_empty());
     }
 
     #[test]
@@ -598,7 +746,7 @@ mod tests {
 
         assert_eq!(registry.equity_vaults.len(), 1);
         assert!(registry.equity_vaults.contains_key(&TEST_TOKEN));
-        assert!(registry.usdc_vault.is_none());
+        assert!(registry.usdc_vaults.is_empty());
     }
 
     #[test]

--- a/src/wrapper/share.rs
+++ b/src/wrapper/share.rs
@@ -215,7 +215,7 @@ mod tests {
         EquityAssetConfig {
             tokenized_equity: Address::random(),
             tokenized_equity_derivative: Address::random(),
-            vault_id: None,
+            vault_ids: Vec::new(),
             trading: OperationMode::Enabled,
             rebalancing: OperationMode::Disabled,
             operational_limit: None,

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -85,7 +85,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
                 EquityAssetConfig {
                     tokenized_equity: *unwrapped,
                     tokenized_equity_derivative: *wrapped,
-                    vault_id: equity_vault_ids.get(symbol).copied(),
+                    vault_ids: equity_vault_ids.get(symbol).copied().into_iter().collect(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
@@ -133,7 +133,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
                 operational_limit: None,
             },
             cash: Some(CashAssetConfig {
-                vault_id: Some(cash_vault_id),
+                vault_ids: vec![cash_vault_id],
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
             }),

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -171,7 +171,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
                 EquityAssetConfig {
                     tokenized_equity: unwrapped,
                     tokenized_equity_derivative: wrapped,
-                    vault_id: equity_vault_ids.get(symbol).copied(),
+                    vault_ids: equity_vault_ids.get(symbol).copied().into_iter().collect(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Enabled,
                     operational_limit: None,
@@ -198,7 +198,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
             operational_limit: None,
         },
         cash: Some(CashAssetConfig {
-            vault_id: Some(cash_vault_id),
+            vault_ids: vec![cash_vault_id],
             rebalancing: cash_rebalancing,
             operational_limit: None,
         }),
@@ -252,7 +252,7 @@ where
                 EquityAssetConfig {
                     tokenized_equity: *unwrapped,
                     tokenized_equity_derivative: *wrapped,
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Disabled,
                     operational_limit: None,
@@ -296,7 +296,7 @@ where
                 operational_limit: None,
             },
             cash: Some(CashAssetConfig {
-                vault_id: Some(usdc_vault_id),
+                vault_ids: vec![usdc_vault_id],
                 rebalancing: OperationMode::Enabled,
                 operational_limit: None,
             }),

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -109,7 +109,7 @@ impl<P> TestInfra<P> {
                 let config = EquityAssetConfig {
                     tokenized_equity: *underlying_addr,
                     tokenized_equity_derivative: *vault_addr,
-                    vault_id: None,
+                    vault_ids: Vec::new(),
                     trading: OperationMode::Enabled,
                     rebalancing: OperationMode::Disabled,
                     operational_limit: None,


### PR DESCRIPTION
## What

Closes [RAI-242](https://linear.app/makeitrain/issue/RAI-242/support-multiple-vaults-per-asset-in-vaultregistry)

Support multiple Raindex vaults per asset (both equities and USDC) in configuration, discovery, and inventory tracking. Previously each asset could only have one vault registered — discovery overwrote earlier vaults, and inventory polling missed balances in additional vaults.

## Why

Assets can have funds spread across multiple Raindex vaults. The old single-vault model (`vault_id: Option<B256>` in config, `BTreeMap<Address, EquityVault>` in registry) meant:

1. Vault discovery from trade events overwrote previous vaults for the same token
2. Inventory polling only queried the single registered vault, **under-counting actual inventory**
3. No way to configure multiple vaults per asset in TOML

## How

**Config** (`src/config.rs`):
- `vault_id: Option<B256>` → `vault_ids: Vec<B256>` on both `EquityAssetConfig` and `CashAssetConfig`
- New `deserialize_vault_ids` function accepts both single string (`vault_id = "0xfab"`) and array (`vault_ids = ["0xfab", "0xfab2"]`) via `serde(alias = "vault_id")` for full backward compatibility
- Extracted `parse_padded_b256` helper from the old single-value deserializer

**VaultRegistry** (`src/vault_registry.rs`):
- `equity_vaults: BTreeMap<Address, EquityVault>` → `BTreeMap<Address, BTreeMap<B256, EquityVault>>` (multiple vaults per token, keyed by vault ID)
- `usdc_vault: Option<UsdcVault>` → `usdc_vaults: BTreeMap<B256, UsdcVault>` (multiple USDC vaults)
- Added `primary_equity_vault` and `primary_usdc_vault` fields to track the first config-seeded vault per asset — preserves operator intent from config ordering for deposit/withdraw operations
- `SCHEMA_VERSION` bumped 2→3 (triggers projection rebuild from events on deploy)
- Discovery accumulates vaults instead of overwriting

**Inventory polling** (`src/inventory/polling.rs`):
- `poll_onchain_equity`: queries all vaults per token in parallel via `try_join_all`, sums balances with `try_fold`
- `poll_onchain_usdc`: queries all USDC vaults in parallel and sums balances
- Downstream snapshot model unchanged (still stores one total balance per symbol)

**Conductor** (`src/conductor.rs`):
- `seed_vault_registry_from_config` iterates `vault_ids` vec and sends one command per vault ID
- Rebalancing uses first configured vault via `.vault_ids.first().copied()`

**CLI** (`src/cli/rebalancing.rs`, `src/cli/vault.rs`):
- CLI commands warn when multiple vaults are configured but only the first is used

**Raindex trait** (`src/onchain/raindex.rs`):
- `lookup_vault_id` / `lookup_vault_info` use `primary_vault_id_by_token` (config-ordered primary) instead of arbitrary BTreeMap ordering

## Testing

- New tests: `multiple_vaults_per_token_are_tracked`, `multiple_usdc_vaults_are_tracked`, `primary_vault_preserves_config_order_not_btreemap_order`, `vault_ids_array_parses_multiple_values`
- All existing tests updated (1679 pass, 4 skipped)
- Proptest coverage updated for `parse_padded_b256`

## Screenshots

N/A

## Anything else

- **Backward compatible**: existing `vault_id = "0xfab"` configs work unchanged via serde alias
- **Schema migration**: `SCHEMA_VERSION` bump to 3 causes automatic projection rebuild from events on deploy — no manual migration needed
- **Config files**: prod config unchanged (uses `vault_id` alias); example config updated to show both formats


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specification and configuration guides to reflect multi-vault support for asset inventory tracking.

* **Refactor**
  * Enhanced vault infrastructure to support multiple vaults per asset while maintaining backward compatibility with existing single-vault configurations.
  * Updated inventory aggregation logic to sum balances across all configured vaults per asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->