### PR TITLE
fix: filter USDCUSD crypto position from Alpaca inventory (RAI-316)

### DIFF
--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -4,7 +4,7 @@ use rain_math_float::Float;
 use serde::Deserialize;
 use st0x_float_macro::float;
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 use super::AlpacaBrokerApiError;
 use super::client::AlpacaBrokerApiClient;
@@ -74,6 +74,22 @@ pub(super) async fn fetch_inventory(
 
     let broker_positions = positions
         .into_iter()
+        .filter(|position| {
+            // USDCUSD is Alpaca's crypto pair for USDC/USD conversion during
+            // rebalancing. It's not an equity position and has no vault in the
+            // registry -- filtering it here prevents downstream
+            // TokenNotInRegistry errors.
+            if position.symbol == "USDCUSD" {
+                trace!(
+                    target: "broker",
+                    quantity = ?position.quantity,
+                    "Skipping USDCUSD crypto position from inventory"
+                );
+                return false;
+            }
+
+            true
+        })
         .map(|position| {
             let symbol = Symbol::new(&position.symbol).inspect_err(|_| {
                 error!(
@@ -545,5 +561,58 @@ mod tests {
         let error = fetch_inventory(&client).await.unwrap_err();
 
         assert!(matches!(error, AlpacaBrokerApiError::HttpClient(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_filters_usdcusd_crypto_position() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "symbol": "AAPL",
+                        "qty_available": "10.0",
+                        "market_value": "1500.00"
+                    },
+                    {
+                        "symbol": "USDCUSD",
+                        "qty_available": "5000.0",
+                        "market_value": "5000.00"
+                    },
+                    {
+                        "symbol": "RKLB",
+                        "qty_available": "3.0",
+                        "market_value": "240.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00",
+                    "non_marginable_buying_power": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        let symbols: Vec<String> = inventory
+            .positions
+            .iter()
+            .map(|position| position.symbol.to_string())
+            .collect();
+
+        assert_eq!(symbols, vec!["AAPL", "RKLB"]);
+        assert_eq!(inventory.positions.len(), 2);
     }
 }


### PR DESCRIPTION
## What

Closes [RAI-316](https://linear.app/makeitrain/issue/RAI-316)

Filter out the `USDCUSD` crypto pair from `fetch_inventory()` before it reaches the vault registry lookup.

## Why

Alpaca's positions API returns `USDCUSD` (a transient crypto pair from USDC/USD conversion during rebalancing) alongside real equity positions. When the rebalancing trigger iterates these and looks up USDCUSD in the vault registry, it fails with `TokenNotInRegistry`. USDC tracking is already handled by dedicated inventory entries (`BaseWalletUsdc`, `EthereumUsdc`, `OffchainUsd`).

Introduced by PR #615 which removed the broken `AlpacaWalletUsdc` polling path but didn't filter USDCUSD from the positions response.

## How

- Add a `.filter()` step in `fetch_inventory()` that skips positions with symbol `"USDCUSD"`, logging at `trace` level
- Placed before the `.map()` that parses symbols so invalid-symbol errors are also avoided

## Testing

- New test: `fetch_inventory_filters_usdcusd_crypto_position` — mocks positions API with AAPL, USDCUSD, and RKLB; asserts only AAPL and RKLB are returned
- All 142 st0x-execution tests pass

## Anything else

Stacked on #634.
