### PR TITLE
fix: compact CQRS inventory snapshot events

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ Workspace crates:
 - **`st0x-dto`** (`crates/dto/`) - Dashboard DTOs and TypeScript binding
   generation
 - **`st0x-event-sorcery`** (`crates/event-sorcery/`) - CQRS/event-sourcing
-  helpers and testing utilities
+  helpers, snapshot-backed loading, compactable observational event streams, and
+  testing utilities
 - **`st0x-execution`** (`crates/execution/`) - Standalone `Executor` trait
   abstraction with Alpaca Broker API and mock implementations
 - **`st0x-bridge`** (`crates/bridge/`) - Cross-chain bridge abstractions and

--- a/SPEC.md
+++ b/SPEC.md
@@ -629,11 +629,13 @@ implementation. Solutions will be developed in later iterations.
 
 ## DDD/CQRS/ES Architecture
 
-The system uses Domain-Driven Design with CQRS and Event Sourcing. All state is
-derived from an immutable event log.
+The system uses Domain-Driven Design with CQRS and Event Sourcing. Audit state
+is derived from retained immutable event streams; compactable observational
+state may use snapshots as the durable source for pre-compaction history.
 
-- **Complete history**: Every state change is a fact with timestamp and sequence
-- **Reproducible state**: Replay facts to rebuild any view
+- **Complete audit history**: Every retained state change is a fact with
+  timestamp and sequence
+- **Reproducible audit state**: Replay retained facts to rebuild any audit view
 - **Temporal queries**: "What was the position at any point in time?"
 - **Zero-downtime projections**: Add new views by replaying existing events
 - **Testable business logic**: Given-When-Then tests validate rules without
@@ -642,9 +644,34 @@ derived from an immutable event log.
 
 ### Architecture
 
-- **Event Store**: Immutable append-only log (single source of truth)
+- **Event Store**: Immutable append-only log for retained event streams
 - **Snapshots**: Performance optimization for aggregate reconstruction
 - **Views**: Materialized projections optimized for queries
+
+Financial audit aggregates retain every event indefinitely. Compaction is
+allowed only by the compaction eligibility policy below.
+
+#### Compaction Eligibility Policy
+
+An aggregate may opt into event compaction only when all of these are true:
+
+- The aggregate type is explicitly allowed by this spec.
+- The aggregate records observational state fetched from external systems, not a
+  financial operation initiated by the bot.
+- Historical events older than the latest aggregate snapshot are not needed for
+  audit, regulatory review, reconciliation, or projection rebuilds.
+- The aggregate can be reconstructed from the `snapshots` table plus newer
+  events, or it has a documented external/snapshot-aware rebuild path.
+- Enabling compaction is reviewed in the PR that sets
+  `COMPACTION_POLICY = CompactAfterSnapshot` for that aggregate.
+
+Eligible aggregate types:
+
+- `InventorySnapshot`: enabled for compaction.
+- `VaultRegistry`: eligible only if a future PR also provides a snapshot-aware
+  projection rebuild path.
+
+All other aggregates retain events unless this section is updated first.
 
 **Grafana Dashboard Strategy**: Views use SQLite generated columns to expose
 JSON fields as queryable columns. Specialized views can pre-compute complex
@@ -654,9 +681,11 @@ metrics, simplifying dashboard queries.
 
 #### Event Sourcing Pattern
 
-All state changes are captured as immutable domain events. The event store is
-the single source of truth. All other data (views, snapshots) is derived and can
-be rebuilt at any time.
+All audit-relevant state changes are captured as immutable domain events. The
+event store is the immutable append-only source of truth for retained event
+streams. Views and snapshots are derived from retained event streams;
+observational aggregates may use snapshots as the durable source for compacted
+pre-snapshot history only when allowed by the compaction eligibility policy.
 
 ##### Key Flow
 

--- a/crates/event-sorcery/src/lib.rs
+++ b/crates/event-sorcery/src/lib.rs
@@ -80,18 +80,19 @@ mod lifecycle;
 mod projection;
 mod reactor;
 mod schema_registry;
+mod sqlite_event_repository;
 #[cfg(any(test, feature = "test-support"))]
 mod testing;
 mod wire;
 
 use async_trait::async_trait;
 pub use cqrs_es::AggregateError;
+use cqrs_es::CqrsFramework;
 pub use cqrs_es::DomainEvent;
 use cqrs_es::EventStore;
 use cqrs_es::persist::PersistedEventStore;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use sqlite_es::{SqliteCqrs, SqliteEventRepository};
 use sqlx::SqlitePool;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
@@ -105,11 +106,24 @@ pub use lifecycle::{LifecycleError, Never};
 pub use projection::{Column, Projection, ProjectionError, SqliteProjectionRepo, Table};
 pub use reactor::Reactor;
 pub use schema_registry::{ReconcileError, Reconciler, SchemaRegistry};
+use sqlite_event_repository::SqliteEventRepository;
 #[cfg(any(test, feature = "test-support"))]
 pub use testing::{
     ReactorHarness, SpyReactor, TestHarness, TestResult, TestStore, replay, test_store,
 };
 pub use wire::StoreBuilder;
+
+pub(crate) type SqliteCqrs<Entity> =
+    CqrsFramework<Lifecycle<Entity>, PersistedEventStore<SqliteEventRepository, Lifecycle<Entity>>>;
+
+/// Whether old events may be deleted after they are captured in a snapshot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionPolicy {
+    /// Keep all events indefinitely.
+    Retain,
+    /// Delete events at or before the current snapshot sequence.
+    CompactAfterSnapshot,
+}
 
 /// The core abstraction for event-sourced domain entities.
 ///
@@ -204,6 +218,20 @@ pub trait EventSourced: Clone + Debug + Send + Sync + Sized + Serialize + Deseri
     /// Schema version for migration reconciliation. Bump when the
     /// event schema changes.
     const SCHEMA_VERSION: u64;
+    /// Event retention policy for this entity.
+    ///
+    /// Financial audit aggregates must use the default
+    /// [`CompactionPolicy::Retain`]. Only observational aggregates
+    /// whose old events have no audit value should opt into compaction.
+    const COMPACTION_POLICY: CompactionPolicy = CompactionPolicy::Retain;
+    /// How many commands between automatic snapshots.
+    ///
+    /// A snapshot of `1` means every command triggers a snapshot
+    /// write -- ideal for compactable aggregates where the snapshot
+    /// is the durable source of pre-compaction state. Retained
+    /// aggregates with low event counts per instance benefit from a
+    /// larger value (e.g., 10-50) to reduce write amplification.
+    const SNAPSHOT_SIZE: usize = 10;
 
     /// Create initial state from a genesis event.
     ///
@@ -266,7 +294,7 @@ pub trait EventSourced: Clone + Debug + Send + Sync + Sized + Serialize + Deseri
 /// query wiring, and schema reconciliation, returning a
 /// ready-to-use `Store`.
 pub struct Store<Entity: EventSourced> {
-    cqrs: SqliteCqrs<Lifecycle<Entity>>,
+    cqrs: SqliteCqrs<Entity>,
     event_store: PersistedEventStore<SqliteEventRepository, Lifecycle<Entity>>,
 }
 
