### PR TITLE
fix: recover orphaned pending offchain orders on startup

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -157,3 +157,21 @@ rebalancing = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0xfbde45df60249203b12148452fc77c3b5f811eb2"
 tokenized_equity_derivative = "0x02512ec661f0ba89c275ea105e31bad6fcfcf319"
+
+[assets.equities.QQQM]
+trading = "enabled"
+rebalancing = "disabled"
+tokenized_equity = "0x09ee803ba675052e10a54bfc8e18c0f67793056b"
+tokenized_equity_derivative = "0x823FF7Bbde2869aAe73A6CD53e7f614442836757"
+
+[assets.equities.VWO]
+trading = "enabled"
+rebalancing = "disabled"
+tokenized_equity = "0x0acfea6833c4a3f41bf2fbd736aa9eea547d90ee"
+tokenized_equity_derivative = "0x23ec6886b49D7ab123E9ee8e474D2fa7AB6Cbc2d"
+
+[assets.equities.ARKK]
+trading = "enabled"
+rebalancing = "disabled"
+tokenized_equity = "0x323804af6f3bb463d688b854667c6870a0fc06ad"
+tokenized_equity_derivative = "0x9FfF48B4535AF3765Ac9E1b164720EDc01DF8EE7"

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -3,7 +3,7 @@ use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use st0x_float_macro::float;
 use std::str::FromStr;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 use uuid::Uuid;
 
 use super::client::AlpacaBrokerApiClient;
