### PR TITLE
fix: backfill on reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "apalis-core"
-version = "1.0.0-rc.7"
+version = "1.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc053b8daf9235fd974cf2a7d7f8ed7ee8108ba1736d3ecce20529d26c32f66"
+checksum = "a1a4356a7881a2636007ee502573549a4d94795c3c178154a5ed28f3f473edff"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -7,10 +7,9 @@ mod manifest;
 pub(crate) mod monitor;
 
 use alloy::primitives::Address;
-use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::providers::{ProviderBuilder, WsConnect};
 use anyhow::Context;
 use chrono::Utc;
-use futures_util::StreamExt;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -28,11 +27,10 @@ use st0x_event_sorcery::{
 use st0x_evm::Wallet;
 use st0x_execution::{
     CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason, ExecutionError,
-    Executor, FractionalShares, MarketOrder, Symbol,
+    Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
 };
 
 use crate::alpaca_wallet::AlpacaWalletService;
-use crate::bindings::IOrderBookV6::{self, IOrderBookV6Instance};
 use crate::conductor::job::cleanup_finished_jobs;
 use crate::config::{AssetsConfig, BrokerCtx, Ctx, CtxError};
 use crate::dashboard::Broadcaster;
@@ -52,7 +50,7 @@ use crate::onchain::USDC_BASE;
 #[cfg(test)]
 use crate::onchain::accumulator::check_all_positions;
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
-use crate::onchain::backfill::{backfill_events, get_backfill_retry_strat};
+use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
@@ -185,10 +183,9 @@ pub(crate) struct AccumulatedPositionExecutionCtx<'a> {
 
 impl Conductor {
     pub(crate) async fn run<E>(
-        executor: E,
+        executor_ctx: impl TryIntoExecutor<Executor = E>,
         ctx: Ctx,
         pool: SqlitePool,
-        executor_maintenance: Option<JoinHandle<()>>,
         event_sender: broadcast::Sender<Statement>,
         inventory: Arc<BroadcastingInventory>,
     ) -> anyhow::Result<()>
@@ -196,38 +193,19 @@ impl Conductor {
         E: Executor + Clone + Send + 'static,
         TradeAccountingError: From<E::Error>,
     {
-        // Phase 1: connect WS and set up apalis tables (parallel)
+        let executor = executor_ctx.try_into_executor().await?;
+        let executor_maintenance = executor.run_executor_maintenance().await;
+
         let ws = WsConnect::new(ctx.evm.ws_rpc_url.as_str());
         let provider = ProviderBuilder::new()
             .connect_ws(ws)
             .await
             .context("failed to connect websocket provider")?;
         let cache = SymbolCache::default();
-        let orderbook = IOrderBookV6Instance::new(ctx.evm.orderbook, &provider);
 
         setup_apalis_tables(&pool).await?;
         let job_queue = DexTradeAccountingJobQueue::new(&pool);
-
-        let mut clear_stream = orderbook.ClearV3_filter().watch().await?.into_stream();
-        let mut take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
-
-        // Phase 2: determine cutoff block from WS subscription
-        let cutoff_block = get_cutoff_block(&mut clear_stream, &mut take_stream, &provider).await?;
-
-        // Phase 3: backfill historical events to the job queue.
-        // Backfill includes the cutoff block because `get_cutoff_block`
-        // consumed one stream item to learn the block number — that event
-        // would otherwise be lost. Duplicate events from the overlap are
-        // harmless: OnChainTrade aggregates deduplicate by (tx_hash, log_index).
-        backfill_events(
-            &provider,
-            &ctx.evm,
-            &pool,
-            cutoff_block,
-            get_backfill_retry_strat(),
-            job_queue.clone(),
-        )
-        .await?;
+        let backfill_queue = BackfillJobQueue::new(&pool);
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())
@@ -326,11 +304,6 @@ impl Conductor {
             snapshot,
         };
 
-        let dex_streams = monitor::order_fills::DexEventStreams {
-            clear: Box::pin(clear_stream),
-            take: Box::pin(take_stream),
-        };
-
         let hedge_queue = crate::conductor::job::JobQueue::new(&pool);
         let job_cleanup = spawn_finished_job_cleanup(
             pool.clone(),
@@ -355,8 +328,8 @@ impl Conductor {
         let mut conductor = builder::spawn()
             .context(conductor_ctx)
             .job_queue(job_queue)
+            .backfill_queue(backfill_queue)
             .hedge_queue(hedge_queue)
-            .dex_streams(dex_streams)
             .maybe_executor_maintenance(executor_maintenance)
             .maybe_rebalancer(rebalancer)
             .job_cleanup(job_cleanup)
@@ -1020,88 +993,6 @@ async fn build_position_cqrs(
     Ok(StoreBuilder::<Position>::new(pool.clone())
         .build(())
         .await?)
-}
-
-/// Determines the block number at which the WS subscription starts.
-///
-/// Waits up to 5 seconds for the first event on either stream. If an event
-/// arrives, its block number is the cutoff. If no events arrive within the
-/// timeout, falls back to the provider's current block number.
-async fn get_cutoff_block<ClearEvents, TakeOrderEvents, P>(
-    clear_stream: &mut ClearEvents,
-    take_stream: &mut TakeOrderEvents,
-    provider: &P,
-) -> anyhow::Result<u64>
-where
-    ClearEvents: futures_util::Stream<
-            Item = Result<(IOrderBookV6::ClearV3, alloy::rpc::types::Log), alloy::sol_types::Error>,
-        > + Unpin,
-    TakeOrderEvents: futures_util::Stream<
-            Item = Result<
-                (IOrderBookV6::TakeOrderV3, alloy::rpc::types::Log),
-                alloy::sol_types::Error,
-            >,
-        > + Unpin,
-    P: Provider + Clone,
-{
-    info!("Waiting for first WebSocket event to determine cutoff block...");
-
-    let timeout = tokio::time::sleep(Duration::from_secs(5));
-    tokio::pin!(timeout);
-
-    loop {
-        let block_number =
-            await_next_block(clear_stream, take_stream, &mut timeout, provider).await?;
-
-        if let Some(block) = block_number {
-            info!("First event at block {block}, using as cutoff");
-            return Ok(block);
-        }
-
-        debug!("Event missing block number, waiting for next event");
-    }
-}
-
-async fn await_next_block<ClearEvents, TakeOrderEvents, P>(
-    clear_stream: &mut ClearEvents,
-    take_stream: &mut TakeOrderEvents,
-    timeout: &mut std::pin::Pin<&mut tokio::time::Sleep>,
-    provider: &P,
-) -> anyhow::Result<Option<u64>>
-where
-    ClearEvents: futures_util::Stream<
-            Item = Result<
-                (
-                    crate::bindings::IOrderBookV6::ClearV3,
-                    alloy::rpc::types::Log,
-                ),
-                alloy::sol_types::Error,
-            >,
-        > + Unpin,
-    TakeOrderEvents: futures_util::Stream<
-            Item = Result<
-                (
-                    crate::bindings::IOrderBookV6::TakeOrderV3,
-                    alloy::rpc::types::Log,
-                ),
-                alloy::sol_types::Error,
-            >,
-        > + Unpin,
-    P: Provider + Clone,
-{
-    tokio::select! {
-        Some(result) = clear_stream.next() => {
-            Ok(result?.1.block_number)
-        }
-        Some(result) = take_stream.next() => {
-            Ok(result?.1.block_number)
-        }
-        () = &mut *timeout => {
-            let current_block = provider.get_block_number().await?;
-            info!("No events within timeout, using current block {current_block} as cutoff");
-            Ok(Some(current_block))
-        }
-    }
 }
 
 fn build_order_poller<E: Executor + Clone + Send + 'static>(
@@ -1882,8 +1773,6 @@ where
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, TxHash, U256, address, bytes, fixed_bytes};
-    use alloy::providers::ProviderBuilder;
-    use alloy::providers::mock::Asserter;
     use apalis::prelude::Status;
     use rain_math_float::Float;
     use sqlx::SqlitePool;
@@ -2171,23 +2060,6 @@ mod tests {
             !actual.contains_key(&spym),
             "Disabled assets should be excluded from Base-wallet wrapped equity polling"
         );
-    }
-
-    #[tokio::test]
-    async fn test_get_cutoff_block_with_timeout() {
-        let asserter = Asserter::new();
-
-        asserter.push_success(&serde_json::Value::from(12345u64));
-        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
-
-        let mut clear_stream = futures_util::stream::empty();
-        let mut take_stream = futures_util::stream::empty();
-
-        let cutoff_block = get_cutoff_block(&mut clear_stream, &mut take_stream, &provider)
-            .await
-            .unwrap();
-
-        assert_eq!(cutoff_block, 12345);
     }
 
     const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -1,35 +1,32 @@
 //! Constructs a fully-wired [`Conductor`] instance from its dependencies.
 
 use alloy::providers::Provider;
-use apalis::layers::WorkerBuilderExt;
-use apalis::layers::retry::RetryPolicy;
-use apalis::prelude::{Monitor, WorkerBuilder};
-use apalis_core::worker::event::Event;
-use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
-use apalis_core::worker::ext::event_listener::EventListenerExt;
-use apalis_cron::CronStream;
+use apalis::prelude::Monitor;
+use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 
 use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 use st0x_finance::{HasZero, Positive, Usd};
 
-use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, FixedInterval, RETRY_BACKOFF, poll_orders, work};
 #[cfg(any(test, feature = "test-support"))]
-use super::job::{FailureInjector, JobKind};
-use super::monitor::order_fills::{DexEventStreams, OrderFillMonitor};
+use super::job::FailureInjector;
+use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, FixedInterval, build_supervised_worker};
+use super::monitor::order_fills::OrderFillMonitor;
 use super::monitor::positions::PositionMonitor;
 use super::{Conductor, MonitorTaskError, build_order_poller, spawn_inventory_poller};
 use crate::config::Ctx;
 use crate::inventory::{
     InventoryPollingService, InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
 };
+use crate::offchain::order_poller::build_order_poller_worker;
 use crate::offchain_order::OffchainOrder;
+use crate::onchain::backfill::{BackfillJobQueue, BackfillRange};
 use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::raindex::RaindexService;
 use crate::onchain_trade::OnChainTrade;
@@ -37,9 +34,9 @@ use crate::position::Position;
 use crate::symbol::cache::SymbolCache;
 use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
-use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue};
+use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue, PlaceHedge};
 use crate::trading::onchain::trade_accountant::{
-    AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
+    AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
 };
 use crate::vault_registry::VaultRegistry;
 
