### PR TITLE
docs: document CheckPositions and PlaceHedge jobs in conductor.md

### DIFF
--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -47,7 +47,7 @@ SupervisorBuilder::default()
 
 ### OrderFillMonitor
 
-Defined in `src/conductor/order_fill_monitor.rs`. Subscribes to
+Defined in `src/conductor/monitor/order_fills.rs`. Subscribes to
 ClearV3/TakeOrderV3 WebSocket streams and pushes each event into the
 `DexTradeAccountingJobQueue` as an `AccountForDexTrade` job.
 
@@ -56,12 +56,26 @@ struct OrderFillMonitor {
     ws_url: Url,
     orderbook: Address,
     job_queue: DexTradeAccountingJobQueue,
+    dex_streams: Arc<Mutex<Option<DexEventStreams>>>,
 }
 ```
 
-The WebSocket connection is created inside `run()`. On disconnect or error,
-`run()` returns `Err(...)`, the supervisor restarts the task, and a fresh
-connection is established.
+On first `run()`, the monitor consumes the pre-established `DexEventStreams`
+passed in at construction (avoiding a gap between the WS subscription used for
+`get_cutoff_block` and the monitor's first iteration). On subsequent restarts,
+it creates a fresh WebSocket connection. On disconnect or error, `run()` returns
+`Err(...)` and the supervisor restarts the task.
+
+### PositionMonitor
+
+Defined in `src/conductor/monitor/positions.rs`. A long-running supervised task
+that periodically scans all positions, filters by orchestration policy (trading
+enabled, no equity transfers in progress), and enqueues durable `PlaceHedge`
+jobs for any positions ready to hedge.
+
+The check interval is configured via `position_check_interval`. Duplicate
+enqueues are safe because the Position aggregate rejects `PlaceOffChainOrder`
+when a pending order already exists.
 
 ## One-shot jobs (apalis + Job trait)
 
@@ -143,45 +157,62 @@ hedging pipeline:
 ### AccountantCtx
 
 Defined in `src/trading/onchain/trade_accountant.rs`. Bundles all dependencies
-the job needs: config, symbol cache, EVM provider, CQRS frameworks, vault
-registry, executor. Wrapped in `Arc` and injected via apalis `Data`.
+the job needs: orderbook address, config, symbol cache, Pyth feed ID cache, EVM
+provider, CQRS frameworks, vault registry, executor. Wrapped in `Arc` and
+injected via apalis `Data`.
+
+### PlaceHedge
+
+Defined in `src/trading/offchain/hedge.rs`. Enqueued by `PositionMonitor` into
+the `HedgeJobQueue` for positions that exceed their execution threshold.
+Implements `Job<HedgeCtx>`. The `perform()` method places the offsetting offchain
+order and updates the Position aggregate.
 
 ## Conductor assembly
 
 `builder::spawn()` (`src/conductor/builder.rs`) uses `#[bon::builder]` to
 construct a running `Conductor`. Required parameters: `ConductorCtx` (shared
-dependencies), `DexTradeAccountingJobQueue`, `DexEventStreams`. Optional:
-`executor_maintenance`, `rebalancer`.
+dependencies), `DexTradeAccountingJobQueue`, `HedgeJobQueue`, `DexEventStreams`,
+`job_cleanup`. Optional: `executor_maintenance`, `rebalancer`.
 
 `ConductorCtx` bundles the shared dependencies (config, symbol cache, provider,
-executor, CQRS frameworks, execution threshold, wallet polling config).
+executor, CQRS frameworks, execution threshold, database pool, poll notifier,
+wallet polling config, tokenizer).
 
 `Conductor` lifecycle:
 
-- `run()` -- the single entry point. Sets up apalis tables, CQRS frameworks,
-  determines cutoff block, backfills historical events, then calls
-  `builder::spawn()` to start the runtime
+- `run()` -- the single entry point. Connects WebSocket, sets up apalis tables,
+  determines cutoff block, backfills historical events, sets up CQRS frameworks,
+  seeds vaults, configures rebalancing, then calls `builder::spawn()` to start
+  the runtime
 - `wait_for_completion()` -- `tokio::select!` across supervisor, apalis monitor,
-  order poller, and position checker; returns when any exits
+  and job cleanup; returns when any exits
 - `abort_all()` -- shuts down supervisor, aborts all task handles
 
 ## Startup sequencing
 
 ```
-Phase 1 (parallel):  connect_ws | setup_cqrs | setup_apalis_tables
-Phase 2 (parallel):  get_cutoff_block | seed_vaults | setup_rebalancing
+Phase 1 (sequential): connect_ws | setup_apalis_tables
+Phase 2 (sequential): get_cutoff_block
 Phase 3 (sequential): backfill checkpoint gap to job queue
-Phase 4:              builder::spawn() starts the runtime
+Phase 4 (sequential): setup_cqrs | seed_vaults | setup_rebalancing
+Phase 5:              builder::spawn() starts the runtime
 ```
 
 The trade accounting worker starts only after backfill completes. The WS
