### PR TITLE
feat: track active transfer aggregate IDs in inventory view

### DIFF
--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -17,6 +17,9 @@ use st0x_float_macro::float;
 
 use super::snapshot::InventorySnapshotEvent;
 use super::venue_balance::{InventoryError, VenueBalance};
+use crate::equity_redemption::RedemptionAggregateId;
+use crate::tokenized_equity_mint::IssuerRequestId;
+use crate::usdc_rebalance::UsdcRebalanceId;
 use crate::wrapper::{RatioError, UnderlyingPerWrapped};
 
 static EXACT_ONE: LazyLock<Float> = LazyLock::new(|| float!(1));
@@ -641,6 +644,24 @@ pub(crate) struct InventoryView {
     /// Gross offchain USD balance in cents (before cash reserve subtraction).
     #[serde(default)]
     offchain_gross_usd_cents: Option<i64>,
+    /// Aggregate ID of the in-flight USDC rebalance, if any.
+    ///
+    /// Populated when a transfer initiates and cleared on terminal events.
+    /// Recovery uses this to load the stalled aggregate from its store.
+    #[serde(default)]
+    active_usdc_rebalance: Option<UsdcRebalanceId>,
+    /// Aggregate IDs of in-flight equity mints, keyed by symbol.
+    ///
+    /// Populated when a non-terminal mint event is processed, cleared on
+    /// terminal mint events.
+    #[serde(default)]
+    active_mints: HashMap<Symbol, IssuerRequestId>,
+    /// Aggregate IDs of in-flight equity redemptions, keyed by symbol.
+    ///
+    /// Populated when a non-terminal redemption event is processed, cleared
+    /// on terminal redemption events.
+    #[serde(default)]
+    active_redemptions: HashMap<Symbol, RedemptionAggregateId>,
 }
 
 impl InventoryView {
@@ -752,6 +773,9 @@ impl Default for InventoryView {
             last_updated: Utc::now(),
             buying_power_cents: None,
             offchain_gross_usd_cents: None,
+            active_usdc_rebalance: None,
+            active_mints: HashMap::new(),
+            active_redemptions: HashMap::new(),
         }
     }
 }
@@ -851,9 +875,7 @@ impl InventoryView {
         Ok(Self {
             equities,
             last_updated: now,
-            usdc: self.usdc,
-            buying_power_cents: self.buying_power_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            ..self
         })
     }
 
@@ -867,9 +889,7 @@ impl InventoryView {
         Ok(Self {
             usdc: updated,
             last_updated: now,
-            equities: self.equities,
-            buying_power_cents: self.buying_power_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            ..self
         })
     }
 
@@ -892,9 +912,7 @@ impl InventoryView {
         Ok(Self {
             equities,
             last_updated: now,
-            usdc: self.usdc,
-            buying_power_cents: self.buying_power_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            ..self
         })
     }
 
