### PR TITLE
feat: resilient rebalancing transfers (RAI-365, RAI-366)

### DIFF
--- a/crates/event-sorcery/src/lib.rs
+++ b/crates/event-sorcery/src/lib.rs
@@ -419,6 +419,35 @@ pub async fn load_entity<Entity: EventSourced>(
     Ok(context.aggregate.into_result()?)
 }
 
+/// Execute a single command against an aggregate without a pre-built
+/// [`Store`].
+///
+/// Creates a temporary CQRS framework with no query processors,
+/// executes the command, and discards the framework. Useful in CLI
+/// contexts where you need to send a command but don't have (or need)
+/// a full server-lifetime Store.
+///
+/// The caller must provide `services` matching the aggregate's
+/// `Services` type. For commands that never invoke services (e.g.,
+/// failure commands), a panicking stub is safe.
+pub async fn send_command<Entity: EventSourced>(
+    pool: &SqlitePool,
+    id: &Entity::Id,
+    command: Entity::Command,
+    services: Entity::Services,
+) -> Result<(), SendError<Entity>> {
+    let repo = SqliteEventRepository::new(pool.clone());
+    let store = PersistedEventStore::<SqliteEventRepository, Lifecycle<Entity>>::new_snapshot_store(
+        repo,
+        Entity::SNAPSHOT_SIZE,
+    );
+
+    #[allow(clippy::disallowed_methods)]
+    let cqrs = CqrsFramework::new(store, vec![], services);
+
+    cqrs.execute(&id.to_string(), command).await
+}
+
 /// Delete compactable events that are already represented by snapshots.
 ///
 /// This is a no-op for entities with [`CompactionPolicy::Retain`]. For

--- a/os.nix
+++ b/os.nix
@@ -17,7 +17,7 @@ let
     name = "stox";
     runtimeInputs = [ st0x-cli ];
     text = ''
-      exec cli \
+      exec st0x-cli \
         --config "''${STOX_CONFIG:-/run/st0x/st0x-hedge.config}" \
         --secrets "''${STOX_SECRETS:-/run/agenix/st0x-hedge.toml}" \
         "$@"

--- a/rust.nix
+++ b/rust.nix
@@ -123,6 +123,10 @@ in {
     cargoExtraArgs = "--bin cli --features wallet-turnkey";
     doCheck = false;
 
+    postInstall = ''
+      mv $out/bin/cli $out/bin/st0x-cli
+    '';
+
     meta = {
       description = "st0x liquidity CLI";
       homepage = "https://github.com/ST0x-Technology/st0x.liquidity";

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,6 +47,15 @@ pub enum ConvertDirection {
     ToUsdc,
 }
 
+/// Transfer type for the fail-transfer command.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum TransferType {
+    /// Tokenized equity mint (Alpaca -> onchain)
+    Mint,
+    /// Equity redemption (onchain -> Alpaca)
+    Redemption,
+}
+
 /// Aggregate types that have materialized views.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AggregateView {
@@ -439,6 +448,27 @@ pub enum Commands {
         yes: bool,
     },
 
+    /// Manually fail a stuck mint or redemption transfer
+    ///
+    /// Marks a transfer aggregate as failed, transitioning it to a terminal
+    /// state. Use when a transfer is permanently stuck (e.g., timed out,
+    /// unrecoverable error) and needs operator intervention.
+    FailTransfer {
+        /// Transfer type: "mint" or "redemption"
+        #[arg(short = 't', long = "type")]
+        transfer_type: TransferType,
+        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
+        #[arg(short = 'i', long = "id")]
+        id: String,
+        /// Reason for failure
+        #[arg(
+            short = 'r',
+            long = "reason",
+            default_value = "Manually failed via CLI"
+        )]
+        reason: String,
+    },
+
     /// Rebuild a materialized view by replaying all events from scratch
     ///
     /// Use as an escape hatch when a view becomes corrupted (e.g., due to
@@ -589,6 +619,11 @@ enum SimpleCommand {
         aggregate: AggregateView,
         id: Option<String>,
         all: bool,
+    },
+    FailTransfer {
+        transfer_type: TransferType,
+        id: String,
+        reason: String,
     },
 }
 
@@ -776,6 +811,15 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::RebuildView { aggregate, id, all } => {
             Ok(SimpleCommand::RebuildView { aggregate, id, all })
         }
+        Commands::FailTransfer {
+            transfer_type,
+            id,
+            reason,
+        } => Ok(SimpleCommand::FailTransfer {
+            transfer_type,
+            id,
+            reason,
+        }),
     }
 }
 
