### PR TITLE
fix: standardize decimal formatting across dashboard (RAI-317)

### DIFF
--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -24,7 +24,7 @@
   type Formatted = { display: string; full: string; truncated: boolean }
 
   const fmtValue = (value: string): Formatted => {
-    const display = trimTrailingZeros(formatDecimal(value, 2))
+    const display = trimTrailingZeros(formatDecimal(value, 3))
     const lossless = trimTrailingZeros(formatDecimal(value, 18))
     const truncated = display !== lossless
     return {

--- a/dashboard/src/lib/components/orders-panel.svelte
+++ b/dashboard/src/lib/components/orders-panel.svelte
@@ -5,7 +5,8 @@
   import { getApiBaseUrl } from '$lib/env'
   /** The REST API proxies an on-chain query that can be slow. */
   const ORDERS_TIMEOUT_MS = 30_000
-  import { formatDecimal, formatTimestamp } from '$lib/format'
+  import { formatDecimal } from '$lib/decimal'
+  import { formatTimestamp } from '$lib/format'
 
   type TokenRef = {
     address: string
@@ -198,11 +199,11 @@
                 <td class="py-2 pr-4 font-medium">{order.inputToken.symbol}</td>
 
                 <td class="py-2 pr-4 text-right font-mono">
-                  {formatDecimal(order.outputVaultBalance)}
+                  {formatDecimal(order.outputVaultBalance, 3)}
                 </td>
 
                 <td class="py-2 pr-4 text-right font-mono">
-                  {formatDecimal(order.ioRatio)}
+                  {formatDecimal(order.ioRatio, 3)}
                 </td>
 
                 <td class="py-2 pr-4">

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -215,12 +215,10 @@
   const directionColor = (direction: string): string =>
     direction === 'Buy' ? 'text-green-500' : 'text-red-500'
 
-  const fmtSize = (value: string): string => {
-    const num = parseFloat(value)
-    if (num === 0) return '0'
-    if (Math.abs(num) < 0.01) return num.toPrecision(2)
-    return num.toFixed(2)
-  }
+  const fmtSize = (value: string): string => formatDecimal(value, 3)
+
+  const isNumeric = (value: unknown): boolean =>
+    typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))
 
   // -- Detail modal state --
 
@@ -525,9 +523,11 @@
                           <span class="text-muted-foreground">{JSON.stringify(value)}</span>
                         {:else if key === 'pyth_price' && typeof value === 'object' && value !== null}
                           {@const pyth = value as Record<string, unknown>}
-                          <span>${formatDecimal(String(pyth['value']), 2)} (conf: {pyth['conf']}, expo: {pyth['expo']})</span>
+                          <span>${formatDecimal(String(pyth['value']), 3)} (conf: {pyth['conf']}, expo: {pyth['expo']})</span>
                         {:else if typeof value === 'object' && value !== null}
                           {JSON.stringify(value)}
+                        {:else if isNumeric(value)}
+                          {formatDecimal(String(value), 3)}
                         {:else}
                           {String(value)}
                         {/if}

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -19,6 +19,9 @@
     detailFields,
   } from '$lib/transfer'
 
