### PR TITLE
feat: add transfer detail modal and fix status display

### DIFF
--- a/crates/dto/src/transfer.rs
+++ b/crates/dto/src/transfer.rs
@@ -158,6 +158,16 @@ impl TransferOperation {
         }
     }
 
+    /// When this transfer was initiated.
+    #[must_use]
+    pub fn started_at(&self) -> DateTime<Utc> {
+        match self {
+            Self::EquityMint(op) => op.started_at,
+            Self::EquityRedemption(op) => op.started_at,
+            Self::UsdcBridge(op) => op.started_at,
+        }
+    }
+
     /// The last time this transfer was updated.
     #[must_use]
     pub fn updated_at(&self) -> DateTime<Utc> {

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -6,7 +6,14 @@
   import { reactive } from '$lib/frp.svelte'
   import { getApiBaseUrl } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
+  import { formatDecimal } from '$lib/decimal'
   import { getExplorerTxUrl } from '$lib/env'
+
+  type TradeEvent = {
+    step: string
+    sequence: number
+    payload: Record<string, unknown>
+  }
 
   type TradeEntry = {
     id: string
@@ -222,6 +229,90 @@
     if (Math.abs(num) < 0.01) return num.toPrecision(2)
     return num.toFixed(2)
   }
+
+  // -- Detail modal state --
+
+  let detailDialogEl: HTMLDialogElement | undefined = $state()
+  const detailEvents = reactive<TradeEvent[]>([])
+  const detailTrade = reactive<TradeEntry | null>(null)
+  const detailLoading = reactive(false)
+  const detailError = reactive<string | null>(null)
+
+  const openDetail = async (trade: TradeEntry) => {
+    detailTrade.update(() => trade)
+    detailLoading.update(() => true)
+    detailError.update(() => null)
+    detailEvents.update(() => [])
+    detailDialogEl?.showModal()
+
+    try {
+      const baseUrl = getApiBaseUrl()
+      const response = await fetch(
+        `${baseUrl}/trades/${trade.venue}/${trade.id}/events`,
+        { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+      )
+
+      if (!response.ok) {
+        detailError.update(() => `HTTP ${String(response.status)}`)
+        return
+      }
+
+      const data = (await response.json()) as { events: TradeEvent[] }
+      detailEvents.update(() => data.events)
+    } catch (err) {
+      detailError.update(() => err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      detailLoading.update(() => false)
+    }
+  }
+
+  // -- Detail rendering helpers --
+
+  const humanizeStep = (step: string): string =>
+    step.replace(/([A-Z])/g, ' $1').trim()
+
+  const isTxHash = (value: unknown): value is string =>
+    typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value)
+
+  const isTimestampField = (key: string): boolean => key.endsWith('_at')
+
+  const formatFieldName = (key: string): string =>
+    key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+
+  const extractTimestamp = (payload: Record<string, unknown>): string | null => {
+    for (const [key, value] of Object.entries(payload)) {
+      if (isTimestampField(key) && typeof value === 'string') return value
+    }
+    return null
+  }
+
+  const stepStyle = (step: string): string => {
+    const lower = step.toLowerCase()
+
+    if (lower.includes('filled') || lower.includes('enriched')) {
+      return 'text-green-500'
+    }
+
+    if (lower.includes('failed')) {
+      return 'text-destructive'
+    }
+
+    return 'text-muted-foreground'
+  }
+
+  const stepDot = (step: string): string => {
+    const lower = step.toLowerCase()
+
+    if (lower.includes('filled') || lower.includes('enriched')) {
+      return 'bg-green-500'
+    }
+
+    if (lower.includes('failed')) {
+      return 'bg-destructive'
+    }
+
+    return 'bg-muted-foreground'
+  }
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-green-500/50">
@@ -297,16 +388,16 @@
         <Table.Body>
           {#each entries.current as trade, idx (trade.id + String(idx))}
             <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
-              <Table.Cell class="px-1">
-                {@const url = explorerUrl(trade)}
-                {#if url}
-                  <a href={url} target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-muted-foreground hover:text-foreground" title="View on explorer">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-                      <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 0 0-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 0 0 .75-.75v-4a.75.75 0 0 1 1.5 0v4A2.25 2.25 0 0 1 12.75 17h-8.5A2.25 2.25 0 0 1 2 14.75v-8.5A2.25 2.25 0 0 1 4.25 4h5a.75.75 0 0 1 0 1.5h-5Z" clip-rule="evenodd" />
-                      <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 0 0 1.06.053L16.5 4.44v2.81a.75.75 0 0 0 1.5 0v-4.5a.75.75 0 0 0-.75-.75h-4.5a.75.75 0 0 0 0 1.5h2.553l-9.056 8.194a.75.75 0 0 0-.053 1.06Z" clip-rule="evenodd" />
-                    </svg>
-                  </a>
-                {/if}
+              <Table.Cell class="w-8 px-1">
+                <button
+                  class="inline-flex items-center text-muted-foreground hover:text-foreground"
+                  title="View trade details"
+                  onclick={() => openDetail(trade)}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+                    <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
               </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
                 {formatUtc(trade.filledAt)}
@@ -334,3 +425,129 @@
     {/if}
   </Card.Content>
 </Card.Root>
+
+<dialog
+  bind:this={detailDialogEl}
+  class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
+  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl?.close() }}
+>
+  {#if detailTrade.current}
+    {@const trade = detailTrade.current}
+    <div class="flex items-center justify-between border-b px-5 py-3">
+      <div class="flex items-center gap-2 text-sm font-semibold">
+        <span class={directionColor(trade.direction)}>{trade.direction}</span>
+        <span class="font-mono text-xs font-normal">{trade.symbol}</span>
+        <span class="font-mono text-xs font-normal text-muted-foreground">{fmtSize(trade.shares)} shares</span>
+        <span class="text-xs font-normal {venueColor(trade.venue)}">{venueLabel(trade.venue)}</span>
+      </div>
+      <button
+        class="text-lg leading-none text-muted-foreground hover:text-foreground"
+        onclick={() => detailDialogEl?.close()}
+      >
+        &times;
+      </button>
+    </div>
+
+    <div class="max-h-[60vh] overflow-y-auto px-5 py-4">
+      {#if detailLoading.current}
+        <div class="flex items-center justify-center py-8 text-sm text-muted-foreground">
+          Loading events...
+        </div>
+      {:else if detailError.current}
+        <div class="flex items-center justify-center py-8 text-sm text-destructive">
+          Failed to load events: {detailError.current}
+        </div>
+      {:else}
+        <!-- Summary fields -->
+        <div class="mb-4 space-y-1.5 text-xs">
+          <div class="flex items-center gap-2 font-mono">
+            <span class="shrink-0 text-muted-foreground">ID</span>
+            {#if trade.venue === 'raindex'}
+              {@const txHash = trade.id.slice(0, trade.id.lastIndexOf(':'))}
+              {@const logIndex = trade.id.slice(trade.id.lastIndexOf(':') + 1)}
+              <a
+                href={getExplorerTxUrl(txHash)}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+              >
+                {txHash.slice(0, 10)}...{txHash.slice(-8)}
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
+                  <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
+                  <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                </svg>
+              </a>
+              <span class="text-muted-foreground">(log {logIndex})</span>
+            {:else}
+              <span class="text-muted-foreground">{trade.id}</span>
+            {/if}
+          </div>
+
+          <div class="flex items-center gap-2 font-mono">
+            <span class="shrink-0 text-muted-foreground">Filled At</span>
+            <span>{formatUtc(trade.filledAt)}</span>
+          </div>
+        </div>
+
+        <!-- Event timeline -->
+        <div class="relative space-y-0 border-l-2 border-muted pl-4">
+          {#each detailEvents.current as event, idx (event.sequence)}
+            {@const timestamp = extractTimestamp(event.payload)}
+            {@const fields = Object.entries(event.payload).filter(([key]) => !isTimestampField(key))}
+            <div class="relative pb-4">
+              <!-- Timeline dot -->
+              <div class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepDot(event.step)}"></div>
+
+              <div class="text-xs font-medium {stepStyle(event.step)}">
+                {humanizeStep(event.step)}
+              </div>
+
+              {#if timestamp}
+                <div class="mt-0.5 font-mono text-xs text-muted-foreground">
+                  {formatUtc(timestamp)}
+                </div>
+              {/if}
+
+              {#if fields.length > 0}
+                <div class="mt-1.5 space-y-1">
+                  {#each fields as [key, value] (key)}
+                    <div class="flex items-start gap-2 font-mono text-xs">
+                      <span class="shrink-0 text-muted-foreground">{formatFieldName(key)}</span>
+                      <span class="min-w-0 break-all">
+                        {#if key === 'error'}
+                          <span class="text-destructive">{value}</span>
+                        {:else if isTxHash(value)}
+                          <a
+                            href={getExplorerTxUrl(value)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                          >
+                            {value.slice(0, 10)}...{value.slice(-8)}
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
+                              <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
+                              <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                            </svg>
+                          </a>
+                        {:else if key === 'executor_order_id' && typeof value === 'object' && value !== null}
+                          <span class="text-muted-foreground">{JSON.stringify(value)}</span>
+                        {:else if key === 'pyth_price' && typeof value === 'object' && value !== null}
+                          {@const pyth = value as Record<string, unknown>}
+                          <span>${formatDecimal(String(pyth['value']), 2)} (conf: {pyth['conf']}, expo: {pyth['expo']})</span>
+                        {:else if typeof value === 'object' && value !== null}
+                          {JSON.stringify(value)}
+                        {:else}
+                          {String(value)}
+                        {/if}
+                      </span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</dialog>

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -4,8 +4,20 @@
   import * as Table from '$lib/components/ui/table'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
-  import { getApiBaseUrl } from '$lib/env'
+  import { getApiBaseUrl, getExplorerTxUrl } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
+  import { formatDecimal } from '$lib/decimal'
+  import {
+    kindLabel,
+    statusStyle,
+    humanizeStatus,
+    humanizeStep,
+    isTxHash,
+    isTransferRef,
+    formatFieldName,
+    extractTimestamp,
+    detailFields,
+  } from '$lib/transfer'
 
   type TransferEntry = {
     kind: string
@@ -25,6 +37,12 @@
     hasMore: boolean
   }
 
+  type TransferEvent = {
+    step: string
+    sequence: number
+    payload: Record<string, unknown>
+  }
+
   const PAGE_SIZE = 100
   const POLL_INTERVAL_MS = 10_000
   const ALL_KINDS = ['equity_mint', 'equity_redemption', 'usdc_bridge'] as const
@@ -42,15 +60,6 @@
 
   let sinceInput: HTMLInputElement | undefined
   let untilInput: HTMLInputElement | undefined
-
-  const kindLabel = (kind: string): string => {
-    switch (kind) {
-      case 'equity_mint': return 'Mint'
-      case 'equity_redemption': return 'Redeem'
-      case 'usdc_bridge': return 'USDC Bridge'
-      default: return kind
-    }
-  }
 
   const kindOptions = ALL_KINDS.map((kind) => ({ value: kind, label: kindLabel(kind) }))
 
@@ -176,21 +185,62 @@
     void fetchTransfers('replace')
   }
 
-  type StatusStyle = { text: string; dot: string }
+  let statusInfoOpen = $state(false)
 
-  const statusStyle = (status: string): StatusStyle => {
-    const lower = status.toLowerCase()
+  // -- Detail modal state --
 
-    if (lower.includes('completed') || lower.includes('deposited') || lower.includes('confirmed')) {
-      return { text: 'text-green-500', dot: 'bg-green-500' }
+  let detailDialogEl: HTMLDialogElement | undefined = $state()
+  const detailEvents = reactive<TransferEvent[]>([])
+  const detailTransfer = reactive<TransferEntry | null>(null)
+  const detailLoading = reactive(false)
+  const detailError = reactive<string | null>(null)
+  let detailAbortController: AbortController | undefined
+
+  const openDetail = async (transfer: TransferEntry) => {
+    detailAbortController?.abort()
+    const controller = new AbortController()
+    detailAbortController = controller
+
+    detailTransfer.update(() => transfer)
+    detailLoading.update(() => true)
+    detailError.update(() => null)
+    detailEvents.update(() => [])
+    detailDialogEl?.showModal()
+
+    try {
+      const baseUrl = getApiBaseUrl()
+      const response = await fetch(
+        `${baseUrl}/transfers/${transfer.kind}/${transfer.id}/events`,
+        {
+          signal: AbortSignal.any([
+            controller.signal,
+            AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          ]),
+        },
+      )
+
+      if (controller.signal.aborted) return
+
+      if (!response.ok) {
+        detailError.update(() => `HTTP ${String(response.status)}`)
+        return
+      }
+
+      const data = (await response.json()) as { events: TransferEvent[] }
+
+      if (controller.signal.aborted) return
+
+      detailEvents.update(() => data.events)
+    } catch (err) {
+      if (controller.signal.aborted) return
+      detailError.update(() => err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      if (!controller.signal.aborted) {
+        detailLoading.update(() => false)
+      }
     }
-
-    if (lower.includes('failed')) {
-      return { text: 'text-destructive', dot: 'bg-destructive' }
-    }
-
-    return { text: 'text-muted-foreground', dot: 'bg-muted-foreground' }
   }
+
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-purple-500/50">
@@ -251,10 +301,22 @@
       <Table.Root>
         <Table.Header>
           <Table.Row>
+            <Table.Head class="w-8"></Table.Head>
             <Table.Head class="text-right">Started (UTC)</Table.Head>
             <Table.Head>Type</Table.Head>
-            <Table.Head>Detail</Table.Head>
-            <Table.Head class="text-right">Status</Table.Head>
+            <Table.Head>Asset</Table.Head>
+            <Table.Head class="text-right">Amount</Table.Head>
+            <Table.Head class="text-right">
+              <span class="inline-flex items-center justify-end gap-1">
+                Status
+                <button
+                  class="text-muted-foreground hover:text-foreground"
+                  onclick={() => { statusInfoOpen = !statusInfoOpen }}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
+                </button>
+              </span>
+            </Table.Head>
             <Table.Head class="text-right">Updated (UTC)</Table.Head>
           </Table.Row>
         </Table.Header>
@@ -263,6 +325,17 @@
             {@const statusText = transfer.status.status}
             {@const style = statusStyle(statusText)}
             <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
+              <Table.Cell class="w-8 px-1">
+                <button
+                  class="inline-flex items-center text-muted-foreground hover:text-foreground"
+                  title="View event history"
+                  onclick={() => openDetail(transfer)}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
+                    <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+              </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
                 {formatUtc(transfer.startedAt)}
               </Table.Cell>
@@ -270,12 +343,15 @@
                 {kindLabel(transfer.kind)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs">
-                {transfer.symbol ?? ''}{#if transfer.quantity} {transfer.quantity}{/if}{#if transfer.amount} {transfer.amount}{/if}
+                {transfer.kind === 'usdc_bridge' ? 'USDC' : transfer.symbol ?? ''}
+              </Table.Cell>
+              <Table.Cell class="text-right font-mono text-xs">
+                {#if transfer.quantity}{formatDecimal(transfer.quantity, 2)}{:else if transfer.amount}{formatDecimal(transfer.amount, 2)}{/if}
               </Table.Cell>
               <Table.Cell class="text-right text-xs {style.text}">
                 <span class="inline-flex items-center gap-1.5">
                   <span class="inline-block h-1.5 w-1.5 rounded-full {style.dot}"></span>
-                  {statusText}
+                  {humanizeStatus(statusText)}
                 </span>
               </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
@@ -298,3 +374,165 @@
     {/if}
   </Card.Content>
 </Card.Root>
+
+{#if statusInfoOpen}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed inset-0 z-40"
+    onclick={() => { statusInfoOpen = false }}
+    onkeydown={(event) => { if (event.key === 'Escape') statusInfoOpen = false }}
+  ></div>
+  <div class="fixed right-8 top-1/3 z-50 w-64 rounded-lg border bg-popover px-4 py-3 text-xs text-popover-foreground shadow-lg">
+    <div class="mb-2 font-semibold">Status flows by type</div>
+
+    <div class="mb-1.5">
+      <div class="mb-0.5 font-medium text-muted-foreground">Mint</div>
+      <div>Minting → Wrapping → Depositing → <span class="text-green-500">Completed</span></div>
+    </div>
+
+    <div class="mb-1.5">
+      <div class="mb-0.5 font-medium text-muted-foreground">Redeem</div>
+      <div>Withdrawing → Unwrapping → Sending → Pending Confirmation → <span class="text-green-500">Completed</span></div>
+    </div>
+
+    <div class="mb-1.5">
+      <div class="mb-0.5 font-medium text-muted-foreground">USDC Bridge</div>
+      <div>Converting → Withdrawing → Bridging → Depositing → <span class="text-green-500">Completed</span></div>
+    </div>
+
+    <div class="text-muted-foreground">Any step can transition to <span class="text-destructive">Failed</span></div>
+  </div>
+{/if}
+
+<dialog
+  bind:this={detailDialogEl}
+  class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
+  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl?.close() }}
+>
+  {#if detailTransfer.current}
+    {@const transfer = detailTransfer.current}
+    <div class="flex items-center justify-between border-b px-5 py-3">
+      <div class="flex items-center gap-2 text-sm font-semibold">
+        <span>{kindLabel(transfer.kind)}</span>
+        <span class="font-mono text-xs font-normal text-muted-foreground">
+          {transfer.kind === 'usdc_bridge' ? 'USDC' : transfer.symbol ?? ''}
+        </span>
+        {#if transfer.quantity}
+          <span class="font-mono text-xs font-normal text-muted-foreground">
+            {formatDecimal(transfer.quantity, 2)}
+          </span>
+        {:else if transfer.amount}
+          <span class="font-mono text-xs font-normal text-muted-foreground">
+            {formatDecimal(transfer.amount, 2)}
+          </span>
+        {/if}
+      </div>
+      <button
+        class="text-lg leading-none text-muted-foreground hover:text-foreground"
+        onclick={() => detailDialogEl?.close()}
+      >
+        &times;
+      </button>
+    </div>
+
+    <div class="max-h-[60vh] overflow-y-auto px-5 py-4">
+      {#if detailLoading.current}
+        <div class="flex items-center justify-center py-8 text-sm text-muted-foreground">
+          Loading events...
+        </div>
+      {:else if detailError.current}
+        <div class="flex items-center justify-center py-8 text-sm text-destructive">
+          Failed to load events: {detailError.current}
+        </div>
+      {:else}
+        <div class="relative space-y-0 border-l-2 border-muted pl-4">
+          {#each detailEvents.current as event (event.sequence)}
+            {@const stepStyle = statusStyle(event.step)}
+            {@const timestamp = extractTimestamp(event.payload)}
+            {@const fields = detailFields(event.payload)}
+            <div class="relative pb-4">
+              <!-- Timeline dot -->
+              <div class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepStyle.dot}"></div>
+
+              <div class="text-xs font-medium {stepStyle.text}">
+                {humanizeStep(event.step)}
+              </div>
+
+              {#if timestamp}
+                <div class="mt-0.5 font-mono text-xs text-muted-foreground">
+                  {formatUtc(timestamp)}
+                </div>
+              {/if}
+
+              {#if fields.length > 0}
+                <div class="mt-1.5 space-y-1">
+                  {#each fields as [key, value] (key)}
+                    <div class="flex items-start gap-2 font-mono text-xs">
+                      <span class="shrink-0 text-muted-foreground">{formatFieldName(key)}</span>
+                      <span class="min-w-0 break-all">
+                        {#if key === 'reason'}
+                          <span class="text-destructive">{value}</span>
+                        {:else if key === 'failure'}
+                          <span class="text-destructive">
+                            {#if typeof value === 'object' && value !== null}
+                              {#if 'ApiError' in value}
+                                API error{@const apiErr = value as Record<string, unknown>}{#if apiErr['status_code']} (status {apiErr['status_code']}){/if}
+                              {:else if 'Timeout' in value}
+                                Timeout
+                              {:else}
+                                {JSON.stringify(value)}
+                              {/if}
+                            {:else}
+                              {String(value)}
+                            {/if}
+                          </span>
+                        {:else if isTxHash(value)}
+                          <a
+                            href={getExplorerTxUrl(value)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                          >
+                            {value.slice(0, 10)}...{value.slice(-8)}
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
+                              <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
+                              <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                            </svg>
+                          </a>
+                        {:else if isTransferRef(value)}
+                          {#if 'OnchainTx' in value}
+                            {@const txHash = String(value['OnchainTx'])}
+                            <a
+                              href={getExplorerTxUrl(txHash)}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                            >
+                              {txHash.slice(0, 10)}...{txHash.slice(-8)}
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
+                                <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
+                                <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                              </svg>
+                            </a>
+                          {:else if 'AlpacaId' in value}
+                            <span class="text-muted-foreground">Alpaca: {value['AlpacaId']}</span>
+                          {:else}
+                            {JSON.stringify(value)}
+                          {/if}
+                        {:else if typeof value === 'object' && value !== null}
+                          {JSON.stringify(value)}
+                        {:else}
+                          {String(value)}
+                        {/if}
+                      </span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</dialog>

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  statusStyle,
+  isTxHash,
+  extractTimestamp,
+  detailFields,
+} from './transfer'
+
+describe('statusStyle', () => {
+  it('matches completed substring case-insensitively', () => {
+    expect(statusStyle('completed').text).toBe('text-green-500')
+    expect(statusStyle('COMPLETED').text).toBe('text-green-500')
+  })
+
+  it('matches PascalCase event names via substring', () => {
+    expect(statusStyle('MintCompleted').text).toBe('text-green-500')
+    expect(statusStyle('TransferFailed').text).toBe('text-destructive')
+  })
+
+  it('green branch takes priority over red when both substrings match', () => {
+    // "completed" check runs before "failed" -- a status containing both
+    // should hit green first. This tests the if-chain ordering.
+    const style = statusStyle('completed_after_failed')
+    expect(style.text).toBe('text-green-500')
+  })
+
+  it('falls through to muted for unrecognized statuses', () => {
+    expect(statusStyle('pending').text).toBe('text-muted-foreground')
+    expect(statusStyle('').text).toBe('text-muted-foreground')
+  })
+})
+
+describe('isTxHash', () => {
+  it('accepts valid 66-char hex string', () => {
+    expect(isTxHash('0x' + 'a1B2'.repeat(16))).toBe(true)
+  })
+
+  it('rejects without 0x prefix', () => {
+    expect(isTxHash('a'.repeat(64))).toBe(false)
+  })
+
+  it('rejects wrong length', () => {
+    expect(isTxHash('0x' + 'a'.repeat(63))).toBe(false)
+    expect(isTxHash('0x' + 'a'.repeat(65))).toBe(false)
+  })
+
+  it('rejects non-hex characters', () => {
+    expect(isTxHash('0x' + 'g'.repeat(64))).toBe(false)
+  })
+
+  it('rejects non-string types', () => {
+    expect(isTxHash(42)).toBe(false)
+    expect(isTxHash(null)).toBe(false)
+    expect(isTxHash(undefined)).toBe(false)
+  })
+})
+
+describe('extractTimestamp', () => {
+  it('returns the first _at field it encounters', () => {
+    // Object.entries order matters -- first _at field wins
+    const result = extractTimestamp({
+      submitted_at: '2024-01-01T00:00:00Z',
+      confirmed_at: '2024-01-02T00:00:00Z',
+    })
+    expect(result).toBe('2024-01-01T00:00:00Z')
+  })
+
+  it('skips _at fields with non-string values', () => {
+    expect(extractTimestamp({
+      created_at: 1234567890,
+      confirmed_at: '2024-06-15T00:00:00Z',
+    })).toBe('2024-06-15T00:00:00Z')
+  })
+
+  it('returns null when no _at fields exist', () => {
+    expect(extractTimestamp({ amount: '100', status: 'ok' })).toBeNull()
+  })
+
+  it('returns null on empty payload', () => {
+    expect(extractTimestamp({})).toBeNull()
+  })
+})
+
+describe('detailFields', () => {
+  it('filters out timestamp fields and attestation', () => {
+    const result = detailFields({
+      amount: '100',
+      created_at: '2024-01-01T00:00:00Z',
+      attestation: 'long-blob',
+      tx_hash: '0xabc',
+      confirmed_at: '2024-01-02T00:00:00Z',
+    })
+    expect(result).toEqual([
+      ['amount', '100'],
+      ['tx_hash', '0xabc'],
+    ])
+  })
+
+  it('preserves field order from the original object', () => {
+    const result = detailFields({ z_field: '1', a_field: '2' })
+    expect(result[0][0]).toBe('z_field')
+    expect(result[1][0]).toBe('a_field')
+  })
+
+  it('returns empty when all fields are filtered', () => {
+    expect(detailFields({
+      created_at: '2024-01-01',
+      attestation: 'x',
+      submitted_at: 'y',
+    })).toEqual([])
+  })
+})

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -1,0 +1,66 @@
+export type StatusStyle = {
+  text: string
+  dot: string
+}
+
+export const kindLabel = (kind: string): string => {
+  switch (kind) {
+    case 'equity_mint': return 'Mint'
+    case 'equity_redemption': return 'Redeem'
+    case 'usdc_bridge': return 'USDC Bridge'
+    default: return kind
+  }
+}
+
+/// Maps a status string to colour classes.  Works for both DTO statuses
+/// (snake_case, used in the table) and raw event names (PascalCase,
+/// used in the detail modal timeline).
+export const statusStyle = (status: string): StatusStyle => {
+  const lower = status.toLowerCase()
+
+  if (lower.includes('completed') || lower.includes('deposited') || lower.includes('confirmed')) {
+    return { text: 'text-green-500', dot: 'bg-green-500' }
+  }
+
+  if (lower.includes('failed') || lower.includes('rejected')) {
+    return { text: 'text-destructive', dot: 'bg-destructive' }
+  }
+
+  return { text: 'text-muted-foreground', dot: 'bg-muted-foreground' }
+}
+
+export const humanizeStatus = (status: string): string =>
+  status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+export const humanizeStep = (step: string): string =>
+  step.replace(/([A-Z])/g, ' $1').trim()
+
+export const isTxHash = (value: unknown): value is string =>
+  typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value)
+
+const SKIP_FIELDS = new Set(['attestation'])
+
+export const isTimestampField = (key: string): boolean => key.endsWith('_at')
+
+export const isTransferRef = (value: unknown): value is Record<string, string> =>
+  typeof value === 'object' &&
+  value !== null &&
+  ('AlpacaId' in value || 'OnchainTx' in value)
+
+export const formatFieldName = (key: string): string =>
+  key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+
+export const extractTimestamp = (payload: Record<string, unknown>): string | null => {
+  for (const [key, value] of Object.entries(payload)) {
+    if (isTimestampField(key) && typeof value === 'string') return value
+  }
+  return null
+}
+
+export const detailFields = (payload: Record<string, unknown>): Array<[string, unknown]> =>
+  Object.entries(payload).filter(
+    ([key]) => !isTimestampField(key) && !SKIP_FIELDS.has(key),
+  )

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,12 @@
 //! HTTP API endpoints for health checks, log retrieval, and order status.
 
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
+use rocket::form::{self, FromFormField, ValueField};
+use rocket::http::Status;
+use rocket::request::FromParam;
 use rocket::response::content::RawJson;
 use rocket::serde::json::Json;
 use rocket::serde::{Deserialize, Serialize};
@@ -10,6 +14,36 @@ use rocket::{Route, State, get, routes};
 use sqlx::SqlitePool;
 
 use crate::config::Ctx;
+use crate::dashboard::transfer_loader::TransferKind;
+
+impl<'a> FromParam<'a> for TransferKind {
+    type Error = String;
+
+    fn from_param(param: &'a str) -> Result<Self, Self::Error> {
+        param.parse()
+    }
+}
+
+/// Comma-separated filter for transfer kinds in query parameters.
+///
+/// Parses `"equity_mint,usdc_bridge"` into `vec![EquityMint, UsdcBridge]`.
+struct TransferKindFilter(Vec<TransferKind>);
+
+impl<'v> FromFormField<'v> for TransferKindFilter {
+    fn from_value(field: ValueField<'v>) -> form::Result<'v, Self> {
+        let kinds: Result<Vec<TransferKind>, _> = field
+            .value
+            .split(',')
+            .map(str::trim)
+            .filter(|segment| !segment.is_empty())
+            .map(TransferKind::from_str)
+            .collect();
+
+        kinds
+            .map(TransferKindFilter)
+            .map_err(|error| form::Error::validation(error).into())
+    }
+}
 
 static STARTED_AT: LazyLock<DateTime<Utc>> = LazyLock::new(Utc::now);
 
@@ -603,19 +637,19 @@ async fn load_offchain_trade_rows(pool: &SqlitePool, filter: &TradeFilter) -> Ve
         .collect()
 }
 
-/// Paginated transfer history via direct SQL on the events table.
+/// Paginated transfer history using event-sourced aggregate replay.
 ///
-/// Extracts timestamps from event payloads and status from the latest
-/// event type. No event replay needed — purely SQL-based for performance.
+/// Replays transfer aggregates to produce proper DTO statuses, then
+/// applies time-range filtering and pagination.
 #[get("/transfers?<limit>&<offset>&<kind>&<since>&<until>")]
 async fn transfers_endpoint(
     pool: &State<SqlitePool>,
     limit: Option<usize>,
     offset: Option<usize>,
-    kind: Option<&str>,
+    kind: Option<TransferKindFilter>,
     since: Option<&str>,
     until: Option<&str>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, Status> {
     let limit = limit.unwrap_or(100).min(500);
     let offset = offset.unwrap_or(0);
 
@@ -630,169 +664,180 @@ async fn transfers_endpoint(
             .map(|dt| dt.with_timezone(&Utc))
     });
 
-    let kinds: Option<Vec<String>> = kind
-        .filter(|val| !val.is_empty())
-        .map(|val| val.split(',').map(|part| part.trim().to_string()).collect());
+    let kind_filter = kind.map(|filter| filter.0);
 
-    // Each aggregate type stores its "started" timestamp in the first
-    // event payload under a type-specific JSON path.
-    let type_configs: Vec<(&str, &str, &str)> = vec![
-        (
-            "TokenizedEquityMint",
-            "equity_mint",
-            "$.MintRequested.requested_at",
-        ),
-        (
-            "EquityRedemption",
-            "equity_redemption",
-            "$.WithdrawnFromRaindex.withdrawn_at",
-        ),
-        (
-            "UsdcRebalance",
-            "usdc_bridge",
-            "$.ConversionInitiated.initiated_at",
-        ),
-    ];
+    let loaded = crate::dashboard::transfer_loader::load_all_transfer_operations(
+        pool.inner(),
+        kind_filter.as_deref(),
+    )
+    .await;
 
-    let mut all_entries: Vec<serde_json::Value> = Vec::new();
+    let mut operations = loaded.operations;
 
-    for (aggregate_type, kind_label, started_path) in &type_configs {
-        if let Some(ref kind_filter) = kinds
-            && !kind_filter.iter().any(|val| val == *kind_label)
-        {
-            continue;
-        }
-
-        let rows = load_transfer_summary(pool.inner(), aggregate_type, started_path).await;
-
-        for row in rows {
-            let started_at = row.started_at.as_deref().unwrap_or("");
+    // Filter by time range
+    if since_dt.is_some() || until_dt.is_some() {
+        operations.retain(|op| {
+            let started = op.started_at();
 
             if let Some(ref since) = since_dt
-                && let Ok(ts) = DateTime::parse_from_rfc3339(started_at)
-                && ts.with_timezone(&Utc) < *since
+                && started < *since
             {
-                continue;
+                return false;
             }
+
             if let Some(ref until) = until_dt
-                && let Ok(ts) = DateTime::parse_from_rfc3339(started_at)
-                && ts.with_timezone(&Utc) > *until
+                && started > *until
             {
-                continue;
+                return false;
             }
 
-            let status = row.latest_event.split("::").last().unwrap_or("Unknown");
-
-            all_entries.push(serde_json::json!({
-                "id": row.aggregate_id,
-                "kind": kind_label,
-                "status": { "status": status },
-                "startedAt": started_at,
-                "updatedAt": row.updated_at.as_deref().unwrap_or(started_at),
-            }));
-        }
+            true
+        });
     }
 
-    // Sort newest first by startedAt
-    all_entries.sort_by(|lhs, rhs| {
-        let lhs_ts = lhs["startedAt"].as_str().unwrap_or("");
-        let rhs_ts = rhs["startedAt"].as_str().unwrap_or("");
-        rhs_ts.cmp(lhs_ts)
-    });
+    // Sort newest first
+    operations.sort_by_key(|op| std::cmp::Reverse(op.started_at()));
 
-    let filtered_total = all_entries.len();
+    let filtered_total = operations.len();
+    let start = offset.min(filtered_total);
     let end = filtered_total.min(offset + limit);
-    let entries = &all_entries[offset.min(filtered_total)..end];
     let has_more = end < filtered_total;
 
-    Json(serde_json::json!({
+    let entries: Vec<serde_json::Value> = operations[start..end]
+        .iter()
+        .map(serde_json::to_value)
+        .collect::<Result<_, _>>()
+        .map_err(|error| {
+            tracing::error!(
+                target: "dashboard",
+                %error,
+                "Failed to serialize transfer operation"
+            );
+            Status::InternalServerError
+        })?;
+
+    let mut response = serde_json::json!({
         "entries": entries,
         "total": filtered_total,
         "hasMore": has_more,
-    }))
+    });
+
+    if !loaded.warnings.is_empty() {
+        response["warnings"] =
+            serde_json::to_value(&loaded.warnings).unwrap_or_else(|_| serde_json::json!([]));
+    }
+
+    Ok(Json(response))
 }
 
-struct TransferSummaryRow {
-    aggregate_id: String,
-    latest_event: String,
-    started_at: Option<String>,
-    updated_at: Option<String>,
-}
+/// Returns the full event history for a single transfer aggregate.
+///
+/// The frontend uses this to populate the detail modal with tx hashes,
+/// IDs, failure reasons, and other debugging context.
+#[get("/transfers/<kind>/<aggregate_id>/events")]
+async fn transfer_events(
+    pool: &State<SqlitePool>,
+    kind: TransferKind,
+    aggregate_id: &str,
+) -> Option<Json<serde_json::Value>> {
+    let aggregate_type = kind.aggregate_type();
 
-async fn load_transfer_summary(
-    pool: &SqlitePool,
-    aggregate_type: &str,
-    started_path: &str,
-) -> Vec<TransferSummaryRow> {
-    // Get the started_at from the first event's payload, the latest
-    // event type, and the last event's timestamp for updated_at.
-    let rows: Vec<(String, String, Option<String>, Option<String>)> =
-        match sqlx::query_as(
-            "SELECT \
-                e.aggregate_id, \
-                (SELECT e2.event_type FROM events e2 \
-                 WHERE e2.aggregate_type = ?1 \
-                   AND e2.aggregate_id = e.aggregate_id \
-                 ORDER BY e2.sequence DESC LIMIT 1) AS latest_event, \
-                (SELECT COALESCE(\
-                    json_extract(e3.payload, ?2), \
-                    json_extract(e3.payload, '$.' || SUBSTR(e3.event_type, INSTR(e3.event_type, '::') + 2) || '.initiated_at'), \
-                    json_extract(e3.payload, '$.' || SUBSTR(e3.event_type, INSTR(e3.event_type, '::') + 2) || '.requested_at'), \
-                    json_extract(e3.payload, '$.' || SUBSTR(e3.event_type, INSTR(e3.event_type, '::') + 2) || '.withdrawn_at') \
-                 ) FROM events e3 \
-                 WHERE e3.aggregate_type = ?1 \
-                   AND e3.aggregate_id = e.aggregate_id \
-                 ORDER BY e3.sequence ASC LIMIT 1) AS started_at, \
-                (SELECT COALESCE(\
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.completed_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.failed_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.deposited_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.confirmed_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.initiated_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.withdrawn_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.requested_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.wrapped_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.unwrapped_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.sent_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.bridged_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.deposit_confirmed_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.deposit_initiated_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.converted_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.burned_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.attested_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.minted_at'), \
-                    json_extract(e4.payload, '$.' || SUBSTR(e4.event_type, INSTR(e4.event_type, '::') + 2) || '.accepted_at') \
-                 ) FROM events e4 \
-                 WHERE e4.aggregate_type = ?1 \
-                   AND e4.aggregate_id = e.aggregate_id \
-                 ORDER BY e4.sequence DESC LIMIT 1) AS updated_at \
-             FROM events e \
-             WHERE e.aggregate_type = ?1 \
-             GROUP BY e.aggregate_id \
-             ORDER BY MAX(e.rowid) DESC",
-        )
-        .bind(aggregate_type)
-        .bind(started_path)
-        .fetch_all(pool)
-        .await
+    let rows: Vec<(String, String, i64)> = match sqlx::query_as(
+        "SELECT event_type, payload, sequence \
+         FROM events \
+         WHERE aggregate_type = ?1 AND aggregate_id = ?2 \
+         ORDER BY sequence ASC",
+    )
+    .bind(aggregate_type)
+    .bind(aggregate_id)
+    .fetch_all(pool.inner())
+    .await
     {
         Ok(rows) => rows,
         Err(error) => {
-            tracing::warn!(target: "dashboard", %error, %aggregate_type, "Failed to load transfer summary");
-            return Vec::new();
+            tracing::warn!(
+                target: "dashboard",
+                %error,
+                %kind,
+                %aggregate_id,
+                "Failed to load transfer event history"
+            );
+            return None;
         }
     };
 
-    rows.into_iter()
-        .map(
-            |(aggregate_id, latest_event, started_at, updated_at)| TransferSummaryRow {
-                aggregate_id,
-                latest_event,
-                started_at,
-                updated_at,
-            },
-        )
-        .collect()
+    let events: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|(event_type, payload, sequence)| {
+            let step = event_type.split("::").last().unwrap_or("Unknown");
+            let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+
+            // Unwrap the variant key: {"MintRequested": {fields...}} -> {fields...}
+            let inner = parsed
+                .as_object()
+                .and_then(|obj| obj.get(step).cloned())
+                .unwrap_or(parsed);
+
+            serde_json::json!({
+                "step": step,
+                "sequence": sequence,
+                "payload": inner,
+            })
+        })
+        .collect();
+
+    Some(Json(serde_json::json!({ "events": events })))
+}
+
+/// Returns the full event history for a single trade aggregate.
+///
+/// For onchain trades (Raindex), returns Filled + optional Enriched events.
+/// For offchain trades (Alpaca), returns the full order lifecycle
+/// (Placed -> Submitted -> PartiallyFilled -> Filled/Failed).
+#[get("/trades/<venue>/<aggregate_id>/events")]
+async fn trade_events(
+    pool: &State<SqlitePool>,
+    venue: &str,
+    aggregate_id: &str,
+) -> Option<Json<serde_json::Value>> {
+    let aggregate_type = match venue {
+        "raindex" => "OnChainTrade",
+        "alpaca" | "dry_run" => "OffchainOrder",
+        _ => return None,
+    };
+
+    let rows: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT event_type, payload, sequence \
+         FROM events \
+         WHERE aggregate_type = ?1 AND aggregate_id = ?2 \
+         ORDER BY sequence ASC",
+    )
+    .bind(aggregate_type)
+    .bind(aggregate_id)
+    .fetch_all(pool.inner())
+    .await
+    .ok()?;
+
+    let events: Vec<serde_json::Value> = rows
+        .into_iter()
+        .map(|(event_type, payload, sequence)| {
+            let step = event_type.split("::").last().unwrap_or("Unknown");
+            let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+
+            let inner = parsed
+                .as_object()
+                .and_then(|obj| obj.get(step).cloned())
+                .unwrap_or(parsed);
+
+            serde_json::json!({
+                "step": step,
+                "sequence": sequence,
+                "payload": inner,
+            })
+        })
+        .collect();
+
+    Some(Json(serde_json::json!({ "events": events })))
 }
 
 fn unavailable_json(reason: &str) -> RawJson<String> {
@@ -857,14 +902,15 @@ pub(crate) fn routes() -> Vec<Route> {
         logs,
         pending_orders,
         trades,
+        trade_events,
         transfers_endpoint,
+        transfer_events,
         raindex_orders
     ]
 }
 
 #[cfg(test)]
 mod tests {
-    use rocket::http::Status;
     use rocket::local::asynchronous::Client;
 
     use super::*;
@@ -873,7 +919,7 @@ mod tests {
     #[test]
     fn test_num_of_routes() {
         let routes_list = routes();
-        assert_eq!(routes_list.len(), 6);
+        assert_eq!(routes_list.len(), 8);
     }
 
     #[tokio::test]

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -16,7 +16,7 @@ use crate::threshold::ExecutionThreshold;
 
 mod event;
 mod trade_loader;
-mod transfer_loader;
+pub(crate) mod transfer_loader;
 pub(crate) use event::Broadcaster;
 
 pub(crate) struct Broadcast {

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -4,7 +4,7 @@ use chrono::{Duration, Utc};
 use sqlx::SqlitePool;
 use tracing::warn;
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display};
 use std::str::FromStr;
 
 use st0x_dto::{TransferOperation, TransferWarning};
@@ -14,6 +14,54 @@ use st0x_finance::Id;
 use crate::equity_redemption::EquityRedemption;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
+
+/// The three categories of cross-venue transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransferKind {
+    EquityMint,
+    EquityRedemption,
+    UsdcBridge,
+}
+
+impl TransferKind {
+    /// The cqrs-es aggregate type stored in the `events` table.
+    pub(crate) fn aggregate_type(self) -> &'static str {
+        match self {
+            Self::EquityMint => "TokenizedEquityMint",
+            Self::EquityRedemption => "EquityRedemption",
+            Self::UsdcBridge => "UsdcRebalance",
+        }
+    }
+}
+
+impl Display for TransferKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EquityMint => formatter.write_str("equity_mint"),
+            Self::EquityRedemption => formatter.write_str("equity_redemption"),
+            Self::UsdcBridge => formatter.write_str("usdc_bridge"),
+        }
+    }
+}
+
+impl FromStr for TransferKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "equity_mint" => Ok(Self::EquityMint),
+            "equity_redemption" => Ok(Self::EquityRedemption),
+            "usdc_bridge" => Ok(Self::UsdcBridge),
+            other => Err(format!("unknown transfer kind: {other}")),
+        }
+    }
+}
+
+/// Result of [`load_all_transfer_operations`] including any replay warnings.
+pub(crate) struct AllTransferOperations {
+    pub(crate) operations: Vec<TransferOperation>,
+    pub(crate) warnings: Vec<TransferWarning>,
+}
 
 /// Loaded transfers split into active (in-progress) and recent (terminal).
 pub(crate) struct LoadedTransfers {
@@ -82,6 +130,106 @@ pub(crate) async fn load_transfers(pool: &SqlitePool) -> LoadedTransfers {
         recent,
         warnings: merged.warnings,
     }
+}
+
+/// Load all transfer DTOs for the REST endpoint's paginated listing.
+///
+/// Unlike [`load_transfers`] (which partitions into active/recent with a
+/// 24h cutoff for the WebSocket), this returns every transfer without
+/// filtering.  The caller handles time-range filtering and pagination.
+pub(crate) async fn load_all_transfer_operations(
+    pool: &SqlitePool,
+    kind_filter: Option<&[TransferKind]>,
+) -> AllTransferOperations {
+    let include = |kind: TransferKind| kind_filter.is_none_or(|allowed| allowed.contains(&kind));
+
+    let mut operations = Vec::new();
+    let mut warnings = Vec::new();
+
+    if include(TransferKind::EquityMint) {
+        let (ops, warns) = replay_all::<TokenizedEquityMint>(
+            pool,
+            |id| TransferWarning::MintReplayFailed {
+                id: Id::new(id.to_string()),
+            },
+            TokenizedEquityMint::to_dto,
+        )
+        .await;
+
+        operations.extend(ops);
+        warnings.extend(warns);
+    }
+
+    if include(TransferKind::EquityRedemption) {
+        let (ops, warns) = replay_all::<EquityRedemption>(
+            pool,
+            |id| TransferWarning::RedemptionReplayFailed {
+                id: Id::new(id.to_string()),
+            },
+            EquityRedemption::to_dto,
+        )
+        .await;
+
+        operations.extend(ops);
+        warnings.extend(warns);
+    }
+
+    if include(TransferKind::UsdcBridge) {
+        let (ops, warns) = replay_all::<UsdcRebalance>(
+            pool,
+            |id| TransferWarning::BridgeReplayFailed {
+                id: Id::new(id.to_string()),
+            },
+            UsdcRebalance::to_dto,
+        )
+        .await;
+
+        operations.extend(ops);
+        warnings.extend(warns);
+    }
+
+    AllTransferOperations {
+        operations,
+        warnings,
+    }
+}
+
+/// Replay every aggregate of a given type and convert to DTOs.
+///
+/// Returns both the successfully replayed operations and any warnings for
+/// aggregates that failed to load, so the caller can surface them.
+async fn replay_all<Entity>(
+    pool: &SqlitePool,
+    make_replay_warning: impl Fn(&Entity::Id) -> TransferWarning + Send + Sync,
+    convert: impl Fn(&Entity, &Entity::Id) -> TransferOperation + Send + Sync,
+) -> (Vec<TransferOperation>, Vec<TransferWarning>)
+where
+    Entity: EventSourced,
+    Entity::Id: Debug,
+    <Entity::Id as FromStr>::Err: Debug,
+{
+    let ids = match load_all_ids::<Entity>(pool).await {
+        Ok(ids) => ids,
+        Err(error) => {
+            warn!(?error, "Failed to load aggregate IDs for REST listing");
+            return (Vec::new(), Vec::new());
+        }
+    };
+
+    let mut operations = Vec::with_capacity(ids.len());
+    let mut warnings = Vec::new();
+
+    for id in &ids {
+        match replay_aggregate::<Entity, _>(pool, id, &make_replay_warning).await {
+            Ok(entity) => operations.push(convert(&entity, id)),
+            Err(warning) => {
+                warn!(?warning, "Skipping transfer in REST listing");
+                warnings.push(warning);
+            }
+        }
+    }
+
+    (operations, warnings)
 }
 
 /// Result of loading a single transfer category.
@@ -587,6 +735,88 @@ mod tests {
             loaded.warnings.is_empty(),
             "expected no warnings, got: {:?}",
             loaded.warnings
+        );
+    }
+
+    #[test]
+    fn transfer_kind_round_trips_through_display_and_parse() {
+        for kind in [
+            TransferKind::EquityMint,
+            TransferKind::EquityRedemption,
+            TransferKind::UsdcBridge,
+        ] {
+            let text = kind.to_string();
+            let parsed: TransferKind = text.parse().unwrap();
+            assert_eq!(parsed, kind);
+        }
+    }
+
+    #[test]
+    fn transfer_kind_rejects_unknown_value() {
+        assert!("invalid".parse::<TransferKind>().is_err());
+    }
+
+    #[test]
+    fn transfer_kind_maps_to_aggregate_types() {
+        assert_eq!(
+            TransferKind::EquityMint.aggregate_type(),
+            "TokenizedEquityMint"
+        );
+        assert_eq!(
+            TransferKind::EquityRedemption.aggregate_type(),
+            "EquityRedemption"
+        );
+        assert_eq!(TransferKind::UsdcBridge.aggregate_type(), "UsdcRebalance");
+    }
+
+    #[tokio::test]
+    async fn load_all_transfer_operations_returns_warnings_for_malformed_aggregate() {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        insert_event(
+            &pool,
+            "TokenizedEquityMint",
+            "bad-mint-1",
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            serde_json::json!({"malformed": true}),
+        )
+        .await;
+
+        let result = load_all_transfer_operations(&pool, None).await;
+
+        assert!(result.operations.is_empty());
+        assert_eq!(result.warnings.len(), 1, "expected one warning");
+        match result.warnings.as_slice() {
+            [TransferWarning::MintReplayFailed { id }] => {
+                assert_eq!(id, &Id::<EquityMintTag>::new("bad-mint-1".to_string()));
+            }
+            other => panic!("expected MintReplayFailed, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_all_transfer_operations_filters_by_kind() {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        seed_transfer_events(&pool).await;
+
+        let mint_only =
+            load_all_transfer_operations(&pool, Some(&[TransferKind::EquityMint])).await;
+
+        assert!(
+            mint_only
+                .operations
+                .iter()
+                .all(|op| { matches!(op, TransferOperation::EquityMint(_)) }),
+            "expected only mint operations, got: {:?}",
+            mint_only.operations
+        );
+
+        assert!(
+            !mint_only.operations.is_empty(),
+            "expected at least one mint operation"
         );
     }
 


### PR DESCRIPTION
Closes RAI-278

## What

Adds a detail modal to the transfer panel and fixes the Status column to display proper DTO statuses instead of raw CQRS event type names.

## Why

The transfer panel had no way to inspect individual transfers — you could only see the summary row. Operators need to see the full event timeline (tx hashes, Alpaca IDs, failure reasons) when debugging transfer issues.

Separately, the Status column was showing raw aggregate event names like `MintRequested` or `DepositedIntoRaindex` because the REST `/transfers` endpoint extracted status by string-splitting the latest event type. The DTO status enums (`EquityMintStatus`, `EquityRedemptionStatus`, `UsdcBridgeStatus`) existed and worked correctly in the WebSocket path but were never used by the REST endpoint.

## How

### Transfer detail modal (`transfer-panel.svelte`)
- Info button (ⓘ) on each row opens a native `<dialog>` modal
- Fetches event history from `GET /transfers/{kind}/{id}/events`
- Renders events as a vertical timeline with color-coded dots
- Transaction hashes render as clickable Basescan links
- Alpaca transfer IDs and `TransferRef` variants displayed appropriately
- Failure reasons and `DetectionFailure` (Timeout/ApiError) highlighted in red
- Skips noisy fields like `attestation` (raw byte arrays)

### Status column fix
- **`src/api.rs`**: Replaced the SQL-based `transfers_endpoint` (which extracted status via `row.latest_event.split("::").last()`) with aggregate replay via `load_all_transfer_operations()`. Deleted `TransferSummaryRow` and the 90-line `load_transfer_summary` function with its complex `json_extract` SQL
- **`src/dashboard/transfer_loader.rs`**: Added `load_all_transfer_operations()` and `replay_all()` — loads every aggregate, replays events, calls `to_dto()` to produce proper DTO statuses. No time cutoff (unlike the WebSocket path's 24h window)
- **`src/dashboard/mod.rs`**: Made `transfer_loader` module `pub(crate)` so `api.rs` can use it
- **`crates/dto/src/transfer.rs`**: Added `started_at()` accessor to `TransferOperation` (mirrors existing `updated_at()`)

### Other dashboard improvements
- Replaced the old "Detail" column with separate **Asset** and **Amount** columns
- Added `humanizeStatus()` to title-case snake_case DTO statuses (`pending_confirmation` → `Pending Confirmation`)
- Added hover tooltip on Status column header showing the status flow for each transfer type (Mint, Redeem, USDC Bridge)
- Added `rejected` to `statusStyle()` so the detail modal colors `MintRejected`/`RedemptionRejected` events correctly

## Testing

- Existing `transfer_loader` tests (6 tests) continue to pass — they exercise aggregate replay and DTO conversion
- Existing DTO tests (16 tests) pass including serialization format assertions
- All 78 transfer-related tests pass
- No new tests for the dashboard UI (Svelte component)

## Anything else

- The endpoint now replays every transfer aggregate on each request instead of doing a single SQL query. This trades query performance for correctness. If transfer volume grows significantly, this could be optimized with a materialized view or caching layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event history modals to view detailed transfer and trade operation timelines with status updates, timestamps, and transaction details.
  * Improved transfer panel with clearer Asset and Amount columns.

* **Improvements**
  * Enhanced transfer and trade listing endpoints with better filtering, sorting, and event retrieval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->