### PR TITLE
feat: failure injector

### DIFF
--- a/dashboard/src/lib/components/log-panel.svelte
+++ b/dashboard/src/lib/components/log-panel.svelte
@@ -398,10 +398,11 @@
   }
 
   const getTarget = (entry: LogEntry): string => {
+    const target = entry.target ?? ''
     const spans = entry.spans?.map(span => span.name).join(' > ')
-    if (spans) return `${entry.target}::${spans}`
-    if (entry.span) return `${entry.target}::${entry.span.name}`
-    return entry.target ?? ''
+    if (spans) return `${target}::${spans}`
+    if (entry.span) return `${target}::${entry.span.name}`
+    return target
   }
 </script>
 

--- a/dashboard/src/lib/components/multi-select.svelte
+++ b/dashboard/src/lib/components/multi-select.svelte
@@ -61,7 +61,7 @@
       {#each options as opt (opt.value)}
         <button
           class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent"
-          onclick={() => toggle(opt.value)}
+          onclick={() => { toggle(opt.value); }}
         >
           <span class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-sm border {selected.has(opt.value) ? 'bg-primary border-primary text-primary-foreground' : 'border-muted-foreground'}">
             {#if selected.has(opt.value)}

--- a/dashboard/src/lib/components/settings-bar.svelte
+++ b/dashboard/src/lib/components/settings-bar.svelte
@@ -67,7 +67,7 @@
   <dialog
     bind:this={dialogEl}
     class="w-full max-w-md rounded-lg border bg-card p-6 text-foreground shadow-lg backdrop:bg-black/50"
-    onclick={(event) => { if (event.target === dialogEl) dialogEl?.close() }}
+    onclick={(event) => { if (event.target === dialogEl) dialogEl.close() }}
   >
     <div class="mb-4 flex items-center justify-between">
       <h3 class="text-sm font-semibold text-foreground">Configuration</h3>

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -212,14 +212,6 @@
     void fetchTrades('replace')
   }
 
-  const explorerUrl = (trade: TradeEntry): string | null => {
-    if (trade.venue !== 'raindex') return null
-    const colonIdx = trade.id.lastIndexOf(':')
-    if (colonIdx === -1) return null
-    const txHash = trade.id.slice(0, colonIdx)
-    return getExplorerTxUrl(txHash)
-  }
-
   const directionColor = (direction: string): string =>
     direction === 'Buy' ? 'text-green-500' : 'text-red-500'
 
@@ -429,7 +421,7 @@
 <dialog
   bind:this={detailDialogEl}
   class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
-  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl?.close() }}
+  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl.close() }}
 >
   {#if detailTrade.current}
     {@const trade = detailTrade.current}
@@ -491,7 +483,7 @@
 
         <!-- Event timeline -->
         <div class="relative space-y-0 border-l-2 border-muted pl-4">
-          {#each detailEvents.current as event, idx (event.sequence)}
+          {#each detailEvents.current as event (event.sequence)}
             {@const timestamp = extractTimestamp(event.payload)}
             {@const fields = Object.entries(event.payload).filter(([key]) => !isTimestampField(key))}
             <div class="relative pb-4">

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -228,8 +228,6 @@
 
       const data = (await response.json()) as { events: TransferEvent[] }
 
-      if (controller.signal.aborted) return
-
       detailEvents.update(() => data.events)
     } catch (err) {
       if (controller.signal.aborted) return
@@ -311,6 +309,7 @@
                 Status
                 <button
                   class="text-muted-foreground hover:text-foreground"
+                  aria-label="Show status legend"
                   onclick={() => { statusInfoOpen = !statusInfoOpen }}
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
@@ -407,7 +406,7 @@
 <dialog
   bind:this={detailDialogEl}
   class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
-  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl?.close() }}
+  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl.close() }}
 >
   {#if detailTransfer.current}
     {@const transfer = detailTransfer.current}
@@ -501,7 +500,7 @@
                           </a>
                         {:else if isTransferRef(value)}
                           {#if 'OnchainTx' in value}
-                            {@const txHash = String(value['OnchainTx'])}
+                            {@const txHash = value['OnchainTx']}
                             <a
                               href={getExplorerTxUrl(txHash)}
                               target="_blank"

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -98,8 +98,10 @@ describe('detailFields', () => {
 
   it('preserves field order from the original object', () => {
     const result = detailFields({ z_field: '1', a_field: '2' })
-    expect(result[0][0]).toBe('z_field')
-    expect(result[1][0]).toBe('a_field')
+    expect(result).toEqual([
+      ['z_field', '1'],
+      ['a_field', '2'],
+    ])
   })
 
   it('returns empty when all fields are filtered', () => {

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -75,20 +75,20 @@
   <!-- Mobile nav: panel tabs + logs -->
   <nav class="flex shrink-0 gap-1 overflow-x-auto border-b bg-card/50 px-2 md:hidden">
     {#if activeTab.current === 'dashboard'}
-      <button class={mobilePanelClass('inventory')} onclick={() => mobilePanel.update(() => 'inventory')}>Inventory</button>
-      <button class={mobilePanelClass('pending')} onclick={() => mobilePanel.update(() => 'pending')}>Pending</button>
-      <button class={mobilePanelClass('trades')} onclick={() => mobilePanel.update(() => 'trades')}>Trades</button>
-      <button class={mobilePanelClass('transfers')} onclick={() => mobilePanel.update(() => 'transfers')}>Transfers</button>
+      <button class={mobilePanelClass('inventory')} onclick={() => { mobilePanel.update(() => 'inventory'); }}>Inventory</button>
+      <button class={mobilePanelClass('pending')} onclick={() => { mobilePanel.update(() => 'pending'); }}>Pending</button>
+      <button class={mobilePanelClass('trades')} onclick={() => { mobilePanel.update(() => 'trades'); }}>Trades</button>
+      <button class={mobilePanelClass('transfers')} onclick={() => { mobilePanel.update(() => 'transfers'); }}>Transfers</button>
     {/if}
     <button
       class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'orders' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => activeTab.update((tab) => tab === 'orders' ? 'dashboard' : 'orders')}
+      onclick={() => { activeTab.update((tab) => tab === 'orders' ? 'dashboard' : 'orders'); }}
     >
       Orders
     </button>
     <button
       class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'logs' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs')}
+      onclick={() => { activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs'); }}
     >
       Logs
     </button>
@@ -98,21 +98,21 @@
   <nav class="hidden shrink-0 gap-1 border-b bg-card/50 px-4 md:flex">
     <button
       class={desktopTabClass(activeTab.current === 'dashboard')}
-      onclick={() => activeTab.update(() => 'dashboard')}
+      onclick={() => { activeTab.update(() => 'dashboard'); }}
     >
       Dashboard
     </button>
 
     <button
       class={desktopTabClass(activeTab.current === 'orders')}
-      onclick={() => activeTab.update(() => 'orders')}
+      onclick={() => { activeTab.update(() => 'orders'); }}
     >
       Orders
     </button>
 
     <button
       class={desktopTabClass(activeTab.current === 'logs')}
-      onclick={() => activeTab.update(() => 'logs')}
+      onclick={() => { activeTab.update(() => 'logs'); }}
     >
       Logs
     </button>

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,80 @@
+# Feature Flags
+
+## Flag inventory
+
+| Flag                 | Purpose                             | Enabled by                   |
+| -------------------- | ----------------------------------- | ---------------------------- |
+| `test-support`       | Test infra visible to e2e tests     | via dev-deps (Cargo feature) |
+| `mock`               | Mock executor / EVM implementations | via dev-deps (Cargo feature) |
+| `wallet-turnkey`     | Turnkey wallet support              | `all-wallets`                |
+| `wallet-private-key` | Local signer wallet support         | `all-wallets`                |
+| `all-wallets`        | All wallet backends                 | `default`                    |
+
+## `test-support` vs `cfg(test)`
+
+- **`cfg(test)`** is set by the compiler only for the crate currently being
+  compiled as a test target — either the lib's own unit-test compilation
+  (`#[cfg(test)] mod tests`) or an integration test crate (`tests/foo.rs`)
+  itself. Library dependencies compiled as part of an integration test build do
+  NOT get `cfg(test)` set; from their perspective it's a regular build.
+- **`feature = "test-support"`** is a cargo feature, activated through Cargo's
+  normal feature selection. We list it under `[dev-dependencies]` (via a
+  self-reference: `st0x-hedge = { features = ["test-support"] }`), so its
+  activation is scoped to dev builds — tests, examples, benches — and not
+  production. It gates types/methods that integration tests (`tests/`) need to
+  see across the crate boundary.
+
+### When to use which
+
+| Scenario                                  | Gate                                |
+| ----------------------------------------- | ----------------------------------- |
+| Unit test helper (same file, `mod tests`) | `#[cfg(test)]`                      |
+| Type/method used by e2e tests in `tests/` | `#[cfg(feature = "test-support")]`  |
+| Type that must exist in all builds but is | Always compiled; methods gated with |
+| only functional in tests                  | `#[cfg(feature = "test-support")]`  |
+
+### Common pitfall: dead code warnings
+
+A `pub` method gated on `cfg(any(test, feature = "test-support"))` will trigger
+`dead_code` warnings during `cargo test` if no unit test calls it — because
+`cfg(test)` makes it visible to the compiler but nothing in the lib crate
+references it.
+
+**Preferred fix:** use the new infra in unit tests — either by adding it to
+existing tests or writing new ones. This is the best outcome when it improves
+correctness guarantees and/or code quality.
+
+**Fallback fix:** gate on `feature = "test-support"` only (not `test`). The
+method won't exist in unit test builds but will exist in e2e builds where
+dev-deps enable `test-support`.
+
+### Pattern: zero-size prod / functional test type
+
+When a type needs to exist in all builds (to avoid `#[cfg]` on every function
+parameter and call site) but only does real work in tests:
+
+```rust
+#[derive(Clone)]
+pub struct MyTestHook(
+    #[cfg(feature = "test-support")] Arc<AtomicBool>,
+    #[cfg(not(feature = "test-support"))] (),
+);
+
+impl MyTestHook {
+    pub fn new() -> Self { /* ... */ }
+
+    #[cfg(feature = "test-support")]
+    pub fn arm(&self) { /* ... */ }
+
+    fn check(&self) -> bool {
+        #[cfg(feature = "test-support")]
+        { self.0.swap(false, Ordering::SeqCst) }
+        #[cfg(not(feature = "test-support"))]
+        false
+    }
+}
+```
+
+The type compiles everywhere (zero-size in prod). Methods that only tests call
+are gated on `feature = "test-support"`. The `check` method always exists but
+returns `false` in prod (the compiler eliminates the branch).

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -750,6 +750,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -837,6 +839,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -283,6 +283,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1094,6 +1094,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -610,6 +610,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -677,6 +679,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -682,6 +682,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -257,6 +257,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -300,6 +302,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -170,6 +170,8 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -308,6 +308,8 @@ impl Conductor {
             poll_notify: Arc::new(tokio::sync::Notify::new()),
             wallet_polling,
             tokenizer,
+            #[cfg(feature = "test-support")]
+            failure_injector: ctx.failure_injector.clone(),
         };
 
         let mut conductor = builder::spawn()

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -13,6 +13,8 @@ use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 
 use super::job::work;
+#[cfg(feature = "test-support")]
+use super::job::{FailureInjector, JobKind};
 use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
 use super::monitor::positions::PositionMonitor;
 use super::{Conductor, spawn_inventory_poller, spawn_order_poller};
@@ -55,6 +57,8 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) poll_notify: Arc<tokio::sync::Notify>,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
+    #[cfg(feature = "test-support")]
+    pub(crate) failure_injector: FailureInjector,
 }
 
 /// Wires all runtime components and returns a running [`Conductor`].
@@ -165,6 +169,11 @@ where
         .build()
         .run();
 
+    #[cfg(feature = "test-support")]
+    let failure_injector = context.failure_injector;
+    #[cfg(feature = "test-support")]
+    let failure_injector_for_hedge = failure_injector.clone();
+
     let monitor = tokio::spawn(async move {
         let apalis_monitor = Monitor::new()
             .should_restart(|_ctx, _error, attempt| {
@@ -172,16 +181,28 @@ where
                 true
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("order-fill-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
-                    .data(accountant_ctx.clone())
-                    .build(work::<AccountantCtx<Prov, Exec>, _>)
+                    .data(accountant_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder
+                    .data(failure_injector.clone())
+                    .data(JobKind::OrderFill);
+
+                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("hedge-worker-{index}"))
+                let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
                     .backend(hedge_queue.clone().into_storage())
-                    .data(hedge_ctx.clone())
-                    .build(work::<HedgeCtx, _>)
+                    .data(hedge_ctx.clone());
+
+                #[cfg(feature = "test-support")]
+                let builder = builder
+                    .data(failure_injector_for_hedge.clone())
+                    .data(JobKind::Hedge);
+
+                builder.build(work::<HedgeCtx, _>)
             });
 
         tokio::select! {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -13,7 +13,13 @@ use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
-use tracing::{debug, error, warn};
+#[cfg(feature = "test-support")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(feature = "test-support"))]
+use tracing::debug;
+#[cfg(feature = "test-support")]
+use tracing::info;
+use tracing::{error, warn};
 
 type Storage<Task> = SqliteStorage<
     Task,
@@ -84,16 +90,94 @@ impl fmt::Display for Label {
     }
 }
 
-/// Generic apalis handler that bridges [`Job`] implementations
-/// with apalis's function-based worker API.
+/// Identifies which job queue a [`FailureInjector`] targets.
+#[cfg(feature = "test-support")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum JobKind {
+    OrderFill,
+    Hedge,
+}
+
+/// Allows e2e tests to force the next job of a specific kind to
+/// fail terminally. Each [`JobKind`] has an independent flag so
+/// arming one queue cannot be consumed by the other.
+#[cfg(feature = "test-support")]
+#[derive(Clone, Debug)]
+pub struct FailureInjector {
+    order_fill: Arc<AtomicBool>,
+    hedge: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "test-support")]
+impl Default for FailureInjector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "test-support")]
+impl FailureInjector {
+    pub fn new() -> Self {
+        Self {
+            order_fill: Arc::new(AtomicBool::new(false)),
+            hedge: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn arm(&self, kind: JobKind) {
+        self.flag(kind).store(true, Ordering::SeqCst);
+    }
+
+    fn is_armed(&self, kind: JobKind) -> bool {
+        self.flag(kind).swap(false, Ordering::SeqCst)
+    }
+
+    fn flag(&self, kind: JobKind) -> &AtomicBool {
+        match kind {
+            JobKind::OrderFill => &self.order_fill,
+            JobKind::Hedge => &self.hedge,
+        }
+    }
+}
+
+/// Generic apalis handler - test-support build.
 ///
-/// Register with apalis via:
-/// ```text
-/// WorkerBuilder::new(name)
-///     .backend(storage)
-///     .data(ctx)
-///     .build(work::<MyCtx, MyJob>)
-/// ```
+/// Accepts a [`FailureInjector`] and [`JobKind`] via apalis `Data`.
+/// When the injector is armed for this kind, the job fails without
+/// calling `perform`.
+#[cfg(feature = "test-support")]
+pub(crate) async fn work<Ctx, J>(
+    job: J,
+    ctx: Data<Arc<Ctx>>,
+    injector: Data<FailureInjector>,
+    kind: Data<JobKind>,
+) where
+    Ctx: Send + Sync + 'static,
+    J: Job<Ctx> + Sync,
+{
+    if injector.is_armed(*kind) {
+        error!(label = %job.label(), ?kind, "Injected terminal failure (test)");
+        return;
+    }
+
+    const MAX_RETRIES: usize = 3;
+    let label = job.label();
+    info!(%label, max_retries = MAX_RETRIES, "Starting job");
+
+    let result = (|| job.perform(&ctx))
+        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
+        .notify(|error, duration| {
+            warn!(%label, %error, ?duration, "Retrying job after transient failure");
+        })
+        .await;
+
+    if let Err(error) = result {
+        error!(%label, %error, "Job failed after retries");
+    }
+}
+
+/// Generic apalis handler - production build.
+#[cfg(not(feature = "test-support"))]
 pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
 where
     Ctx: Send + Sync + 'static,
@@ -139,6 +223,53 @@ mod tests {
     use super::*;
     use crate::conductor::setup_apalis_tables;
     use crate::test_utils::setup_test_db;
+
+    #[test]
+    fn failure_injector_not_armed_by_default() {
+        let injector = FailureInjector::new();
+        assert!(!injector.is_armed(JobKind::OrderFill));
+        assert!(!injector.is_armed(JobKind::Hedge));
+    }
+
+    #[test]
+    fn failure_injector_arm_then_check_auto_disarms() {
+        let injector = FailureInjector::new();
+
+        injector.arm(JobKind::OrderFill);
+        assert!(injector.is_armed(JobKind::OrderFill));
+        assert!(
+            !injector.is_armed(JobKind::OrderFill),
+            "second check should be false (auto-disarmed)"
+        );
+    }
+
+    #[test]
+    fn failure_injector_kinds_are_independent() {
+        let injector = FailureInjector::new();
+
+        injector.arm(JobKind::OrderFill);
+        assert!(
+            !injector.is_armed(JobKind::Hedge),
+            "arming OrderFill should not affect Hedge"
+        );
+        assert!(injector.is_armed(JobKind::OrderFill));
+    }
+
+    #[test]
+    fn failure_injector_shared_across_clones() {
+        let injector = FailureInjector::new();
+        let clone = injector.clone();
+
+        injector.arm(JobKind::Hedge);
+        assert!(
+            clone.is_armed(JobKind::Hedge),
+            "arming original should be visible from clone"
+        );
+        assert!(
+            !injector.is_armed(JobKind::Hedge),
+            "should be disarmed after clone consumed it"
+        );
+    }
 
     async fn insert_job(
         pool: &SqlitePool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,6 +397,8 @@ pub struct Ctx {
     /// Alpaca redemption wallet from `[tokenization]`.
     /// `Some` when the config includes a `[tokenization]` section.
     pub(crate) redemption_wallet: Option<Address>,
+    #[cfg(feature = "test-support")]
+    pub failure_injector: crate::conductor::job::FailureInjector,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -461,7 +463,8 @@ impl std::fmt::Debug for BrokerCtx {
 
 impl std::fmt::Debug for Ctx {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Ctx")
+        let mut debug_struct = f.debug_struct("Ctx");
+        debug_struct
             .field("database_url", &self.database_url)
             .field("log_level", &self.log_level)
             .field("log_dir", &self.log_dir)
@@ -484,8 +487,12 @@ impl std::fmt::Debug for Ctx {
             .field("assets", &self.assets)
             .field("travel_rule_configured", &self.travel_rule.is_some())
             .field("redemption_wallet", &self.redemption_wallet)
-            .field("rest_api", &self.rest_api)
-            .finish()
+            .field("rest_api", &self.rest_api);
+
+        #[cfg(feature = "test-support")]
+        debug_struct.field("failure_injector", &self.failure_injector);
+
+        debug_struct.finish()
     }
 }
 
@@ -803,6 +810,8 @@ impl Ctx {
             travel_rule: parts.travel_rule,
             rest_api: parts.rest_api,
             redemption_wallet: parts.redemption_wallet,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 
@@ -951,6 +960,8 @@ impl Ctx {
             travel_rule,
             rest_api,
             redemption_wallet,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 }
@@ -1154,6 +1165,8 @@ pub(crate) mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
+            #[cfg(feature = "test-support")]
+            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ mod wrapper;
 
 pub use telemetry::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
 
+#[cfg(feature = "test-support")]
+pub use conductor::job::{FailureInjector, JobKind};
 #[cfg(any(test, feature = "test-support"))]
 pub use config::TradingMode;
 #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
## What

Adds a `FailureInjector` mechanism gated behind the `test-support` feature flag, along with a new `docs/feature-flags.md` reference document covering the full feature flag inventory and guidance on when to use `cfg(test)` vs `feature = "test-support"`.

## Why

End-to-end tests need a way to force conductor jobs to fail terminally without modifying production code paths. A dedicated injector type, invisible in production builds, provides this capability cleanly.

## How

`FailureInjector` wraps an `Arc<AtomicBool>`. Calling `arm()` sets the flag; the next call to `is_armed()` atomically swaps it back to `false` and returns `true`, ensuring single-use semantics and automatic disarming. The type is `Clone` so it can be shared across worker registrations.

In `test-support` builds, the apalis `work` handler gains an additional `Data<FailureInjector>` parameter. When armed, the handler logs a terminal failure and returns early without invoking `Job::perform`. In production builds, the original single-parameter `work` signature is used unchanged via `#[cfg(not(feature = "test-support"))]`.

`FailureInjector` is threaded through `ConductorCtx`, `Ctx`, and both worker registrations (order-fill and hedge) using `#[cfg(feature = "test-support")]` guards so no production code is affected.

The feature flags documentation covers the full flag inventory, the distinction between `cfg(test)` and `feature = "test-support"`, common dead-code warning pitfalls, and the zero-size-in-prod / functional-in-test struct pattern.

## Testing

Unit tests added directly in `conductor/job.rs` (gated on `test-support`) verify:

- `FailureInjector` is not armed by default.
- Arming and then checking auto-disarms on the first read.
- Arming via one clone is visible from another clone, and is consumed exactly once.

## Anything else

Several files contain unresolved merge conflict markers (`<<<<<<< HEAD` / `>>>>>>>`) between the `rest_api`/`redemption_wallet` fields and the new `failure_injector` field. These conflicts need to be resolved before this branch can be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive feature-flags guide covering test-support, mock, wallet flags, unit vs e2e guidance, gating pitfalls (dead_code), a decision table, and a pattern for zero-size-in-production / functional-in-tests.

* **New Features**
  * Test-only, feature-gated failure-injection for job workers to simulate terminal failures; exposed to tests when enabled.

* **UI Improvements**
  * Improved log/message rendering, dialog backdrop behavior, click-handler consistency, list keys, and minor event parsing.

* **Accessibility**
  * Added aria-label for a status toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->