@@ -439,7 +439,7 @@ fn truncate_shares_to_alpaca_precision(
         )?;
 
     if !truncated_float.eq(original)? {
-        warn!(
+        debug!(
             original = %shares,
             truncated = %FractionalShares::new(truncated_float),
             "Truncated order quantity to {} decimal places for Alpaca",

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -312,6 +312,9 @@ impl Conductor {
                 .build(order_placer)
                 .await?;
 
+        recover_orphaned_pending_offchain_orders(&position, &position_projection, &offchain_order)
+            .await?;
+
         let frameworks = CqrsFrameworks {
             onchain_trade,
             position,
@@ -907,6 +910,102 @@ async fn resume_interrupted_transfers(
         failed_redemptions,
         "Interrupted tokenization transfer resume completed"
     );
+}
+
+/// Recovers positions whose `pending_offchain_order_id` references an
+/// offchain order that has already reached a terminal state (Filled or
+/// Failed) but whose completion was never propagated back to the position
+/// aggregate.
+///
+/// This can happen when `complete_offchain_order_fill` succeeds but the
+/// subsequent `complete_position_order` call fails -- the two operations
+/// are not atomic. Since the order poller only polls `Submitted` orders,
+/// it will never retry the failed position update, leaving the position
+/// permanently stuck.
+async fn recover_orphaned_pending_offchain_orders(
+    position: &Arc<Store<Position>>,
+    position_projection: &Arc<Projection<Position>>,
+    offchain_order: &Arc<Store<OffchainOrder>>,
+) -> anyhow::Result<()> {
+    let positions = position_projection.load_all().await?;
+
+    let orphaned: Vec<_> = positions
+        .into_iter()
+        .filter_map(|(symbol, pos)| {
+            pos.pending_offchain_order_id
+                .map(|order_id| (symbol, order_id))
+        })
+        .collect();
+
+    if orphaned.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        count = orphaned.len(),
+        "Found positions with pending offchain orders, checking for orphans"
+    );
+
+    for (symbol, order_id) in orphaned {
+        recover_single_orphaned_order(position, offchain_order, &symbol, order_id).await?;
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::cognitive_complexity)]
+async fn recover_single_orphaned_order(
+    position: &Arc<Store<Position>>,
+    offchain_order: &Arc<Store<OffchainOrder>>,
+    symbol: &Symbol,
+    order_id: OffchainOrderId,
+) -> anyhow::Result<()> {
+    let Some(order) = offchain_order.load(&order_id).await? else {
+        warn!(%symbol, %order_id, "Pending offchain order not found in store -- skipping");
+        return Ok(());
+    };
+
+    let command = match order {
+        OffchainOrder::Filled {
+            ref executor_order_id,
+            price,
+            filled_at,
+            ..
+        } => {
+            info!(%symbol, %order_id, "Orphaned order already Filled -- recovering");
+            PositionCommand::CompleteOffChainOrder {
+                offchain_order_id: order_id,
+                shares_filled: order.shares(),
+                direction: order.direction(),
+                executor_order_id: executor_order_id.clone(),
+                price,
+                broker_timestamp: filled_at,
+            }
+        }
+
+        OffchainOrder::Failed { .. } => {
+            info!(%symbol, %order_id, "Orphaned order already Failed -- recovering");
+            PositionCommand::FailOffChainOrder {
+                offchain_order_id: order_id,
+                error: "recovered from orphaned state on startup".to_string(),
+            }
+        }
+
+        OffchainOrder::Submitted { .. } | OffchainOrder::PartiallyFilled { .. } => {
+            debug!(%symbol, %order_id, "Pending offchain order still in progress");
+            return Ok(());
+        }
+
+        OffchainOrder::Pending { .. } => {
+            warn!(%symbol, %order_id, "Offchain order still Pending -- may not have been submitted");
+            return Ok(());
+        }
+    };
+
+    position.send(symbol, command).await?;
+    info!(%symbol, %order_id, "Orphaned pending order recovered");
+
+    Ok(())
 }
 
 /// Constructs the position CQRS framework with its view query
@@ -3966,6 +4065,318 @@ mod tests {
         assert!(
             registry.is_none(),
             "Vault registry should have no state after validation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_clears_filled_order() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain_order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("RKLB").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        // Step 1: Initialize position via an onchain fill
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000001"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(78),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Step 2: Place an offchain order on the position (sets pending)
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Step 3: Create the offchain order aggregate (Place -> Submitted -> Filled)
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::CompleteFill {
+                    price: Usd::new(float!(78)),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Verify position is stuck: pending_offchain_order_id is set
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+
+        // Step 4: Run recovery
+        recover_orphaned_pending_offchain_orders(&position, &position_projection, &offchain_order)
+            .await
+            .unwrap();
+
+        // Verify recovery cleared the pending order
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "Recovery should clear pending_offchain_order_id for filled orders"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_skips_submitted_order() {
+        let pool = setup_test_db().await;
+
+        struct BlockingPlacer;
+
+        #[async_trait::async_trait]
+        impl crate::offchain_order::OrderPlacer for BlockingPlacer {
+            async fn place_market_order(
+                &self,
+                _order: MarketOrder,
+            ) -> Result<OrderPlacementResult, Box<dyn std::error::Error + Send + Sync>>
+            {
+                Ok(OrderPlacementResult {
+                    executor_order_id: ExecutorOrderId::new("test-submitted"),
+                    placed_shares: Positive::new(st0x_execution::FractionalShares::new(float!(
+                        0.5
+                    )))
+                    .unwrap(),
+                })
+            }
+        }
+
+        let order_placer: Arc<dyn crate::offchain_order::OrderPlacer> = Arc::new(BlockingPlacer);
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("SGOV").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        // Initialize position
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000002"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(100),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Place offchain order on position
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Create offchain order in Submitted state (Place triggers submission)
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Verify: order is Submitted, position has pending
+        let order = offchain_order
+            .load(&offchain_order_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(order, OffchainOrder::Submitted { .. }));
+
+        // Run recovery
+        recover_orphaned_pending_offchain_orders(&position, &position_projection, &offchain_order)
+            .await
+            .unwrap();
+
+        // Verify: pending_offchain_order_id is NOT cleared
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id,
+            Some(offchain_order_id),
+            "Recovery must not clear pending order that is still Submitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_clears_failed_order() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain_order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("TSLA").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        // Initialize position
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000003"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(400),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Place offchain order on position
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Create offchain order that transitions to Failed
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::Place {
+                    symbol: symbol.clone(),
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                },
+            )
+            .await
+            .unwrap();
+
+        offchain_order
+            .send(
+                &offchain_order_id,
+                OffchainOrderCommand::MarkFailed {
+                    error: "insufficient qty".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Verify position is stuck
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+
+        // Run recovery
+        recover_orphaned_pending_offchain_orders(&position, &position_projection, &offchain_order)
+            .await
+            .unwrap();
+
+        // Verify recovery cleared the pending order
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "Recovery should clear pending_offchain_order_id for failed orders"
         );
     }
 }

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use alloy::primitives::Address;
 use rain_math_float::{Float, FloatError};
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace};
 
 use st0x_execution::{FractionalShares, Positive, Symbol};
 
@@ -176,7 +176,7 @@ fn truncate_for_alpaca(
     let truncated = FractionalShares::new(truncated_value);
 
     if truncated != quantity {
-        warn!(
+        debug!(
             target: "rebalance",
             %symbol,
             original = %quantity,


### PR DESCRIPTION
Closes [RAI-368](https://linear.app/makeitrain/issue/RAI-368)

## What

Adds a startup recovery routine that detects positions stuck with a
`pending_offchain_order_id` pointing to an offchain order that has already
reached a terminal state (Filled or Failed), and replays the missing
position command to unblock the position.

Also downgrades two share-truncation log messages from `warn!` to `debug!`
since truncation is expected behavior, not a warning-worthy event.

Adds three new tokenized ETFs to the production config: QQQM, VWO, and ARKK
(from [ST0x-Technology/st0x.registry#14](https://github.com/ST0x-Technology/st0x.registry/pull/14)).

## Why

`complete_offchain_order_fill` and the subsequent `complete_position_order`
are not atomic. If the order aggregate transitions to Filled/Failed but the
position update fails (crash, transient error), the position is left with a
stale `pending_offchain_order_id`. The order poller only polls `Submitted`
orders, so it never retries the failed position update — the position stays
permanently stuck and cannot place new offchain orders.

The new tokens are launching this week and need to be in the prod config so
the bot hedges them once Raindex orders are deployed.

## How

- **`recover_orphaned_pending_offchain_orders`** (`src/conductor.rs`): Loads
  all positions via the projection, filters those with a
  `pending_offchain_order_id`, then loads each referenced offchain order to
  check its state.
- **`recover_single_orphaned_order`**: For each orphaned position:
  - **Filled** → sends `PositionCommand::CompleteOffChainOrder`
  - **Failed** → sends `PositionCommand::FailOffChainOrder`
  - **Submitted / PartiallyFilled** → skips (order is still in progress)
  - **Pending** → skips with a warning (order may not have been submitted)
- Runs once during `Conductor::start`, after CQRS frameworks are built but
  before the main event loop begins.
- **Log level change**: `warn!` → `debug!` for share truncation messages in
  `crates/execution/src/alpaca_broker_api/order.rs` and
  `src/rebalancing/trigger/equity.rs` — truncation to Alpaca's precision is
  routine, not exceptional.
- **Prod config**: Added QQQM, VWO, ARKK with `trading = "enabled"`,
  `rebalancing = "disabled"`, using wrapper and SFT addresses from the
  token registry.

## Testing

Three tests added in `src/conductor.rs`:
- `recover_orphaned_pending_clears_filled_order` — verifies a position with
  a Filled orphan gets its `pending_offchain_order_id` cleared.
- `recover_orphaned_pending_skips_submitted_order` — verifies a Submitted
  order is left alone (not a false positive).
- `recover_orphaned_pending_clears_failed_order` — verifies a Failed orphan
  also gets cleared.

## Anything else

This is a startup-only recovery path. It does not add runtime detection or
retry logic — the non-atomicity between order and position updates remains.
A future improvement could make these two updates transactional or add a
saga/outbox pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic recovery mechanism that resolves positions with pending orders during startup.
  * Added three new tradeable equities to the platform: QQQM, VWO, and ARKK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->