### PR TITLE
fix: remove redundant AlpacaWalletUsdc polling path

### DIFF
--- a/migrations/20260429143927_delete_alpaca_wallet_usdc_events.sql
+++ b/migrations/20260429143927_delete_alpaca_wallet_usdc_events.sql
@@ -1,0 +1,9 @@
+-- Delete persisted AlpacaWalletUsdc / AlpacaWalletCash events from the
+-- InventorySnapshot aggregate. The variant has been removed from the enum,
+-- so these rows would fail serde deserialization during event replay.
+DELETE FROM events
+WHERE aggregate_type = 'InventorySnapshot'
+  AND (
+    event_type = 'InventorySnapshotEvent::AlpacaWalletUsdc'
+    OR event_type = 'InventorySnapshotEvent::AlpacaWalletCash'
+  );

--- a/src/alpaca_wallet/asset.rs
+++ b/src/alpaca_wallet/asset.rs
@@ -4,28 +4,10 @@
 //! whitelist behavior.
 
 use alloy::primitives::Address;
-use rain_math_float::Float;
 use serde::Deserialize;
-use tracing::trace;
 
 use super::client::{AlpacaWalletClient, AlpacaWalletError};
 use super::transfer::{Network, TokenSymbol};
-
-/// A single asset entry returned by Alpaca's crypto wallet listing endpoint.
-///
-/// The account has one crypto wallet context, but that wallet can hold multiple
-/// assets such as USDC or BTC. This type models one asset row from
-/// `GET /v1/accounts/{account_id}/wallets`.
-#[derive(Debug, Clone, Deserialize)]
-
-pub(super) struct WalletAsset {
-    pub(super) asset: TokenSymbol,
-    #[serde(
-        alias = "qty",
-        deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
-    )]
-    pub(super) balance: Float,
-}
 
 impl AlpacaWalletClient {
     /// Gets or creates a wallet deposit address for a specific asset and network.
@@ -58,27 +40,6 @@ impl AlpacaWalletClient {
 
         Ok(serde_json::from_str::<WalletAddressResponse>(&text)?.address)
     }
-
-    /// Lists the existing crypto wallet assets for the account.
-    ///
-    /// This intentionally calls `GET /wallets` without an `asset` query
-    /// parameter. Alpaca's docs say querying by `asset` can create a wallet for
-    /// that asset if one does not already exist, while the bare endpoint only
-    /// lists existing wallet assets.
-    pub(super) async fn list_wallet_assets(&self) -> Result<Vec<WalletAsset>, AlpacaWalletError> {
-        let path = format!("/v1/accounts/{}/wallets", self.account_id());
-
-        let response = self.get(&path).await?;
-        let text = response.text().await?;
-
-        let assets = serde_json::from_str::<Vec<WalletAsset>>(&text)?;
-        trace!(
-            target: "wallet",
-            asset_count = assets.len(),
-            "Listed wallet assets"
-        );
-        Ok(assets)
-    }
 }
 
 #[cfg(test)]
@@ -90,7 +51,6 @@ mod tests {
     use st0x_execution::AlpacaAccountId;
 
     use super::*;
-    use st0x_float_macro::float;
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
@@ -163,44 +123,6 @@ mod tests {
                 .unwrap_err(),
             AlpacaWalletError::ApiError { status, .. } if status == reqwest::StatusCode::BAD_REQUEST
         ));
-        mock.assert();
-    }
-
-    #[tokio::test]
-    async fn test_list_wallet_assets_returns_assets() {
-        let server = MockServer::start();
-
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets"));
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "USDC",
-                        "balance": "1250.75"
-                    },
-                    {
-                        "asset": "BTC",
-                        "balance": "0.50"
-                    }
-                ]));
-        });
-
-        let client = AlpacaWalletClient::new(
-            server.base_url(),
-            TEST_ACCOUNT_ID,
-            "test_key_id".to_string(),
-            "test_secret_key".to_string(),
-        );
-
-        let assets = client.list_wallet_assets().await.unwrap();
-
-        assert_eq!(assets.len(), 2);
-        assert_eq!(assets[0].asset, TokenSymbol::new("USDC"));
-        assert!(assets[0].balance.eq(float!(1250.75)).unwrap());
-        assert_eq!(assets[1].asset, TokenSymbol::new("BTC"));
-        assert!(assets[1].balance.eq(float!(0.50)).unwrap());
         mock.assert();
     }
 

