### PR TITLE
repro: silent event processing after failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ the limit:
 - [docs/float.md](docs/float.md) - Float type, precision-safe financial
   arithmetic, Solidity-backed operations for guaranteed compatibility with smart
   contracts
+- [docs/feature-flags.md](docs/feature-flags.md) - Cargo feature flags,
+  `test-support` vs `cfg(test)`, common pitfalls with dead code warnings
 
 **Update at the end:**
 
@@ -41,6 +43,11 @@ the limit:
 - **ROADMAP.md** — mark completed issues, link PRs. When a PR is chained
   (depends on a parent PR), mark both as done in the roadmap so it's up to date
   by the time they merge.
+- **`docs/`** — when research or trial-and-error reveals non-obvious patterns,
+  pitfalls, or framework behavior, document it in the relevant `docs/` file (or
+  create a new one) to prevent rediscovery. Prioritize documenting:
+  framework-specific idioms, integration gotchas, and "X doesn't work because Y"
+  findings.
 
 ## Ownership Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "apalis-cron"
+version = "1.0.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "623a80caf0a084acf22cc3f43e49b984214e1c00b79779b16683ab55d46fa764"
+dependencies = [
+ "apalis-core",
+ "chrono",
+ "futures-util",
+ "ulid",
+]
+
+[[package]]
 name = "apalis-sql"
 version = "1.0.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6918,6 +6930,7 @@ dependencies = [
  "apalis",
  "apalis-codec",
  "apalis-core",
+ "apalis-cron",
  "apalis-sqlite",
  "approx",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ apalis = "1.0.0-rc.7"
 apalis-sqlite = "1.0.0-rc.6"
 apalis-codec = "0.1.0-rc.7"
 apalis-core = "1.0.0-rc.4"
+apalis-cron = { version = "1.0.0-rc.7", default-features = false }
 task-supervisor = "0.4"
 
 aes-gcm.workspace = true

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -96,35 +96,90 @@ logging.
 ### work
 
 Generic apalis handler that bridges `Job` implementations with apalis's
-function-based worker API:
+function-based worker API. Returns `Result<(), JobError>` so apalis can
+distinguish success from failure.
 
 ```rust
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
-where
-    Ctx: Send + Sync + 'static,
-    J: Job<Ctx>,
-{
-    // Retries with exponential backoff, then logs on final failure.
+pub(crate) async fn work<Ctx, J>(
+    job: J, ctx: Data<Arc<Ctx>>,
+) -> Result<(), JobError> {
+    let label = job.label();
+    info!(%label, "Processing job");
+    job.perform(&ctx).await.map_err(|source| JobError::Failed {
+        label,
+        source: Box::new(source),
+    })
 }
 ```
 
-### Wiring a job into apalis
+### Worker middleware stack
+
+Apalis workers use a Tower middleware stack configured on `WorkerBuilder`. The
+layers are applied in order — outermost first:
 
 ```
 WorkerBuilder::new(name)
-    .backend(job_queue)       // SqliteStorage<MyJob, ...>
-    .data(ctx)                // Arc<MyCtx>
+    .backend(job_queue)
+    .data(ctx)
+    .concurrency(1)                                          // sequential processing
+    .retry(RetryPolicy::retries(3).with_backoff(backoff))    // 1 + 3 = 4 attempts, with backoff
+    .break_circuit_with(fail_stop_config)                    // halt on terminal failure
+    .on_event(|ctx, event| { ... })                          // observability + lifecycle
     .build(work::<MyCtx, MyJob>)
 ```
 
-The apalis `Monitor` wraps workers and restarts them on failure:
+**Layer roles:**
+
+- **`.concurrency(1)`** — serializes job processing. Without it,
+  `CallAllUnordered` processes jobs in parallel and a failing job can't prevent
+  the next job from starting.
+- **`.retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF))`** — retries
+  failed jobs (replaces backon in the handler). `retries(3)` = 4 total attempts.
+  `RETRY_BACKOFF` is a deterministic exponential backoff (1s base, doubles each
+  attempt, capped at 30s) so transient failures (RPC blips, broker rate limits)
+  don't fast-fail into the circuit breaker. No jitter -- single-worker queues
+  don't thunder.
+- **`.break_circuit_with(config)`** — opens the circuit after
+  `failure_threshold` errors, returning `Poll::Pending` from `poll_ready` to
+  block new job pickup. Use `failure_threshold(1)` + very long
+  `recovery_timeout` for fail-stop.
+- **`.on_event()`** — fires on `Event::Error` (after retries exhaust),
+  `Event::Success`, `Event::Start`, `Event::Stop`. Use for logging AND for
+  calling `ctx.stop()` on terminal failure. The circuit breaker alone only
+  pauses the worker (`Poll::Pending`); `ctx.stop()` is needed to actually make
+  the worker exit.
+
+### Error propagation: handler failure -> bot shutdown
+
+1. `work()` returns `Err` -> retry layer retries
+2. Retries exhaust -> error reaches circuit breaker -> circuit opens
+3. Error becomes `Ok(Event::Error)` in apalis `poll_tasks`
+4. `on_event` catches `Event::Error`, fires the shared `failure_notify`
+   (`tokio::sync::Notify`), and calls `ctx.stop()`
+5. Worker exits cleanly (`Ok(())`)
+6. The spawned monitor task's biased `tokio::select!` observes the Notify and
+   returns `Err(MonitorTaskError::TerminalJobFailure)` immediately -- it does
+   not wait for `apalis_monitor.run()` to wind down. The conductor's
+   `wait_for_completion` sees the monitor task exit with that error and shuts
+   the bot down.
+
+**Critical:** the spawned monitor task must select on the shared Notify
+alongside `apalis_monitor.run()` and return the terminal error. Without the
+Notify branch, the conductor would only learn of the failure once apalis
+finished tearing down all workers; without returning the error, the conductor
+would never see the failure at all.
+
+### Monitor configuration
 
 ```
 Monitor::new()
-    .should_restart(|_ctx, _error, _attempt| true)
+    .should_restart(|_ctx, _error, _attempt| false)
     .register(|index| { /* WorkerBuilder as above */ })
     .run().await
 ```
