### PR TITLE
docs: drop implementation phases from spec, track in linear

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -472,14 +472,33 @@ The system provides two top-level capabilities:
 │                                                                         │
 │  st0x-execution      st0x-tokenization  st0x-bridge    st0x-raindex     │
 │  ├─ Executor trait   ├─ Tokenizer trait ├─ Bridge trait├─ Raindex trait │
+│  ├─ Alpaca wallet    │                  │              │                │
+│  ├─ Pyth feeds       │                  │              │                │
 │  │                   │                  │              │                │
 │  │ features:         │ features:        │ features:    │ features:      │
 │  │ ├─ alpaca-broker  │ └─ alpaca        │ └─ cctp      │ └─ rain        │
 │  │ └─ mock           │                  │              │                │
 │                                                                         │
-└───────┬──────────────────┬──────────────────┬──────────────┬────────────┘
-        │                  │                  │              │
-        ▼                  ▼                  ▼              ▼
+│  st0x-evm                              st0x-wrapper                     │
+│  ├─ Wallet trait                       └─ Wrap/unwrap (ERC-4626)        │
+│  ├─ Provider/signer                                                     │
+│  ├─ ABI bindings (IERC20, ...)                                          │
+│  └─ Chain constants (USDC_*)                                            │
+│                                                                         │
+└─────────────────────────────────┬───────────────────────────────────────┘
+                                  │
+                                  ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        SHARED METADATA                                  │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  st0x-registry                                                          │
+│  ├─ SymbolCache                                                         │
+│  └─ VaultRegistry                                                       │
+│                                                                         │
+└─────────────────────────────────┬───────────────────────────────────────┘
+                                  │
+                                  ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                          DOMAIN LOGIC                                   │
 │                    (business rules, uses traits)                        │
@@ -491,7 +510,8 @@ The system provides two top-level capabilities:
 │  └─ CQRS aggregates                    ├─ Mint/Redeem managers          │
 │                                         └─ CQRS aggregates              │
 │  depends on: execution                 depends on: tokenization,        │
-│                                                    bridge, raindex      │
+│                                                    bridge, raindex,     │
+│                                                    wrapper              │
 │                                                                         │
 └──────────────────────────────────┬──────────────────────────────────────┘
                                    │
@@ -503,55 +523,76 @@ The system provides two top-level capabilities:
 │  st0x-baton (orchestration toolkit, wraps apalis)                       │
 │  ├─ Job trait, worker patterns, apalis helpers                          │
 │                                                                         │
-│  st0x-server                           st0x-dashboard                   │
-│  ├─ Conductor (uses Baton)             ├─ Websocket events              │
-│  ├─ Startup, Monitor, job wiring       ├─ Admin UI backend              │
-│  └─ API endpoints                      └─ Own conductor (future)        │
+│  st0x-config (RESTRICTED: only st0x-server and st0x-cli may depend)     │
+│  ├─ Ctx, BrokerCtx, Env (TOML loading and assembly)                     │
+│  └─ setup_tracing                                                       │
+│                                                                         │
+│  st0x-server          st0x-dashboard         st0x-cli                   │
+│  ├─ Bot binary        ├─ Admin UI backend    ├─ Operator binary         │
+│  ├─ Conductor         ├─ Websocket events    ├─ Manual operations       │
+│  ├─ Startup, Monitor  └─ Manual operations   └─ View rebuilds           │
+│  └─ API endpoints                                                       │
+│                                                                         │
+│  All three are thin wrappers; domain logic lives in the layers above.   │
 │                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
