### PR TITLE
fix: detect and recover from silent WebSocket stream closure

### DIFF
--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -70,8 +70,8 @@ impl SupervisedTask for OrderFillMonitor {
 
 #[derive(Debug, thiserror::Error)]
 enum OrderFillMonitorError {
-    #[error("DEX event streams closed unexpectedly")]
-    StreamsClosed,
+    #[error("{0} event stream closed unexpectedly")]
+    StreamClosed(&'static str),
 }
 
 type BoxedStream<T, Err = sol_types::Error> = Pin<Box<dyn Stream<Item = Result<T, Err>> + Send>>;
@@ -114,21 +114,24 @@ impl OrderFillMonitor {
         > + Unpin,
     ) -> TaskResult {
         loop {
-            let trade_event = tokio::select! {
-                Some(result) = clear_stream.next() => {
+            let (event, log) = tokio::select! {
+                item = clear_stream.next() => {
+                    let Some(result) = item else {
+                        error!("ClearV3 event stream closed unexpectedly");
+                        return Err(OrderFillMonitorError::StreamClosed("ClearV3").into());
+                    };
                     let (event, log) = result?;
-                    Some((RaindexTradeEvent::ClearV3(Box::new(event)), log))
+                    (RaindexTradeEvent::ClearV3(Box::new(event)), log)
                 }
-                Some(result) = take_stream.next() => {
-                    let (event, log) = result?;
-                    Some((RaindexTradeEvent::TakeOrderV3(Box::new(event)), log))
-                }
-                else => None,
-            };
 
-            let Some((event, log)) = trade_event else {
-                error!("Both DEX event streams ended unexpectedly");
-                return Err(OrderFillMonitorError::StreamsClosed.into());
+                item = take_stream.next() => {
+                    let Some(result) = item else {
+                        error!("TakeOrderV3 event stream closed unexpectedly");
+                        return Err(OrderFillMonitorError::StreamClosed("TakeOrderV3").into());
+                    };
+                    let (event, log) = result?;
+                    (RaindexTradeEvent::TakeOrderV3(Box::new(event)), log)
+                }
             };
 
             self.enqueue_trade_event(event, &log).await?;
@@ -232,7 +235,7 @@ mod tests {
         let log = create_log(0);
 
         let clear_stream = stream::iter(vec![Ok((test_clear_event(), log))]);
-        let take_stream = stream::empty();
+        let take_stream = stream::pending();
 
         let _result = monitor.listen(clear_stream, take_stream).await;
 
@@ -244,7 +247,7 @@ mod tests {
         let (mut monitor, pool) = create_test_monitor_with_pool().await;
         let log = create_log(1);
 
-        let clear_stream = stream::empty();
+        let clear_stream = stream::pending();
         let take_stream = stream::iter(vec![Ok((test_take_event(), log))]);
 
         let _result = monitor.listen(clear_stream, take_stream).await;
@@ -267,7 +270,47 @@ mod tests {
             .unwrap_err()
             .downcast::<OrderFillMonitorError>()
             .expect("expected OrderFillMonitorError");
-        assert!(matches!(*error, OrderFillMonitorError::StreamsClosed));
+        assert!(matches!(*error, OrderFillMonitorError::StreamClosed(_)));
+    }
+
+    #[tokio::test]
+    async fn listen_returns_error_when_clear_stream_closes() {
+        let (mut monitor, _pool) = create_test_monitor_with_pool().await;
+
+        let clear_stream =
+            stream::empty::<Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>>();
+        let take_stream = stream::pending();
+
+        let result = monitor.listen(clear_stream, take_stream).await;
+
+        let error = result
+            .unwrap_err()
+            .downcast::<OrderFillMonitorError>()
+            .expect("expected OrderFillMonitorError");
+        assert!(matches!(
+            *error,
+            OrderFillMonitorError::StreamClosed("ClearV3")
+        ));
+    }
+
+    #[tokio::test]
+    async fn listen_returns_error_when_take_stream_closes() {
+        let (mut monitor, _pool) = create_test_monitor_with_pool().await;
+
+        let clear_stream = stream::pending();
+        let take_stream =
+            stream::empty::<Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>>();
+
+        let result = monitor.listen(clear_stream, take_stream).await;
+
+        let error = result
+            .unwrap_err()
+            .downcast::<OrderFillMonitorError>()
+            .expect("expected OrderFillMonitorError");
+        assert!(matches!(
+            *error,
+            OrderFillMonitorError::StreamClosed("TakeOrderV3")
+        ));
     }
 
     #[tokio::test]
@@ -316,10 +359,20 @@ mod tests {
         let clear_log = create_log(0);
         let take_log = create_log(1);
 
-        let clear_stream = stream::iter(vec![Ok((test_clear_event(), clear_log))]);
-        let take_stream = stream::iter(vec![Ok((test_take_event(), take_log))]);
+        // Chain with stream::pending() so streams don't close after yielding
+        // their item — avoids a tokio::select! race where the exhausted stream
+        // is polled before the other stream's item is consumed.
+        let clear_stream =
+            stream::iter(vec![Ok((test_clear_event(), clear_log))]).chain(stream::pending());
+        let take_stream =
+            stream::iter(vec![Ok((test_take_event(), take_log))]).chain(stream::pending());
 
-        let _result = monitor.listen(clear_stream, take_stream).await;
+        // listen blocks on the now-pending streams after processing both events
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            monitor.listen(clear_stream, take_stream),
+        )
+        .await;
 
         assert_eq!(job_count(&pool).await, 2);
     }


### PR DESCRIPTION
## What

Fixes a bug where the `OrderFillMonitor`'s `TakeOrderV3` WebSocket stream
could silently close while the `ClearV3` stream kept running, causing all
`TakeOrderV3` events to be permanently lost without any error or reconnection.

## Why

In production, the `TakeOrderV3` stream died on Apr 24 ~20:00 UTC - the
first day after the last deploy. The `ClearV3` stream continued working, so the
bot appeared healthy. For 10 days, every onchain trade executed via
`TakeOrderV3` (IAU, SIVR, PPLT, TSLA) was silently dropped with no hedging.

The root cause is `tokio::select!` with `Some(result) = stream.next()` - when
a stream yields `None`, `select!` disables that branch and keeps polling the
other stream indefinitely. The `else` branch only fires when *both* streams
close simultaneously.

## How

Changed `listen()` to use `item = stream.next()` instead of
`Some(result) = stream.next()` in both `select!` branches. Each branch now
explicitly checks for `None` and returns `Err(StreamClosed("<stream name>"))`,
which triggers the supervisor to restart the monitor with a fresh WebSocket
connection for both streams.

Replaced the `StreamsClosed` error variant with `StreamClosed(&'static str)`
that names which stream died, for clearer error logging.

## Testing

- Updated existing tests to use `stream::pending()` (never resolves) for idle
  streams instead of `stream::empty()` (which now correctly triggers an error).
- Added `listen_returns_error_when_clear_stream_closes` - verifies ClearV3
  closure produces the correct error.
- Added `listen_returns_error_when_take_stream_closes` - verifies TakeOrderV3
  closure produces the correct error.
- All 9 order_fills tests pass. Full workspace suite clean.

## Screenshots

N/A

## Anything else

The supervisor automatically restarts `OrderFillMonitor` on error, which calls
`connect_and_listen()` to create a fresh WebSocket with both subscriptions.
No additional reconnection logic needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for WebSocket stream closures with specific identification of which stream connection failed.
  * Enhanced error handling and diagnostics to provide clearer messages during connectivity issues.
  * Strengthened order fill monitoring robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->