+
+`should_restart(false)` — terminal job failure is fail-stop. The worker must not
+restart and process the next job with stale state.
 
 ### AccountForDexTrade
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -15,7 +15,7 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use task_supervisor::SupervisorHandle;
+use task_supervisor::{SupervisorError, SupervisorHandle};
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tokio::task::{JoinError, JoinHandle};
 use tokio::time::MissedTickBehavior;
@@ -102,10 +102,11 @@ pub(crate) struct TradeProcessingCqrs {
 /// accounting) into a unified lifecycle. Waits for either the supervisor or
 /// the apalis monitor to exit, then aborts all remaining tasks.
 pub(crate) struct Conductor {
-    /// Manages long-running tasks (order fill monitor) with automatic restart.
+    /// Manages long-running tasks (order fill monitor, position monitor)
+    /// with automatic restart.
     supervisor: SupervisorHandle,
     /// Runs the apalis job queue workers that process trade accounting jobs.
-    monitor: JoinHandle<()>,
+    monitor: JoinHandle<Result<(), MonitorTaskError>>,
     /// Periodic executor upkeep (e.g. Schwab token refresh). Absent when
     /// the executor requires no background maintenance.
     executor_maintenance: Option<JoinHandle<()>>,
@@ -116,6 +117,33 @@ pub(crate) struct Conductor {
     inventory_poller: Option<JoinHandle<()>>,
     /// Periodically removes terminal rows from the persistent job queue.
     job_cleanup: JoinHandle<()>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MonitorTaskError {
+    #[error("Apalis worker failed after retries")]
+    TerminalJobFailure,
+    #[error("Apalis monitor exited unexpectedly")]
+    UnexpectedExit {
+        #[source]
+        source: Option<apalis::prelude::MonitorError>,
+    },
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ConductorExitError {
+    #[error(transparent)]
+    Supervisor(#[from] SupervisorError),
+    #[error(transparent)]
+    Monitor(#[from] MonitorTaskError),
+    #[error("{task} exited unexpectedly")]
+    UnexpectedTaskExit { task: &'static str },
+    #[error("{task} failed")]
+    TaskFailed {
+        task: &'static str,
+        #[source]
+        source: JoinError,
+    },
 }
 
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
@@ -317,7 +345,7 @@ impl Conductor {
             poll_notify: Arc::new(tokio::sync::Notify::new()),
             wallet_polling,
             tokenizer,
-            #[cfg(feature = "test-support")]
+            #[cfg(any(test, feature = "test-support"))]
             failure_injector: ctx.failure_injector.clone(),
         };
 
@@ -341,12 +369,13 @@ impl Conductor {
 impl Conductor {
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
         let exit = tokio::select! {
-            result = self.supervisor.wait() => ConductorExit::Supervisor(result.map_err(anyhow::Error::new)),
+            result = self.supervisor.wait() => ConductorExit::Supervisor(result),
             result = &mut self.monitor => ConductorExit::Monitor(result),
             result = &mut self.job_cleanup => ConductorExit::JobCleanup(result),
         };
 
-        handle_conductor_exit(exit)
+        handle_conductor_exit(exit)?;
+        Ok(())
     }
 
     pub(crate) fn abort_all(&self) {
@@ -370,35 +399,57 @@ impl Conductor {
 }
 
 enum ConductorExit {
-    Supervisor(anyhow::Result<()>),
-    Monitor(Result<(), JoinError>),
+    Supervisor(Result<(), SupervisorError>),
+    Monitor(Result<Result<(), MonitorTaskError>, JoinError>),
     JobCleanup(Result<(), JoinError>),
 }
 
-fn handle_conductor_exit(exit: ConductorExit) -> anyhow::Result<()> {
+fn handle_conductor_exit(exit: ConductorExit) -> Result<(), ConductorExitError> {
     match exit {
-        ConductorExit::Supervisor(result) => {
-            result?;
-            info!("Supervisor exited");
-        }
-        ConductorExit::Monitor(result) => {
-            handle_task_exit(result, "Apalis monitor")?;
-            info!("Apalis monitor exited");
-        }
-        ConductorExit::JobCleanup(result) => {
-            handle_required_background_task_exit(result, "Job cleanup")?;
-            info!("Job cleanup exited");
-        }
+        ConductorExit::Supervisor(result) => handle_supervisor_exit(result),
+        ConductorExit::Monitor(join_result) => handle_monitor_exit(join_result),
+        ConductorExit::JobCleanup(result) => handle_required_task_exit(result, "Job cleanup"),
     }
+}
 
+fn handle_supervisor_exit(result: Result<(), SupervisorError>) -> Result<(), ConductorExitError> {
+    result?;
+    info!("Supervisor exited");
     Ok(())
 }
 
-fn handle_task_exit(result: Result<(), JoinError>, task: &'static str) -> anyhow::Result<()> {
+fn handle_monitor_exit(
+    join_result: Result<Result<(), MonitorTaskError>, JoinError>,
+) -> Result<(), ConductorExitError> {
+    let inner = join_result.map_err(|source| ConductorExitError::TaskFailed {
+        task: "Apalis monitor",
+        source,
+    })?;
+    inner?;
+    info!("Apalis monitor exited");
+    Ok(())
+}
+
+fn handle_required_task_exit(
+    result: Result<(), JoinError>,
+    task: &'static str,
+) -> Result<(), ConductorExitError> {
+    handle_required_background_task_exit(result, task)?;
+    info!("{task} exited");
+    Ok(())
+}
+
+fn handle_task_exit(
+    result: Result<(), JoinError>,
+    task: &'static str,
+) -> Result<(), ConductorExitError> {
     if let Err(join_error) = result
         && !join_error.is_cancelled()
     {
-        return Err(anyhow::Error::new(join_error).context(format!("{task} failed")));
+        return Err(ConductorExitError::TaskFailed {
+            task,
+            source: join_error,
+        });
     }
 
     Ok(())
@@ -407,9 +458,9 @@ fn handle_task_exit(result: Result<(), JoinError>, task: &'static str) -> anyhow
 fn handle_required_background_task_exit(
     result: Result<(), JoinError>,
     task: &'static str,
-) -> anyhow::Result<()> {
+) -> Result<(), ConductorExitError> {
     match result {
-        Ok(()) => Err(anyhow::anyhow!("{task} exited unexpectedly")),
+        Ok(()) => Err(ConductorExitError::UnexpectedTaskExit { task }),
         Err(join_error) => handle_task_exit(Err(join_error), task),
     }
 }
@@ -950,31 +1001,26 @@ where
     }
 }
 
-fn spawn_order_poller<E: Executor + Clone + Send + 'static>(
+fn build_order_poller<E: Executor + Clone + Send + 'static>(
     ctx: &Ctx,
     executor: E,
     offchain_order_projection: Projection<OffchainOrder>,
     offchain_order: Arc<Store<OffchainOrder>>,
     position: Arc<Store<Position>>,
-) -> JoinHandle<()> {
+) -> OrderStatusPoller<E> {
     let poller_ctx = ctx.get_order_poller_ctx();
     info!(
-        "Starting order status poller with interval: {:?}, max jitter: {:?}",
+        "Constructing order status poller with interval: {:?}, max jitter: {:?}",
         poller_ctx.polling_interval, poller_ctx.max_jitter
     );
 
-    let poller = OrderStatusPoller::new(
+    OrderStatusPoller::new(
         poller_ctx,
         executor,
         offchain_order_projection,
         offchain_order,
         position,
-    );
-    tokio::spawn(async move {
-        if let Err(error) = poller.run().await {
-            error!("Order poller failed: {error}");
-        }
-    })
+    )
 }
 
 fn spawn_inventory_poller<Chain, Exe>(
@@ -1778,7 +1824,7 @@ mod tests {
 
     fn conductor_with_job_cleanup(job_cleanup: JoinHandle<()>) -> Conductor {
         let supervisor = SupervisorBuilder::default().build().run();
-        let monitor = tokio::spawn(pending::<()>());
+        let monitor = tokio::spawn(pending::<Result<(), MonitorTaskError>>());
 
         Conductor {
             supervisor,

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1,7 +1,13 @@
 //! Constructs a fully-wired [`Conductor`] instance from its dependencies.
 
 use alloy::providers::Provider;
+use apalis::layers::WorkerBuilderExt;
+use apalis::layers::retry::RetryPolicy;
 use apalis::prelude::{Monitor, WorkerBuilder};
+use apalis_core::worker::event::Event;
+use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+use apalis_core::worker::ext::event_listener::EventListenerExt;
+use apalis_cron::CronStream;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
@@ -12,12 +18,12 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 
-use super::job::work;
-#[cfg(feature = "test-support")]
+use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, FixedInterval, RETRY_BACKOFF, poll_orders, work};
+#[cfg(any(test, feature = "test-support"))]
 use super::job::{FailureInjector, JobKind};
 use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
 use super::monitor::positions::PositionMonitor;
-use super::{Conductor, spawn_inventory_poller, spawn_order_poller};
+use super::{Conductor, MonitorTaskError, build_order_poller, spawn_inventory_poller};
 use crate::config::Ctx;
 use crate::inventory::{InventoryPollingService, InventorySnapshot, WalletPollingCtx};
 use crate::offchain_order::OffchainOrder;
@@ -57,7 +63,7 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) poll_notify: Arc<tokio::sync::Notify>,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
 }
 
@@ -109,13 +115,14 @@ where
     ));
     log_optional_task_status("inventory poller", inventory_poller.is_some());
 
-    let order_poller_handle = spawn_order_poller(
+    let order_poller = Arc::new(build_order_poller(
         &context.ctx,
         context.executor.clone(),
         (*context.frameworks.offchain_order_projection).clone(),
         context.frameworks.offchain_order.clone(),
         context.frameworks.position.clone(),
-    );
+    ));
+    let order_poller_schedule = FixedInterval::new(order_poller.polling_interval());
 
     let counter_trade_submission_lock = Arc::new(tokio::sync::Mutex::new(()));
 
@@ -161,59 +168,110 @@ where
         dex_streams,
     );
 
-    // NOTE: latest versions of apalias are adding tooling for long-running tasks too,
-    // so we will be able to get rid of this task-supervisor inconsistency
     let supervisor = SupervisorBuilder::default()
         .with_task("order-fill-monitor", order_fill_monitor)
         .with_task("position-monitor", position_monitor)
         .build()
         .run();
 
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     let failure_injector = context.failure_injector;
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     let failure_injector_for_hedge = failure_injector.clone();
+    let failure_notify = Arc::new(tokio::sync::Notify::new());
+    let failure_notify_for_hedge = failure_notify.clone();
+    let failure_notify_for_poller = failure_notify.clone();
 
-    let monitor = tokio::spawn(async move {
+    let fail_stop = CircuitBreakerConfig::default()
+        .with_failure_threshold(1)
+        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+    let fail_stop_for_hedge = fail_stop.clone();
+    let fail_stop_for_poller = fail_stop.clone();
+
+    let monitor: JoinHandle<Result<(), MonitorTaskError>> = tokio::spawn(async move {
+        let failure_notify_for_accountant = failure_notify.clone();
+        let failure_notify_for_select = failure_notify.clone();
         let apalis_monitor = Monitor::new()
-            .should_restart(|_ctx, _error, attempt| {
-                info!(attempt, "Restarting worker");
-                true
-            })
+            .should_restart(|_ctx, _error, _attempt| false)
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
                     .backend(job_queue.clone().into_storage())
                     .data(accountant_ctx.clone());
 
-                #[cfg(feature = "test-support")]
+                #[cfg(any(test, feature = "test-support"))]
                 let builder = builder
                     .data(failure_injector.clone())
                     .data(JobKind::OrderFill);
 
-                builder.build(work::<AccountantCtx<Prov, Exec>, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
+                    .break_circuit_with(fail_stop.clone())
+                    .on_event({
+                        let failure_notify = failure_notify_for_accountant.clone();
+                        move |ctx, event| {
+                            if let Event::Error(err) = event {
+                                error!(%err, worker = %ctx.name(), "Job failed after retries");
+                                failure_notify.notify_waiters();
+                                let _ = ctx.stop();
+                            }
+                        }
+                    })
+                    .build(work::<AccountantCtx<Prov, Exec>, _>)
             })
             .register(move |index| {
                 let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
                     .backend(hedge_queue.clone().into_storage())
                     .data(hedge_ctx.clone());
 
-                #[cfg(feature = "test-support")]
+                #[cfg(any(test, feature = "test-support"))]
                 let builder = builder
                     .data(failure_injector_for_hedge.clone())
                     .data(JobKind::Hedge);
 
-                builder.build(work::<HedgeCtx, _>)
+                builder
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
+                    .break_circuit_with(fail_stop_for_hedge.clone())
+                    .on_event({
+                        let failure_notify = failure_notify_for_hedge.clone();
+                        move |ctx, event| {
+                            if let Event::Error(err) = event {
+                                error!(%err, worker = %ctx.name(), "Job failed after retries");
+                                failure_notify.notify_waiters();
+                                let _ = ctx.stop();
+                            }
+                        }
+                    })
+                    .build(work::<HedgeCtx, _>)
+            })
+            .register(move |index| {
+                WorkerBuilder::new(format!("order-poller-{index}"))
+                    .backend(CronStream::new(order_poller_schedule.clone()))
+                    .data(order_poller.clone())
+                    .concurrency(1)
+                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
+                    .break_circuit_with(fail_stop_for_poller.clone())
+                    .on_event({
+                        let failure_notify = failure_notify_for_poller.clone();
+                        move |ctx, event| {
+                            if let Event::Error(err) = event {
+                                error!(%err, worker = %ctx.name(), "Order poller failed after retries");
+                                failure_notify.notify_waiters();
+                                let _ = ctx.stop();
+                            }
+                        }
+                    })
+                    .build(poll_orders::<Exec>)
             });
 
         tokio::select! {
-            result = apalis_monitor.run() => {
-                if let Err(monitor_error) = result {
-                    error!(%monitor_error, "Apalis monitor exited with error");
-                }
-            }
-            _ = order_poller_handle => {
-                error!("Order poller exited unexpectedly");
-            }
+            biased;
+            () = failure_notify_for_select.notified() => Err(MonitorTaskError::TerminalJobFailure),
+            result = apalis_monitor.run() => match result {
+                Ok(()) => Err(MonitorTaskError::UnexpectedExit { source: None }),
+                Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
+            },
         }
     });
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -5,21 +5,87 @@
 //! `SqliteStorage`; the generic [`work`] handler deserializes
 //! it and calls [`Job::perform`] with the shared context.
 
-use apalis::prelude::{Data, Status, TaskSink};
+use apalis::layers::retry::backoff::Backoff;
+use apalis::prelude::{Attempt, Data, Status, TaskSink};
+use apalis_cron::Schedule;
 use apalis_sqlite::SqliteStorage;
-use backon::{ExponentialBuilder, Retryable};
+use chrono::{DateTime, TimeZone, Utc};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
-#[cfg(feature = "test-support")]
-use std::sync::atomic::{AtomicBool, Ordering};
-#[cfg(not(feature = "test-support"))]
-use tracing::debug;
-#[cfg(feature = "test-support")]
-use tracing::info;
-use tracing::{error, warn};
+#[cfg(any(test, feature = "test-support"))]
+use std::sync::Mutex;
+use std::time::Duration;
+use tracing::{error, info, warn};
+
+use st0x_execution::Executor;
+
+use crate::offchain::order_poller::{OrderPollingError, OrderStatusPoller};
+
+/// Recovery timeout for the fail-stop circuit breaker. Effectively
+/// infinite for any plausible bot uptime; chosen to be finite so
+/// `last_failure + recovery_timeout` cannot overflow if apalis
+/// changes its check from `elapsed() >=` to addition.
+pub(crate) const FAIL_STOP_RECOVERY_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+
+/// Deterministic exponential backoff for the apalis retry layer.
+/// Doubles the delay each attempt up to `max`, with no jitter (unnecessary
+/// for single-worker queues). Infallible to construct so the production
+/// wiring needs no fallback path for invalid config.
+#[derive(Clone, Debug)]
+pub(crate) struct ExponentialBackoff {
+    base: Duration,
+    max: Duration,
+    iteration: u32,
+}
+
+impl ExponentialBackoff {
+    pub(crate) const fn new(base: Duration, max: Duration) -> Self {
+        Self {
+            base,
+            max,
+            iteration: 0,
+        }
+    }
+}
+
+impl Backoff for ExponentialBackoff {
+    type Future = tokio::time::Sleep;
+
+    fn next_backoff(&mut self) -> Self::Future {
+        let factor = 2u32.saturating_pow(self.iteration);
+        let delay = self.base.saturating_mul(factor).min(self.max);
+        self.iteration = self.iteration.saturating_add(1);
+        tokio::time::sleep(delay)
+    }
+}
+
+/// Production retry backoff: 1s base, doubles each attempt, capped at 30s.
+/// Sequence for `RetryPolicy::retries(3)`: 1s, 2s, 4s.
+pub(crate) const RETRY_BACKOFF: ExponentialBackoff =
+    ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
+
+/// `apalis_cron::Schedule` impl that fires at a fixed interval after each tick.
+/// Construction is typed and infallible -- no cron-string parsing.
+#[derive(Clone, Debug)]
+pub(crate) struct FixedInterval {
+    interval: Duration,
+}
+
+impl FixedInterval {
+    pub(crate) const fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+}
+
+impl<Tz: TimeZone> Schedule<Tz> for FixedInterval {
+    fn next_tick(&mut self, timezone: &Tz) -> Option<DateTime<Tz>> {
+        let interval = chrono::Duration::from_std(self.interval).ok()?;
+        Some(Utc::now().with_timezone(timezone) + interval)
+    }
+}
 
 type Storage<Task> = SqliteStorage<
     Task,
@@ -76,11 +142,17 @@ where
 }
 
 /// Human-readable identifier for an enqueued job, used in structured logging.
+#[derive(Debug)]
 pub(crate) struct Label(String);
 
 impl Label {
     pub(crate) fn new(label: impl Into<String>) -> Self {
         Self(label.into())
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -91,112 +163,185 @@ impl fmt::Display for Label {
 }
 
 /// Identifies which job queue a [`FailureInjector`] targets.
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum JobKind {
     OrderFill,
     Hedge,
 }
 
-/// Allows e2e tests to force the next job of a specific kind to
-/// fail terminally. Each [`JobKind`] has an independent flag so
-/// arming one queue cannot be consumed by the other.
-#[cfg(feature = "test-support")]
-#[derive(Clone, Debug)]
-pub struct FailureInjector {
-    order_fill: Arc<AtomicBool>,
-    hedge: Arc<AtomicBool>,
+/// Job execution error. Wraps the concrete `Job::Error` type at
+/// the `work()` boundary where the handler is generic over job types.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum JobError {
+    #[error("{label}: {source}")]
+    Failed {
+        label: Label,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[error("injected terminal job failure")]
+    Injected,
 }
 
-#[cfg(feature = "test-support")]
+/// Allows e2e tests to force the next job of a specific kind to
+/// fail terminally. Each [`JobKind`] has an independent injection
+/// state so arming one queue cannot be consumed by the other.
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Clone, Debug)]
+pub struct FailureInjector {
+    order_fill: Arc<Mutex<InjectionState>>,
+    hedge: Arc<Mutex<InjectionState>>,
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[derive(Debug, Default)]
+enum InjectionState {
+    #[default]
+    Idle,
+    Armed,
+    Targeted(String),
+}
+
+#[cfg(any(test, feature = "test-support"))]
 impl Default for FailureInjector {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
 impl FailureInjector {
     pub fn new() -> Self {
         Self {
-            order_fill: Arc::new(AtomicBool::new(false)),
-            hedge: Arc::new(AtomicBool::new(false)),
+            order_fill: Arc::new(Mutex::new(InjectionState::Idle)),
+            hedge: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
     pub fn arm(&self, kind: JobKind) {
-        self.flag(kind).store(true, Ordering::SeqCst);
+        *self.lock_state(kind) = InjectionState::Armed;
     }
 
+    #[cfg(test)]
     fn is_armed(&self, kind: JobKind) -> bool {
-        self.flag(kind).swap(false, Ordering::SeqCst)
+        let state = &mut *self.lock_state(kind);
+        let was_armed = matches!(state, InjectionState::Armed);
+
+        if was_armed {
+            *state = InjectionState::Idle;
+        }
+
+        was_armed
     }
 
-    fn flag(&self, kind: JobKind) -> &AtomicBool {
-        match kind {
+    fn should_inject(&self, kind: JobKind, label: &Label) -> bool {
+        let state = &mut *self.lock_state(kind);
+
+        match state {
+            InjectionState::Idle => false,
+            InjectionState::Armed => {
+                *state = InjectionState::Targeted(label.as_str().to_owned());
+                true
+            }
+            InjectionState::Targeted(target_label) => target_label == label.as_str(),
+        }
+    }
+
+    fn lock_state(&self, kind: JobKind) -> std::sync::MutexGuard<'_, InjectionState> {
+        let mutex = match kind {
             JobKind::OrderFill => &self.order_fill,
             JobKind::Hedge => &self.hedge,
+        };
+
+        match mutex.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
         }
+    }
+
+    async fn perform<Ctx, J: Job<Ctx> + Sync>(
+        &self,
+        kind: JobKind,
+        job: &J,
+        ctx: &Ctx,
+        attempt: usize,
+    ) -> Result<(), JobError>
+    where
+        Ctx: Send + Sync + 'static,
+    {
+        let label = job.label();
+
+        if self.should_inject(kind, &label) {
+            return Err(JobError::Injected);
+        }
+
+        log_processing(&label, attempt);
+        job.perform(ctx).await.map_err(|source| JobError::Failed {
+            label,
+            source: Box::new(source),
+        })
     }
 }
 
-/// Generic apalis handler - test-support build.
-///
-/// Accepts a [`FailureInjector`] and [`JobKind`] via apalis `Data`.
-/// When the injector is armed for this kind, the job fails without
-/// calling `perform`.
-#[cfg(feature = "test-support")]
+fn log_processing(label: &Label, attempt: usize) {
+    if attempt <= 1 {
+        info!(%label, "Processing job");
+    } else {
+        warn!(%label, attempt, "Retrying job after transient failure");
+    }
+}
+
+/// Generic apalis handler -- test-support build.
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) async fn work<Ctx, J>(
     job: J,
     ctx: Data<Arc<Ctx>>,
     injector: Data<FailureInjector>,
     kind: Data<JobKind>,
-) where
-    Ctx: Send + Sync + 'static,
-    J: Job<Ctx> + Sync,
-{
-    if injector.is_armed(*kind) {
-        error!(label = %job.label(), ?kind, "Injected terminal failure (test)");
-        return;
-    }
-
-    const MAX_RETRIES: usize = 3;
-    let label = job.label();
-    info!(%label, max_retries = MAX_RETRIES, "Starting job");
-
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
-}
-
-/// Generic apalis handler - production build.
-#[cfg(not(feature = "test-support"))]
-pub(crate) async fn work<Ctx, J>(job: J, ctx: Data<Arc<Ctx>>)
+    attempt: Attempt,
+) -> Result<(), JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
 {
-    const MAX_RETRIES: usize = 3;
+    injector.perform(*kind, &job, &ctx, attempt.current()).await
+}
+
+/// Generic apalis handler -- production build.
+#[cfg(not(feature = "test-support"))]
+pub(crate) async fn work<Ctx, J>(
+    job: J,
+    ctx: Data<Arc<Ctx>>,
+    attempt: Attempt,
+) -> Result<(), JobError>
+where
+    Ctx: Send + Sync + 'static,
+    J: Job<Ctx> + Sync,
+{
     let label = job.label();
-    debug!(%label, max_retries = MAX_RETRIES, "Starting job");
+    log_processing(&label, attempt.current());
+    job.perform(&ctx).await.map_err(|source| JobError::Failed {
+        label,
+        source: Box::new(source),
+    })
+}
 
-    let result = (|| job.perform(&ctx))
-        .retry(ExponentialBuilder::default().with_max_times(MAX_RETRIES))
-        .notify(|error, duration| {
-            warn!(%label, %error, ?duration, "Retrying job after transient failure");
-        })
-        .await;
-
-    if let Err(error) = result {
-        error!(%label, %error, "Job failed after retries");
-    }
+/// apalis-cron handler for the order status poller. One invocation per tick.
+/// Per-order errors are absorbed inside [`OrderStatusPoller::poll_pending_orders`];
+/// only cycle-level failures (storage, projection) propagate here. Returning
+/// the error feeds apalis' retry/circuit-breaker stack so the next tick is not
+/// scheduled on top of a broken cycle.
+pub(crate) async fn poll_orders<E>(
+    _tick: apalis_cron::Tick<Utc>,
+    poller: Data<Arc<OrderStatusPoller<E>>>,
+) -> Result<(), OrderPollingError>
+where
+    E: Executor + Clone + Send + Sync + 'static,
+{
+    poller.poll_pending_orders().await
 }
 
 pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
@@ -218,7 +363,15 @@ pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx
 
 #[cfg(test)]
 mod tests {
+    use apalis::layers::WorkerBuilderExt;
+    use apalis::layers::retry::RetryPolicy;
+    use apalis::prelude::{Monitor, WorkerBuilder};
+    use apalis_core::worker::event::Event;
+    use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
+    use apalis_core::worker::ext::event_listener::EventListenerExt;
     use sqlx::SqlitePool;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use super::*;
     use crate::conductor::setup_apalis_tables;
@@ -256,6 +409,36 @@ mod tests {
     }
 
     #[test]
+    fn failure_injector_targeted_label_latches_across_retries() {
+        let injector = FailureInjector::new();
+        let first = Label::new("job-a");
+        let same = Label::new("job-a");
+        let different = Label::new("job-b");
+
+        injector.arm(JobKind::OrderFill);
+
+        assert!(
+            injector.should_inject(JobKind::OrderFill, &first),
+            "Armed state should inject for the first label"
+        );
+        assert!(
+            matches!(
+                &*injector.lock_state(JobKind::OrderFill),
+                InjectionState::Targeted(target) if target == "job-a"
+            ),
+            "state should latch to Targeted with the first label"
+        );
+        assert!(
+            injector.should_inject(JobKind::OrderFill, &same),
+            "Targeted state should keep injecting for the same label across retries"
+        );
+        assert!(
+            !injector.should_inject(JobKind::OrderFill, &different),
+            "Targeted state should not inject for a different label"
+        );
+    }
+
+    #[test]
     fn failure_injector_shared_across_clones() {
         let injector = FailureInjector::new();
         let clone = injector.clone();
@@ -268,6 +451,94 @@ mod tests {
         assert!(
             !injector.is_armed(JobKind::Hedge),
             "should be disarmed after clone consumed it"
+        );
+    }
+
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    struct TestJob {
+        should_fail: bool,
+    }
+
+    struct TestCtx {
+        success_count: AtomicUsize,
+    }
+
+    impl Job<TestCtx> for TestJob {
+        type Error = TestJobError;
+
+        fn label(&self) -> Label {
+            Label::new(format!("test-job(should_fail={})", self.should_fail))
+        }
+
+        async fn perform(&self, ctx: &TestCtx) -> Result<(), Self::Error> {
+            if self.should_fail {
+                return Err(TestJobError);
+            }
+
+            ctx.success_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test job deliberately failed")]
+    struct TestJobError;
+
+    /// A job that fails after all retries must halt further processing --
+    /// the worker must not pick up the next job with stale state.
+    #[tokio::test]
+    async fn job_failure_after_retries_halts_processing() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&pool);
+        queue.push(TestJob { should_fail: true }).await.unwrap();
+        queue.push(TestJob { should_fail: false }).await.unwrap();
+
+        let ctx = Arc::new(TestCtx {
+            success_count: AtomicUsize::new(0),
+        });
+        let ctx_for_assert = ctx.clone();
+
+        let monitor_handle = tokio::spawn({
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    let fail_stop = CircuitBreakerConfig::default()
+                        .with_failure_threshold(1)
+                        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+
+                    WorkerBuilder::new(format!("test-worker-{index}"))
+                        .backend(queue.clone().into_storage())
+                        .data(ctx.clone())
+                        .data(FailureInjector::new())
+                        .data(JobKind::OrderFill)
+                        .concurrency(1)
+                        .retry(RetryPolicy::retries(3))
+                        .break_circuit_with(fail_stop)
+                        .on_event(|ctx, event| {
+                            if let Event::Error(_) = event {
+                                let _ = ctx.stop();
+                            }
+                        })
+                        .build(work::<TestCtx, TestJob>)
+                });
+
+            async move { monitor.run().await }
+        });
+
+        // RetryPolicy retries instantly, so the monitor should exit
+        // quickly once the failing job exhausts retries.
+        let join_result = tokio::time::timeout(Duration::from_secs(5), monitor_handle)
+            .await
+            .expect("Monitor should exit within 5s after terminal job failure");
+        let _ = join_result.expect("Monitor task should not panic");
+
+        assert_eq!(
+            ctx_for_assert.success_count.load(Ordering::SeqCst),
+            0,
+            "The second job should NOT have been processed after a prior \
+             job failed all retries."
         );
     }
 

--- a/src/offchain/order_poller.rs
+++ b/src/offchain/order_poller.rs
@@ -4,7 +4,6 @@ use num_traits::ToPrimitive;
 use rand::Rng;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::{Interval, interval};
 use tracing::{debug, info, trace, warn};
 
 use st0x_event_sorcery::{Column, Projection, ProjectionError, SendError, Store};
@@ -59,16 +58,16 @@ impl Default for OrderPollerCtx {
     }
 }
 
-pub struct OrderStatusPoller<E: Executor> {
+#[derive(Clone)]
+pub struct OrderStatusPoller<E: Executor + Clone> {
     ctx: OrderPollerCtx,
-    interval: Interval,
     executor: E,
     offchain_order_projection: Projection<OffchainOrder>,
     offchain_order: Arc<Store<OffchainOrder>>,
     position: Arc<Store<Position>>,
 }
 
-impl<E: Executor> OrderStatusPoller<E> {
+impl<E: Executor + Clone> OrderStatusPoller<E> {
     pub fn new(
         ctx: OrderPollerCtx,
         executor: E,
@@ -76,11 +75,8 @@ impl<E: Executor> OrderStatusPoller<E> {
         offchain_order: Arc<Store<OffchainOrder>>,
         position: Arc<Store<Position>>,
     ) -> Self {
-        let interval = interval(ctx.polling_interval);
-
         Self {
             ctx,
-            interval,
             executor,
             offchain_order_projection,
             offchain_order,
@@ -88,20 +84,8 @@ impl<E: Executor> OrderStatusPoller<E> {
         }
     }
 
-    pub async fn run(mut self) -> Result<(), OrderPollingError> {
-        info!(
-            target: "broker",
-            polling_interval = ?self.ctx.polling_interval,
-            "Starting order status poller..."
-        );
-
-        loop {
-            self.interval.tick().await;
-
-            if let Err(error) = self.poll_pending_orders().await {
-                warn!(target: "broker", %error, "Order polling failed");
-            }
-        }
+    pub(crate) fn polling_interval(&self) -> Duration {
+        self.ctx.polling_interval
     }
 
     #[tracing::instrument(skip(self), target = "broker", level = tracing::Level::DEBUG)]

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -13,6 +13,8 @@ pub(crate) mod assertions;
 use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
+#[cfg(feature = "test-support")]
+use st0x_hedge::{FailureInjector, JobKind};
 
 use self::assertions::*;
 use crate::poll::poll_for_all_jobs_done;
@@ -1446,5 +1448,94 @@ async fn duplicate_event_delivery() -> anyhow::Result<()> {
 
     pool.close().await;
     bot2.abort();
+    Ok(())
+}
+
+/// RAI-199: when a job fails terminally, the bot must halt -- not
+/// silently continue processing subsequent events with stale state.
+///
+/// This is a stopgap: a single worker failure brings down the whole
+/// system. Future work (tracked in Linear) will add system-level
+/// invariant enforcement infrastructure and robust auto-recovery so
+/// individual worker failures are isolated and state inconsistencies
+/// are made impossible, rather than relying on a full halt.
+#[cfg(feature = "test-support")]
+#[test_log::test(tokio::test)]
+async fn job_failure_halts_bot() -> anyhow::Result<()> {
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let mut ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+
+    let injector = FailureInjector::new();
+    ctx.failure_injector = injector.clone();
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // First trade processes normally
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    // Snapshot event count before the injected failure
+    let pool = connect_db(&infra.db_path).await?;
+    let events_before = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    // Arm the injector, then submit a second trade
+    injector.arm(JobKind::OrderFill);
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // The bot should exit -- the injected failure should halt processing
+    let join_result = tokio::time::timeout(Duration::from_secs(30), &mut bot)
+        .await
+        .expect("Bot should exit within 30s after terminal job failure");
+    let inner_result = join_result.expect("Bot task should fail, not panic");
+    let error = inner_result
+        .expect_err("Bot should fail after terminal job failure, not exit successfully");
+    let chain = format!("{error:#}");
+    assert!(
+        chain.contains("Apalis worker failed after retries"),
+        "Bot error chain should contain TerminalJobFailure, got: {chain}"
+    );
+
+    // The second trade's onchain event should NOT have been processed
+    let pool = connect_db(&infra.db_path).await?;
+    let events_after = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+
+    assert_eq!(
+        events_before, events_after,
+        "No new OnChainTrade events should be persisted after terminal failure"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## What

Closes RAI-199. Adds test coverage enforcing that a terminally-failed job halts further processing rather than silently continuing with stale state.

## Why

When a job exhausted all retries, `work()` was swallowing the error and the worker would pick up the next queued job anyway. This meant subsequent jobs could run against inconsistent state with no signal that something had gone wrong upstream.

## How

A `FailureInjector` can be armed to force a specific `JobKind` to fail. When the injected failure causes a job to exhaust its retries, the worker halts rather than continuing to the next job. This is an intentional stopgap: a single terminal worker failure brings down the whole bot. Future work will add system-level invariant enforcement and robust auto-recovery so that individual worker failures are isolated and state inconsistencies are made structurally impossible rather than handled via a full halt.

## Testing

Two new tests cover this behaviour:

- **Unit test** (`job_failure_after_retries_halts_processing`): pushes a failing job followed by a succeeding job into a `JobQueue`, runs the monitor, and asserts that the second job's side-effect (`success_count`) is never observed after the first job fails all retries.

- **E2E test** (`job_failure_halts_bot`): runs a full bot against a live test chain, processes one trade normally, arms the `FailureInjector` for `JobKind::OrderFill`, submits a second trade, and asserts that the bot process exits within 30 seconds and that no additional `OnChainTrade` events are persisted.

## Anything else

The e2e test relies on a 30-second timeout to confirm the bot exits. Future recovery infrastructure (tracked in Linear) will allow individual worker failures to be isolated so a full halt is no longer the only safe response to a terminal job error.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for job worker retry behavior and terminal job failure handling with end-to-end tests.

* **Documentation**
  * Updated conductor documentation with concrete implementation examples.
  * Added developer guidelines for feature flag documentation and framework pattern documentation.

* **Chores**
  * Added apalis-cron dependency for enhanced job orchestration capabilities.
  * Improved conductor error handling with structured error types and refined supervision orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->