--- a/src/alpaca_wallet/client.rs
+++ b/src/alpaca_wallet/client.rs
@@ -1,7 +1,6 @@
 //! Authenticated HTTP transport for Alpaca Broker API wallet modules.
 
 use alloy::primitives::{Address, TxHash, hex::FromHexError};
-use rain_math_float::{Float, FloatError};
 use reqwest::{Client, Response, StatusCode};
 use thiserror::Error;
 use tracing::trace;
@@ -56,13 +55,6 @@ pub enum AlpacaWalletError {
         previous: TransferStatus,
         next: TransferStatus,
     },
-    #[error(
-        "negative USDC balance returned from Alpaca wallet API: {}",
-        st0x_float_serde::format_float_with_fallback(balance)
-    )]
-    NegativeUsdcBalance { balance: Float },
-    #[error("Float operation failed: {0}")]
-    Float(#[from] FloatError),
 }
 
 pub struct AlpacaWalletClient {

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -28,12 +28,11 @@ mod transfer;
 mod whitelist;
 
 use alloy::primitives::{Address, TxHash};
-use rain_math_float::Float;
 use std::sync::Arc;
 use tracing::error;
 
 use st0x_execution::{AlpacaAccountId, Positive};
-use st0x_finance::{HasZero, Usdc};
+use st0x_finance::Usdc;
 
 pub(crate) use client::{AlpacaWalletClient, AlpacaWalletError};
 pub(crate) use status::PollingConfig;
@@ -139,28 +138,6 @@ impl AlpacaWalletService {
         tx_hash: &TxHash,
     ) -> Result<Transfer, AlpacaWalletError> {
         status::poll_deposit_by_tx_hash(&self.client, tx_hash, &self.polling_config).await
-    }
-
-    /// Gets the current USDC balance held in Alpaca's crypto wallet.
-    ///
-    /// If Alpaca reports no USDC wallet entry, this returns zero.
-    pub(crate) async fn get_usdc_balance(&self) -> Result<Usdc, AlpacaWalletError> {
-        let usdc = TokenSymbol::new("USDC");
-        let wallet_assets = self.client.list_wallet_assets().await?;
-
-        let Some(balance) = wallet_assets
-            .into_iter()
-            .find(|wallet_asset| wallet_asset.asset == usdc)
-            .map(|wallet_asset| wallet_asset.balance)
-        else {
-            return Ok(Usdc::ZERO);
-        };
-
-        if balance.lt(Float::zero()?)? {
-            return Err(AlpacaWalletError::NegativeUsdcBalance { balance });
-        }
-
-        Ok(Usdc::new(balance))
     }
 
     pub(crate) async fn get_wallet_address(
@@ -445,79 +422,6 @@ mod tests {
 
         assert_eq!(result.status, transfer::TransferStatus::Complete);
         status_mock.assert();
-    }
-
-    #[tokio::test]
-    async fn test_get_usdc_balance_returns_wallet_balance() {
-        let server = MockServer::start();
-        let service = create_test_service(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "USDC",
-                        "balance": "1250.75"
-                    }
-                ]));
-        });
-
-        let balance = service.get_usdc_balance().await.unwrap();
-
-        assert!(balance.inner().eq(float!(1250.75)).unwrap());
-        wallets_mock.assert();
-    }
-
-    #[tokio::test]
-    async fn test_get_usdc_balance_returns_zero_when_wallet_missing() {
-        let server = MockServer::start();
-        let service = create_test_service(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "BTC",
-                        "balance": "0.5"
-                    }
-                ]));
-        });
-
-        let balance = service.get_usdc_balance().await.unwrap();
-
-        assert_eq!(balance, Usdc::ZERO);
-        wallets_mock.assert();
-    }
-
-    #[tokio::test]
-    async fn test_get_usdc_balance_rejects_negative_balance() {
-        let server = MockServer::start();
-        let service = create_test_service(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "USDC",
-                        "balance": "-10"
-                    }
-                ]));
-        });
-
-        assert!(matches!(
-            service.get_usdc_balance().await.unwrap_err(),
-            AlpacaWalletError::NegativeUsdcBalance { balance } if balance.eq(float!(-10)).unwrap_or(false)
-        ));
-        wallets_mock.assert();
     }
 
     #[tokio::test]

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -240,7 +240,6 @@ impl Conductor {
                 let wallet_polling = crate::inventory::WalletPollingCtx {
                     ethereum: Arc::new(ethereum_wallet),
                     base: Arc::new(base_wallet),
-                    alpaca_wallet: infra.alpaca_wallet,
                     unwrapped_equity_token_addresses: base_wallet_unwrapped_equity_token_addresses(
                         &ctx,
                     ),
@@ -429,7 +428,6 @@ struct RebalancingInfrastructure {
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
     rebalancer: JoinHandle<()>,
-    alpaca_wallet: Arc<AlpacaWalletService>,
     tokenizer: Arc<dyn Tokenizer>,
 }
 
@@ -655,7 +653,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             position_projection: built.position_projection,
             snapshot: built.snapshot,
             rebalancer: handle,
-            alpaca_wallet,
             tokenizer,
         })
     })

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -20,7 +20,7 @@ use st0x_execution::{
     Executor, FractionalShares, InventoryResult, SharesBlockchain, SharesConversionError, Symbol,
 };
 
