### PR TITLE
fix: display dislocation in USD instead of shares (RAI-315)

### DIFF
--- a/crates/dto/src/position.rs
+++ b/crates/dto/src/position.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use st0x_finance::Symbol;
-use st0x_float_serde::float_string_serde;
+use st0x_float_serde::{float_string_serde, option_float_string_serde};
 
 /// Per-symbol net position.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
@@ -15,4 +15,9 @@ pub struct Position {
     #[serde(with = "float_string_serde")]
     #[ts(type = "string")]
     pub net: Float,
+    /// Last traded price in USDC, used to convert share dislocation to dollar
+    /// values for display alongside USD-denominated hedge thresholds.
+    #[serde(default, with = "option_float_string_serde")]
+    #[ts(type = "string | null")]
+    pub last_price_usdc: Option<Float>,
 }

--- a/crates/dto/src/statement.rs
+++ b/crates/dto/src/statement.rs
@@ -178,6 +178,7 @@ mod tests {
         let msg = Statement::PositionUpdate(Position {
             symbol: Symbol::new("AAPL").unwrap(),
             net: rain_math_float::Float::parse("5.5".to_string()).unwrap(),
+            last_price_usdc: None,
         });
         let json = serde_json::to_value(&msg).expect("serialization should succeed");
         assert_eq!(json["type"], json!("position_update"));

--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -46,7 +46,7 @@
   }
 
   type SortDir = 'asc' | 'desc'
-  type Col = 'asset' | 'alpaca' | 'inflight' | 'raindex' | 'total' | 'ratio' | 'dislocation'
+  type Col = 'asset' | 'alpaca' | 'inflight' | 'raindex' | 'total' | 'ratio' | 'exposure'
   type SortState = { column: Col; dir: SortDir } | null
 
   const sort = reactive<SortState>(null)
@@ -83,8 +83,16 @@
   const formatRatio = (ratio: number): string =>
     `${(ratio * 100).toFixed(1)}%`
 
+  type PositionInfo = { net: number; priceUsdc: number }
+
   const positionMap = $derived(
-    new Map(positions.map((position) => [position.symbol, parseFloat(position.net)]))
+    new Map(positions.map((position) => [
+      position.symbol,
+      {
+        net: parseFloat(position.net),
+        priceUsdc: position.last_price_usdc ? parseFloat(position.last_price_usdc) : 0,
+      } satisfies PositionInfo,
+    ]))
   )
 
   type Row = {
@@ -94,7 +102,7 @@
     raindex: Formatted
     total: Formatted
     ratio: number
-    dislocation: number
+    exposure: number
     isCash: boolean
     trading: boolean
   }
@@ -118,7 +126,11 @@
         raindex: fmt(item.onchainAvailable),
         total: fmtValue(totalVal),
         ratio: computeRatio(item.onchainAvailable, item.offchainAvailable),
-        dislocation: positionMap.get(stripped) ?? 0,
+        exposure: (() => {
+          const pos = positionMap.get(stripped)
+          if (!pos) return 0
+          return pos.net * pos.priceUsdc
+        })(),
         isCash: false,
         trading: tradingSet.has(stripped),
       }
@@ -141,7 +153,7 @@
       raindex: fmt(usdc.onchainAvailable),
       total: fmtValue(total),
       ratio: computeRatio(usdc.onchainAvailable, usdc.offchainAvailable),
-      dislocation: 0,
+      exposure: 0,
       isCash: true,
       trading: true,
     }
@@ -154,7 +166,7 @@
     raindex: (lhs, rhs) => decimalCompare(lhs.raindex.full, rhs.raindex.full),
     total: (lhs, rhs) => decimalCompare(lhs.total.full, rhs.total.full),
     ratio: (lhs, rhs) => lhs.ratio - rhs.ratio,