@@ -75,8 +72,8 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
 pub(crate) fn spawn<Prov, Exec>(
     context: ConductorCtx<Prov, Exec>,
     job_queue: DexTradeAccountingJobQueue,
+    backfill_queue: BackfillJobQueue,
     hedge_queue: HedgeJobQueue,
-    dex_streams: DexEventStreams,
     job_cleanup: JoinHandle<()>,
     executor_maintenance: Option<JoinHandle<()>>,
     rebalancer: Option<JoinHandle<()>>,
@@ -153,7 +150,7 @@ where
         hedge_queue.clone(),
         std::time::Duration::from_secs(context.ctx.position_check_interval),
         context.ctx.clone(),
-        context.pool,
+        context.pool.clone(),
     );
 
     let trade_cqrs = super::TradeProcessingCqrs {
@@ -175,13 +172,15 @@ where
         cqrs: trade_cqrs,
         vault_registry: context.frameworks.vault_registry,
         executor: context.executor,
+        pool: context.pool.clone(),
+        job_queue: job_queue.clone(),
     });
 
     let order_fill_monitor = OrderFillMonitor::new(
-        context.ctx.evm.ws_rpc_url.clone(),
-        context.ctx.evm.orderbook,
+        context.ctx.evm.clone(),
         job_queue.clone(),
-        dex_streams,
+        backfill_queue.clone(),
+        context.pool,
     );
 
     let supervisor = SupervisorBuilder::default()
@@ -194,91 +193,71 @@ where
     let failure_injector = context.failure_injector;
     #[cfg(any(test, feature = "test-support"))]
     let failure_injector_for_hedge = failure_injector.clone();
+    #[cfg(any(test, feature = "test-support"))]
+    let failure_injector_for_backfill = failure_injector.clone();
     let failure_notify = Arc::new(tokio::sync::Notify::new());
     let failure_notify_for_hedge = failure_notify.clone();
+    let failure_notify_for_backfill = failure_notify.clone();
     let failure_notify_for_poller = failure_notify.clone();
+    let failure_notify_for_select = failure_notify.clone();
 
     let fail_stop = CircuitBreakerConfig::default()
         .with_failure_threshold(1)
         .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
     let fail_stop_for_hedge = fail_stop.clone();
+    let fail_stop_for_backfill = fail_stop.clone();
     let fail_stop_for_poller = fail_stop.clone();
 