-use crate::alpaca_wallet::{AlpacaWalletError, AlpacaWalletService};
+use crate::alpaca_wallet::AlpacaWalletError;
 use crate::bindings::IERC20;
 use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
@@ -70,7 +70,6 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
 pub(crate) struct WalletPollingCtx {
     pub(crate) ethereum: Arc<dyn Wallet<Provider = RootProvider>>,
     pub(crate) base: Arc<dyn Wallet<Provider = RootProvider>>,
-    pub(crate) alpaca_wallet: Arc<AlpacaWalletService>,
     pub(crate) unwrapped_equity_token_addresses: HashMap<Symbol, Address>,
     pub(crate) wrapped_equity_token_addresses: HashMap<Symbol, Address>,
 }
@@ -319,15 +318,6 @@ where
                 .await?;
         }
 
-        let usdc_balance = wallets.alpaca_wallet.get_usdc_balance().await?;
-
-        self.snapshot
-            .send(
-                snapshot_id,
-                InventorySnapshotCommand::AlpacaWalletUsdc { usdc_balance },
-            )
-            .await?;
-
         Ok(())
     }
 
@@ -548,18 +538,12 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
     use httpmock::prelude::*;
-    use serde_json::json;
     use sqlx::{Row, SqlitePool};
-    use uuid::uuid;
-
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_evm::ReadOnlyEvm;
-    use st0x_execution::{
-        AlpacaAccountId, EquityPosition, FractionalShares, Inventory, MockExecutor, Symbol,
-    };
+    use st0x_execution::{EquityPosition, FractionalShares, Inventory, MockExecutor, Symbol};
 
     use super::*;
-    use crate::alpaca_wallet::{AlpacaWalletClient, AlpacaWalletError, AlpacaWalletService};
     use crate::inventory::snapshot::InventorySnapshotEvent;
     use crate::test_utils::setup_test_db;
     use crate::tokenized_equity_mint::TokenizationRequestId;
@@ -644,17 +628,6 @@ mod tests {
         }
     }
 
-    fn create_test_alpaca_wallet(server: &MockServer) -> Arc<AlpacaWalletService> {
-        let client = AlpacaWalletClient::new(
-            server.base_url(),
-            AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b")),
-            "test_key".to_string(),
-            "test_secret".to_string(),
-        );
-
-        Arc::new(AlpacaWalletService::new_with_client(client, None))
-    }
-
     fn zero_balance_wallet_asserter(response_count: usize) -> Asserter {
         let asserter = Asserter::new();
         let zero = alloy::hex::encode_prefixed(U256::ZERO.abi_encode());
@@ -664,29 +637,17 @@ mod tests {
         asserter
     }
 
-    fn mock_alpaca_wallets_endpoint(server: &MockServer) {
-        server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([{"asset": "USDC", "balance": "0"}]));
-        });
-    }
-
     /// Creates a fully-mocked `WalletPollingCtx` where all wallets return
     /// zero balances. The `server` must outlive the returned context. Each
     /// wallet gets enough responses for up to 5 consecutive `poll_and_record`
     /// calls.
