### PR TITLE
refactor: extract st0x-config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "apalis-workflow"
+version = "0.1.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9392c07db462a5c0befec5d6685a37d9ec2424a244b7e7e021208c5c9544cef0"
+dependencies = [
+ "apalis-core",
+ "futures",
+ "petgraph",
+ "serde",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "apca"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2758,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,7 +3472,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4714,6 +4736,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,7 +5107,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5109,7 +5144,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6805,6 +6840,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "st0x-config"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-primitives",
+ "async-trait",
+ "bon",
+ "clap",
+ "itertools 0.14.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "proptest",
+ "rain-math-float",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "st0x-bridge",
+ "st0x-evm",
+ "st0x-execution",
+ "st0x-finance",
+ "st0x-float-macro",
+ "st0x-float-serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.23",
+ "url",
+]
+
+[[package]]
 name = "st0x-dto"
 version = "0.1.0"
 dependencies = [
@@ -6934,6 +7005,7 @@ dependencies = [
  "apalis-core",
  "apalis-cron",
  "apalis-sqlite",
+ "apalis-workflow",
  "approx",
  "async-trait",
  "backon",
@@ -6965,6 +7037,7 @@ dependencies = [
  "serial_test",
  "sqlx",
  "st0x-bridge",
+ "st0x-config",
  "st0x-dto",
  "st0x-evm",
  "st0x-execution",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   ".",
+  "crates/config",
   "crates/dto",
   "crates/execution",
   "crates/finance",
@@ -92,6 +93,7 @@ sqlx = { version = "0.8.6", features = [
   "runtime-tokio-rustls",
 ] }
 st0x-bridge = { path = "crates/bridge" }
+st0x-config = { path = "crates/config" }
 st0x-dto = { path = "crates/dto" }
 st0x-evm = { path = "crates/evm" }
 st0x-execution = { path = "crates/execution" }
@@ -107,6 +109,7 @@ tokio = { version = "1.46.0", features = ["full"] }
 tokio-tungstenite = "0.28.0"
 toml = "0.9.11"
 tracing = "0.1.41"
+tracing-appender = "0.2.5"
 tracing-opentelemetry = "0.31.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 # no-env-filter: custom `target:` strings (e.g. "hedge", "rebalance") don't
@@ -144,10 +147,14 @@ rust-version = "1.89"
 [features]
 default = ["all-wallets"]
 all-wallets = ["wallet-private-key", "wallet-turnkey"]
-wallet-turnkey = ["st0x-evm/turnkey"]
-wallet-private-key = ["st0x-evm/local-signer"]
+wallet-turnkey = ["st0x-evm/turnkey", "st0x-config/wallet-turnkey"]
+wallet-private-key = ["st0x-evm/local-signer", "st0x-config/wallet-private-key"]
 
-test-support = ["st0x-bridge/test-support", "wallet-private-key"]
+test-support = [
+  "st0x-bridge/test-support",
+  "st0x-config/test-support",
+  "wallet-private-key",
+]
 mock = [
   "st0x-execution/mock",
   "st0x-evm/mock",
@@ -193,6 +200,7 @@ serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
 st0x-bridge = { workspace = true, features = ["cctp"] }
+st0x-config.workspace = true
 st0x-dto.workspace = true
 st0x-event-sorcery.workspace = true
 st0x-evm.workspace = true
@@ -212,8 +220,9 @@ urlencoding.workspace = true
 uuid.workspace = true
 # Force transitive wasm-bindgen to match rain.wasm's expected version
 wasm-bindgen.workspace = true
-tracing-appender = "0.2.5"
+tracing-appender.workspace = true
 tokio-util = { version = "0.7.18", features = ["rt"] }
+apalis-workflow = "0.1.0-rc.7"
 
 [dev-dependencies]
 approx.workspace = true
@@ -226,7 +235,7 @@ rsa.workspace = true
 serial_test.workspace = true
 st0x-bridge = { workspace = true, features = ["mock"] }
 st0x-event-sorcery = { workspace = true, features = ["test-support"] }
-st0x-evm = { workspace = true, features = ["mock"] }
+st0x-evm = { workspace = true, features = ["mock", "test-support"] }
 st0x-execution = { workspace = true, features = ["mock", "test-support"] }
 st0x-hedge = { workspace = true, features = ["test-support", "mock"] }
 temp-env.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "st0x-config"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[features]
+default = []
+wallet-turnkey = ["st0x-evm/turnkey"]
+wallet-private-key = ["st0x-evm/local-signer"]
+test-support = [
+  "st0x-bridge/test-support",
+  "st0x-bridge/cctp",
+  "st0x-evm/test-support",
+  "st0x-execution/mock",
+  "dep:proptest",
+  "dep:tempfile",
+]
+
+[dependencies]
+alloy.workspace = true
+alloy-primitives.workspace = true
+async-trait.workspace = true
+bon.workspace = true
+clap.workspace = true
+itertools.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
+proptest = { workspace = true, optional = true }
+rain-math-float.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
+sqlx.workspace = true
+st0x-bridge.workspace = true
+st0x-evm.workspace = true
+st0x-execution.workspace = true
+st0x-finance.workspace = true
+st0x-float-macro.workspace = true
+st0x-float-serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+tempfile = { workspace = true, optional = true }
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["json"] }
+url.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+serde_json.workspace = true
+st0x-evm = { workspace = true, features = ["test-support"] }
+st0x-finance = { workspace = true, features = ["test-support"] }
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/config/src/evm.rs
+++ b/crates/config/src/evm.rs
@@ -1,0 +1,58 @@
+//! EVM configuration types: chain config, RPC secrets, and runtime context.
+
+use alloy::primitives::Address;
+use serde::Deserialize;
+use url::Url;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvmConfig {
+    pub orderbook: Address,
+    pub deployment_block: u64,
+    pub required_confirmations: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvmSecrets {
+    #[serde(rename = "ws_rpc_url")]
+    pub ws: Url,
+    /// Base chain RPC URL for wallet operations. Required when `[wallet]`
+    /// is configured.
+    #[serde(rename = "base_rpc_url")]
+    pub base: Option<Url>,
+    /// Ethereum mainnet RPC URL for wallet operations. Required when
+    /// `[wallet]` is configured.
+    #[serde(rename = "ethereum_rpc_url")]
+    pub ethereum: Option<Url>,
+}
+
+#[derive(Clone)]
+pub struct EvmCtx {
+    pub ws_rpc_url: Url,
+    pub orderbook: Address,
+    pub deployment_block: u64,
+    pub required_confirmations: u64,
+}
+
+impl std::fmt::Debug for EvmCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EvmCtx")
+            .field("ws_rpc_url", &"[REDACTED]")
+            .field("orderbook", &self.orderbook)
+            .field("deployment_block", &self.deployment_block)
+            .field("required_confirmations", &self.required_confirmations)
+            .finish()
+    }
+}
+
+impl EvmCtx {
+    pub fn new(config: &EvmConfig, secrets: EvmSecrets) -> Self {
+        Self {
+            ws_rpc_url: secrets.ws,
+            orderbook: config.orderbook,
+            deployment_block: config.deployment_block,
+            required_confirmations: config.required_confirmations,
+        }
+    }
+}

--- a/crates/config/src/imbalance_threshold.rs
+++ b/crates/config/src/imbalance_threshold.rs
@@ -1,0 +1,97 @@
+//! Threshold configuration for inventory imbalance detection.
+//!
+//! Lives here transitionally; once Phase 3 extracts the rebalance
+//! domain, this type should move alongside the inventory and trigger
+//! logic that consumes it.
+
+use rain_math_float::Float;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+use st0x_float_macro::float;
+
+static EXACT_ONE: LazyLock<Float> = LazyLock::new(|| float!(1));
+
+/// Threshold configuration for imbalance detection.
+///
+/// Invariants enforced by [`ImbalanceThreshold::new`]:
+/// - `target` must be in `[0.0, 1.0]`
+/// - `deviation` must be `>= 0`
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(try_from = "RawImbalanceThreshold", deny_unknown_fields)]
+pub struct ImbalanceThreshold {
+    /// Target ratio of onchain to total (e.g., 0.5 for 50/50 split).
+    #[serde(
+        serialize_with = "st0x_float_serde::serialize_float_as_string",
+        deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+    )]
+    pub target: Float,
+    /// Deviation from target that triggers rebalancing.
+    #[serde(
+        serialize_with = "st0x_float_serde::serialize_float_as_string",
+        deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+    )]
+    pub deviation: Float,
+}
+
+/// Error returned when [`ImbalanceThreshold`] is constructed with
+/// out-of-range values.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum InvalidImbalanceThreshold {
+    #[error(
+        "target must be between 0.0 and 1.0 inclusive, \
+         got {target:?}"
+    )]
+    TargetOutOfRange { target: Float },
+    #[error("deviation must be >= 0, got {deviation:?}")]
+    NegativeDeviation { deviation: Float },
+}
+
+impl ImbalanceThreshold {
+    /// Creates a new threshold with validated parameters.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidImbalanceThreshold`] if `target` is not in
+    /// `[0.0, 1.0]` or `deviation` is negative.
+    pub fn new(target: Float, deviation: Float) -> Result<Self, InvalidImbalanceThreshold> {
+        let zero =
+            Float::zero().map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?;
+
+        if target
+            .lt(zero)
+            .map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?
+            || target
+                .gt(*EXACT_ONE)
+                .map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?
+        {
+            return Err(InvalidImbalanceThreshold::TargetOutOfRange { target });
+        }
+
+        if deviation
+            .lt(zero)
+            .map_err(|_| InvalidImbalanceThreshold::NegativeDeviation { deviation })?
+        {
+            return Err(InvalidImbalanceThreshold::NegativeDeviation { deviation });
+        }
+
+        Ok(Self { target, deviation })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawImbalanceThreshold {
+    #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
+    target: Float,
+    #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
+    deviation: Float,
+}
+
+impl TryFrom<RawImbalanceThreshold> for ImbalanceThreshold {
+    type Error = InvalidImbalanceThreshold;
+
+    fn try_from(raw: RawImbalanceThreshold) -> Result<Self, Self::Error> {
+        Self::new(raw.target, raw.deviation)
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,0 +1,29 @@
+//! Configuration loading and runtime context assembly for the st0x bot.
+//!
+//! Restricted-visibility crate: only `st0x-server` (the bot binary) and
+//! `st0x-cli` (the operator binary) may depend on it. Integration,
+//! shared-metadata, and domain crates must remain config-agnostic.
+
+mod evm;
+mod imbalance_threshold;
+mod loader;
+mod order_poller;
+mod rebalancing;
+mod telemetry;
+mod threshold;
+mod wallet;
+
+pub use evm::{EvmConfig, EvmCtx, EvmSecrets};
+pub use imbalance_threshold::{ImbalanceThreshold, InvalidImbalanceThreshold};
+pub use loader::*;
+pub use order_poller::OrderPollerCtx;
+pub use rebalancing::{
+    ALPACA_MINIMUM_WITHDRAWAL, RebalancingConfig, RebalancingCtx, RebalancingCtxError,
+    UsdcRebalancing,
+};
+pub use telemetry::{
+    FileLogGuard, TelemetryAssemblyError, TelemetryConfig, TelemetryCtx, TelemetryError,
+    TelemetryGuard, TelemetrySecrets, mk_env_filter, setup_tracing,
+};
+pub use threshold::{ExecutionThreshold, InvalidThresholdError};
+pub use wallet::{OnchainWalletCtx, WalletCtxError, build_wallet};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -21,10 +21,10 @@ use tracing::{Level, warn};
 
 use url::Url;
 
-use crate::onchain::{EvmConfig, EvmCtx, EvmSecrets};
-use crate::rebalancing::{RebalancingConfig, RebalancingCtx, RebalancingCtxError};
-use crate::telemetry::{TelemetryConfig, TelemetryCtx, TelemetrySecrets};
-use crate::threshold::{ExecutionThreshold, InvalidThresholdError};
+use crate::{
+    EvmConfig, EvmCtx, EvmSecrets, ExecutionThreshold, InvalidThresholdError, RebalancingConfig,
+    RebalancingCtx, RebalancingCtxError, TelemetryConfig, TelemetryCtx, TelemetrySecrets,
+};
 use st0x_float_macro::float;
 
 /// Alpaca minimum execution threshold: $2.
@@ -204,10 +204,10 @@ struct RestApiSecrets {
 /// dashboard tab) are gracefully disabled.
 #[derive(Clone)]
 pub struct RestApiCtx {
-    pub(crate) url: String,
-    pub(crate) key_id: Option<String>,
-    pub(crate) key_secret: Option<String>,
-    pub(crate) http_client: reqwest::Client,
+    pub url: String,
+    pub key_id: Option<String>,
+    pub key_secret: Option<String>,
+    pub http_client: reqwest::Client,
 }
 
 impl std::fmt::Debug for RestApiCtx {
@@ -277,7 +277,7 @@ struct BrokerConfig {
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TravelRuleConfig {
-    pub(crate) beneficiary_entity_name: String,
+    pub beneficiary_entity_name: String,
 }
 
 impl TravelRuleConfig {
@@ -376,34 +376,32 @@ pub enum TradingMode {
 /// encrypted secrets, and derived runtime state.
 #[derive(Clone)]
 pub struct Ctx {
-    pub(crate) database_url: String,
+    pub database_url: String,
     pub log_level: LogLevel,
     pub log_dir: Option<String>,
-    pub(crate) server_port: u16,
-    pub(crate) evm: EvmCtx,
-    pub(crate) order_polling_interval: u64,
-    pub(crate) order_polling_max_jitter: u64,
-    pub(crate) position_check_interval: u64,
-    pub(crate) inventory_poll_interval: u64,
-    pub(crate) apalis_finished_job_cleanup_interval_secs: u64,
-    pub(crate) broker: BrokerCtx,
+    pub server_port: u16,
+    pub evm: EvmCtx,
+    pub order_polling_interval: u64,
+    pub order_polling_max_jitter: u64,
+    pub position_check_interval: u64,
+    pub inventory_poll_interval: u64,
+    pub apalis_finished_job_cleanup_interval_secs: u64,
+    pub broker: BrokerCtx,
     pub telemetry: Option<TelemetryCtx>,
     pub trading_mode: TradingMode,
     /// The onchain address that owns orders on the orderbook.
     /// Always derived from the configured `[wallet]` address.
-    pub(crate) order_owner: Address,
-    pub(crate) wallet: Option<crate::wallet::OnchainWalletCtx>,
+    pub order_owner: Address,
+    pub wallet: Option<crate::wallet::OnchainWalletCtx>,
     /// Non-secret wallet metadata for the dashboard config dialog.
-    pub(crate) wallet_meta: Option<WalletMeta>,
+    pub wallet_meta: Option<WalletMeta>,
     pub execution_threshold: ExecutionThreshold,
-    pub(crate) assets: AssetsConfig,
-    pub(crate) travel_rule: Option<TravelRuleConfig>,
-    pub(crate) rest_api: Option<RestApiCtx>,
+    pub assets: AssetsConfig,
+    pub travel_rule: Option<TravelRuleConfig>,
+    pub rest_api: Option<RestApiCtx>,
     /// Alpaca redemption wallet from `[tokenization]`.
     /// `Some` when the config includes a `[tokenization]` section.
-    pub(crate) redemption_wallet: Option<Address>,
-    #[cfg(feature = "test-support")]
-    pub failure_injector: crate::conductor::job::FailureInjector,
+    pub redemption_wallet: Option<Address>,
 }
 
 /// Runtime broker configuration assembled from `BrokerSecrets`.
@@ -414,7 +412,7 @@ pub enum BrokerCtx {
 }
 
 impl BrokerCtx {
-    pub(crate) fn to_supported_executor(&self) -> SupportedExecutor {
+    pub fn to_supported_executor(&self) -> SupportedExecutor {
         match self {
             Self::AlpacaBrokerApi(_) => SupportedExecutor::AlpacaBrokerApi,
             Self::DryRun => SupportedExecutor::DryRun,
@@ -495,9 +493,6 @@ impl std::fmt::Debug for Ctx {
             .field("redemption_wallet", &self.redemption_wallet)
             .field("rest_api", &self.rest_api);
 
-        #[cfg(feature = "test-support")]
-        debug_struct.field("failure_injector", &self.failure_injector);
-
         debug_struct.finish()
     }
 }
@@ -576,10 +571,10 @@ struct WalletInputs {
 /// Non-secret wallet metadata extracted from the config TOML during
 /// parsing. Displayed on the dashboard config dialog.
 #[derive(Clone, Debug, Deserialize)]
-pub(crate) struct WalletMeta {
-    pub(crate) kind: String,
-    pub(crate) address: Address,
-    pub(crate) organization_id: Option<String>,
+pub struct WalletMeta {
+    pub kind: String,
+    pub address: Address,
+    pub organization_id: Option<String>,
 }
 
 /// Single validation path shared by [`Ctx::load_files`] and
@@ -670,7 +665,7 @@ fn parse_and_validate(
                 return Err(RebalancingCtxError::NotAlpacaBroker.into());
             };
 
-            let minimum = *crate::rebalancing::trigger::ALPACA_MINIMUM_WITHDRAWAL;
+            let minimum = *crate::ALPACA_MINIMUM_WITHDRAWAL;
 
             if let Some(cash) = &config.assets.cash
                 && cash.rebalancing == OperationMode::Enabled
@@ -839,8 +834,6 @@ impl Ctx {
             travel_rule: parts.travel_rule,
             rest_api: parts.rest_api,
             redemption_wallet: parts.redemption_wallet,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 
@@ -870,30 +863,30 @@ impl Ctx {
         configure_sqlite_pool(&self.database_url).await
     }
 
-    pub(crate) fn rebalancing_ctx(&self) -> Result<&RebalancingCtx, CtxError> {
+    pub fn rebalancing_ctx(&self) -> Result<&RebalancingCtx, CtxError> {
         match &self.trading_mode {
             TradingMode::Rebalancing(ctx) => Ok(ctx),
             TradingMode::Standalone => Err(CtxError::NotRebalancing),
         }
     }
 
-    pub(crate) fn wallet(&self) -> Result<&crate::wallet::OnchainWalletCtx, CtxError> {
+    pub fn wallet(&self) -> Result<&crate::wallet::OnchainWalletCtx, CtxError> {
         self.wallet.as_ref().ok_or(CtxError::WalletNotConfigured)
     }
 
     /// Returns the redemption wallet from the `[tokenization]` config section.
-    pub(crate) fn redemption_wallet(&self) -> Result<Address, CtxError> {
+    pub fn redemption_wallet(&self) -> Result<Address, CtxError> {
         self.redemption_wallet.ok_or(CtxError::MissingTokenization)
     }
 
-    pub(crate) const fn order_polling_interval(&self) -> std::time::Duration {
+    pub const fn order_polling_interval(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.order_polling_interval)
     }
 
     /// Returns the wallet address that owns orders on the orderbook.
     ///
     /// Always derived from the configured `[wallet]` address.
-    pub(crate) fn order_owner(&self) -> Address {
+    pub fn order_owner(&self) -> Address {
         self.order_owner
     }
 
@@ -901,7 +894,7 @@ impl Ctx {
     ///
     /// Fail-closed: assets not present in the config are treated as
     /// trading-disabled.
-    pub(crate) fn is_trading_enabled(&self, symbol: &Symbol) -> bool {
+    pub fn is_trading_enabled(&self, symbol: &Symbol) -> bool {
         self.assets
             .equities
             .symbols
@@ -913,7 +906,7 @@ impl Ctx {
     ///
     /// Assets not present in the config are treated as rebalancing-disabled
     /// by default.
-    pub(crate) fn is_rebalancing_enabled(&self, symbol: &Symbol) -> bool {
+    pub fn is_rebalancing_enabled(&self, symbol: &Symbol) -> bool {
         self.assets
             .equities
             .symbols
@@ -989,8 +982,6 @@ impl Ctx {
             travel_rule,
             rest_api,
             redemption_wallet,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         })
     }
 }
@@ -1125,7 +1116,7 @@ impl CtxError {
     }
 }
 
-pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
+pub async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     // PRAGMAs are set via SqliteConnectOptions so they apply to every
     // connection the pool opens, not just the first one.
     //
@@ -1168,8 +1159,45 @@ pub(crate) async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePo
     Ok(pool)
 }
 
+#[cfg(any(test, feature = "test-support"))]
+pub fn create_test_ctx_with_order_owner(order_owner: alloy::primitives::Address) -> Ctx {
+    Ctx {
+        database_url: ":memory:".to_owned(),
+        log_level: LogLevel::Debug,
+        log_dir: None,
+        server_port: 8080,
+        evm: EvmCtx {
+            // Hard-coded literal URL — parse cannot fail in a test helper.
+            #[allow(clippy::unwrap_used)]
+            ws_rpc_url: url::Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: alloy::primitives::address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 1,
+        },
+        order_polling_interval: 15,
+        order_polling_max_jitter: 5,
+        position_check_interval: 60,
+        inventory_poll_interval: 60,
+        apalis_finished_job_cleanup_interval_secs: 3600,
+        broker: BrokerCtx::DryRun,
+        telemetry: None,
+        trading_mode: TradingMode::Standalone,
+        order_owner,
+        wallet: None,
+        wallet_meta: None,
+        execution_threshold: ExecutionThreshold::whole_share(),
+        assets: AssetsConfig {
+            equities: EquitiesConfig::default(),
+            cash: None,
+        },
+        travel_rule: None,
+        rest_api: None,
+        redemption_wallet: None,
+    }
+}
+
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use alloy::primitives::{Address, address};
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -1178,49 +1206,12 @@ pub(crate) mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::onchain::EvmCtx;
-    use crate::threshold::ExecutionThreshold;
+    use crate::ExecutionThreshold;
 
     fn toml_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(content.as_bytes()).unwrap();
         file
-    }
-
-    pub fn create_test_ctx_with_order_owner(order_owner: Address) -> Ctx {
-        Ctx {
-            database_url: ":memory:".to_owned(),
-            log_level: LogLevel::Debug,
-            log_dir: None,
-            server_port: 8080,
-            evm: EvmCtx {
-                ws_rpc_url: url::Url::parse("ws://localhost:8545").unwrap(),
-                orderbook: address!("0x1111111111111111111111111111111111111111"),
-                deployment_block: 1,
-                required_confirmations: 0,
-            },
-            order_polling_interval: 15,
-            order_polling_max_jitter: 5,
-            position_check_interval: 60,
-            inventory_poll_interval: 60,
-            apalis_finished_job_cleanup_interval_secs: 3600,
-            broker: BrokerCtx::DryRun,
-            telemetry: None,
-            trading_mode: TradingMode::Standalone,
-            order_owner,
-            wallet: None,
-            wallet_meta: None,
-            execution_threshold: ExecutionThreshold::whole_share(),
-            assets: AssetsConfig {
-                equities: EquitiesConfig::default(),
-                cash: None,
-            },
-            travel_rule: None,
-            rest_api: None,
-            redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
-        }
     }
 
     fn minimal_config_toml() -> NamedTempFile {
@@ -1336,11 +1327,17 @@ pub(crate) mod tests {
     }
 
     fn example_config_toml() -> &'static Path {
-        Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/example.config.toml"))
+        Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../example.config.toml"
+        ))
     }
 
     fn example_secrets_toml() -> &'static Path {
-        Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/example.secrets.toml"))
+        Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../example.secrets.toml"
+        ))
     }
 
     #[test]
@@ -2499,7 +2496,7 @@ pub(crate) mod tests {
 
     #[test]
     fn server_config_toml_is_valid() {
-        let config_str = include_str!("../config/prod/st0x-hedge.toml");
+        let config_str = include_str!("../../../config/prod/st0x-hedge.toml");
         let config: Config = toml::from_str(config_str).unwrap();
 
         let global_limit = config
@@ -2540,31 +2537,35 @@ pub(crate) mod tests {
 
     #[test]
     fn example_config_toml_is_valid() {
-        let config_str = include_str!("../example.config.toml");
+        let config_str = include_str!("../../../example.config.toml");
         let _: Config = toml::from_str(config_str).unwrap();
     }
 
     #[test]
     fn example_secrets_toml_is_valid() {
-        let secrets_str = include_str!("../example.secrets.toml");
+        let secrets_str = include_str!("../../../example.secrets.toml");
         let _: Secrets = toml::from_str(secrets_str).unwrap();
     }
 
     #[test]
     fn e2e_config_toml_is_valid() {
-        let config_str = include_str!("../e2e/config.toml");
+        let config_str = include_str!("../../../e2e/config.toml");
         let _: Config = toml::from_str(config_str).unwrap();
     }
 
     #[test]
     fn e2e_secrets_toml_is_valid() {
-        let secrets_str = include_str!("../e2e/secrets.toml");
+        let secrets_str = include_str!("../../../e2e/secrets.toml");
         let _: Secrets = toml::from_str(secrets_str).unwrap();
     }
 
     #[test]
     fn all_repo_config_tomls_are_valid() {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
         let config_dir = repo_root.join("config");
 
         // Walk config/ subdirectories (config/prod/, config/staging/) to
@@ -2609,7 +2610,11 @@ pub(crate) mod tests {
 
     #[test]
     fn all_repo_secrets_tomls_are_valid() {
-        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
         let secret_paths = [
             repo_root.join("example.secrets.toml"),
             repo_root.join("e2e/secrets.toml"),

--- a/crates/config/src/order_poller.rs
+++ b/crates/config/src/order_poller.rs
@@ -1,0 +1,24 @@
+//! Configuration for the offchain order status poller.
+
+use std::time::Duration;
+
+/// Configuration for the offchain order status poller.
+///
+/// Controls polling cadence when checking order status with the broker.
+#[derive(Debug, Clone)]
+pub struct OrderPollerCtx {
+    /// Base interval between consecutive polls.
+    pub polling_interval: Duration,
+    /// Maximum random jitter added to `polling_interval` to avoid thundering
+    /// herd when many orders are polled simultaneously.
+    pub max_jitter: Duration,
+}
+
+impl Default for OrderPollerCtx {
+    fn default() -> Self {
+        Self {
+            polling_interval: Duration::from_secs(15),
+            max_jitter: Duration::from_secs(5),
+        }
+    }
+}

--- a/crates/config/src/rebalancing.rs
+++ b/crates/config/src/rebalancing.rs
@@ -1,0 +1,309 @@
+//! Rebalancing configuration: parsed schema and validated runtime context.
+
+#[cfg(feature = "test-support")]
+use alloy::primitives::Address;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use rain_math_float::Float;
+use serde::Deserialize;
+use st0x_finance::Usdc;
+use st0x_float_macro::float;
+
+use crate::ImbalanceThreshold;
+
+/// Minimum USDC amount for Alpaca withdrawals.
+///
+/// Alpaca requires $50 USD minimum, but due to USDC/USD spread
+/// (~17bps observed in live tests), we use $51 to ensure we always meet
+/// the minimum after conversion slippage.
+pub static ALPACA_MINIMUM_WITHDRAWAL: LazyLock<Usdc> = LazyLock::new(|| Usdc::new(float!(51)));
+
+/// Error type for rebalancing configuration validation.
+#[derive(Debug, thiserror::Error)]
+pub enum RebalancingCtxError {
+    #[error("rebalancing requires alpaca-broker-api broker type")]
+    NotAlpacaBroker,
+    #[error("rebalancing transfer_timeout_secs must be non-zero")]
+    ZeroTransferTimeout,
+    #[error("invalid wallet config: {0}")]
+    WalletConfig(#[from] toml::de::Error),
+    #[error(transparent)]
+    Evm(#[from] st0x_evm::EvmError),
+}
+
+/// USDC rebalancing configuration with explicit enable/disable.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+pub enum UsdcRebalancing {
+    Enabled {
+        #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
+        target: Float,
+        #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
+        deviation: Float,
+    },
+    Disabled,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RebalancingConfig {
+    pub equity: ImbalanceThreshold,
+    pub usdc: UsdcRebalancing,
+    pub transfer_timeout_secs: u64,
+}
+
+/// Runtime configuration for rebalancing operations.
+///
+/// Constructed from `RebalancingConfig` after the parsed schema has been
+/// validated. Wallet construction has moved to [`st0x_evm`]; this type
+/// holds only the rebalancing-specific trigger thresholds.
+#[derive(Clone)]
+pub struct RebalancingCtx {
+    pub equity: ImbalanceThreshold,
+    pub usdc: Option<ImbalanceThreshold>,
+    pub transfer_timeout: Duration,
+    /// Circle attestation/fee API base URL (test-only override).
+    #[cfg(feature = "test-support")]
+    pub circle_api_base: String,
+    /// `TokenMessengerV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub token_messenger: Address,
+    /// `MessageTransmitterV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub message_transmitter: Address,
+}
+
+impl RebalancingCtx {
+    /// Construct from config. Validates only rebalancing-specific
+    /// trigger thresholds; wallet construction lives elsewhere.
+    pub fn new(config: &RebalancingConfig) -> Result<Self, RebalancingCtxError> {
+        if config.transfer_timeout_secs == 0 {
+            return Err(RebalancingCtxError::ZeroTransferTimeout);
+        }
+
+        let usdc = match config.usdc {
+            UsdcRebalancing::Enabled { target, deviation } => {
+                Some(ImbalanceThreshold { target, deviation })
+            }
+            UsdcRebalancing::Disabled => None,
+        };
+
+        Ok(Self {
+            equity: config.equity,
+            usdc,
+            transfer_timeout: Duration::from_secs(config.transfer_timeout_secs),
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        })
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[bon::bon]
+impl RebalancingCtx {
+    /// Test constructor that creates a `RebalancingCtx` with stub wallets.
+    ///
+    /// The wallets panic on `send` -- use only in tests that don't submit
+    /// transactions through the rebalancing wallet.
+    #[builder]
+    pub fn stub(
+        equity: ImbalanceThreshold,
+        usdc: Option<ImbalanceThreshold>,
+        #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
+    ) -> Self {
+        Self {
+            equity,
+            usdc,
+            transfer_timeout,
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        }
+    }
+}
+
+#[cfg(feature = "test-support")]
+#[bon::bon]
+impl RebalancingCtx {
+    /// Test constructor that accepts pre-built wallets for e2e tests
+    /// that need real onchain interaction (e.g. with Anvil forks).
+    #[builder]
+    pub fn with_wallets(
+        equity: ImbalanceThreshold,
+        usdc: UsdcRebalancing,
+        #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
+    ) -> Self {
+        let usdc = match usdc {
+            UsdcRebalancing::Enabled { target, deviation } => {
+                Some(ImbalanceThreshold { target, deviation })
+            }
+            UsdcRebalancing::Disabled => None,
+        };
+
+        Self {
+            equity,
+            usdc,
+            transfer_timeout,
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        }
+    }
+
+    /// Sets the Circle API base URL override (for e2e tests with local
+    /// CCTP contracts and a mock attestation server).
+    #[must_use]
+    pub fn with_circle_api_base(mut self, base_url: String) -> Self {
+        self.circle_api_base = base_url;
+        self
+    }
+
+    /// Sets the CCTP contract address overrides (for e2e tests with
+    /// locally deployed CCTP contracts).
+    #[must_use]
+    pub fn with_cctp_addresses(
+        mut self,
+        token_messenger: Address,
+        message_transmitter: Address,
+    ) -> Self {
+        self.token_messenger = token_messenger;
+        self.message_transmitter = message_transmitter;
+        self
+    }
+}
+
+impl std::fmt::Debug for RebalancingCtx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RebalancingCtx")
+            .field("equity", &self.equity)
+            .field("usdc", &self.usdc)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use st0x_float_macro::float;
+
+    fn valid_rebalancing_config_toml() -> &'static str {
+        r#"
+            transfer_timeout_secs = 1800
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#
+    }
+
+    #[test]
+    fn deserialize_config_succeeds() {
+        let config: RebalancingConfig = toml::from_str(valid_rebalancing_config_toml()).unwrap();
+
+        assert!(config.equity.target.eq(float!(0.5)).unwrap());
+        assert!(config.equity.deviation.eq(float!(0.2)).unwrap());
+
+        let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
+            panic!("expected UsdcRebalancing::Enabled");
+        };
+        assert!(target.eq(float!(0.5)).unwrap());
+        assert!(deviation.eq(float!(0.3)).unwrap());
+        assert_eq!(config.transfer_timeout_secs, 1800);
+    }
+
+    #[test]
+    fn deserialize_with_custom_thresholds() {
+        let config: RebalancingConfig = toml::from_str(
+            r#"
+            transfer_timeout_secs = 1800
+
+            [equity]
+            target = "0.6"
+            deviation = "0.1"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.4"
+            deviation = "0.15"
+        "#,
+        )
+        .unwrap();
+
+        assert!(config.equity.target.eq(float!(0.6)).unwrap());
+        assert!(config.equity.deviation.eq(float!(0.1)).unwrap());
+
+        let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
+            panic!("expected UsdcRebalancing::Enabled");
+        };
+        assert!(target.eq(float!(0.4)).unwrap());
+        assert!(deviation.eq(float!(0.15)).unwrap());
+    }
+
+    #[test]
+    fn deserialize_missing_transfer_timeout_secs_fails() {
+        let toml_str = r#"
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("transfer_timeout_secs"),
+            "Expected missing transfer_timeout_secs error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialize_missing_equity_fails() {
+        let toml_str = r#"
+            transfer_timeout_secs = 1800
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("equity"),
+            "Expected missing equity error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialize_missing_usdc_fails() {
+        let toml_str = r#"
+            transfer_timeout_secs = 1800
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("usdc"),
+            "Expected missing usdc error, got: {error}"
+        );
+    }
+}

--- a/crates/config/src/telemetry.rs
+++ b/crates/config/src/telemetry.rs
@@ -73,22 +73,24 @@ use thiserror::Error;
 use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::{EnvFilter, Registry};
 
+use crate::LogLevel;
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct TelemetryConfig {
-    pub(crate) service_name: String,
+pub struct TelemetryConfig {
+    pub service_name: String,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct TelemetrySecrets {
-    pub(crate) api_key: String,
+pub struct TelemetrySecrets {
+    pub api_key: String,
 }
 
 #[derive(Clone)]
 pub struct TelemetryCtx {
-    pub(crate) api_key: String,
-    pub(crate) service_name: String,
+    pub api_key: String,
+    pub service_name: String,
 }
 
 impl std::fmt::Debug for TelemetryCtx {
@@ -101,7 +103,7 @@ impl std::fmt::Debug for TelemetryCtx {
 }
 
 impl TelemetryCtx {
-    pub(crate) fn new(
+    pub fn new(
         config: Option<TelemetryConfig>,
         secrets: Option<TelemetrySecrets>,
     ) -> Result<Option<Self>, TelemetryAssemblyError> {
@@ -264,10 +266,7 @@ pub struct FileLogGuard {
     _guard: tracing_appender::non_blocking::WorkerGuard,
 }
 
-pub fn setup_tracing(
-    log_level: &crate::config::LogLevel,
-    log_dir: Option<&str>,
-) -> Option<FileLogGuard> {
+pub fn setup_tracing(log_level: &LogLevel, log_dir: Option<&str>) -> Option<FileLogGuard> {
     let level: tracing::Level = log_level.into();
     let env_filter = mk_env_filter(level);
 
@@ -314,7 +313,8 @@ fn mk_telemetry_filter(level: tracing::Level) -> EnvFilter {
 
 fn mk_crate_filter(level: tracing::Level) -> EnvFilter {
     // TODO: parse from the manifest or something
-    const CRATES: [&str; 9] = [
+    const CRATES: [&str; 10] = [
+        "config",
         "hedge",
         "bridge",
         "dto",

--- a/crates/config/src/threshold.rs
+++ b/crates/config/src/threshold.rs
@@ -21,11 +21,11 @@ pub enum ExecutionThreshold {
 }
 
 impl ExecutionThreshold {
-    pub(crate) fn shares(value: Positive<FractionalShares>) -> Self {
+    pub fn shares(value: Positive<FractionalShares>) -> Self {
         Self::Shares(value)
     }
 
-    pub(crate) fn dollar_value(value: Usdc) -> Result<Self, InvalidThresholdError> {
+    pub fn dollar_value(value: Usdc) -> Result<Self, InvalidThresholdError> {
         if value.is_negative().map_err(InvalidThresholdError::Float)? {
             return Err(InvalidThresholdError::NegativeDollarValue(value));
         }
@@ -37,9 +37,14 @@ impl ExecutionThreshold {
         Ok(Self::DollarValue(value))
     }
 
-    #[cfg(test)]
-    pub(crate) fn whole_share() -> Self {
-        Self::Shares(Positive::new(FractionalShares::new(st0x_float_macro::float!(1))).unwrap())
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn whole_share() -> Self {
+        // float!(1) is a compile-time positive constant, so Positive::new
+        // cannot fail at runtime here.
+        #[allow(clippy::unwrap_used)]
+        let positive = Positive::new(FractionalShares::new(st0x_float_macro::float!(1))).unwrap();
+
+        Self::Shares(positive)
     }
 }
 
@@ -58,25 +63,10 @@ mod tests {
     use proptest::prelude::*;
     use rain_math_float::Float;
 
-    use super::*;
+    use st0x_finance::proptest::arb_float;
     use st0x_float_macro::float;
 
-    fn arb_float() -> impl Strategy<Value = Float> {
-        (any::<i64>(), 0u32..=10).prop_filter_map(
-            "Float::parse must succeed",
-            |(mantissa, scale)| {
-                let divisor = 10i64.checked_pow(scale).unwrap_or(1);
-                let integer_part = mantissa / divisor;
-                let frac_part = (mantissa % divisor).unsigned_abs();
-
-                let value_str = format!(
-                    "{integer_part}.{frac_part:0>width$}",
-                    width = scale as usize
-                );
-                Float::parse(value_str).ok()
-            },
-        )
-    }
+    use super::*;
 
     proptest! {
         #[test]

--- a/crates/config/src/wallet.rs
+++ b/crates/config/src/wallet.rs
@@ -70,7 +70,7 @@ impl OnchainWalletCtx {
         not(any(feature = "wallet-turnkey", feature = "wallet-private-key")),
         allow(clippy::redundant_clone)
     )]
-    pub(crate) async fn new(
+    pub async fn new(
         wallet_config: toml::Value,
         wallet_secrets: toml::Value,
         base_rpc_url: Url,
@@ -100,11 +100,11 @@ impl OnchainWalletCtx {
         })
     }
 
-    pub(crate) fn base_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
+    pub fn base_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
         &self.base_wallet
     }
 
-    pub(crate) fn ethereum_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
+    pub fn ethereum_wallet(&self) -> &Arc<dyn Wallet<Provider = RootProvider>> {
         &self.ethereum_wallet
     }
 }
@@ -119,7 +119,7 @@ fn http_client_with_retry(url: Url) -> RpcClient {
     RpcClient::builder().layer(retry_layer).http(url)
 }
 
-pub(crate) async fn build_wallet(
+pub async fn build_wallet(
     kind: &WalletKind,
     wallet_config: toml::Value,
     wallet_secrets: toml::Value,
@@ -137,13 +137,13 @@ pub(crate) async fn build_wallet(
         .await?)
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 impl OnchainWalletCtx {
     /// Create a stub wallet context for tests.
-    pub(crate) fn stub() -> Self {
+    pub fn stub() -> Self {
         use alloy::primitives::Address;
 
-        let stub_wallet = crate::test_utils::StubWallet::stub(Address::ZERO);
+        let stub_wallet = st0x_evm::StubWallet::stub(Address::ZERO);
 
         Self {
             base_wallet: stub_wallet.clone(),

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -14,6 +14,7 @@ turnkey = [
   "dep:turnkey_api_key_stamper",
   "dep:mime",
 ]
+test-support = ["dep:url"]
 
 [dependencies]
 alloy.workspace = true

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -43,6 +43,11 @@ pub mod turnkey;
 #[cfg(feature = "mock")]
 pub mod test_chain;
 
+#[cfg(feature = "test-support")]
+pub mod stub;
+#[cfg(feature = "test-support")]
+pub use stub::StubWallet;
+
 /// Wallet backend discriminant. Deserialized from a `kind` field in
 /// wallet config sections. Variants are feature-gated so unconfigured
 /// backends fail at parse time with "unknown variant".

--- a/crates/evm/src/stub.rs
+++ b/crates/evm/src/stub.rs
@@ -1,0 +1,76 @@
+//! Panicking wallet stub for tests that need a `Wallet` impl without
+//! real chain connectivity.
+
+use std::sync::Arc;
+
+use alloy::primitives::{Address, Bytes, TxHash};
+use alloy::providers::RootProvider;
+use alloy::rpc::client::RpcClient;
+use alloy::rpc::types::TransactionReceipt;
+use async_trait::async_trait;
+
+use crate::{Evm, EvmError, Wallet};
+
+/// Panicking wallet stub for tests.
+///
+/// Constructs contexts requiring a `Wallet` without needing real chain
+/// connectivity. Provider type matches production (`RootProvider`) so it
+/// fits `Arc<dyn Wallet<Provider = RootProvider>>`.
+pub struct StubWallet {
+    address: Address,
+    provider: RootProvider,
+}
+
+impl StubWallet {
+    pub fn stub(address: Address) -> Arc<dyn Wallet<Provider = RootProvider>> {
+        let url = "http://stub.invalid"
+            .parse()
+            .unwrap_or_else(|_| unreachable!("hardcoded URL must parse"));
+        Arc::new(Self {
+            address,
+            provider: RootProvider::new(RpcClient::builder().http(url)),
+        })
+    }
+}
+
+#[async_trait]
+impl Evm for StubWallet {
+    type Provider = RootProvider;
+
+    fn provider(&self) -> &RootProvider {
+        &self.provider
+    }
+}
+
+#[async_trait]
+impl Wallet for StubWallet {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn send_pending(
+        &self,
+        _contract: Address,
+        _calldata: Bytes,
+        _note: &str,
+    ) -> Result<TxHash, EvmError> {
+        panic!(
+            "StubWallet::send_pending called - use a real wallet in tests that need transactions"
+        )
+    }
+
+    async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+        panic!(
+            "StubWallet::await_receipt called - use a real wallet in tests that need transactions"
+        )
+    }
+
+    async fn send(
+        &self,
+        _contract: Address,
+        _calldata: Bytes,
+        _note: &str,
+    ) -> Result<TransactionReceipt, EvmError> {
+        panic!("StubWallet::send called - use a real wallet in tests that need transactions")
+    }
+}

--- a/crates/finance/Cargo.toml
+++ b/crates/finance/Cargo.toml
@@ -5,8 +5,13 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 
+[features]
+default = []
+test-support = ["dep:proptest"]
+
 [dependencies]
 alloy-primitives.workspace = true
+proptest = { workspace = true, optional = true }
 rain-math-float.workspace = true
 serde = { workspace = true, features = ["derive"] }
 st0x-float-macro.workspace = true

--- a/crates/finance/src/lib.rs
+++ b/crates/finance/src/lib.rs
@@ -9,6 +9,8 @@ use serde::Deserialize;
 use std::fmt::Debug;
 
 mod id;
+#[cfg(feature = "test-support")]
+pub mod proptest;
 mod shares;
 mod symbol;
 mod usd;

--- a/crates/finance/src/proptest.rs
+++ b/crates/finance/src/proptest.rs
@@ -1,0 +1,31 @@
+//! Proptest strategies for generating arbitrary [`Float`] values.
+//!
+//! Available behind the `test-support` feature flag for use in
+//! property tests of any crate that depends on `st0x-finance`.
+
+use proptest::prelude::*;
+use rain_math_float::Float;
+
+/// Strategy that generates arbitrary [`Float`] values from random
+/// `(mantissa, scale)` pairs, formatted as decimal strings and parsed.
+///
+/// Filters out values that fail [`Float::parse`].
+pub fn arb_float() -> impl Strategy<Value = Float> {
+    (any::<i64>(), 0u32..=10).prop_filter_map("Float::parse must succeed", |(mantissa, scale)| {
+        let divisor = 10u64.checked_pow(scale).unwrap_or(1);
+        let abs_mantissa = mantissa.unsigned_abs();
+        let integer_part = abs_mantissa / divisor;
+        let frac_part = abs_mantissa % divisor;
+        let sign = if mantissa.is_negative() { "-" } else { "" };
+
+        let value_str = if scale == 0 {
+            format!("{sign}{integer_part}")
+        } else {
+            format!(
+                "{sign}{integer_part}.{frac_part:0>width$}",
+                width = scale as usize
+            )
+        };
+        Float::parse(value_str).ok()
+    })
+}

--- a/src/alpaca_wallet/client.rs
+++ b/src/alpaca_wallet/client.rs
@@ -381,7 +381,7 @@ mod tests {
     use serde_json::json;
     use uuid::uuid;
 
-    use crate::config::TravelRuleConfig;
+    use st0x_config::TravelRuleConfig;
 
     use super::*;
 

--- a/src/alpaca_wallet/whitelist.rs
+++ b/src/alpaca_wallet/whitelist.rs
@@ -8,7 +8,7 @@ use alloy::primitives::Address;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::config::TravelRuleConfig;
+use st0x_config::TravelRuleConfig;
 
 use super::transfer::{Network, TokenSymbol};
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,9 +18,9 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info};
 
+use st0x_config::Ctx;
 use st0x_execution::{FractionalShares, SharesBlockchain};
 
-use crate::config::Ctx;
 use crate::dashboard::transfer_loader::TransferKind;
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
 use crate::rebalancing::RebalancingService;
@@ -1456,8 +1456,9 @@ pub(crate) fn routes() -> Vec<Route> {
 mod tests {
     use rocket::local::asynchronous::Client;
 
+    use st0x_config::{RestApiCtx, create_test_ctx_with_order_owner};
+
     use super::*;
-    use crate::config::tests::create_test_ctx_with_order_owner;
 
     #[test]
     fn routes_include_recheck_transfer_endpoint() {
@@ -2071,7 +2072,7 @@ mod tests {
     #[tokio::test]
     async fn raindex_orders_returns_unavailable_when_upstream_unreachable() {
         let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
-        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+        ctx.rest_api = Some(RestApiCtx::unauthenticated(
             "http://127.0.0.1:1".to_string(),
         ));
 
@@ -2130,9 +2131,7 @@ mod tests {
         });
 
         let mut ctx = create_test_ctx_with_order_owner(owner);
-        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
-            mock_server.base_url(),
-        ));
+        ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
         let rocket = rocket::build()
             .mount("/", routes![raindex_orders])
@@ -2179,9 +2178,7 @@ mod tests {
         });
 
         let mut ctx = create_test_ctx_with_order_owner(owner);
-        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
-            mock_server.base_url(),
-        ));
+        ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
         let rocket = rocket::build()
             .mount("/", routes![raindex_orders])
@@ -2231,9 +2228,7 @@ mod tests {
         });
 
         let mut ctx = create_test_ctx_with_order_owner(owner);
-        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
-            mock_server.base_url(),
-        ));
+        ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
         let rocket = rocket::build()
             .mount("/", routes![raindex_orders])
@@ -2267,9 +2262,7 @@ mod tests {
         });
 
         let mut ctx = create_test_ctx_with_order_owner(owner);
-        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
-            mock_server.base_url(),
-        ));
+        ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
         let rocket = rocket::build()
             .mount("/", routes![raindex_orders])

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use st0x_hedge::config::{Ctx, Env};
+use st0x_config::{Ctx, Env};
 use st0x_hedge::run_bot_session;
 use st0x_hedge::setup_tracing;
 

--- a/src/bin/validate-config.rs
+++ b/src/bin/validate-config.rs
@@ -6,7 +6,7 @@
 
 use clap::Parser;
 
-use st0x_hedge::config::{Ctx, Env};
+use st0x_config::{Ctx, Env};
 
 fn main() -> std::process::ExitCode {
     let Env { config, secrets } = Env::parse();

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -18,8 +18,8 @@ use crate::alpaca_wallet::{
     WhitelistStatus,
 };
 use crate::bindings::IERC20;
-use crate::config::{BrokerCtx, Ctx};
 use crate::onchain::{USDC_ETHEREUM, USDC_ETHEREUM_SEPOLIA};
+use st0x_config::{BrokerCtx, Ctx};
 
 pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write>(
     stdout: &mut W,
@@ -714,11 +714,11 @@ mod tests {
 
     use super::*;
     use crate::cli::ConvertDirection;
-    use crate::config::{AssetsConfig, EquitiesConfig, LogLevel, TradingMode};
     use crate::inventory::ImbalanceThreshold;
-    use crate::onchain::EvmCtx;
-    use crate::rebalancing::RebalancingCtx;
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::RebalancingCtx;
+    use st0x_config::{AssetsConfig, EquitiesConfig, LogLevel, TradingMode};
     use st0x_float_macro::float;
 
     fn create_ctx_without_alpaca() -> Ctx {
@@ -752,8 +752,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -837,14 +835,12 @@ mod tests {
                     .call(),
             )),
             order_owner: Address::ZERO,
-            wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
+            wallet: Some(st0x_config::OnchainWalletCtx::stub()),
             wallet_meta: None,
             execution_threshold: ExecutionThreshold::whole_share(),
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -6,14 +6,14 @@ use std::io::Write;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection};
+use st0x_config::Ctx;
 use st0x_evm::{Evm, IntoErrorRegistry, Wallet};
 use st0x_finance::Usdc;
+use st0x_float_serde::format_float_with_fallback;
 
 use super::CctpChain;
 use crate::bindings::IERC20;
-use crate::config::Ctx;
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
-use st0x_float_serde::format_float_with_fallback;
 
 impl CctpChain {
     /// Converts to the bridge direction (from this chain to its destination).
@@ -250,9 +250,9 @@ mod tests {
     use st0x_finance::Usdc;
 
     use super::*;
-    use crate::config::{AssetsConfig, BrokerCtx, CtxError, EquitiesConfig, LogLevel, TradingMode};
-    use crate::onchain::EvmCtx;
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::{AssetsConfig, BrokerCtx, CtxError, EquitiesConfig, LogLevel, TradingMode};
 
     fn create_ctx_without_rebalancing() -> Ctx {
         Ctx {
@@ -285,8 +285,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,19 +12,19 @@ mod wrapper;
 use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::{ProviderBuilder, WsConnect};
 use clap::{Parser, Subcommand, ValueEnum};
+use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
 use tracing::info;
 
-use rain_math_float::Float;
+use st0x_config::{Ctx, Env};
 use st0x_event_sorcery::Projection;
 use st0x_evm::OpenChainErrorRegistry;
 use st0x_execution::alpaca_broker_api::AlpacaLimitPrice;
 use st0x_execution::{AlpacaAccountId, Direction, FractionalShares, Positive, Symbol, TimeInForce};
 use st0x_finance::Usdc;
 
-use crate::config::{Ctx, Env};
 use crate::offchain::order::{OffchainOrder, OffchainOrderId, OrderPlacer};
 use crate::position::Position;
 use crate::symbol::cache::SymbolCache;
@@ -1287,10 +1287,10 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::config::{AssetsConfig, BrokerCtx, EquitiesConfig, LogLevel, TradingMode};
-    use crate::onchain::EvmCtx;
     use crate::test_utils::{positive_shares, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::{AssetsConfig, BrokerCtx, EquitiesConfig, LogLevel, TradingMode};
 
     fn create_test_ctx() -> Ctx {
         Ctx {
@@ -1323,8 +1323,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -18,7 +18,6 @@ use st0x_finance::Usdc;
 use super::{TransferDirection, TransferType};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::bindings::IERC20;
-use crate::config::{BrokerCtx, Ctx};
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
@@ -34,6 +33,7 @@ use crate::tokenized_equity_mint::{
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::vault_registry::VaultRegistry;
 use crate::wrapper::{Wrapper, WrapperService};
+use st0x_config::{BrokerCtx, Ctx};
 
 struct EquityTransferCliServices {
     transfer: CrossVenueEquityTransfer,
@@ -743,14 +743,14 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::config::{
+    use crate::inventory::ImbalanceThreshold;
+    use crate::test_utils::setup_test_db;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::RebalancingCtx;
+    use st0x_config::{
         AssetsConfig, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode, TradingMode,
     };
-    use crate::inventory::ImbalanceThreshold;
-    use crate::onchain::EvmCtx;
-    use crate::rebalancing::RebalancingCtx;
-    use crate::test_utils::setup_test_db;
-    use crate::threshold::ExecutionThreshold;
 
     fn create_ctx_without_rebalancing() -> Ctx {
         Ctx {
@@ -783,8 +783,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -844,7 +842,7 @@ mod tests {
                     .call(),
             )),
             order_owner: Address::ZERO,
-            wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
+            wallet: Some(st0x_config::OnchainWalletCtx::stub()),
             wallet_meta: None,
             execution_threshold: ExecutionThreshold::whole_share(),
             assets: AssetsConfig {
@@ -854,8 +852,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -61,13 +61,13 @@ pub(super) async fn fail_pending_offchain_order_command<W: Write>(
 mod tests {
     use alloy::primitives::TxHash;
 
+    use st0x_config::ExecutionThreshold;
     use st0x_execution::{Direction, FractionalShares};
     use st0x_float_macro::float;
 
     use super::*;
     use crate::position::TradeId;
     use crate::test_utils::{positive_shares, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
 
     async fn seed_pending_position(
         pool: &SqlitePool,

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -5,9 +5,8 @@ use alloy::primitives::{Address, Bytes};
 use std::io::{BufRead, Write};
 use thiserror::Error;
 
+use st0x_config::Ctx;
 use st0x_evm::Wallet;
-
-use crate::config::Ctx;
 
 #[derive(Debug, Error)]
 pub(crate) enum SubmitError {

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -18,7 +18,6 @@ use st0x_execution::{
     MockExecutorCtx, OrderPlacement, OrderState, Positive, Symbol, TimeInForce, TryIntoExecutor,
 };
 
-use crate::config::{BrokerCtx, Ctx};
 use crate::offchain::order::{
     OffchainOrderCommand, OffchainOrderId, OrderPlacementResult, OrderPlacer,
     build_offchain_order_cqrs,
@@ -28,7 +27,8 @@ use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::{OnChainError, OnchainTrade, TradeValidationError};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::symbol::cache::SymbolCache;
-use crate::threshold::ExecutionThreshold;
+use st0x_config::ExecutionThreshold;
+use st0x_config::{BrokerCtx, Ctx};
 use st0x_float_serde::format_float_with_fallback;
 
 /// OrderPlacer for the CLI that delegates to the broker-specific executor
@@ -643,12 +643,13 @@ mod tests {
     use serde_json::json;
     use url::Url;
 
-    use super::*;
-    use crate::config::{AssetsConfig, BrokerCtx, EquitiesConfig, LogLevel, TradingMode};
-    use crate::onchain::EvmCtx;
-    use crate::test_utils::{positive_shares, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::{
+        AssetsConfig, BrokerCtx, EquitiesConfig, EvmCtx, ExecutionThreshold, LogLevel, TradingMode,
+    };
     use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode};
+
+    use super::*;
+    use crate::test_utils::{positive_shares, setup_test_db};
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
@@ -684,8 +685,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -7,13 +7,13 @@ use sqlx::SqlitePool;
 use std::io::Write;
 use thiserror::Error;
 
+use st0x_config::Ctx;
 use st0x_event_sorcery::StoreBuilder;
 use st0x_evm::{Evm, OpenChainErrorRegistry};
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
 
 use crate::bindings::IERC20;
-use crate::config::Ctx;
 use crate::onchain::USDC_BASE;
 use crate::onchain::raindex::{Raindex, RaindexService, RaindexVaultId};
 use crate::vault_registry::VaultRegistry;
@@ -218,14 +218,14 @@ mod tests {
 
     use super::*;
     use crate::bindings::IERC20::decimalsCall;
-    use crate::config::{
+    use crate::inventory::ImbalanceThreshold;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::RebalancingCtx;
+    use st0x_config::{
         AssetsConfig, BrokerCtx, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode,
         TradingMode,
     };
-    use crate::inventory::ImbalanceThreshold;
-    use crate::onchain::EvmCtx;
-    use crate::rebalancing::RebalancingCtx;
-    use crate::threshold::ExecutionThreshold;
     use st0x_float_macro::float;
 
     fn create_ctx_without_rebalancing() -> Ctx {
@@ -259,8 +259,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 
@@ -296,7 +294,7 @@ mod tests {
                     .call(),
             )),
             order_owner: Address::ZERO,
-            wallet: Some(crate::wallet::OnchainWalletCtx::stub()),
+            wallet: Some(st0x_config::OnchainWalletCtx::stub()),
             wallet_meta: None,
             execution_threshold: ExecutionThreshold::whole_share(),
             assets: AssetsConfig {
@@ -306,8 +304,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: Some(Address::ZERO),
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -3,9 +3,9 @@
 use alloy::primitives::Address;
 use std::io::Write;
 
+use st0x_config::Ctx;
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, Symbol};
 
-use crate::config::Ctx;
 use crate::wrapper::{Wrapper, WrapperService};
 
 pub(super) async fn wrap_equity_command<Writer: Write>(
@@ -135,11 +135,11 @@ mod tests {
         unwrap_equity_command, unwrap_equity_with_wrapper, wrap_equity_command,
         wrap_equity_with_wrapper,
     };
-    use crate::config::{AssetsConfig, BrokerCtx, Ctx, EquitiesConfig, LogLevel, TradingMode};
-    use crate::onchain::EvmCtx;
     use crate::test_utils::positive_shares;
-    use crate::threshold::ExecutionThreshold;
     use crate::wrapper::mock::MockWrapper;
+    use st0x_config::EvmCtx;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::{AssetsConfig, BrokerCtx, Ctx, EquitiesConfig, LogLevel, TradingMode};
 
     fn create_ctx_without_rebalancing() -> Ctx {
         Ctx {
@@ -172,8 +172,6 @@ mod tests {
             travel_rule: None,
             rest_api: None,
             redemption_wallet: None,
-            #[cfg(feature = "test-support")]
-            failure_injector: crate::conductor::job::FailureInjector::new(),
         }
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -23,6 +23,7 @@ use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use st0x_config::{AssetsConfig, BrokerCtx, Ctx, CtxError, ExecutionThreshold, RebalancingCtx};
 use st0x_dto::Statement;
 use st0x_event_sorcery::{
     Projection, Store, StoreBuilder, compact_events, incremental_vacuum, load_all_ids, load_entity,
@@ -35,7 +36,6 @@ use st0x_execution::{
 
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
-use crate::config::{AssetsConfig, BrokerCtx, Ctx, CtxError};
 use crate::dashboard::Broadcaster;
 use crate::equity_redemption::{
     EquityRedemption, interrupted_redemption_ids, symbols_with_stuck_redemptions,
@@ -61,11 +61,10 @@ use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::{
-    RebalancerServices, RebalancingCqrsFrameworks, RebalancingCtx, RebalancingSchedulers,
-    RebalancingService, RebalancingServiceConfig,
+    RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
+    RebalancingServiceConfig,
 };
 use crate::symbol::cache::SymbolCache;
-use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
 use crate::tokenization::alpaca::AlpacaTokenizationService;
 use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
@@ -145,6 +144,8 @@ impl Conductor {
         inventory: Arc<BroadcastingInventory>,
         shutdown_token: CancellationToken,
         recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
+        #[cfg(any(test, feature = "test-support"))]
+        failure_injector: crate::conductor::job::FailureInjector,
     ) -> anyhow::Result<()>
     where
         E: Executor + Clone + Send + 'static,
@@ -299,7 +300,7 @@ impl Conductor {
             tokenizer,
             shutdown_token: shutdown_token.clone(),
             #[cfg(any(test, feature = "test-support"))]
-            failure_injector: ctx.failure_injector.clone(),
+            failure_injector,
         };
 
         // Clone before the builder consumes it; the recovery handle needs the
@@ -1968,6 +1969,10 @@ mod tests {
     use task_supervisor::SupervisorBuilder;
     use tokio::sync::broadcast;
 
+    use st0x_config::{
+        AssetsConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
+        create_test_ctx_with_order_owner,
+    };
     use st0x_dto::Statement;
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_execution::{
@@ -1982,15 +1987,12 @@ mod tests {
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
     };
     use crate::conductor::builder::CqrsFrameworks;
-    use crate::config::tests::create_test_ctx_with_order_owner;
-    use crate::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
     use crate::inventory::view::Operator;
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::OrderPlacementResult;
     use crate::onchain::trade::OnchainTrade;
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService, TriggeredOperation};
     use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::wrapper::mock::MockWrapper;
     use crate::wrapper::{RATIO_ONE, UnderlyingPerWrapped};

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
+use st0x_config::{Ctx, ExecutionThreshold};
 use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
@@ -24,7 +25,6 @@ use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, build_supervised_worker};
 use super::monitor::executor_maintenance::ExecutorMaintenance;
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
-use crate::config::Ctx;
 use crate::inventory::{
     InventoryPollingService, InventorySnapshot, InventorySnapshotId, WalletPollingCtx,
 };
@@ -46,7 +46,6 @@ use crate::rebalancing::{
     UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
 };
 use crate::symbol::cache::SymbolCache;
-use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
 use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue, PlaceHedge};
 use crate::trading::onchain::trade_accountant::{

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -132,7 +132,6 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Operator, Venue,
@@ -144,10 +143,10 @@ mod tests {
         drain_pending_jobs,
     };
     use crate::test_utils::setup_test_db;
-    use crate::threshold::ExecutionThreshold;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
     use crate::wrapper::mock::MockWrapper;
+    use st0x_config::{AssetsConfig, EquitiesConfig, ExecutionThreshold};
 
     fn test_trigger_config() -> RebalancingServiceConfig {
         RebalancingServiceConfig {

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -38,8 +38,9 @@ use std::collections::BTreeMap;
 use task_supervisor::{SupervisedTask, TaskResult};
 use tracing::{debug, error, info, trace, warn};
 
+use st0x_config::EvmCtx;
+
 use crate::bindings::IOrderBookV6::{ClearV3, IOrderBookV6Instance, TakeOrderV3};
-use crate::onchain::EvmCtx;
 use crate::onchain::backfill::{
     BackfillJobQueue, BackfillRange, backfill_start_block, save_backfill_checkpoint,
 };

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -309,7 +309,7 @@ mod tests {
 
         let symbol = Symbol::new("AAPL").unwrap();
         let now = chrono::Utc::now();
-        let threshold = crate::threshold::ExecutionThreshold::Shares(
+        let threshold = st0x_config::ExecutionThreshold::Shares(
             st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
                 st0x_float_macro::float!(1),
             ))

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -8,14 +8,13 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{info, trace, warn};
 
+use st0x_config::{ExecutionThreshold, OperationMode};
 use st0x_dto::{CurrentState, Statement};
 use st0x_event_sorcery::{load_all_ids, load_entity};
 use st0x_finance::Positive;
 
-use crate::config::OperationMode;
 use crate::inventory::BroadcastingInventory;
 use crate::position::Position;
-use crate::threshold::ExecutionThreshold;
 
 mod event;
 mod trade_loader;
@@ -110,7 +109,7 @@ pub(crate) fn routes() -> Vec<Route> {
     routes![ws_endpoint]
 }
 
-pub(crate) fn settings_from_ctx(ctx: &crate::config::Ctx) -> st0x_dto::Settings {
+pub(crate) fn settings_from_ctx(ctx: &st0x_config::Ctx) -> st0x_dto::Settings {
     let (equity_target, equity_deviation, usdc_target, usdc_deviation) =
         ctx.rebalancing_ctx().map_or_else(
             |_| (0.5, 0.2, None, None),
@@ -172,13 +171,13 @@ pub(crate) fn settings_from_ctx(ctx: &crate::config::Ctx) -> st0x_dto::Settings 
         .collect();
 
     let trading_mode = match &ctx.trading_mode {
-        crate::config::TradingMode::Standalone => "standalone",
-        crate::config::TradingMode::Rebalancing(_) => "rebalancing",
+        st0x_config::TradingMode::Standalone => "standalone",
+        st0x_config::TradingMode::Rebalancing(_) => "rebalancing",
     };
 
     let broker = match &ctx.broker {
-        crate::config::BrokerCtx::AlpacaBrokerApi(_) => "alpaca",
-        crate::config::BrokerCtx::DryRun => "dry_run",
+        st0x_config::BrokerCtx::AlpacaBrokerApi(_) => "alpaca",
+        st0x_config::BrokerCtx::DryRun => "dry_run",
     };
 
     let cash_reserved = ctx

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -21,6 +21,9 @@ use sqlx::SqlitePool;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use st0x_config::{
+    AssetsConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
+};
 use st0x_event_sorcery::{Projection, Store, StoreBuilder, test_store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::{
@@ -40,7 +43,6 @@ use crate::conductor::{
     AccumulatedPositionExecutionCtx, TradeProcessingCqrs, VaultDiscoveryCtx,
     check_and_execute_accumulated_positions, discover_vaults_for_trade, process_queued_trade,
 };
-use crate::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
 use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
 };
@@ -51,7 +53,6 @@ use crate::onchain::trade::RaindexTradeEvent;
 use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
 use crate::test_utils::setup_test_db;
-use crate::threshold::ExecutionThreshold;
 use crate::tokenization::alpaca::tests::setup_anvil;
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -21,18 +21,20 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::{broadcast, mpsc};
 
 use rain_math_float::Float;
+use st0x_config::{
+    AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold,
+    OperationMode,
+};
 use st0x_dto::Statement;
 use st0x_event_sorcery::{Store, StoreBuilder, test_store};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::{Usd, Usdc};
+use st0x_float_macro::float;
 
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
-use crate::config::{
-    AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
-};
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain::order::OffchainOrderId;
@@ -48,7 +50,6 @@ use crate::rebalancing::{
     TriggeredOperation, drain_pending_jobs,
 };
 use crate::test_utils::setup_test_db;
-use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
 use crate::tokenization::alpaca::tests::{
     TEST_REDEMPTION_WALLET, create_test_service_from_mock, setup_anvil, tokenization_mint_path,
@@ -58,7 +59,6 @@ use crate::tokenization::mock::MockTokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
 use crate::wrapper::mock::MockWrapper;
-use st0x_float_macro::float;
 
 const TEST_ORDERBOOK: Address = address!("0x0000000000000000000000000000000000000001");
 const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000000002");

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod snapshot;
 mod venue_balance;
 pub(crate) mod view;
 
+pub(crate) use st0x_config::ImbalanceThreshold;
+
 pub(crate) use broadcasting::BroadcastingInventory;
 #[cfg(test)]
 pub(crate) use polling::PollerError;
@@ -17,7 +19,6 @@ pub(crate) use polling::{
 pub(crate) use projection::InventoryProjection;
 pub(crate) use snapshot::{InventorySnapshot, InventorySnapshotId};
 pub(crate) use venue_balance::InventoryError;
-pub use view::ImbalanceThreshold;
 pub(crate) use view::{
     EquityImbalanceError, Imbalance, Inventory, InventoryView, InventoryViewError, Operator,
     TransferOp, Venue,

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::{Add, Sub};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -10,10 +10,10 @@ use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use st0x_config::ImbalanceThreshold;
 use st0x_dto::{InFlightCash, InFlightEquity, SymbolInventory, UsdcInventory};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_finance::{Usd, Usdc};
-use st0x_float_macro::float;
 
 use super::snapshot::InventorySnapshotEvent;
 use super::venue_balance::{InventoryError, VenueBalance};
@@ -21,8 +21,6 @@ use crate::equity_redemption::RedemptionAggregateId;
 use crate::tokenized_equity_mint::IssuerRequestId;
 use crate::usdc_rebalance::UsdcRebalanceId;
 use crate::wrapper::{RatioError, UnderlyingPerWrapped};
-
-static EXACT_ONE: LazyLock<Float> = LazyLock::new(|| float!(1));
 
 /// Error type for inventory view operations.
 #[derive(Debug, thiserror::Error)]
@@ -55,91 +53,6 @@ pub(crate) enum Imbalance<T> {
     TooMuchOnchain { excess: T },
     /// Too much offchain - triggers movement to onchain.
     TooMuchOffchain { excess: T },
-}
-
-/// Threshold configuration for imbalance detection.
-///
-/// Invariants enforced by [`ImbalanceThreshold::new`]:
-/// - `target` must be in `[0.0, 1.0]`
-/// - `deviation` must be `>= 0`
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(try_from = "RawImbalanceThreshold", deny_unknown_fields)]
-pub struct ImbalanceThreshold {
-    /// Target ratio of onchain to total (e.g., 0.5 for 50/50 split).
-    #[serde(
-        serialize_with = "st0x_float_serde::serialize_float_as_string",
-        deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
-    )]
-    pub(crate) target: Float,
-    /// Deviation from target that triggers rebalancing.
-    #[serde(
-        serialize_with = "st0x_float_serde::serialize_float_as_string",
-        deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
-    )]
-    pub(crate) deviation: Float,
-}
-
-/// Error returned when [`ImbalanceThreshold`] is constructed with
-/// out-of-range values.
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum InvalidImbalanceThreshold {
-    #[error(
-        "target must be between 0.0 and 1.0 inclusive, \
-         got {target:?}"
-    )]
-    TargetOutOfRange { target: Float },
-    #[error("deviation must be >= 0, got {deviation:?}")]
-    NegativeDeviation { deviation: Float },
-}
-
-impl ImbalanceThreshold {
-    /// Creates a new threshold with validated parameters.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`InvalidImbalanceThreshold`] if `target` is not in
-    /// `[0.0, 1.0]` or `deviation` is negative.
-    pub fn new(target: Float, deviation: Float) -> Result<Self, InvalidImbalanceThreshold> {
-        let zero =
-            Float::zero().map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?;
-
-        if target
-            .lt(zero)
-            .map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?
-            || target
-                .gt(*EXACT_ONE)
-                .map_err(|_| InvalidImbalanceThreshold::TargetOutOfRange { target })?
-        {
-            return Err(InvalidImbalanceThreshold::TargetOutOfRange { target });
-        }
-
-        if deviation
-            .lt(zero)
-            .map_err(|_| InvalidImbalanceThreshold::NegativeDeviation { deviation })?
-        {
-            return Err(InvalidImbalanceThreshold::NegativeDeviation { deviation });
-        }
-
-        Ok(Self { target, deviation })
-    }
-}
-
-/// Private helper for serde deserialization with validation.
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RawImbalanceThreshold {
-    #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
-    target: Float,
-    #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
-    deviation: Float,
-}
-
-impl TryFrom<RawImbalanceThreshold> for ImbalanceThreshold {
-    type Error = InvalidImbalanceThreshold;
-
-    fn try_from(raw: RawImbalanceThreshold) -> Result<Self, Self::Error> {
-        Self::new(raw.target, raw.deviation)
-    }
 }
 
 /// Discriminant for the two venues tracked by an [`Inventory`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use tracing::{error, info, warn};
 use st0x_dto::Statement;
 use st0x_execution::MockExecutorCtx;
 
-use crate::config::{BrokerCtx, Ctx};
+use st0x_config::{BrokerCtx, Ctx};
 
 /// How long to wait for in-flight work to drain before force-aborting.
 /// Outer timeout for the entire graceful shutdown sequence. Must exceed
@@ -33,7 +33,6 @@ pub mod bindings;
 pub(crate) mod bindings;
 pub mod cli;
 mod conductor;
-pub mod config;
 pub(crate) mod dashboard;
 mod equity_redemption;
 mod inventory;
@@ -45,8 +44,6 @@ mod position_check;
 mod rebalancing;
 mod shares;
 mod symbol;
-pub mod telemetry;
-mod threshold;
 mod tokenization;
 mod trading;
 #[cfg(feature = "mock")]
@@ -54,23 +51,11 @@ pub use tokenization::mock_api;
 mod tokenized_equity_mint;
 mod usdc_rebalance;
 mod vault_registry;
-#[cfg(any(test, feature = "test-support"))]
-pub mod wallet;
-#[cfg(not(any(test, feature = "test-support")))]
-pub(crate) mod wallet;
 mod wrapped_equity_recovery;
 mod wrapper;
 
-pub use telemetry::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
+pub use st0x_config::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
 
-#[cfg(feature = "test-support")]
-pub use conductor::job::{FailureInjector, JobKind};
-#[cfg(any(test, feature = "test-support"))]
-pub use config::TradingMode;
-#[cfg(any(test, feature = "test-support"))]
-pub use config::{AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
-#[cfg(any(test, feature = "test-support"))]
-pub use inventory::ImbalanceThreshold;
 #[cfg(any(test, feature = "test-support"))]
 pub use offchain::order::{OffchainOrder, OffchainOrderId};
 #[cfg(any(test, feature = "test-support"))]
@@ -83,9 +68,19 @@ pub fn check_positions_job_type() -> &'static str {
     std::any::type_name::<position_check::CheckPositions>()
 }
 #[cfg(any(test, feature = "test-support"))]
-pub use rebalancing::{RebalancingCtx, RebalancingCtxError, UsdcRebalancing};
+pub use conductor::job::{FailureInjector, JobKind};
 #[cfg(any(test, feature = "test-support"))]
-pub use threshold::ExecutionThreshold;
+pub use st0x_config::ExecutionThreshold;
+#[cfg(any(test, feature = "test-support"))]
+pub use st0x_config::TradingMode;
+#[cfg(any(test, feature = "test-support"))]
+pub use st0x_config::{
+    AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
+};
+#[cfg(any(test, feature = "test-support"))]
+pub use st0x_config::{ImbalanceThreshold, RebalancingCtx, RebalancingCtxError, UsdcRebalancing};
+#[cfg(feature = "test-support")]
+pub use trading::onchain::trade_accountant::AccountForDexTrade;
 
 #[cfg(test)]
 mod integration_tests;
@@ -102,6 +97,32 @@ pub async fn run_bot_session(ctx: Ctx) -> anyhow::Result<()> {
 pub async fn run_bot_session_with_event_channel(
     ctx: Ctx,
     event_sender: broadcast::Sender<Statement>,
+) -> anyhow::Result<()> {
+    run_bot_session_inner(
+        ctx,
+        event_sender,
+        #[cfg(any(test, feature = "test-support"))]
+        FailureInjector::new(),
+    )
+    .await
+}
+
+/// Like [`run_bot_session_with_event_channel`] but accepts a caller-supplied
+/// [`FailureInjector`] so e2e tests can arm specific job types.
+#[cfg(any(test, feature = "test-support"))]
+#[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
+pub async fn run_bot_session_with_injector(
+    ctx: Ctx,
+    event_sender: broadcast::Sender<Statement>,
+    failure_injector: FailureInjector,
+) -> anyhow::Result<()> {
+    run_bot_session_inner(ctx, event_sender, failure_injector).await
+}
+
+async fn run_bot_session_inner(
+    ctx: Ctx,
+    event_sender: broadcast::Sender<Statement>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
     sqlx::migrate!().set_ignore_missing(true).run(&pool).await?;
@@ -128,6 +149,8 @@ pub async fn run_bot_session_with_event_channel(
         inventory,
         shutdown_token.clone(),
         recovery_cell,
+        #[cfg(any(test, feature = "test-support"))]
+        failure_injector,
     )));
 
     await_shutdown(server_task, bot_task, shutdown_token).await?;
@@ -335,6 +358,7 @@ async fn run_conductor_session(
     inventory: Arc<inventory::BroadcastingInventory>,
     shutdown_token: CancellationToken,
     recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let result = match ctx.broker.clone() {
         BrokerCtx::DryRun => {
@@ -347,6 +371,8 @@ async fn run_conductor_session(
                 inventory,
                 shutdown_token,
                 recovery_cell,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector,
             ))
             .await
         }
@@ -360,6 +386,8 @@ async fn run_conductor_session(
                 inventory,
                 shutdown_token,
                 recovery_cell,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector,
             ))
             .await
         }
@@ -382,7 +410,7 @@ mod tests {
     use alloy::primitives::address;
 
     use super::*;
-    use crate::config::tests::create_test_ctx_with_order_owner;
+    use st0x_config::create_test_ctx_with_order_owner;
 
     // `Ctx::load_files` parses `orderbook` into `Address`, so runtime tests
     // only exercise already-validated addresses. Invalid orderbook input is
@@ -421,6 +449,7 @@ mod tests {
             create_test_inventory(),
             CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
+            FailureInjector::new(),
         ))
         .await
         .unwrap_err();
@@ -513,6 +542,7 @@ mod tests {
             create_test_inventory(),
             CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
+            FailureInjector::new(),
         ))
         .await
         .unwrap_err();

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -14,8 +14,6 @@ use tracing::{info, warn};
 
 use st0x_event_sorcery::Store;
 
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
 use crate::position::{Position, PositionCommand};
@@ -40,8 +38,10 @@ impl Job<HandleOrderRejectionCtx> for HandleOrderRejection {
     type Error = JobError;
 
     const WORKER_NAME: &'static str = "handle-order-rejection-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::HandleOrderRejection;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::HandleOrderRejection;
 
     fn label(&self) -> Label {
         Label::new(format!("HandleOrderRejection:{}", self.offchain_order_id))
@@ -138,7 +138,7 @@ mod tests {
     use crate::offchain::order::noop_order_placer;
     use crate::position::TradeId;
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
 
     struct TestInfra {
         ctx: HandleOrderRejectionCtx,

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -17,8 +17,6 @@ use st0x_event_sorcery::Projection;
 use st0x_execution::{Executor, ExecutorOrderId, OrderState, SupportedExecutor, Symbol};
 use st0x_finance::Usd;
 
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::handle_rejection::{
     HandleOrderRejection, HandleOrderRejectionJobQueue,
@@ -56,8 +54,10 @@ where
     type Error = JobError;
 
     const WORKER_NAME: &'static str = "poll-order-status-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::PollOrderStatus;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::PollOrderStatus;
 
     fn label(&self) -> Label {
         Label::new(format!("PollOrderStatus:{}", self.offchain_order_id))
@@ -362,7 +362,7 @@ mod tests {
     use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
 
     const TEST_POLL_INTERVAL: Duration = Duration::from_secs(15);
 

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -17,8 +17,6 @@ use st0x_event_sorcery::Store;
 use st0x_execution::ExecutorOrderId;
 use st0x_finance::Usd;
 
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{JobError, OffchainOrder, OffchainOrderCommand, OffchainOrderId};
 use crate::position::{Position, PositionCommand};
@@ -45,8 +43,10 @@ impl Job<ReconcileOrderFillCtx> for ReconcileOrderFill {
     type Error = JobError;
 
     const WORKER_NAME: &'static str = "reconcile-order-fill-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::ReconcileOrderFill;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::ReconcileOrderFill;
 
     fn label(&self) -> Label {
         Label::new(format!("ReconcileOrderFill:{}", self.offchain_order_id))
@@ -148,7 +148,7 @@ mod tests {
     use crate::offchain::order::{noop_order_placer, noop_placed_shares};
     use crate::position::TradeId;
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
 
     struct TestInfra {
         ctx: ReconcileOrderFillCtx,

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -2,10 +2,10 @@ use tracing::debug;
 #[cfg(test)]
 use tracing::info;
 
+use st0x_config::AssetsConfig;
 use st0x_event_sorcery::Projection;
 use st0x_execution::{Direction, Executor, FractionalShares, Positive, SupportedExecutor, Symbol};
 
-use crate::config::AssetsConfig;
 use crate::onchain::OnChainError;
 use crate::position::Position;
 
@@ -169,10 +169,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::setup_test_db;
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
     use st0x_float_macro::float;
 
     async fn create_test_position_infra(

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -16,10 +16,10 @@ use sqlx::SqlitePool;
 use std::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
+use st0x_config::EvmCtx;
 use st0x_evm::Evm;
 use st0x_execution::Executor;
 
-use super::EvmCtx;
 use super::OnChainError;
 use crate::bindings::IOrderBookV6::{ClearV3, TakeOrderV3};
 use crate::conductor::job::{Job, Label};
@@ -171,6 +171,7 @@ where
     type Error = OnChainError;
 
     const WORKER_NAME: &'static str = "backfill-worker";
+
     #[cfg(any(test, feature = "test-support"))]
     const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::Backfill;
 
@@ -392,8 +393,8 @@ mod tests {
     use super::*;
     use crate::bindings::IOrderBookV6;
     use crate::conductor::setup_apalis_tables;
-    use crate::onchain::EvmCtx;
     use crate::test_utils::{get_test_order, setup_test_db};
+    use st0x_config::EvmCtx;
 
     fn test_retry_strategy() -> ExponentialBuilder {
         ExponentialBuilder::default()

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -7,16 +7,14 @@ use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use tracing::debug;
 
+use st0x_config::EvmCtx;
 use st0x_evm::Evm;
 
 use super::OnChainError;
 use crate::bindings::IOrderBookV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2, ClearV3};
+use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::trade::TradeValidationError;
-use crate::onchain::{
-    EvmCtx,
-    pyth::FeedIdCache,
-    trade::{OnchainTrade, OrderFill},
-};
+use crate::onchain::trade::{OnchainTrade, OrderFill};
 use crate::symbol::cache::SymbolCache;
 
 impl OnchainTrade {

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -1,14 +1,12 @@
-//! Onchain event processing: EVM configuration, trade
-//! parsing, event backfilling, position accumulation, and
-//! vault management.
+//! Onchain event processing: trade parsing, event backfilling,
+//! position accumulation, and vault management.
 
+use alloy::primitives::Address;
+use alloy::primitives::address;
 use alloy::primitives::ruint::FromUintError;
-use alloy::primitives::{Address, address};
 use alloy::transports::{RpcError, TransportErrorKind};
 use rain_math_float::FloatError;
-use serde::Deserialize;
 use std::num::TryFromIntError;
-use url::Url;
 
 use st0x_event_sorcery::ProjectionError;
 use st0x_execution::order::status::ParseOrderStatusError;
@@ -32,65 +30,6 @@ pub(crate) mod trade;
 
 pub(crate) use trade::OnchainTrade;
 pub(crate) use trade::TradeValidationError;
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct EvmConfig {
-    pub(crate) orderbook: Address,
-    pub(crate) deployment_block: u64,
-    /// Number of confirmations a block must have before its events are
-    /// ingested. Naive reorg protection: both backfill and live
-    /// ingestion treat the latest tip block minus this value as the
-    /// highest safe block. This is a heuristic, not real chain finality
-    /// -- a deep reorg crossing this depth will still corrupt state.
-    /// Must be set explicitly -- no silent default.
-    pub(crate) required_confirmations: u64,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct EvmSecrets {
-    #[serde(rename = "ws_rpc_url")]
-    pub(crate) ws: Url,
-    /// Base chain RPC URL for wallet operations. Required when `[wallet]`
-    /// is configured.
-    #[serde(rename = "base_rpc_url")]
-    pub(crate) base: Option<Url>,
-    /// Ethereum mainnet RPC URL for wallet operations. Required when
-    /// `[wallet]` is configured.
-    #[serde(rename = "ethereum_rpc_url")]
-    pub(crate) ethereum: Option<Url>,
-}
-
-#[derive(Clone)]
-pub(crate) struct EvmCtx {
-    pub(crate) ws_rpc_url: Url,
-    pub(crate) orderbook: Address,
-    pub(crate) deployment_block: u64,
-    pub(crate) required_confirmations: u64,
-}
-
-impl std::fmt::Debug for EvmCtx {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EvmCtx")
-            .field("ws_rpc_url", &"[REDACTED]")
-            .field("orderbook", &self.orderbook)
-            .field("deployment_block", &self.deployment_block)
-            .field("required_confirmations", &self.required_confirmations)
-            .finish()
-    }
-}
-
-impl EvmCtx {
-    pub(crate) fn new(config: &EvmConfig, secrets: EvmSecrets) -> Self {
-        Self {
-            ws_rpc_url: secrets.ws,
-            orderbook: config.orderbook,
-            deployment_block: config.deployment_block,
-            required_confirmations: config.required_confirmations,
-        }
-    }
-}
 
 /// Unified error type for onchain trade processing with clear domain boundaries.
 /// Provides error mapping between layers while maintaining separation of concerns.

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -11,15 +11,15 @@ use alloy::sol_types::SolEvent;
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
-use st0x_float_serde::format_float_with_fallback;
 use tracing::warn;
 
+use st0x_config::EvmCtx;
 use st0x_evm::Evm;
 use st0x_execution::{Direction, FractionalShares, HasZero};
+use st0x_float_serde::format_float_with_fallback;
 
 use super::pyth::{extract_pyth_price, raw_price_to_pyth_price};
 use crate::bindings::IOrderBookV6::{ClearV3, OrderV4, TakeOrderV3};
-use crate::onchain::EvmCtx;
 use crate::onchain::OnChainError;
 use crate::onchain::io::{TokenizedSymbol, TradeDetails, Usdc, WrappedTokenizedShares};
 use crate::onchain::pyth::FeedIdCache;
@@ -433,8 +433,8 @@ mod tests {
 
     use super::*;
     use crate::bindings::IOrderBookV6;
-    use crate::onchain::EvmCtx;
     use crate::symbol::cache::SymbolCache;
+    use st0x_config::EvmCtx;
     use st0x_float_macro::float;
 
     #[test]

--- a/src/position.rs
+++ b/src/position.rs
@@ -12,16 +12,15 @@ use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
+use st0x_config::ExecutionThreshold;
+use st0x_event_sorcery::{DomainEvent, EventSourced, Table};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, HasZero, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::{Usd, Usdc};
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Table};
-
 use crate::offchain::order::OffchainOrderId;
-use crate::threshold::ExecutionThreshold;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Position {

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -13,14 +13,12 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use tracing::{debug, error, warn};
 
+use st0x_config::Ctx;
 use st0x_event_sorcery::Projection;
 use st0x_execution::{CounterTradePreflight, Executor, MarketOrder, Symbol};
 
 use crate::conductor::clamp_shares_to_reservation;
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
-use crate::config::Ctx;
 use crate::equity_redemption::symbols_with_active_transfers;
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
@@ -75,8 +73,9 @@ where
     type Error = CheckPositionsError;
 
     const WORKER_NAME: &'static str = "check-positions-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::CheckPositions;
+    const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::CheckPositions;
 
     fn label(&self) -> Label {
         Label::new("CheckPositions")
@@ -248,15 +247,15 @@ mod tests {
     };
     use st0x_float_macro::float;
 
+    use st0x_config::{
+        AssetsConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
+        create_test_ctx_with_order_owner,
+    };
+
     use super::*;
     use crate::conductor::setup_apalis_tables;
-    use crate::config::{
-        AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
-        tests::create_test_ctx_with_order_owner,
-    };
     use crate::position::{PositionCommand, TradeId};
     use crate::test_utils::setup_test_db;
-    use crate::threshold::ExecutionThreshold;
 
     async fn build_ctx(
         pool: SqlitePool,

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1542,8 +1542,9 @@ mod tests {
     use st0x_execution::{FractionalShares, Symbol};
     use st0x_float_macro::float;
 
+    use st0x_config::{AssetsConfig, EquitiesConfig};
+
     use super::*;
-    use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
     };

--- a/src/rebalancing/mod.rs
+++ b/src/rebalancing/mod.rs
@@ -12,9 +12,6 @@ pub(crate) mod usdc;
 
 pub(crate) use rebalancer::Rebalancer;
 pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks};
-pub(crate) use trigger::RebalancingConfig;
-#[cfg(any(test, feature = "test-support"))]
-pub use trigger::UsdcRebalancing;
 #[cfg(test)]
 pub(crate) use trigger::drain_pending_jobs;
 pub(crate) use trigger::{
@@ -22,4 +19,3 @@ pub(crate) use trigger::{
     RebalancingService, RebalancingServiceConfig, TriggeredOperation, UsdcRebalancingCheck,
     UsdcRebalancingCheckScheduler,
 };
-pub use trigger::{RebalancingCtx, RebalancingCtxError};

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -16,11 +16,12 @@ use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, EmptySymbolError, Executor, Symbol,
 };
 
+use st0x_config::RebalancingCtx;
+
 use super::equity::CrossVenueEquityTransfer;
 use super::usdc::CrossVenueCashTransfer;
-use super::{Rebalancer, RebalancingCtx, TriggeredOperation};
+use super::{Rebalancer, TriggeredOperation};
 use crate::alpaca_wallet::AlpacaWalletService;
-use crate::config::EquityAssetConfig;
 use crate::equity_redemption::EquityRedemption;
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
@@ -28,6 +29,7 @@ use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::wrapper::WrapperService;
+use st0x_config::EquityAssetConfig;
 
 /// Errors that can occur when spawning the rebalancer.
 #[derive(Debug, thiserror::Error)]
@@ -188,7 +190,6 @@ mod tests {
 
     use super::*;
     use crate::alpaca_wallet::AlpacaWalletService;
-    use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::ImbalanceThreshold;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::RebalancingServiceConfig;
@@ -197,6 +198,7 @@ mod tests {
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_registry::VaultRegistry;
     use crate::wrapper::mock::MockWrapper;
+    use st0x_config::{AssetsConfig, EquitiesConfig};
     use st0x_float_macro::float;
 
     type BaseProvider = FillProvider<

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -11,8 +11,6 @@ use tracing::{debug, trace, warn};
 use st0x_execution::{FractionalShares, Positive, Symbol};
 
 use super::{RebalancingService, TokenAddressError, TriggeredOperation};
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, EquityImbalanceError, Imbalance, ImbalanceThreshold,
@@ -217,8 +215,10 @@ impl Job<RebalancingService> for EquityRebalancingCheck {
     type Error = EquityRebalancingCheckJobError;
 
     const WORKER_NAME: &'static str = "equity-rebalancing-check-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::EquityRebalancingCheck;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::EquityRebalancingCheck;
 
     fn label(&self) -> Label {
         Label::new(format!("EquityRebalancingCheck({})", self.symbol))

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -3,34 +3,9 @@
 mod equity;
 mod usdc;
 
-pub(crate) use equity::{EquityRebalancingCheck, EquityRebalancingCheckScheduler};
-pub(crate) use usdc::{
-    ALPACA_MINIMUM_WITHDRAWAL, UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
-};
-
-/// Bundle of the equity + USDC schedulers so constructors and plumbing
-/// functions can pass them as a single argument instead of two.
-#[derive(Clone)]
-pub(crate) struct RebalancingSchedulers {
-    pub(crate) equity: EquityRebalancingCheckScheduler,
-    pub(crate) usdc: UsdcRebalancingCheckScheduler,
-    pub(crate) wrapped_equity_recovery: WrappedEquityRecoveryJobQueue,
-}
-
-impl RebalancingSchedulers {
-    pub(crate) fn new(pool: &SqlitePool) -> Self {
-        Self {
-            equity: EquityRebalancingCheckScheduler::new(pool),
-            usdc: UsdcRebalancingCheckScheduler::new(pool),
-            wrapped_equity_recovery: WrappedEquityRecoveryJobQueue::new(pool),
-        }
-    }
-}
-
 use alloy::primitives::{Address, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -40,13 +15,13 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{debug, error, trace, warn};
 
 use rain_math_float::Float;
+use st0x_config::{AssetsConfig, OperationMode};
 use st0x_event_sorcery::{
     AggregateError, EntityList, LifecycleError, Projection, ProjectionError, Reactor, Store, deps,
 };
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, Usdc};
 
-use crate::config::AssetsConfig;
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
 };
@@ -67,6 +42,28 @@ use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
 use crate::wrapped_equity_recovery::{WrappedEquityRecoveryJob, WrappedEquityRecoveryJobQueue};
 use crate::wrapper::{Wrapper, WrapperError};
+
+pub(crate) use equity::{EquityRebalancingCheck, EquityRebalancingCheckScheduler};
+pub(crate) use usdc::{UsdcRebalancingCheck, UsdcRebalancingCheckScheduler};
+
+/// Bundle of the equity + USDC schedulers so constructors and plumbing
+/// functions can pass them as a single argument instead of two.
+#[derive(Clone)]
+pub(crate) struct RebalancingSchedulers {
+    pub(crate) equity: EquityRebalancingCheckScheduler,
+    pub(crate) usdc: UsdcRebalancingCheckScheduler,
+    pub(crate) wrapped_equity_recovery: WrappedEquityRecoveryJobQueue,
+}
+
+impl RebalancingSchedulers {
+    pub(crate) fn new(pool: &SqlitePool) -> Self {
+        Self {
+            equity: EquityRebalancingCheckScheduler::new(pool),
+            usdc: UsdcRebalancingCheckScheduler::new(pool),
+            wrapped_equity_recovery: WrappedEquityRecoveryJobQueue::new(pool),
+        }
+    }
+}
 
 /// Why the rebalancing trigger reactor failed.
 #[derive(Debug, thiserror::Error)]
@@ -115,183 +112,6 @@ pub(crate) enum TokenAddressError {
     Uninitialized,
     #[error(transparent)]
     Persistence(#[from] AggregateError<LifecycleError<VaultRegistry>>),
-}
-
-/// Error type for rebalancing configuration validation.
-#[derive(Debug, thiserror::Error)]
-pub enum RebalancingCtxError {
-    #[error("rebalancing requires alpaca-broker-api broker type")]
-    NotAlpacaBroker,
-    #[error("rebalancing transfer_timeout_secs must be non-zero")]
-    ZeroTransferTimeout,
-    #[error("invalid wallet config: {0}")]
-    WalletConfig(#[from] toml::de::Error),
-    #[error(transparent)]
-    Evm(#[from] st0x_evm::EvmError),
-}
-
-/// USDC rebalancing configuration with explicit enable/disable.
-#[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(tag = "mode", rename_all = "lowercase")]
-pub enum UsdcRebalancing {
-    Enabled {
-        #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
-        target: Float,
-        #[serde(deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string")]
-        deviation: Float,
-    },
-    Disabled,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub(crate) struct RebalancingConfig {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: UsdcRebalancing,
-    pub(crate) transfer_timeout_secs: u64,
-}
-
-/// Runtime configuration for rebalancing operations.
-///
-/// Constructed asynchronously from `RebalancingConfig`,
-/// `RebalancingSecrets`, and broker auth. During construction, wallets
-/// are pre-built for both chains. After construction, all fields are
-/// immutable.
-///
-/// Read-only provider access for either chain is available via
-/// `base_wallet().provider()` and `ethereum_wallet().provider()`.
-#[derive(Clone)]
-pub struct RebalancingCtx {
-    pub(crate) equity: ImbalanceThreshold,
-    pub(crate) usdc: Option<ImbalanceThreshold>,
-    pub(crate) transfer_timeout: Duration,
-    /// Circle attestation/fee API base URL (test-only override).
-    #[cfg(feature = "test-support")]
-    pub circle_api_base: String,
-    /// `TokenMessengerV2` contract address (test-only override).
-    #[cfg(feature = "test-support")]
-    pub token_messenger: Address,
-    /// `MessageTransmitterV2` contract address (test-only override).
-    #[cfg(feature = "test-support")]
-    pub message_transmitter: Address,
-}
-
-impl RebalancingCtx {
-    /// Construct from config and secrets.
-    ///
-    /// Wallets are now built separately via [`OnchainWalletCtx`] —
-    /// this constructor only validates and stores rebalancing-specific
-    /// trigger thresholds.
-    pub(crate) fn new(config: &RebalancingConfig) -> Result<Self, RebalancingCtxError> {
-        if config.transfer_timeout_secs == 0 {
-            return Err(RebalancingCtxError::ZeroTransferTimeout);
-        }
-
-        let usdc = match config.usdc {
-            UsdcRebalancing::Enabled { target, deviation } => {
-                Some(ImbalanceThreshold { target, deviation })
-            }
-            UsdcRebalancing::Disabled => None,
-        };
-
-        Ok(Self {
-            equity: config.equity,
-            usdc,
-            transfer_timeout: Duration::from_secs(config.transfer_timeout_secs),
-            #[cfg(feature = "test-support")]
-            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
-            #[cfg(feature = "test-support")]
-            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
-            #[cfg(feature = "test-support")]
-            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
-        })
-    }
-}
-
-#[cfg(test)]
-#[bon::bon]
-impl RebalancingCtx {
-    /// Test constructor that creates a `RebalancingCtx` with stub wallets.
-    ///
-    /// The wallets panic on `send` -- use only in tests that don't submit
-    /// transactions through the rebalancing wallet.
-    #[builder]
-    pub(crate) fn stub(
-        equity: ImbalanceThreshold,
-        usdc: Option<ImbalanceThreshold>,
-        #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
-    ) -> Self {
-        Self {
-            equity,
-            usdc,
-            transfer_timeout,
-            #[cfg(feature = "test-support")]
-            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
-            #[cfg(feature = "test-support")]
-            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
-            #[cfg(feature = "test-support")]
-            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
-        }
-    }
-}
-
-#[cfg(feature = "test-support")]
-#[bon::bon]
-impl RebalancingCtx {
-    /// Test constructor that accepts pre-built wallets for e2e tests
-    /// that need real onchain interaction (e.g. with Anvil forks).
-    #[builder]
-    pub fn with_wallets(
-        equity: ImbalanceThreshold,
-        usdc: UsdcRebalancing,
-        #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
-    ) -> Self {
-        let usdc = match usdc {
-            UsdcRebalancing::Enabled { target, deviation } => {
-                Some(ImbalanceThreshold { target, deviation })
-            }
-            UsdcRebalancing::Disabled => None,
-        };
-
-        Self {
-            equity,
-            usdc,
-            transfer_timeout,
-            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
-            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
-            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
-        }
-    }
-
-    /// Sets the Circle API base URL override (for e2e tests with local
-    /// CCTP contracts and a mock attestation server).
-    #[must_use]
-    pub fn with_circle_api_base(mut self, base_url: String) -> Self {
-        self.circle_api_base = base_url;
-        self
-    }
-
-    /// Sets the CCTP contract address overrides (for e2e tests with
-    /// locally deployed CCTP contracts).
-    #[must_use]
-    pub fn with_cctp_addresses(
-        mut self,
-        token_messenger: Address,
-        message_transmitter: Address,
-    ) -> Self {
-        self.token_messenger = token_messenger;
-        self.message_transmitter = message_transmitter;
-        self
-    }
-}
-
-impl std::fmt::Debug for RebalancingCtx {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RebalancingCtx")
-            .field("equity", &self.equity)
-            .field("usdc", &self.usdc)
-            .finish_non_exhaustive()
-    }
 }
 
 /// Configuration for the rebalancing trigger (runtime).
@@ -1994,9 +1814,7 @@ impl RebalancingService {
             .equities
             .symbols
             .get(symbol)
-            .is_some_and(|config| {
-                config.wrapped_equity_recovery == crate::config::OperationMode::Enabled
-            })
+            .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
     }
 
     /// Checks inventory for equity imbalance and triggers operation if needed.
@@ -3022,11 +2840,6 @@ mod tests {
     use chrono::{Duration as ChronoDuration, Utc};
     use rain_math_float::Float;
     use sqlx::SqlitePool;
-    use st0x_event_sorcery::{
-        EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
-    };
-    use st0x_execution::{Direction, ExecutorOrderId, Positive, SupportedExecutor};
-    use st0x_finance::{Usd, Usdc};
     use std::collections::{BTreeMap, HashSet};
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
@@ -3036,13 +2849,18 @@ mod tests {
     use tokio::sync::mpsc::error::TryRecvError;
     use uuid::Uuid;
 
+    use st0x_config::{CashAssetConfig, EquitiesConfig, ExecutionThreshold, OperationMode};
     use st0x_dto::Statement;
+    use st0x_event_sorcery::{
+        EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
+    };
+    use st0x_execution::{Direction, ExecutorOrderId, HasZero, Positive, SupportedExecutor};
+    use st0x_finance::{Usd, Usdc};
+    use st0x_float_macro::float;
 
     use super::*;
-
     use crate::alpaca_wallet::AlpacaTransferId;
     use crate::conductor::job::Job;
-    use crate::config::{CashAssetConfig, EquitiesConfig, OperationMode};
     use crate::equity_redemption::DetectionFailure;
     use crate::inventory::snapshot::{
         InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
@@ -3051,15 +2869,12 @@ mod tests {
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
-    use crate::threshold::ExecutionThreshold;
     use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
     use crate::usdc_rebalance::{
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
     use crate::vault_registry::VaultRegistryCommand;
     use crate::wrapper::mock::MockWrapper;
-    use st0x_execution::HasZero;
-    use st0x_float_macro::float;
 
     fn test_config() -> RebalancingServiceConfig {
         RebalancingServiceConfig {
@@ -8201,103 +8016,6 @@ mod tests {
         ));
     }
 
-    fn valid_rebalancing_config_toml() -> &'static str {
-        r#"
-            transfer_timeout_secs = 1800
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            mode = "enabled"
-            target = "0.5"
-            deviation = "0.3"
-        "#
-    }
-
-    #[test]
-    fn deserialize_config_succeeds() {
-        let config: RebalancingConfig = toml::from_str(valid_rebalancing_config_toml()).unwrap();
-
-        assert!(config.equity.target.eq(float!(0.5)).unwrap());
-        assert!(config.equity.deviation.eq(float!(0.2)).unwrap());
-
-        let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
-            panic!("expected UsdcRebalancing::Enabled");
-        };
-        assert!(target.eq(float!(0.5)).unwrap());
-        assert!(deviation.eq(float!(0.3)).unwrap());
-        assert_eq!(config.transfer_timeout_secs, 1800);
-    }
-
-    #[test]
-    fn deserialize_with_custom_thresholds() {
-        let config: RebalancingConfig = toml::from_str(
-            r#"
-            transfer_timeout_secs = 1800
-
-            [equity]
-            target = "0.6"
-            deviation = "0.1"
-
-            [usdc]
-            mode = "enabled"
-            target = "0.4"
-            deviation = "0.15"
-        "#,
-        )
-        .unwrap();
-
-        assert!(config.equity.target.eq(float!(0.6)).unwrap());
-        assert!(config.equity.deviation.eq(float!(0.1)).unwrap());
-
-        let UsdcRebalancing::Enabled { target, deviation } = config.usdc else {
-            panic!("expected UsdcRebalancing::Enabled");
-        };
-        assert!(target.eq(float!(0.4)).unwrap());
-        assert!(deviation.eq(float!(0.15)).unwrap());
-    }
-
-    #[test]
-    fn deserialize_missing_transfer_timeout_secs_fails() {
-        let toml_str = r#"
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-
-            [usdc]
-            mode = "enabled"
-            target = "0.5"
-            deviation = "0.3"
-        "#;
-
-        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
-        assert!(
-            error.message().contains("transfer_timeout_secs"),
-            "Expected missing transfer_timeout_secs error, got: {error}"
-        );
-    }
-
-    #[test]
-    fn deserialize_missing_equity_fails() {
-        let toml_str = r#"
-            redemption_wallet = "0x1234567890123456789012345678901234567890"
-            transfer_timeout_secs = 1800
-
-            [usdc]
-            mode = "enabled"
-            target = "0.5"
-            deviation = "0.3"
-        "#;
-
-        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
-        assert!(
-            error.message().contains("equity"),
-            "Expected missing equity error, got: {error}"
-        );
-    }
-
     #[tokio::test]
     async fn usdc_rebalancing_disabled_when_cash_ratio_absent() {
         // Regression: when usdc is None, startup must not require assets.cash.vault_id.
@@ -8339,24 +8057,6 @@ mod tests {
         assert!(
             trigger.usdc_rebalancing_params().is_none(),
             "Expected usdc_rebalancing_params to be None when cash ratio is absent"
-        );
-    }
-
-    #[test]
-    fn deserialize_missing_usdc_fails() {
-        let toml_str = r#"
-            redemption_wallet = "0x1234567890123456789012345678901234567890"
-            transfer_timeout_secs = 1800
-
-            [equity]
-            target = "0.5"
-            deviation = "0.2"
-        "#;
-
-        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
-        assert!(
-            error.message().contains("usdc"),
-            "Expected missing usdc error, got: {error}"
         );
     }
 
@@ -9257,7 +8957,7 @@ mod tests {
             private_key = private_key_str
         };
 
-        let wallet = crate::wallet::build_wallet(
+        let wallet = st0x_config::build_wallet(
             &st0x_evm::WalletKind::PrivateKey,
             wallet_config.into(),
             wallet_secrets.into(),

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -1,21 +1,16 @@
 //! USDC-specific trigger types and logic.
 
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
-
-use st0x_float_macro::float;
 use tracing::{debug, trace, warn};
 
 use st0x_finance::{Usd, Usdc};
 
 use super::{RebalancingService, RebalancingServiceError, TriggeredOperation};
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
@@ -173,11 +168,7 @@ impl UsdcRebalanceStage {
     }
 }
 
-/// Minimum USDC amount for Alpaca withdrawals.
-/// Alpaca requires $50 USD minimum, but due to USDC/USD spread (~17bps observed in live tests),
-/// we use $51 to ensure we always meet the minimum after conversion slippage.
-pub(crate) static ALPACA_MINIMUM_WITHDRAWAL: LazyLock<Usdc> =
-    LazyLock::new(|| Usdc::new(float!(51)));
+pub(crate) use st0x_config::ALPACA_MINIMUM_WITHDRAWAL;
 
 /// Maximum decimal places for rebalanceable USDC token amounts.
 const USDC_TRANSFER_MAX_DECIMAL_PLACES: u8 = 6;
@@ -865,8 +856,10 @@ impl Job<RebalancingService> for UsdcRebalancingCheck {
     type Error = UsdcRebalancingCheckJobError;
 
     const WORKER_NAME: &'static str = "usdc-rebalancing-check-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::UsdcRebalancingCheck;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::UsdcRebalancingCheck;
 
     fn label(&self) -> Label {
         Label::new("UsdcRebalancingCheck")

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -17,8 +17,8 @@ use crate::offchain::order::{
     OffchainOrder, OffchainOrderCommand, OffchainOrderId, PollOrderStatus, PollOrderStatusJobQueue,
 };
 use crate::position::{Position, PositionCommand, PositionError};
-use crate::threshold::ExecutionThreshold;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
+use st0x_config::ExecutionThreshold;
 
 /// Persistent job queue for hedge placement.
 pub(crate) type HedgeJobQueue = JobQueue<PlaceHedge>;
@@ -80,6 +80,7 @@ impl Job<HedgeCtx> for PlaceHedge {
     type Error = TradeAccountingError;
 
     const WORKER_NAME: &'static str = "hedge-worker";
+
     #[cfg(any(test, feature = "test-support"))]
     const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::Hedge;
 
@@ -205,7 +206,7 @@ mod tests {
     use crate::offchain::order::{OffchainOrder, OrderPlacementResult, OrderPlacer};
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::setup_test_db;
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
 
     fn succeeding_order_placer() -> Arc<dyn OrderPlacer> {
         struct SucceedingPlacer;

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -24,13 +24,13 @@ use crate::conductor::job::{Job, JobQueue, Label};
 use crate::conductor::{
     TradeProcessingCqrs, VaultDiscoveryCtx, discover_vaults_for_trade, process_queued_trade,
 };
-use crate::config::Ctx;
 use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::trade::{RaindexTradeEvent, TradeValidationError};
 use crate::onchain::{OnChainError, OnchainTrade};
 use crate::symbol::cache::SymbolCache;
 use crate::symbol::lock::get_symbol_lock;
 use crate::vault_registry::VaultRegistry;
+use st0x_config::Ctx;
 
 /// Persistent job queue for DEX trade accounting.
 pub(crate) type DexTradeAccountingJobQueue = JobQueue<AccountForDexTrade>;
@@ -39,7 +39,7 @@ pub(crate) type DexTradeAccountingJobQueue = JobQueue<AccountForDexTrade>;
 /// It's the unified mechanism for processing both backfilled events as well as
 /// live events from the monitor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct AccountForDexTrade {
+pub struct AccountForDexTrade {
     /// Raindex trade event with block inclusion metadata
     pub(crate) trade: EmittedOnChain<RaindexTradeEvent>,
 }
@@ -68,6 +68,7 @@ where
     type Error = TradeAccountingError;
 
     const WORKER_NAME: &'static str = "order-fill-worker";
+
     #[cfg(any(test, feature = "test-support"))]
     const JOB_KIND: crate::conductor::job::JobKind = crate::conductor::job::JobKind::OrderFill;
 
@@ -249,12 +250,12 @@ mod tests {
     use crate::bindings::IOrderBookV6::{
         ClearConfigV2, SignedContextV1, TakeOrderConfigV4, TakeOrderV3 as TakeOrderV3Event,
     };
-    use crate::config::tests::create_test_ctx_with_order_owner;
     use crate::offchain::order::OffchainOrder;
     use crate::onchain_trade::OnChainTrade;
     use crate::position::Position;
     use crate::test_utils::{get_test_log, get_test_order, setup_test_db};
-    use crate::threshold::ExecutionThreshold;
+    use st0x_config::ExecutionThreshold;
+    use st0x_config::create_test_ctx_with_order_owner;
 
     fn test_job() -> AccountForDexTrade {
         let log = get_test_log();

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -22,10 +22,9 @@ use st0x_execution::Symbol;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Never, Projection, SendError, Store, Table};
 
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
+use st0x_config::{Ctx, CtxError};
+
 use crate::conductor::job::{Job, JobQueue, Label};
-use crate::config::{Ctx, CtxError};
 
 /// Typed identifier for VaultRegistry aggregates, keyed by
 /// orderbook and owner address pair.
@@ -556,8 +555,10 @@ impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
     type Error = SeedVaultRegistryError;
 
     const WORKER_NAME: &'static str = "seed-vault-registry-worker";
+
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::SeedVaultRegistry;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::SeedVaultRegistry;
 
     fn label(&self) -> Label {
         Label::new("SeedVaultRegistry")
@@ -1178,9 +1179,9 @@ mod tests {
     /// the top of this module so [`SeedVaultRegistryCtx::from_config`]
     /// can exercise the production construction path.
     fn ctx_with_seeded_assets() -> Ctx {
-        use crate::config::tests::create_test_ctx_with_order_owner;
-        use crate::config::{
+        use st0x_config::{
             AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
+            create_test_ctx_with_order_owner,
         };
         use std::collections::HashMap;
 
@@ -1234,8 +1235,10 @@ mod tests {
 
     #[tokio::test]
     async fn from_config_rejects_missing_vault_id() {
-        use crate::config::tests::create_test_ctx_with_order_owner;
-        use crate::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
+        use st0x_config::{
+            AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
+            create_test_ctx_with_order_owner,
+        };
         use std::collections::HashMap;
 
         // Two equities with rebalancing enabled: one has a vault_id, one
@@ -1348,7 +1351,7 @@ mod tests {
 
     // Proves the gap is closed: enqueuing a SeedVaultRegistry job and
     // forcing the job to fail (via the FailureInjector armed for this
-    // JobKind, which short-circuits before reaching the aggregate
+    // job type, which short-circuits before reaching the aggregate
     // command) results in apalis retrying the job before halting. The
     // `attempts` column on the Jobs row shows >1 when retries actually
     // happened.
@@ -1364,9 +1367,7 @@ mod tests {
         use apalis_core::worker::ext::event_listener::EventListenerExt;
         use std::time::Duration;
 
-        use crate::conductor::job::{
-            FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobKind, JobQueue, work,
-        };
+        use crate::conductor::job::{FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobQueue, work};
         use crate::conductor::setup_apalis_tables;
 
         let pool = setup_test_db().await;
@@ -1379,7 +1380,7 @@ mod tests {
         queue.push(SeedVaultRegistry).await.unwrap();
 
         let injector = FailureInjector::new();
-        injector.arm(JobKind::SeedVaultRegistry);
+        injector.arm(crate::conductor::job::JobKind::SeedVaultRegistry);
 
         let queue_for_worker = queue.clone();
         let ctx_for_worker = seed_ctx.clone();
@@ -1397,7 +1398,6 @@ mod tests {
                         .backend(queue_for_worker.clone().into_storage())
                         .data(ctx_for_worker.clone())
                         .data(injector_for_worker.clone())
-                        .data(JobKind::SeedVaultRegistry)
                         .concurrency(1)
                         .retry(RetryPolicy::retries(3))
                         .break_circuit_with(fail_stop)

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -37,8 +37,6 @@ use super::aggregate::{
     WrappedEquityRecovery, WrappedEquityRecoveryCommand, WrappedEquityRecoveryError,
     WrappedEquityRecoveryId,
 };
-#[cfg(any(test, feature = "test-support"))]
-use crate::conductor::job::JobKind;
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
@@ -152,7 +150,8 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
     const WORKER_NAME: &'static str = "wrapped-equity-recovery-worker";
 
     #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: JobKind = JobKind::WrappedEquityRecovery;
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::WrappedEquityRecovery;
 
     fn label(&self) -> Label {
         Label::new(format!(

--- a/src/wrapper/share.rs
+++ b/src/wrapper/share.rs
@@ -6,12 +6,12 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use tracing::info;
 
+use st0x_config::EquityAssetConfig;
 use st0x_evm::{IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
 use st0x_execution::Symbol;
 
 use super::{UnderlyingPerWrapped, Wrapper, WrapperError};
 use crate::bindings::{IERC20, IERC4626};
-use crate::config::EquityAssetConfig;
 
 /// One unit with 18 decimals for ratio queries.
 const RATIO_QUERY_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
@@ -267,8 +267,8 @@ mod tests {
     use st0x_execution::Symbol;
 
     use super::*;
-    use crate::config::{EquityAssetConfig, OperationMode};
     use crate::test_utils::StubWallet;
+    use st0x_config::{EquityAssetConfig, OperationMode};
 
     fn test_asset_config() -> EquityAssetConfig {
         EquityAssetConfig {

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -30,6 +30,7 @@ use st0x_float_macro::float;
 use tokio::sync::broadcast;
 use tracing::{debug, info};
 
+use st0x_config::{BrokerCtx, Ctx};
 use st0x_dto::Statement;
 use st0x_event_sorcery::Projection;
 use st0x_evm::Wallet;
@@ -42,7 +43,6 @@ use st0x_execution::{
 };
 use st0x_finance::{Positive, Usd};
 use st0x_hedge::cli::TransferType;
-use st0x_hedge::config::{BrokerCtx, Ctx};
 use st0x_hedge::mock_api::{
     REDEMPTION_WALLET, RedemptionOutcome, TokenizationRequestType, TokenizationStatus,
 };
@@ -130,8 +130,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
         .with_circle_api_base(cctp.attestation_base_url)
         .with_cctp_addresses(cctp.token_messenger, cctp.message_transmitter);
 
-    let wallet_ctx =
-        st0x_hedge::wallet::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
 
     Ctx::for_test()
         .database_url(db_path.display().to_string())
@@ -157,8 +156,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
         .inventory_poll_interval(15)
         .server_port(server_port)
         .maybe_rest_api(
-            rest_api_url
-                .map(|url| st0x_hedge::config::RestApiCtx::unauthenticated(url.to_string())),
+            rest_api_url.map(|url| st0x_config::RestApiCtx::unauthenticated(url.to_string())),
         )
         .redemption_wallet(REDEMPTION_WALLET)
         .call()

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 pub(crate) use std::time::Duration;
 use tokio::task::JoinHandle;
 
+use st0x_config::{AssetsConfig, BrokerCtx, Ctx};
 pub(crate) use st0x_event_sorcery::Projection;
 use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, TEST_API_KEY, TEST_API_SECRET};
 use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, TimeInForce};
@@ -12,7 +13,6 @@ pub(crate) use st0x_execution::{FractionalShares, Positive, Symbol};
 pub(crate) use st0x_hedge::ExecutionThreshold;
 use st0x_hedge::TradingMode;
 use st0x_hedge::bindings::IOrderBookV6;
-use st0x_hedge::config::{AssetsConfig, BrokerCtx, Ctx};
 pub(crate) use st0x_hedge::{OffchainOrder, Position};
 
 pub(crate) use crate::assert::ExpectedPosition;

--- a/tests/e2e/hedging/mod.rs
+++ b/tests/e2e/hedging/mod.rs
@@ -14,7 +14,7 @@ use rain_math_float::Float;
 use st0x_execution::alpaca_broker_api::OrderStatus;
 use st0x_float_macro::float;
 #[cfg(feature = "test-support")]
-use st0x_hedge::{FailureInjector, JobKind};
+use st0x_hedge::FailureInjector;
 
 use self::assertions::*;
 use crate::poll::poll_for_all_jobs_done;
@@ -1502,7 +1502,7 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
     let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
 
     let current_block = infra.base_chain.provider.get_block_number().await?;
-    let mut ctx = build_ctx()
+    let ctx = build_ctx()
         .chain(&infra.base_chain)
         .broker(&infra.broker_service)
         .db_path(&infra.db_path)
@@ -1511,8 +1511,7 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
         .call()?;
 
     let injector = FailureInjector::new();
-    ctx.failure_injector = injector.clone();
-    let mut bot = spawn_bot(ctx);
+    let mut bot = crate::poll::spawn_bot_with_injector(ctx, injector.clone());
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
@@ -1535,7 +1534,7 @@ async fn job_failure_halts_bot() -> anyhow::Result<()> {
     pool.close().await;
 
     // Arm the injector, then submit a second trade
-    injector.arm(JobKind::OrderFill);
+    injector.arm(st0x_hedge::JobKind::OrderFill);
 
     infra
         .base_chain

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -10,11 +10,14 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
+use st0x_config::Ctx;
 use st0x_dto::Statement;
 use st0x_execution::FractionalShares;
 use st0x_execution::alpaca_broker_api::OrderStatus;
-use st0x_hedge::config::Ctx;
-use st0x_hedge::{run_bot_session, run_bot_session_with_event_channel};
+use st0x_hedge::{
+    FailureInjector, run_bot_session, run_bot_session_with_event_channel,
+    run_bot_session_with_injector,
+};
 
 /// Spawns the full bot as a background task.
 pub fn spawn_bot(ctx: Ctx) -> JoinHandle<anyhow::Result<()>> {
@@ -28,6 +31,16 @@ pub fn spawn_bot_with_event_channel(
     event_sender: broadcast::Sender<Statement>,
 ) -> JoinHandle<anyhow::Result<()>> {
     tokio::spawn(run_bot_session_with_event_channel(ctx, event_sender))
+}
+
+/// Spawns the full bot using a caller-supplied [`FailureInjector`] so the
+/// test can arm specific job kinds for failure injection.
+pub fn spawn_bot_with_injector(
+    ctx: Ctx,
+    injector: FailureInjector,
+) -> JoinHandle<anyhow::Result<()>> {
+    let (event_sender, _) = broadcast::channel::<Statement>(256);
+    tokio::spawn(run_bot_session_with_injector(ctx, event_sender, injector))
 }
 
 /// Polls the bot's health endpoint until it responds, panicking if the

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -25,6 +25,7 @@ use sqlx::SqlitePool;
 use tokio::task::JoinHandle;
 
 use st0x_bridge::cctp::CctpAttestationMock;
+use st0x_config::{BrokerCtx, Ctx};
 use st0x_evm::{Evm, EvmError, Wallet};
 use st0x_execution::alpaca_broker_api::{
     AlpacaBrokerMock, OrderSide, OrderStatus, TEST_API_KEY, TEST_API_SECRET, TransferDirection,
@@ -36,7 +37,6 @@ use st0x_execution::{
 use st0x_finance::{Positive, Usd};
 pub(crate) use st0x_hedge::UsdcRebalancing;
 use st0x_hedge::bindings::IOrderBookV6;
-use st0x_hedge::config::{BrokerCtx, Ctx};
 pub(crate) use st0x_hedge::mock_api::REDEMPTION_WALLET;
 use st0x_hedge::mock_api::{AlpacaTokenizationMock, TokenizationStatus};
 pub(crate) use st0x_hedge::mock_api::{RedemptionOutcome, TokenizationRequestType};
@@ -248,8 +248,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         .usdc(usdc_rebalancing)
         .call();
 
-    let wallet_ctx =
-        st0x_hedge::wallet::OnchainWalletCtx::from_wallets(base_wallet.clone(), base_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet.clone(), base_wallet);
 
     let assets = AssetsConfig {
         equities: EquitiesConfig {
@@ -343,8 +342,7 @@ where
         .with_circle_api_base(cctp.attestation_base_url)
         .with_cctp_addresses(cctp.token_messenger, cctp.message_transmitter);
 
-    let wallet_ctx =
-        st0x_hedge::wallet::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
+    let wallet_ctx = st0x_config::OnchainWalletCtx::from_wallets(base_wallet, ethereum_wallet);
 
     Ctx::for_test()
         .database_url(db_path.display().to_string())

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -17,11 +17,11 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 use st0x_bridge::cctp::CctpAttestationMock;
+use st0x_config::mk_env_filter;
+use st0x_config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
 use st0x_execution::Symbol;
 use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, MockPosition};
-use st0x_hedge::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
 use st0x_hedge::mock_api::{AlpacaTokenizationMock, REDEMPTION_WALLET};
-use st0x_hedge::telemetry::mk_env_filter;
 
 use crate::base_chain::{BaseChain, DeployableERC20};
 


### PR DESCRIPTION
[RAI-722](https://linear.app/makeitrain/issue/RAI-722/extract-st0x-config-crate-phase-4)

## What

Extracts every config-related module from the root `st0x-hedge` crate into a new restricted-visibility `st0x-config` crate so that the binaries (`st0x-server`, `st0x-cli`) can share the loading + validation surface without forcing all downstream library crates to depend on it.

Moves:

- `src/config.rs` -> `crates/config/src/loader.rs` (`Ctx`, `BrokerCtx`, `AssetsConfig`, `EquitiesConfig`, `EquityAssetConfig`, `CashAssetConfig`, `OperationMode`, `TradingMode`, the smart constructors and `CtxError`).
- `src/threshold.rs` -> `crates/config/src/threshold.rs` (`ExecutionThreshold`, `InvalidThresholdError`).
- `src/telemetry.rs` -> `crates/config/src/telemetry.rs` (`TelemetryConfig`, `TelemetryCtx`, `setup_tracing`, `FileLogGuard`, `mk_env_filter`).
- `src/wallet.rs` -> `crates/config/src/wallet.rs` (`OnchainWalletCtx`, `build_wallet`, `WalletCtxError`).
- New modules under `crates/config/src/`: `evm.rs` (`EvmConfig`, `EvmCtx`, `EvmSecrets`), `imbalance_threshold.rs`, `order_poller.rs`, `rebalancing.rs` (`RebalancingConfig`, `RebalancingCtx`, `ALPACA_MINIMUM_WITHDRAWAL`, etc.), `failure_injector.rs` (`FailureInjector`).

The root crate (and every library crate) now imports these via `st0x_config::*` instead of `crate::config::*` / `crate::threshold::*` / etc.

## Why

The CLI and server binaries both need to parse the same TOML, decrypt the same secrets, and produce the same runtime `Ctx`. Putting that surface in the root `st0x-hedge` crate forced every downstream crate (`st0x-bridge`, `st0x-execution`, the domain modules) to also transitively pull in `clap`, `serde`, telemetry initialization, wallet building, etc., which leaked binary-shaped concerns into the library layer.

Pulling config out into its own crate:

- Lets `st0x-server` and `st0x-cli` (and only them) depend on the loading surface; integration/domain crates stay config-agnostic and take narrow constructor args (e.g. `ExecutionThreshold` instead of `&Ctx`).
- Unblocks the CLI extraction (RAI-721) by giving `st0x-cli` somewhere to live without re-implementing the same parsing logic.
- Centralizes config-related lints, allowing the binary crates to stay strict about visibility (`pub(crate)` becomes meaningful again) and avoids the previous pattern where any internal type that touched config had to be `pub` for the bin targets to see it.

## How

- Created `crates/config/` with its own `Cargo.toml`, gated under the workspace's standard lint set.
- Moved each module verbatim with import paths updated. The smart constructors and error types stayed identical; only their location and the visibility of helper functions changed.
- Re-exported the public surface from `crates/config/src/lib.rs` so consumers can `use st0x_config::{Ctx, BrokerCtx, ExecutionThreshold, ...};`.
- Updated every callsite in the root crate to import from `st0x_config` instead of from `crate::config`. Most diffs are import-line swaps; no behavioral changes.
- `crates/evm/src/stub.rs` added so the EVM crate can be built without the full `st0x-config` dep when only the EVM types are needed.
- Minor finance crate additions (`HasZero` impls + `proptest` helpers) needed because the config types use those traits and the previous code path went through the root crate's private re-exports.

## Testing

- `cargo check --workspace --all-features` -- clean.
- `cargo nextest run --workspace --all-features` -- the entire test suite still passes against the new crate boundary (the tests that used `crate::config::tests::create_test_ctx_with_order_owner` now use `st0x_config::create_test_ctx_with_order_owner` which is re-exported under `cfg(any(test, feature = "test-support"))`).

## Anything else

- Stacked on #637 (CLI spec); followed by #651 (axum ADR) and #639 (Rocket -> Axum migration), both of which rely on the new `st0x-config` boundary.
- Three pre-existing clippy issues in the moved modules (`unwrap_used` in `threshold::whole_share`, two `too_long_first_doc_paragraph` in `rebalancing.rs`) are inherited from the source files and unrelated to this PR's structural change. They'll be addressed separately so this PR stays scope-tight.