-
-                · · · · · · · · · · · · · · · · · · · · ·
-                ·                                       ·
-                ·  st0x-cli (temporary utility)         ·
-                ·  ├─ Debug commands                    ·
-                ·  └─ To be deprecated                  ·
-                ·                                       ·
-                · · · · · · · · · · · · · · · · · · · · ·
 ```
 
 ### Crate Descriptions
 
 **Integration Layer** (external API wrappers):
 
-| Crate               | Purpose                                              | Feature Flags                     |
-| ------------------- | ---------------------------------------------------- | --------------------------------- |
-| `st0x-execution`    | Brokerage API integration for trade execution        | `mock`                            |
-| `st0x-tokenization` | Tokenization API for minting/redeeming equity tokens | `alpaca`                          |
-| `st0x-bridge`       | Cross-chain asset transfers                          | `cctp`                            |
-| `st0x-raindex`      | Rain orderbook vault deposit/withdraw operations     | `rain`                            |
-| `st0x-evm`          | EVM chain interaction and wallet abstraction         | `turnkey`, `local-signer`, `mock` |
+| Crate               | Purpose                                                                        | Feature Flags                     |
+| ------------------- | ------------------------------------------------------------------------------ | --------------------------------- |
+| `st0x-execution`    | Brokerage API integration for trade execution; Alpaca wallet ops; Pyth feeds   | `alpaca-broker`, `mock`           |
+| `st0x-tokenization` | Tokenization API for minting/redeeming equity tokens                           | `alpaca`                          |
+| `st0x-bridge`       | Cross-chain asset transfers                                                    | `cctp`                            |
+| `st0x-raindex`      | Rain orderbook vault deposit/withdraw operations                               | `rain`                            |
+| `st0x-evm`          | EVM chain interaction, wallet abstraction, ABI bindings, chain/token constants | `turnkey`, `local-signer`, `mock` |
+| `st0x-wrapper`      | ERC-4626 wrap/unwrap operations and ratio math                                 |                                   |
 
 Each integration crate defines a trait (e.g., `Executor`, `Tokenizer`, `Bridge`,
-`Raindex`, `Wallet`) with one or more implementations selectable via feature
-flags. This allows swapping implementations without changing domain logic.
+`Raindex`, `Wallet`, `Wrapper`) with one or more implementations selectable via
+feature flags. This allows swapping implementations without changing domain
+logic.
+
+**Shared Metadata Layer** (caches consumed by domain and application crates):
+
+| Crate           | Purpose                                                               |
+| --------------- | --------------------------------------------------------------------- |
+| `st0x-registry` | Symbol metadata cache and vault registry, sourced from chain + config |
+
+`st0x-registry` is the only crate that both domain and application crates may
+consume to resolve symbols and vault addresses. It does not contain business
+rules; it caches reference data.
 
 **Domain Logic Layer** (business rules):
 
-| Crate            | Purpose                                                  | Dependencies                                       |
-| ---------------- | -------------------------------------------------------- | -------------------------------------------------- |
-| `st0x-hedge`     | Hedging logic: accumulator, position tracking, queue     | `st0x-execution`                                   |
-| `st0x-rebalance` | Balance maintenance: triggers, managers, CQRS aggregates | `st0x-tokenization`, `st0x-bridge`, `st0x-raindex` |
+| Crate            | Purpose                                                  | Dependencies                                                       |
+| ---------------- | -------------------------------------------------------- | ------------------------------------------------------------------ |
+| `st0x-hedge`     | Hedging logic: accumulator, position tracking, queue     | `st0x-execution`, `st0x-registry`                                  |
+| `st0x-rebalance` | Balance maintenance: triggers, managers, CQRS aggregates | `st0x-tokenization`, `st0x-bridge`, `st0x-raindex`, `st0x-wrapper` |
 
 Domain crates depend on integration traits, not concrete implementations. This
-enables testing with mocks and future implementation swaps.
+enables testing with mocks and future implementation swaps. **Domain crates must
+be config-agnostic**: they accept narrow constructor arguments (`&dyn Wallet`,
+`&dyn Executor`, vault addresses, RPC URLs, threshold values), never `Ctx` or
+`BrokerCtx` from `st0x-config`.
 
 **Application Layer** (binaries and wiring):
 
-| Crate            | Purpose                                                                |
-| ---------------- | ---------------------------------------------------------------------- |
-| `st0x-server`    | Main bot binary, conductor, wires hedging + rebalancing, API endpoints |
-| `st0x-dashboard` | Admin dashboard backend, websocket events, manual operations           |
-| `st0x-cli`       | Temporary utility for manual trading and debug operations              |
+| Crate            | Purpose                                                                                                                                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `st0x-config`    | TOML/secrets loading, `Ctx`/`BrokerCtx`/`Env` assembly, `setup_tracing`. **Restricted visibility: only `st0x-server` and `st0x-cli` may depend on it. No integration, shared, or domain crate may import it.**        |
+| `st0x-server`    | Main bot binary, conductor, wires hedging + rebalancing, API endpoints                                                                                                                                                |
+| `st0x-dashboard` | Admin dashboard backend, websocket events, manual operations                                                                                                                                                          |
+| `st0x-cli`       | Operator binary; thin wrapper exposing manual operations (orders, equity/USDC transfers, vault deposit/withdraw, CCTP bridging, wrap/unwrap, Alpaca wallet ops, view rebuilds) over the integration and domain crates |
+
+The binary crates wire the layers above into a runnable artifact: `st0x-server`
+runs the bot, `st0x-dashboard` exposes the admin UI, `st0x-cli` exposes the same
+domain capabilities to a human operator. A command added to the CLI corresponds
+to a feature already implemented in an integration or domain crate -- the CLI
+does not contain business rules.
 
 ### Feature Flag Strategy
 
@@ -574,44 +615,6 @@ This enables:
 - Compile-time selection of integrations (no unused code in binary)
 - Easy addition of new implementations behind new feature flags
 - Fork-friendly architecture for different asset classes
-
-### Implementation Phases
-
-The crate extraction is sequenced in phases:
-
-### Phase 1: Prerequisite Refactors
-
-Fix coupling issues before extraction:
-
-- Split `Evm` struct: Extract generic `EvmClient<P,S>` (provider + signer) from
-  CCTP-specific contracts, so vault doesn't depend on cctp
-- Move ID types: `IssuerRequestId`/`TokenizationRequestId` move from aggregate
-  to tokenization module, reversing the dependency direction
-
-### Phase 2: Integration Layer Extraction
-
-Extract external API wrappers (no CQRS/ES dependencies):
-
-- `st0x-tokenization`: Alpaca tokenization API, defines `Tokenizer` trait
-- `st0x-bridge`: CCTP cross-chain transfers, defines `Bridge` trait
-- `st0x-raindex`: Rain orderbook vault operations, defines `Raindex` trait
-
-### Phase 3: Rebalancing Domain Extraction
-
-Extract rebalancing logic (already clean CQRS, no legacy persistence):
-
-- `st0x-rebalance`: CrossVenueEquityTransfer, CrossVenueCashTransfer and their
-  lifecycle aggregates plus orchestration logic
-
-### Phase 4: Hedging Extraction & Application Layer
-
-Extract hedging logic and create application binary (must happen atomically):
-
-- `st0x-hedge`: Pure library with accumulator, position tracking, queue
-- `st0x-server`: Application binary with conductor, wires hedging + rebalancing
-  together
-- Dashboard stays as feature-gated module in server
-- CLI remains temporary utility
 
 ## System Risks
 


### PR DESCRIPTION
## What

Drops the entire "Implementation Phases" section from `SPEC.md` (Phases 1-5 plus the transitional-state paragraph) and moves the breakdown into Linear under the new [Workspace crate extraction](https://linear.app/makeitrain/project/workspace-crate-extraction-f5d671e52adf) project.

The architectural sections that were added in earlier commits on this branch (Shared Metadata Layer, `st0x-config`, `st0x-wrapper`, `st0x-registry`, the updated layer model and feature-flag strategy) stay in `SPEC.md` -- they describe the target architecture, not the implementation order.

## Why

`SPEC.md` is the source-of-truth for system behavior, not project management. Per-phase task lists, sequencing, and transitional-state notes belong with the issues they describe, not the spec they implement. Keeping them in `SPEC.md` made the doc grow stale every time a phase landed and forced spec edits for sequencing changes that have no behavioral meaning.

Linear is where this work is actually tracked. The new project bundles the existing extraction issues (RAI-47, 48, 49, 50, 720, 721, 722) with eight new ones for the Phase 1 / Phase 2 gaps (RAI-743 through 750) plus RAI-669, so the full breakdown lives in one place with status, ownership, and dependency views.

## How

* Deleted lines 619-715 of `SPEC.md` -- the `### Implementation Phases` heading through the closing `**Transitional state**` paragraph (-98 lines).
* Created Linear project `Workspace crate extraction` (slug `f5d671e52adf`) with a short layer-model blurb as the description.
* Created 8 new issues covering work the previous Phases section called out but had no Linear ticket for: RAI-743 (split `Evm`), RAI-744 (move ID types), RAI-745 (delete `src/shares.rs`), RAI-746 (decouple `Ctx`), RAI-747 (`st0x-wrapper`), RAI-748 (`st0x-registry`), RAI-749 (fold into `st0x-evm`), RAI-750 (fold into `st0x-execution`).
* Re-parented all 16 issues (8 new + RAI-47/48/49/50/669/720/721/722) into the new project.

## Testing

Spec-only change; no runtime behavior affected.

## Anything else

The architectural content from the earlier commit on this branch (target layer model, crate definitions) survived this edit -- only the sequencing prose moved out. Reviewers comparing to master will still see +306/-73 in `SPEC.md`.