-    fn mock_wallet_polling_ctx(server: &MockServer) -> WalletPollingCtx {
+    fn mock_wallet_polling_ctx(_server: &MockServer) -> WalletPollingCtx {
         let ethereum_asserter = zero_balance_wallet_asserter(5);
         let base_asserter = zero_balance_wallet_asserter(5);
-        mock_alpaca_wallets_endpoint(server);
 
         WalletPollingCtx {
             ethereum: MockEthereumWallet::with_asserter(&ethereum_asserter),
             base: MockBaseWallet::with_asserter(&base_asserter),
-            alpaca_wallet: create_test_alpaca_wallet(server),
             unwrapped_equity_token_addresses: HashMap::new(),
             wrapped_equity_token_addresses: HashMap::new(),
         }
@@ -1467,188 +1428,6 @@ mod tests {
         };
         let expected = u256_to_usdc(raw_usdc).unwrap();
         assert_eq!(*usdc_balance, expected, "USDC balance mismatch");
-    }
-
-    #[tokio::test]
-    async fn poll_and_record_emits_alpaca_wallet_usdc_when_wallet_provided() {
-        let pool = setup_test_db().await;
-        let provider = mock_provider();
-        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
-        let (orderbook, order_owner) = test_addresses();
-        let wallet_mock_server = MockServer::start();
-        let server = MockServer::start();
-        let alpaca_wallet = create_test_alpaca_wallet(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "USDC",
-                        "balance": "1250.75"
-                    }
-                ]));
-        });
-
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            Some(WalletPollingCtx {
-                alpaca_wallet,
-                ..mock_wallet_polling_ctx(&wallet_mock_server)
-            }),
-            None,
-        );
-
-        service.poll_and_record().await.unwrap();
-
-        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let alpaca_wallet_usdc_event = events
-            .iter()
-            .find(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }))
-            .expect("Expected AlpacaWalletUsdc event to be emitted");
-
-        let InventorySnapshotEvent::AlpacaWalletUsdc { usdc_balance, .. } =
-            alpaca_wallet_usdc_event
-        else {
-            panic!("Expected AlpacaWalletUsdc event, got {alpaca_wallet_usdc_event:?}");
-        };
-        assert!(usdc_balance.inner().eq(float!(1250.75)).unwrap());
-        wallets_mock.assert();
-    }
-
-    #[tracing_test::traced_test]
-    #[tokio::test]
-    async fn poll_and_record_skips_alpaca_wallet_usdc_when_no_wallet() {
-        let pool = setup_test_db().await;
-        let provider = mock_provider();
-        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
-        let (orderbook, order_owner) = test_addresses();
-
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            None,
-            None,
-        );
-
-        service.poll_and_record().await.unwrap();
-
-        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let has_alpaca_wallet_usdc = events
-            .iter()
-            .any(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }));
-
-        assert!(
-            !has_alpaca_wallet_usdc,
-            "Should NOT emit AlpacaWalletUsdc when no Alpaca wallet configured"
-        );
-        assert!(logs_contain(
-            "No wallet polling configured, skipping wallet balance polling"
-        ));
-    }
-
-    #[tokio::test]
-    async fn poll_and_record_propagates_alpaca_wallet_api_failure() {
-        let pool = setup_test_db().await;
-        let provider = mock_provider();
-        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
-        let (orderbook, order_owner) = test_addresses();
-        let wallet_mock_server = MockServer::start();
-        let server = MockServer::start();
-        let alpaca_wallet = create_test_alpaca_wallet(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(500).json_body(json!({
-                "message": "wallet service unavailable"
-            }));
-        });
-
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            Some(WalletPollingCtx {
-                alpaca_wallet,
-                ..mock_wallet_polling_ctx(&wallet_mock_server)
-            }),
-            None,
-        );
-
-        let error = service.poll_and_record().await.unwrap_err();
-        assert!(matches!(
-            error,
-            InventoryPollingError::AlpacaWallet(AlpacaWalletError::ApiError { .. })
-        ));
-        wallets_mock.assert();
-    }
-
-    #[tokio::test]
-    async fn poll_and_record_skips_unchanged_alpaca_wallet_usdc_snapshot() {
-        let pool = setup_test_db().await;
-        let provider = mock_provider();
-        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
-        let (orderbook, order_owner) = test_addresses();
-        let wallet_mock_server = MockServer::start();
-        let server = MockServer::start();
-        let alpaca_wallet = create_test_alpaca_wallet(&server);
-
-        let wallets_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([
-                    {
-                        "asset": "USDC",
-                        "balance": "12.34"
-                    }
-                ]));
-        });
-
-        let service = InventoryPollingService::new(
-            raindex_service,
-            MockExecutor::new(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            orderbook,
-            order_owner,
-            Arc::new(test_store(pool.clone(), ())),
-            Some(WalletPollingCtx {
-                alpaca_wallet,
-                ..mock_wallet_polling_ctx(&wallet_mock_server)
-            }),
-            None,
-        );
-
-        service.poll_and_record().await.unwrap();
-        service.poll_and_record().await.unwrap();
-
-        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
-        let alpaca_wallet_usdc_event_count = events
-            .iter()
-            .filter(|event| matches!(event, InventorySnapshotEvent::AlpacaWalletUsdc { .. }))
-            .count();
-
-        assert_eq!(
-            alpaca_wallet_usdc_event_count, 1,
-            "Should not emit a second AlpacaWalletUsdc event when the balance is unchanged"
-        );
-        wallets_mock.assert_calls(2);
     }
 
     #[tracing_test::traced_test]

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -80,8 +80,6 @@ pub(crate) struct InventorySnapshot {
     pub(crate) ethereum_usdc: Option<Usdc>,
     /// Latest Base wallet USDC balance (outside Raindex vaults)
     pub(crate) base_wallet_usdc: Option<Usdc>,
-    /// Latest USDC balance in Alpaca's crypto wallet
-    pub(crate) alpaca_wallet_usdc: Option<Usdc>,
     /// Latest Base wallet unwrapped equity token balances
     pub(crate) base_wallet_unwrapped_equity: BTreeMap<Symbol, FractionalShares>,
     /// Latest Base wallet wrapped equity token balances
@@ -105,7 +103,7 @@ impl EventSourced for InventorySnapshot {
 
     const AGGREGATE_TYPE: &'static str = "InventorySnapshot";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 4;
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         let mut snapshot = Self {
@@ -118,7 +116,6 @@ impl EventSourced for InventorySnapshot {
             base_wallet_usdc: None,
             inflight_mints: BTreeMap::new(),
             inflight_redemptions: BTreeMap::new(),
-            alpaca_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
             base_wallet_wrapped_equity: BTreeMap::new(),
             last_updated: event.timestamp(),
@@ -173,10 +170,6 @@ impl EventSourced for InventorySnapshot {
             InflightEquity { mints, redemptions } => InventorySnapshotEvent::InflightEquity {
                 mints,
                 redemptions,
-                fetched_at: now,
-            },
-            AlpacaWalletUsdc { usdc_balance } => InventorySnapshotEvent::AlpacaWalletUsdc {
-                usdc_balance,
                 fetched_at: now,
             },
             BaseWalletUnwrappedEquity { balances } => {
@@ -259,15 +252,6 @@ impl EventSourced for InventorySnapshot {
                     fetched_at: now,
                 }])
             }
-            AlpacaWalletUsdc { usdc_balance } => {
-                if self.alpaca_wallet_usdc == Some(usdc_balance) {
-                    return Ok(vec![]);
-                }
-                Ok(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
-                    usdc_balance,
-                    fetched_at: now,
-                }])
-            }
             BaseWalletUnwrappedEquity { balances } => {
                 if self.base_wallet_unwrapped_equity == balances {
                     return Ok(vec![]);
@@ -327,9 +311,6 @@ impl InventorySnapshot {
                 self.inflight_mints = mints.clone();
                 self.inflight_redemptions = redemptions.clone();
             }
-            InventorySnapshotEvent::AlpacaWalletUsdc { usdc_balance, .. } => {
-                self.alpaca_wallet_usdc = Some(*usdc_balance);
-            }
             InventorySnapshotEvent::BaseWalletUnwrappedEquity { balances, .. } => {
                 self.base_wallet_unwrapped_equity = balances.clone();
             }
@@ -361,9 +342,6 @@ pub(crate) enum InventorySnapshotCommand {
         usdc_balance: Usdc,
     },
     BaseWalletUsdc {
-        usdc_balance: Usdc,
-    },
-    AlpacaWalletUsdc {
         usdc_balance: Usdc,
     },
     BaseWalletUnwrappedEquity {
@@ -424,11 +402,6 @@ pub(crate) enum InventorySnapshotEvent {
         redemptions: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
     },
-    #[serde(alias = "AlpacaWalletCash")]
-    AlpacaWalletUsdc {
-        usdc_balance: Usdc,
-        fetched_at: DateTime<Utc>,
-    },
     BaseWalletUnwrappedEquity {
         balances: BTreeMap<Symbol, FractionalShares>,
         fetched_at: DateTime<Utc>,
@@ -449,7 +422,6 @@ impl InventorySnapshotEvent {
             | Self::OffchainMarginSafeBuyingPower { fetched_at, .. }
             | Self::EthereumUsdc { fetched_at, .. }
             | Self::BaseWalletUsdc { fetched_at, .. }
-            | Self::AlpacaWalletUsdc { fetched_at, .. }
             | Self::BaseWalletUnwrappedEquity { fetched_at, .. }
             | Self::BaseWalletWrappedEquity { fetched_at, .. }
             | Self::InflightEquity { fetched_at, .. } => *fetched_at,
@@ -469,7 +441,6 @@ impl DomainEvent for InventorySnapshotEvent {
             }
             Self::EthereumUsdc { .. } => "InventorySnapshotEvent::EthereumUsdc".to_string(),
             Self::BaseWalletUsdc { .. } => "InventorySnapshotEvent::BaseWalletUsdc".to_string(),
-            Self::AlpacaWalletUsdc { .. } => "InventorySnapshotEvent::AlpacaWalletUsdc".to_string(),
             Self::BaseWalletUnwrappedEquity { .. } => {
                 "InventorySnapshotEvent::BaseWalletUnwrappedEquity".to_string()
             }
@@ -907,87 +878,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(snapshot.base_wallet_usdc, Some(usdc));
-    }
-
-    #[tokio::test]
-    async fn alpaca_wallet_usdc_initializes_on_first_command() {
-        let usdc_balance = Usdc::from_str("750").unwrap();
-
-        let events = TestHarness::<InventorySnapshot>::with(())
-            .given_no_previous_events()
-            .when(InventorySnapshotCommand::AlpacaWalletUsdc { usdc_balance })
-            .await
-            .events();
-
-        assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::AlpacaWalletUsdc {
-            usdc_balance: event_balance,
-            ..
-        } = &events[0]
-        else {
-            panic!("Expected AlpacaWalletUsdc event, got {:?}", events[0]);
-        };
-        assert_eq!(*event_balance, usdc_balance);
-    }
-
-    #[tokio::test]
-    async fn alpaca_wallet_usdc_emits_on_change() {
-        let old_balance = Usdc::from_str("750").unwrap();
-        let new_balance = Usdc::from_str("0").unwrap();
-
-        let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
-                usdc_balance: old_balance,
-                fetched_at: Utc::now(),
-            }])
-            .when(InventorySnapshotCommand::AlpacaWalletUsdc {
-                usdc_balance: new_balance,
-            })
-            .await
-            .events();
-
-        assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::AlpacaWalletUsdc {
-            usdc_balance: event_balance,
-            ..
-        } = &events[0]
-        else {
-            panic!("Expected AlpacaWalletUsdc event, got {:?}", events[0]);
-        };
-        assert_eq!(*event_balance, new_balance);
-    }
-
-    #[tokio::test]
-    async fn alpaca_wallet_usdc_skips_when_unchanged() {
-        let balance = Usdc::from_str("750").unwrap();
-
-        let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
-                usdc_balance: balance,
-                fetched_at: Utc::now(),
-            }])
-            .when(InventorySnapshotCommand::AlpacaWalletUsdc {
-                usdc_balance: balance,
-            })
-            .await
-            .events();
-
-        assert!(events.is_empty());
-    }
-
-    #[test]
-    fn apply_event_updates_alpaca_wallet_usdc() {
-        let usdc = Usdc::from_str("987.65").unwrap();
-
-        let snapshot =
-            replay::<InventorySnapshot>(vec![InventorySnapshotEvent::AlpacaWalletUsdc {
-                usdc_balance: usdc,
-                fetched_at: Utc::now(),
-            }])
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(snapshot.alpaca_wallet_usdc, Some(usdc));
     }
 
     #[tokio::test]

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -1073,7 +1073,6 @@ impl InventoryView {
 
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
-            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. } => Ok(self),
 