+  const isNumeric = (value: unknown): boolean =>
+    typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))
+
   type TransferEntry = {
     kind: string
     id: string
@@ -348,7 +351,7 @@
                 {transfer.kind === 'usdc_bridge' ? 'USDC' : transfer.symbol ?? ''}
               </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs">
-                {#if transfer.quantity}{formatDecimal(transfer.quantity, 2)}{:else if transfer.amount}{formatDecimal(transfer.amount, 2)}{/if}
+                {#if transfer.quantity}{formatDecimal(transfer.quantity, 3)}{:else if transfer.amount}{formatDecimal(transfer.amount, 3)}{/if}
               </Table.Cell>
               <Table.Cell class="text-right text-xs {style.text}">
                 <span class="inline-flex items-center gap-1.5">
@@ -421,11 +424,11 @@
         </span>
         {#if transfer.quantity}
           <span class="font-mono text-xs font-normal text-muted-foreground">
-            {formatDecimal(transfer.quantity, 2)}
+            {formatDecimal(transfer.quantity, 3)}
           </span>
         {:else if transfer.amount}
           <span class="font-mono text-xs font-normal text-muted-foreground">
-            {formatDecimal(transfer.amount, 2)}
+            {formatDecimal(transfer.amount, 3)}
           </span>
         {/if}
       </div>
@@ -484,6 +487,8 @@
                               {:else}
                                 {JSON.stringify(value)}
                               {/if}
+                            {:else if isNumeric(value)}
+                              {formatDecimal(String(value), 3)}
                             {:else}
                               {String(value)}
                             {/if}
@@ -523,6 +528,8 @@
                           {/if}
                         {:else if typeof value === 'object' && value !== null}
                           {JSON.stringify(value)}
+                        {:else if isNumeric(value)}
+                          {formatDecimal(String(value), 3)}
                         {:else}
                           {String(value)}
                         {/if}

--- a/dashboard/src/lib/format.test.ts
+++ b/dashboard/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatBalance, formatDecimal, formatTimestamp } from './format'
+import { formatBalance, formatTimestamp } from './format'
 
 describe('formatBalance', () => {
   it('returns "0" for empty string', () => {
@@ -36,42 +36,6 @@ describe('formatBalance', () => {
 
   it('handles large values', () => {
     expect(formatBalance('100000000000000000000000', 18)).toBe('100000')
-  })
-})
-
-describe('formatDecimal', () => {
-  it('returns "0" for empty or zero', () => {
-    expect(formatDecimal('')).toBe('0')
-    expect(formatDecimal('0')).toBe('0')
-  })
-
-  it('returns non-numeric strings as-is', () => {
-    expect(formatDecimal('abc')).toBe('abc')
-  })
-
-  it('trims excessive decimals on values >= 1', () => {
-    expect(formatDecimal('1993.82413955615987854')).toBe('1993.82414')
-  })
-
-  it('trims trailing zeros', () => {
-    expect(formatDecimal('100.500000')).toBe('100.5')
-  })
-
-  it('handles integers', () => {
-    expect(formatDecimal('42')).toBe('42')
-  })
-
-  it('preserves significant digits for tiny values', () => {
-    expect(formatDecimal('0.00000000000010996')).toBe('1.0996e-13')
-  })
-
-  it('formats normal small values', () => {
-    expect(formatDecimal('0.123456789')).toBe('0.123457')
-  })
-
-  it('handles IO ratio style values', () => {
-    expect(formatDecimal('180.79830445')).toBe('180.798304')
-    expect(formatDecimal('0.5')).toBe('0.5')
   })
 })
 

--- a/dashboard/src/lib/format.ts
+++ b/dashboard/src/lib/format.ts
@@ -13,32 +13,6 @@ export const formatBalance = (raw: string, decimals: number): string => {
   return trimmed ? `${intPart}.${trimmed}` : intPart
 }
 
-/// Formats a decimal string for display by rounding to a sensible number
-/// of significant digits. Handles values the upstream API returns as
-/// pre-formatted decimals (e.g. "10.996", "1993.824…").
-///
-/// Rules:
-///  - Values >= 1: show up to 6 decimal places, trim trailing zeros.
-///  - Values < 1: preserve up to 6 significant digits after the leading zeros.
-///  - Non-numeric / empty: returned as-is.
-export const formatDecimal = (value: string): string => {
-  if (!value || value === '0') return '0'
-
-  const num = Number(value)
-  if (Number.isNaN(num)) return value
-
-  if (num === 0) return '0'
-
-  // For values >= 1, fixed 6 decimal places is plenty.
-  if (Math.abs(num) >= 1) {
-    return parseFloat(num.toFixed(6)).toString()
-  }
-
-  // For tiny values (< 1), toFixed(6) would round to "0.000000".
-  // Use toPrecision to keep 6 significant digits instead.
-  return parseFloat(num.toPrecision(6)).toString()
-}
-
 /// Formats a Unix epoch timestamp (seconds) to a UTC datetime string.
 export const formatTimestamp = (epoch: number): string => {
   if (epoch === 0) return '-'


### PR DESCRIPTION
## What

Closes [RAI-317](https://linear.app/makeitrain/issue/RAI-317)

Standardize all dashboard numeric formatting on `formatDecimal(value, 3)` from `$lib/decimal.ts`, removing the competing implementation in `$lib/format.ts`.

## Why

The dashboard had two `formatDecimal` functions with different signatures and rounding behavior. Some panels showed 2 decimal places, others 6 significant digits, and trade detail modals displayed raw API precision (18+ digits). This made values hard to compare across panels.

## How

- Remove `formatDecimal` from `$lib/format.ts` (auto-rounding, 1-param)
- Switch `orders-panel` import to `$lib/decimal`
- Replace ad-hoc `fmtSize()` in `trade-history-panel` with `formatDecimal`
- Add `isNumeric` guard in trade and transfer detail modals so numeric event payload values get formatted
- Bump `available-inventory` and `transfer-panel` from 2 to 3 decimal places

## Testing

- Removed dead `formatDecimal` tests from `format.test.ts` (function no longer exists)
- Existing `decimal.test.ts` covers the retained implementation
- Manual verification needed for visual formatting across panels

## Anything else

Stacked on `master`. Parent of #634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced numeric display precision across dashboard components—inventory, orders, trade history, and transfer panels now render monetary and quantity values with 3 decimal places for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->