@@ -928,6 +972,11 @@ async fn run_simple_command<W: Write>(
         SimpleCommand::RebuildView { aggregate, id, all } => {
             rebuild_view(stdout, pool, aggregate, id, all).await
         }
+        SimpleCommand::FailTransfer {
+            transfer_type,
+            id,
+            reason,
+        } => rebalancing::fail_transfer_command(stdout, pool, transfer_type, &id, &reason).await,
     }
 }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -15,11 +15,11 @@ use st0x_execution::{
 };
 use st0x_finance::Usdc;
 
-use super::TransferDirection;
+use super::{TransferDirection, TransferType};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::bindings::IERC20;
 use crate::config::{BrokerCtx, Ctx};
-use crate::equity_redemption::EquityRedemption;
+use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
@@ -28,7 +28,9 @@ use crate::rebalancing::usdc::CrossVenueCashTransfer;
 use crate::tokenization::{
     AlpacaTokenizationService, TokenizationRequest, TokenizationRequestStatus, Tokenizer,
 };
-use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
+use crate::tokenized_equity_mint::{
+    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand,
+};
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::vault_registry::VaultRegistry;
 use crate::wrapper::{Wrapper, WrapperService};
@@ -555,6 +557,106 @@ fn format_tokenization_request<Writer: Write>(
 
     if let Some(ref issuer_id) = request.issuer_request_id {
         writeln!(stdout, "   Issuer ID: {}", issuer_id.0)?;
+    }
+
+    Ok(())
+}
+
+/// Manually fail a stuck mint or redemption transfer aggregate.
+///
+/// Loads the aggregate from the event store, determines its current state,
+/// and sends the appropriate failure command. Rejects if the aggregate is
+/// already in a terminal state.
+pub(crate) async fn fail_transfer_command<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    transfer_type: TransferType,
+    id: &str,
+    reason: &str,
+) -> anyhow::Result<()> {
+    let services = EquityTransferServices::panicking();
+
+    match transfer_type {
+        TransferType::Mint => {
+            let mint_id = IssuerRequestId::new(id);
+
+            let entity = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(pool, &mint_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Mint aggregate not found: {id}"))?;
+
+            let command = match entity {
+                TokenizedEquityMint::MintAccepted { .. } => {
+                    TokenizedEquityMintCommand::FailAcceptance {
+                        reason: reason.to_string(),
+                    }
+                }
+                TokenizedEquityMint::TokensReceived { .. } => {
+                    TokenizedEquityMintCommand::FailWrapping {
+                        reason: reason.to_string(),
+                    }
+                }
+                TokenizedEquityMint::TokensWrapped { .. } => {
+                    TokenizedEquityMintCommand::FailRaindexDeposit {
+                        reason: reason.to_string(),
+                    }
+                }
+                TokenizedEquityMint::MintRequested { .. } => {
+                    anyhow::bail!("Mint {id} is at MintRequested -- cannot fail before acceptance");
+                }
+                TokenizedEquityMint::DepositedIntoRaindex { .. } => {
+                    anyhow::bail!("Mint {id} already completed (DepositedIntoRaindex)");
+                }
+                TokenizedEquityMint::Failed { .. } => {
+                    anyhow::bail!("Mint {id} already failed");
+                }
+            };
+
+            st0x_event_sorcery::send_command::<TokenizedEquityMint>(
+                pool, &mint_id, command, services,
+            )
+            .await?;
+
+            writeln!(stdout, "Mint {id} marked as failed")?;
+        }
+
+        TransferType::Redemption => {
+            let redemption_id: RedemptionAggregateId = id
+                .parse()
+                .map_err(|error| anyhow::anyhow!("Invalid redemption ID: {error}"))?;
+
+            let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(pool, &redemption_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Redemption aggregate not found: {id}"))?;
+
+            match entity {
+                EquityRedemption::WithdrawnFromRaindex { .. }
+                | EquityRedemption::TokensUnwrapped { .. } => {}
+                EquityRedemption::TokensSent { .. } | EquityRedemption::Pending { .. } => {
+                    anyhow::bail!(
+                        "Redemption {id} is past the transfer stage -- \
+                         use FailDetection or RejectRedemption instead"
+                    );
+                }
+                EquityRedemption::Completed { .. } => {
+                    anyhow::bail!("Redemption {id} already completed");
+                }
+                EquityRedemption::Failed { .. } => {
+                    anyhow::bail!("Redemption {id} already failed");
+                }
+            }
+
+            st0x_event_sorcery::send_command::<EquityRedemption>(
+                pool,
+                &redemption_id,
+                EquityRedemptionCommand::FailTransfer {
+                    reason: reason.to_string(),
+                },
+                services,
+            )
+            .await?;
+
+            writeln!(stdout, "Redemption {id} marked as failed")?;
+        }
     }
 
     Ok(())

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -725,6 +725,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .build(deps.pool.clone(), equity_transfer_services)
             .await?;
 
+        rebalancing_trigger
+            .set_stores(built.mint.clone(), built.redemption.clone())
+            .await;
+
         let recovery_transfer = CrossVenueEquityTransfer::new(
             raindex_service.clone(),
             tokenizer.clone(),

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -527,6 +527,7 @@ mod tests {
             "EquityRedemptionEvent::TransferFailed",
             serde_json::to_value(EquityRedemptionEvent::TransferFailed {
                 tx_hash: None,
+                reason: None,
                 failed_at: two_days_ago,
             })
             .unwrap(),

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -205,6 +205,9 @@ pub(crate) enum EquityRedemptionCommand {
     Complete,
     /// Alpaca rejected the redemption.
     RejectRedemption { reason: String },
+    /// Operator or timeout-driven failure from `WithdrawnFromRaindex` or
+    /// `TokensUnwrapped` states.
+    FailTransfer { reason: String },
 }
 
 /// Reason for detection failure when polling Alpaca for redemption detection.
@@ -239,6 +242,10 @@ pub(crate) enum EquityRedemptionEvent {
     /// Raindex withdraw succeeded but transfer to redemption wallet failed.
     TransferFailed {
         tx_hash: Option<TxHash>,
+        /// Reason for failure (timeout, EVM revert, operator action).
+        /// Absent in events emitted before this field was added.
+        #[serde(default)]
+        reason: Option<String>,
         failed_at: DateTime<Utc>,
     },
 
@@ -317,13 +324,15 @@ impl PartialEq for EquityRedemptionEvent {
             (
                 Self::TransferFailed {
                     tx_hash: h1,
+                    reason: r1,
                     failed_at: f1,
                 },
                 Self::TransferFailed {
                     tx_hash: h2,
+                    reason: r2,
                     failed_at: f2,
                 },
-            ) => h1 == h2 && f1 == f2,
+            ) => h1 == h2 && r1 == r2 && f1 == f2,
             (
                 Self::TokensSent {
                     redemption_wallet: w1,
@@ -496,6 +505,10 @@ pub(crate) enum EquityRedemption {
         raindex_withdraw_tx: Option<TxHash>,
         redemption_tx: Option<TxHash>,
         tokenization_request_id: Option<TokenizationRequestId>,
+        /// Reason for failure (timeout, operator action, etc.).
+        /// Absent for aggregates that failed before this field was added.
+        #[serde(default)]
+        reason: Option<String>,
         /// When the redemption process started (withdrawn_at or sent_at from prior state)
         started_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
@@ -641,7 +654,11 @@ impl EventSourced for EquityRedemption {
         Ok(match event {
             WithdrawnFromRaindex { .. } => None,
 
-            TransferFailed { tx_hash, failed_at } => match entity {
+            TransferFailed {
+                tx_hash,
+                reason,
+                failed_at,
+            } => match entity {
                 Self::WithdrawnFromRaindex {
                     symbol,
                     quantity,
@@ -661,6 +678,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: Some(*raindex_withdraw_tx),
                     redemption_tx: *tx_hash,
                     tokenization_request_id: None,
+                    reason: reason.clone(),
                     started_at: *withdrawn_at,
                     failed_at: *failed_at,
                 }),
@@ -787,6 +805,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: Some(*raindex_withdraw_tx),
                     redemption_tx: Some(*redemption_tx),
                     tokenization_request_id: None,
+                    reason: None,
                     started_at: *sent_at,
                     failed_at: *failed_at,
                 })
@@ -834,6 +853,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: None,
                     redemption_tx: Some(*redemption_tx),
                     tokenization_request_id: Some(tokenization_request_id.clone()),
+                    reason: None,
                     started_at: *sent_at,
                     failed_at: *rejected_at,
                 })
@@ -894,7 +914,8 @@ impl EventSourced for EquityRedemption {
             | Detect { .. }
             | FailDetection { .. }
             | Complete
-            | RejectRedemption { .. } => Err(EquityRedemptionError::NotStarted),
+            | RejectRedemption { .. }
+            | FailTransfer { .. } => Err(EquityRedemptionError::NotStarted),
         }
     }
 
@@ -972,6 +993,7 @@ impl EventSourced for EquityRedemption {
                         warn!(target: "rebalance", %symbol, "Redemption wallet not configured");
                         return Ok(vec![TransferFailed {
                             tx_hash: None,
+                            reason: None,
                             failed_at: Utc::now(),
                         }]);
                     };
@@ -990,6 +1012,7 @@ impl EventSourced for EquityRedemption {
                             warn!(target: "rebalance", %error, %token, %amount, "Send for redemption failed");
                             Ok(vec![TransferFailed {
                                 tx_hash: None,
+                                reason: None,
                                 failed_at: Utc::now(),
                             }])
                         }
@@ -1049,6 +1072,25 @@ impl EventSourced for EquityRedemption {
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            },
+
+            FailTransfer { reason } => match self {
+                Self::WithdrawnFromRaindex { symbol, .. }
+                | Self::TokensUnwrapped { symbol, .. } => {
+                    warn!(
+                        target: "rebalance",
+                        %symbol, %reason,
+                        "Marking redemption as transfer-failed"
+                    );
+                    Ok(vec![TransferFailed {
+                        tx_hash: None,
+                        reason: Some(reason),
+                        failed_at: Utc::now(),
+                    }])
+                }
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::AlreadyStarted),
             },
         }
     }
@@ -1300,6 +1342,15 @@ mod tests {
             redemption_wallet: Address::random(),
             redemption_tx: TxHash::random(),
             sent_at: Utc::now(),
+        }
+    }
+
+    fn tokens_unwrapped_event() -> EquityRedemptionEvent {
+        EquityRedemptionEvent::TokensUnwrapped {
+            underlying_token: Address::random(),
+            unwrap_tx_hash: TxHash::random(),
+            unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+            unwrapped_at: Utc::now(),
         }
     }
 
@@ -2529,6 +2580,7 @@ mod tests {
             raindex_withdraw_tx: Some(TxHash::random()),
             redemption_tx: Some(TxHash::random()),
             tokenization_request_id: Some(TokenizationRequestId("TOK001".to_string())),
+            reason: None,
             started_at: now,
             failed_at: later,
         };
@@ -2541,5 +2593,74 @@ mod tests {
         assert_eq!(failed_at, later);
         assert_eq!(op.started_at, now);
         assert_eq!(op.updated_at, later);
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_from_withdrawn_transitions_to_failed() {
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event()])
+            .when(EquityRedemptionCommand::FailTransfer {
+                reason: "Transfer timed out".to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            EquityRedemptionEvent::TransferFailed { tx_hash: None, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_from_unwrapped_transitions_to_failed() {
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_unwrapped_event(),
+            ])
+            .when(EquityRedemptionCommand::FailTransfer {
+                reason: "Transfer timed out".to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            EquityRedemptionEvent::TransferFailed { tx_hash: None, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_rejected_from_tokens_sent() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
+            .when(EquityRedemptionCommand::FailTransfer {
+                reason: "should not work".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(EquityRedemptionError::AlreadyStarted)
+        ));
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_rejected_before_start() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given_no_previous_events()
+            .when(EquityRedemptionCommand::FailTransfer {
+                reason: "should not work".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(EquityRedemptionError::NotStarted)
+        ));
     }
 }

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -26,16 +26,16 @@ use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
-use crate::onchain::raindex::{Raindex, RaindexError};
+use crate::onchain::raindex::{Raindex, RaindexError, RaindexVaultId};
 use crate::tokenization::{
-    AlpacaTokenizationError, MintVerificationError, TokenizationRequestStatus, Tokenizer,
-    TokenizerError,
+    AlpacaTokenizationError, MintVerificationError, TokenizationRequest, TokenizationRequestStatus,
+    Tokenizer, TokenizerError,
 };
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TOKENIZED_EQUITY_DECIMALS, TokenizationRequestId, TokenizedEquityMint,
     TokenizedEquityMintCommand,
 };
-use crate::wrapper::{Wrapper, WrapperError};
+use crate::wrapper::{UnderlyingPerWrapped, Wrapper, WrapperError};
 
 /// A quantity of equity in a specific symbol.
 #[derive(Debug)]
@@ -69,6 +69,156 @@ pub(crate) struct EquityTransferServices {
     pub(crate) raindex: Arc<dyn Raindex>,
     pub(crate) tokenizer: Arc<dyn Tokenizer>,
     pub(crate) wrapper: Arc<dyn Wrapper>,
+}
+
+impl EquityTransferServices {
+    /// Constructs a services instance whose methods all panic.
+    ///
+    /// Safe for sending commands that never invoke services (e.g., the
+    /// `FailWrapping`, `FailAcceptance`, `FailRaindexDeposit`, and
+    /// `FailTransfer` commands). Used by the CLI `fail-transfer`
+    /// subcommand where no real broker/RPC connection exists.
+    pub(crate) fn panicking() -> Self {
+        Self {
+            raindex: Arc::new(PanickingRaindex),
+            tokenizer: Arc::new(PanickingTokenizer),
+            wrapper: Arc::new(PanickingWrapper),
+        }
+    }
+}
+
+/// Panicking Raindex stub for CLI-only use. All methods panic.
+struct PanickingRaindex;
+
+#[async_trait]
+impl Raindex for PanickingRaindex {
+    async fn lookup_vault_id(&self, _: Address) -> Result<RaindexVaultId, RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+
+    async fn lookup_vault_info(
+        &self,
+        _: &Symbol,
+    ) -> Result<(Address, RaindexVaultId), RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+
+    async fn deposit(
+        &self,
+        _: Address,
+        _: RaindexVaultId,
+        _: U256,
+        _: u8,
+    ) -> Result<TxHash, RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+
+    async fn withdraw(
+        &self,
+        _: Address,
+        _: RaindexVaultId,
+        _: U256,
+        _: u8,
+    ) -> Result<TxHash, RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+}
+
+/// Panicking Tokenizer stub for CLI-only use. All methods panic.
+struct PanickingTokenizer;
+
+#[async_trait]
+impl Tokenizer for PanickingTokenizer {
+    async fn request_mint(
+        &self,
+        _: Symbol,
+        _: FractionalShares,
+        _: Address,
+        _: IssuerRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn poll_mint_until_complete(
+        &self,
+        _: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    fn redemption_wallet(&self) -> Option<Address> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn send_for_redemption(&self, _: Address, _: U256) -> Result<TxHash, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn poll_for_redemption(&self, _: &TxHash) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn poll_redemption_until_complete(
+        &self,
+        _: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn verify_mint_tx(
+        &self,
+        _: TxHash,
+        _: Address,
+        _: Address,
+        _: U256,
+    ) -> Result<(), MintVerificationError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+}
+
+/// Panicking Wrapper stub for CLI-only use. All methods panic.
+struct PanickingWrapper;
+
+#[async_trait]
+impl Wrapper for PanickingWrapper {
+    async fn get_ratio_for_symbol(&self, _: &Symbol) -> Result<UnderlyingPerWrapped, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    fn lookup_underlying(&self, _: &Symbol) -> Result<Address, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    fn lookup_derivative(&self, _: &Symbol) -> Result<Address, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn to_wrapped(
+        &self,
+        _: Address,
+        _: U256,
+        _: Address,
+    ) -> Result<(TxHash, U256), WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn to_underlying(
+        &self,
+        _: Address,
+        _: U256,
+        _: Address,
+        _: Address,
+    ) -> Result<(TxHash, U256), WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    fn owner(&self) -> Address {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -22,7 +22,9 @@ use st0x_execution::{FractionalShares, Positive, Symbol};
 use st0x_finance::Usdc;
 
 use crate::config::AssetsConfig;
-use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent, RedemptionAggregateId};
+use crate::equity_redemption::{
+    EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
+};
 use crate::inventory::projection::InventoryProjectionError;
 use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
 use crate::inventory::{
@@ -31,7 +33,7 @@ use crate::inventory::{
 };
 use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::{
-    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintEvent,
+    IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
 };
 use crate::usdc_rebalance::{
     RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
@@ -456,6 +458,12 @@ pub(crate) struct RebalancingTrigger {
     mint_event_sync: Arc<Mutex<()>>,
     redemption_event_sync: Arc<Mutex<()>>,
     usdc_event_sync: Arc<Mutex<()>>,
+    /// CQRS stores for emitting failure events on timeout.
+    /// Set after construction via `set_stores` because the stores
+    /// are built after the trigger (the trigger is a Reactor dependency
+    /// of the stores' query manifest).
+    mint_store: RwLock<Option<Arc<Store<TokenizedEquityMint>>>>,
+    redemption_store: RwLock<Option<Arc<Store<EquityRedemption>>>>,
 }
 
 type EquityInventoryUpdate = Box<
@@ -499,7 +507,22 @@ impl RebalancingTrigger {
             mint_event_sync: Arc::new(Mutex::new(())),
             redemption_event_sync: Arc::new(Mutex::new(())),
             usdc_event_sync: Arc::new(Mutex::new(())),
+            mint_store: RwLock::new(None),
+            redemption_store: RwLock::new(None),
         }
+    }
+
+    /// Attach CQRS stores so the trigger can emit failure events on timeout.
+    ///
+    /// Called after construction because the stores are built by the query
+    /// manifest, which depends on the trigger as a reactor.
+    pub(crate) async fn set_stores(
+        &self,
+        mint_store: Arc<Store<TokenizedEquityMint>>,
+        redemption_store: Arc<Store<EquityRedemption>>,
+    ) {
+        *self.mint_store.write().await = Some(mint_store);
+        *self.redemption_store.write().await = Some(redemption_store);
     }
 
     async fn expire_stuck_operations(
@@ -567,16 +590,46 @@ impl RebalancingTrigger {
                 continue;
             };
 
+            let elapsed_secs = elapsed.as_secs();
             error!(
                 target: "rebalance",
                 aggregate_id = %id,
                 symbol = %tracking.symbol,
                 stage = %tracking.stage,
-                ?elapsed,
+                elapsed_secs,
+                outcome = "timeout",
                 "Mint transfer timed out; clearing trigger guard and inventory inflight"
             );
 
             self.clear_equity_in_progress(&tracking.symbol);
+
+            if let Some(store) = self.mint_store.read().await.as_ref() {
+                let reason = format!(
+                    "Transfer timed out after {elapsed_secs}s at stage {}",
+                    tracking.stage
+                );
+
+                let command = match tracking.stage {
+                    MintTrackingStage::Accepted => {
+                        TokenizedEquityMintCommand::FailAcceptance { reason }
+                    }
+                    MintTrackingStage::TokensReceived => {
+                        TokenizedEquityMintCommand::FailWrapping { reason }
+                    }
+                    MintTrackingStage::TokensWrapped => {
+                        TokenizedEquityMintCommand::FailRaindexDeposit { reason }
+                    }
+                    MintTrackingStage::Requested => continue,
+                };
+
+                if let Err(error) = store.send(&id, command).await {
+                    warn!(
+                        target: "rebalance",
+                        %id, %error,
+                        "Failed to emit timeout failure event for mint"
+                    );
+                }
+            }
         }
 
         Ok(())
@@ -609,16 +662,50 @@ impl RebalancingTrigger {
                 continue;
             };
 
+            let elapsed_secs = elapsed.as_secs();
             error!(
                 target: "rebalance",
                 aggregate_id = %id,
                 symbol = %tracking.symbol,
                 stage = %tracking.stage,
-                ?elapsed,
+                elapsed_secs,
+                outcome = "timeout",
                 "Redemption transfer timed out; clearing trigger guard and inventory inflight"
             );
 
             self.clear_equity_in_progress(&tracking.symbol);
+
+            if let Some(store) = self.redemption_store.read().await.as_ref() {
+                let reason = format!(
+                    "Transfer timed out after {elapsed_secs}s at stage {}",
+                    tracking.stage
+                );
+
+                let command = match tracking.stage {
+                    RedemptionTrackingStage::WithdrawnFromRaindex
+                    | RedemptionTrackingStage::TokensUnwrapped => {
+                        Some(EquityRedemptionCommand::FailTransfer { reason })
+                    }
+                    RedemptionTrackingStage::TokensSent => {
+                        Some(EquityRedemptionCommand::FailDetection {
+                            failure: crate::equity_redemption::DetectionFailure::Timeout,
+                        })
+                    }
+                    RedemptionTrackingStage::Detected => {
+                        Some(EquityRedemptionCommand::RejectRedemption { reason })
+                    }
+                };
+
+                if let Some(command) = command
+                    && let Err(error) = store.send(&id, command).await
+                {
+                    warn!(
+                        target: "rebalance",
+                        %id, %error,
+                        "Failed to emit timeout failure event for redemption"
+                    );
+                }
+            }
         }
 
         Ok(())
@@ -2623,6 +2710,7 @@ mod tests {
         TokenizedEquityMintEvent::WrappingFailed {
             symbol: symbol.clone(),
             quantity,
+            reason: None,
             failed_at: Utc::now(),
         }
     }
@@ -2637,6 +2725,7 @@ mod tests {
     fn make_transfer_failed() -> EquityRedemptionEvent {
         EquityRedemptionEvent::TransferFailed {
             tx_hash: Some(TxHash::random()),
+            reason: None,
             failed_at: Utc::now(),
         }
     }

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -246,6 +246,18 @@ pub(crate) enum TokenizedEquityMintCommand {
     DepositToVault {
         vault_deposit_tx_hash: TxHash,
     },
+    /// Operator or timeout-driven failure from `MintAccepted` state.
+    FailAcceptance {
+        reason: String,
+    },
+    /// Operator or timeout-driven failure from `TokensReceived` state.
+    FailWrapping {
+        reason: String,
+    },
+    /// Operator or timeout-driven failure from `TokensWrapped` state.
+    FailRaindexDeposit {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -307,6 +319,10 @@ pub(crate) enum TokenizedEquityMintEvent {
             deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
         )]
         quantity: Float,
+        /// Reason for the wrapping failure (timeout, EVM revert, operator action).
+        /// Absent in events emitted before this field was added.
+        #[serde(default)]
+        reason: Option<String>,
         failed_at: DateTime<Utc>,
     },
 
@@ -429,14 +445,21 @@ impl PartialEq for TokenizedEquityMintEvent {
                 Self::WrappingFailed {
                     symbol: sym_a,
                     quantity: qty_a,
+                    reason: reason_a,
                     failed_at: time_a,
                 },
                 Self::WrappingFailed {
                     symbol: sym_b,
                     quantity: qty_b,
+                    reason: reason_b,
                     failed_at: time_b,
                 },
-            ) => sym_a == sym_b && qty_a.eq(*qty_b).unwrap_or(false) && time_a == time_b,
+            ) => {
+                sym_a == sym_b
+                    && qty_a.eq(*qty_b).unwrap_or(false)
+                    && reason_a == reason_b
+                    && time_a == time_b
+            }
             (
                 Self::DepositedIntoRaindex {
                     vault_deposit_tx_hash: hash_a,
@@ -993,6 +1016,7 @@ impl EventSourced for TokenizedEquityMint {
             WrappingFailed {
                 symbol,
                 quantity,
+                reason,
                 failed_at,
             } => {
                 let Self::TokensReceived { requested_at, .. } = entity else {
@@ -1001,7 +1025,9 @@ impl EventSourced for TokenizedEquityMint {
                 Some(Self::Failed {
                     symbol: symbol.clone(),
                     quantity: *quantity,
-                    reason: "ERC-4626 wrapping failed".to_string(),
+                    reason: reason
+                        .clone()
+                        .unwrap_or_else(|| "ERC-4626 wrapping failed".to_string()),
                     requested_at: *requested_at,
                     failed_at: *failed_at,
                 })
@@ -1429,6 +1455,53 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            },
+
+            TokenizedEquityMintCommand::FailAcceptance { reason } => match self {
+                Self::MintAccepted { .. } => Ok(vec![MintAcceptanceFailed {
+                    reason,
+                    failed_at: Utc::now(),
+                }]),
+                Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
+
+            TokenizedEquityMintCommand::FailWrapping { reason } => match self {
+                Self::TokensReceived {
+                    symbol, quantity, ..
+                } => {
+                    warn!(
+                        target: "rebalance",
+                        %symbol, %reason,
+                        "Marking mint as wrapping-failed"
+                    );
+                    Ok(vec![WrappingFailed {
+                        symbol: symbol.clone(),
+                        quantity: *quantity,
+                        reason: Some(reason),
+                        failed_at: Utc::now(),
+                    }])
+                }
+                Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
+
+            TokenizedEquityMintCommand::FailRaindexDeposit { reason } => match self {
+                Self::TokensWrapped { .. } => Ok(vec![RaindexDepositFailed {
+                    reason,
+                    failed_at: Utc::now(),
+                }]),
+                Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
             },
         }
     }
@@ -1995,6 +2068,7 @@ mod tests {
         let event = TokenizedEquityMintEvent::WrappingFailed {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(10),
+            reason: None,
             failed_at: Utc::now(),
         };
 
@@ -2291,5 +2365,149 @@ mod tests {
         }
         assert_eq!(op.started_at, now);
         assert_eq!(op.updated_at, later);
+    }
+
+    #[tokio::test]
+    async fn fail_acceptance_from_accepted_transitions_to_failed() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = IssuerRequestId::new("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "Timed out".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "Expected Failed state, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_wrapping_from_tokens_received_transitions_to_failed() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = IssuerRequestId::new("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailWrapping {
+                    reason: "RPC timeout".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "Expected Failed state, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_raindex_deposit_from_tokens_wrapped_transitions_to_failed() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = IssuerRequestId::new("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: TxHash::random(),
+                    wrapped_shares: U256::from(100u64),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailRaindexDeposit {
+                    reason: "Vault deposit timeout".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Failed { .. }),
+            "Expected Failed state, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_wrapping_rejected_from_wrong_state() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = IssuerRequestId::new("ISS001");
+
+        // MintAccepted state -- FailWrapping requires TokensReceived
+        store.send(&id, mint_command()).await.unwrap();
+
+        let result = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailWrapping {
+                    reason: "should not work".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "FailWrapping should fail from MintAccepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_acceptance_rejected_from_terminal_state() {
+        let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
+        let id = IssuerRequestId::new("ISS001");
+
+        store.send(&id, mint_command()).await.unwrap();
+        store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "first fail".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let result = store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "second fail".to_string(),
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "FailAcceptance should fail from Failed state"
+        );
     }
 }


### PR DESCRIPTION
## What

- [RAI-365](https://linear.app/makeitrain/issue/RAI-365/persist-onchain-tx-hash-before-confirmation-to-prevent-non-idempotent) — Persist onchain tx hash before confirmation to prevent non-idempotent recovery
- [RAI-366](https://linear.app/makeitrain/issue/RAI-366/emit-failure-events-on-transfer-timeout-cli-to-manually-fail-stuck) — Emit failure events on transfer timeout + CLI to manually fail stuck aggregates

Adds failure commands to both mint and redemption aggregates, wires the rebalancing trigger to emit failure events when transfers time out, and provides a CLI `fail-transfer` subcommand for operators to manually resolve stuck aggregates. Also fixes the nix `st0x-cli` binary naming mismatch.

This PR implements RAI-366 in full and lays the groundwork for RAI-365 (the failure commands added here are needed as fallback when receipt polling fails permanently in Phase 2).

## Why

Two linked issues were discovered on staging where 6 RKLB mints and 5 SGOV redemptions were permanently stuck:

1. **No failure events on timeout (RAI-366):** When a transfer times out (30 min with no progress), the `RebalancingTrigger` cleans up tracking state but never emits a CQRS failure event. The aggregate stays in a non-terminal state forever — dashboard shows "in progress" permanently, operators have no visibility, and startup recovery retries them (often failing again).

2. **Non-idempotent recovery (RAI-365):** Every onchain step does `submit tx → wait minutes for receipt → persist event`. If the bot dies during the wait, the tx lands onchain but the event is lost. Recovery re-submits, which can silently double-mint if the wallet happens to have enough balance from other operations. Phase 2 will address this by splitting submit/confirm with intermediate events — this PR provides the failure commands that Phase 2 needs as fallback.

## How

**New failure commands on `TokenizedEquityMint`:**
- `FailAcceptance { reason }` — valid from `MintAccepted`, emits `MintAcceptanceFailed`
- `FailWrapping { reason }` — valid from `TokensReceived`, emits `WrappingFailed`
- `FailRaindexDeposit { reason }` — valid from `TokensWrapped`, emits `RaindexDepositFailed`

**New failure command on `EquityRedemption`:**
- `FailTransfer { reason }` — valid from `WithdrawnFromRaindex` or `TokensUnwrapped`, emits `TransferFailed`

**Failure reason persistence:** Added `reason: Option<String>` with `#[serde(default)]` to `WrappingFailed`, `TransferFailed` events, and `EquityRedemption::Failed` state. Backward-compatible — existing events deserialize with `None`. The `evolve` handlers propagate the reason into the failed aggregate state.

**Timeout-driven failure events:** `RebalancingTrigger` gains `mint_store` and `redemption_store` fields (set via `set_stores()` after construction). When `expire_stuck_mints` / `expire_stuck_redemptions` fires, it sends the appropriate failure command based on the tracked stage:
- Mint: `Accepted` → `FailAcceptance`, `TokensReceived` → `FailWrapping`, `TokensWrapped` → `FailRaindexDeposit`, `Requested` → skipped
- Redemption: `WithdrawnFromRaindex`/`TokensUnwrapped` → `FailTransfer`, `TokensSent` → `FailDetection { Timeout }`, `Detected` → `RejectRedemption`

**CLI `fail-transfer` command:** `stox fail-transfer --type mint|redemption --id <aggregate_id> [--reason "..."]`. Loads the aggregate, validates state, sends the appropriate failure command. Rejects terminal states with clear error messages.

**Supporting infrastructure:**
- `st0x_event_sorcery::send_command()` — lightweight command execution without a pre-built `Store`, for CLI contexts
- `EquityTransferServices::panicking()` — stub services for failure-only commands that never invoke broker/RPC

**Nix CLI fix:** `rust.nix` `postInstall` renames the binary from `cli` to `st0x-cli` to match the derivation `pname`. `os.nix` `stox` wrapper updated to call `st0x-cli`.

## Testing

9 new aggregate-level tests:
- `fail_acceptance_from_accepted_transitions_to_failed`
- `fail_wrapping_from_tokens_received_transitions_to_failed`
- `fail_raindex_deposit_from_tokens_wrapped_transitions_to_failed`
- `fail_wrapping_rejected_from_wrong_state`
- `fail_acceptance_rejected_from_terminal_state`
- `fail_transfer_from_withdrawn_transitions_to_failed`
- `fail_transfer_from_unwrapped_transitions_to_failed`
- `fail_transfer_rejected_from_tokens_sent`
- `fail_transfer_rejected_before_start`

Full CI passes: 1729 tests, 0 failures. 5 cross-review iterations converged clean.

## Screenshots

N/A

## Anything else

The `#[allow(clippy::disallowed_methods)]` on `send_command` in event-sorcery is intentional — CLI commands need lightweight CQRS framework construction outside the server path, analogous to how tests construct frameworks directly.

Structured observability fields (`elapsed_secs`, `outcome`) added to timeout log lines for future RPC performance analysis.

Phase 2 (RAI-365) will stack on this branch and split every onchain submit+wait into two phases with an intermediate event (`WrapSubmitted`, `VaultDepositSubmitted`, etc.), preventing double-minting when the bot restarts mid-confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New CLI command allows operators to manually fail stuck mint and redemption transfers with optional reason recording
  * Transfer failure events now include optional reason field for improved diagnostics and troubleshooting

* **Bug Fixes**
  * Fixed test data format for transfer failure event payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->