@@ -909,10 +927,82 @@ impl InventoryView {
         Ok(Self {
             usdc: cleared,
             last_updated: now,
-            equities: self.equities,
-            buying_power_cents: self.buying_power_cents,
-            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            ..self
         })
+    }
+
+    /// Returns the aggregate ID of the in-flight USDC rebalance, if any.
+    #[cfg(test)]
+    pub(crate) fn active_usdc_rebalance(&self) -> Option<&UsdcRebalanceId> {
+        self.active_usdc_rebalance.as_ref()
+    }
+
+    /// Returns the aggregate ID of the in-flight mint for `symbol`, if any.
+    #[cfg(test)]
+    pub(crate) fn active_mint(&self, symbol: &Symbol) -> Option<&IssuerRequestId> {
+        self.active_mints.get(symbol)
+    }
+
+    /// Returns the aggregate ID of the in-flight redemption for `symbol`, if any.
+    #[cfg(test)]
+    pub(crate) fn active_redemption(&self, symbol: &Symbol) -> Option<&RedemptionAggregateId> {
+        self.active_redemptions.get(symbol)
+    }
+
+    /// Records `id` as the in-flight USDC rebalance.
+    pub(crate) fn set_active_usdc_rebalance(self, id: UsdcRebalanceId) -> Self {
+        Self {
+            active_usdc_rebalance: Some(id),
+            ..self
+        }
+    }
+
+    /// Clears the in-flight USDC rebalance ID (no-op if already empty).
+    pub(crate) fn clear_active_usdc_rebalance(self) -> Self {
+        Self {
+            active_usdc_rebalance: None,
+            ..self
+        }
+    }
+
+    /// Records `id` as the in-flight mint for `symbol`.
+    pub(crate) fn set_active_mint(self, symbol: Symbol, id: IssuerRequestId) -> Self {
+        let mut active_mints = self.active_mints;
+        active_mints.insert(symbol, id);
+        Self {
+            active_mints,
+            ..self
+        }
+    }
+
+    /// Clears the in-flight mint ID for `symbol` (no-op if absent).
+    pub(crate) fn clear_active_mint(self, symbol: &Symbol) -> Self {
+        let mut active_mints = self.active_mints;
+        active_mints.remove(symbol);
+        Self {
+            active_mints,
+            ..self
+        }
+    }
+
+    /// Records `id` as the in-flight redemption for `symbol`.
+    pub(crate) fn set_active_redemption(self, symbol: Symbol, id: RedemptionAggregateId) -> Self {
+        let mut active_redemptions = self.active_redemptions;
+        active_redemptions.insert(symbol, id);
+        Self {
+            active_redemptions,
+            ..self
+        }
+    }
+
+    /// Clears the in-flight redemption ID for `symbol` (no-op if absent).
+    pub(crate) fn clear_active_redemption(self, symbol: &Symbol) -> Self {
+        let mut active_redemptions = self.active_redemptions;
+        active_redemptions.remove(symbol);
+        Self {
+            active_redemptions,
+            ..self
+        }
     }
 
     /// Returns the set of symbols that currently have inflight balances
@@ -1199,7 +1289,6 @@ mod tests {
     use alloy::primitives::U256;
     use chrono::{Duration, Utc};
     use rain_math_float::Float;
-    use std::collections::HashMap;
 
     use st0x_finance::Usdc;
 
@@ -1446,9 +1535,7 @@ mod tests {
         InventoryView {
             usdc: usdc_make_inventory(1000, 0, 1000, 0),
             equities: equities.into_iter().collect(),
-            last_updated: Utc::now(),
-            buying_power_cents: None,
-            offchain_gross_usd_cents: None,
+            ..InventoryView::default()
         }
     }
 
@@ -1465,10 +1552,7 @@ mod tests {
                 offchain_available,
                 offchain_inflight,
             ),
-            equities: HashMap::new(),
-            last_updated: Utc::now(),
-            buying_power_cents: None,
-            offchain_gross_usd_cents: None,
+            ..InventoryView::default()
         }
     }
 
@@ -2035,9 +2119,7 @@ mod tests {
         let view = InventoryView {
             equities: std::iter::once((tsla, make_inventory(80, 20, 40, 10))).collect(),
             usdc: usdc_make_inventory(5000, 1000, 3000, 500),
-            last_updated: Utc::now(),
-            buying_power_cents: None,
-            offchain_gross_usd_cents: None,
+            ..InventoryView::default()
         };
 
         let dto = view.to_dto();
@@ -2077,9 +2159,7 @@ mod tests {
             ))
             .collect(),
             usdc: Inventory::default(),
-            last_updated: Utc::now(),
-            buying_power_cents: None,
-            offchain_gross_usd_cents: None,
+            ..InventoryView::default()
         };
 
         let dto = view.to_dto();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -830,10 +830,10 @@ impl RebalancingTrigger {
         }
 
         let mut inventory = self.inventory.write().await;
-        *inventory =
-            inventory
-                .clone()
-                .clear_equity_inflight(&tracking.symbol, Venue::Hedging, now)?;
+        *inventory = inventory
+            .clone()
+            .clear_equity_inflight(&tracking.symbol, Venue::Hedging, now)?
+            .clear_active_mint(&tracking.symbol);
         drop(inventory);
 
         self.timed_out_mints.write().await.insert(id.clone(), now);