-    dislocation: (lhs, rhs) => lhs.dislocation - rhs.dislocation,
+    exposure: (lhs, rhs) => lhs.exposure - rhs.exposure,
   }
 
   const sortedEquities = $derived.by(() => {
@@ -204,15 +216,14 @@
     return 'text-muted-foreground'
   }
 
-  const isNegligible = (value: number): boolean => Math.abs(value) < 0.001
+  const isNegligible = (value: number): boolean => Math.abs(value) < 0.01
 
-  const fmtDislocation = (value: number): string => {
-    if (value === 0) return '0'
-    if (isNegligible(value)) return '~0'
+  const fmtExposure = (value: number): string => {
+    if (value === 0) return '$0'
+    if (isNegligible(value)) return '~$0'
     const sign = value > 0 ? '+' : '-'
     const abs = Math.abs(value)
-    if (abs < 0.01) return `${sign}${abs.toPrecision(2)}`
-    return `${sign}${abs.toFixed(2)}`
+    return `${sign}$${abs.toFixed(2)}`
   }
 
 </script>
@@ -260,13 +271,13 @@
         </button>
       </Table.Head>
 
-      <Table.Head aria-sort={ariaSort(sort.current, 'dislocation')}>
+      <Table.Head aria-sort={ariaSort(sort.current, 'exposure')}>
         <button
           class="{sortBtnClass} text-left"
-          onclick={toggleSort('dislocation')}
+          onclick={toggleSort('exposure')}
           title="Net directional exposure from counterparty fills"
         >
-          Dislocation{sortIndicator(sort.current, 'dislocation')}
+          Exposure{sortIndicator(sort.current, 'exposure')}
         </button>
       </Table.Head>
     </Table.Row>
@@ -351,11 +362,11 @@
         </Table.Cell>
         <Table.Cell>
           <div class="flex items-center gap-1.5 font-mono text-xs">
-            {#if !isNegligible(row.dislocation) && row.dislocation !== 0}
-              <span class="text-base leading-none {row.dislocation > 0 ? 'text-green-500' : 'text-red-500'}">{row.dislocation > 0 ? '\u25B2' : '\u25BC'}</span>
+            {#if !isNegligible(row.exposure) && row.exposure !== 0}
+              <span class="text-base leading-none {row.exposure > 0 ? 'text-green-500' : 'text-red-500'}">{row.exposure > 0 ? '\u25B2' : '\u25BC'}</span>
             {/if}
-            <span class={row.dislocation === 0 || isNegligible(row.dislocation) ? 'text-muted-foreground' : row.dislocation > 0 ? 'text-green-500' : 'text-red-500'}>
-              {fmtDislocation(row.dislocation)}
+            <span class={row.exposure === 0 || isNegligible(row.exposure) ? 'text-muted-foreground' : row.exposure > 0 ? 'text-green-500' : 'text-red-500'}>
+              {fmtExposure(row.exposure)}
             </span>
           </div>
         </Table.Cell>

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -110,6 +110,7 @@ impl Reactor for Broadcaster {
                         self.broadcast_position(st0x_dto::Position {
                             symbol: position.symbol,
                             net: position.net.inner(),
+                            last_price_usdc: position.last_price_usdc,
                         });
                     }
                     Ok(None) => warn!(target: "dashboard", %id, "Position not found after event"),

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -219,8 +219,10 @@ fn float_to_f64(value: rain_math_float::Float, fallback: f64) -> f64 {
 }
 
 async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
-    let rows: Vec<(String, Option<String>)> = match sqlx::query_as(
-        "SELECT symbol, net_position FROM position_view WHERE symbol IS NOT NULL",
+    let rows: Vec<(String, Option<String>, Option<String>)> = match sqlx::query_as(
+        "SELECT symbol, net_position, \
+         json_extract(payload, '$.Live.last_price_usdc') \
+         FROM position_view WHERE symbol IS NOT NULL",
     )
     .fetch_all(pool)
     .await
@@ -233,7 +235,7 @@ async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
     };
 
     rows.into_iter()
-        .filter_map(|(raw_symbol, net_str)| {
+        .filter_map(|(raw_symbol, net_str, price_str)| {
             let symbol = st0x_execution::Symbol::new(&raw_symbol)
                 .inspect_err(|error| {
                     warn!(target: "dashboard", %error, %raw_symbol, "Invalid symbol in position view, skipping");
@@ -250,7 +252,19 @@ async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
                 })
                 .unwrap_or_else(|| st0x_float_macro::float!(0));
 
-            Some(st0x_dto::Position { symbol, net })
+            let last_price_usdc = price_str.and_then(|value| {
+                rain_math_float::Float::parse(value)
+                    .inspect_err(|error| {
+                        warn!(target: "dashboard", %error, %raw_symbol, "Unparseable last_price_usdc, ignoring");
+                    })
+                    .ok()
+            });
+
+            Some(st0x_dto::Position {
+                symbol,
+                net,
+                last_price_usdc,
+            })
         })
         .collect()
 }


### PR DESCRIPTION
## What

Closes [RAI-315](https://linear.app/makeitrain/issue/RAI-315)

Convert the "Dislocation" column (now renamed "Exposure") in the available-inventory table from raw share counts to USD values, making it directly comparable to the hedge execution threshold.

## Why

The hedge threshold is configured in USD (e.g., `DollarValue($2)`), but dislocation was displayed in shares. Users had to mentally multiply by the current price to judge whether a hedge was imminent.

## How

- Add `last_price_usdc: Option<Float>` to the `Position` DTO
- Update `load_positions()` SQL to extract `last_price_usdc` from the position view JSON payload
- Propagate the price through the WebSocket position broadcast
- Compute exposure as `net_shares * last_price_usdc` in the Svelte component
- Rename column from "Dislocation" to "Exposure", format as `+$3.50` / `-$1.20`
- Raise the negligible threshold from 0.001 to 0.01 (sub-cent values are noise)

## Testing

- All 32 dashboard tests pass
- Manual verification needed for live WebSocket updates

## Anything else

Stacked on #633. Parent of #635.