+    let accountant_ctx_for_backfill = accountant_ctx.clone();
+
     let monitor: JoinHandle<Result<(), MonitorTaskError>> = tokio::spawn(async move {
-        let failure_notify_for_accountant = failure_notify.clone();
-        let failure_notify_for_select = failure_notify.clone();
         let apalis_monitor = Monitor::new()
             .should_restart(|_ctx, _error, _attempt| false)
             .register(move |index| {
-                let builder = WorkerBuilder::new(format!("order-fill-worker-{index}"))
-                    .backend(job_queue.clone().into_storage())
-                    .data(accountant_ctx.clone());
-
-                #[cfg(any(test, feature = "test-support"))]
-                let builder = builder
-                    .data(failure_injector.clone())
-                    .data(JobKind::OrderFill);
-
-                builder
-                    .concurrency(1)
-                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
-                    .break_circuit_with(fail_stop.clone())
-                    .on_event({
-                        let failure_notify = failure_notify_for_accountant.clone();
-                        move |ctx, event| {
-                            if let Event::Error(err) = event {
-                                error!(%err, worker = %ctx.name(), "Job failed after retries");
-                                failure_notify.notify_waiters();
-                                let _ = ctx.stop();
-                            }
-                        }
-                    })
-                    .build(work::<AccountantCtx<Prov, Exec>, _>)
+                build_supervised_worker!(
+                    ::<AccountantCtx<Prov, Exec>, AccountForDexTrade>,
+                    index,
+                    job_queue.clone(),
+                    accountant_ctx.clone(),
+                    fail_stop.clone(),
+                    failure_notify.clone(),
+                    #[cfg(any(test, feature = "test-support"))]
+                    failure_injector.clone(),
+                )
             })
             .register(move |index| {
-                let builder = WorkerBuilder::new(format!("hedge-worker-{index}"))
-                    .backend(hedge_queue.clone().into_storage())
-                    .data(hedge_ctx.clone());
-
-                #[cfg(any(test, feature = "test-support"))]
-                let builder = builder
-                    .data(failure_injector_for_hedge.clone())
-                    .data(JobKind::Hedge);
-
-                builder
-                    .concurrency(1)
-                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
-                    .break_circuit_with(fail_stop_for_hedge.clone())
-                    .on_event({
-                        let failure_notify = failure_notify_for_hedge.clone();
-                        move |ctx, event| {
-                            if let Event::Error(err) = event {
-                                error!(%err, worker = %ctx.name(), "Job failed after retries");
-                                failure_notify.notify_waiters();
-                                let _ = ctx.stop();
-                            }
-                        }
-                    })
-                    .build(work::<HedgeCtx, _>)
+                build_supervised_worker!(
+                    ::<HedgeCtx, PlaceHedge>,
+                    index,
+                    hedge_queue.clone(),
+                    hedge_ctx.clone(),
+                    fail_stop_for_hedge.clone(),
+                    failure_notify_for_hedge.clone(),
+                    #[cfg(any(test, feature = "test-support"))]
+                    failure_injector_for_hedge.clone(),
+                )
             })
             .register(move |index| {
-                WorkerBuilder::new(format!("order-poller-{index}"))
-                    .backend(CronStream::new(order_poller_schedule.clone()))
-                    .data(order_poller.clone())
-                    .concurrency(1)
-                    .retry(RetryPolicy::retries(3).with_backoff(RETRY_BACKOFF.clone()))
-                    .break_circuit_with(fail_stop_for_poller.clone())
-                    .on_event({
-                        let failure_notify = failure_notify_for_poller.clone();
-                        move |ctx, event| {
-                            if let Event::Error(err) = event {
-                                error!(%err, worker = %ctx.name(), "Order poller failed after retries");
-                                failure_notify.notify_waiters();
-                                let _ = ctx.stop();
-                            }
-                        }
-                    })
-                    .build(poll_orders::<Exec>)
+                build_supervised_worker!(
+                    ::<AccountantCtx<Prov, Exec>, BackfillRange>,
+                    index,
+                    backfill_queue.clone(),
+                    accountant_ctx_for_backfill.clone(),
+                    fail_stop_for_backfill.clone(),
+                    failure_notify_for_backfill.clone(),
+                    #[cfg(any(test, feature = "test-support"))]
+                    failure_injector_for_backfill.clone(),
+                )
+            })
+            .register(move |index| {
+                build_order_poller_worker!(
+                    index,
+                    order_poller.clone(),
+                    order_poller_schedule.clone(),
+                    fail_stop_for_poller.clone(),
+                    failure_notify_for_poller.clone(),
+                    Exec,
+                )
             });
 
         tokio::select! {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -7,8 +7,11 @@
 
 use apalis::layers::retry::backoff::Backoff;
 use apalis::prelude::{Attempt, Data, Status, TaskSink};
+use apalis_core::backend::poll_strategy::{BackoffConfig, IntervalStrategy, StrategyBuilder};
+use apalis_core::worker::context::WorkerContext;
+use apalis_core::worker::event::Event;
 use apalis_cron::Schedule;
-use apalis_sqlite::SqliteStorage;
+use apalis_sqlite::{Config, SqliteStorage};
 use chrono::{DateTime, TimeZone, Utc};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -102,9 +105,36 @@ impl<Task> Clone for JobQueue<Task> {
     }
 }
 
+/// Pickup latency SLO for queued jobs.
+///
+/// Hedge placement (and the upstream trade-processing pipeline) needs
+/// to react to events on the order of a single second: a missed window
+/// here translates directly into directional exposure that the hedger
+/// is supposed to be neutralising. Apalis defaults to exponential
+/// poll backoff capped at 60s, which is sensible for long-running
+/// systems that idle for hours but violates the SLO this service
+/// operates under -- after even a brief idle period a worker can be
+/// sleeping for tens of seconds when a new job lands.
+///
+/// We cap the polling interval at 1s end-to-end so the worst-case
+/// pickup latency matches the SLO regardless of prior queue state.
+fn build_poll_config<T: 'static>() -> Config {
+    let strategy = StrategyBuilder::new()
+        .apply(
+            IntervalStrategy::new(Duration::from_millis(100))
+                .with_backoff(BackoffConfig::new(Duration::from_secs(1))),
+        )
+        .build();
+
+    Config::new(std::any::type_name::<T>()).with_poll_interval(strategy)
+}
+
 impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueue<Task> {
     pub(crate) fn new(pool: &SqlitePool) -> Self {
-        Self(SqliteStorage::new(pool))
+        Self(SqliteStorage::new_with_config(
+            pool,
+            &build_poll_config::<Task>(),
+        ))
     }
 
     pub(crate) async fn push(
@@ -127,19 +157,103 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
 /// needed to process a single job. The `Ctx` type parameter
 /// bundles all runtime dependencies (executor, CQRS frameworks,
 /// config, etc.) into one struct injected via apalis `Data`.
+///
+/// The `Output` associated type is what downstream apalis-workflow
+/// stages receive when this job is composed into a DAG. Leaf jobs
+/// that don't feed anything use `type Output = ();`.
+///
+/// `WORKER_NAME`, `TERMINAL_FAILURE_MSG`, and `JOB_KIND` are read
+/// by the shared [`build_supervised_worker!`] macro so each Job
+/// impl carries everything `Monitor::register` needs.
 pub(crate) trait Job<Ctx>: Serialize + DeserializeOwned + Send + 'static
 where
     Ctx: Send + Sync + 'static,
 {
+    /// Value produced on successful completion. Becomes the input
+    /// of the next stage in apalis-workflow DAGs.
+    type Output: Send + 'static;
+
     /// Error type returned by [`perform`](Job::perform).
     type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Worker name prefix; the registered worker name is
+    /// `format!("{WORKER_NAME}-{index}")`.
+    const WORKER_NAME: &'static str;
+
+    /// Logged when retries are exhausted and the supervisor receives
+    /// a terminal failure for this job.
+    const TERMINAL_FAILURE_MSG: &'static str = "Job failed after retries";
+
+    /// Identifier for this job type in the e2e [`FailureInjector`].
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: JobKind;
 
     /// Human-readable label for structured logging.
     fn label(&self) -> Label;
 
     /// Process this job using the provided context.
-    async fn perform(&self, ctx: &Ctx) -> Result<(), Self::Error>;
+    async fn perform(&self, ctx: &Ctx) -> Result<Self::Output, Self::Error>;
 }
+
+/// Builds a `Worker` for a `Job<Ctx>` impl.
+///
+/// Mirrors the `work::<Ctx, Job>` turbofish style: pass the same two
+/// types and the macro expands to a fully-wired worker (queue backend,
+/// retry policy, fail-stop circuit breaker, terminal-failure notifier,
+/// `.build(work::<Ctx, Job>)`).
+///
+/// A macro because `.build()` returns a deeply-nested
+/// `Worker<Args, Ctx, Backend, Svc, Middleware>` whose `Svc` and
+/// `Middleware` types accumulate from the layer stack and have no
+/// public alias or `impl Trait` shorthand. Macro expansion lets the
+/// compiler infer the type at the call site.
+macro_rules! build_supervised_worker {
+    (
+        ::<$ctx_type:ty, $job:ty>,
+        $index:expr,
+        $queue:expr,
+        $ctx:expr,
+        $fail_stop:expr,
+        $failure_notify:expr
+        $(, $failure_injector:expr)? $(,)?
+    ) => {{
+        use ::apalis::layers::WorkerBuilderExt;
+        use ::apalis::layers::retry::RetryPolicy;
+        use ::apalis::prelude::WorkerBuilder;
+        use ::apalis_core::worker::ext::circuit_breaker::CircuitBreaker;
+        use ::apalis_core::worker::ext::event_listener::EventListenerExt;
+
+        let builder = WorkerBuilder::new(format!(
+            "{}-{}",
+            <$job as $crate::conductor::job::Job<$ctx_type>>::WORKER_NAME,
+            $index,
+        ))
+        .backend($queue.into_storage())
+        .data($ctx);
+
+        $(
+            #[cfg(any(test, feature = "test-support"))]
+            let builder = builder.data($failure_injector).data(
+                <$job as $crate::conductor::job::Job<$ctx_type>>::JOB_KIND,
+            );
+        )?
+
+        builder
+            .concurrency(1)
+            .retry(
+                RetryPolicy::retries(3)
+                    .with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
+            )
+            .break_circuit_with($fail_stop)
+            .on_event($crate::conductor::job::on_terminal_failure(
+                $failure_notify,
+                <$job as $crate::conductor::job::Job<$ctx_type>>::TERMINAL_FAILURE_MSG,
+            ))
+            .build($crate::conductor::job::work::<$ctx_type, $job>)
+    }};
+}
+
+pub(crate) use build_supervised_worker;
 
 /// Human-readable identifier for an enqueued job, used in structured logging.
 #[derive(Debug)]
@@ -168,6 +282,7 @@ impl fmt::Display for Label {
 pub enum JobKind {
     OrderFill,
     Hedge,
+    Backfill,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -194,6 +309,7 @@ pub(crate) enum JobError {
 pub struct FailureInjector {
     order_fill: Arc<Mutex<InjectionState>>,
     hedge: Arc<Mutex<InjectionState>>,
+    backfill: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -218,6 +334,7 @@ impl FailureInjector {
         Self {
             order_fill: Arc::new(Mutex::new(InjectionState::Idle)),
             hedge: Arc::new(Mutex::new(InjectionState::Idle)),
+            backfill: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -254,6 +371,7 @@ impl FailureInjector {
         let mutex = match kind {
             JobKind::OrderFill => &self.order_fill,
             JobKind::Hedge => &self.hedge,
+            JobKind::Backfill => &self.backfill,
         };
 
         match mutex.lock() {
@@ -268,7 +386,7 @@ impl FailureInjector {
         job: &J,
         ctx: &Ctx,
         attempt: usize,
-    ) -> Result<(), JobError>
+    ) -> Result<J::Output, JobError>
     where
         Ctx: Send + Sync + 'static,
     {
@@ -302,7 +420,7 @@ pub(crate) async fn work<Ctx, J>(
     injector: Data<FailureInjector>,
     kind: Data<JobKind>,
     attempt: Attempt,
-) -> Result<(), JobError>
+) -> Result<J::Output, JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
@@ -316,7 +434,7 @@ pub(crate) async fn work<Ctx, J>(
     job: J,
     ctx: Data<Arc<Ctx>>,
     attempt: Attempt,
-) -> Result<(), JobError>
+) -> Result<J::Output, JobError>
 where
     Ctx: Send + Sync + 'static,
     J: Job<Ctx> + Sync,
@@ -342,6 +460,22 @@ where
     E: Executor + Clone + Send + Sync + 'static,
 {
     poller.poll_pending_orders().await
+}
+
+/// On-event handler shared by every supervised worker: when apalis
+/// reports a terminal job failure (retries exhausted), notify the
+/// monitor task and stop the worker.
+pub(crate) fn on_terminal_failure(
+    failure_notify: Arc<tokio::sync::Notify>,
+    error_msg: &'static str,
+) -> impl Fn(&WorkerContext, &Event) + Send + Sync + 'static {
+    move |ctx, event| {
+        if let Event::Error(err) = event {
+            error!(%err, worker = %ctx.name(), "{error_msg}");
+            failure_notify.notify_waiters();
+            let _ = ctx.stop();
+        }
+    }
 }
 
 pub(crate) async fn cleanup_finished_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
@@ -464,13 +598,17 @@ mod tests {
     }
 
     impl Job<TestCtx> for TestJob {
+        type Output = ();
         type Error = TestJobError;
+
+        const WORKER_NAME: &'static str = "test-worker";
+        const JOB_KIND: JobKind = JobKind::OrderFill;
 
         fn label(&self) -> Label {
             Label::new(format!("test-job(should_fail={})", self.should_fail))
         }
 
-        async fn perform(&self, ctx: &TestCtx) -> Result<(), Self::Error> {
+        async fn perform(&self, ctx: &TestCtx) -> Result<Self::Output, Self::Error> {
             if self.should_fail {
                 return Err(TestJobError);
             }

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -1,24 +1,34 @@
 //! Supervised order fill monitor that subscribes to onchain events
 //! and pushes them into apalis storage for processing.
 //!
-//! The WebSocket connection is created inside [`SupervisedTask::run`],
-//! so a fresh connection is established on each restart. This provides
-//! automatic reconnection via the supervisor's restart policy.
+//! On every (re)connect -- both initial startup and supervisor restarts
+//! after a WebSocket disconnect -- the monitor:
+//! 1. Subscribes to fresh `ClearV3` / `TakeOrderV3` streams.
+//! 2. Determines a cutoff block from the provider's current head.
+//! 3. Enqueues a `BackfillRange` apalis job covering
+//!    `(checkpoint+1, cutoff)` to recover events emitted while the
+//!    previous subscription was unavailable.
+//! 4. Enters the live listen loop, advancing the backfill checkpoint
+//!    after every event is durably enqueued.
+//!
+//! The supervisor's restart policy provides automatic reconnection;
+//! this design keeps the disconnect-window data loss issue from
+//! recurring on every restart.
 
-use alloy::primitives::Address;
+use alloy::providers::Provider;
 use alloy::providers::ProviderBuilder;
 use alloy::providers::WsConnect;
-use alloy::rpc::types::Log;
 use alloy::sol_types;
 use futures_util::{Stream, StreamExt};
-use std::pin::Pin;
-use std::sync::Arc;
+use sqlx::SqlitePool;
 use task_supervisor::{SupervisedTask, TaskResult};
-use tokio::sync::Mutex;
-use tracing::{error, info, trace, warn};
-use url::Url;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::bindings::IOrderBookV6::{ClearV3, IOrderBookV6Instance, TakeOrderV3};
+use crate::onchain::EvmCtx;
+use crate::onchain::backfill::{
+    BackfillJobQueue, BackfillRange, backfill_start_block, save_backfill_checkpoint,
+};
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{AccountForDexTrade, DexTradeAccountingJobQueue};
@@ -26,44 +36,38 @@ use crate::trading::onchain::trade_accountant::{AccountForDexTrade, DexTradeAcco
 /// Monitors DEX WebSocket streams and pushes
 /// [`AccountForDexTrade`] jobs into apalis storage.
 ///
-/// Implements [`SupervisedTask`] so the supervisor restarts it
-/// on WebSocket disconnection or errors. On first run, it consumes
-/// pre-established streams from `Conductor::start`; on subsequent
-/// restarts it creates a fresh WS connection.
+/// Implements [`SupervisedTask`] so the supervisor restarts it on
+/// WebSocket disconnection or errors. On every invocation -- first
+/// run and every restart -- the monitor opens a fresh WS subscription,
+/// determines a cutoff block, enqueues a [`BackfillRange`] job for
+/// the gap since the last checkpoint, and then enters the live
+/// listen loop.
 #[derive(Clone)]
 pub(crate) struct OrderFillMonitor {
-    ws_url: Url,
-    orderbook: Address,
+    evm_ctx: EvmCtx,
     job_queue: DexTradeAccountingJobQueue,
-    dex_streams: Arc<Mutex<Option<DexEventStreams>>>,
+    backfill_queue: BackfillJobQueue,
+    pool: SqlitePool,
 }
 
 impl OrderFillMonitor {
     pub(crate) fn new(
-        ws_url: Url,
-        orderbook: Address,
+        evm_ctx: EvmCtx,
         job_queue: DexTradeAccountingJobQueue,
-        dex_streams: DexEventStreams,
+        backfill_queue: BackfillJobQueue,
+        pool: SqlitePool,
     ) -> Self {
         Self {
-            ws_url,
-            orderbook,
+            evm_ctx,
             job_queue,
-            dex_streams: Arc::new(Mutex::new(Some(dex_streams))),
+            backfill_queue,
+            pool,
         }
     }
 }
 
 impl SupervisedTask for OrderFillMonitor {
     async fn run(&mut self) -> TaskResult {
-        info!(ws_url = %self.ws_url, "Connecting to DEX WebSocket");
-        let initial = self.dex_streams.lock().await.take();
-
-        if let Some(streams) = initial {
-            info!("Order fill monitor using pre-established streams");
-            return self.listen(streams.clear, streams.take).await;
-        }
-
         self.connect_and_listen().await
     }
 }
@@ -74,45 +78,120 @@ enum OrderFillMonitorError {
     StreamClosed(&'static str),
 }
 
-type BoxedStream<T, Err = sol_types::Error> = Pin<Box<dyn Stream<Item = Result<T, Err>> + Send>>;
-
-/// DEX event streams (ClearV3 / TakeOrderV3) for monitoring order fills.
-///
-/// Passed from `Conductor::start` to avoid a gap between the WS
-/// subscription (used for `get_cutoff_block`) and the monitor's first
-/// `run()` invocation.
-pub(crate) struct DexEventStreams {
-    pub(crate) clear: BoxedStream<(ClearV3, Log)>,
-    pub(crate) take: BoxedStream<(TakeOrderV3, Log)>,
-}
-
 impl OrderFillMonitor {
     async fn connect_and_listen(&mut self) -> TaskResult {
-        info!(ws_url = %self.ws_url, "Reconnecting to DEX WebSocket");
+        // Production WS URLs (Infura, Alchemy) embed API keys in the
+        // path or query, so log only scheme/host/port.
+        info!(
+            ws_host = %self.evm_ctx.ws_rpc_url.host_str().unwrap_or("<unknown>"),
+            ws_scheme = %self.evm_ctx.ws_rpc_url.scheme(),
+            "Connecting to DEX WebSocket"
+        );
 
-        let ws = WsConnect::new(self.ws_url.as_str());
+        let ws = WsConnect::new(self.evm_ctx.ws_rpc_url.as_str());
         let provider = ProviderBuilder::new().connect_ws(ws).await?;
-        let orderbook = IOrderBookV6Instance::new(self.orderbook, &provider);
+        let orderbook = IOrderBookV6Instance::new(self.evm_ctx.orderbook, &provider);
 
-        let clear_stream = orderbook.ClearV3_filter().watch().await?.into_stream();
-        let take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
+        let mut clear_stream = orderbook.ClearV3_filter().watch().await?.into_stream();
+        let mut take_stream = orderbook.TakeOrderV3_filter().watch().await?.into_stream();
 
-        info!("Order fill monitor connected and listening");
+        self.prepare_and_listen(&provider, &mut clear_stream, &mut take_stream)
+            .await
+    }
+
+    /// Enqueues a `BackfillRange` job for the gap since the last
+    /// checkpoint, then enters the live listen loop. Backfill is
+    /// enqueued before any awaitable work that could be preempted so
+    /// that the job is durably persisted even if the supervisor or
+    /// runtime aborts the task mid-startup. Split out so unit tests
+    /// can drive the post-subscribe path with mocked streams.
+    async fn prepare_and_listen<P, ClearEvents, TakeOrderEvents>(
+        &mut self,
+        provider: &P,
+        clear_stream: &mut ClearEvents,
+        take_stream: &mut TakeOrderEvents,
+    ) -> TaskResult
+    where
+        P: Provider + Clone,
+        ClearEvents:
+            Stream<Item = Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>> + Unpin,
+        TakeOrderEvents:
+            Stream<Item = Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>> + Unpin,
+    {
+        // Cutoff is the provider's current head at the moment of
+        // (re)connect: events at or before this block are caught by
+        // backfill, events after it are caught by the live stream.
+        // The two ranges may overlap at the boundary; OnChainTrade
+        // deduplicates by (tx_hash, log_index).
+        let cutoff_block = provider.get_block_number().await?;
+        let from_block = backfill_start_block(&self.pool, &self.evm_ctx).await?;
+
+        if from_block <= cutoff_block {
+            info!(
+                from_block,
+                cutoff_block, "Enqueuing backfill range for missed events on (re)connect"
+            );
+
+            self.backfill_queue
+                .push(BackfillRange {
+                    from_block,
+                    to_block: cutoff_block,
+                })
+                .await?;
+        } else {
+            debug!(
+                from_block,
+                cutoff_block, "Already caught up on (re)connect; skipping backfill enqueue"
+            );
+        }
 
         self.listen(clear_stream, take_stream).await
     }
 }
 
+/// Tracks the highest block observed on each WS subscription so the
+/// reconnect-time backfill checkpoint only advances past blocks that
+/// both streams have crossed. `listen()` merges two unordered
+/// subscriptions; advancing solely from the latest event would risk
+/// skipping straggling events on the other stream when a future
+/// backfill resumes from `checkpoint+1`.
+#[derive(Default)]
+struct StreamWatermarks {
+    clear_high: Option<u64>,
+    take_high: Option<u64>,
+}
+
+impl StreamWatermarks {
+    fn observe(&mut self, event: &RaindexTradeEvent, block: u64) {
+        let slot = match event {
+            RaindexTradeEvent::ClearV3(_) => &mut self.clear_high,
+            RaindexTradeEvent::TakeOrderV3(_) => &mut self.take_high,
+        };
+        *slot = Some(slot.map_or(block, |existing| existing.max(block)));
+    }
+
+    /// The highest block both streams have provably crossed. Returns
+    /// `None` until at least one event has been observed on each stream.
+    fn safe_advance_to(&self) -> Option<u64> {
+        self.clear_high
+            .zip(self.take_high)
+            .and_then(|(clear, take)| clear.min(take).checked_sub(1))
+    }
+}
+
 impl OrderFillMonitor {
-    async fn listen(
+    async fn listen<ClearEvents, TakeOrderEvents>(
         &mut self,
-        mut clear_stream: impl Stream<
-            Item = Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>,
-        > + Unpin,
-        mut take_stream: impl Stream<
-            Item = Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>,
-        > + Unpin,
-    ) -> TaskResult {
+        clear_stream: &mut ClearEvents,
+        take_stream: &mut TakeOrderEvents,
+    ) -> TaskResult
+    where
+        ClearEvents:
+            Stream<Item = Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>> + Unpin,
+        TakeOrderEvents:
+            Stream<Item = Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>> + Unpin,
+    {
+        let mut watermarks = StreamWatermarks::default();
         loop {
             let (event, log) = tokio::select! {
                 item = clear_stream.next() => {
@@ -134,7 +213,8 @@ impl OrderFillMonitor {
                 }
             };
 
-            self.enqueue_trade_event(event, &log).await?;
+            self.enqueue_trade_event(event, &log, &mut watermarks)
+                .await?;
         }
     }
 
@@ -142,6 +222,7 @@ impl OrderFillMonitor {
         &mut self,
         event: RaindexTradeEvent,
         log: &alloy::rpc::types::Log,
+        watermarks: &mut StreamWatermarks,
     ) -> TaskResult {
         let trade_event = match EmittedOnChain::<RaindexTradeEvent>::from_log(event, log) {
             Ok(trade_event) => trade_event,
@@ -151,6 +232,8 @@ impl OrderFillMonitor {
             }
         };
 
+        let block_number = trade_event.block_number;
+
         trace!(
             target: "hedge",
             tx_hash = ?trade_event.tx_hash,
@@ -158,9 +241,21 @@ impl OrderFillMonitor {
             "Enqueuing trade accounting job"
         );
 
+        watermarks.observe(&trade_event.event, block_number);
+
         self.job_queue
             .push(AccountForDexTrade { trade: trade_event })
             .await?;
+
+        // Apalis storage now durably owns this event. Only advance the
+        // checkpoint past blocks that both streams have crossed --
+        // otherwise a straggling event on the slower stream could be
+        // skipped when a future backfill resumes from `checkpoint+1`.
+        // The checkpoint is monotonic via `MAX(...)` upsert, so calling
+        // `save_backfill_checkpoint` with a stale value is harmless.
+        if let Some(advance_to) = watermarks.safe_advance_to() {
+            save_backfill_checkpoint(&self.pool, &self.evm_ctx, advance_to).await?;
+        }
 
         Ok(())
     }
@@ -184,24 +279,22 @@ mod tests {
             .unwrap()
     }
 
-    async fn create_test_monitor_with_pool() -> (OrderFillMonitor, SqlitePool) {
+    async fn create_test_monitor_with_pool() -> (OrderFillMonitor, SqlitePool, EvmCtx) {
         let pool = setup_test_db().await;
         setup_apalis_tables(&pool).await.unwrap();
         let job_queue = DexTradeAccountingJobQueue::new(&pool);
+        let backfill_queue = BackfillJobQueue::new(&pool);
 
-        let dex_streams = DexEventStreams {
-            clear: Box::pin(stream::empty()),
-            take: Box::pin(stream::empty()),
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: url::Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: Address::ZERO,
+            deployment_block: 1,
         };
 
-        let monitor = OrderFillMonitor::new(
-            Url::parse("ws://localhost:8545").unwrap(),
-            Address::ZERO,
-            job_queue,
-            dex_streams,
-        );
+        let monitor =
+            OrderFillMonitor::new(evm_ctx.clone(), job_queue, backfill_queue, pool.clone());
 
-        (monitor, pool)
+        (monitor, pool, evm_ctx)
     }
 
     fn test_clear_event() -> ClearV3 {
@@ -231,40 +324,42 @@ mod tests {
 
     #[tokio::test]
     async fn listen_enqueues_clear_event() {
-        let (mut monitor, pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, pool, _evm_ctx) = create_test_monitor_with_pool().await;
         let log = create_log(0);
 
-        let clear_stream = stream::iter(vec![Ok((test_clear_event(), log))]);
-        let take_stream = stream::pending();
+        let mut clear_stream = stream::iter(vec![Ok((test_clear_event(), log))]);
+        let mut take_stream =
+            stream::pending::<Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>>();
 
-        let _result = monitor.listen(clear_stream, take_stream).await;
+        let _result = monitor.listen(&mut clear_stream, &mut take_stream).await;
 
         assert_eq!(job_count(&pool).await, 1);
     }
 
     #[tokio::test]
     async fn listen_enqueues_take_event() {
-        let (mut monitor, pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, pool, _evm_ctx) = create_test_monitor_with_pool().await;
         let log = create_log(1);
 
-        let clear_stream = stream::pending();
-        let take_stream = stream::iter(vec![Ok((test_take_event(), log))]);
+        let mut clear_stream =
+            stream::pending::<Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>>();
+        let mut take_stream = stream::iter(vec![Ok((test_take_event(), log))]);
 
-        let _result = monitor.listen(clear_stream, take_stream).await;
+        let _result = monitor.listen(&mut clear_stream, &mut take_stream).await;
 
         assert_eq!(job_count(&pool).await, 1);
     }
 
     #[tokio::test]
     async fn listen_returns_error_when_both_streams_empty() {
-        let (mut monitor, _pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, _pool, _evm_ctx) = create_test_monitor_with_pool().await;
 
-        let clear_stream =
+        let mut clear_stream =
             stream::empty::<Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>>();
-        let take_stream =
+        let mut take_stream =
             stream::empty::<Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>>();
 
-        let result = monitor.listen(clear_stream, take_stream).await;
+        let result = monitor.listen(&mut clear_stream, &mut take_stream).await;
 
         let error = result
             .unwrap_err()
@@ -275,13 +370,13 @@ mod tests {
 
     #[tokio::test]
     async fn listen_returns_error_when_clear_stream_closes() {
-        let (mut monitor, _pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, _pool, _evm_ctx) = create_test_monitor_with_pool().await;
 
-        let clear_stream =
+        let mut clear_stream =
             stream::empty::<Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>>();
-        let take_stream = stream::pending();
+        let mut take_stream = stream::pending();
 
-        let result = monitor.listen(clear_stream, take_stream).await;
+        let result = monitor.listen(&mut clear_stream, &mut take_stream).await;
 
         let error = result
             .unwrap_err()
@@ -295,13 +390,13 @@ mod tests {
 
     #[tokio::test]
     async fn listen_returns_error_when_take_stream_closes() {
-        let (mut monitor, _pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, _pool, _evm_ctx) = create_test_monitor_with_pool().await;
 
-        let clear_stream = stream::pending();
-        let take_stream =
+        let mut clear_stream = stream::pending();
+        let mut take_stream =
             stream::empty::<Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>>();
 
-        let result = monitor.listen(clear_stream, take_stream).await;
+        let result = monitor.listen(&mut clear_stream, &mut take_stream).await;
 
         let error = result
             .unwrap_err()
@@ -315,18 +410,22 @@ mod tests {
 
     #[tokio::test]
     async fn enqueue_trade_event_persists_to_storage() {
-        let (mut monitor, pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, pool, _evm_ctx) = create_test_monitor_with_pool().await;
         let log = create_log(42);
         let event = RaindexTradeEvent::ClearV3(Box::new(test_clear_event()));
+        let mut watermarks = StreamWatermarks::default();
 
-        monitor.enqueue_trade_event(event, &log).await.unwrap();
+        monitor
+            .enqueue_trade_event(event, &log, &mut watermarks)
+            .await
+            .unwrap();
 
         assert_eq!(job_count(&pool).await, 1);
     }
 
     #[tokio::test]
     async fn enqueue_trade_event_survives_invalid_log() {
-        let (mut monitor, pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, pool, _evm_ctx) = create_test_monitor_with_pool().await;
 
         let invalid_log = alloy::rpc::types::Log {
             inner: alloy::primitives::Log {
@@ -343,9 +442,10 @@ mod tests {
         };
 
         let event = RaindexTradeEvent::ClearV3(Box::new(test_clear_event()));
+        let mut watermarks = StreamWatermarks::default();
 
         monitor
-            .enqueue_trade_event(event, &invalid_log)
+            .enqueue_trade_event(event, &invalid_log, &mut watermarks)
             .await
             .unwrap();
 
@@ -354,26 +454,236 @@ mod tests {
 
     #[tokio::test]
     async fn listen_processes_events_from_both_streams() {
-        let (mut monitor, pool) = create_test_monitor_with_pool().await;
+        let (mut monitor, pool, _evm_ctx) = create_test_monitor_with_pool().await;
 
         let clear_log = create_log(0);
         let take_log = create_log(1);
 
-        // Chain with stream::pending() so streams don't close after yielding
-        // their item — avoids a tokio::select! race where the exhausted stream
-        // is polled before the other stream's item is consumed.
-        let clear_stream =
+        let mut clear_stream =
             stream::iter(vec![Ok((test_clear_event(), clear_log))]).chain(stream::pending());
-        let take_stream =
+        let mut take_stream =
             stream::iter(vec![Ok((test_take_event(), take_log))]).chain(stream::pending());
 
-        // listen blocks on the now-pending streams after processing both events
         let _ = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
-            monitor.listen(clear_stream, take_stream),
+            std::time::Duration::from_millis(50),
+            monitor.listen(&mut clear_stream, &mut take_stream),
         )
         .await;
 
         assert_eq!(job_count(&pool).await, 2);
+    }
+
+    fn log_at_block(block_number: u64) -> alloy::rpc::types::Log {
+        alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: Address::ZERO,
+                data: alloy::primitives::LogData::empty(),
+            },
+            block_hash: None,
+            block_number: Some(block_number),
+            block_timestamp: None,
+            transaction_hash: Some(alloy::primitives::B256::ZERO),
+            transaction_index: None,
+            log_index: Some(0),
+            removed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_trade_event_does_not_advance_until_both_streams_observed() {
+        let (mut monitor, pool, evm_ctx) = create_test_monitor_with_pool().await;
+        let log = log_at_block(100);
+        let event = RaindexTradeEvent::ClearV3(Box::new(test_clear_event()));
+        let mut watermarks = StreamWatermarks::default();
+
+        monitor
+            .enqueue_trade_event(event, &log, &mut watermarks)
+            .await
+            .unwrap();
+
+        let checkpoint = crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            checkpoint, None,
+            "checkpoint must not advance until both streams have crossed a block"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_trade_event_advances_to_min_of_both_streams() {
+        let (mut monitor, pool, evm_ctx) = create_test_monitor_with_pool().await;
+        let mut watermarks = StreamWatermarks::default();
+
+        let clear_log = log_at_block(200);
+        let take_log = log_at_block(150);
+
+        monitor
+            .enqueue_trade_event(
+                RaindexTradeEvent::ClearV3(Box::new(test_clear_event())),
+                &clear_log,
+                &mut watermarks,
+            )
+            .await
+            .unwrap();
+
+        // Only clear stream observed: no advance.
+        assert_eq!(
+            crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+                .await
+                .unwrap(),
+            None
+        );
+
+        monitor
+            .enqueue_trade_event(
+                RaindexTradeEvent::TakeOrderV3(Box::new(test_take_event())),
+                &take_log,
+                &mut watermarks,
+            )
+            .await
+            .unwrap();
+
+        // Both observed: advance to min(200, 150) - 1 = 149.
+        assert_eq!(
+            crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+                .await
+                .unwrap(),
+            Some(149),
+            "checkpoint must advance to min(clear_high, take_high) - 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_trade_event_checkpoint_is_monotonic() {
+        let (mut monitor, pool, evm_ctx) = create_test_monitor_with_pool().await;
+        let mut watermarks = StreamWatermarks::default();
+
+        // Establish initial frontier at block 200 on both streams.
+        monitor
+            .enqueue_trade_event(
+                RaindexTradeEvent::ClearV3(Box::new(test_clear_event())),
+                &log_at_block(200),
+                &mut watermarks,
+            )
+            .await
+            .unwrap();
+        monitor
+            .enqueue_trade_event(
+                RaindexTradeEvent::TakeOrderV3(Box::new(test_take_event())),
+                &log_at_block(200),
+                &mut watermarks,
+            )
+            .await
+            .unwrap();
+
+        // An out-of-order earlier event must not rewind the checkpoint.
+        monitor
+            .enqueue_trade_event(
+                RaindexTradeEvent::ClearV3(Box::new(test_clear_event())),
+                &log_at_block(50),
+                &mut watermarks,
+            )
+            .await
+            .unwrap();
+
+        let checkpoint = crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            checkpoint,
+            Some(199),
+            "checkpoint must never rewind when an out-of-order event is observed"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_and_listen_enqueues_backfill_for_disconnect_window() {
+        // RAI-198 repro: when the monitor (re)connects, it must
+        // enqueue a BackfillRange covering (checkpoint+1, cutoff)
+        // so events emitted during the WS disconnect window are
+        // recovered. Pre-fix: no BackfillRange is enqueued and
+        // those events are silently dropped.
+        let (mut monitor, pool, evm_ctx) = create_test_monitor_with_pool().await;
+
+        // Simulate prior progress: live monitor processed events up
+        // through block 99 before the disconnect.
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
+            .await
+            .unwrap();
+
+        // Mock provider returns block 105 from `eth_blockNumber`,
+        // which the monitor will use as the cutoff.
+        let asserter = alloy::providers::mock::Asserter::new();
+        asserter.push_success(&serde_json::Value::from(105_u64));
+        let provider = alloy::providers::ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let mut clear_stream =
+            stream::empty::<Result<(ClearV3, alloy::rpc::types::Log), sol_types::Error>>();
+        let mut take_stream =
+            stream::empty::<Result<(TakeOrderV3, alloy::rpc::types::Log), sol_types::Error>>();
+
+        // prepare_and_listen returns Err(StreamsClosed) once it falls
+        // through to the listen loop with empty streams; we don't
+        // care about that -- we only care that the backfill job was
+        // enqueued before the listen loop starts.
+        let _ = monitor
+            .prepare_and_listen(&provider, &mut clear_stream, &mut take_stream)
+            .await;
+
+        let job_count = job_count(&pool).await;
+        assert_eq!(
+            job_count, 1,
+            "exactly one job (the BackfillRange) must be enqueued on reconnect"
+        );
+
+        let job_payload = sqlx::query_scalar::<_, Vec<u8>>(
+            "SELECT job FROM Jobs WHERE job_type LIKE '%BackfillRange%'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let job: BackfillRange = serde_json::from_slice(&job_payload).unwrap();
+        assert_eq!(job.from_block, 100, "backfill must resume after checkpoint");
+        assert_eq!(job.to_block, 105, "backfill must extend up to the cutoff");
+    }
+
+    #[tokio::test]
+    async fn enqueue_trade_event_does_not_advance_on_invalid_log() {
+        let (mut monitor, pool, evm_ctx) = create_test_monitor_with_pool().await;
+
+        let invalid_log = alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: Address::ZERO,
+                data: alloy::primitives::LogData::empty(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        };
+
+        let event = RaindexTradeEvent::ClearV3(Box::new(test_clear_event()));
+        let mut watermarks = StreamWatermarks::default();
+
+        monitor
+            .enqueue_trade_event(event, &invalid_log, &mut watermarks)
+            .await
+            .unwrap();
+
+        let checkpoint = crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            checkpoint, None,
+            "checkpoint must not advance when the log lacks block metadata"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use tokio::task::{AbortHandle, JoinError, JoinHandle};
 use tracing::{error, info};
 
 use st0x_dto::Statement;
-use st0x_execution::{Executor, MockExecutorCtx, TryIntoExecutor};
+use st0x_execution::MockExecutorCtx;
 
 use crate::config::{BrokerCtx, Ctx};
 
@@ -144,7 +144,14 @@ async fn await_shutdown(
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            handle_ctrl_c(&server_abort, &bot_abort);
+            info!(
+                target: "startup",
+                "Received shutdown signal, shutting down gracefully..."
+            );
+
+            abort_task("server", &server_abort);
+            abort_task("bot", &bot_abort);
+
             Ok(())
         }
         result = server_task => {
@@ -156,12 +163,6 @@ async fn await_shutdown(
             check_bot_result(result)
         }
     }
-}
-
-fn handle_ctrl_c(server_abort: &AbortHandle, bot_abort: &AbortHandle) {
-    info!(target: "startup", "Received shutdown signal, shutting down gracefully...");
-    abort_task("server", server_abort);
-    abort_task("bot", bot_abort);
 }
 
 fn abort_task(name: &str, handle: &AbortHandle) {
@@ -213,7 +214,30 @@ async fn run_conductor_session(
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
 ) -> anyhow::Result<()> {
-    let result = Box::pin(dispatch_to_executor(ctx, pool, event_sender, inventory)).await;
+    let result = match ctx.broker.clone() {
+        BrokerCtx::DryRun => {
+            info!(target: "startup", "Initializing test executor for dry-run mode");
+            Box::pin(conductor::Conductor::run(
+                MockExecutorCtx,
+                ctx,
+                pool,
+                event_sender,
+                inventory,
+            ))
+            .await
+        }
+        BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
+            info!(target: "startup", "Initializing Alpaca Broker API executor");
+            Box::pin(conductor::Conductor::run(
+                alpaca_auth,
+                ctx,
+                pool,
+                event_sender,
+                inventory,
+            ))
+            .await
+        }
+    };
 
     match result {
         Ok(()) => {
@@ -223,32 +247,6 @@ async fn run_conductor_session(
         Err(error) => {
             error!(target: "startup", %error, "Bot session failed");
             Err(error)
-        }
-    }
-}
-
-async fn dispatch_to_executor(
-    ctx: Ctx,
-    pool: SqlitePool,
-    event_sender: broadcast::Sender<Statement>,
-    inventory: Arc<inventory::BroadcastingInventory>,
-) -> anyhow::Result<()> {
-    match ctx.broker.clone() {
-        BrokerCtx::DryRun => {
-            info!(target: "startup", "Initializing test executor for dry-run mode");
-            let executor = MockExecutorCtx.try_into_executor().await?;
-            let maintenance = executor.run_executor_maintenance().await;
-
-            conductor::Conductor::run(executor, ctx, pool, maintenance, event_sender, inventory)
-                .await
-        }
-        BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
-            info!(target: "startup", "Initializing Alpaca Broker API executor");
-            let executor = alpaca_auth.try_into_executor().await?;
-            let maintenance = executor.run_executor_maintenance().await;
-
-            conductor::Conductor::run(executor, ctx, pool, maintenance, event_sender, inventory)
-                .await
         }
     }
 }

--- a/src/offchain/order_poller.rs
+++ b/src/offchain/order_poller.rs
@@ -58,6 +58,43 @@ impl Default for OrderPollerCtx {
     }
 }
 
+/// Builds the cron-driven order-status poller worker. See
+/// `build_order_fill_worker!` in `trade_accountant` for the rationale
+/// behind the macro form.
+macro_rules! build_order_poller_worker {
+    (
+        $index:expr,
+        $poller:expr,
+        $schedule:expr,
+        $fail_stop:expr,
+        $failure_notify:expr,
+        $exec:ty $(,)?
+    ) => {{
+        use ::apalis::layers::WorkerBuilderExt;
+        use ::apalis::layers::retry::RetryPolicy;
+        use ::apalis::prelude::WorkerBuilder;
+        use ::apalis_core::worker::ext::circuit_breaker::CircuitBreaker;
+        use ::apalis_core::worker::ext::event_listener::EventListenerExt;
+        use ::apalis_cron::CronStream;
+
+        WorkerBuilder::new(format!("order-poller-{}", $index))
+            .backend(CronStream::new($schedule))
+            .data($poller)
+            .concurrency(1)
+            .retry(
+                RetryPolicy::retries(3).with_backoff($crate::conductor::job::RETRY_BACKOFF.clone()),
+            )
+            .break_circuit_with($fail_stop)
+            .on_event($crate::conductor::job::on_terminal_failure(
+                $failure_notify,
+                "Order poller failed after retries",
+            ))
+            .build($crate::conductor::job::poll_orders::<$exec>)
+    }};
+}
+
+pub(crate) use build_order_poller_worker;
+
 #[derive(Clone)]
 pub struct OrderStatusPoller<E: Executor + Clone> {
     ctx: OrderPollerCtx,

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -11,16 +11,23 @@ use alloy::sol_types::SolEvent;
 use backon::{BackoffBuilder, ExponentialBuilder, Retryable};
 use futures_util::future;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::time::Duration;
 use tracing::{debug, info, trace, warn};
 
+use st0x_evm::Evm;
+use st0x_execution::Executor;
+
 use super::EvmCtx;
 use super::OnChainError;
 use crate::bindings::IOrderBookV6::{ClearV3, TakeOrderV3};
+use crate::conductor::job::{Job, Label};
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::trading::onchain::inclusion::EmittedOnChain;
-use crate::trading::onchain::trade_accountant::{AccountForDexTrade, DexTradeAccountingJobQueue};
+use crate::trading::onchain::trade_accountant::{
+    AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
+};
 
 pub(crate) fn get_backfill_retry_strat() -> ExponentialBuilder {
     const BACKFILL_MAX_RETRIES: usize = 15;
@@ -34,6 +41,12 @@ pub(crate) fn get_backfill_retry_strat() -> ExponentialBuilder {
         .with_jitter()
 }
 
+/// Loads the checkpoint and backfills up to `end_block`. Retained
+/// for tests that exercise the "resume from checkpoint" branch
+/// alongside the batched fetch logic. Production code uses
+/// [`BackfillRange`] (and thus [`backfill_range`]) directly via the
+/// monitor.
+#[cfg(test)]
 #[tracing::instrument(
     target = "orderbook",
     skip(provider, evm_ctx, pool, retry_strategy, job_queue),
@@ -50,57 +63,142 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
 ) -> Result<(), OnChainError> {
     let start_block = backfill_start_block(pool, evm_ctx).await?;
 
-    if start_block > end_block {
+    backfill_range(
+        provider,
+        evm_ctx,
+        pool,
+        start_block,
+        end_block,
+        retry_strategy,
+        job_queue,
+    )
+    .await
+}
+
+/// Fetches `ClearV3` / `TakeOrderV3` logs in `[from_block, to_block]`,
+/// pushes an `AccountForDexTrade` job for each, and advances the
+/// backfill checkpoint to `to_block` on success.
+///
+/// Skips RPC calls when `from_block > to_block` (already caught up),
+/// but still moves the checkpoint forward so a stale row does not
+/// cause repeated no-op fetches.
+#[tracing::instrument(
+    target = "orderbook",
+    skip(provider, evm_ctx, pool, retry_strategy, job_queue),
+    fields(from_block, to_block),
+    level = tracing::Level::INFO,
+)]
+pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clone>(
+    provider: &P,
+    evm_ctx: &EvmCtx,
+    pool: &SqlitePool,
+    from_block: u64,
+    to_block: u64,
+    retry_strategy: B,
+    job_queue: DexTradeAccountingJobQueue,
+) -> Result<(), OnChainError> {
+    if from_block > to_block {
         info!(
             target: "orderbook",
             "Already caught up to block {}, skipping backfill",
-            end_block
+            to_block
         );
 
-        save_backfill_checkpoint(pool, evm_ctx, end_block).await?;
+        save_backfill_checkpoint(pool, evm_ctx, to_block).await?;
         return Ok(());
     }
 
-    let total_blocks = end_block - start_block + 1;
+    let total_blocks = to_block - from_block + 1;
 
     info!(
         target: "orderbook",
         "Backfilling from block {} to {} ({} blocks)",
-        start_block, end_block, total_blocks
+        from_block, to_block, total_blocks
     );
 
-    let batch_ranges = generate_batch_ranges(start_block, end_block);
+    let batch_ranges = generate_batch_ranges(from_block, to_block);
 
-    let batch_tasks = batch_ranges
-        .into_iter()
-        .map(|(batch_start, batch_end)| {
-            enqueue_batch_events(
-                provider,
-                evm_ctx,
-                batch_start,
-                batch_end,
-                retry_strategy.clone(),
-                job_queue.clone(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let batch_results = future::join_all(batch_tasks).await;
-
-    let total_enqueued = batch_results
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .sum::<usize>();
+    let mut total_enqueued: usize = 0;
+    for (batch_start, batch_end) in batch_ranges {
+        let enqueued = enqueue_batch_events(
+            provider,
+            evm_ctx,
+            batch_start,
+            batch_end,
+            retry_strategy.clone(),
+            job_queue.clone(),
+        )
+        .await?;
+        total_enqueued += enqueued;
+    }
 
     info!(target: "orderbook", total_enqueued, "Backfill completed");
 
-    save_backfill_checkpoint(pool, evm_ctx, end_block).await?;
+    save_backfill_checkpoint(pool, evm_ctx, to_block).await?;
 
     Ok(())
 }
 
-async fn backfill_start_block(pool: &SqlitePool, evm_ctx: &EvmCtx) -> Result<u64, OnChainError> {
+/// Persistent job queue for backfill jobs.
+pub(crate) type BackfillJobQueue = crate::conductor::job::JobQueue<BackfillRange>;
+
+/// Apalis job that backfills missed `ClearV3` / `TakeOrderV3` events
+/// between `from_block` and `to_block` (inclusive).
+///
+/// Enqueued by `OrderFillMonitor::run` on every (re)connect to cover
+/// the gap between the previously checkpointed block and the cutoff
+/// of the new WebSocket subscription. Job durability via apalis
+/// storage means a crash mid-backfill is retried automatically.
+///
+/// Assumes the startup WS provider from `Conductor::run` (used here
+/// via `ctx.evm.provider()`) stays usable for `eth_getLogs` — backfill
+/// does not pick up the fresh provider that `OrderFillMonitor` opens
+/// on reconnect. Apalis retries plus the conductor restart loop
+/// provide defense in depth if that assumption breaks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BackfillRange {
+    pub(crate) from_block: u64,
+    pub(crate) to_block: u64,
+}
+
+impl<Node, Exec> Job<AccountantCtx<Node, Exec>> for BackfillRange
+where
+    Node: Provider + Clone + Send + Sync + 'static,
+    Exec: Executor + Clone + Send + Sync + 'static,
+    TradeAccountingError: From<Exec::Error>,
+{
+    type Output = ();
+    type Error = OnChainError;
+
+    const WORKER_NAME: &'static str = "backfill-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::Backfill;
+
+    fn label(&self) -> Label {
+        Label::new(format!(
+            "BackfillRange:{}:{}",
+            self.from_block, self.to_block
+        ))
+    }
+
+    async fn perform(&self, ctx: &AccountantCtx<Node, Exec>) -> Result<Self::Output, Self::Error> {
+        backfill_range(
+            ctx.evm.provider(),
+            &ctx.ctx.evm,
+            &ctx.pool,
+            self.from_block,
+            self.to_block,
+            get_backfill_retry_strat(),
+            ctx.job_queue.clone(),
+        )
+        .await
+    }
+}
+
+pub(crate) async fn backfill_start_block(
+    pool: &SqlitePool,
+    evm_ctx: &EvmCtx,
+) -> Result<u64, OnChainError> {
     load_backfill_checkpoint(pool, evm_ctx)
         .await?
         .map_or(Ok(evm_ctx.deployment_block), |last_processed_block| {
@@ -108,7 +206,7 @@ async fn backfill_start_block(pool: &SqlitePool, evm_ctx: &EvmCtx) -> Result<u64
         })
 }
 
-async fn load_backfill_checkpoint(
+pub(crate) async fn load_backfill_checkpoint(
     pool: &SqlitePool,
     evm_ctx: &EvmCtx,
 ) -> Result<Option<u64>, OnChainError> {
@@ -124,7 +222,7 @@ async fn load_backfill_checkpoint(
         .map_err(OnChainError::IntConversion)
 }
 
-async fn save_backfill_checkpoint(
+pub(crate) async fn save_backfill_checkpoint(
     pool: &SqlitePool,
     evm_ctx: &EvmCtx,
     last_processed_block: u64,

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -45,7 +45,12 @@ pub(crate) struct PlaceHedge {
 }
 
 impl Job<HedgeCtx> for PlaceHedge {
+    type Output = ();
     type Error = TradeAccountingError;
+
+    const WORKER_NAME: &'static str = "hedge-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::Hedge;
 
     fn label(&self) -> Label {
         Label::new(format!(
@@ -54,7 +59,7 @@ impl Job<HedgeCtx> for PlaceHedge {
         ))
     }
 
-    async fn perform(&self, ctx: &HedgeCtx) -> Result<(), Self::Error> {
+    async fn perform(&self, ctx: &HedgeCtx) -> Result<Self::Output, Self::Error> {
         // Only specific business rejections are safe to swallow:
         // - PendingExecution: another hedge already claimed this
         //   position — idempotent, no action needed.

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -10,6 +10,7 @@ use alloy::primitives::{Address, IntoLogData};
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -53,6 +54,8 @@ pub(crate) struct AccountantCtx<Node, Exec> {
     pub(crate) cqrs: TradeProcessingCqrs,
     pub(crate) vault_registry: Arc<Store<VaultRegistry>>,
     pub(crate) executor: Exec,
+    pub(crate) pool: SqlitePool,
+    pub(crate) job_queue: DexTradeAccountingJobQueue,
 }
 
 impl<Node, Exec> Job<AccountantCtx<Node, Exec>> for AccountForDexTrade
@@ -61,7 +64,12 @@ where
     Exec: Executor + Clone + Send + 'static,
     TradeAccountingError: From<Exec::Error>,
 {
+    type Output = ();
     type Error = TradeAccountingError;
+
+    const WORKER_NAME: &'static str = "order-fill-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::OrderFill;
 
     fn label(&self) -> Label {
         let EmittedOnChain {
@@ -75,7 +83,7 @@ where
     }
 
     #[allow(clippy::cognitive_complexity)]
-    async fn perform(&self, ctx: &AccountantCtx<Node, Exec>) -> Result<(), Self::Error> {
+    async fn perform(&self, ctx: &AccountantCtx<Node, Exec>) -> Result<Self::Output, Self::Error> {
         use RaindexTradeEvent::{ClearV3, TakeOrderV3};
 
         let trade_event = &self.trade;
@@ -319,6 +327,8 @@ mod tests {
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
 
+        let job_queue = DexTradeAccountingJobQueue::new(&pool);
+
         let accountant_ctx = AccountantCtx {
             orderbook: ctx.evm.orderbook,
             ctx,
@@ -328,6 +338,8 @@ mod tests {
             cqrs,
             vault_registry,
             executor,
+            pool: pool.clone(),
+            job_queue,
         };
 
         let job = test_job();
@@ -441,6 +453,8 @@ mod tests {
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
 
+        let job_queue = DexTradeAccountingJobQueue::new(&pool);
+
         let accountant_ctx = AccountantCtx {
             orderbook: ctx.evm.orderbook,
             ctx,
@@ -450,6 +464,8 @@ mod tests {
             cqrs,
             vault_registry,
             executor,
+            pool: pool.clone(),
+            job_queue,
         };
 
         // Should succeed (skip) rather than error.

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -575,6 +575,12 @@ async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::
     )
     .await;
 
+    // Redemption is driven by the inventory poller observing the
+    // post-take vault balance, so it can complete before the bot has
+    // processed the TakeOrderV3 event and placed its hedge. Wait for
+    // the position to settle so broker assertions are deterministic.
+    poll_for_hedge_completion(&mut bot, &infra.db_path, "AAPL", Duration::from_secs(30)).await;
+
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
         .amount(trade_amount)
@@ -959,6 +965,17 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
         .start_deposit_watcher(eth_deposit_provider, USDC_ETHEREUM, infra.base_chain.owner)
         .await?;
 
+    // Capture the Ethereum USDC balance before spawning the bot, so the
+    // baseline cannot include CCTP mints from a rebalance that fires
+    // shortly after startup. The bot is the only thing that triggers
+    // the CCTP receiveMessage on Ethereum, so its absence here pins the
+    // baseline to the pristine pre-test state.
+    let ethereum_usdc_balance_before_rebalance =
+        crate::base_chain::IERC20::new(USDC_ETHEREUM, &eth_balance_provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+
     let current_block = infra.base_chain.provider.get_block_number().await?;
     let reserved = Positive::new(Usd::new(float!(3000)))?;
     let ctx = build_usdc_rebalancing_ctx()
@@ -997,12 +1014,6 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
         })
         .expect("at least one take should touch the USDC input vault")
         .input_vault_balance_before_take;
-
-    let ethereum_usdc_balance_before_rebalance =
-        crate::base_chain::IERC20::new(USDC_ETHEREUM, &eth_balance_provider)
-            .balanceOf(infra.base_chain.owner)
-            .call()
-            .await?;
 
     poll_for_events_with_timeout(
         &mut bot,


### PR DESCRIPTION
Closes RAI-198.

## What

Introduces a durable `BackfillRange` apalis job and a `BackfillJobQueue` so that events emitted during a WebSocket disconnect window are recovered automatically on every (re)connect. The `OrderFillMonitor` now enqueues a `BackfillRange` covering `(checkpoint+1, cutoff_block)` before entering the live listen loop, rather than performing a one-shot backfill at startup. A `StreamWatermarks` tracker ensures the backfill checkpoint only advances past blocks that both the `ClearV3` and `TakeOrderV3` streams have crossed, preventing straggling events from being silently skipped.

## Why

Previously, backfill was performed once at startup by waiting for the first WebSocket event to determine a cutoff block. Any events emitted while the subscription was unavailable — including across supervisor-driven restarts — were silently dropped. The checkpoint also had no protection against rewinding on out-of-order events.

## How

- `BackfillRange` implements `Job<AccountantCtx>` and is processed by a new `backfill-worker` registered in the apalis `Monitor`. Its `perform` delegates to `backfill_range`, which fetches logs in batches and enqueues `AccountForDexTrade` jobs.
- `OrderFillMonitor::run` no longer consumes pre-established streams. On every invocation it calls `prepare_and_listen`, which reads the current provider head as the cutoff, enqueues a `BackfillRange` durably before any awaitable work, then enters the live listen loop.
- `StreamWatermarks` tracks the per-stream high-water mark and exposes `safe_advance_to` (the minimum of both high-water marks minus one), which gates checkpoint writes so neither stream can be skipped.
- The `Job` trait gains `Output`, `WORKER_NAME`, `TERMINAL_FAILURE_MSG`, and `JOB_KIND` associated items. A `build_supervised_worker!` macro replaces the repeated inline worker-wiring blocks in `builder.rs`.
- `AccountantCtx` now carries a `SqlitePool` and `DexTradeAccountingJobQueue` so `BackfillRange::perform` has everything it needs without additional context types.
- The `get_cutoff_block` / `await_next_block` helpers and the `DexEventStreams` hand-off struct are removed.
- Apalis poll interval is capped at 1 s (100 ms initial, 1 s max backoff) to meet the hedge-placement latency SLO.

## Testing

New unit tests cover:
- Checkpoint does not advance until both streams have been observed.
- Checkpoint advances to `min(clear_high, take_high) - 1` once both streams are observed.
- Checkpoint is monotonic and does not rewind on out-of-order events.
- `prepare_and_listen` enqueues exactly one `BackfillRange` job with the correct `from_block` / `to_block` on reconnect (RAI-198 regression test).
- Checkpoint does not advance when a log lacks block metadata.

E2E tests gain explicit `poll_for_hedge_completion` waits and a pre-bot USDC balance snapshot to eliminate timing-dependent assertion races.

## Summary by CodeRabbit

## Release Notes

- **New Features**
    - Added backfill job queue system for improved on-chain data synchronization and order fill monitoring.
- **Bug Fixes**
    - Enhanced checkpoint management to prevent out-of-order event processing and ensure monotonic progress tracking.
    - Improved reconnection handling with automatic backfill scheduling to catch missed events.
- **Tests**
    - Improved E2E test determinism with better timing and event synchronization validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented persistent checkpoint-based historical event backfill with range support for improved recovery on reconnection.

* **Improvements**
  * Enhanced WebSocket connection handling with automatic backfill gap detection.
  * Restructured conductor initialization for more robust startup flow.
  * Improved job system with better output tracking and enhanced failure handling.
  * Better test reliability for rebalancing and USDC scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->