@@ -868,10 +868,10 @@ impl RebalancingTrigger {
         }
 
         let mut inventory = self.inventory.write().await;
-        *inventory =
-            inventory
-                .clone()
-                .clear_equity_inflight(&tracking.symbol, Venue::MarketMaking, now)?;
+        *inventory = inventory
+            .clone()
+            .clear_equity_inflight(&tracking.symbol, Venue::MarketMaking, now)?
+            .clear_active_redemption(&tracking.symbol);
         drop(inventory);
 
         self.timed_out_redemptions
@@ -911,7 +911,8 @@ impl RebalancingTrigger {
         let mut inventory = self.inventory.write().await;
         *inventory = inventory
             .clone()
-            .clear_usdc_inflight(tracking.source_venue(), now)?;
+            .clear_usdc_inflight(tracking.source_venue(), now)?
+            .clear_active_usdc_rebalance();
         drop(inventory);
 
         self.timed_out_usdc_rebalances
@@ -1457,6 +1458,44 @@ impl RebalancingTrigger {
         Ok(())
     }
 
+    /// Sets `active_mints[symbol] = id` while the aggregate is alive,
+    /// clears it on terminal events. Mirrors the lifecycle of
+    /// `mint_tracking` so `InventoryView` reflects which aggregate
+    /// currently owns the symbol's mint slot.
+    async fn update_active_mint(
+        &self,
+        id: &IssuerRequestId,
+        symbol: &Symbol,
+        event: &TokenizedEquityMintEvent,
+    ) {
+        let mut inventory = self.inventory.write().await;
+        *inventory = if Self::is_terminal_mint_event(event) {
+            inventory.clone().clear_active_mint(symbol)
+        } else {
+            inventory
+                .clone()
+                .set_active_mint(symbol.clone(), id.clone())
+        };
+    }
+
+    /// Sets `active_redemptions[symbol] = id` while the aggregate is
+    /// alive, clears it on terminal events. Mirrors `redemption_tracking`.
+    async fn update_active_redemption(
+        &self,
+        id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        event: &EquityRedemptionEvent,
+    ) {
+        let mut inventory = self.inventory.write().await;
+        *inventory = if Self::is_terminal_redemption_event(event) {
+            inventory.clone().clear_active_redemption(symbol)
+        } else {
+            inventory
+                .clone()
+                .set_active_redemption(symbol.clone(), id.clone())
+        };
+    }
+
     async fn load_redemption_tracking(
         &self,
         id: &RedemptionAggregateId,
@@ -1666,14 +1705,16 @@ impl RebalancingTrigger {
                 );
                 self.mark_equity_in_progress(symbol);
 
+                let mut inventory = self.inventory.write().await;
+                let mut updated = inventory.clone();
                 if matches!(entity, MintAccepted { .. }) {
-                    let mut inventory = self.inventory.write().await;
-                    *inventory = inventory.clone().update_equity(
+                    updated = updated.update_equity(
                         symbol,
                         Inventory::set_inflight(Venue::Hedging, quantity),
                         Utc::now(),
                     )?;
                 }
+                *inventory = updated.set_active_mint(symbol.clone(), id.clone());
             }
             DepositedIntoRaindex { .. } | Failed { .. } => {}
         }
@@ -1729,11 +1770,12 @@ impl RebalancingTrigger {
                 self.mark_equity_in_progress(symbol);
 
                 let mut inventory = self.inventory.write().await;
-                *inventory = inventory.clone().update_equity(
+                let updated = inventory.clone().update_equity(
                     symbol,
                     Inventory::set_inflight(Venue::MarketMaking, quantity),
                     Utc::now(),
                 )?;
+                *inventory = updated.set_active_redemption(symbol.clone(), id.clone());
             }
             Completed { .. } | Failed { .. } => {}
         }
@@ -1763,6 +1805,8 @@ impl RebalancingTrigger {
         if let Some(update) = Self::mint_inventory_update(&event, tracking.quantity) {
             self.apply_equity_update(&symbol, update).await?;
         }
+
+        self.update_active_mint(&id, &symbol, &event).await;
 
         let should_check_usdc = if Self::is_terminal_mint_event(&event) {
             self.mint_tracking.write().await.remove(&id);
@@ -1804,6 +1848,8 @@ impl RebalancingTrigger {
         if let Some(update) = Self::redemption_inventory_update(&event, tracking.quantity) {
             self.apply_equity_update(&symbol, update).await?;
         }
+
+        self.update_active_redemption(&id, &symbol, &event).await;
 
         let should_check_usdc = if Self::is_terminal_redemption_event(&event) {
             self.redemption_tracking.write().await.remove(&id);
@@ -7553,6 +7599,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timed_out_mint_cleanup_clears_active_mint_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let id = IssuerRequestId::new("timed-out-mint-active-id");
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, shares(10)),
+                now,
+            )
+            .unwrap()
+            .set_active_mint(symbol.clone(), id.clone());
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+            inventory,
+            &symbol,
+            test_config_with_timeout(Duration::from_secs(60)),
+        )
+        .await;
+
+        trigger.mint_tracking.write().await.insert(
+            id.clone(),
+            MintTracking {
+                symbol: symbol.clone(),
+                quantity: shares(10),
+                stage: MintTrackingStage::Accepted,
+                last_progress_at: now - ChronoDuration::minutes(5),
+            },
+        );
+
+        let cleanup = trigger.cleanup_timed_out_mint(&id, now).await.unwrap();
+        assert!(cleanup.is_some(), "cleanup should tombstone the stale mint");
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_mint(&symbol),
+            None,
+            "timed-out mint cleanup must clear the active mint ID from InventoryView"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
     async fn mint_event_rechecks_tombstone_after_waiting_for_sync_gate() {
         let symbol = Symbol::new("AAPL").unwrap();
         let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
@@ -7670,6 +7759,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timed_out_redemption_cleanup_clears_active_redemption_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let id = RedemptionAggregateId::new("timed-out-redemption-active-id");
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .update_equity(
+                &symbol,
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, shares(10)),
+                now,
+            )
+            .unwrap()
+            .set_active_redemption(symbol.clone(), id.clone());
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+            inventory,
+            &symbol,
+            test_config_with_timeout(Duration::from_secs(60)),
+        )
+        .await;
+
+        trigger.redemption_tracking.write().await.insert(
+            id.clone(),
+            RedemptionTracking {
+                symbol: symbol.clone(),
+                quantity: shares(10),
+                stage: RedemptionTrackingStage::TokensSent,
+                last_progress_at: now - ChronoDuration::minutes(5),
+            },
+        );
+
+        let cleanup = trigger
+            .cleanup_timed_out_redemption(&id, now)
+            .await
+            .unwrap();
+        assert!(
+            cleanup.is_some(),
+            "cleanup should tombstone the stale redemption"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_redemption(&symbol),
+            None,
+            "timed-out redemption cleanup must clear the active redemption ID from InventoryView"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
     async fn redemption_event_rechecks_tombstone_after_waiting_for_sync_gate() {
         let symbol = Symbol::new("AAPL").unwrap();
         let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
@@ -7782,6 +7920,49 @@ mod tests {
             inventory.usdc_inflight(Venue::Hedging),
             Some(usdc(300)),
             "USDC cleanup must preserve unrelated destination inflight"
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn timed_out_usdc_cleanup_clears_active_usdc_rebalance_id() {
+        let now = Utc::now();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(5000), usdc(5000))
+            .update_usdc(
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(700)),
+                now,
+            )
+            .unwrap()
+            .set_active_usdc_rebalance(id.clone());
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(700),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::DepositConfirmed,
+                last_progress_at: now - ChronoDuration::minutes(40),
+            },
+        );
+
+        let cleanup = trigger
+            .cleanup_timed_out_usdc_rebalance(&id, now)
+            .await
+            .unwrap();
+        assert!(
+            cleanup.is_some(),
+            "cleanup should tombstone the stale USDC rebalance"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_usdc_rebalance(),
+            None,
+            "timed-out USDC cleanup must clear the active USDC rebalance ID from InventoryView"
         );
         drop(inventory);
     }