@@ -276,9 +304,9 @@ impl<Entity: EventSourced> Store<Entity> {
     /// Prefer using `StoreBuilder::build()` which handles wiring
     /// and reconciliation. This constructor exists for cases
     /// where direct construction is needed (e.g., tests).
-    pub(crate) fn new(cqrs: SqliteCqrs<Lifecycle<Entity>>, pool: SqlitePool) -> Self {
+    pub(crate) fn new(cqrs: SqliteCqrs<Entity>, pool: SqlitePool) -> Self {
         let repo = SqliteEventRepository::new(pool);
-        let event_store = PersistedEventStore::new_event_store(repo);
+        let event_store = PersistedEventStore::new_snapshot_store(repo, Entity::SNAPSHOT_SIZE);
         Self { cqrs, event_store }
     }
 
@@ -324,7 +352,10 @@ impl<Entity: EventSourced> Store<Entity> {
     ) -> Result<Option<Entity>, SendError<Entity>> {
         let repo = SqliteEventRepository::new(pool);
         let event_store =
-            PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_event_store(repo);
+            PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_snapshot_store(
+                repo,
+                Entity::SNAPSHOT_SIZE,
+            );
         let context = event_store.load_aggregate(&id.to_string()).await?;
 
         Ok(context.aggregate.into_result()?)
@@ -378,18 +409,81 @@ pub async fn load_entity<Entity: EventSourced>(
 ) -> Result<Option<Entity>, SendError<Entity>> {
     let repo = SqliteEventRepository::new(pool.clone());
     let event_store =
-        PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_event_store(repo);
+        PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_snapshot_store(
+            repo,
+            Entity::SNAPSHOT_SIZE,
+        );
 
     let context = event_store.load_aggregate(&id.to_string()).await?;
 
     Ok(context.aggregate.into_result()?)
 }
 
+/// Delete compactable events that are already represented by snapshots.
+///
+/// This is a no-op for entities with [`CompactionPolicy::Retain`]. For
+/// compactable entities, events with `sequence <= snapshots.last_sequence` are
+/// removed. Snapshot-backed loading can still reconstruct the aggregate from the
+/// snapshot and replay any newer events.
+///
+/// # Errors
+///
+/// Returns database errors from the delete query.
+pub async fn compact_events<Entity: EventSourced>(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    if Entity::COMPACTION_POLICY == CompactionPolicy::Retain {
+        return Ok(0);
+    }
+
+    let result = sqlx::query(
+        "DELETE FROM events \
+         WHERE aggregate_type = ?1 \
+           AND sequence <= COALESCE( \
+               (SELECT last_sequence FROM snapshots \
+                WHERE snapshots.aggregate_type = events.aggregate_type \
+                  AND snapshots.aggregate_id = events.aggregate_id), \
+               0 \
+           )",
+    )
+    .bind(Entity::AGGREGATE_TYPE)
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+/// Reclaim SQLite file space after event compaction.
+///
+/// Full `VACUUM` can take an exclusive database lock and should be reserved for
+/// explicit maintenance windows, not hot runtime loops.
+///
+/// # Errors
+///
+/// Returns database errors from SQLite `VACUUM`.
+pub async fn vacuum(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query("VACUUM").execute(pool).await?;
+    Ok(())
+}
+
+/// Reclaim a bounded number of SQLite freelist pages.
+///
+/// This is intended for periodic background cleanup on databases configured
+/// with `auto_vacuum = INCREMENTAL`.
+///
+/// # Errors
+///
+/// Returns database errors from SQLite `PRAGMA incremental_vacuum`.
+pub async fn incremental_vacuum(pool: &SqlitePool, pages: u32) -> Result<(), sqlx::Error> {
+    sqlx::query(&format!("PRAGMA incremental_vacuum({pages})"))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 /// Load all aggregate IDs for a given entity type.
 ///
-/// Queries the events table for distinct aggregate IDs. Used
-/// by dashboard transfer loading to enumerate all transfer
-/// aggregates without requiring access to a [`Store`].
+/// Queries events and snapshots for distinct aggregate IDs. Used by dashboard
+/// transfer loading to enumerate all transfer aggregates without requiring
+/// access to a [`Store`].
 ///
 /// Returns an error if any stored aggregate ID fails to parse,
 /// since that indicates data corruption or a schema mismatch.
@@ -405,8 +499,11 @@ where
     <Entity::Id as FromStr>::Err: Debug,
 {
     let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT DISTINCT aggregate_id FROM events \
-         WHERE aggregate_type = ?1 \
+        "SELECT aggregate_id FROM ( \
+             SELECT aggregate_id FROM events WHERE aggregate_type = ?1 \
+             UNION \
+             SELECT aggregate_id FROM snapshots WHERE aggregate_type = ?1 \
+         ) \
          ORDER BY aggregate_id ASC",
     )
     .bind(Entity::AGGREGATE_TYPE)
@@ -447,7 +544,7 @@ where
 ///
 /// Returns up to `limit` IDs starting from `offset`, ordered by most
 /// recently created aggregate first (based on the maximum rowid of each
-/// aggregate's events).
+/// aggregate's events or snapshot).
 ///
 /// # Errors
 ///
@@ -461,10 +558,19 @@ where
     <Entity::Id as FromStr>::Err: Debug,
 {
     let rows: Vec<(String,)> = sqlx::query_as(
-        "SELECT aggregate_id FROM events \
-         WHERE aggregate_type = ?1 \
+        "SELECT aggregate_id FROM ( \
+             SELECT aggregate_id, MAX(rowid) AS latest_rowid \
+             FROM events \
+             WHERE aggregate_type = ?1 \
+             GROUP BY aggregate_id \
+             UNION ALL \
+             SELECT aggregate_id, MAX(rowid) AS latest_rowid \
+             FROM snapshots \
+             WHERE aggregate_type = ?1 \
+             GROUP BY aggregate_id \
+         ) \
          GROUP BY aggregate_id \
-         ORDER BY MAX(rowid) DESC \
+         ORDER BY MAX(latest_rowid) DESC \
          LIMIT ?2 OFFSET ?3",
     )
     .bind(Entity::AGGREGATE_TYPE)
@@ -512,8 +618,11 @@ pub async fn count_aggregates<Entity: EventSourced>(
     pool: &SqlitePool,
 ) -> Result<usize, LoadAllIdsError> {
     let row: (i64,) = sqlx::query_as(
-        "SELECT COUNT(DISTINCT aggregate_id) FROM events \
-         WHERE aggregate_type = ?1",
+        "SELECT COUNT(*) FROM ( \
+             SELECT aggregate_id FROM events WHERE aggregate_type = ?1 \
+             UNION \
+             SELECT aggregate_id FROM snapshots WHERE aggregate_type = ?1 \
+         )",
     )
     .bind(Entity::AGGREGATE_TYPE)
     .fetch_one(pool)
@@ -574,11 +683,15 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     enum WidgetEvent {
         Created { name: String },
+        Renamed { name: String },
     }
 
     impl DomainEvent for WidgetEvent {
         fn event_type(&self) -> String {
-            "WidgetEvent::Created".to_string()
+            match self {
+                Self::Created { .. } => "WidgetEvent::Created".to_string(),
+                Self::Renamed { .. } => "WidgetEvent::Renamed".to_string(),
+            }
         }
 
         fn event_version(&self) -> String {
@@ -592,6 +705,7 @@ mod tests {
 
     enum WidgetCommand {
         Create { name: String },
+        Rename { name: String },
     }
 
     #[async_trait]
@@ -606,15 +720,21 @@ mod tests {
         const AGGREGATE_TYPE: &'static str = "Widget";
         const PROJECTION: Nil = Nil;
         const SCHEMA_VERSION: u64 = 1;
+        const COMPACTION_POLICY: CompactionPolicy = CompactionPolicy::CompactAfterSnapshot;
+        const SNAPSHOT_SIZE: usize = 1;
 
         fn originate(event: &WidgetEvent) -> Option<Self> {
             match event {
                 WidgetEvent::Created { name } => Some(Self { name: name.clone() }),
+                WidgetEvent::Renamed { .. } => None,
             }
         }
 
-        fn evolve(_entity: &Self, _event: &WidgetEvent) -> Result<Option<Self>, WidgetError> {
-            Ok(None)
+        fn evolve(_entity: &Self, event: &WidgetEvent) -> Result<Option<Self>, WidgetError> {
+            match event {
+                WidgetEvent::Created { .. } => Ok(None),
+                WidgetEvent::Renamed { name } => Ok(Some(Self { name: name.clone() })),
+            }
         }
 
         async fn initialize(
@@ -623,15 +743,19 @@ mod tests {
         ) -> Result<Vec<WidgetEvent>, WidgetError> {
             match command {
                 WidgetCommand::Create { name } => Ok(vec![WidgetEvent::Created { name }]),
+                WidgetCommand::Rename { name } => Ok(vec![WidgetEvent::Renamed { name }]),
             }
         }
 
         async fn transition(
             &self,
-            _command: WidgetCommand,
+            command: WidgetCommand,
             _services: &(),
         ) -> Result<Vec<WidgetEvent>, WidgetError> {
-            Ok(vec![])
+            match command {
+                WidgetCommand::Create { .. } => Ok(vec![]),
+                WidgetCommand::Rename { name } => Ok(vec![WidgetEvent::Renamed { name }]),
+            }
         }
     }
 
@@ -677,6 +801,164 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn load_entity_uses_snapshot_after_events_are_compacted() {
+        let pool = test_pool().await;
+        let store = testing::test_store::<Widget>(pool.clone(), ());
+
+        store
+            .send(
+                &NumericId(42),
+                WidgetCommand::Create {
+                    name: "first".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &NumericId(42),
+                WidgetCommand::Rename {
+                    name: "second".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let deleted = compact_events::<Widget>(&pool).await.unwrap();
+
+        assert_eq!(deleted, 2);
+        let event_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events \
+             WHERE aggregate_type = 'Widget' AND aggregate_id = '42'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(event_count, 0);
+
+        let entity = load_entity::<Widget>(&pool, &NumericId(42)).await.unwrap();
+
+        let widget = entity.expect("entity should load from snapshot after compaction");
+        assert_eq!(widget.name, "second");
+    }
+
+    #[tokio::test]
+    async fn snapshot_version_advances_across_loads() {
+        let pool = test_pool().await;
+        let store = testing::test_store::<Widget>(pool.clone(), ());
+
+        store
+            .send(
+                &NumericId(42),
+                WidgetCommand::Create {
+                    name: "first".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &NumericId(42),
+                WidgetCommand::Rename {
+                    name: "second".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let snapshot_version: i64 = sqlx::query_scalar(
+            "SELECT snapshot_version FROM snapshots \
+             WHERE aggregate_type = 'Widget' AND aggregate_id = '42'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(snapshot_version, 2);
+    }
+
+    #[tokio::test]
+    async fn retain_policy_does_not_compact_events() {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        struct RetainedWidget {
+            name: String,
+        }
+
+        #[async_trait]
+        impl EventSourced for RetainedWidget {
+            type Id = NumericId;
+            type Event = WidgetEvent;
+            type Command = WidgetCommand;
+            type Error = WidgetError;
+            type Services = ();
+            type Materialized = Nil;
+
+            const AGGREGATE_TYPE: &'static str = "RetainedWidget";
+            const PROJECTION: Nil = Nil;
+            const SCHEMA_VERSION: u64 = 1;
+
+            fn originate(event: &WidgetEvent) -> Option<Self> {
+                match event {
+                    WidgetEvent::Created { name } => Some(Self { name: name.clone() }),
+                    WidgetEvent::Renamed { .. } => None,
+                }
+            }
+
+            fn evolve(_entity: &Self, event: &WidgetEvent) -> Result<Option<Self>, WidgetError> {
+                match event {
+                    WidgetEvent::Created { .. } => Ok(None),
+                    WidgetEvent::Renamed { name } => Ok(Some(Self { name: name.clone() })),
+                }
+            }
+
+            async fn initialize(
+                command: WidgetCommand,
+                _services: &(),
+            ) -> Result<Vec<WidgetEvent>, WidgetError> {
+                match command {
+                    WidgetCommand::Create { name } => Ok(vec![WidgetEvent::Created { name }]),
+                    WidgetCommand::Rename { name } => Ok(vec![WidgetEvent::Renamed { name }]),
+                }
+            }
+
+            async fn transition(
+                &self,
+                command: WidgetCommand,
+                _services: &(),
+            ) -> Result<Vec<WidgetEvent>, WidgetError> {
+                match command {
+                    WidgetCommand::Create { .. } => Ok(vec![]),
+                    WidgetCommand::Rename { name } => Ok(vec![WidgetEvent::Renamed { name }]),
+                }
+            }
+        }
+
+        let pool = test_pool().await;
+        let store = testing::test_store::<RetainedWidget>(pool.clone(), ());
+        store
+            .send(
+                &NumericId(7),
+                WidgetCommand::Create {
+                    name: "kept".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let deleted = compact_events::<RetainedWidget>(&pool).await.unwrap();
+
+        assert_eq!(deleted, 0);
+        let event_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events \
+             WHERE aggregate_type = 'RetainedWidget' AND aggregate_id = '7'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(event_count, 1);
+    }
+
+    #[tokio::test]
     async fn load_entity_returns_none_when_no_events() {
         let pool = test_pool().await;
 
@@ -694,6 +976,26 @@ mod tests {
         let ids = load_all_ids::<Widget>(&pool).await.unwrap();
 
         assert_eq!(ids, vec![NumericId(10), NumericId(20)]);
+    }
+
+    #[tokio::test]
+    async fn load_all_ids_includes_snapshot_only_aggregates() {
+        let pool = test_pool().await;
+        let store = testing::test_store::<Widget>(pool.clone(), ());
+        store
+            .send(
+                &NumericId(30),
+                WidgetCommand::Create {
+                    name: "snapshot-only".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        compact_events::<Widget>(&pool).await.unwrap();
+
+        let ids = load_all_ids::<Widget>(&pool).await.unwrap();
+
+        assert_eq!(ids, vec![NumericId(30)]);
     }
 
     #[tokio::test]
@@ -741,5 +1043,25 @@ mod tests {
         let ids = load_all_ids::<Widget>(&pool).await.unwrap();
 
         assert_eq!(ids, vec![NumericId(1)]);
+    }
+
+    #[tokio::test]
+    async fn count_aggregates_includes_snapshot_only_aggregates() {
+        let pool = test_pool().await;
+        let store = testing::test_store::<Widget>(pool.clone(), ());
+        store
+            .send(
+                &NumericId(30),
+                WidgetCommand::Create {
+                    name: "snapshot-only".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        compact_events::<Widget>(&pool).await.unwrap();
+
+        let count = count_aggregates::<Widget>(&pool).await.unwrap();
+
+        assert_eq!(count, 1);
     }
 }

--- a/crates/event-sorcery/src/schema_registry.rs
+++ b/crates/event-sorcery/src/schema_registry.rs
@@ -22,6 +22,7 @@ use sqlx::SqlitePool;
 use std::collections::BTreeMap;
 use tracing::{debug, info};
 
+use crate::CompactionPolicy;
 use crate::lifecycle::{Lifecycle, LifecycleError, Never};
 use crate::{DomainEvent, EventSourced, Nil};
 
@@ -174,6 +175,26 @@ impl Reconciler {
         let needs_clear = stored_version != Some(current_version);
 
         if needs_clear {
+            // Compactable aggregates may have deleted their pre-snapshot
+            // events. Clearing their snapshots would permanently lose
+            // that state with no way to rebuild. Refuse and require an
+            // explicit migration instead.
+            //
+            // Skip the guard on first registration (stored_version = None):
+            // there are no snapshots to clear and no compacted events yet.
+            if stored_version.is_some()
+                && matches!(
+                    Entity::COMPACTION_POLICY,
+                    CompactionPolicy::CompactAfterSnapshot
+                )
+            {
+                return Err(ReconcileError::CompactedSnapshotClear {
+                    aggregate: name.to_string(),
+                    old_version: stored_version,
+                    new_version: current_version,
+                });
+            }
+
             sqlx::query("DELETE FROM snapshots WHERE aggregate_type = ?")
                 .bind(name)
                 .execute(&self.pool)
@@ -215,6 +236,22 @@ pub enum ReconcileError {
     Aggregate(#[from] AggregateError<LifecycleError<SchemaRegistry>>),
     #[error(transparent)]
     Persistence(#[from] PersistenceError),
+
+    /// A compactable aggregate's schema version changed but its
+    /// snapshots cannot be safely deleted because compacted events
+    /// are already gone. Requires an explicit migration.
+    #[error(
+        "Cannot clear snapshots for compactable aggregate '{aggregate}' \
+         (version {old_version:?} -> {new_version}). \
+         Compacted events have been deleted; clearing snapshots would \
+         permanently lose state. Write a migration that handles the \
+         schema change without deleting snapshots."
+    )]
+    CompactedSnapshotClear {
+        aggregate: String,
+        old_version: Option<u64>,
+        new_version: u64,
+    },
 }
 
 impl From<Never> for ReconcileError {
@@ -362,5 +399,107 @@ mod tests {
         // Should have SchemaRegistry at version 1
         let registry = reconciler.load_registry().await.unwrap().unwrap();
         assert_eq!(registry.version_of("SchemaRegistry"), Some(1));
+    }
+
+    /// Minimal compactable entity for testing the reconciliation guard.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct CompactableWidget;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    enum CompactableEvent {
+        Created,
+    }
+
+    impl cqrs_es::DomainEvent for CompactableEvent {
+        fn event_type(&self) -> String {
+            "Created".to_string()
+        }
+        fn event_version(&self) -> String {
+            "1.0".to_string()
+        }
+    }
+
+    #[async_trait]
+    impl EventSourced for CompactableWidget {
+        type Id = String;
+        type Event = CompactableEvent;
+        type Command = ();
+        type Error = Never;
+        type Services = ();
+        type Materialized = Nil;
+
+        const AGGREGATE_TYPE: &'static str = "CompactableWidget";
+        const PROJECTION: Nil = Nil;
+        const SCHEMA_VERSION: u64 = 2;
+        const COMPACTION_POLICY: CompactionPolicy = CompactionPolicy::CompactAfterSnapshot;
+
+        fn originate(_event: &Self::Event) -> Option<Self> {
+            Some(Self)
+        }
+
+        fn evolve(_entity: &Self, _event: &Self::Event) -> Result<Option<Self>, Never> {
+            Ok(Some(Self))
+        }
+
+        async fn initialize(
+            _command: Self::Command,
+            _services: &Self::Services,
+        ) -> Result<Vec<Self::Event>, Never> {
+            Ok(vec![CompactableEvent::Created])
+        }
+
+        async fn transition(
+            &self,
+            _command: Self::Command,
+            _services: &Self::Services,
+        ) -> Result<Vec<Self::Event>, Never> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_allows_first_registration_for_compactable_aggregate() {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+
+        let reconciler = Reconciler::new(pool);
+
+        // First reconcile: stored=None, current=2. No prior snapshots
+        // exist, so this should succeed even for compactable entities.
+        let cleared = reconciler.reconcile::<CompactableWidget>().await.unwrap();
+
+        assert!(cleared);
+    }
+
+    #[tokio::test]
+    async fn reconcile_errors_on_version_mismatch_for_compactable_aggregate() {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+
+        let reconciler = Reconciler::new(pool.clone());
+
+        // First registration succeeds (stored=None)
+        reconciler.reconcile::<CompactableWidget>().await.unwrap();
+
+        // Manually update the stored version to simulate a version
+        // bump (we can't change the const at runtime).
+        sqlx::query(
+            "UPDATE events SET payload = \
+             '{\"VersionUpdated\":{\"name\":\"CompactableWidget\",\"version\":999}}' \
+             WHERE aggregate_type = 'SchemaRegistry' \
+             AND payload LIKE '%CompactableWidget%'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Second reconcile: stored=999, current=2. The entity is
+        // compactable, so reconcile should refuse.
+        let result = reconciler.reconcile::<CompactableWidget>().await;
+
+        assert!(
+            matches!(result, Err(ReconcileError::CompactedSnapshotClear { .. })),
+            "Expected CompactedSnapshotClear error, got {result:?}"
+        );
     }
 }

--- a/crates/event-sorcery/src/sqlite_event_repository.rs
+++ b/crates/event-sorcery/src/sqlite_event_repository.rs
@@ -1,0 +1,325 @@
+use async_trait::async_trait;
+use cqrs_es::Aggregate;
+use cqrs_es::persist::{
+    PersistedEventRepository, PersistenceError, ReplayStream, SerializedEvent, SerializedSnapshot,
+};
+use serde_json::Value;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{Row, SqlitePool};
+
+#[derive(Debug, thiserror::Error)]
+enum SqliteEventRepositoryError {
+    #[error("optimistic lock error: aggregate has been modified concurrently")]
+    OptimisticLock,
+    #[error("snapshot update was requested without persisted events")]
+    EmptySnapshotUpdate,
+    #[error(transparent)]
+    Sql(#[from] sqlx::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Integer(#[from] std::num::TryFromIntError),
+}
+
+impl From<SqliteEventRepositoryError> for PersistenceError {
+    fn from(error: SqliteEventRepositoryError) -> Self {
+        use SqliteEventRepositoryError::*;
+        match error {
+            OptimisticLock => Self::OptimisticLockError,
+            EmptySnapshotUpdate => Self::UnknownError(Box::new(error)),
+            Sql(source) => Self::ConnectionError(Box::new(source)),
+            Json(source) => Self::DeserializationError(Box::new(source)),
+            Integer(source) => Self::UnknownError(Box::new(source)),
+        }
+    }
+}
+
+pub(crate) struct SqliteEventRepository {
+    pool: SqlitePool,
+    stream_channel_size: usize,
+}
+
+impl SqliteEventRepository {
+    pub(crate) fn new(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            stream_channel_size: 1000,
+        }
+    }
+
+    async fn load_events<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+    ) -> Result<Vec<SerializedEvent>, SqliteEventRepositoryError> {
+        let rows = sqlx::query(
+            "SELECT aggregate_type, aggregate_id, sequence, event_type, \
+             event_version, payload, metadata \
+             FROM events \
+             WHERE aggregate_type = ?1 AND aggregate_id = ?2 \
+             ORDER BY sequence",
+        )
+        .bind(A::aggregate_type())
+        .bind(aggregate_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_serialized_event).collect()
+    }
+
+    async fn load_events_since<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+        last_sequence: usize,
+    ) -> Result<Vec<SerializedEvent>, SqliteEventRepositoryError> {
+        let last_sequence = i64::try_from(last_sequence)?;
+        let rows = sqlx::query(
+            "SELECT aggregate_type, aggregate_id, sequence, event_type, \
+             event_version, payload, metadata \
+             FROM events \
+             WHERE aggregate_type = ?1 AND aggregate_id = ?2 AND sequence > ?3 \
+             ORDER BY sequence",
+        )
+        .bind(A::aggregate_type())
+        .bind(aggregate_id)
+        .bind(last_sequence)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.iter().map(row_to_serialized_event).collect()
+    }
+
+    async fn load_snapshot<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+    ) -> Result<Option<SerializedSnapshot>, SqliteEventRepositoryError> {
+        let row = sqlx::query(
+            "SELECT aggregate_type, aggregate_id, last_sequence, snapshot_version, payload, timestamp \
+             FROM snapshots \
+             WHERE aggregate_type = ?1 AND aggregate_id = ?2",
+        )
+        .bind(A::aggregate_type())
+        .bind(aggregate_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.as_ref().map(row_to_serialized_snapshot).transpose()
+    }
+
+    async fn persist_events<A: Aggregate>(
+        &self,
+        events: &[SerializedEvent],
+        snapshot_update: Option<(String, Value, usize)>,
+    ) -> Result<(), SqliteEventRepositoryError> {
+        let mut tx = self.pool.begin().await?;
+
+        for event in events {
+            let sequence = i64::try_from(event.sequence)?;
+            let result = sqlx::query(
+                "INSERT INTO events \
+                 (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            )
+            .bind(&event.aggregate_type)
+            .bind(&event.aggregate_id)
+            .bind(sequence)
+            .bind(&event.event_type)
+            .bind(&event.event_version)
+            .bind(&event.payload)
+            .bind(&event.metadata)
+            .execute(&mut *tx)
+            .await;
+
+            if let Err(error) = result {
+                if is_optimistic_lock_error(&error) {
+                    return Err(SqliteEventRepositoryError::OptimisticLock);
+                }
+                return Err(SqliteEventRepositoryError::Sql(error));
+            }
+        }
+
+        if let Some((aggregate_id, aggregate, snapshot_version)) = snapshot_update {
+            let last_sequence = events
+                .last()
+                .map(|event| event.sequence)
+                .ok_or(SqliteEventRepositoryError::EmptySnapshotUpdate)?;
+            let last_sequence = i64::try_from(last_sequence)?;
+            let snapshot_version = i64::try_from(snapshot_version)?;
+
+            sqlx::query(
+                "INSERT OR REPLACE INTO snapshots \
+                 (aggregate_type, aggregate_id, last_sequence, snapshot_version, payload, timestamp) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            )
+            .bind(A::aggregate_type())
+            .bind(aggregate_id)
+            .bind(last_sequence)
+            .bind(snapshot_version)
+            .bind(aggregate)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Stream events from the `events` table for replay.
+    ///
+    /// **Compaction caveat:** This only queries the `events` table.
+    /// Fully-compacted aggregates (all events deleted, only a
+    /// snapshot remains) will not appear in the stream.
+    /// [`load_aggregate`](cqrs_es::persist::PersistedEventStore::load_aggregate)
+    /// handles this correctly via snapshot loading, but
+    /// stream-based replay will miss snapshot-only entities.
+    fn stream_events_impl<A: Aggregate>(&self, aggregate_id: Option<&str>) -> ReplayStream {
+        let (mut feed, stream) = ReplayStream::new(self.stream_channel_size);
+        let pool = self.pool.clone();
+        let aggregate_type = A::aggregate_type();
+        let aggregate_id = aggregate_id.map(String::from);
+
+        tokio::spawn(async move {
+            let rows = match &aggregate_id {
+                Some(aggregate_id) => {
+                    sqlx::query(
+                        "SELECT aggregate_type, aggregate_id, sequence, event_type, \
+                         event_version, payload, metadata \
+                         FROM events \
+                         WHERE aggregate_type = ?1 AND aggregate_id = ?2 \
+                         ORDER BY sequence",
+                    )
+                    .bind(&aggregate_type)
+                    .bind(aggregate_id)
+                    .fetch_all(&pool)
+                    .await
+                }
+                None => {
+                    sqlx::query(
+                        "SELECT aggregate_type, aggregate_id, sequence, event_type, \
+                         event_version, payload, metadata \
+                         FROM events \
+                         WHERE aggregate_type = ?1 \
+                         ORDER BY sequence",
+                    )
+                    .bind(&aggregate_type)
+                    .fetch_all(&pool)
+                    .await
+                }
+            };
+
+            let rows = match rows {
+                Ok(rows) => rows,
+                Err(error) => {
+                    let _ = feed
+                        .push(Err(PersistenceError::ConnectionError(Box::new(error))))
+                        .await;
+                    return;
+                }
+            };
+
+            for row in &rows {
+                let event = match row_to_serialized_event(row) {
+                    Ok(event) => event,
+                    Err(error) => {
+                        let _ = feed.push(Err(PersistenceError::from(error))).await;
+                        return;
+                    }
+                };
+
+                if feed.push(Ok(event)).await.is_err() {
+                    return;
+                }
+            }
+        });
+
+        stream
+    }
+}
+
+#[async_trait]
+impl PersistedEventRepository for SqliteEventRepository {
+    async fn get_events<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
+        Ok(self.load_events::<A>(aggregate_id).await?)
+    }
+
+    async fn get_last_events<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+        last_sequence: usize,
+    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
+        Ok(self
+            .load_events_since::<A>(aggregate_id, last_sequence)
+            .await?)
+    }
+
+    async fn get_snapshot<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+    ) -> Result<Option<SerializedSnapshot>, PersistenceError> {
+        Ok(self.load_snapshot::<A>(aggregate_id).await?)
+    }
+
+    async fn persist<A: Aggregate>(
+        &self,
+        events: &[SerializedEvent],
+        snapshot_update: Option<(String, Value, usize)>,
+    ) -> Result<(), PersistenceError> {
+        Ok(self.persist_events::<A>(events, snapshot_update).await?)
+    }
+
+    async fn stream_events<A: Aggregate>(
+        &self,
+        aggregate_id: &str,
+    ) -> Result<ReplayStream, PersistenceError> {
+        Ok(self.stream_events_impl::<A>(Some(aggregate_id)))
+    }
+
+    async fn stream_all_events<A: Aggregate>(&self) -> Result<ReplayStream, PersistenceError> {
+        Ok(self.stream_events_impl::<A>(None))
+    }
+}
+
+fn row_to_serialized_event(row: &SqliteRow) -> Result<SerializedEvent, SqliteEventRepositoryError> {
+    let sequence: i64 = row.try_get("sequence")?;
+    let payload: String = row.try_get("payload")?;
+    let metadata: String = row.try_get("metadata")?;
+
+    Ok(SerializedEvent {
+        aggregate_type: row.try_get("aggregate_type")?,
+        aggregate_id: row.try_get("aggregate_id")?,
+        sequence: usize::try_from(sequence)?,
+        event_type: row.try_get("event_type")?,
+        event_version: row.try_get("event_version")?,
+        payload: serde_json::from_str(&payload)?,
+        metadata: serde_json::from_str(&metadata)?,
+    })
+}
+
+fn row_to_serialized_snapshot(
+    row: &SqliteRow,
+) -> Result<SerializedSnapshot, SqliteEventRepositoryError> {
+    let current_sequence: i64 = row.try_get("last_sequence")?;
+    let current_snapshot: i64 = row.try_get("snapshot_version")?;
+    let payload: String = row.try_get("payload")?;
+
+    Ok(SerializedSnapshot {
+        aggregate_id: row.try_get("aggregate_id")?,
+        aggregate: serde_json::from_str(&payload)?,
+        current_sequence: usize::try_from(current_sequence)?,
+        current_snapshot: usize::try_from(current_snapshot)?,
+    })
+}
+
+fn is_optimistic_lock_error(error: &sqlx::Error) -> bool {
+    match error {
+        sqlx::Error::Database(database_error) => {
+            database_error.is_unique_violation()
+                || database_error
+                    .message()
+                    .contains("UNIQUE constraint failed")
+        }
+        _ => false,
+    }
+}

--- a/crates/event-sorcery/src/testing.rs
+++ b/crates/event-sorcery/src/testing.rs
@@ -9,6 +9,7 @@
 //! Lifecycle/Aggregate internals.
 
 use async_trait::async_trait;
+use cqrs_es::persist::PersistedEventStore;
 use cqrs_es::{Aggregate, CqrsFramework, EventStore, Query, mem_store};
 use std::fmt::Debug;
 use std::str::FromStr;
@@ -18,6 +19,7 @@ use tokio::sync::Mutex;
 use crate::dependency::HasEntity;
 use crate::lifecycle::{Lifecycle, LifecycleError, ReactorBridge};
 use crate::reactor::Reactor;
+use crate::sqlite_event_repository::SqliteEventRepository;
 use crate::{EventSourced, Store};
 
 /// Replay events through EventSourced to reconstruct entity state.
@@ -138,8 +140,14 @@ pub fn test_store<Entity: EventSourced>(
     pool: sqlx::SqlitePool,
     services: Entity::Services,
 ) -> Store<Entity> {
+    let repo = SqliteEventRepository::new(pool.clone());
+    let event_store =
+        PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_snapshot_store(
+            repo,
+            Entity::SNAPSHOT_SIZE,
+        );
     #[allow(clippy::disallowed_methods)]
-    let cqrs = sqlite_es::sqlite_cqrs(pool.clone(), vec![], services);
+    let cqrs = CqrsFramework::new(event_store, vec![], services);
     Store::new(cqrs, pool)
 }
 

--- a/crates/event-sorcery/src/wire.rs
+++ b/crates/event-sorcery/src/wire.rs
@@ -2,9 +2,9 @@
 //!
 //! All CQRS framework construction must go through
 //! [`StoreBuilder`], which reconciles schema versions and
-//! registers reactors. Direct calls to `sqlite_es::sqlite_cqrs`
-//! are blocked via clippy's `disallowed-methods`; `StoreBuilder`
-//! contains the single `#[allow]` escape hatch.
+//! registers reactors. Direct CQRS framework construction is
+//! blocked via clippy's `disallowed-methods`; `StoreBuilder`
+//! contains the narrow escape hatch.
 //!
 //! # Registering reactors
 //!
@@ -35,8 +35,9 @@ use std::fmt::Debug;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use cqrs_es::Query;
+use cqrs_es::persist::PersistedEventStore;
 use cqrs_es::persist::PersistenceError;
+use cqrs_es::{CqrsFramework, Query};
 use sqlx::SqlitePool;
 
 use crate::Nil;
@@ -45,7 +46,8 @@ use crate::lifecycle::{Lifecycle, ReactorBridge};
 use crate::projection::{Projection, ProjectionError, Table};
 use crate::reactor::Reactor;
 use crate::schema_registry::{ReconcileError, Reconciler};
-use crate::{EventSourced, Store};
+use crate::sqlite_event_repository::SqliteEventRepository;
+use crate::{CompactionPolicy, EventSourced, SqliteCqrs, Store};
 
 /// Builder for a single CQRS framework.
 ///
@@ -93,6 +95,20 @@ impl<Entity: EventSourced> StoreBuilder<Entity> {
     }
 }
 
+fn sqlite_snapshot_cqrs<Entity: EventSourced>(
+    pool: SqlitePool,
+    queries: Vec<Box<dyn Query<Lifecycle<Entity>>>>,
+    services: Entity::Services,
+) -> SqliteCqrs<Entity> {
+    let repo = SqliteEventRepository::new(pool);
+    let store = PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_snapshot_store(
+        repo,
+        Entity::SNAPSHOT_SIZE,
+    );
+    #[allow(clippy::disallowed_methods)]
+    CqrsFramework::new(store, queries, services)
+}
+
 /// Projected entities: auto-creates and wires a [`Projection`],
 /// returning `(Arc<Store>, Arc<Projection>)`.
 impl<Entity: EventSourced<Materialized = Table> + 'static> StoreBuilder<Entity, Table>
@@ -105,6 +121,19 @@ where
         mut self,
         services: Entity::Services,
     ) -> Result<(Arc<Store<Entity>>, Arc<Projection<Entity>>), ReconcileError> {
+        // Projected entities must retain all events so that
+        // `catch_up`/`rebuild_all` can replay the full history.
+        // Compacted aggregates lose events after snapshot, making
+        // projection rebuilds silently incomplete.
+        const {
+            assert!(
+                matches!(Entity::COMPACTION_POLICY, CompactionPolicy::Retain),
+                "CompactAfterSnapshot entities must not have table projections -- \
+                 rebuild_all only reads the events table and would miss \
+                 compacted snapshot-only aggregates"
+            );
+        }
+
         Reconciler::new(self.pool.clone())
             .reconcile::<Entity>()
             .await?;
@@ -127,8 +156,7 @@ where
             reactor: projection.clone(),
         }));
 
-        #[allow(clippy::disallowed_methods)]
-        let cqrs = sqlite_es::sqlite_cqrs(self.pool.clone(), self.queries, services);
+        let cqrs = sqlite_snapshot_cqrs(self.pool.clone(), self.queries, services);
         Ok((Arc::new(Store::new(cqrs, self.pool)), projection))
     }
 }
@@ -143,8 +171,7 @@ impl<Entity: EventSourced<Materialized = Nil>> StoreBuilder<Entity, Nil> {
             .reconcile::<Entity>()
             .await?;
 
-        #[allow(clippy::disallowed_methods)]
-        let cqrs = sqlite_es::sqlite_cqrs(self.pool.clone(), self.queries, services);
+        let cqrs = sqlite_snapshot_cqrs(self.pool.clone(), self.queries, services);
         Ok(Arc::new(Store::new(cqrs, self.pool)))
     }
 }

--- a/docs/cqrs.md
+++ b/docs/cqrs.md
@@ -369,13 +369,15 @@ events.
 
 1. **NEVER write directly to the `events` table** -- use `Store::send()`
 2. **NEVER query the `events` table with raw SQL** -- use framework APIs
-3. **NEVER modify or delete events** -- they're immutable historical facts
-4. **NEVER implement `Aggregate` directly** -- implement `EventSourced`
-5. **NEVER construct `Lifecycle` in application code** -- it's an internal
+3. **NEVER modify events** -- they're immutable historical facts
+4. **NEVER delete retained events** -- only explicit compactable observational
+   aggregates may prune pre-snapshot events through event-sorcery compaction
+5. **NEVER implement `Aggregate` directly** -- implement `EventSourced`
+6. **NEVER construct `Lifecycle` in application code** -- it's an internal
    adapter
-6. **NEVER call `sqlite_cqrs()` or `CqrsFramework::new()` in production code**
+7. **NEVER call `sqlite_cqrs()` or `CqrsFramework::new()` in production code**
    -- use `StoreBuilder`
-7. **NEVER create multiple `Store<Entity>` for the same entity type** -- one per
+8. **NEVER create multiple `Store<Entity>` for the same entity type** -- one per
    entity, wired once at startup
 
 ## Single Framework Instance Per Entity
@@ -427,6 +429,7 @@ CREATE TABLE IF NOT EXISTS snapshots (
     aggregate_type TEXT NOT NULL,
     aggregate_id   TEXT NOT NULL,
     last_sequence  BIGINT NOT NULL,
+    snapshot_version BIGINT NOT NULL DEFAULT 0,
     payload        JSON NOT NULL,
     timestamp      TEXT NOT NULL,
     PRIMARY KEY (aggregate_type, aggregate_id)
@@ -435,17 +438,41 @@ CREATE TABLE IF NOT EXISTS snapshots (
 
 - **payload**: Aggregate state serialized via `serde_json::to_value(&aggregate)`
 - **last_sequence**: The event sequence at the time of the snapshot
+- **snapshot_version**: The cqrs-es snapshot version used to determine the next
+  snapshot update
 - **timestamp**: ISO 8601 timestamp of when the snapshot was taken
 
-**Not currently enabled** -- all aggregates use `new_event_store`. To enable,
-replace `new_event_store(repo)` with `new_snapshot_store(repo, N)` where `N` is
-the snapshot frequency. Must reset snapshots after changing aggregate struct
-layout. Deleting snapshots is always safe (replays from events).
+Snapshots are enabled for all aggregates through `StoreBuilder`. They are used
+as a replay starting point so hot aggregates do not reload their full event
+history on every command.
+
+After changing aggregate struct layout, bump `SCHEMA_VERSION` so startup clears
+stale snapshots through the schema reconciler. Manual snapshot deletion is safe
+only for retained event streams where the full event history remains available
+for replay.
 
 ```sql
--- Reset snapshots for an aggregate after struct changes
+-- Retained streams only: reset snapshots when full event replay is available.
 DELETE FROM snapshots WHERE aggregate_type = 'Mint';
 ```
+
+Do not manually delete snapshots for aggregates using
+`CompactionPolicy::CompactAfterSnapshot`. For compacted streams, the snapshot
+may be the only durable pre-snapshot state. Those aggregates need a
+snapshot-aware rebuild path or an external source before snapshots can be
+discarded.
+
+### Event Compaction
+
+Financial audit aggregates retain every event indefinitely. Observational
+aggregates may opt into `CompactionPolicy::CompactAfterSnapshot`, which deletes
+events already represented by an aggregate snapshot. This is currently intended
+for high-frequency external-state snapshots such as `InventorySnapshot`.
+
+Only compact aggregates when historical events have no long-term audit value and
+the aggregate can be reconstructed from the `snapshots` table plus newer events.
+Do not enable compaction for projections that must support full rebuild from the
+`events` table unless the projection also has a snapshot-aware rebuild path.
 
 ### View Tables (Projections)
 
@@ -660,10 +687,12 @@ For entities that don't need services, use `type Services = ()`.
 2. **Never query the `events` table directly with raw SQL** - use `EventStore`
    trait methods or the framework's query API
 3. **Never query view tables with raw SQL** - use `GenericQuery::load()`
-4. **Never modify or delete events** - they're immutable historical facts
-5. **Never worry about changing aggregates/views** - they're just
+4. **Never modify events** - they're immutable historical facts
+5. **Never delete retained events** - only explicit compactable observational
+   aggregates may prune pre-snapshot events through event-sorcery compaction
+6. **Never worry about changing aggregates/views** - they're just
    interpretations
-6. **Never add events you don't need yet** - YAGNI applies especially to events
+7. **Never add events you don't need yet** - YAGNI applies especially to events
 
 ## Single Framework Instance Per Aggregate
 
@@ -688,8 +717,8 @@ while the application continues operating as if everything worked.
   type in the bot flow
 - **REQUIRED**: Wire all query processors via `StoreBuilder::wire()` before
   calling `build()`
-- **ALLOWED**: Direct construction in test code (via `wire::test_cqrs()`), CLI
-  code, and migration code (different execution contexts)
+- **ALLOWED**: Direct construction in test helpers, CLI code, and migration code
+  (different execution contexts)
 
 ### Adding a New Query Processor
 

--- a/migrations/20260429110108_snapshot_version_for_cqrs_snapshots.sql
+++ b/migrations/20260429110108_snapshot_version_for_cqrs_snapshots.sql
@@ -1,0 +1,1 @@
+ALTER TABLE snapshots ADD COLUMN snapshot_version BIGINT NOT NULL DEFAULT 0;

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -22,7 +22,9 @@ use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, trace, warn};
 
 use st0x_dto::Statement;
-use st0x_event_sorcery::{Projection, Store, StoreBuilder};
+use st0x_event_sorcery::{
+    Projection, Store, StoreBuilder, compact_events, incremental_vacuum, load_all_ids, load_entity,
+};
 use st0x_evm::Wallet;
 use st0x_execution::{
     CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason, ExecutionError,
@@ -268,6 +270,13 @@ impl Conductor {
                 (position, position_projection, snapshot, None, None, None)
             };
 
+        // Hydrate the in-memory InventoryView from persisted snapshot
+        // state so the runtime projection has the same data as the
+        // database. Without this, the first post-restart poll may emit
+        // no events (unchanged values are deduplicated), leaving the
+        // view empty and potentially causing incorrect rebalancing.
+        hydrate_inventory_from_snapshot(&pool, &inventory).await;
+
         let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
 
         let (offchain_order, offchain_order_projection) =
@@ -421,8 +430,76 @@ fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> J
                     error!(%error, "Failed to clean up finished job queue rows");
                 }
             }
+
+            match compact_inventory_snapshot_events(&pool).await {
+                Ok(deleted) => {
+                    debug!(deleted, "Compacted inventory snapshot events");
+                }
+                Err(error) => {
+                    error!(%error, "Failed to compact inventory snapshot events");
+                }
+            }
         }
     })
+}
+
+async fn compact_inventory_snapshot_events(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let deleted = compact_events::<InventorySnapshot>(pool).await?;
+    if deleted > 0 {
+        incremental_vacuum(pool, 100).await?;
+    }
+    Ok(deleted)
+}
+
+/// Replay persisted [`InventorySnapshot`] state into the in-memory
+/// [`BroadcastingInventory`] so the runtime view starts warm.
+async fn hydrate_inventory_from_snapshot(
+    pool: &SqlitePool,
+    inventory: &Arc<BroadcastingInventory>,
+) {
+    let ids = match load_all_ids::<InventorySnapshot>(pool).await {
+        Ok(ids) => ids,
+        Err(error) => {
+            warn!(?error, "Failed to load InventorySnapshot IDs for hydration");
+            return;
+        }
+    };
+
+    for id in &ids {
+        hydrate_single_snapshot(pool, inventory, id).await;
+    }
+}
+
+async fn hydrate_single_snapshot(
+    pool: &SqlitePool,
+    inventory: &Arc<BroadcastingInventory>,
+    id: &crate::inventory::snapshot::InventorySnapshotId,
+) {
+    let Ok(Some(snapshot)) = load_entity::<InventorySnapshot>(pool, id).await else {
+        return;
+    };
+
+    let events = snapshot.hydration_events();
+    if events.is_empty() {
+        return;
+    }
+
+    apply_hydration_events(inventory, &events).await;
+    info!(%id, event_count = events.len(), "Hydrated InventoryView from persisted snapshot");
+}
+
+async fn apply_hydration_events(
+    inventory: &Arc<BroadcastingInventory>,
+    events: &[crate::inventory::snapshot::InventorySnapshotEvent],
+) {
+    let now = chrono::Utc::now();
+    let mut view = inventory.write().await;
+
+    for event in events {
+        if let Ok(updated) = view.clone().apply_snapshot_event(event, now) {
+            *view = updated;
+        }
+    }
 }
 
 struct RebalancingInfrastructure {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use alloy::primitives::{Address, B256};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use sqlx::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use st0x_execution::{
     AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, FractionalShares, Positive,
     SupportedExecutor, Symbol, TimeInForce,
@@ -1111,10 +1111,32 @@ pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePo
     let options: SqliteConnectOptions = database_url
         .parse::<SqliteConnectOptions>()?
         .create_if_missing(true)
+        .auto_vacuum(SqliteAutoVacuum::Incremental)
         .journal_mode(SqliteJournalMode::Wal)
         .busy_timeout(std::time::Duration::from_secs(10));
 
-    SqlitePool::connect_with(options).await
+    let pool = SqlitePool::connect_with(options).await?;
+
+    // auto_vacuum can only be changed on a newly created database, or by
+    // running `PRAGMA auto_vacuum = INCREMENTAL` followed by a full
+    // `VACUUM` on an existing one. If the database was created before this
+    // setting was added, the pragma in SqliteConnectOptions is silently
+    // ignored and incremental_vacuum() calls will be no-ops.
+    let auto_vacuum: i32 = sqlx::query_scalar("PRAGMA auto_vacuum")
+        .fetch_one(&pool)
+        .await?;
+
+    if auto_vacuum != 2 {
+        warn!(
+            auto_vacuum,
+            "Database auto_vacuum mode is not INCREMENTAL (2). \
+             Event compaction will not reclaim disk space. \
+             Run `PRAGMA auto_vacuum = INCREMENTAL; VACUUM;` \
+             once to enable it."
+        );
+    }
+
+    Ok(pool)
 }
 
 #[cfg(test)]

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -191,10 +191,12 @@ impl Reactor for Broadcaster {
 
 #[cfg(test)]
 mod tests {
-    use st0x_event_sorcery::ReactorHarness;
+    use st0x_event_sorcery::{ReactorHarness, StoreBuilder};
     use st0x_execution::Symbol;
 
     use super::*;
+    use crate::offchain_order::{OffchainOrderCommand, OffchainOrderEvent, noop_order_placer};
+    use crate::position::{PositionCommand, PositionEvent, TradeId};
     use crate::test_utils::setup_test_db;
 
     fn test_broadcaster(pool: SqlitePool) -> (Broadcaster, broadcast::Receiver<Statement>) {
@@ -255,90 +257,49 @@ mod tests {
         }
     }
 
-    async fn insert_event(
-        pool: &SqlitePool,
-        aggregate_type: &str,
-        aggregate_id: &str,
-        sequence: i64,
-        event_type: &str,
-        payload: serde_json::Value,
-    ) {
-        sqlx::query(
-            "INSERT INTO events (aggregate_type, aggregate_id, sequence,
-             event_type, event_version, payload, metadata)
-             VALUES (?1, ?2, ?3, ?4, '1.0', ?5, '{}')",
-        )
-        .bind(aggregate_type)
-        .bind(aggregate_id)
-        .bind(sequence)
-        .bind(event_type)
-        .bind(serde_json::to_string(&payload).unwrap())
-        .execute(pool)
-        .await
-        .unwrap();
-    }
-
     #[tokio::test]
     async fn offchain_order_filled_broadcasts_fill() {
-        use crate::offchain_order::OffchainOrderEvent;
-
         let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
+            .build(noop_order_placer())
+            .await
+            .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
         let harness = ReactorHarness::new(broadcaster);
 
         let now = chrono::Utc::now();
         let id = crate::offchain_order::OffchainOrderId::new();
 
-        // Seed OffchainOrder aggregate to Filled state via direct event insertion
-        let placed = OffchainOrderEvent::Placed {
-            symbol: Symbol::new("TSLA").unwrap(),
-            shares: st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
-                st0x_float_macro::float!(5),
-            ))
-            .unwrap(),
-            direction: st0x_execution::Direction::Sell,
-            executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
-            placed_at: now,
-        };
-        let submitted = OffchainOrderEvent::Submitted {
-            executor_order_id: st0x_execution::ExecutorOrderId::new("test-order"),
-            submitted_at: now,
-        };
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::Place {
+                    symbol: Symbol::new("TSLA").unwrap(),
+                    shares: st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                        st0x_float_macro::float!(5),
+                    ))
+                    .unwrap(),
+                    direction: st0x_execution::Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                OffchainOrderCommand::CompleteFill {
+                    price: st0x_finance::Usd::new(st0x_float_macro::float!(245)),
+                },
+            )
+            .await
+            .unwrap();
+
         let filled = OffchainOrderEvent::Filled {
             price: st0x_finance::Usd::new(st0x_float_macro::float!(245)),
             filled_at: now,
         };
 
-        let id_str = id.to_string();
-        insert_event(
-            &pool,
-            "OffchainOrder",
-            &id_str,
-            0,
-            "OffchainOrderEvent::Placed",
-            serde_json::to_value(&placed).unwrap(),
-        )
-        .await;
-        insert_event(
-            &pool,
-            "OffchainOrder",
-            &id_str,
-            1,
-            "OffchainOrderEvent::Submitted",
-            serde_json::to_value(&submitted).unwrap(),
-        )
-        .await;
-        insert_event(
-            &pool,
-            "OffchainOrder",
-            &id_str,
-            2,
-            "OffchainOrderEvent::Filled",
-            serde_json::to_value(&filled).unwrap(),
-        )
-        .await;
-
-        // Fire the Filled event through the reactor
         harness.receive::<OffchainOrder>(id, filled).await.unwrap();
 
         let msg = receiver.recv().await.expect("should receive fill");
@@ -355,36 +316,47 @@ mod tests {
 
     #[tokio::test]
     async fn position_update_broadcasts_net_position() {
-        use crate::position::PositionEvent;
-
         let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
         let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
         let harness = ReactorHarness::new(broadcaster);
 
         let symbol = Symbol::new("AAPL").unwrap();
         let now = chrono::Utc::now();
+        let threshold = crate::threshold::ExecutionThreshold::Shares(
+            st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                st0x_float_macro::float!(1),
+            ))
+            .unwrap(),
+        );
 
-        // Seed a Position aggregate via direct event insertion
+        store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: alloy::primitives::TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(1)),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+
         let initialized = PositionEvent::Initialized {
             symbol: symbol.clone(),
-            threshold: crate::threshold::ExecutionThreshold::Shares(
-                st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
-                    st0x_float_macro::float!(1),
-                ))
-                .unwrap(),
-            ),
+            threshold,
             initialized_at: now,
         };
-
-        insert_event(
-            &pool,
-            "Position",
-            &symbol.to_string(),
-            0,
-            "PositionEvent::Initialized",
-            serde_json::to_value(&initialized).unwrap(),
-        )
-        .await;
 
         harness
             .receive::<Position>(symbol.clone(), initialized)

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 use thiserror::Error;
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Never, Nil};
+use st0x_event_sorcery::{CompactionPolicy, DomainEvent, EventSourced, Never, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Usdc;
 
@@ -104,6 +104,8 @@ impl EventSourced for InventorySnapshot {
     const AGGREGATE_TYPE: &'static str = "InventorySnapshot";
     const PROJECTION: Nil = Nil;
     const SCHEMA_VERSION: u64 = 5;
+    const COMPACTION_POLICY: CompactionPolicy = CompactionPolicy::CompactAfterSnapshot;
+    const SNAPSHOT_SIZE: usize = 1;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         let mut snapshot = Self {
@@ -196,27 +198,48 @@ impl EventSourced for InventorySnapshot {
         let now = Utc::now();
 
         match command {
-            OnchainEquity { balances } => Ok(vec![InventorySnapshotEvent::OnchainEquity {
-                balances,
-                fetched_at: now,
-            }]),
-            OnchainUsdc { usdc_balance } => Ok(vec![InventorySnapshotEvent::OnchainUsdc {
-                usdc_balance,
-                fetched_at: now,
-            }]),
-            OffchainEquity { positions } => Ok(vec![InventorySnapshotEvent::OffchainEquity {
-                positions,
-                fetched_at: now,
-            }]),
-            OffchainUsd { usd_balance_cents } => Ok(vec![InventorySnapshotEvent::OffchainUsd {
-                usd_balance_cents,
-                fetched_at: now,
-            }]),
+            OnchainEquity { balances } => {
+                if self.onchain_equity == balances {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::OnchainEquity {
+                    balances,
+                    fetched_at: now,
+                }])
+            }
+            OnchainUsdc { usdc_balance } => {
+                if self.onchain_usdc == Some(usdc_balance) {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance,
+                    fetched_at: now,
+                }])
+            }
+            OffchainEquity { positions } => {
+                if self.offchain_equity == positions {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::OffchainEquity {
+                    positions,
+                    fetched_at: now,
+                }])
+            }
+            OffchainUsd { usd_balance_cents } => {
+                if self.offchain_usd_cents == Some(usd_balance_cents) {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents,
+                    fetched_at: now,
+                }])
+            }
             OffchainMarginSafeBuyingPower {
                 margin_safe_buying_power_cents,
             } => {
-                // Always emit so the status readout reflects poll freshness,
-                // mirroring OffchainUsd.
+                if self.offchain_margin_safe_buying_power_cents == margin_safe_buying_power_cents {
+                    return Ok(vec![]);
+                }
                 Ok(vec![
                     InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
                         margin_safe_buying_power_cents,
@@ -275,6 +298,90 @@ impl EventSourced for InventorySnapshot {
 }
 
 impl InventorySnapshot {
+    /// Produce events representing the full persisted state.
+    ///
+    /// Used to hydrate the in-memory [`InventoryView`] on startup so
+    /// that the runtime projection has the same state as the
+    /// persisted snapshot, even when deduplication suppresses the
+    /// first post-restart poll (unchanged values emit no events).
+    pub(crate) fn hydration_events(&self) -> Vec<InventorySnapshotEvent> {
+        let fetched_at = self.last_updated;
+        let mut events = Vec::new();
+
+        if !self.onchain_equity.is_empty() {
+            events.push(InventorySnapshotEvent::OnchainEquity {
+                balances: self.onchain_equity.clone(),
+                fetched_at,
+            });
+        }
+
+        if let Some(usdc_balance) = self.onchain_usdc {
+            events.push(InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance,
+                fetched_at,
+            });
+        }
+
+        if !self.offchain_equity.is_empty() {
+            events.push(InventorySnapshotEvent::OffchainEquity {
+                positions: self.offchain_equity.clone(),
+                fetched_at,
+            });
+        }
+
+        if let Some(usd_balance_cents) = self.offchain_usd_cents {
+            events.push(InventorySnapshotEvent::OffchainUsd {
+                usd_balance_cents,
+                fetched_at,
+            });
+        }
+
+        if self.offchain_margin_safe_buying_power_cents.is_some() {
+            events.push(InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
+                margin_safe_buying_power_cents: self.offchain_margin_safe_buying_power_cents,
+                fetched_at,
+            });
+        }
+
+        if let Some(usdc_balance) = self.ethereum_usdc {
+            events.push(InventorySnapshotEvent::EthereumUsdc {
+                usdc_balance,
+                fetched_at,
+            });
+        }
+
+        if let Some(usdc_balance) = self.base_wallet_usdc {
+            events.push(InventorySnapshotEvent::BaseWalletUsdc {
+                usdc_balance,
+                fetched_at,
+            });
+        }
+
+        if !self.base_wallet_unwrapped_equity.is_empty() {
+            events.push(InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                balances: self.base_wallet_unwrapped_equity.clone(),
+                fetched_at,
+            });
+        }
+
+        if !self.base_wallet_wrapped_equity.is_empty() {
+            events.push(InventorySnapshotEvent::BaseWalletWrappedEquity {
+                balances: self.base_wallet_wrapped_equity.clone(),
+                fetched_at,
+            });
+        }
+
+        if !self.inflight_mints.is_empty() || !self.inflight_redemptions.is_empty() {
+            events.push(InventorySnapshotEvent::InflightEquity {
+                mints: self.inflight_mints.clone(),
+                redemptions: self.inflight_redemptions.clone(),
+                fetched_at,
+            });
+        }
+
+        events
+    }
+
     fn apply_event(&mut self, event: &InventorySnapshotEvent) {
         self.last_updated = event.timestamp();
 
@@ -635,11 +742,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offchain_margin_safe_buying_power_emits_even_when_unchanged() {
-        // Unchanged buying power must still emit so the status readout
-        // reflects poll freshness (mirroring OffchainUsd). Without this,
-        // the BuyPwr timestamp would freeze between value changes while
-        // the USD timestamp kept ticking.
+    async fn offchain_margin_safe_buying_power_skips_unchanged_value() {
         let margin_safe_buying_power_cents = Some(3_000_000);
 
         let events = TestHarness::<InventorySnapshot>::with(())
@@ -655,19 +758,61 @@ mod tests {
             .await
             .events();
 
-        assert_eq!(
-            events.len(),
-            1,
-            "unchanged OffchainMarginSafeBuyingPower must still emit a fresh event"
+        assert!(
+            events.is_empty(),
+            "unchanged OffchainMarginSafeBuyingPower should not emit"
         );
-        match &events[0] {
-            InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents: event_cents,
-                ..
-            } => {
-                assert_eq!(*event_cents, margin_safe_buying_power_cents);
-            }
-            _ => panic!("Expected OffchainMarginSafeBuyingPower event"),
+    }
+
+    #[tokio::test]
+    async fn unchanged_inventory_fields_do_not_emit_events() {
+        let mut balances = BTreeMap::new();
+        balances.insert(test_symbol("AAPL"), test_shares(100));
+        let usdc_balance = Usdc::from_str("1000").unwrap();
+        let mut positions = BTreeMap::new();
+        positions.insert(test_symbol("AAPL"), test_shares(75));
+        let usd_balance_cents = 50_000_000;
+        let fetched_at = Utc::now();
+
+        let cases = vec![
+            (
+                vec![InventorySnapshotEvent::OnchainEquity {
+                    balances: balances.clone(),
+                    fetched_at,
+                }],
+                InventorySnapshotCommand::OnchainEquity { balances },
+            ),
+            (
+                vec![InventorySnapshotEvent::OnchainUsdc {
+                    usdc_balance,
+                    fetched_at,
+                }],
+                InventorySnapshotCommand::OnchainUsdc { usdc_balance },
+            ),
+            (
+                vec![InventorySnapshotEvent::OffchainEquity {
+                    positions: positions.clone(),
+                    fetched_at,
+                }],
+                InventorySnapshotCommand::OffchainEquity { positions },
+            ),
+            (
+                vec![InventorySnapshotEvent::OffchainUsd {
+                    usd_balance_cents,
+                    fetched_at,
+                }],
+                InventorySnapshotCommand::OffchainUsd { usd_balance_cents },
+            ),
+        ];
+
+        for (given, command) in cases {
+            let events = TestHarness::<InventorySnapshot>::with(())
+                .given(given)
+                .when(command)
+                .await
+                .events();
+
+            assert!(events.is_empty(), "unchanged inventory field emitted event");
         }
     }
 
@@ -1333,5 +1478,67 @@ mod tests {
             !snapshot.inflight_mints.contains_key(&test_symbol("AAPL")),
             "Previous inflight mints should be fully replaced"
         );
+    }
+
+    #[test]
+    fn hydration_events_empty_snapshot_produces_no_events() {
+        let snapshot = InventorySnapshot {
+            onchain_equity: BTreeMap::new(),
+            onchain_usdc: None,
+            offchain_equity: BTreeMap::new(),
+            offchain_usd_cents: None,
+            offchain_margin_safe_buying_power_cents: None,
+            ethereum_usdc: None,
+            base_wallet_usdc: None,
+            base_wallet_unwrapped_equity: BTreeMap::new(),
+            base_wallet_wrapped_equity: BTreeMap::new(),
+            inflight_mints: BTreeMap::new(),
+            inflight_redemptions: BTreeMap::new(),
+            last_updated: Utc::now(),
+        };
+
+        assert!(snapshot.hydration_events().is_empty());
+    }
+
+    #[test]
+    fn hydration_events_roundtrips_populated_snapshot() {
+        let now = Utc::now();
+        let mut onchain_equity = BTreeMap::new();
+        onchain_equity.insert(test_symbol("AAPL"), test_shares(100));
+        let mut inflight_mints = BTreeMap::new();
+        inflight_mints.insert(test_symbol("TSLA"), test_shares(50));
+
+        let original = InventorySnapshot {
+            onchain_equity: onchain_equity.clone(),
+            onchain_usdc: Some(Usdc::from_str("5000").unwrap()),
+            offchain_equity: BTreeMap::new(),
+            offchain_usd_cents: Some(42_00),
+            offchain_margin_safe_buying_power_cents: Some(10_000),
+            ethereum_usdc: None,
+            base_wallet_usdc: None,
+            base_wallet_unwrapped_equity: BTreeMap::new(),
+            base_wallet_wrapped_equity: BTreeMap::new(),
+            inflight_mints: inflight_mints.clone(),
+            inflight_redemptions: BTreeMap::new(),
+            last_updated: now,
+        };
+
+        let events = original.hydration_events();
+
+        // Replay those events into a fresh snapshot and verify the
+        // fields match the original.
+        let reconstructed = replay::<InventorySnapshot>(events).unwrap().unwrap();
+
+        assert_eq!(reconstructed.onchain_equity, original.onchain_equity);
+        assert_eq!(reconstructed.onchain_usdc, original.onchain_usdc);
+        assert_eq!(
+            reconstructed.offchain_usd_cents,
+            original.offchain_usd_cents
+        );
+        assert_eq!(
+            reconstructed.offchain_margin_safe_buying_power_cents,
+            original.offchain_margin_safe_buying_power_cents
+        );
+        assert_eq!(reconstructed.inflight_mints, original.inflight_mints);
     }
 }

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -214,6 +214,77 @@ pub async fn poll_for_aggregate_events_containing(
     }
 }
 
+/// Polls the `snapshots` table until a snapshot for the given aggregate
+/// contains a non-empty value for the given JSON field.
+///
+/// Useful for compactable aggregates where events may be deleted before
+/// a test can observe them. The snapshot is the durable record.
+pub async fn poll_for_snapshot_field(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    aggregate_type: &str,
+    field_name: &str,
+    timeout: Duration,
+) {
+    let connect_opts = SqliteConnectOptions::new().filename(db_path);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("{aggregate_type} snapshot with non-empty {field_name}");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect_with(connect_opts.clone()).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let query_result = sqlx::query_as::<_, (String,)>(
+            "SELECT payload FROM snapshots WHERE aggregate_type = ? LIMIT 1",
+        )
+        .bind(aggregate_type)
+        .fetch_optional(&pool)
+        .await;
+
+        pool.close().await;
+
+        match query_result {
+            Ok(Some((payload,))) => {
+                if let Ok(snapshot) = serde_json::from_str::<serde_json::Value>(&payload) {
+                    // Snapshot payload is wrapped in Lifecycle state (e.g. {"Live": {...}})
+                    let inner = snapshot.get("Live").and_then(|live| live.get(field_name));
+                    match inner {
+                        Some(value) if !value.is_null() => {
+                            let is_non_empty = match value {
+                                serde_json::Value::Object(map) => !map.is_empty(),
+                                serde_json::Value::Array(arr) => !arr.is_empty(),
+                                _ => true,
+                            };
+                            if is_non_empty {
+                                return;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(query_error) => assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} \
+                 (query failed: {query_error})",
+            ),
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
 /// Polls the Position projection view until the given symbol has no
 /// pending offchain order (hedge cycle completed).
 ///

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -51,7 +51,7 @@ use crate::base_chain::{self, TakeOrderResult};
 pub(crate) use crate::cctp::{CctpInfra, CctpOverrides, USDC_ETHEREUM};
 pub(crate) use crate::poll::{
     DEFAULT_POLL_TIMEOUT_SECS, connect_db, fetch_events_by_type, poll_for_events_with_timeout,
-    poll_for_hedge_completion, sleep_or_crash, spawn_bot,
+    poll_for_hedge_completion, poll_for_snapshot_field, sleep_or_crash, spawn_bot,
 };
 pub(crate) use crate::test_infra::TestInfra;
 use st0x_float_macro::float;
@@ -322,6 +322,11 @@ pub(crate) enum EquityRebalanceType<'a> {
     },
 }
 
+/// Asserts inventory snapshot state by reading the CQRS snapshot table.
+///
+/// Events are compacted for `InventorySnapshot`, so querying the events
+/// table is unreliable. The snapshot table always contains the latest
+/// persisted state.
 async fn assert_inventory_snapshots(
     pool: &SqlitePool,
     orderbook: Address,
@@ -329,106 +334,66 @@ async fn assert_inventory_snapshots(
     expected_symbols: &[&str],
     assert_cash: bool,
 ) -> anyhow::Result<()> {
-    let events = fetch_events_by_type(pool, "InventorySnapshot").await?;
-    assert!(
-        !events.is_empty(),
-        "Expected InventorySnapshot events, got 0"
-    );
-
     let expected_aggregate_id = format!(
         "{}:{}",
         orderbook.to_checksum(None),
         owner.to_checksum(None),
     );
-    for event in &events {
-        assert_eq!(
-            event.aggregate_id, expected_aggregate_id,
-            "InventorySnapshot aggregate_id mismatch: expected {expected_aggregate_id}, got {}",
-            event.aggregate_id
-        );
-    }
 
-    let event_types: Vec<&str> = events.iter().map(|ev| ev.event_type.as_str()).collect();
+    let snapshot_row = sqlx::query_as::<_, (String, String)>(
+        "SELECT aggregate_id, payload FROM snapshots \
+         WHERE aggregate_type = 'InventorySnapshot' AND aggregate_id = ?",
+    )
+    .bind(&expected_aggregate_id)
+    .fetch_optional(pool)
+    .await?;
 
-    assert!(
-        event_types.contains(&"InventorySnapshotEvent::OnchainEquity"),
-        "Missing OnchainEquity event, got types: {event_types:?}"
-    );
-    assert!(
-        event_types.contains(&"InventorySnapshotEvent::OffchainEquity"),
-        "Missing OffchainEquity event, got types: {event_types:?}"
+    let (aggregate_id, payload_str) =
+        snapshot_row.ok_or_else(|| anyhow::anyhow!("No InventorySnapshot snapshot found"))?;
+
+    assert_eq!(
+        aggregate_id, expected_aggregate_id,
+        "InventorySnapshot aggregate_id mismatch"
     );
 
-    if assert_cash {
-        assert!(
-            event_types.contains(&"InventorySnapshotEvent::OnchainUsdc"),
-            "Missing OnchainUsdc event, got types: {event_types:?}"
-        );
-        assert!(
-            event_types.contains(&"InventorySnapshotEvent::OffchainUsd"),
-            "Missing OffchainUsd event, got types: {event_types:?}"
-        );
-    }
+    let payload: serde_json::Value = serde_json::from_str(&payload_str)?;
+    let live = payload
+        .get("Live")
+        .ok_or_else(|| anyhow::anyhow!("Snapshot not in Live state: {payload}"))?;
 
-    let last_onchain_equity = events
-        .iter()
-        .rev()
-        .find(|ev| ev.event_type == "InventorySnapshotEvent::OnchainEquity")
-        .ok_or_else(|| anyhow::anyhow!("Missing OnchainEquity event"))?;
-    let onchain_balances = last_onchain_equity
-        .payload
-        .get("OnchainEquity")
-        .and_then(|val| val.get("balances"))
-        .ok_or_else(|| anyhow::anyhow!("OnchainEquity payload missing balances"))?;
+    let onchain_equity = live
+        .get("onchain_equity")
+        .ok_or_else(|| anyhow::anyhow!("Snapshot missing onchain_equity"))?;
+    let offchain_equity = live
+        .get("offchain_equity")
+        .ok_or_else(|| anyhow::anyhow!("Snapshot missing offchain_equity"))?;
 
     for symbol in expected_symbols {
-        let balance_str = onchain_balances
+        let balance_str = onchain_equity
             .get(*symbol)
             .and_then(|val| val.as_str())
             .unwrap_or_else(|| {
-                panic!("OnchainEquity missing symbol {symbol}, got: {onchain_balances}")
+                panic!("onchain_equity missing symbol {symbol}, got: {onchain_equity}")
             });
-        let _parsed_balance = Float::parse(balance_str.to_string())
+        let _parsed = Float::parse(balance_str.to_string())
             .unwrap_or_else(|err| panic!("Failed to parse onchain balance for {symbol}: {err:?}"));
-    }
 
-    let last_offchain_equity = events
-        .iter()
-        .rev()
-        .find(|ev| ev.event_type == "InventorySnapshotEvent::OffchainEquity")
-        .ok_or_else(|| anyhow::anyhow!("Missing OffchainEquity event"))?;
-    let offchain_positions = last_offchain_equity
-        .payload
-        .get("OffchainEquity")
-        .and_then(|val| val.get("positions"))
-        .ok_or_else(|| anyhow::anyhow!("OffchainEquity payload missing positions"))?;
-
-    for symbol in expected_symbols {
-        let position_str = offchain_positions
+        let position_str = offchain_equity
             .get(*symbol)
             .and_then(|val| val.as_str())
             .unwrap_or_else(|| {
-                panic!("OffchainEquity missing symbol {symbol}, got: {offchain_positions}")
+                panic!("offchain_equity missing symbol {symbol}, got: {offchain_equity}")
             });
-        let _position = Float::parse(position_str.to_string()).unwrap_or_else(|err| {
+        let _parsed = Float::parse(position_str.to_string()).unwrap_or_else(|err| {
             panic!("Failed to parse offchain position for {symbol}: {err:?}")
         });
     }
 
     if assert_cash {
-        let last_onchain_usdc = events
-            .iter()
-            .rev()
-            .find(|ev| ev.event_type == "InventorySnapshotEvent::OnchainUsdc")
-            .ok_or_else(|| anyhow::anyhow!("Missing OnchainUsdc event"))?;
-        let usdc_balance_str = last_onchain_usdc
-            .payload
-            .get("OnchainUsdc")
-            .and_then(|val| val.get("usdc_balance"))
+        let _usdc = live
+            .get("onchain_usdc")
             .and_then(|val| val.as_str())
-            .ok_or_else(|| anyhow::anyhow!("OnchainUsdc payload missing usdc_balance"))?;
-        let _usdc_balance = Float::parse(usdc_balance_str.to_string())
-            .unwrap_or_else(|err| panic!("Failed to parse onchain USDC balance: {err:?}"));
+            .ok_or_else(|| anyhow::anyhow!("Snapshot missing onchain_usdc"))?;
     }
 
     Ok(())

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -61,6 +61,69 @@ fn count_tokenization_requests(
         .count()
 }
 
+#[derive(Debug, sqlx::FromRow)]
+struct StoredSnapshot {
+    last_sequence: i64,
+    payload: String,
+}
+
+async fn latest_inventory_snapshot(
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<Option<StoredSnapshot>> {
+    let snapshot = sqlx::query_as::<_, StoredSnapshot>(
+        "SELECT last_sequence, payload \
+         FROM snapshots \
+         WHERE aggregate_type = 'InventorySnapshot' \
+         ORDER BY last_sequence DESC \
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(snapshot)
+}
+
+fn snapshot_has_inflight_mint(snapshot: &StoredSnapshot, symbol: &str) -> anyhow::Result<bool> {
+    let payload: serde_json::Value = serde_json::from_str(&snapshot.payload)?;
+    let live = payload.get("Live").unwrap_or(&payload);
+    let has_symbol = live
+        .get("inflight_mints")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|mints| mints.contains_key(symbol));
+
+    Ok(has_symbol)
+}
+
+async fn poll_for_inflight_mint_snapshot(
+    bot: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    symbol: &str,
+    timeout: Duration,
+) -> anyhow::Result<StoredSnapshot> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("InventorySnapshot snapshot with inflight mint for {symbol}");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        if let Ok(pool) = connect_db(db_path).await {
+            let snapshot = latest_inventory_snapshot(&pool).await?;
+            pool.close().await;
+
+            if let Some(snapshot) = snapshot
+                && snapshot_has_inflight_mint(&snapshot, symbol)?
+            {
+                return Ok(snapshot);
+            }
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
 /// Control test: direct high-precision sell-side Raindex prices should not
 /// break equity rebalancing. This avoids buy-side reciprocal math and verifies
 /// that direct decimal price literals do not block the mint pipeline.
@@ -1363,45 +1426,43 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
 
     let mut bot = spawn_bot(ctx);
 
-    // Wait for at least one InflightEquity event to be emitted.
-    poll_for_events_with_timeout(
+    // Poll the snapshot table for inflight data instead of the events
+    // table, because compaction may delete the event before we observe
+    // it. The snapshot is the durable record.
+    poll_for_snapshot_field(
         &mut bot,
         &infra.db_path,
-        "InventorySnapshotEvent::InflightEquity",
-        1,
+        "InventorySnapshot",
+        "inflight_mints",
         Duration::from_secs(30),
     )
     .await;
 
     let pool = connect_db(&infra.db_path).await?;
 
-    // Verify InflightEquity events were emitted.
-    let snapshot_events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
-    let inflight_events: Vec<_> = snapshot_events
-        .iter()
-        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
-        .collect();
-    assert!(
-        !inflight_events.is_empty(),
-        "Expected at least 1 InflightEquity event from polling"
-    );
+    // Verify the snapshot contains the injected pending mint for AAPL
+    // with the exact quantity we injected (25 shares).
+    let snapshot_payload: (String,) = sqlx::query_as(
+        "SELECT payload FROM snapshots \
+         WHERE aggregate_type = 'InventorySnapshot' LIMIT 1",
+    )
+    .fetch_one(&pool)
+    .await?;
+    let snapshot: serde_json::Value = serde_json::from_str(&snapshot_payload.0)?;
 
-    // Verify the first InflightEquity event payload contains the injected
-    // pending mint for AAPL with the exact quantity we injected (25 shares).
-    let payload = &inflight_events[0].payload;
-    let inner = payload
-        .get("InflightEquity")
-        .expect("Event payload should be wrapped in InflightEquity variant");
-    let mints = inner
-        .get("mints")
-        .expect("InflightEquity should contain mints field");
+    let live = snapshot
+        .get("Live")
+        .expect("Snapshot should be in Live state");
+    let mints = live
+        .get("inflight_mints")
+        .expect("Snapshot should contain inflight_mints");
     let aapl_quantity = mints
         .get("AAPL")
-        .expect("InflightEquity mints should contain AAPL from the injected pending request");
+        .expect("inflight_mints should contain AAPL from the injected pending request");
     assert_eq!(
         aapl_quantity.as_str().unwrap(),
         "25",
-        "InflightEquity mint quantity for AAPL should match the injected \
+        "inflight_mints quantity for AAPL should match the injected \
          pending request (25 shares), got: {aapl_quantity}"
     );
 
@@ -1808,22 +1869,18 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Inflight state survives bot restart via CQRS event replay.
+/// Inflight state survives bot restart via CQRS snapshots.
 ///
 /// When the bot restarts against the same database, the CQRS aggregate
-/// replays all previous events including `InflightEquity`. The trigger's
-/// `on_snapshot` handler processes the replayed events and restores the
-/// inflight state in the `InventoryView`.
+/// restores compacted `InventorySnapshot` state from the latest snapshot.
 ///
 /// This test:
-/// 1. Starts a bot, lets it poll and emit `InflightEquity` with a pending
+/// 1. Starts a bot, lets it poll and persist inflight state with a pending
 ///    mint
 /// 2. Stops the bot
 /// 3. Starts a new bot on the same database
-/// 4. Verifies the second bot starts successfully (CQRS replay doesn't
-///    crash) and continues emitting snapshot events (is functional)
-/// 5. Verifies dedup: the aggregate suppresses duplicate InflightEquity
-///    events when the pending request state hasn't changed
+/// 4. Verifies the second bot starts successfully and the inflight state
+///    is still present after restart
 #[test_log::test(tokio::test)]
 async fn inflight_state_survives_restart() -> anyhow::Result<()> {
     let broker_fill_price = float!("150.00");
@@ -1860,7 +1917,7 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
     let cash_vault_id = prepared.input_vault_id;
     let equity_vault_ids = HashMap::from([("AAPL".to_owned(), prepared.output_vault_id)]);
 
-    // --- First bot: let it poll and emit InflightEquity events ---
+    // --- First bot: let it poll and snapshot inflight equity ---
     let ctx1 = build_rebalancing_ctx()
         .chain(&infra.base_chain)
         .broker(&infra.broker_service)
@@ -1876,30 +1933,11 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
 
     let mut bot1 = spawn_bot(ctx1);
 
-    // Wait for at least one InflightEquity event from the first bot.
-    poll_for_events_with_timeout(
-        &mut bot1,
-        &infra.db_path,
-        "InventorySnapshotEvent::InflightEquity",
-        1,
-        Duration::from_secs(30),
-    )
-    .await;
-
-    // Record the total event count before stopping the first bot.
-    let pool = connect_db(&infra.db_path).await?;
-    let events_before_restart = fetch_events_by_type(&pool, "InventorySnapshot").await?;
-    let total_count_before = events_before_restart.len();
-    let inflight_count_before = events_before_restart
-        .iter()
-        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
-        .count();
-    pool.close().await;
-
-    assert!(
-        inflight_count_before >= 1,
-        "First bot should have emitted at least 1 InflightEquity event"
-    );
+    // Wait for the first bot to persist inflight state. InventorySnapshot
+    // events are compactable, so the durable assertion is the snapshot row.
+    let snapshot_before_restart =
+        poll_for_inflight_mint_snapshot(&mut bot1, &infra.db_path, "AAPL", Duration::from_secs(30))
+            .await?;
 
     // Stop the first bot.
     bot1.abort();
@@ -1922,9 +1960,8 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
 
     let bot2 = spawn_bot(ctx2);
 
-    // Wait for the second bot to start polling and emit new snapshot
-    // events. This proves the CQRS replay succeeded and the bot is
-    // functional after restart.
+    // Wait for the second bot to start polling. This proves snapshot
+    // restoration succeeded and the bot is functional after restart.
     tokio::time::sleep(Duration::from_secs(15)).await;
 
     // Verify the second bot is still alive (didn't crash on replay).
@@ -1934,33 +1971,20 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
     );
 
     let pool = connect_db(&infra.db_path).await?;
+    let snapshot_after_restart = latest_inventory_snapshot(&pool)
+        .await?
+        .expect("InventorySnapshot snapshot should exist after restart");
 
-    // The second bot should have emitted new snapshot events after
-    // replaying the first bot's events, proving it's functional.
-    let events_after_restart = fetch_events_by_type(&pool, "InventorySnapshot").await?;
-    let total_count_after = events_after_restart.len();
     assert!(
-        total_count_after > total_count_before,
-        "Second bot should emit new snapshot events after restart \
-         (before: {total_count_before}, after: {total_count_after})"
+        snapshot_after_restart.last_sequence >= snapshot_before_restart.last_sequence,
+        "InventorySnapshot sequence should not move backwards across restart \
+         (before: {}, after: {})",
+        snapshot_before_restart.last_sequence,
+        snapshot_after_restart.last_sequence
     );
-
-    // Verify aggregate dedup: the InflightEquity event count should not
-    // explode after restart. The aggregate replays previous events and
-    // sets its state. When the poller emits the same inflight data, the
-    // aggregate's `handle` method suppresses the duplicate. We allow a
-    // modest increase for natural state transitions (e.g., the pending
-    // request completing after polls_until_complete).
-    let inflight_count_after = events_after_restart
-        .iter()
-        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
-        .count();
-    let new_inflight_events = inflight_count_after - inflight_count_before;
     assert!(
-        new_inflight_events <= 3,
-        "Expected at most 3 new InflightEquity events after restart \
-         (dedup should suppress duplicates), got {new_inflight_events} \
-         (before: {inflight_count_before}, after: {inflight_count_after})"
+        snapshot_has_inflight_mint(&snapshot_after_restart, "AAPL")?,
+        "Inflight mint state should survive restart via the compacted snapshot"
     );
 
     pool.close().await;


### PR DESCRIPTION
## What

Closes RAI-246.

Adds snapshot-backed CQRS loading and compaction for high-volume observational inventory snapshot events.

## Why

`InventorySnapshot` can accumulate tens of thousands of polling events for a single aggregate. Without snapshot-backed replay and compaction, each command has to reload stale polling history and the `events` table grows linearly with uptime.

## How

- Add a local SQLite event repository that supports CQRS snapshots and replaying only events newer than the snapshot sequence.
- Persist cqrs-es snapshot version metadata so snapshot cadence remains correct across aggregate reloads.
- Enable snapshot-backed stores through `StoreBuilder` and test helpers.
- Add `CompactionPolicy` so financial audit aggregates retain events by default while observational aggregates can opt into compaction.
- Mark `InventorySnapshot` compactable and periodically delete events already represented by snapshots.
- Replace periodic full SQLite `VACUUM` with bounded incremental vacuuming and configure new SQLite connections for incremental auto-vacuum.
- Stop emitting inventory snapshot events for unchanged values, including offchain USD and margin-safe buying power.
- Update dashboard/rebalancing event reads so snapshot-only aggregates remain visible after compaction.

## Testing

- [x] `nix develop -c cargo nextest run -p st0x-event-sorcery`
- [x] `nix develop -c cargo nextest run -p st0x-hedge inventory::snapshot::tests skips_unchanged`
- [x] `nix develop -c cargo check -p st0x-hedge`
- [x] `nix develop -c cargo clippy -p st0x-event-sorcery --all-targets --all-features`
- [x] `nix develop -c cargo clippy -p st0x-hedge --all-targets --all-features`

## Screenshots

N/A

## Anything else

Financial audit aggregates keep the default retain policy. Compaction is only enabled for `InventorySnapshot`, which the ticket classifies as observational and safe to compact after snapshotting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced event compaction with configurable policies for snapshot-backed persistence.
  * Added database maintenance APIs: `compact_events`, `vacuum`, and `incremental_vacuum`.
  * Implemented snapshot deduplication to reduce redundant event emission.

* **Documentation**
  * Updated architecture documentation with compaction eligibility policies and audit vs. observational state distinction.

* **Improvements**
  * Enabled incremental auto-vacuum on SQLite connections for improved storage efficiency.
  * Enhanced snapshot restoration validation across service restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->