-subscription is established in phase 1, so no events are missed -- they buffer
+subscription is established in Phase 1, so no events are missed -- they buffer
 until the monitor starts.
 
 Backfill reads the last successful checkpoint from SQLite. The configured
 `deployment_block` seeds only the first run; subsequent runs start at
 `checkpoint + 1`. The checkpoint advances only after the full requested range
 has been enqueued successfully.
+
+During Phase 4, when rebalancing is configured, the conductor also queries for
+interrupted `TokenizedEquityMint` and `EquityRedemption` aggregates (those whose
+latest event is non-terminal) and resumes them from their persisted state. This
+ensures mints and redemptions that were in progress when the process crashed are
+not left stuck indefinitely.
 
 The conductor also runs periodic cleanup for terminal apalis jobs at the
 configured `apalis_finished_job_cleanup_interval_secs` cadence. Those rows are

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -270,6 +270,36 @@ the job needs: config, symbol cache, configured Pyth feed IDs (`PythFeedIds`),
 EVM provider, orderbook address, CQRS frameworks, vault registry, executor,
 database pool, and job queue. Wrapped in `Arc` and injected via apalis `Data`.
 
+### CheckPositions
+
+Defined in `src/position_check.rs`. A durable, self-rescheduling apalis job that
+replaced the former supervised position-polling task. A single instance is
+enqueued at startup; each run scans all positions from the `Position`
+projection, skips symbols with active equity transfers or an already-claimed
+pending order, and enqueues an independent `PlaceHedge` job for every symbol
+whose net exposure has crossed the execution threshold. Per-symbol scan errors
+are logged and swallowed so one symbol's failure cannot block the others; only
+failures of the loop itself propagate. After each scan the job re-enqueues
+itself with a delay of the configured `position_check_interval`.
+
+Each tick also re-drives orders stuck `Pending` between broker acceptance and
+the outcome commit (ADR 0014), serialized against live placements via the shared
+counter-trade submission lock.
+
+### PlaceHedge
+
+Defined in `src/trading/offchain/hedge.rs`. Enqueued by `CheckPositions` (one
+job per ready symbol) into the `HedgeJobQueue`. Implements `Job<HedgeCtx>`. The
+`perform()` method places the offsetting broker order via the `OrderPlacer`
+service and rolls the position back if the broker rejects. The
+`offchain_order_id` is generated at enqueue time, not inside `perform()`, so
+retries reuse the same ID -- a crash between claiming the position and placing
+the order cannot strand the position with a pending ID no retry can claim.
+
+During an Extended market session, only symbols with
+`extended_hours_counter_trading = enabled` place (limit) orders, priced with the
+configured `counter_trade_slippage_bps` buffer; disabled symbols skip.
+
 ## Conductor assembly
 
 `builder::spawn()` (`src/conductor/builder.rs`) uses `#[bon::builder]` to


### PR DESCRIPTION
## What

Document the position-scan and hedge-placement jobs in `docs/conductor.md`:
new `CheckPositions` and `PlaceHedge` sections under "One-shot jobs".

## Why

`docs/conductor.md` covered `OrderFillMonitor`, `AccountForDexTrade`, and
`AccountantCtx` but never documented how positions get scanned and hedges get
placed. This PR originally patched the WebSocket-era supervised
`PositionMonitor` task; that design is gone (replaced by a durable,
self-rescheduling apalis job), so the branch was rewritten against the current
code instead of restacking the stale text.

## How

- `CheckPositions` (`src/position_check.rs`): durable self-rescheduling apalis
  job — scans positions from the projection, skips symbols with active equity
  transfers or an already-claimed pending order, enqueues one `PlaceHedge` per
  ready symbol, re-enqueues itself at `position_check_interval`, and re-drives
  `Pending`-stuck placements (ADR 0014).
- `PlaceHedge` (`src/trading/offchain/hedge.rs`): places the offsetting broker
  order, rolls the position back on broker rejection, reuses its enqueue-time
  `offchain_order_id` across retries, and gates extended-hours limit orders on
  `extended_hours_counter_trading`.

## Testing

Doc-only change. Every claim was verified against the module docstrings and
context structs in `src/position_check.rs` and `src/trading/offchain/hedge.rs`.

## Anything else

Part of the stale-docs stack on #946; the original conductor path/struct fixes
this PR carried are already on master via the conductor.md rewrite.