@@ -1160,7 +1159,6 @@ impl InventoryView {
 
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
-            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. } => Ok(self),
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -957,7 +957,6 @@ impl RebalancingTrigger {
 
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
-            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
 
@@ -1097,7 +1096,6 @@ impl RebalancingTrigger {
 
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
-            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
 
@@ -1145,7 +1143,6 @@ impl RebalancingTrigger {
             }
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
-            | AlpacaWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. }
             // Buying power is display-only and doesn't feed venue balances,

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -1317,37 +1317,6 @@ pub(crate) async fn assert_base_wallet_usdc_event_exists(
     Ok(())
 }
 
-pub(crate) async fn assert_alpaca_wallet_usdc_event(
-    db_path: &std::path::Path,
-    expected_balance: Float,
-) -> anyhow::Result<()> {
-    let pool = connect_db(db_path).await?;
-    let events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
-
-    let alpaca_wallet_usdc = events
-        .iter()
-        .rev()
-        .find(|event| event.event_type == "InventorySnapshotEvent::AlpacaWalletUsdc")
-        .ok_or_else(|| anyhow::anyhow!("Missing AlpacaWalletUsdc event"))?;
-
-    let balance_str = alpaca_wallet_usdc
-        .payload
-        .get("AlpacaWalletUsdc")
-        .and_then(|value| value.get("usdc_balance"))
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| anyhow::anyhow!("AlpacaWalletUsdc payload missing usdc_balance"))?;
-    let balance = Float::parse(balance_str.to_string())
-        .unwrap_or_else(|error| panic!("Failed to parse Alpaca wallet USDC balance: {error}"));
-
-    assert!(
-        balance.eq(expected_balance).unwrap(),
-        "Expected Alpaca wallet USDC snapshot balance {expected_balance:?}, got {balance:?}"
-    );
-
-    pool.close().await;
-    Ok(())
-}
-
 #[bon::builder]
 pub(crate) async fn assert_usdc_rebalancing_flow<P: Provider>(
     expected_positions: &[ExpectedPosition],

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -697,8 +697,6 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
     let onchain_price = float!(158.39);
     let broker_fill_price = float!(155.00);
     let amount_per_trade = float!(7.5);
-    let expected_alpaca_wallet_balance = float!(1250.75);
-
     let infra = TestInfra::start(
         vec![("AAPL", broker_fill_price)],
         vec![("AAPL", float!(30))],
@@ -732,9 +730,6 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
     }
 
     let current_block = infra.base_chain.provider.get_block_number().await?;
-    infra
-        .broker_service
-        .set_wallet_usdc_balance(expected_alpaca_wallet_balance);
 
     let ctx = build_usdc_rebalancing_ctx()
         .base_chain(&infra.base_chain)
@@ -830,7 +825,6 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
 
     assert_ethereum_usdc_event_exists(&infra.db_path).await?;
     assert_base_wallet_usdc_event_exists(&infra.db_path).await?;
-    assert_alpaca_wallet_usdc_event(&infra.db_path, expected_alpaca_wallet_balance).await?;
 
     bot.abort();
     Ok(())


### PR DESCRIPTION
## What

[RAI-247](https://linear.app/makeitrain/issue/RAI-247/remove-redundant-alpacawalletusdc-inventory-polling-path)

Remove the `AlpacaWalletUsdc` inventory snapshot command, event, and polling path. The feature was broken since introduction (PR #485) and the balance it tracked is already captured by `OffchainEquity` as the `USDCUSD` position.

## Why

PR #485 (closing #428) added `AlpacaWalletUsdc` polling to track USDC in Alpaca's crypto wallet during rebalancing transfers. The implementation called `GET /v1/accounts/{id}/wallets` expecting `{asset, balance}` fields, but the real Alpaca API returns only wallet metadata: `{asset_id, address, created_at}` — no balance information. This was never caught because:

1. The code was only tested against mocks with an assumed response shape
2. Wallet polling is only enabled when rebalancing is configured, which wasn't enabled in staging until today
3. The `ParseError` variant used `#[error("Failed to parse response")]` without `{0}`, silently dropping the serde error

The in-flight USDC balance this feature aimed to track is already captured by `OffchainEquity` polling — it appears as a `USDCUSD` position from the Alpaca positions endpoint. The separate wallet polling path is redundant.

## How

Pure deletion (-518 lines, +16 lines). Removes the feature end-to-end:

- **`alpaca_wallet/mod.rs`**: remove `get_usdc_balance()` method
- **`alpaca_wallet/client.rs`**: remove `NegativeUsdcBalance` and `Float` error variants
- **`alpaca_wallet/asset.rs`**: replace broken `WalletAsset` struct with `WalletEntry` matching the real API response; remove `list_wallet_assets()` method
- **`inventory/snapshot.rs`**: remove `AlpacaWalletUsdc` command and event variants, `alpaca_wallet_usdc` field from `InventorySnapshot` struct, bump `SCHEMA_VERSION` 4 -> 5
- **`inventory/polling.rs`**: remove `alpaca_wallet` from `WalletPollingCtx`, remove the `get_usdc_balance()` call in `poll_wallets()`
- **`inventory/view.rs`**: remove `AlpacaWalletUsdc` match arms (2 sites)
- **`rebalancing/trigger/mod.rs`**: remove `AlpacaWalletUsdc` match arms (3 sites)
- **`conductor.rs`**: remove `alpaca_wallet` field from `RebalancingInfrastructure` and its wiring into `WalletPollingCtx`

The `AlpacaWalletClient` and `AlpacaWalletService` are untouched — they're still used for transfers, whitelisting, and deposit address lookups.

Also fixes the `ParseError` display to include the underlying serde error: `"Failed to parse response"` -> `"Failed to parse response: {0}"`.

## Testing

9 tests removed (tested the deleted feature), 1196 remaining tests pass. Workspace check, clippy, and fmt all clean.

Removed tests:
- `alpaca_wallet_usdc_initializes_on_first_command`
- `alpaca_wallet_usdc_emits_on_change`
- `alpaca_wallet_usdc_skips_when_unchanged`
- `apply_event_updates_alpaca_wallet_usdc`
- `test_get_usdc_balance_returns_wallet_balance`
- `test_get_usdc_balance_returns_zero_when_wallet_missing`
- `test_get_usdc_balance_rejects_negative_balance`
- `poll_and_record_emits_alpaca_wallet_usdc_when_wallet_provided`
- `poll_and_record_skips_unchanged_alpaca_wallet_usdc_snapshot`
- `poll_and_record_propagates_alpaca_wallet_api_failure`
- `test_list_wallet_assets_returns_assets`

## Anything else

- **Schema version bump**: `InventorySnapshot` schema version 4 -> 5. Staging DB was already nuked to recover from a separate view deserialization crash, so no migration concerns there. Prod has never had rebalancing enabled, so no `AlpacaWalletUsdc` events exist.
- **E2e tests**: `assert_alpaca_wallet_usdc_event` in `tests/e2e/rebalancing/assertions.rs` will need updating if those tests are run. They're not in the `--lib` test scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed Alpaca wallet USDC balance tracking, related polling, and associated event handling across the inventory and rebalancing systems.

* **Chores**
  * Migration applied to remove legacy Alpaca wallet USDC events from persisted event storage.

* **Tests**
  * Removed tests and end-to-end assertions related to Alpaca wallet USDC tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->