@@ -7996,6 +8177,241 @@ mod tests {
         assert!(
             trigger.timed_out_usdc_rebalances.read().await.is_empty(),
             "expired USDC tombstones should be pruned"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_active_aggregate_ids_when_idle() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory(
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), None);
+        assert_eq!(inventory.active_mint(&symbol), None);
+        assert_eq!(inventory.active_redemption(&symbol), None);
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn mint_accepted_records_active_mint_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
+            &symbol,
+        )
+        .await;
+        let id = IssuerRequestId::new("mint-active-id");
+
+        trigger
+            .on_mint(id.clone(), make_mint_requested(&symbol, float!(10)))
+            .await
+            .unwrap();
+        trigger
+            .on_mint(id.clone(), make_mint_accepted())
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_mint(&symbol),
+            Some(&id),
+            "MintAccepted should record the aggregate ID for its symbol",
+        );
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(10)),
+            "MintAccepted should also start the inflight balance",
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn mint_terminal_event_clears_active_mint_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
+            &symbol,
+        )
+        .await;
+        let id = IssuerRequestId::new("mint-clear-id");
+
+        trigger
+            .on_mint(id.clone(), make_mint_requested(&symbol, float!(10)))
+            .await
+            .unwrap();
+        trigger
+            .on_mint(id.clone(), make_mint_accepted())
+            .await
+            .unwrap();
+        assert_eq!(
+            trigger.inventory.read().await.active_mint(&symbol),
+            Some(&id),
+        );
+
+        trigger
+            .on_mint(id.clone(), make_tokens_received())
+            .await
+            .unwrap();
+        trigger
+            .on_mint(id.clone(), make_deposited_into_raindex())
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_mint(&symbol),
+            None,
+            "DepositedIntoRaindex (terminal) should clear the active mint ID",
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn redemption_withdrawn_records_active_redemption_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
+            &symbol,
+        )
+        .await;
+        let id = RedemptionAggregateId::new("redemption-active-id");
+
+        trigger
+            .on_redemption(id.clone(), make_withdrawn_from_raindex(&symbol, float!(10)))
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_redemption(&symbol),
+            Some(&id),
+            "WithdrawnFromRaindex should record the aggregate ID for its symbol",
+        );
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(10)),
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn redemption_completed_clears_active_redemption_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
+            &symbol,
+        )
+        .await;
+        let id = RedemptionAggregateId::new("redemption-clear-id");
+
+        trigger
+            .on_redemption(id.clone(), make_withdrawn_from_raindex(&symbol, float!(10)))
+            .await
+            .unwrap();
+        assert_eq!(
+            trigger.inventory.read().await.active_redemption(&symbol),
+            Some(&id),
+        );
+
+        trigger
+            .on_redemption(id.clone(), make_redemption_completed())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger.inventory.read().await.active_redemption(&symbol),
+            None,
+            "Completed (terminal) should clear the active redemption ID",
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_initiation_records_active_rebalance_id() {
+        let (trigger, _receiver) =
+            make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(500), usdc(500)))
+                .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger
+            .on_usdc_rebalance(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(100)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.active_usdc_rebalance(),
+            Some(&id),
+            "USDC initiation should record the aggregate ID alongside the inflight balance",
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(usdc(100)),
+        );
+        drop(inventory);
+    }
+
+    #[tokio::test]
+    async fn usdc_terminal_clears_active_rebalance_id() {
+        let (trigger, _receiver) =
+            make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(500), usdc(500)))
+                .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger
+            .on_usdc_rebalance(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(100)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+        );
+
+        trigger
+            .on_usdc_rebalance(id.clone(), make_usdc_bridging_initiated())
+            .await
+            .unwrap();
+        trigger
+            .on_usdc_rebalance(id.clone(), make_usdc_bridge_attestation_received())
+            .await
+            .unwrap();
+        trigger
+            .on_usdc_rebalance(id.clone(), make_usdc_bridged())
+            .await
+            .unwrap();
+        trigger
+            .on_usdc_rebalance(
+                id.clone(),
+                UsdcRebalanceEvent::DepositInitiated {
+                    deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                    deposit_initiated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        trigger
+            .on_usdc_rebalance(
+                id.clone(),
+                UsdcRebalanceEvent::DepositConfirmed {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    deposit_confirmed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "DepositConfirmed (AlpacaToBase terminal) should clear the active USDC rebalance ID",
         );
     }
 }

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -369,6 +369,14 @@ impl RebalancingTrigger {
         self.apply_usdc_rebalance_event(&id, &event).await?;
 
         let is_terminal = Self::is_terminal_usdc_rebalance_event(&event);
+        {
+            let mut inventory = self.inventory.write().await;
+            *inventory = if is_terminal {
+                inventory.clone().clear_active_usdc_rebalance()
+            } else {
+                inventory.clone().set_active_usdc_rebalance(id.clone())
+            };
+        }
         if is_terminal {
             self.usdc_tracking.write().await.remove(&id);
             self.clear_usdc_in_progress();


### PR DESCRIPTION
Closes RAI-95.

## What

`InventoryView` now tracks the aggregate IDs of in-flight USDC rebalances, equity mints, and equity redemptions via three new fields: `active_usdc_rebalance`, `active_mints`, and `active_redemptions`. Setter and clearer methods are exposed on `InventoryView`, and `RebalancingTrigger` calls them at the appropriate lifecycle points — setting IDs when operations begin and clearing them on terminal events or timeout cleanup.

## Why

During recovery, the system needs to know which aggregate currently owns each in-flight operation so it can reload stalled aggregates from their stores. Without persisting these IDs in `InventoryView`, that information is lost across restarts.

## How

- Added `active_usdc_rebalance: Option<UsdcRebalanceId>`, `active_mints: HashMap<Symbol, IssuerRequestId>`, and `active_redemptions: HashMap<Symbol, RedemptionAggregateId>` to `InventoryView`, all serialized with `#[serde(default)]`.
- Added `set_active_usdc_rebalance`, `clear_active_usdc_rebalance`, `set_active_mint`, `clear_active_mint`, `set_active_redemption`, and `clear_active_redemption` builder-style methods on `InventoryView`.
- `RebalancingTrigger` calls these setters in `on_mint`, `on_redemption`, and `on_usdc_rebalance` event handlers, and calls the clearers in the corresponding timeout cleanup paths (`cleanup_timed_out_mint`, `cleanup_timed_out_redemption`, `cleanup_timed_out_usdc_rebalance`).
- Two new private helpers, `update_active_mint` and `update_active_redemption`, centralize the set-or-clear logic for mint and redemption events.
- Existing struct literal constructions in `InventoryView` update methods and tests are simplified to use `..self` / `..InventoryView::default()` spread syntax now that the struct has additional fields.

## Testing

New tests verify the full lifecycle for each operation type:
- `no_active_aggregate_ids_when_idle` — all three fields are `None` at rest.
- `mint_accepted_records_active_mint_id` / `mint_terminal_event_clears_active_mint_id` — ID is set on `MintAccepted` and cleared on `DepositedIntoRaindex`.
- `redemption_withdrawn_records_active_redemption_id` / `redemption_completed_clears_active_redemption_id` — ID is set on `WithdrawnFromRaindex` and cleared on `Completed`.
- `usdc_initiation_records_active_rebalance_id` / `usdc_terminal_clears_active_rebalance_id` — ID is set on initiation and cleared on the terminal `DepositConfirmed` event.
- `timed_out_mint_cleanup_clears_active_mint_id`, `timed_out_redemption_cleanup_clears_active_redemption_id`, `timed_out_usdc_cleanup_clears_active_usdc_rebalance_id` — timeout cleanup paths also clear the IDs.

## Anything else

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith` with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Track active in-flight equity mints, redemptions, and USDC rebalances per asset to preserve ongoing operation state.
  * Ensure state recovery restores active in-flight markers alongside balances.
  * Improve timeout and terminal cleanup to reliably clear stale active markers.

* **Tests**
  * Expanded tests to validate active-tracking across lifecycle events.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/643)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->