### PR TITLE
refactor: replace rocket with axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "apalis-board"
+version = "1.0.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b220330c3885c58fcc88129feeecd510b83b486371c4ccac8e3aef85b44d763b"
+dependencies = [
+ "apalis-board-api",
+]
+
+[[package]]
+name = "apalis-board-api"
+version = "1.0.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873de5584baefd4502afd3c09ff597956f3048a2d87eabede67b60b7c1e97306"
+dependencies = [
+ "apalis-board-types",
+ "apalis-core",
+ "axum",
+ "futures",
+ "include_dir",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing-core",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "apalis-board-types"
+version = "1.0.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6864e55559e5f817aa02b25cc0123ac6946e32aacac740d9899bb0db0f61293a"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "apalis-codec"
 version = "0.1.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,21 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
-
-[[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1594,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backon"
@@ -1612,12 +1690,6 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
-name = "binascii"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bincode"
@@ -1835,12 +1907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,17 +2117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
 ]
 
 [[package]]
@@ -2394,39 +2449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "devise"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d90b0c4c777a2cad215e3c7be59ac7c15adf45cf76317009b7d096d46f651d"
-dependencies = [
- "devise_codegen",
- "devise_core",
-]
-
-[[package]]
-name = "devise_codegen"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b28680d8be17a570a2334922518be6adc3f58ecc880cbb404eaeb8624fd867"
-dependencies = [
- "devise_core",
- "quote",
-]
-
-[[package]]
-name = "devise_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b035a542cf7abf01f2e3c4d5a7acbaebfefe120ae4efc7bde3df98186e4b8af7"
-dependencies = [
- "bitflags 2.11.1",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,20 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic 0.6.1",
- "pear",
- "serde",
- "toml 0.8.23",
- "uncased",
- "version_check",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,19 +2956,6 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
-
-[[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
 
 [[package]]
 name = "generic-array"
@@ -3640,6 +3635,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,12 +3676,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "inlinable_string"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
@@ -3698,17 +3706,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3968,21 +3965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,6 +3998,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -4064,25 +4052,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.4.0",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "tokio",
- "tokio-util",
- "version_check",
 ]
 
 [[package]]
@@ -4688,29 +4657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pear"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
-dependencies = [
- "inlinable_string",
- "pear_codegen",
- "yansi",
-]
-
-[[package]]
-name = "pear_codegen"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
-dependencies = [
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,7 +4902,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4988,19 +4934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -5697,98 +5630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocket"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a516907296a31df7dc04310e7043b61d71954d703b603cc6867a026d7e72d73f"
-dependencies = [
- "async-stream",
- "async-trait",
- "atomic 0.5.3",
- "binascii",
- "bytes",
- "either",
- "figment",
- "futures",
- "indexmap 2.14.0",
- "log",
- "memchr",
- "multer",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "rand 0.8.6",
- "ref-cast",
- "rocket_codegen",
- "rocket_http",
- "serde",
- "serde_json",
- "state",
- "tempfile",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "ubyte",
- "version_check",
- "yansi",
-]
-
-[[package]]
-name = "rocket_codegen"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
-dependencies = [
- "devise",
- "glob",
- "indexmap 2.14.0",
- "proc-macro2",
- "quote",
- "rocket_http",
- "syn 2.0.117",
- "unicode-xid",
- "version_check",
-]
-
-[[package]]
-name = "rocket_http"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e274915a20ee3065f611c044bd63c40757396b6dbc057d6046aec27f14f882b9"
-dependencies = [
- "cookie",
- "either",
- "futures",
- "http 0.2.12",
- "hyper 0.14.32",
- "indexmap 2.14.0",
- "log",
- "memchr",
- "pear",
- "percent-encoding",
- "pin-project-lite",
- "ref-cast",
- "serde",
- "smallvec",
- "stable-pattern",
- "state",
- "time",
- "tokio",
- "uncased",
-]
-
-[[package]]
-name = "rocket_ws"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1877668c937b701177c349f21383c556cd3bb4ba8fa1d07fa96ccb3a8782e"
-dependencies = [
- "rocket",
- "tokio-tungstenite 0.21.0",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,12 +5841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6193,21 +6028,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
  "serde",
 ]
 
@@ -7001,6 +6838,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "apalis",
+ "apalis-board",
  "apalis-codec",
  "apalis-core",
  "apalis-cron",
@@ -7008,6 +6846,7 @@ dependencies = [
  "apalis-workflow",
  "approx",
  "async-trait",
+ "axum",
  "backon",
  "base64 0.22.1",
  "bon",
@@ -7029,8 +6868,6 @@ dependencies = [
  "rain-math-float",
  "rand 0.8.6",
  "reqwest 0.12.28",
- "rocket",
- "rocket_ws",
  "rsa",
  "serde",
  "serde_json",
@@ -7054,6 +6891,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "toml 0.9.12+spec-1.1.0",
+ "tower",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -7067,28 +6905,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable-pattern"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "state"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
-dependencies = [
- "loom",
-]
 
 [[package]]
 name = "static_assertions"
@@ -7547,18 +7367,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.21.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -7588,6 +7396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7603,25 +7423,13 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -7636,20 +7444,11 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7672,20 +7471,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
@@ -7704,12 +7489,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.2",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8006,25 +7785,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.6",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
@@ -8059,6 +7819,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8102,15 +7878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "ubyte"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8144,16 +7911,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "serde",
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -8550,15 +8307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9007,15 +8755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-dependencies = [
- "is-terminal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,12 @@ alloy = { version = "1.0.38", features = ["full", "rand", "node-bindings"] }
 alloy-primitives = "1.4"
 alloy-signer-turnkey = "=1.0.41"
 anyhow = "1.0.102"
+apalis-board = { version = "1.0.0-rc.8", features = ["axum", "ui"] }
+apalis-workflow = "0.1.0-rc.7"
 apca = "0.30.0"
 approx = "0.5.1"
 async-trait = "0.1.81"
+axum = { version = "0.8.9", features = ["ws", "json"] }
 backon = { version = "1.5.1", features = ["tokio"] }
 base64 = "0.22"
 bon = "3.9.0"
@@ -81,8 +84,6 @@ reqwest = { version = "0.12.4", features = [
   "gzip",
   "blocking",
 ] }
-rocket = { version = "0.5.1", features = ["json"] }
-rocket_ws = "0.1.1"
 rsa = { version = "0.9.10", features = ["pem"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.140"
@@ -107,6 +108,7 @@ test-log = { version = "0.2.19", features = ["trace"] }
 thiserror = "2.0.12"
 tokio = { version = "1.46.0", features = ["full"] }
 tokio-tungstenite = "0.28.0"
+tokio-util = { version = "0.7.18", features = ["rt"] }
 toml = "0.9.11"
 tracing = "0.1.41"
 tracing-appender = "0.2.5"
@@ -194,8 +196,6 @@ rain-error-decoding.workspace = true
 rain-math-float.workspace = true
 rand.workspace = true
 reqwest.workspace = true
-rocket.workspace = true
-rocket_ws.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
@@ -221,8 +221,10 @@ uuid.workspace = true
 # Force transitive wasm-bindgen to match rain.wasm's expected version
 wasm-bindgen.workspace = true
 tracing-appender.workspace = true
-tokio-util = { version = "0.7.18", features = ["rt"] }
-apalis-workflow = "0.1.0-rc.7"
+tokio-util.workspace = true
+apalis-workflow.workspace = true
+axum.workspace = true
+apalis-board.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
@@ -243,6 +245,7 @@ tempfile.workspace = true
 test-log.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tokio-tungstenite.workspace = true
+tower = { version = "0.5.3", features = ["util"] }
 tracing-subscriber.workspace = true
 tracing-test.workspace = true
 url.workspace = true

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -1,5 +1,7 @@
 # HTTP API port for the dashboard and health checks.
 server_port = 8001
+# HTTP port for the apalis-board job queue UI.
+board_port = 8002
 # Minimum log level: trace, debug, info, warn, error.
 log_level = "trace"
 # Directory for rotated log files (stdout if omitted).

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -1,5 +1,7 @@
 # HTTP API port for the dashboard and health checks.
 server_port = 8001
+# HTTP port for the apalis-board job queue UI.
+board_port = 8002
 # Minimum log level: trace, debug, info, warn, error.
 log_level = "trace"
 # Directory for rotated log files (stdout if omitted).

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,8 +22,8 @@ pub use rebalancing::{
     UsdcRebalancing,
 };
 pub use telemetry::{
-    FileLogGuard, TelemetryAssemblyError, TelemetryConfig, TelemetryCtx, TelemetryError,
-    TelemetryGuard, TelemetrySecrets, mk_env_filter, setup_tracing,
+    ExtraLayer, FileLogGuard, TelemetryAssemblyError, TelemetryConfig, TelemetryCtx,
+    TelemetryError, TelemetryGuard, TelemetrySecrets, mk_env_filter, setup_tracing,
 };
 pub use threshold::{ExecutionThreshold, InvalidThresholdError};
 pub use wallet::{OnchainWalletCtx, WalletCtxError, build_wallet};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -167,7 +167,8 @@ struct Config {
     database_url: String,
     log_level: Option<LogLevel>,
     log_dir: Option<String>,
-    server_port: Option<u16>,
+    server_port: u16,
+    board_port: u16,
     raindex: EvmConfig,
     order_polling_interval: Option<u64>,
     order_polling_max_jitter: Option<u64>,
@@ -380,6 +381,7 @@ pub struct Ctx {
     pub log_level: LogLevel,
     pub log_dir: Option<String>,
     pub server_port: u16,
+    pub board_port: u16,
     pub evm: EvmCtx,
     pub order_polling_interval: u64,
     pub order_polling_max_jitter: u64,
@@ -472,6 +474,7 @@ impl std::fmt::Debug for Ctx {
             .field("log_level", &self.log_level)
             .field("log_dir", &self.log_dir)
             .field("server_port", &self.server_port)
+            .field("board_port", &self.board_port)
             .field("evm", &self.evm)
             .field("order_polling_interval", &self.order_polling_interval)
             .field("order_polling_max_jitter", &self.order_polling_max_jitter)
@@ -538,6 +541,7 @@ struct ValidatedParts {
     log_level: LogLevel,
     log_dir: Option<String>,
     server_port: u16,
+    board_port: u16,
     evm: EvmCtx,
     order_polling_interval: u64,
     order_polling_max_jitter: u64,
@@ -595,6 +599,12 @@ fn parse_and_validate(
             path: secrets_path.to_path_buf(),
             source,
         })?;
+
+    if config.server_port == config.board_port {
+        return Err(CtxError::ServerAndBoardPortsMatch {
+            port: config.server_port,
+        });
+    }
 
     let broker = BrokerCtx::from_parts(secrets.broker, config.broker.as_ref())?;
     let telemetry = TelemetryCtx::new(config.telemetry, secrets.telemetry)?;
@@ -747,7 +757,8 @@ fn parse_and_validate(
         database_url: config.database_url,
         log_level,
         log_dir: config.log_dir,
-        server_port: config.server_port.unwrap_or(8080),
+        server_port: config.server_port,
+        board_port: config.board_port,
         evm,
         order_polling_interval,
         order_polling_max_jitter: config.order_polling_max_jitter.unwrap_or(5),
@@ -816,6 +827,7 @@ impl Ctx {
             log_level: parts.log_level,
             log_dir: parts.log_dir,
             server_port: parts.server_port,
+            board_port: parts.board_port,
             evm: parts.evm,
             order_polling_interval: parts.order_polling_interval,
             order_polling_max_jitter: parts.order_polling_max_jitter,
@@ -937,6 +949,7 @@ impl Ctx {
         #[builder(default = 2)] inventory_poll_interval: u64,
         #[builder(default = 3600)] apalis_finished_job_cleanup_interval_secs: u64,
         #[builder(default = 0)] server_port: u16,
+        #[builder(default = 0)] board_port: u16,
         execution_threshold_override: Option<ExecutionThreshold>,
         travel_rule: Option<TravelRuleConfig>,
         rest_api: Option<RestApiCtx>,
@@ -960,6 +973,7 @@ impl Ctx {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port,
+            board_port,
             evm: EvmCtx {
                 ws_rpc_url,
                 orderbook,
@@ -1066,6 +1080,8 @@ pub enum CtxError {
     MissingEquityVaultId { symbol: Symbol },
     #[error("{field} polling interval must be non-zero")]
     ZeroPollingInterval { field: &'static str },
+    #[error("server_port and board_port must differ; both set to {port}")]
+    ServerAndBoardPortsMatch { port: u16 },
     #[error(
         "[broker.travel_rule] is required when using Alpaca Broker API \
          -- Alpaca rejects whitelist requests without it since 2026-03-27"
@@ -1104,6 +1120,7 @@ impl CtxError {
             Self::MissingCashVaultId => "missing cash vault_ids",
             Self::MissingEquityVaultId { .. } => "missing equity vault_ids",
             Self::ZeroPollingInterval { .. } => "zero polling interval",
+            Self::ServerAndBoardPortsMatch { .. } => "server_port and board_port must differ",
             Self::FloatComparison(_) => "float comparison failed",
             Self::InvalidTravelRule { .. } => "invalid travel rule config",
             Self::MissingTravelRule => "missing travel rule config",
@@ -1160,12 +1177,13 @@ pub async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sql
 }
 
 #[cfg(any(test, feature = "test-support"))]
-pub fn create_test_ctx_with_order_owner(order_owner: alloy::primitives::Address) -> Ctx {
+pub fn create_test_ctx_with_order_owner(order_owner: Address) -> Ctx {
     Ctx {
         database_url: ":memory:".to_owned(),
         log_level: LogLevel::Debug,
         log_dir: None,
         server_port: 8080,
+        board_port: 8081,
         evm: EvmCtx {
             // Hard-coded literal URL — parse cannot fail in a test helper.
             #[allow(clippy::unwrap_used)]
@@ -1219,6 +1237,8 @@ mod tests {
         file.write_all(
             br#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1244,6 +1264,8 @@ mod tests {
         toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1271,6 +1293,8 @@ mod tests {
         toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1399,6 +1423,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1437,6 +1463,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1480,6 +1508,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1520,6 +1550,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1577,7 +1609,6 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(ctx.log_level, LogLevel::Debug));
-        assert_eq!(ctx.server_port, 8080);
         assert_eq!(ctx.order_polling_interval, 15);
         assert_eq!(ctx.order_polling_max_jitter, 5);
         assert_eq!(ctx.position_check_interval, 60);
@@ -1589,6 +1620,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
 
             [assets.equities]
 
@@ -1618,10 +1651,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn server_port_is_required() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            board_port = 8081
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+
+            deployment_block = 1
+            required_confirmations = 3
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CtxError::ConfigToml { .. }),
+            "expected config parse failure for missing server_port, got: {error:#}"
+        );
+
+        let source = std::error::Error::source(&error).unwrap();
+        let source_display = source.to_string();
+        assert!(
+            source_display.contains("server_port"),
+            "expected parse error to mention server_port, got: {source_display}"
+        );
+    }
+
+    #[tokio::test]
+    async fn board_port_is_required() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+
+            deployment_block = 1
+            required_confirmations = 3
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CtxError::ConfigToml { .. }),
+            "expected config parse failure for missing board_port, got: {error:#}"
+        );
+
+        let source = std::error::Error::source(&error).unwrap();
+        let source_display = source.to_string();
+        assert!(
+            source_display.contains("board_port"),
+            "expected parse error to mention board_port, got: {source_display}"
+        );
+    }
+
+    #[tokio::test]
     async fn apalis_finished_job_cleanup_interval_must_be_non_zero() {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 0
 
             [assets.equities]
@@ -1654,6 +1759,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn server_port_and_board_port_must_differ() {
+        let config = toml_file(
+            r#"
+            database_url = ":memory:"
+            server_port = 8080
+            board_port = 8080
+            apalis_finished_job_cleanup_interval_secs = 3600
+
+            [assets.equities]
+
+            [raindex]
+            orderbook = "0x1111111111111111111111111111111111111111"
+
+            deployment_block = 1
+            required_confirmations = 3
+
+            [wallet]
+            kind = "private-key"
+            address = "0x0000000000000000000000000000000000000001"
+        "#,
+        );
+        let secrets = dry_run_secrets_toml();
+        let error = Ctx::load_files(config.path(), secrets.path())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CtxError::ServerAndBoardPortsMatch { port: 8080 }),
+            "expected ServerAndBoardPortsMatch for equal ports, got: {error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn rebalancing_with_low_cash_operational_limit_fails() {
         let secrets = toml_file(
             r#"
@@ -1677,6 +1815,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1732,6 +1872,7 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
             log_level = "warn"
             server_port = 9090
@@ -1789,6 +1930,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1875,6 +2018,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1925,6 +2070,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -1986,6 +2133,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2040,6 +2189,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2098,6 +2249,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2162,6 +2315,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2210,6 +2365,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2305,6 +2462,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2442,6 +2601,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -2635,6 +2796,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
             bogus_field = "should fail"
 
@@ -2661,6 +2824,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets]
@@ -2691,6 +2856,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities.AAPL]
@@ -2724,6 +2891,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.cash]
@@ -2809,6 +2978,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
             bogus_field = "should fail"
 
@@ -3556,6 +3727,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             bogus_field = "should fail"
 
             [raindex]
@@ -3600,6 +3773,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -3632,6 +3807,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -3679,6 +3856,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -3762,6 +3941,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
 
             [assets.equities]
@@ -3800,6 +3981,8 @@ mod tests {
         let config = toml_file(
             r#"
             database_url = ":memory:"
+            server_port = 8080
+            board_port = 8081
             apalis_finished_job_cleanup_interval_secs = 3600
             position_check_interval = 0
 

--- a/crates/config/src/telemetry.rs
+++ b/crates/config/src/telemetry.rs
@@ -122,6 +122,7 @@ impl TelemetryCtx {
         &self,
         log_level: tracing::Level,
         log_dir: Option<&str>,
+        extra_layer: Option<ExtraLayer>,
     ) -> Result<(Option<FileLogGuard>, TelemetryGuard), TelemetryError> {
         let headers = HashMap::from([("authorization".to_string(), self.api_key.clone())]);
 
@@ -176,6 +177,7 @@ impl TelemetryCtx {
                 .with_filter(mk_crate_filter(log_level));
 
             let subscriber = Registry::default()
+                .with(extra_layer)
                 .with(fmt_layer)
                 .with(telemetry_layer)
                 .with(file_layer);
@@ -184,7 +186,10 @@ impl TelemetryCtx {
 
             Some(FileLogGuard { _guard: guard })
         } else {
-            let subscriber = Registry::default().with(fmt_layer).with(telemetry_layer);
+            let subscriber = Registry::default()
+                .with(extra_layer)
+                .with(fmt_layer)
+                .with(telemetry_layer);
 
             tracing::subscriber::set_global_default(subscriber)?;
 
@@ -266,7 +271,17 @@ pub struct FileLogGuard {
     _guard: tracing_appender::non_blocking::WorkerGuard,
 }
 
-pub fn setup_tracing(log_level: &LogLevel, log_dir: Option<&str>) -> Option<FileLogGuard> {
+/// Boxed Layer trait object used to plug in caller-owned extra layers
+/// (e.g. an apalis-board SSE broadcaster) without making `setup_tracing`
+/// generic over them.
+pub type ExtraLayer =
+    Box<dyn tracing_subscriber::Layer<tracing_subscriber::Registry> + Send + Sync + 'static>;
+
+pub fn setup_tracing(
+    log_level: &LogLevel,
+    log_dir: Option<&str>,
+    extra_layer: Option<ExtraLayer>,
+) -> Option<FileLogGuard> {
     let level: tracing::Level = log_level.into();
     let env_filter = mk_env_filter(level);
 
@@ -283,7 +298,10 @@ pub fn setup_tracing(log_level: &LogLevel, log_dir: Option<&str>) -> Option<File
             .compact()
             .with_filter(env_filter);
 
-        let subscriber = Registry::default().with(fmt_layer).with(file_layer);
+        let subscriber = Registry::default()
+            .with(extra_layer)
+            .with(fmt_layer)
+            .with(file_layer);
 
         if tracing::subscriber::set_global_default(subscriber).is_err() {
             eprintln!("Failed to set global subscriber (already set)");
@@ -292,10 +310,15 @@ pub fn setup_tracing(log_level: &LogLevel, log_dir: Option<&str>) -> Option<File
 
         Some(FileLogGuard { _guard: guard })
     } else {
-        tracing_subscriber::fmt()
-            .with_env_filter(env_filter)
+        let fmt_layer = tracing_subscriber::fmt::layer()
             .compact()
-            .init();
+            .with_filter(env_filter);
+
+        let subscriber = Registry::default().with(extra_layer).with(fmt_layer);
+
+        if tracing::subscriber::set_global_default(subscriber).is_err() {
+            eprintln!("Failed to set global subscriber (already set)");
+        }
 
         None
     }

--- a/crates/dto/src/trade.rs
+++ b/crates/dto/src/trade.rs
@@ -15,6 +15,43 @@ pub enum TradingVenue {
     DryRun,
 }
 
+impl TradingVenue {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Raindex => "raindex",
+            Self::Alpaca => "alpaca",
+            Self::DryRun => "dry_run",
+        }
+    }
+}
+
+impl std::fmt::Display for TradingVenue {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for TradingVenue {
+    type Err = InvalidTradingVenue;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "raindex" => Ok(Self::Raindex),
+            "alpaca" => Ok(Self::Alpaca),
+            "dry_run" => Ok(Self::DryRun),
+            other => Err(InvalidTradingVenue {
+                venue_provided: other.to_owned(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid trading venue: {venue_provided}")]
+pub struct InvalidTradingVenue {
+    venue_provided: String,
+}
+
 /// Whether the trade was a buy or sell. Canonical Direction type used by
 /// both broker execution and dashboard DTOs -- there is no separate
 /// "TradeDirection" that needs converting back and forth.

--- a/e2e/config.toml
+++ b/e2e/config.toml
@@ -1,4 +1,5 @@
 server_port = 8001
+board_port = 8002
 log_level = "trace"
 database_url = ":memory:"
 apalis_finished_job_cleanup_interval_secs = 3600

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,4 +1,5 @@
 server_port = 8080
+board_port = 8081
 log_level = "debug"
 database_url = ":memory:"
 apalis_finished_job_cleanup_interval_secs = 3600

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,59 +1,41 @@
-//! HTTP API endpoints for health checks, log retrieval, order status,
-//! and transfer recovery.
+//! HTTP API endpoints for health checks, log retrieval, and order status.
 
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
 use alloy::primitives::U256;
+use axum::Json;
+use axum::Router;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
 use chrono::{DateTime, Utc};
-use rocket::form::{self, FromFormField, ValueField};
-use rocket::http::Status;
-use rocket::request::FromParam;
-use rocket::response::content::RawJson;
-use rocket::serde::json::Json;
-use rocket::serde::{Deserialize, Serialize};
-use rocket::{Route, State, get, post, routes};
+use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use tokio::sync::Mutex;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use st0x_config::Ctx;
+use st0x_dto::TradingVenue;
 use st0x_execution::{FractionalShares, SharesBlockchain};
 
-use crate::dashboard::transfer_loader::TransferKind;
+use crate::AppState;
+use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
 use crate::rebalancing::RebalancingService;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMintEvent};
 
-impl<'a> FromParam<'a> for TransferKind {
-    type Error = String;
-
-    fn from_param(param: &'a str) -> Result<Self, Self::Error> {
-        param.parse()
-    }
-}
-
 /// Comma-separated filter for transfer kinds in query parameters.
 ///
 /// Parses `"equity_mint,usdc_bridge"` into `vec![EquityMint, UsdcBridge]`.
-struct TransferKindFilter(Vec<TransferKind>);
-
-impl<'v> FromFormField<'v> for TransferKindFilter {
-    fn from_value(field: ValueField<'v>) -> form::Result<'v, Self> {
-        let kinds: Result<Vec<TransferKind>, _> = field
-            .value
-            .split(',')
-            .map(str::trim)
-            .filter(|segment| !segment.is_empty())
-            .map(TransferKind::from_str)
-            .collect();
-
-        kinds
-            .map(TransferKindFilter)
-            .map_err(|error| form::Error::validation(error).into())
-    }
+fn parse_transfer_kind_filter(value: &str) -> Result<Vec<TransferKind>, InvalidTransferKind> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(TransferKind::from_str)
+        .collect()
 }
 
 static STARTED_AT: LazyLock<DateTime<Utc>> = LazyLock::new(Utc::now);
@@ -99,7 +81,7 @@ struct PendingOrderResponse {
 
 /// Where the stranded equity physically sits for a failed transfer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(crate = "rocket::serde", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 enum StuckLocation {
     /// At the issuer (Alpaca): a mint was accepted but failed before tokens
     /// were received on-chain.
@@ -117,7 +99,7 @@ enum StuckLocation {
 
 /// Why a transfer is stranded, mirroring the terminal failure event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(crate = "rocket::serde", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 enum StuckReason {
     MintAcceptanceFailed,
     WrappingFailed,
@@ -127,7 +109,6 @@ enum StuckReason {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(crate = "rocket::serde")]
 struct StuckTransferInfo {
     #[serde(rename = "stuckAmount")]
     amount: String,
@@ -156,8 +137,7 @@ struct TradeResponse {
     has_more: bool,
 }
 
-#[get("/health")]
-fn health() -> Json<HealthResponse> {
+async fn health() -> Json<HealthResponse> {
     let uptime = Utc::now() - *STARTED_AT;
 
     Json(HealthResponse {
@@ -166,6 +146,17 @@ fn health() -> Json<HealthResponse> {
         git_commit: GIT_COMMIT.to_string(),
         uptime_seconds: uptime.num_seconds(),
     })
+}
+
+#[derive(Deserialize, Default)]
+struct LogsQuery {
+    limit: Option<usize>,
+    offset: Option<usize>,
+    search: Option<String>,
+    level: Option<String>,
+    target: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
 }
 
 /// Returns log entries with pagination, search, level, and time range
@@ -178,21 +169,11 @@ fn health() -> Json<HealthResponse> {
 /// - `target`: comma-separated domain targets to include (e.g. `hedge,rebalance`)
 /// - `since`: ISO 8601 UTC lower bound (inclusive)
 /// - `until`: ISO 8601 UTC upper bound (inclusive)
-#[get("/logs?<limit>&<offset>&<search>&<level>&<target>&<since>&<until>")]
-fn logs(
-    ctx: &State<Ctx>,
-    limit: Option<usize>,
-    offset: Option<usize>,
-    search: Option<&str>,
-    level: Option<&str>,
-    target: Option<&str>,
-    since: Option<&str>,
-    until: Option<&str>,
-) -> Json<LogResponse> {
-    let limit = limit.unwrap_or(100).min(5000);
-    let offset = offset.unwrap_or(0);
+async fn logs(State(state): State<AppState>, Query(query): Query<LogsQuery>) -> Json<LogResponse> {
+    let limit = query.limit.unwrap_or(100).min(5000);
+    let offset = query.offset.unwrap_or(0);
 
-    let Some(ref log_dir) = ctx.log_dir else {
+    let Some(ref log_dir) = state.ctx.log_dir else {
         return Json(LogResponse {
             entries: Vec::new(),
             total: 0,
@@ -201,25 +182,35 @@ fn logs(
     };
 
     let filter = LogFilter {
-        search_lower: search
-            .filter(|query| !query.is_empty())
+        search_lower: query
+            .search
+            .as_deref()
+            .filter(|val| !val.is_empty())
             .map(str::to_lowercase),
-        levels: level.filter(|lvl| !lvl.is_empty()).map(|lvl| {
-            lvl.split(',')
-                .map(|part| part.trim().to_uppercase())
-                .collect()
-        }),
-        targets: target.filter(|tgt| !tgt.is_empty()).map(|tgt| {
-            tgt.split(',')
-                .map(|part| part.trim().to_lowercase())
-                .collect()
-        }),
-        since: since.and_then(|val| {
+        levels: query
+            .level
+            .as_deref()
+            .filter(|val| !val.is_empty())
+            .map(|val| {
+                val.split(',')
+                    .map(|part| part.trim().to_uppercase())
+                    .collect()
+            }),
+        targets: query
+            .target
+            .as_deref()
+            .filter(|val| !val.is_empty())
+            .map(|val| {
+                val.split(',')
+                    .map(|part| part.trim().to_lowercase())
+                    .collect()
+            }),
+        since: query.since.as_deref().and_then(|val| {
             DateTime::parse_from_rfc3339(val)
                 .ok()
                 .map(|dt| dt.with_timezone(&Utc))
         }),
-        until: until.and_then(|val| {
+        until: query.until.as_deref().and_then(|val| {
             DateTime::parse_from_rfc3339(val)
                 .ok()
                 .map(|dt| dt.with_timezone(&Utc))
@@ -425,14 +416,13 @@ fn extract_log_file_date(entry: &std::fs::DirEntry) -> Option<chrono::NaiveDate>
 }
 
 /// Returns non-terminal offchain orders (Pending, Submitted, PartiallyFilled).
-#[get("/orders/pending")]
-async fn pending_orders(pool: &State<SqlitePool>) -> Json<Vec<PendingOrderResponse>> {
+async fn pending_orders(State(state): State<AppState>) -> Json<Vec<PendingOrderResponse>> {
     let rows: Vec<(String, String, String)> = match sqlx::query_as(
         "SELECT view_id, status, payload FROM offchain_order_view \
          WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled') \
          ORDER BY rowid DESC LIMIT 100",
     )
-    .fetch_all(pool.inner())
+    .fetch_all(&state.pool)
     .await
     {
         Ok(rows) => rows,
@@ -474,44 +464,56 @@ fn parse_pending_order(
     })
 }
 
+#[derive(Deserialize, Default)]
+struct TradesQuery {
+    limit: Option<usize>,
+    offset: Option<usize>,
+    symbol: Option<String>,
+    venue: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+}
+
 /// Paginated trade history from both onchain and offchain fills.
 ///
 /// Returns newest-first. Supports filtering by symbol, venue, and time range.
-#[get("/trades?<limit>&<offset>&<symbol>&<venue>&<since>&<until>")]
 async fn trades(
-    pool: &State<SqlitePool>,
-    limit: Option<usize>,
-    offset: Option<usize>,
-    symbol: Option<&str>,
-    venue: Option<&str>,
-    since: Option<&str>,
-    until: Option<&str>,
+    State(state): State<AppState>,
+    Query(query): Query<TradesQuery>,
 ) -> Json<TradeResponse> {
-    let limit = limit.unwrap_or(100).min(500);
-    let offset = offset.unwrap_or(0);
+    let limit = query.limit.unwrap_or(100).min(500);
+    let offset = query.offset.unwrap_or(0);
 
-    let since_dt = since.and_then(|val| {
+    let since_dt = query.since.as_deref().and_then(|val| {
         DateTime::parse_from_rfc3339(val)
             .ok()
             .map(|dt| dt.with_timezone(&Utc))
     });
-    let until_dt = until.and_then(|val| {
+    let until_dt = query.until.as_deref().and_then(|val| {
         DateTime::parse_from_rfc3339(val)
             .ok()
             .map(|dt| dt.with_timezone(&Utc))
     });
 
-    let venues = venue.filter(|val| !val.is_empty()).map(|val| {
-        val.split(',')
-            .map(|part| part.trim().to_string())
-            .collect::<Vec<_>>()
-    });
+    let venues = query
+        .venue
+        .as_deref()
+        .filter(|val| !val.is_empty())
+        .map(|val| {
+            val.split(',')
+                .map(|part| part.trim().to_string())
+                .collect::<Vec<_>>()
+        });
 
-    let symbols = symbol.filter(|val| !val.is_empty()).map(|val| {
-        val.split(',')
-            .map(|part| part.trim().to_string())
-            .collect::<Vec<_>>()
-    });
+    let symbols = query
+        .symbol
+        .as_deref()
+        .filter(|val| !val.is_empty())
+        .map(|val| {
+            val.split(',')
+                .map(|part| part.trim().to_string())
+                .collect::<Vec<_>>()
+        });
 
     let trade_filter = TradeFilter {
         symbols,
@@ -520,7 +522,7 @@ async fn trades(
         until: until_dt,
     };
 
-    let mut all_trades = load_trade_rows(pool.inner(), &trade_filter).await;
+    let mut all_trades = load_trade_rows(&state.pool, &trade_filter).await;
     all_trades.sort_by(|lhs, rhs| rhs.filled_at.cmp(&lhs.filled_at));
 
     let total = all_trades.len();
@@ -690,37 +692,47 @@ async fn load_offchain_trade_rows(pool: &SqlitePool, filter: &TradeFilter) -> Ve
         .collect()
 }
 
+#[derive(Deserialize, Default)]
+struct TransfersQuery {
+    limit: Option<usize>,
+    offset: Option<usize>,
+    kind: Option<String>,
+    since: Option<String>,
+    until: Option<String>,
+}
+
 /// Paginated transfer history using event-sourced aggregate replay.
 ///
 /// Replays transfer aggregates to produce proper DTO statuses, then
 /// applies time-range filtering and pagination.
-#[get("/transfers?<limit>&<offset>&<kind>&<since>&<until>")]
 async fn transfers_endpoint(
-    pool: &State<SqlitePool>,
-    limit: Option<usize>,
-    offset: Option<usize>,
-    kind: Option<TransferKindFilter>,
-    since: Option<&str>,
-    until: Option<&str>,
-) -> Result<Json<serde_json::Value>, Status> {
-    let limit = limit.unwrap_or(100).min(500);
-    let offset = offset.unwrap_or(0);
+    State(state): State<AppState>,
+    Query(query): Query<TransfersQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let limit = query.limit.unwrap_or(100).min(500);
+    let offset = query.offset.unwrap_or(0);
 
-    let since_dt = since.and_then(|val| {
+    let since_dt = query.since.as_deref().and_then(|val| {
         DateTime::parse_from_rfc3339(val)
             .ok()
             .map(|dt| dt.with_timezone(&Utc))
     });
-    let until_dt = until.and_then(|val| {
+    let until_dt = query.until.as_deref().and_then(|val| {
         DateTime::parse_from_rfc3339(val)
             .ok()
             .map(|dt| dt.with_timezone(&Utc))
     });
 
-    let kind_filter = kind.map(|filter| filter.0);
+    let kind_filter = match query.kind.as_deref().filter(|val| !val.is_empty()) {
+        Some(value) => Some(parse_transfer_kind_filter(value).map_err(|error| {
+            tracing::warn!(target: "dashboard", %error, "Invalid transfer kind filter");
+            StatusCode::BAD_REQUEST
+        })?),
+        None => None,
+    };
 
     let loaded = crate::dashboard::transfer_loader::load_all_transfer_operations(
-        pool.inner(),
+        &state.pool,
         kind_filter.as_deref(),
     )
     .await;
@@ -766,7 +778,7 @@ async fn transfers_endpoint(
                 %error,
                 "Failed to serialize transfer operation"
             );
-            Status::InternalServerError
+            StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
     let mut response = serde_json::json!({
@@ -787,12 +799,11 @@ async fn transfers_endpoint(
 ///
 /// The frontend uses this to populate the detail modal with tx hashes,
 /// IDs, failure reasons, and other debugging context.
-#[get("/transfers/<kind>/<aggregate_id>/events")]
 async fn transfer_events(
-    pool: &State<SqlitePool>,
-    kind: TransferKind,
-    aggregate_id: &str,
-) -> Option<Json<serde_json::Value>> {
+    State(state): State<AppState>,
+    Path((kind_str, aggregate_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let kind = TransferKind::from_str(&kind_str).map_err(|_| StatusCode::NOT_FOUND)?;
     let aggregate_type = kind.aggregate_type();
 
     let rows: Vec<(String, String, i64)> = match sqlx::query_as(
@@ -802,8 +813,8 @@ async fn transfer_events(
          ORDER BY sequence ASC",
     )
     .bind(aggregate_type)
-    .bind(aggregate_id)
-    .fetch_all(pool.inner())
+    .bind(&aggregate_id)
+    .fetch_all(&state.pool)
     .await
     {
         Ok(rows) => rows,
@@ -815,7 +826,7 @@ async fn transfer_events(
                 %aggregate_id,
                 "Failed to load transfer event history"
             );
-            return None;
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
     };
 
@@ -825,7 +836,7 @@ async fn transfer_events(
         .iter()
         .map(|(event_type, payload, sequence)| {
             let step = event_step(event_type);
-            let inner = event_payload_inner(step, payload);
+            let inner = event_payload_inner(step, payload, *sequence);
 
             serde_json::json!({
                 "step": step,
@@ -835,7 +846,7 @@ async fn transfer_events(
         })
         .collect();
 
-    Some(Json(serde_json::json!({
+    Ok(Json(serde_json::json!({
         "events": events,
         "stuck": stuck,
     })))
@@ -845,22 +856,26 @@ fn event_step(event_type: &str) -> &str {
     event_type.split("::").last().unwrap_or("Unknown")
 }
 
-fn event_payload_inner(step: &str, payload: &str) -> serde_json::Value {
-    let parsed: serde_json::Value = serde_json::from_str(payload)
-        .inspect_err(|error| {
-            tracing::warn!(
+fn event_payload_inner(step: &str, payload: &str, sequence: i64) -> serde_json::Value {
+    match serde_json::from_str::<serde_json::Value>(payload) {
+        Ok(parsed) => parsed
+            .as_object()
+            .and_then(|obj| obj.get(step).cloned())
+            .unwrap_or(parsed),
+        Err(error) => {
+            warn!(
                 target: "dashboard",
                 %error,
                 step,
+                sequence,
                 "Failed to parse event payload for display"
             );
-        })
-        .unwrap_or_default();
-
-    parsed
-        .as_object()
-        .and_then(|obj| obj.get(step).cloned())
-        .unwrap_or(parsed)
+            serde_json::json!({
+                "parseError": error.to_string(),
+                "sequence": sequence,
+            })
+        }
+    }
 }
 
 fn stuck_transfer_info(
@@ -1052,16 +1067,14 @@ fn shares_from_u256_18_decimal(amount: U256) -> Option<String> {
 /// For onchain trades (Raindex), returns Filled + optional Enriched events.
 /// For offchain trades (Alpaca), returns the full order lifecycle
 /// (Placed -> Submitted -> PartiallyFilled -> Filled/Failed).
-#[get("/trades/<venue>/<aggregate_id>/events")]
 async fn trade_events(
-    pool: &State<SqlitePool>,
-    venue: &str,
-    aggregate_id: &str,
-) -> Option<Json<serde_json::Value>> {
+    State(state): State<AppState>,
+    Path((venue_str, aggregate_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let venue = TradingVenue::from_str(&venue_str).map_err(|_| StatusCode::NOT_FOUND)?;
     let aggregate_type = match venue {
-        "raindex" => "OnChainTrade",
-        "alpaca" | "dry_run" => "OffchainOrder",
-        _ => return None,
+        TradingVenue::Raindex => "OnChainTrade",
+        TradingVenue::Alpaca | TradingVenue::DryRun => "OffchainOrder",
     };
 
     let rows: Vec<(String, String, i64)> = sqlx::query_as(
@@ -1071,21 +1084,25 @@ async fn trade_events(
          ORDER BY sequence ASC",
     )
     .bind(aggregate_type)
-    .bind(aggregate_id)
-    .fetch_all(pool.inner())
+    .bind(&aggregate_id)
+    .fetch_all(&state.pool)
     .await
-    .ok()?;
+    .map_err(|error| {
+        warn!(
+            target: "dashboard",
+            %error,
+            venue = %venue,
+            %aggregate_id,
+            "Failed to load trade event history"
+        );
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let events: Vec<serde_json::Value> = rows
         .into_iter()
         .map(|(event_type, payload, sequence)| {
-            let step = event_type.split("::").last().unwrap_or("Unknown");
-            let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
-
-            let inner = parsed
-                .as_object()
-                .and_then(|obj| obj.get(step).cloned())
-                .unwrap_or(parsed);
+            let step = event_step(&event_type);
+            let inner = event_payload_inner(step, &payload, sequence);
 
             serde_json::json!({
                 "step": step,
@@ -1095,34 +1112,36 @@ async fn trade_events(
         })
         .collect();
 
-    Some(Json(serde_json::json!({ "events": events })))
+    Ok(Json(serde_json::json!({ "events": events })))
 }
 
-fn unavailable_json(reason: &str) -> RawJson<String> {
-    RawJson(
-        serde_json::json!({
-            "unavailable": true,
-            "reason": reason,
-        })
-        .to_string(),
-    )
+fn unavailable_json(reason: &str) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "unavailable": true,
+        "reason": reason,
+    }))
+}
+
+#[derive(Deserialize, Default)]
+struct RaindexOrdersQuery {
+    page: Option<u32>,
+    page_size: Option<u32>,
 }
 
 /// Proxies the bot's active Raindex orders from the st0x REST API.
 /// When `[rest_api]` is not configured, returns an unavailable indicator
 /// so the dashboard can show a friendly message instead of an error.
-#[get("/orders/raindex?<page>&<page_size>")]
 #[allow(clippy::cognitive_complexity)]
 async fn raindex_orders(
-    ctx: &State<Ctx>,
-    page: Option<u32>,
-    page_size: Option<u32>,
-) -> RawJson<String> {
-    let Some(rest_api) = &ctx.rest_api else {
+    State(state): State<AppState>,
+    Query(query): Query<RaindexOrdersQuery>,
+) -> Json<serde_json::Value> {
+    let RaindexOrdersQuery { page, page_size } = query;
+    let Some(rest_api) = &state.ctx.rest_api else {
         return unavailable_json("REST API not configured (simulate mode)");
     };
 
-    let owner = ctx.order_owner();
+    let owner = state.ctx.order_owner();
     let url = format!(
         "{}/v1/orders/owner/{:#x}",
         rest_api.url.trim_end_matches('/'),
@@ -1158,7 +1177,13 @@ async fn raindex_orders(
     }
 
     match response.text().await {
-        Ok(body) => RawJson(body),
+        Ok(body) => match serde_json::from_str(&body) {
+            Ok(value) => Json(value),
+            Err(error) => {
+                tracing::warn!(target: "dashboard", %error, "st0x REST API returned non-JSON body");
+                unavailable_json("REST API returned non-JSON")
+            }
+        },
         Err(error) => {
             tracing::warn!(target: "dashboard", %error, "Failed to read st0x REST API response body");
             unavailable_json("Failed to read REST API response")
@@ -1193,28 +1218,27 @@ struct InterruptedTransfersResponse {
     interrupted_redemptions: Vec<String>,
 }
 
-#[get("/transfers/interrupted")]
 async fn interrupted_transfers(
-    pool: &State<SqlitePool>,
-) -> Result<Json<InterruptedTransfersResponse>, (Status, Json<ErrorResponse>)> {
-    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(pool.inner())
+    State(state): State<AppState>,
+) -> Result<Json<InterruptedTransfersResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(&state.pool)
         .await
         .map_err(|error| {
             error!(?error, "Failed to query interrupted mints");
             (
-                Status::InternalServerError,
+                StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
                     error: "Failed to query interrupted mints".to_string(),
                 }),
             )
         })?;
 
-    let redemptions = crate::equity_redemption::interrupted_redemption_ids(pool.inner())
+    let redemptions = crate::equity_redemption::interrupted_redemption_ids(&state.pool)
         .await
         .map_err(|error| {
             error!(?error, "Failed to query interrupted redemptions");
             (
-                Status::InternalServerError,
+                StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
                     error: "Failed to query interrupted redemptions".to_string(),
                 }),
@@ -1236,48 +1260,45 @@ struct ResumeResponse {
     redemptions_failed: usize,
 }
 
-#[post("/transfers/resume")]
 async fn resume_transfers(
-    pool: &State<SqlitePool>,
-    recovery: &State<Arc<tokio::sync::OnceCell<RecoveryHandle>>>,
-    resume_lock: &State<ResumeLock>,
-) -> Result<Json<ResumeResponse>, (Status, Json<ErrorResponse>)> {
-    let _guard = resume_lock.0.try_lock().map_err(|_| {
+    State(state): State<AppState>,
+) -> Result<Json<ResumeResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let _guard = state.resume_lock.0.try_lock().map_err(|_| {
         (
-            Status::Conflict,
+            StatusCode::CONFLICT,
             Json(ErrorResponse {
                 error: "A resume operation is already in progress".to_string(),
             }),
         )
     })?;
 
-    let handle = recovery.get().ok_or_else(|| {
+    let handle = state.recovery.get().ok_or_else(|| {
         (
-            Status::ServiceUnavailable,
+            StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
                 error: "Recovery not ready yet (conductor still starting)".to_string(),
             }),
         )
     })?;
 
-    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(pool.inner())
+    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(&state.pool)
         .await
         .map_err(|error| {
             error!(?error, "Failed to query interrupted mints");
             (
-                Status::InternalServerError,
+                StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
                     error: "Failed to query interrupted mints".to_string(),
                 }),
             )
         })?;
 
-    let redemptions = crate::equity_redemption::interrupted_redemption_ids(pool.inner())
+    let redemptions = crate::equity_redemption::interrupted_redemption_ids(&state.pool)
         .await
         .map_err(|error| {
             error!(?error, "Failed to query interrupted redemptions");
             (
-                Status::InternalServerError,
+                StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
                     error: "Failed to query interrupted redemptions".to_string(),
                 }),
@@ -1320,7 +1341,7 @@ async fn resume_transfers(
 }
 
 #[derive(Serialize)]
-#[serde(crate = "rocket::serde", rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 struct RecheckResponse {
     outcome: RecheckOutcome,
 }
@@ -1336,26 +1357,31 @@ struct RecheckResponse {
 /// unauthenticated. The `/transfers/*` mutation endpoints need an auth guard
 /// before the listener is exposed beyond the operator network -- tracked as a
 /// follow-up. Until then, deployment must keep the bind address firewalled.
-#[post("/transfers/recheck/<kind>/<id>")]
 async fn recheck_transfer(
-    pool: &State<SqlitePool>,
-    recovery: &State<Arc<tokio::sync::OnceCell<RecoveryHandle>>>,
-    resume_lock: &State<ResumeLock>,
-    kind: TransferKind,
-    id: &str,
-) -> Result<Json<RecheckResponse>, (Status, Json<ErrorResponse>)> {
-    let _guard = resume_lock.0.try_lock().map_err(|_| {
+    State(state): State<AppState>,
+    Path((kind_str, id)): Path<(String, String)>,
+) -> Result<Json<RecheckResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let kind = TransferKind::from_str(&kind_str).map_err(|error| {
         (
-            Status::Conflict,
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Unknown transfer kind: {error}"),
+            }),
+        )
+    })?;
+
+    let _guard = state.resume_lock.0.try_lock().map_err(|_| {
+        (
+            StatusCode::CONFLICT,
             Json(ErrorResponse {
                 error: "A resume or recheck operation is already in progress".to_string(),
             }),
         )
     })?;
 
-    let handle = recovery.get().ok_or_else(|| {
+    let handle = state.recovery.get().ok_or_else(|| {
         (
-            Status::ServiceUnavailable,
+            StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
                 error: "Recovery not ready yet (conductor still starting)".to_string(),
             }),
@@ -1367,8 +1393,8 @@ async fn recheck_transfer(
             handle
                 .transfer
                 .recover_mint(
-                    &IssuerRequestId::new(id),
-                    pool.inner(),
+                    &IssuerRequestId::new(&id),
+                    &state.pool,
                     &handle.rebalancing_service,
                 )
                 .await
@@ -1376,7 +1402,7 @@ async fn recheck_transfer(
         TransferKind::EquityRedemption => {
             let redemption_id = id.parse::<RedemptionAggregateId>().map_err(|error| {
                 (
-                    Status::BadRequest,
+                    StatusCode::BAD_REQUEST,
                     Json(ErrorResponse {
                         error: format!("Invalid redemption ID: {error}"),
                     }),
@@ -1389,7 +1415,7 @@ async fn recheck_transfer(
         }
         TransferKind::UsdcBridge => {
             return Err((
-                Status::BadRequest,
+                StatusCode::BAD_REQUEST,
                 Json(ErrorResponse {
                     error: "recheck is not supported for USDC bridges".to_string(),
                 }),
@@ -1417,68 +1443,79 @@ async fn recheck_transfer(
 /// for the not-recoverable variants carry the typed error's message, which only
 /// references aggregate/request ids; internal failures stay generic so they do
 /// not leak internals (the full error is logged at the call site).
-fn recheck_error_response(error: &RecheckError) -> (Status, String) {
+fn recheck_error_response(error: &RecheckError) -> (StatusCode, String) {
     match error {
         RecheckError::NoAcceptedRequest(_)
         | RecheckError::MissingTxHash(_)
-        | RecheckError::MalformedWallet { .. } => (Status::UnprocessableEntity, error.to_string()),
+        | RecheckError::MalformedWallet { .. } => {
+            (StatusCode::UNPROCESSABLE_ENTITY, error.to_string())
+        }
         RecheckError::Tokenizer(_) => (
-            Status::BadGateway,
+            StatusCode::BAD_GATEWAY,
             "Tokenization provider unavailable; retry later".to_string(),
         ),
         RecheckError::Mint(_)
         | RecheckError::Redemption(_)
         | RecheckError::Rebalancing(_)
         | RecheckError::Database(_) => (
-            Status::InternalServerError,
+            StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to recheck transfer".to_string(),
         ),
     }
 }
 
-pub(crate) fn routes() -> Vec<Route> {
-    routes![
-        health,
-        logs,
-        pending_orders,
-        trades,
-        trade_events,
-        transfers_endpoint,
-        transfer_events,
-        raindex_orders,
-        interrupted_transfers,
-        resume_transfers,
-        recheck_transfer
-    ]
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/health", get(health))
+        .route("/logs", get(logs))
+        .route("/orders/pending", get(pending_orders))
+        .route("/trades", get(trades))
+        .route("/trades/{venue}/{aggregate_id}/events", get(trade_events))
+        .route("/transfers", get(transfers_endpoint))
+        .route(
+            "/transfers/{kind}/{aggregate_id}/events",
+            get(transfer_events),
+        )
+        .route("/orders/raindex", get(raindex_orders))
+        .route("/transfers/interrupted", get(interrupted_transfers))
+        .route("/transfers/resume", post(resume_transfers))
+        .route("/transfers/recheck/{kind}/{id}", post(recheck_transfer))
 }
 
 #[cfg(test)]
 mod tests {
-    use rocket::local::asynchronous::Client;
+    use std::sync::Arc;
 
-    use st0x_config::{RestApiCtx, create_test_ctx_with_order_owner};
+    use alloy::primitives::Address;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use sqlx::SqlitePool;
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    use st0x_config::{Ctx, RestApiCtx, create_test_ctx_with_order_owner};
 
     use super::*;
+    use crate::dashboard;
+    use crate::inventory::{self, BroadcastingInventory};
 
-    #[test]
-    fn routes_include_recheck_transfer_endpoint() {
-        let recheck_routes: Vec<_> = routes()
-            .into_iter()
-            .filter(|route| {
-                route.method == rocket::http::Method::Post
-                    && route.uri.to_string().contains("/transfers/recheck/")
-            })
-            .collect();
+    async fn empty_app_state(ctx: Ctx) -> AppState {
+        let (sender, _) = broadcast::channel(16);
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
 
-        assert_eq!(
-            recheck_routes.len(),
-            1,
-            "exactly one POST /transfers/recheck route must be wired into routes(), found: {:?}",
-            routes()
-                .iter()
-                .map(|route| format!("{} {}", route.method, route.uri))
-                .collect::<Vec<_>>()
-        );
+        AppState {
+            settings: dashboard::settings_from_ctx(&ctx),
+            ctx,
+            pool,
+            event_sender: sender.clone(),
+            inventory: Arc::new(BroadcastingInventory::new(
+                inventory::InventoryView::default(),
+                sender,
+            )),
+            recovery: Arc::new(tokio::sync::OnceCell::new()),
+            resume_lock: Arc::new(ResumeLock(Mutex::new(()))),
+        }
     }
 
     #[test]
@@ -1800,39 +1837,23 @@ mod tests {
         (event_type.to_string(), payload.to_string(), sequence)
     }
 
-    #[tokio::test]
-    async fn test_health_endpoint() {
-        let ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
-        let rocket = rocket::build()
-            .mount("/", routes![health, logs])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+    fn build_app(state: AppState) -> Router {
+        routes().with_state(state)
+    }
+
+    async fn body_to_string(response: axum::response::Response) -> String {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    async fn get_log_response(app: &Router, uri: &str) -> LogResponse {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
             .await
-            .expect("valid rocket instance");
-
-        let response = client.get("/health").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
-        let health_response: HealthResponse =
-            serde_json::from_str(&body).expect("valid JSON response");
-
-        assert_eq!(health_response.status, "healthy");
-        assert!(health_response.timestamp <= chrono::Utc::now());
-        assert!(!health_response.git_commit.is_empty());
-        assert!(health_response.uptime_seconds >= 0);
-    }
-
-    fn make_test_rocket(ctx: Ctx) -> rocket::Rocket<rocket::Build> {
-        rocket::build()
-            .mount("/", routes![health, logs])
-            .manage(ctx)
-    }
-
-    async fn get_log_response(client: &Client, uri: &str) -> LogResponse {
-        let response = client.get(uri).dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-        let body = response.into_string().await.expect("response body");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_to_string(response).await;
         serde_json::from_str(&body).expect("valid LogResponse JSON")
     }
 
@@ -1845,13 +1866,37 @@ mod tests {
 {"timestamp":"2026-04-20T10:00:02Z","level":"WARN","target":"st0x_hedge","message":"Slow response"}"#;
 
     #[tokio::test]
-    async fn logs_returns_empty_when_no_log_dir() {
-        let ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+    async fn test_health_endpoint() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
 
-        let result = get_log_response(&client, "/logs").await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let health_response: HealthResponse =
+            serde_json::from_str(&body).expect("valid JSON response");
+
+        assert_eq!(health_response.status, "healthy");
+        assert!(health_response.timestamp <= chrono::Utc::now());
+        assert!(!health_response.git_commit.is_empty());
+        assert!(health_response.uptime_seconds >= 0);
+    }
+
+    #[tokio::test]
+    async fn logs_returns_empty_when_no_log_dir() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let result = get_log_response(&app, "/logs").await;
         assert!(result.entries.is_empty());
         assert_eq!(result.total, 0);
         assert!(!result.has_more);
@@ -1866,14 +1911,12 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
-        let result = get_log_response(&client, "/logs").await;
+        let result = get_log_response(&app, "/logs").await;
         assert_eq!(result.entries.len(), 3);
         assert_eq!(result.total, 3);
         assert!(!result.has_more);
@@ -1891,14 +1934,12 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
-        let result = get_log_response(&client, "/logs?limit=2").await;
+        let result = get_log_response(&app, "/logs?limit=2").await;
         assert_eq!(result.entries.len(), 2);
         assert_eq!(result.total, 3);
         assert!(result.has_more);
@@ -1916,21 +1957,19 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
         // Page 1: newest 2
-        let page1 = get_log_response(&client, "/logs?limit=2&offset=0").await;
+        let page1 = get_log_response(&app, "/logs?limit=2&offset=0").await;
         assert_eq!(page1.entries.len(), 2);
         assert!(page1.has_more);
         assert_eq!(page1.entries[0]["message"], "Slow response");
 
         // Page 2: older entries
-        let page2 = get_log_response(&client, "/logs?limit=2&offset=2").await;
+        let page2 = get_log_response(&app, "/logs?limit=2&offset=2").await;
         assert_eq!(page2.entries.len(), 1);
         assert!(!page2.has_more);
         assert_eq!(page2.entries[0]["message"], "Bot started");
@@ -1945,14 +1984,12 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
-        let result = get_log_response(&client, "/logs?search=slow").await;
+        let result = get_log_response(&app, "/logs?search=slow").await;
         assert_eq!(result.entries.len(), 1);
         assert_eq!(result.total, 1);
         assert!(!result.has_more);
@@ -1968,14 +2005,12 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
-        let result = get_log_response(&client, "/logs?level=INFO,WARN").await;
+        let result = get_log_response(&app, "/logs?level=INFO,WARN").await;
         assert_eq!(result.entries.len(), 2);
         assert_eq!(result.total, 2);
         // Newest first: WARN before INFO
@@ -1992,16 +2027,14 @@ mod tests {
             THREE_ENTRY_LOG,
         );
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
         // Only entries between 10:00:00 and 10:00:01 inclusive
         let result = get_log_response(
-            &client,
+            &app,
             "/logs?since=2026-04-20T10:00:00Z&until=2026-04-20T10:00:01Z",
         )
         .await;
@@ -2025,22 +2058,20 @@ mod tests {
 
         write_test_logs(temp_dir.path(), "st0x-hedge.log.2026-04-20", &log_content);
 
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
 
-        let client = Client::tracked(make_test_rocket(ctx))
-            .await
-            .expect("valid rocket instance");
+        let app = build_app(empty_app_state(ctx).await);
 
         // Newest first: trade 4, trade 3, trade 2, trade 1, trade 0
-        let page1 = get_log_response(&client, "/logs?search=trade&limit=2").await;
+        let page1 = get_log_response(&app, "/logs?search=trade&limit=2").await;
         assert_eq!(page1.entries.len(), 2);
         assert_eq!(page1.total, 5);
         assert!(page1.has_more);
         assert_eq!(page1.entries[0]["message"], "trade 4");
         assert_eq!(page1.entries[1]["message"], "trade 3");
 
-        let page2 = get_log_response(&client, "/logs?search=trade&limit=2&offset=2").await;
+        let page2 = get_log_response(&app, "/logs?search=trade&limit=2&offset=2").await;
         assert_eq!(page2.entries.len(), 2);
         assert!(page2.has_more);
         assert_eq!(page2.entries[0]["message"], "trade 2");
@@ -2049,20 +2080,23 @@ mod tests {
 
     #[tokio::test]
     async fn raindex_orders_returns_unavailable_when_rest_api_not_configured() {
-        let ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
         assert!(ctx.rest_api.is_none());
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client.get("/orders/raindex").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
 
         assert_eq!(parsed["unavailable"], true);
@@ -2071,22 +2105,25 @@ mod tests {
 
     #[tokio::test]
     async fn raindex_orders_returns_unavailable_when_upstream_unreachable() {
-        let mut ctx = create_test_ctx_with_order_owner(alloy::primitives::Address::ZERO);
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
         ctx.rest_api = Some(RestApiCtx::unauthenticated(
             "http://127.0.0.1:1".to_string(),
         ));
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client.get("/orders/raindex").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value =
             serde_json::from_str(&body).expect("response must be valid JSON even on error");
 
@@ -2117,7 +2154,7 @@ mod tests {
             }
         });
 
-        let owner = alloy::primitives::Address::ZERO;
+        let owner = Address::ZERO;
         let expected_path = format!("/v1/orders/owner/{owner:#x}");
 
         mock_server.mock(|when, then| {
@@ -2133,17 +2170,20 @@ mod tests {
         let mut ctx = create_test_ctx_with_order_owner(owner);
         ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client.get("/orders/raindex").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
 
         assert_eq!(parsed["orders"][0]["orderHash"], "0xabcd");
@@ -2164,7 +2204,7 @@ mod tests {
             }
         });
 
-        let owner = alloy::primitives::Address::ZERO;
+        let owner = Address::ZERO;
         let expected_path = format!("/v1/orders/owner/{owner:#x}");
 
         mock_server.mock(|when, then| {
@@ -2180,20 +2220,20 @@ mod tests {
         let mut ctx = create_test_ctx_with_order_owner(owner);
         ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex?page=3&page_size=500")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client
-            .get("/orders/raindex?page=3&page_size=500")
-            .dispatch()
-            .await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
 
         assert_eq!(parsed["pagination"]["page"], 3);
@@ -2214,7 +2254,7 @@ mod tests {
             }
         });
 
-        let owner = alloy::primitives::Address::ZERO;
+        let owner = Address::ZERO;
         let expected_path = format!("/v1/orders/owner/{owner:#x}");
 
         mock_server.mock(|when, then| {
@@ -2230,20 +2270,20 @@ mod tests {
         let mut ctx = create_test_ctx_with_order_owner(owner);
         ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex?page=0&page_size=0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client
-            .get("/orders/raindex?page=0&page_size=0")
-            .dispatch()
-            .await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
 
         assert_eq!(parsed["pagination"]["page"], 1);
@@ -2253,7 +2293,7 @@ mod tests {
     #[tokio::test]
     async fn raindex_orders_returns_unavailable_on_upstream_500() {
         let mock_server = httpmock::MockServer::start();
-        let owner = alloy::primitives::Address::ZERO;
+        let owner = Address::ZERO;
 
         mock_server.mock(|when, then| {
             when.method(httpmock::Method::GET)
@@ -2264,17 +2304,20 @@ mod tests {
         let mut ctx = create_test_ctx_with_order_owner(owner);
         ctx.rest_api = Some(RestApiCtx::unauthenticated(mock_server.base_url()));
 
-        let rocket = rocket::build()
-            .mount("/", routes![raindex_orders])
-            .manage(ctx);
-        let client = Client::tracked(rocket)
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders/raindex")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
-            .expect("valid rocket instance");
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let response = client.get("/orders/raindex").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.expect("response body");
+        let body = body_to_string(response).await;
         let parsed: serde_json::Value =
             serde_json::from_str(&body).expect("response must be valid JSON on upstream error");
 
@@ -2282,75 +2325,77 @@ mod tests {
         assert!(parsed["reason"].as_str().unwrap().contains("error"));
     }
 
-    async fn create_test_pool() -> SqlitePool {
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        pool
-    }
-
     #[tokio::test]
     async fn interrupted_transfers_returns_empty_on_fresh_db() {
-        let pool = create_test_pool().await;
-        let rocket = rocket::build()
-            .mount("/", routes![interrupted_transfers])
-            .manage(pool);
-        let client = Client::tracked(rocket).await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
 
-        let response = client.get("/transfers/interrupted").dispatch().await;
-        assert_eq!(response.status(), Status::Ok);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/transfers/interrupted")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-        let body: serde_json::Value =
-            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        let body = body_to_string(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
 
-        assert_eq!(body["interruptedMints"], serde_json::json!([]));
-        assert_eq!(body["interruptedRedemptions"], serde_json::json!([]));
+        assert_eq!(parsed["interruptedMints"], serde_json::json!([]));
+        assert_eq!(parsed["interruptedRedemptions"], serde_json::json!([]));
     }
 
     #[tokio::test]
     async fn resume_transfers_returns_503_before_conductor_ready() {
-        let pool = create_test_pool().await;
-        let recovery = Arc::new(tokio::sync::OnceCell::<RecoveryHandle>::new());
-        let rocket = rocket::build()
-            .mount("/", routes![resume_transfers])
-            .manage(pool)
-            .manage(recovery)
-            .manage(ResumeLock(Mutex::new(())));
-        let client = Client::tracked(rocket).await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
 
-        let response = client.post("/transfers/resume").dispatch().await;
-        assert_eq!(response.status(), Status::ServiceUnavailable);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/transfers/resume")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let body: serde_json::Value =
-            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        let body = body_to_string(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
 
         assert_eq!(
-            body["error"],
+            parsed["error"],
             "Recovery not ready yet (conductor still starting)"
         );
     }
 
     #[tokio::test]
     async fn recheck_transfer_returns_503_before_conductor_ready() {
-        let pool = create_test_pool().await;
-        let recovery = Arc::new(tokio::sync::OnceCell::<RecoveryHandle>::new());
-        let rocket = rocket::build()
-            .mount("/", routes![recheck_transfer])
-            .manage(pool)
-            .manage(recovery)
-            .manage(ResumeLock(Mutex::new(())));
-        let client = Client::tracked(rocket).await.unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
 
-        let response = client
-            .post("/transfers/recheck/equity_mint/some-id")
-            .dispatch()
-            .await;
-        assert_eq!(response.status(), Status::ServiceUnavailable);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/transfers/recheck/equity_mint/some-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-        let body: serde_json::Value =
-            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        let body = body_to_string(response).await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
 
         assert_eq!(
-            body["error"],
+            parsed["error"],
             "Recovery not ready yet (conductor still starting)"
         );
     }
@@ -2365,7 +2410,7 @@ mod tests {
         let (status, message) = recheck_error_response(&RecheckError::NoAcceptedRequest(
             IssuerRequestId::new("mint-1"),
         ));
-        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(
             message,
             "mint mint-1 has no accepted provider request to re-check"
@@ -2374,16 +2419,14 @@ mod tests {
         let (status, _) = recheck_error_response(&RecheckError::MissingTxHash(
             TokenizationRequestId("tok-1".to_string()),
         ));
-        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
 
-        let parse_error = "not-an-address"
-            .parse::<alloy::primitives::Address>()
-            .unwrap_err();
+        let parse_error = "not-an-address".parse::<Address>().unwrap_err();
         let (status, _) = recheck_error_response(&RecheckError::MalformedWallet {
             id: IssuerRequestId::new("mint-1"),
             source: parse_error,
         });
-        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
 
         // Transient upstream provider failure -> 502 so the operator knows to
         // retry, with a generic message that does not leak provider internals.
@@ -2392,13 +2435,13 @@ mod tests {
                 tx_hash: alloy::primitives::TxHash::random(),
             }),
         ));
-        assert_eq!(status, Status::BadGateway);
+        assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert_eq!(message, "Tokenization provider unavailable; retry later");
 
         // Genuinely internal failure -> 500 with a generic body.
         let (status, message) =
             recheck_error_response(&RecheckError::Database(sqlx::Error::RowNotFound));
-        assert_eq!(status, Status::InternalServerError);
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(message, "Failed to recheck transfer");
     }
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -6,7 +6,7 @@ use st0x_hedge::setup_tracing;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let (ctx, command) = cli::CliEnv::parse_and_convert().await?;
-    let _file_log_guard = setup_tracing(&ctx.log_level, ctx.log_dir.as_deref());
+    let _file_log_guard = setup_tracing(&ctx.log_level, ctx.log_dir.as_deref(), None);
 
     Box::pin(cli::run_command(ctx, command)).await?;
     Ok(())

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use st0x_config::{Ctx, Env};
 use st0x_hedge::run_bot_session;
-use st0x_hedge::setup_tracing;
+use st0x_hedge::{apalis_board_tracing_layer, setup_tracing};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -11,16 +11,28 @@ async fn main() -> anyhow::Result<()> {
     let log_level: tracing::Level = (&ctx.log_level).into();
 
     let (_file_log_guard, telemetry_guard) = if let Some(ref telemetry) = ctx.telemetry {
-        match telemetry.setup(log_level, ctx.log_dir.as_deref()) {
+        match telemetry.setup(
+            log_level,
+            ctx.log_dir.as_deref(),
+            Some(apalis_board_tracing_layer(log_level)),
+        ) {
             Ok((file_guard, tele_guard)) => (file_guard, Some(tele_guard)),
             Err(error) => {
                 eprintln!("Failed to setup telemetry: {error}");
-                let file_guard = setup_tracing(&ctx.log_level, ctx.log_dir.as_deref());
+                let file_guard = setup_tracing(
+                    &ctx.log_level,
+                    ctx.log_dir.as_deref(),
+                    Some(apalis_board_tracing_layer(log_level)),
+                );
                 (file_guard, None)
             }
         }
     } else {
-        let file_guard = setup_tracing(&ctx.log_level, ctx.log_dir.as_deref());
+        let file_guard = setup_tracing(
+            &ctx.log_level,
+            ctx.log_dir.as_deref(),
+            Some(apalis_board_tracing_layer(log_level)),
+        );
         (file_guard, None)
     };
 

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -727,6 +727,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),
@@ -796,6 +797,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -260,6 +260,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1298,6 +1298,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),
@@ -1632,6 +1633,8 @@ mod tests {
             &config_path,
             r#"
                 database_url = ":memory:"
+                server_port = 8080
+                board_port = 8081
                 apalis_finished_job_cleanup_interval_secs = 3600
 
                 [assets.equities]

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -758,6 +758,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),
@@ -816,6 +817,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -660,6 +660,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -234,6 +234,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),
@@ -268,6 +269,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: address!("0x1234567890123456789012345678901234567890"),

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -147,6 +147,7 @@ mod tests {
             log_level: LogLevel::Debug,
             log_dir: None,
             server_port: 8080,
+            board_port: 8081,
             evm: EvmCtx {
                 ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
                 orderbook: Address::random(),

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -1,10 +1,13 @@
 //! WebSocket-based dashboard for real-time server state streaming.
 
-use futures_util::SinkExt;
-use rocket::{Route, State, get, routes};
-use rocket_ws::{Channel, Message, WebSocket};
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use futures_util::sink::SinkExt;
+use futures_util::stream::{SplitSink, StreamExt};
 use sqlx::SqlitePool;
-use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{info, trace, warn};
 
@@ -13,7 +16,7 @@ use st0x_dto::{CurrentState, Statement};
 use st0x_event_sorcery::{load_all_ids, load_entity};
 use st0x_finance::Positive;
 
-use crate::inventory::BroadcastingInventory;
+use crate::AppState;
 use crate::position::Position;
 
 mod event;
@@ -21,92 +24,117 @@ mod trade_loader;
 pub(crate) mod transfer_loader;
 pub(crate) use event::Broadcaster;
 
-pub(crate) struct Broadcast {
-    pub(crate) sender: broadcast::Sender<Statement>,
+async fn ws_endpoint(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-pub(crate) struct DashboardState {
-    pub(crate) inventory: Arc<BroadcastingInventory>,
-    pub(crate) pool: SqlitePool,
-    pub(crate) settings: st0x_dto::Settings,
+/// Outcome of attempting to send a serialized message over the socket.
+enum SendOutcome {
+    Sent,
+    SerializeFailed,
+    SocketClosed,
 }
 
-#[get("/ws")]
-fn ws_endpoint<'r>(
-    ws: WebSocket,
-    broadcast: &'r State<Broadcast>,
-    dashboard: &'r State<DashboardState>,
-) -> Channel<'r> {
-    let mut receiver = broadcast.sender.subscribe();
-    let inventory = Arc::clone(&dashboard.inventory);
-    let pool = dashboard.pool.clone();
-    let settings = dashboard.settings.clone();
+async fn send_json(sink: &mut SplitSink<WebSocket, Message>, value: &Statement) -> SendOutcome {
+    let json = match serde_json::to_string(value) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            warn!(target: "dashboard", %error, "Failed to serialize message");
+            return SendOutcome::SerializeFailed;
+        }
+    };
 
-    ws.channel(move |mut stream| {
-        Box::pin(async move {
-            let inventory_dto = inventory.read().await.to_dto();
-            let transfers = transfer_loader::load_transfers(&pool).await;
-            let trades = trade_loader::load_trades(&pool).await;
-            let positions = load_positions(&pool).await;
+    if let Err(error) = sink.send(Message::Text(json.into())).await {
+        warn!(target: "dashboard", %error, "Failed to send message to client");
+        return SendOutcome::SocketClosed;
+    }
 
-            let state = CurrentState {
-                trades,
-                inventory: inventory_dto,
-                positions,
-                settings,
-                active_transfers: transfers.active,
-                recent_transfers: transfers.recent,
-                warnings: transfers.warnings,
-            };
+    SendOutcome::Sent
+}
 
-            let initial = Statement::CurrentState(Box::new(state));
-            let json = match serde_json::to_string(&initial) {
-                Ok(serialized) => serialized,
-                Err(error) => {
-                    warn!(target: "dashboard", %error, "Failed to serialize initial state");
-                    return Ok(());
-                }
-            };
+async fn handle_socket(socket: WebSocket, state: AppState) {
+    let mut receiver = state.event_sender.subscribe();
+    let (mut sink, mut stream) = socket.split();
 
-            if let Err(error) = stream.send(Message::Text(json)).await {
-                warn!(target: "dashboard", %error, "Failed to send initial state");
-                return Ok(());
+    if !send_initial_state(&mut sink, &state).await {
+        return;
+    }
+
+    tokio::select! {
+        () = stream_broadcasts(&mut sink, &mut receiver) => {}
+        () = drain_client_messages(&mut stream) => {}
+    }
+}
+
+/// Polls the client side of the socket so that Close / Ping / Pong are
+/// observed promptly. Exits when the client closes the socket or sends
+/// nothing more — at which point [`handle_socket`] tears down the send half.
+async fn drain_client_messages(stream: &mut futures_util::stream::SplitStream<WebSocket>) {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(Message::Close(_)) => break,
+            Ok(_) => {}
+            Err(error) => {
+                warn!(target: "dashboard", %error, "WebSocket receive error");
+                break;
             }
+        }
+    }
+}
+
+async fn send_initial_state(sink: &mut SplitSink<WebSocket, Message>, state: &AppState) -> bool {
+    let inventory_dto = state.inventory.read().await.to_dto();
+    let transfers = transfer_loader::load_transfers(&state.pool).await;
+    let trades = trade_loader::load_trades(&state.pool).await;
+    let positions = load_positions(&state.pool).await;
+
+    let initial = Statement::CurrentState(Box::new(CurrentState {
+        trades,
+        inventory: inventory_dto,
+        positions,
+        settings: state.settings.clone(),
+        active_transfers: transfers.active,
+        recent_transfers: transfers.recent,
+        warnings: transfers.warnings,
+    }));
+
+    match send_json(sink, &initial).await {
+        SendOutcome::Sent => {
             info!(target: "dashboard", "Sent initial state to dashboard client");
-
-            loop {
-                match receiver.recv().await {
-                    Ok(msg) => {
-                        trace!(target: "dashboard", ?msg, "Broadcasting to dashboard client");
-                        let json = match serde_json::to_string(&msg) {
-                            Ok(serialized) => serialized,
-                            Err(error) => {
-                                warn!(target: "dashboard", %error, "Failed to serialize message");
-                                continue;
-                            }
-                        };
-
-                        if let Err(error) = stream.send(Message::Text(json)).await {
-                            warn!(target: "dashboard", %error, "Failed to send message to client");
-                            break;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                        warn!(target: "dashboard", skipped, "Client lagged, skipped messages");
-                    }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        break;
-                    }
-                }
-            }
-
-            Ok(())
-        })
-    })
+            true
+        }
+        SendOutcome::SerializeFailed | SendOutcome::SocketClosed => false,
+    }
 }
 
-pub(crate) fn routes() -> Vec<Route> {
-    routes![ws_endpoint]
+async fn stream_broadcasts(
+    sink: &mut SplitSink<WebSocket, Message>,
+    receiver: &mut broadcast::Receiver<Statement>,
+) {
+    loop {
+        match receiver.recv().await {
+            Ok(msg) => {
+                trace!(target: "dashboard", ?msg, "Broadcasting to dashboard client");
+                match send_json(sink, &msg).await {
+                    SendOutcome::Sent => {}
+                    SendOutcome::SerializeFailed | SendOutcome::SocketClosed => break,
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(
+                    target: "dashboard",
+                    skipped,
+                    "Client lagged, closing socket so the client reconnects and refetches state"
+                );
+                break;
+            }
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+}
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new().route("/ws", get(ws_endpoint))
 }
 
 pub(crate) fn settings_from_ctx(ctx: &st0x_config::Ctx) -> st0x_dto::Settings {
@@ -261,17 +289,19 @@ async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
     use futures_util::StreamExt;
     use futures_util::future::join_all;
-    use rocket::config::Config;
-    use rocket::fairing::AdHoc;
     use serde_json::json;
-    use st0x_dto::{Direction, Trade, TradingVenue};
-    use std::sync::Mutex;
-    use tokio::sync::oneshot;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
     use tokio_tungstenite::connect_async;
 
+    use st0x_dto::{Direction, Trade, TradingVenue};
+
     use super::*;
+    use crate::inventory::{self, BroadcastingInventory};
+    use st0x_config::create_test_ctx_with_order_owner;
 
     fn dummy_fill(symbol: &str) -> Statement {
         Statement::TradeFill(Trade {
@@ -284,69 +314,96 @@ mod tests {
         })
     }
 
+    fn empty_settings() -> st0x_dto::Settings {
+        st0x_dto::Settings {
+            equity_target: 0.5,
+            equity_deviation: 0.2,
+            usdc_target: None,
+            usdc_deviation: None,
+            cash_reserved: None,
+            execution_threshold: "$2".to_string(),
+            assets: Vec::new(),
+            wallet: None,
+            log_level: "Debug".to_string(),
+            server_port: 8001,
+            orderbook: "0x0".to_string(),
+            deployment_block: 0,
+            trading_mode: "standalone".to_string(),
+            broker: "dry_run".to_string(),
+            order_polling_interval: 5,
+            inventory_poll_interval: 15,
+        }
+    }
+
     fn empty_current_state() -> Box<CurrentState> {
         Box::new(CurrentState {
             trades: Vec::new(),
             inventory: st0x_dto::Inventory::empty(),
             positions: Vec::new(),
-            settings: st0x_dto::Settings {
-                equity_target: 0.5,
-                equity_deviation: 0.2,
-                usdc_target: None,
-                usdc_deviation: None,
-                cash_reserved: None,
-                execution_threshold: "$2".to_string(),
-                assets: Vec::new(),
-                wallet: None,
-                log_level: "Debug".to_string(),
-                server_port: 8001,
-                orderbook: "0x0".to_string(),
-                deployment_block: 0,
-                trading_mode: "standalone".to_string(),
-                broker: "dry_run".to_string(),
-                order_polling_interval: 5,
-                inventory_poll_interval: 15,
-            },
+            settings: empty_settings(),
             active_transfers: Vec::new(),
             recent_transfers: Vec::new(),
             warnings: Vec::new(),
         })
     }
 
-    fn create_test_broadcast() -> Broadcast {
+    async fn create_test_state() -> AppState {
         let (sender, _) = broadcast::channel(256);
-        Broadcast { sender }
-    }
-
-    async fn create_test_dashboard_state(
-        event_sender: broadcast::Sender<Statement>,
-    ) -> DashboardState {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
-        DashboardState {
-            inventory: Arc::new(BroadcastingInventory::new(
-                crate::inventory::InventoryView::default(),
-                event_sender,
+
+        AppState {
+            ctx: create_test_ctx_with_order_owner(address!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )),
             pool,
-            settings: st0x_dto::Settings {
-                equity_target: 0.5,
-                equity_deviation: 0.2,
-                usdc_target: None,
-                usdc_deviation: None,
-                cash_reserved: None,
-                execution_threshold: "$2".to_string(),
-                assets: Vec::new(),
-                wallet: None,
-                log_level: "Debug".to_string(),
-                server_port: 8001,
-                orderbook: "0x0".to_string(),
-                deployment_block: 0,
-                trading_mode: "standalone".to_string(),
-                broker: "dry_run".to_string(),
-                order_polling_interval: 5,
-                inventory_poll_interval: 15,
-            },
+            event_sender: sender.clone(),
+            inventory: Arc::new(BroadcastingInventory::new(
+                inventory::InventoryView::default(),
+                sender,
+            )),
+            settings: empty_settings(),
+            recovery: Arc::new(tokio::sync::OnceCell::new()),
+            resume_lock: Arc::new(crate::api::ResumeLock(tokio::sync::Mutex::new(()))),
+        }
+    }
+
+    struct TestServer {
+        port: u16,
+        handle: Option<tokio::task::JoinHandle<()>>,
+        event_sender: broadcast::Sender<Statement>,
+        inventory: Arc<BroadcastingInventory>,
+    }
+
+    impl TestServer {
+        async fn shutdown(&mut self) {
+            let Some(handle) = self.handle.take() else {
+                return;
+            };
+            handle.abort();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+        }
+    }
+
+    async fn start_test_server() -> TestServer {
+        let state = create_test_state().await;
+        let event_sender = state.event_sender.clone();
+        let inventory = Arc::clone(&state.inventory);
+
+        let app = Router::new().nest("/api", routes()).with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        TestServer {
+            port,
+            handle: Some(handle),
+            event_sender,
+            inventory,
         }
     }
 
@@ -356,24 +413,7 @@ mod tests {
             trades: Vec::new(),
             inventory: st0x_dto::Inventory::empty(),
             positions: Vec::new(),
-            settings: st0x_dto::Settings {
-                equity_target: 0.5,
-                equity_deviation: 0.2,
-                usdc_target: None,
-                usdc_deviation: None,
-                cash_reserved: None,
-                execution_threshold: "$2".to_string(),
-                assets: Vec::new(),
-                wallet: None,
-                log_level: "Debug".to_string(),
-                server_port: 8001,
-                orderbook: "0x0".to_string(),
-                deployment_block: 0,
-                trading_mode: "standalone".to_string(),
-                broker: "dry_run".to_string(),
-                order_polling_interval: 5,
-                inventory_poll_interval: 15,
-            },
+            settings: empty_settings(),
             active_transfers: Vec::new(),
             recent_transfers: Vec::new(),
             warnings: Vec::new(),
@@ -398,85 +438,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcast_channel_delivers_messages_to_subscribers() {
-        let broadcast = create_test_broadcast();
-        let mut rx = broadcast.sender.subscribe();
-
-        let sent_msg = Statement::CurrentState(empty_current_state());
-        broadcast
-            .sender
-            .send(sent_msg.clone())
-            .expect("send should succeed");
-
-        let recv_msg = rx.recv().await.expect("receive should succeed");
-        let original_json = serde_json::to_string(&sent_msg).expect("serialization should succeed");
-        let received_json = serde_json::to_string(&recv_msg).expect("serialization should succeed");
-        assert_eq!(original_json, received_json);
-    }
-
-    #[tokio::test]
-    async fn broadcast_supports_multiple_subscribers() {
-        let broadcast = create_test_broadcast();
-        let mut receiver1 = broadcast.sender.subscribe();
-        let mut receiver2 = broadcast.sender.subscribe();
-
-        let msg = Statement::CurrentState(empty_current_state());
-        broadcast.sender.send(msg).expect("send should succeed");
-
-        receiver1
-            .recv()
-            .await
-            .expect("receiver1 should get message");
-        receiver2
-            .recv()
-            .await
-            .expect("receiver2 should get message");
-    }
-
-    #[tokio::test]
-    async fn websocket_routes_returns_one_route() {
-        let route_list = routes();
-        assert_eq!(route_list.len(), 1);
-    }
-
-    #[tokio::test]
     async fn websocket_endpoint_sends_initial_message() {
-        let broadcast = create_test_broadcast();
-        let dashboard_state = create_test_dashboard_state(broadcast.sender.clone()).await;
+        let mut server = start_test_server().await;
+        let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
-        let config = Config {
-            port: 0, // Let OS assign a random available port
-            log_level: rocket::config::LogLevel::Off,
-            ..Config::debug_default()
-        };
-
-        let (port_tx, port_rx) = oneshot::channel::<u16>();
-        let port_tx = Mutex::new(Some(port_tx));
-
-        let rocket = rocket::build()
-            .configure(config)
-            .mount("/api", routes())
-            .manage(broadcast)
-            .manage(dashboard_state)
-            .attach(AdHoc::on_liftoff("Port Sender", move |rocket| {
-                Box::pin(async move {
-                    let maybe_tx = port_tx.lock().unwrap().take();
-                    if let Some(tx) = maybe_tx {
-                        let _ = tx.send(rocket.config().port);
-                    }
-                })
-            }));
-
-        let rocket = rocket.ignite().await.expect("ignite failed");
-        let shutdown_handle = rocket.shutdown();
-
-        tokio::spawn(async move {
-            let _ = rocket.launch().await;
-        });
-
-        let port = port_rx.await.expect("failed to receive port");
-
-        let url = format!("ws://127.0.0.1:{port}/api/ws");
         let (mut ws_stream, _response) = connect_async(&url)
             .await
             .expect("WebSocket connection failed");
@@ -494,67 +459,12 @@ mod tests {
         assert!(parsed["data"]["trades"].is_array());
         assert!(parsed["data"]["inventory"].is_object());
 
-        shutdown_handle.notify();
-    }
-
-    struct TestServer {
-        port: u16,
-        shutdown: rocket::Shutdown,
-        broadcast: Broadcast,
-        inventory: Arc<BroadcastingInventory>,
-    }
-
-    async fn start_test_server() -> TestServer {
-        let broadcast = create_test_broadcast();
-        let broadcast_clone = Broadcast {
-            sender: broadcast.sender.clone(),
-        };
-        let dashboard_state = create_test_dashboard_state(broadcast.sender.clone()).await;
-        let inventory = Arc::clone(&dashboard_state.inventory);
-
-        let config = Config {
-            port: 0,
-            log_level: rocket::config::LogLevel::Off,
-            ..Config::debug_default()
-        };
-
-        let (port_tx, port_rx) = oneshot::channel::<u16>();
-        let port_tx = Mutex::new(Some(port_tx));
-
-        let rocket = rocket::build()
-            .configure(config)
-            .mount("/api", routes())
-            .manage(broadcast_clone)
-            .manage(dashboard_state)
-            .attach(AdHoc::on_liftoff("Port Sender", move |rocket| {
-                Box::pin(async move {
-                    let maybe_tx = port_tx.lock().unwrap().take();
-                    if let Some(tx) = maybe_tx {
-                        let _ = tx.send(rocket.config().port);
-                    }
-                })
-            }));
-
-        let rocket = rocket.ignite().await.expect("ignite failed");
-        let shutdown = rocket.shutdown();
-
-        tokio::spawn(async move {
-            let _ = rocket.launch().await;
-        });
-
-        let port = port_rx.await.expect("failed to receive port");
-
-        TestServer {
-            port,
-            shutdown,
-            broadcast,
-            inventory,
-        }
+        server.shutdown().await;
     }
 
     #[tokio::test]
     async fn multiple_concurrent_clients_receive_initial_message() {
-        let server = start_test_server().await;
+        let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
         let (mut client1, _) = connect_async(&url)
@@ -588,12 +498,12 @@ mod tests {
             );
         }
 
-        server.shutdown.notify();
+        server.shutdown().await;
     }
 
     #[tokio::test]
     async fn broadcast_message_reaches_connected_clients() {
-        let server = start_test_server().await;
+        let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
         let (mut client1, _) = connect_async(&url)
@@ -603,18 +513,14 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
         client1.next().await.expect("client1 initial").unwrap();
         client2.next().await.expect("client2 initial").unwrap();
 
-        // Broadcast a fill message
         server
-            .broadcast
-            .sender
+            .event_sender
             .send(dummy_fill("AAPL"))
             .expect("broadcast send");
 
-        // Both clients should receive the broadcast
         let results = join_all([client1.next(), client2.next()]).await;
 
         for (i, result) in results.into_iter().enumerate() {
@@ -634,12 +540,12 @@ mod tests {
             assert_eq!(parsed["data"]["symbol"], "AAPL");
         }
 
-        server.shutdown.notify();
+        server.shutdown().await;
     }
 
     #[tokio::test]
     async fn client_disconnect_does_not_affect_other_clients() {
-        let server = start_test_server().await;
+        let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
         let (mut client1, _) = connect_async(&url)
@@ -649,23 +555,17 @@ mod tests {
             .await
             .expect("client2 connection failed");
 
-        // Consume initial messages
         client1.next().await.expect("client1 initial").unwrap();
 
-        // Drop client2 to simulate disconnect
         drop(client2);
 
-        // Give the server a moment to process the disconnect
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
-        // Broadcast a message - should still reach client1
         server
-            .broadcast
-            .sender
+            .event_sender
             .send(dummy_fill("TSLA"))
             .expect("broadcast send");
 
-        // client1 should still receive messages
         let msg = client1
             .next()
             .await
@@ -678,33 +578,27 @@ mod tests {
         assert_eq!(parsed["type"], "trade_fill");
         assert_eq!(parsed["data"]["symbol"], "TSLA");
 
-        server.shutdown.notify();
+        server.shutdown().await;
     }
 
     #[tokio::test]
     async fn new_client_receives_initial_not_previous_broadcasts() {
-        let server = start_test_server().await;
+        let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
-        // Connect first client to have a receiver
         let (mut client1, _) = connect_async(&url)
             .await
             .expect("client1 connection failed");
 
-        // Consume initial message for client1
         client1.next().await.expect("client1 initial").unwrap();
 
-        // Broadcast a message (client1 will receive it)
         server
-            .broadcast
-            .sender
+            .event_sender
             .send(dummy_fill("MSFT"))
             .expect("broadcast send");
 
-        // Consume the broadcast on client1
         client1.next().await.expect("client1 broadcast").unwrap();
 
-        // Now connect a second client - should get initial, not the old broadcast
         let (mut client2, _) = connect_async(&url)
             .await
             .expect("client2 connection failed");
@@ -723,22 +617,20 @@ mod tests {
             "new client should receive current_state, not previous broadcast"
         );
 
-        server.shutdown.notify();
+        server.shutdown().await;
     }
 
     #[tokio::test]
     async fn inventory_mutation_sends_snapshot_to_websocket_client() {
-        let server = start_test_server().await;
+        let mut server = start_test_server().await;
         let url = format!("ws://127.0.0.1:{}/api/ws", server.port);
 
         let (mut client, _) = connect_async(&url)
             .await
             .expect("WebSocket connection failed");
 
-        // Consume initial message
         client.next().await.expect("initial").unwrap();
 
-        // Mutate inventory through the shared BroadcastingInventory
         {
             let mut guard = server.inventory.write().await;
             *guard = std::mem::take(&mut *guard).with_equity(
@@ -748,7 +640,6 @@ mod tests {
             );
         }
 
-        // Client should receive the snapshot broadcast
         let msg = client
             .next()
             .await
@@ -769,6 +660,6 @@ mod tests {
         assert_eq!(aapl["offchainAvailable"], json!("5"));
         assert_eq!(aapl["offchainInflight"], json!("0"));
 
-        server.shutdown.notify();
+        server.shutdown().await;
     }
 }

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -2,6 +2,7 @@
 
 use chrono::{Duration, Utc};
 use sqlx::SqlitePool;
+use thiserror::Error;
 use tracing::warn;
 
 use std::fmt::{self, Debug, Display};
@@ -44,15 +45,21 @@ impl Display for TransferKind {
     }
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum InvalidTransferKind {
+    #[error("unknown transfer kind: {0}")]
+    Unknown(String),
+}
+
 impl FromStr for TransferKind {
-    type Err = String;
+    type Err = InvalidTransferKind;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "equity_mint" => Ok(Self::EquityMint),
             "equity_redemption" => Ok(Self::EquityRedemption),
             "usdc_bridge" => Ok(Self::UsdcBridge),
-            other => Err(format!("unknown transfer kind: {other}")),
+            other => Err(InvalidTransferKind::Unknown(other.to_owned())),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,24 +5,34 @@
 //! traditional brokerages.
 
 use anyhow::Context;
-use rocket::{Ignite, Rocket};
+use apalis_board::axum::framework::{ApiBuilder, RegisterRoute};
+use apalis_board::axum::sse::TracingBroadcaster;
+use apalis_board::axum::ui::ServeUI;
+use axum::{Extension, Router};
 use sqlx::SqlitePool;
-use std::sync::Arc;
+use std::future::Future;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+use task_supervisor::{
+    SupervisedTask, SupervisorBuilder, SupervisorError, SupervisorHandle, TaskResult,
+};
+use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use tokio::task::{AbortHandle, JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
+use tracing_subscriber::Layer;
 
+use st0x_config::{BrokerCtx, Ctx};
 use st0x_dto::Statement;
 use st0x_execution::MockExecutorCtx;
 
-use st0x_config::{BrokerCtx, Ctx};
+use crate::trading::offchain::hedge::HedgeJobQueue;
+use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
 
-/// How long to wait for in-flight work to drain before force-aborting.
 /// Outer timeout for the entire graceful shutdown sequence. Must exceed
-/// the rebalancer drain timeout (60s) plus margin for supervisor
-/// shutdown and apalis drain.
+/// the rebalancer drain timeout (60s) plus margin for supervisor shutdown
+/// and apalis drain.
 const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(90);
 
 mod alpaca_wallet;
@@ -54,7 +64,9 @@ mod vault_registry;
 mod wrapped_equity_recovery;
 mod wrapper;
 
-pub use st0x_config::{FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing};
+pub use st0x_config::{
+    ExtraLayer, FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing,
+};
 
 #[cfg(any(test, feature = "test-support"))]
 pub use offchain::order::{OffchainOrder, OffchainOrderId};
@@ -86,6 +98,44 @@ pub use trading::onchain::trade_accountant::AccountForDexTrade;
 mod integration_tests;
 #[cfg(test)]
 pub mod test_utils;
+
+/// Returns the global apalis-board log broadcaster, creating it on first access.
+///
+/// The same instance must be wired into the tracing subscriber (so log
+/// events are pushed into it) and into the board router as an `Extension`
+/// (so the `/api/v1/events` SSE handler can read them out). The wiring is
+/// done via [`apalis_board_tracing_layer`] passed to `setup_tracing` /
+/// `TelemetryConfig::setup`.
+pub fn apalis_broadcaster() -> &'static Arc<Mutex<TracingBroadcaster>> {
+    static BROADCASTER: OnceLock<Arc<Mutex<TracingBroadcaster>>> = OnceLock::new();
+    BROADCASTER.get_or_init(TracingBroadcaster::create)
+}
+
+/// Builds the tracing layer that forwards events into the apalis-board
+/// broadcaster's SSE feed. Filter level is the same as the global env filter.
+///
+/// Returned as an `ExtraLayer` so it can be plugged into
+/// `setup_tracing` / `TelemetryConfig::setup` without coupling
+/// `st0x-config` to `apalis-board`.
+pub fn apalis_board_tracing_layer(level: tracing::Level) -> ExtraLayer {
+    Box::new(
+        apalis_board::axum::sse::TracingSubscriber::new(apalis_broadcaster())
+            .layer()
+            .with_filter(mk_env_filter(level)),
+    )
+}
+
+/// Shared application state passed to all axum handlers.
+#[derive(Clone)]
+pub(crate) struct AppState {
+    pub(crate) ctx: Ctx,
+    pub(crate) pool: SqlitePool,
+    pub(crate) event_sender: broadcast::Sender<Statement>,
+    pub(crate) inventory: Arc<inventory::BroadcastingInventory>,
+    pub(crate) settings: st0x_dto::Settings,
+    pub(crate) recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
+    pub(crate) resume_lock: Arc<api::ResumeLock>,
+}
 
 #[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
 pub async fn run_bot_session(ctx: Ctx) -> anyhow::Result<()> {
@@ -126,6 +176,7 @@ async fn run_bot_session_inner(
 ) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
     sqlx::migrate!().set_ignore_missing(true).run(&pool).await?;
+    conductor::setup_apalis_tables(&pool).await?;
 
     let inventory = Arc::new(inventory::BroadcastingInventory::new(
         inventory::InventoryView::default(),
@@ -134,13 +185,26 @@ async fn run_bot_session_inner(
 
     let shutdown_token = CancellationToken::new();
     let recovery_cell = Arc::new(tokio::sync::OnceCell::new());
+    let resume_lock = Arc::new(api::ResumeLock(tokio::sync::Mutex::new(())));
 
-    let server_task = spawn_server_task(
+    // Pre-bind both server ports synchronously so a port-in-use failure
+    // surfaces at startup instead of looping in the supervisor.
+    let main_listener = TcpListener::bind(("0.0.0.0", ctx.server_port))
+        .await
+        .with_context(|| format!("failed to bind axum server on port {}", ctx.server_port))?;
+    let board_listener = TcpListener::bind(("0.0.0.0", ctx.board_port))
+        .await
+        .with_context(|| format!("failed to bind apalis-board on port {}", ctx.board_port))?;
+
+    let server_supervisor = spawn_server_supervisor(
         &ctx,
         &pool,
         event_sender.clone(),
         inventory.clone(),
         recovery_cell.clone(),
+        resume_lock,
+        main_listener,
+        board_listener,
     );
     let bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
@@ -153,181 +217,211 @@ async fn run_bot_session_inner(
         failure_injector,
     )));
 
-    await_shutdown(server_task, bot_task, shutdown_token).await?;
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .context("failed to register SIGTERM handler")?;
+    let shutdown_signal = async move {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => info!(target: "shutdown", "Received SIGINT"),
+            _ = sigterm.recv() => info!(target: "shutdown", "Received SIGTERM"),
+        }
+    };
+
+    await_shutdown(
+        server_supervisor,
+        bot_task,
+        shutdown_token,
+        shutdown_signal,
+        GRACEFUL_SHUTDOWN_TIMEOUT,
+    )
+    .await?;
 
     info!(target: "startup", "Shutdown complete");
     Ok(())
 }
 
-fn spawn_server_task(
+/// Long-running axum HTTP server, supervised so a bind/serve failure
+/// doesn't silently take the API and dashboard down for the rest of
+/// the bot's lifetime.
+///
+/// The listener is pre-bound by the caller and handed in via
+/// `Arc<Mutex<Option<TcpListener>>>` so the supervisor can't loop-restart
+/// on bind failures: if `axum::serve` exits and the supervisor restarts
+/// `run()`, the slot is empty and the task fails permanently, triggering
+/// the supervisor's dead-task threshold instead of hot-spinning on bind.
+#[derive(Clone)]
+struct ServerTask {
+    router: Router,
+    listener: Arc<Mutex<Option<TcpListener>>>,
+}
+
+impl SupervisedTask for ServerTask {
+    async fn run(&mut self) -> TaskResult {
+        let listener = self
+            .listener
+            .lock()
+            .map_err(|_| "listener mutex poisoned".to_string())?
+            .take()
+            .ok_or(
+                "listener already consumed; supervisor cannot restart axum \
+                 server without a fresh bind",
+            )?;
+        let port = listener.local_addr().map(|addr| addr.port()).ok();
+        info!(target: "startup", ?port, "Server listening");
+        axum::serve(listener, self.router.clone()).await?;
+        Err("axum server exited unexpectedly".into())
+    }
+}
+
+fn spawn_server_supervisor(
     ctx: &Ctx,
     pool: &SqlitePool,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
-    recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
-) -> JoinHandle<Result<Rocket<Ignite>, rocket::Error>> {
-    let rocket_config = rocket::Config::figment()
-        .merge(("port", ctx.server_port))
-        .merge(("address", "0.0.0.0"));
+    recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
+    resume_lock: Arc<api::ResumeLock>,
+    main_listener: TcpListener,
+    board_listener: TcpListener,
+) -> SupervisorHandle {
+    let state = AppState {
+        ctx: ctx.clone(),
+        pool: pool.clone(),
+        event_sender,
+        inventory,
+        settings: dashboard::settings_from_ctx(ctx),
+        recovery,
+        resume_lock,
+    };
 
-    let rocket = rocket::custom(rocket_config)
-        .mount("/", api::routes())
-        .mount("/api", dashboard::routes())
-        .manage(pool.clone())
-        .manage(ctx.clone())
-        .manage(dashboard::Broadcast {
-            sender: event_sender,
-        })
-        .manage(dashboard::DashboardState {
-            inventory,
-            pool: pool.clone(),
-            settings: dashboard::settings_from_ctx(ctx),
-        })
-        .manage(recovery_cell)
-        .manage(api::ResumeLock(tokio::sync::Mutex::new(())));
+    let main_router = Router::new()
+        .merge(api::routes())
+        .nest("/api", dashboard::routes())
+        .with_state(state);
 
-    tokio::spawn(rocket.launch())
+    // apalis-board's embedded UI is built with hardcoded absolute paths
+    // (`/apalis-board-web-*`) and the wasm calls `/api/v1/*` directly,
+    // so it must own its origin. Run it on its own port instead of
+    // nesting under the main router.
+    let dex_storage = DexTradeAccountingJobQueue::new(pool).into_storage();
+    let hedge_storage = HedgeJobQueue::new(pool).into_storage();
+    let board_api = ApiBuilder::new(Router::new())
+        .register(dex_storage)
+        .register(hedge_storage)
+        .build();
+    let board_router = Router::new()
+        .nest("/api/v1", board_api)
+        .fallback_service(ServeUI::new())
+        .layer(Extension(apalis_broadcaster().clone()));
+
+    SupervisorBuilder::default()
+        // Any dead task means a server is permanently down (max restarts
+        // exhausted). Both servers are essential -- escalate immediately so
+        // the bot exits gracefully instead of trading without an API.
+        .with_dead_tasks_threshold(Some(0.0))
+        .with_task(
+            "axum-server",
+            ServerTask {
+                router: main_router,
+                listener: Arc::new(Mutex::new(Some(main_listener))),
+            },
+        )
+        .with_task(
+            "apalis-board",
+            ServerTask {
+                router: board_router,
+                listener: Arc::new(Mutex::new(Some(board_listener))),
+            },
+        )
+        .build()
+        .run()
 }
 
-async fn await_shutdown(
-    mut server_task: JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
+async fn await_shutdown<S>(
+    server_supervisor: SupervisorHandle,
     mut bot_task: JoinHandle<anyhow::Result<()>>,
     shutdown_token: CancellationToken,
-) -> anyhow::Result<()> {
-    let server_abort = server_task.abort_handle();
+    shutdown_signal: S,
+    drain_timeout: Duration,
+) -> anyhow::Result<()>
+where
+    S: Future<Output = ()>,
+{
     let bot_abort = bot_task.abort_handle();
+    tokio::pin!(shutdown_signal);
 
-    let trigger = await_shutdown_trigger(&mut server_task, &mut bot_task).await?;
+    let trigger: ShutdownTrigger = tokio::select! {
+        () = shutdown_signal.as_mut() => ShutdownTrigger::Signal,
+        result = server_supervisor.wait() => ShutdownTrigger::ServerExit(result),
+        result = &mut bot_task => ShutdownTrigger::BotExit(result),
+    };
 
     match trigger {
-        ShutdownTrigger::Signal(early_exit) => {
-            info!(target: "shutdown", "Initiating graceful shutdown");
+        ShutdownTrigger::Signal => {
+            info!(target: "shutdown", "Shutdown signal received, draining gracefully");
             shutdown_token.cancel();
-            abort_task("server", &server_abort);
-            drain_bot_with_timeout(bot_task, bot_abort, early_exit, GRACEFUL_SHUTDOWN_TIMEOUT).await
+            shutdown_supervisor(&server_supervisor);
+            drain_bot_with_timeout(bot_task, bot_abort, drain_timeout).await
         }
-        ShutdownTrigger::BotExited(result) => {
-            abort_task("server", &server_abort);
+        ShutdownTrigger::ServerExit(result) => {
+            info!(target: "shutdown", "Server supervisor exited, draining bot");
+            shutdown_token.cancel();
+            drain_bot_with_timeout(bot_task, bot_abort, drain_timeout).await?;
+            check_server_result(result)
+        }
+        ShutdownTrigger::BotExit(result) => {
+            shutdown_supervisor(&server_supervisor);
             check_bot_result(result)
         }
     }
 }
 
 enum ShutdownTrigger {
-    /// An OS signal (or server exit) triggered shutdown; includes any
-    /// server error to propagate after the bot drains.
-    Signal(Option<anyhow::Result<()>>),
-    /// The bot task exited on its own before any signal.
-    BotExited(Result<anyhow::Result<()>, JoinError>),
+    Signal,
+    ServerExit(Result<(), SupervisorError>),
+    BotExit(Result<anyhow::Result<()>, JoinError>),
 }
 
-/// Waits for the first shutdown trigger: SIGINT, SIGTERM, or task exit.
-async fn await_shutdown_trigger(
-    server_task: &mut JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
-    bot_task: &mut JoinHandle<anyhow::Result<()>>,
-) -> anyhow::Result<ShutdownTrigger> {
-    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .context("failed to register SIGTERM handler")?;
-
-    let trigger = tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            info!(target: "shutdown", "Received SIGINT");
-            ShutdownTrigger::Signal(None)
-        }
-        _ = sigterm.recv() => {
-            info!(target: "shutdown", "Received SIGTERM");
-            ShutdownTrigger::Signal(None)
-        }
-        result = server_task => {
-            ShutdownTrigger::Signal(Some(check_server_result(result)))
-        }
-        result = bot_task => {
-            ShutdownTrigger::BotExited(result)
-        }
-    };
-
-    Ok(trigger)
-}
-
+/// Cancels the bot via timeout if it doesn't drain in time.
+///
+/// Caller must have already triggered the drain by either cancelling
+/// `shutdown_token` (signal/server-exit branches) or by waiting for the
+/// bot to exit naturally; this function only enforces the timeout.
 async fn drain_bot_with_timeout(
     bot_task: JoinHandle<anyhow::Result<()>>,
     bot_abort: AbortHandle,
-    early_exit: Option<anyhow::Result<()>>,
     timeout: Duration,
 ) -> anyhow::Result<()> {
     info!(
         target: "shutdown",
-        "Waiting up to {}s for in-flight work to drain (send signal again to force quit)",
+        "Waiting up to {}s for bot to drain",
         timeout.as_secs()
     );
 
-    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .context("failed to register SIGTERM handler for drain")?;
-
-    let drain_result = tokio::select! {
-        result = tokio::time::timeout(timeout, bot_task) => result,
-        _ = tokio::signal::ctrl_c() => {
-            warn!(target: "shutdown", "Received second signal, force-aborting immediately");
-            abort_task("bot", &bot_abort);
-            if let Some(server_result) = early_exit {
-                return server_result;
-            }
-            return Ok(());
-        }
-        _ = sigterm.recv() => {
-            warn!(target: "shutdown", "Received second SIGTERM, force-aborting immediately");
-            abort_task("bot", &bot_abort);
-            if let Some(server_result) = early_exit {
-                return server_result;
-            }
-            return Ok(());
-        }
-    };
-
-    match drain_result {
-        Ok(result) => {
-            info!(target: "shutdown", "Bot drained gracefully");
-            let bot_outcome = check_bot_result(result);
-            if let Some(server_result) = early_exit {
-                server_result?;
-            }
-            bot_outcome
-        }
-        Err(_elapsed) => {
-            warn!(
-                target: "shutdown",
-                "Drain timeout expired after {}s, force-aborting bot",
-                timeout.as_secs()
-            );
-            abort_task("bot", &bot_abort);
-            if let Some(server_result) = early_exit {
-                server_result?;
-            }
+    tokio::time::timeout(timeout, bot_task).await.map_or_else(
+        |_elapsed| {
+            warn!(target: "shutdown", "Bot drain timed out, force-aborting");
+            bot_abort.abort();
             Ok(())
-        }
+        },
+        check_bot_result,
+    )
+}
+
+fn shutdown_supervisor(handle: &SupervisorHandle) {
+    info!(target: "startup", name = "server", "Shutting down supervisor");
+    if let Err(error) = handle.shutdown() {
+        error!(target: "startup", %error, "Failed to shutdown server supervisor");
     }
 }
 
-fn abort_task(name: &str, handle: &AbortHandle) {
-    info!(target: "shutdown", name, "Aborting task");
-    handle.abort();
-}
-
-fn check_server_result(
-    result: Result<Result<Rocket<Ignite>, rocket::Error>, JoinError>,
-) -> anyhow::Result<()> {
+fn check_server_result(result: Result<(), SupervisorError>) -> anyhow::Result<()> {
     match result {
-        Ok(Ok(_)) => {
-            info!(target: "startup", "Server completed successfully");
+        Ok(()) => {
+            info!(target: "startup", "Server supervisor completed successfully");
             Ok(())
         }
-        Ok(Err(error)) => {
-            error!(target: "startup", %error, "Server failed");
-            Err(anyhow::anyhow!("Server failed: {error}"))
-        }
         Err(error) => {
-            error!(target: "startup", %error, "Server task panicked");
-            Err(anyhow::anyhow!("Server task panicked: {error}"))
+            error!(target: "startup", %error, "Server supervisor failed");
+            Err(anyhow::anyhow!("Server supervisor failed: {error}"))
         }
     }
 }
@@ -356,7 +450,7 @@ async fn run_conductor_session(
     pool: SqlitePool,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
-    shutdown_token: CancellationToken,
+    shutdown_token: tokio_util::sync::CancellationToken,
     recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
@@ -408,9 +502,11 @@ async fn run_conductor_session(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use st0x_config::create_test_ctx_with_order_owner;
 
     use super::*;
-    use st0x_config::create_test_ctx_with_order_owner;
 
     // `Ctx::load_files` parses `orderbook` into `Address`, so runtime tests
     // only exercise already-validated addresses. Invalid orderbook input is
@@ -436,6 +532,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn signal_cancels_token_and_drains_bot() {
+        let shutdown_token = CancellationToken::new();
+        let token_clone = shutdown_token.clone();
+        let drained = Arc::new(AtomicBool::new(false));
+        let drained_clone = Arc::clone(&drained);
+
+        let bot_task = tokio::spawn(async move {
+            token_clone.cancelled().await;
+            drained_clone.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let supervisor = SupervisorBuilder::default().build().run();
+        let supervisor_handle_for_assert = supervisor.clone();
+
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+        let signal_fut = async move {
+            let _ = signal_rx.await;
+        };
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = signal_tx.send(());
+        });
+
+        await_shutdown(
+            supervisor,
+            bot_task,
+            shutdown_token,
+            signal_fut,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            drained.load(Ordering::SeqCst),
+            "bot drain did not run after signal-triggered shutdown"
+        );
+
+        let post_wait =
+            tokio::time::timeout(Duration::from_secs(1), supervisor_handle_for_assert.wait()).await;
+        assert!(
+            post_wait.is_ok(),
+            "supervisor.wait() should return after signal-triggered shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn bot_exit_shuts_down_supervisor() {
+        let shutdown_token = CancellationToken::new();
+        let bot_task = tokio::spawn(async { Ok(()) });
+        let supervisor = SupervisorBuilder::default().build().run();
+        let supervisor_handle_for_assert = supervisor.clone();
+
+        let signal_fut = std::future::pending::<()>();
+
+        await_shutdown(
+            supervisor,
+            bot_task,
+            shutdown_token,
+            signal_fut,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let post_wait =
+            tokio::time::timeout(Duration::from_secs(1), supervisor_handle_for_assert.wait()).await;
+        assert!(
+            post_wait.is_ok(),
+            "supervisor.wait() should return after await_shutdown shut it down"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_exit_cancels_token_and_drains_bot() {
+        let shutdown_token = CancellationToken::new();
+        let token_clone = shutdown_token.clone();
+        let drained = Arc::new(AtomicBool::new(false));
+        let drained_clone = Arc::clone(&drained);
+
+        let bot_task = tokio::spawn(async move {
+            token_clone.cancelled().await;
+            drained_clone.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let supervisor = SupervisorBuilder::default().build().run();
+        let supervisor_for_external_shutdown = supervisor.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = supervisor_for_external_shutdown.shutdown();
+        });
+
+        let signal_fut = std::future::pending::<()>();
+
+        await_shutdown(
+            supervisor,
+            bot_task,
+            shutdown_token,
+            signal_fut,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            drained.load(Ordering::SeqCst),
+            "bot drain did not run after server-exit-triggered shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_timeout_force_aborts_unresponsive_bot() {
+        let shutdown_token = CancellationToken::new();
+
+        let bot_task = tokio::spawn(async { std::future::pending::<anyhow::Result<()>>().await });
+
+        let supervisor = SupervisorBuilder::default().build().run();
+
+        let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+        let signal_fut = async move {
+            let _ = signal_rx.await;
+        };
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let _ = signal_tx.send(());
+        });
+
+        await_shutdown(
+            supervisor,
+            bot_task,
+            shutdown_token,
+            signal_fut,
+            Duration::from_millis(50),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
     async fn test_run_function_websocket_connection_error() {
         let mut ctx = create_test_ctx_with_order_owner(address!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -447,7 +686,7 @@ mod tests {
             pool,
             create_test_event_sender(),
             create_test_inventory(),
-            CancellationToken::new(),
+            tokio_util::sync::CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
             FailureInjector::new(),
         ))
@@ -459,72 +698,6 @@ mod tests {
                 .to_string()
                 .contains("failed to connect websocket provider"),
             "expected websocket provider connection failure, got: {error:#}"
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_bot_with_timeout_succeeds_when_bot_drains() {
-        let bot_task = tokio::spawn(async { Ok(()) });
-        let bot_abort = bot_task.abort_handle();
-        drain_bot_with_timeout(bot_task, bot_abort, None, GRACEFUL_SHUTDOWN_TIMEOUT)
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn drain_bot_with_timeout_propagates_bot_error() {
-        let bot_task = tokio::spawn(async { Err(anyhow::anyhow!("bot failed")) });
-        let bot_abort = bot_task.abort_handle();
-        let result =
-            drain_bot_with_timeout(bot_task, bot_abort, None, GRACEFUL_SHUTDOWN_TIMEOUT).await;
-        let error = result.unwrap_err();
-        assert!(
-            error.to_string().contains("bot failed"),
-            "should propagate bot error, got: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_bot_with_timeout_propagates_server_error_on_success() {
-        let bot_task = tokio::spawn(async { Ok(()) });
-        let bot_abort = bot_task.abort_handle();
-        let early_exit = Some(Err(anyhow::anyhow!("server crashed")));
-        let result =
-            drain_bot_with_timeout(bot_task, bot_abort, early_exit, GRACEFUL_SHUTDOWN_TIMEOUT)
-                .await;
-        let error = result.unwrap_err();
-        assert!(
-            error.to_string().contains("server crashed"),
-            "should propagate server error, got: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_bot_with_timeout_force_aborts_on_timeout() {
-        // Bot that never completes, forcing the timeout path
-        let bot_task = tokio::spawn(async { std::future::pending::<anyhow::Result<()>>().await });
-        let bot_abort = bot_task.abort_handle();
-
-        let result =
-            drain_bot_with_timeout(bot_task, bot_abort, None, Duration::from_millis(10)).await;
-
-        result.unwrap();
-    }
-
-    #[tokio::test]
-    async fn drain_bot_with_timeout_force_abort_propagates_server_error() {
-        let bot_task = tokio::spawn(async { std::future::pending::<anyhow::Result<()>>().await });
-        let bot_abort = bot_task.abort_handle();
-        let early_exit = Some(Err(anyhow::anyhow!("server crashed")));
-
-        let result =
-            drain_bot_with_timeout(bot_task, bot_abort, early_exit, Duration::from_millis(10))
-                .await;
-
-        let error = result.unwrap_err();
-        assert!(
-            error.to_string().contains("server crashed"),
-            "should propagate server error on force-abort, got: {error}"
         );
     }
 
@@ -540,7 +713,7 @@ mod tests {
             pool,
             create_test_event_sender(),
             create_test_inventory(),
-            CancellationToken::new(),
+            tokio_util::sync::CancellationToken::new(),
             Arc::new(tokio::sync::OnceCell::new()),
             FailureInjector::new(),
         ))
@@ -552,6 +725,54 @@ mod tests {
                 .to_string()
                 .contains("failed to connect websocket provider"),
             "expected websocket provider connection failure, got: {error:#}"
+        );
+    }
+
+    #[test]
+    fn check_server_result_returns_ok_for_clean_exit() {
+        check_server_result(Ok(())).unwrap();
+    }
+
+    #[test]
+    fn check_server_result_wraps_supervisor_error() {
+        let supervisor_error = SupervisorError::TooManyDeadTasks {
+            current_percentage: 100.0,
+            threshold: 0.0,
+        };
+        let error = check_server_result(Err(supervisor_error)).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("Server supervisor failed"),
+            "expected wrapped supervisor message, got: {message}"
+        );
+        assert!(
+            message.contains("Too many tasks are dead"),
+            "expected underlying supervisor error preserved, got: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_bot_result_returns_ok_for_clean_exit() {
+        let join_result = tokio::spawn(async { Ok::<(), anyhow::Error>(()) }).await;
+        check_bot_result(join_result).unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_bot_result_propagates_bot_error() {
+        let join_result =
+            tokio::spawn(async { Err::<(), anyhow::Error>(anyhow::anyhow!("bot blew up")) }).await;
+        let error = check_bot_result(join_result).unwrap_err();
+        assert_eq!(error.to_string(), "bot blew up");
+    }
+
+    #[tokio::test]
+    async fn check_bot_result_reports_panicked_task() {
+        let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async { panic!("explosion") });
+        let error = check_bot_result(handle.await).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("Bot task panicked"),
+            "expected panic to be reported, got: {message}"
         );
     }
 }

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -570,7 +570,7 @@ async fn confirm_orphan_deposit_or_fail(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{TxHash, fixed_bytes};
+    use alloy::primitives::{Address, TxHash, fixed_bytes};
     use chrono::Utc;
     use rain_math_float::Float;
 
@@ -623,7 +623,7 @@ mod tests {
             raindex.clone(),
             Arc::new(MockTokenizer::new()),
             wrapper.clone(),
-            alloy::primitives::Address::random(),
+            Address::random(),
             mint_store,
             redemption_store,
         ));
@@ -814,7 +814,7 @@ mod tests {
             raindex.clone(),
             Arc::new(MockTokenizer::new()),
             wrapper.clone(),
-            alloy::primitives::Address::random(),
+            Address::random(),
             mint_store,
             redemption_store,
         ));

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -78,6 +78,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
     rest_api_url: Option<&str>,
     cash_reserved: Option<Positive<Usd>>,
     server_port: u16,
+    board_port: u16,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -155,6 +156,7 @@ fn build_full_system_ctx<P: Provider + Clone>(
         })
         .inventory_poll_interval(15)
         .server_port(server_port)
+        .board_port(board_port)
         .maybe_rest_api(
             rest_api_url.map(|url| st0x_config::RestApiCtx::unauthenticated(url.to_string())),
         )
@@ -318,6 +320,7 @@ fn write_simulate_failure_cli_files<P: Provider + Clone>(
     infra: &TestInfra<P>,
     cctp: &CctpInfra,
     server_port: u16,
+    board_port: u16,
     current_block: u64,
     usdc_vault_id: B256,
     equity_vault_ids: &HashMap<String, B256>,
@@ -334,6 +337,7 @@ fn write_simulate_failure_cli_files<P: Provider + Clone>(
 
     let config = format!(
         r#"server_port = {server_port}
+board_port = {board_port}
 log_level = "debug"
 database_url = "{database_url}"
 apalis_finished_job_cleanup_interval_secs = 3600
@@ -580,6 +584,7 @@ async fn full_system() -> anyhow::Result<()> {
         .cash_vault_id(usdc_vault_id)
         .cctp(cctp.cctp_overrides())
         .server_port(8001)
+        .board_port(8002)
         .call()?;
 
     let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
@@ -882,6 +887,7 @@ async fn simulate() -> anyhow::Result<()> {
         .cctp(cctp.cctp_overrides())
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
+        .board_port(server_port + 1)
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
 
@@ -1080,6 +1086,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         .cctp(cctp.cctp_overrides())
         .cash_reserved(Positive::new(Usd::new(float!(25000)))?)
         .server_port(server_port)
+        .board_port(server_port + 1)
         .call()?;
     ctx.log_dir = Some(log_dir.display().to_string());
     let cli_ctx = ctx.clone();
@@ -1088,6 +1095,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         &infra,
         &cctp,
         server_port,
+        server_port + 1,
         current_block,
         usdc_vault_id,
         &equity_vault_ids,

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -26,7 +26,7 @@
 
 pub(crate) mod assertions;
 
-use alloy::primitives::TxHash;
+use alloy::primitives::{Address, TxHash};
 use rain_math_float::Float;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::collections::HashMap;
@@ -1417,7 +1417,7 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
     // This simulates another conductor sharing the same Alpaca account.
     // If the bot doesn't filter by wallet, it would see 1000 extra shares
     // of inflight and make incorrect rebalancing decisions.
-    let foreign_wallet = alloy::primitives::Address::random();
+    let foreign_wallet = Address::random();
     infra.tokenization_service.inject_pending_request(
         "AAPL",
         float!("1000"),

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -76,9 +76,16 @@ pub fn init_tracing_with_log_dir(log_dir: &Path) -> tracing_appender::non_blocki
         .with_writer(std::io::stderr)
         .with_filter(console_filter);
 
+    let board_filter = mk_env_filter(tracing::Level::DEBUG);
+    let board_layer =
+        apalis_board::axum::sse::TracingSubscriber::new(st0x_hedge::apalis_broadcaster())
+            .layer()
+            .with_filter(board_filter);
+
     tracing_subscriber::registry()
         .with(console_layer)
         .with(file_layer)
+        .with(board_layer)
         .try_init()
         .expect("Failed to initialize tracing subscriber with log dir");
 


### PR DESCRIPTION
[RAI-69](https://linear.app/makeitrain/issue/RAI-69/migrate-from-rocket-to-axum)

## What

Replaces the `rocket` and `rocket_ws` web framework with `axum` across the entire server stack.

## Why

Free per-job and per-worker observability via a web UI provided by `apalis-board` but `rocket` is not one of the supported options. `axum` also is a better fit for our `tower`\-heavy stack.

## How

All HTTP and WebSocket handlers in `src/api.rs` and `src/dashboard/mod.rs` have been rewritten to use `axum` extractors (`State`, `Query`, `Path`, `Json`) and response types. A single `AppState` struct is now the shared state passed to all handlers, replacing the multiple `rocket::State<T>` managed types.

The WebSocket handler in the dashboard module was refactored into smaller composable async functions (`send_initial_state`, `stream_broadcasts`, `send_json`) with an explicit `SendOutcome` enum to clarify control flow. Route registration now returns `Router<AppState>` instead of `Vec<Route>`.

The server startup in `src/lib.rs` binds a `TcpListener` directly and calls `axum::serve`, removing the Rocket configuration layer. An `apalis-board` router is mounted at `/board` using `ApiBuilder`, wired to the `DexTradeAccountingJobQueue` storage.

## Testing

All existing tests were ported from Rocket's `Client`\-based test harness to `tower::ServiceExt::oneshot` for unit-style handler tests, and to a `TcpListener`\-bound `TestServer` helper for WebSocket integration tests. The `TestServer` struct now uses `AbortHandle` for clean shutdown instead of Rocket's `Shutdown` notifier.

## Anything else

A number of transitive dependencies pulled in exclusively by `rocket` have been removed from the lockfile (`figment`, `pear`, `devise`, `cookie`, `loom`, `generator`, `atomic`, `state`, `ubyte`, `yansi`, `uncased`, `multer`, `binascii`, `stable-pattern`, `rocket_codegen`, `rocket_http`, `rocket_ws`). The `tungstenite` version used by `axum`'s WebSocket support is `0.29.0`, replacing the previously pinned `0.21.0` variant.

Stacked on #651 (ADR 0001 axum+tower); downstream from the `feat/extract-config` crate split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apalis-board job queue UI on its own configurable port.

* **Configuration**
  * Configs now require a separate board_port; server_port and board_port must differ.

* **Infrastructure**
  * Reworked HTTP server and dashboard to a new framework for more reliable API, WebSocket, and graceful shutdown behavior.

* **Telemetry**
  * Tracing now supports an extra customizable layer for improved observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->