### PR TITLE
feat: track all usdc stages

### DIFF
--- a/crates/dto/src/inventory.rs
+++ b/crates/dto/src/inventory.rs
@@ -42,6 +42,34 @@ pub struct UsdcInventory {
     pub offchain_gross: Option<Usdc>,
     /// Margin-safe buying power from the offchain broker, formatted as USD string.
     pub buying_power: Option<String>,
+    /// USDC observed at intermediate wallet locations between venues.
+    pub inflight_cash: InFlightCash,
+}
+
+/// USDC sitting in wallets between venues, observed by polling.
+///
+/// `None` means the wallet has not been observed yet; `Some(ZERO)` means
+/// it was observed empty. The values are tracked separately from venue
+/// inventory and never feed into imbalance math.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct InFlightCash {
+    /// USDC parked on the Ethereum wallet between Alpaca and CCTP.
+    #[ts(type = "string | null")]
+    pub ethereum_wallet: Option<Usdc>,
+    /// USDC parked on the Base wallet between CCTP and the Raindex vaults.
+    #[ts(type = "string | null")]
+    pub base_wallet: Option<Usdc>,
+}
+
+impl InFlightCash {
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            ethereum_wallet: None,
+            base_wallet: None,
+        }
+    }
 }
 
 /// Full inventory snapshot across all symbols and USDC.
@@ -64,6 +92,7 @@ impl Inventory {
                 offchain_inflight: Usdc::ZERO,
                 offchain_gross: None,
                 buying_power: None,
+                inflight_cash: InFlightCash::empty(),
             },
         }
     }
@@ -101,6 +130,10 @@ mod tests {
                 offchain_inflight: Usdc::new(float!(500)),
                 offchain_gross: Some(Usdc::new(float!(6000))),
                 buying_power: Some("$4,500.00".to_string()),
+                inflight_cash: InFlightCash {
+                    ethereum_wallet: Some(Usdc::new(float!(250))),
+                    base_wallet: Some(Usdc::ZERO),
+                },
             },
         };
 
@@ -120,5 +153,7 @@ mod tests {
         assert_eq!(usdc["offchainInflight"], json!("500"));
         assert_eq!(usdc["offchainGross"], json!("6000"));
         assert_eq!(usdc["buyingPower"], json!("$4,500.00"));
+        assert_eq!(usdc["inflightCash"]["ethereumWallet"], json!("250"));
+        assert_eq!(usdc["inflightCash"]["baseWallet"], json!("0"));
     }
 }

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -56,6 +56,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     Inventory::export_all_to(out_dir)?;
     InventorySnapshot::export_all_to(out_dir)?;
     UsdcInventory::export_all_to(out_dir)?;
+    InFlightCash::export_all_to(out_dir)?;
     TransferOperation::export_all_to(out_dir)?;
     EquityMintOperation::export_all_to(out_dir)?;
     EquityMintStatus::export_all_to(out_dir)?;

--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -304,6 +304,19 @@
         </Table.Cell>
         <Table.Cell class="text-right font-mono opacity-50">
           <span class={approxClass(cashRow.inflight)} title={cashRow.inflight.truncated ? cashRow.inflight.full : undefined}>{cashRow.inflight.display}</span>
+          {#if usdc?.inflightCash && (usdc.inflightCash.ethereumWallet !== null || usdc.inflightCash.baseWallet !== null)}
+            {@const eth = usdc.inflightCash.ethereumWallet === null ? null : fmt(usdc.inflightCash.ethereumWallet)}
+            {@const base = usdc.inflightCash.baseWallet === null ? null : fmt(usdc.inflightCash.baseWallet)}
+            <div class="text-xs text-muted-foreground" title="Wallet-observed USDC sitting between venues. Not part of imbalance math.">
+              {#if eth}
+                Eth: <span class={approxClass(eth)} title={eth.truncated ? eth.full : undefined}>{eth.display}</span>
+              {/if}
+              {#if eth && base} · {/if}
+              {#if base}
+                Base: <span class={approxClass(base)} title={base.truncated ? base.full : undefined}>{base.display}</span>
+              {/if}
+            </div>
+          {/if}
         </Table.Cell>
         <Table.Cell class="text-right font-mono opacity-90">
           <span class={approxClass(cashRow.raindex)} title={cashRow.raindex.truncated ? cashRow.raindex.full : undefined}>{cashRow.raindex.display}</span>

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -197,7 +197,8 @@ describe('createWebSocket', () => {
               offchainAvailable: '0',
               offchainInflight: '0',
               offchainGross: null,
-              buyingPower: null
+              buyingPower: null,
+              inflightCash: { ethereumWallet: null, baseWallet: null }
             }
           },
           positions: [],
@@ -303,7 +304,8 @@ describe('createWebSocket', () => {
           offchainAvailable: '500',
           offchainInflight: '0',
           offchainGross: null,
-          buyingPower: null
+          buyingPower: null,
+          inflightCash: { ethereumWallet: null, baseWallet: null }
         }
       }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -584,29 +584,25 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Mint aggregate not found: {id}"))?;
 
+            use TokenizedEquityMint::*;
+            use TokenizedEquityMintCommand::*;
             let command = match entity {
-                TokenizedEquityMint::MintAccepted { .. } => {
-                    TokenizedEquityMintCommand::FailAcceptance {
-                        reason: reason.to_string(),
-                    }
-                }
-                TokenizedEquityMint::TokensReceived { .. } => {
-                    TokenizedEquityMintCommand::FailWrapping {
-                        reason: reason.to_string(),
-                    }
-                }
-                TokenizedEquityMint::TokensWrapped { .. } => {
-                    TokenizedEquityMintCommand::FailRaindexDeposit {
-                        reason: reason.to_string(),
-                    }
-                }
-                TokenizedEquityMint::MintRequested { .. } => {
+                MintAccepted { .. } => FailAcceptance {
+                    reason: reason.to_string(),
+                },
+                TokensReceived { .. } => FailWrapping {
+                    reason: reason.to_string(),
+                },
+                TokensWrapped { .. } => FailRaindexDeposit {
+                    reason: reason.to_string(),
+                },
+                MintRequested { .. } => {
                     anyhow::bail!("Mint {id} is at MintRequested -- cannot fail before acceptance");
                 }
-                TokenizedEquityMint::DepositedIntoRaindex { .. } => {
+                DepositedIntoRaindex { .. } => {
                     anyhow::bail!("Mint {id} already completed (DepositedIntoRaindex)");
                 }
-                TokenizedEquityMint::Failed { .. } => {
+                Failed { .. } => {
                     anyhow::bail!("Mint {id} already failed");
                 }
             };
@@ -628,19 +624,19 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 .await?
                 .ok_or_else(|| anyhow::anyhow!("Redemption aggregate not found: {id}"))?;
 
+            use EquityRedemption::*;
             match entity {
-                EquityRedemption::WithdrawnFromRaindex { .. }
-                | EquityRedemption::TokensUnwrapped { .. } => {}
-                EquityRedemption::TokensSent { .. } | EquityRedemption::Pending { .. } => {
+                WithdrawnFromRaindex { .. } | TokensUnwrapped { .. } => {}
+                TokensSent { .. } | Pending { .. } => {
                     anyhow::bail!(
                         "Redemption {id} is past the transfer stage -- \
                          use FailDetection or RejectRedemption instead"
                     );
                 }
-                EquityRedemption::Completed { .. } => {
+                Completed { .. } => {
                     anyhow::bail!("Redemption {id} already completed");
                 }
-                EquityRedemption::Failed { .. } => {
+                Failed { .. } => {
                     anyhow::bail!("Redemption {id} already failed");
                 }
             }

--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -103,6 +103,7 @@ mod tests {
     use crate::inventory::snapshot::{
         InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
     };
+    use crate::inventory::view::InFlightCashLocation;
     use crate::inventory::{InventoryView, Venue};
     use crate::test_utils::setup_test_db;
 
@@ -175,22 +176,123 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_wallet_read_events_are_noops_on_view() {
+    async fn apply_ethereum_usdc_populates_inflight_cash_only() {
         let (projection, inventory) = make_projection();
 
+        let balance = Usdc::new(float!(100));
         let event = InventorySnapshotEvent::EthereumUsdc {
-            usdc_balance: Usdc::new(float!(100)),
+            usdc_balance: balance,
             fetched_at: Utc::now(),
         };
 
         projection.apply(&event).await.unwrap();
 
+        let (mm_available, hedging_available, ethereum_inflight, base_wallet_inflight) = {
+            let view = inventory.read().await;
+            (
+                view.usdc_available(Venue::MarketMaking),
+                view.usdc_available(Venue::Hedging),
+                view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+                view.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            )
+        };
+
         assert_eq!(
-            read_usdc_available(&inventory, Venue::MarketMaking).await,
-            None,
-            "EthereumUsdc should not touch tracked inventory slots",
+            mm_available, None,
+            "EthereumUsdc must not touch tracked venue inventory slots",
         );
-        assert_eq!(read_usdc_available(&inventory, Venue::Hedging).await, None,);
+        assert_eq!(hedging_available, None);
+        assert_eq!(
+            ethereum_inflight,
+            Some(balance),
+            "EthereumUsdc must populate the Ethereum inflight cash slot",
+        );
+        assert_eq!(
+            base_wallet_inflight, None,
+            "BaseWallet inflight cash must remain untouched",
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_base_wallet_usdc_populates_inflight_cash_only() {
+        let (projection, inventory) = make_projection();
+
+        let balance = Usdc::new(float!(75));
+        let event = InventorySnapshotEvent::BaseWalletUsdc {
+            usdc_balance: balance,
+            fetched_at: Utc::now(),
+        };
+
+        projection.apply(&event).await.unwrap();
+
+        let (mm_available, hedging_available, ethereum_inflight, base_wallet_inflight) = {
+            let view = inventory.read().await;
+            (
+                view.usdc_available(Venue::MarketMaking),
+                view.usdc_available(Venue::Hedging),
+                view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+                view.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            )
+        };
+
+        assert_eq!(
+            mm_available, None,
+            "BaseWalletUsdc must not touch tracked venue inventory slots",
+        );
+        assert_eq!(hedging_available, None);
+        assert_eq!(
+            base_wallet_inflight,
+            Some(balance),
+            "BaseWalletUsdc must populate the BaseWallet inflight cash slot",
+        );
+        assert_eq!(
+            ethereum_inflight, None,
+            "Ethereum inflight cash must remain untouched",
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_wallet_equity_events_remain_noops_on_view() {
+        let (projection, inventory) = make_projection();
+
+        let mut balances = std::collections::BTreeMap::new();
+        balances.insert(symbol("AAPL"), shares(10));
+
+        let inflight_cash_before = inventory.read().await.inflight_cash_snapshot();
+
+        projection
+            .apply(&InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                balances: balances.clone(),
+                fetched_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        projection
+            .apply(&InventorySnapshotEvent::BaseWalletWrappedEquity {
+                balances,
+                fetched_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let (mm_available, hedging_available, inflight_cash_after) = {
+            let view = inventory.read().await;
+            (
+                view.equity_available(&symbol("AAPL"), Venue::MarketMaking),
+                view.equity_available(&symbol("AAPL"), Venue::Hedging),
+                view.inflight_cash_snapshot(),
+            )
+        };
+        assert_eq!(
+            mm_available, None,
+            "BaseWalletUnwrappedEquity / BaseWalletWrappedEquity stay no-ops on venue equity",
+        );
+        assert_eq!(hedging_available, None);
+        assert_eq!(
+            inflight_cash_after, inflight_cash_before,
+            "wallet equity events must not mutate inflight_cash either",
+        );
     }
 
     /// Force-apply must leave untouched venue slots alone while

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -8,9 +8,9 @@ use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 
-use st0x_dto::{SymbolInventory, UsdcInventory};
+use st0x_dto::{InFlightCash, SymbolInventory, UsdcInventory};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_finance::Usdc;
 use st0x_float_macro::float;
@@ -632,6 +632,36 @@ where
     }
 }
 
+/// Locations where USDC may sit in transit between venues.
+///
+/// These slots track wallet balances observed by polling rather than
+/// venue inventory. The underlying imbalance math
+/// ([`InventoryView::check_usdc_imbalance`]) operates strictly on venue
+/// totals so wallet readings can never compensate a real venue
+/// imbalance. Wallet-residue-driven suppression is deferred to a broader
+/// orphan-state detection mechanism.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum InFlightCashLocation {
+    /// USDC parked on the Ethereum wallet between Alpaca withdrawal and
+    /// CCTP burn (or between CCTP mint and Alpaca deposit, depending on
+    /// direction).
+    EthereumWallet,
+    /// USDC parked on the Base wallet outside the Raindex vaults
+    /// (between vault withdrawal and CCTP burn, or between CCTP mint
+    /// and vault deposit).
+    BaseWallet,
+}
+
+/// A wallet-read USDC observation paired with the time it was fetched.
+///
+/// `fetched_at` discriminates concurrent or out-of-order snapshots so the
+/// view ignores readings older than the one it currently holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct InFlightCashEntry {
+    pub(crate) amount: Usdc,
+    pub(crate) fetched_at: DateTime<Utc>,
+}
+
 /// Cross-aggregate projection tracking inventory across venues.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct InventoryView {
@@ -644,6 +674,14 @@ pub(crate) struct InventoryView {
     /// Gross offchain USD balance in cents (before cash reserve subtraction).
     #[serde(default)]
     offchain_gross_usd_cents: Option<i64>,
+    /// USDC observed at intermediate locations between the two venues.
+    /// Populated from wallet-read snapshots and exposed for visibility
+    /// into in-flight transit. Does not feed the imbalance math.
+    ///
+    /// Each entry carries the snapshot's `fetched_at` so out-of-order
+    /// wallet polls cannot overwrite a fresher reading with a stale one.
+    #[serde(default)]
+    inflight_cash: HashMap<InFlightCashLocation, InFlightCashEntry>,
     /// Aggregate ID of the in-flight USDC rebalance, if any.
     ///
     /// Populated when a transfer initiates and cleared on terminal events.
@@ -696,6 +734,12 @@ impl InventoryView {
 
     /// Checks USDC inventory for imbalance against the threshold.
     /// Returns the imbalance if one exists.
+    ///
+    /// Wallet readings (`inflight_cash`) never enter the imbalance math:
+    /// the design explicitly keeps `check_usdc_imbalance` venue-only so
+    /// wallet observations cannot mask or compensate a real venue
+    /// imbalance. Suppression-based on wallet residue is tracked
+    /// separately by a broader orphan-state detection mechanism.
     pub(crate) fn check_usdc_imbalance(
         &self,
         threshold: &ImbalanceThreshold,
@@ -738,6 +782,17 @@ impl InventoryView {
 
         let offchain_gross = self.offchain_gross_usd_cents.and_then(Usdc::from_cents);
 
+        let inflight_cash = InFlightCash {
+            ethereum_wallet: self
+                .inflight_cash
+                .get(&InFlightCashLocation::EthereumWallet)
+                .map(|entry| entry.amount),
+            base_wallet: self
+                .inflight_cash
+                .get(&InFlightCashLocation::BaseWallet)
+                .map(|entry| entry.amount),
+        };
+
         st0x_dto::Inventory {
             per_symbol,
             usdc: UsdcInventory {
@@ -747,6 +802,7 @@ impl InventoryView {
                 offchain_inflight: usdc_offchain_inflight,
                 offchain_gross,
                 buying_power,
+                inflight_cash,
             },
         }
     }
@@ -773,6 +829,7 @@ impl Default for InventoryView {
             last_updated: Utc::now(),
             buying_power_cents: None,
             offchain_gross_usd_cents: None,
+            inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
@@ -856,6 +913,21 @@ impl InventoryView {
         }
     }
 
+    /// Returns the in-flight USDC observed at the given intermediate location.
+    #[cfg(test)]
+    pub(crate) fn inflight_cash_at(&self, location: InFlightCashLocation) -> Option<Usdc> {
+        self.inflight_cash.get(&location).map(|entry| entry.amount)
+    }
+
+    /// Returns a clone of the full in-flight cash map for use in tests
+    /// that need to assert no-op semantics across multiple events.
+    #[cfg(test)]
+    pub(crate) fn inflight_cash_snapshot(
+        &self,
+    ) -> HashMap<InFlightCashLocation, InFlightCashEntry> {
+        self.inflight_cash.clone()
+    }
+
     pub(crate) fn update_equity(
         self,
         symbol: &Symbol,
@@ -875,7 +947,13 @@ impl InventoryView {
         Ok(Self {
             equities,
             last_updated: now,
-            ..self
+            usdc: self.usdc,
+            buying_power_cents: self.buying_power_cents,
+            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            inflight_cash: self.inflight_cash,
+            active_usdc_rebalance: self.active_usdc_rebalance,
+            active_mints: self.active_mints,
+            active_redemptions: self.active_redemptions,
         })
     }
 
@@ -889,8 +967,47 @@ impl InventoryView {
         Ok(Self {
             usdc: updated,
             last_updated: now,
-            ..self
+            equities: self.equities,
+            buying_power_cents: self.buying_power_cents,
+            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            inflight_cash: self.inflight_cash,
+            active_usdc_rebalance: self.active_usdc_rebalance,
+            active_mints: self.active_mints,
+            active_redemptions: self.active_redemptions,
         })
+    }
+
+    /// Record the latest wallet-read USDC balance at an intermediate location.
+    ///
+    /// Wallet readings replace any prior value at the same location only when
+    /// the incoming `fetched_at` is at least as recent as the existing entry's.
+    /// Polls running concurrently against different RPC nodes can land out of
+    /// order, so dropping older snapshots prevents a stale reading from
+    /// overwriting a fresher one.
+    pub(crate) fn set_inflight_cash(
+        mut self,
+        location: InFlightCashLocation,
+        amount: Usdc,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        if let Some(existing) = self.inflight_cash.get(&location)
+            && existing.fetched_at > fetched_at
+        {
+            warn!(
+                target: "inventory",
+                ?location,
+                existing_fetched_at = ?existing.fetched_at,
+                incoming_fetched_at = ?fetched_at,
+                "ignoring stale inflight_cash snapshot",
+            );
+            return self;
+        }
+
+        self.inflight_cash
+            .insert(location, InFlightCashEntry { amount, fetched_at });
+        self.last_updated = now;
+        self
     }
 
     pub(crate) fn clear_equity_inflight(
@@ -912,7 +1029,13 @@ impl InventoryView {
         Ok(Self {
             equities,
             last_updated: now,
-            ..self
+            usdc: self.usdc,
+            buying_power_cents: self.buying_power_cents,
+            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            inflight_cash: self.inflight_cash,
+            active_usdc_rebalance: self.active_usdc_rebalance,
+            active_mints: self.active_mints,
+            active_redemptions: self.active_redemptions,
         })
     }
 
@@ -927,7 +1050,13 @@ impl InventoryView {
         Ok(Self {
             usdc: cleared,
             last_updated: now,
-            ..self
+            equities: self.equities,
+            buying_power_cents: self.buying_power_cents,
+            offchain_gross_usd_cents: self.offchain_gross_usd_cents,
+            inflight_cash: self.inflight_cash,
+            active_usdc_rebalance: self.active_usdc_rebalance,
+            active_mints: self.active_mints,
+            active_redemptions: self.active_redemptions,
         })
     }
 
@@ -1178,10 +1307,27 @@ impl InventoryView {
                 })
             }
 
-            EthereumUsdc { .. }
-            | BaseWalletUsdc { .. }
-            | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => Ok(self),
+            EthereumUsdc {
+                usdc_balance,
+                fetched_at,
+            } => Ok(self.set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                *usdc_balance,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletUsdc {
+                usdc_balance,
+                fetched_at,
+            } => Ok(self.set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                *usdc_balance,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => Ok(self),
 
             InflightEquity {
                 mints, redemptions, ..
@@ -1270,10 +1416,27 @@ impl InventoryView {
                 ..self
             }),
 
-            EthereumUsdc { .. }
-            | BaseWalletUsdc { .. }
-            | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => Ok(self),
+            EthereumUsdc {
+                usdc_balance,
+                fetched_at,
+            } => Ok(self.set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                *usdc_balance,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletUsdc {
+                usdc_balance,
+                fetched_at,
+            } => Ok(self.set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                *usdc_balance,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => Ok(self),
 
             InflightEquity {
                 mints,
@@ -1287,7 +1450,8 @@ impl InventoryView {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::U256;
-    use chrono::{Duration, Utc};
+    use chrono::{Duration, TimeZone, Utc};
+    use proptest::prelude::*;
     use rain_math_float::Float;
 
     use st0x_finance::Usdc;
@@ -1535,7 +1699,13 @@ mod tests {
         InventoryView {
             usdc: usdc_make_inventory(1000, 0, 1000, 0),
             equities: equities.into_iter().collect(),
-            ..InventoryView::default()
+            last_updated: Utc::now(),
+            buying_power_cents: None,
+            offchain_gross_usd_cents: None,
+            inflight_cash: HashMap::new(),
+            active_usdc_rebalance: None,
+            active_mints: HashMap::new(),
+            active_redemptions: HashMap::new(),
         }
     }
 
@@ -1552,7 +1722,14 @@ mod tests {
                 offchain_available,
                 offchain_inflight,
             ),
-            ..InventoryView::default()
+            equities: HashMap::new(),
+            last_updated: Utc::now(),
+            buying_power_cents: None,
+            offchain_gross_usd_cents: None,
+            inflight_cash: HashMap::new(),
+            active_usdc_rebalance: None,
+            active_mints: HashMap::new(),
+            active_redemptions: HashMap::new(),
         }
     }
 
@@ -1793,6 +1970,240 @@ mod tests {
         assert_eq!(
             view.check_usdc_imbalance(&threshold("0.5", "0.3")).unwrap(),
             None
+        );
+    }
+
+    /// Wallet-read events must populate `inflight_cash` rather than the
+    /// venue inventory slots. The venue snapshot semantics ("wallet
+    /// balances are a transfer-in-progress signal, not part of the
+    /// imbalance math") depend on this separation.
+    #[test]
+    fn apply_snapshot_event_populates_inflight_cash_for_ethereum_usdc() {
+        let view = InventoryView::default();
+        let now = Utc::now();
+        let balance = Usdc::new(float!(123));
+
+        let updated = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::EthereumUsdc {
+                    usdc_balance: balance,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            updated.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+            Some(balance),
+            "EthereumUsdc must populate the Ethereum inflight cash slot",
+        );
+        assert_eq!(
+            updated.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            None,
+            "Ethereum event must not touch the BaseWallet slot",
+        );
+        assert_eq!(
+            updated.usdc_available(Venue::MarketMaking),
+            None,
+            "EthereumUsdc must not initialize venue inventory",
+        );
+        assert_eq!(updated.usdc_available(Venue::Hedging), None);
+    }
+
+    #[test]
+    fn apply_snapshot_event_populates_inflight_cash_for_base_wallet_usdc() {
+        let view = InventoryView::default();
+        let now = Utc::now();
+        let balance = Usdc::new(float!(45));
+
+        let updated = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUsdc {
+                    usdc_balance: balance,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            updated.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            Some(balance),
+            "BaseWalletUsdc must populate the BaseWallet inflight cash slot",
+        );
+        assert_eq!(
+            updated.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+            None,
+            "BaseWallet event must not touch the Ethereum slot",
+        );
+    }
+
+    /// The two inflight tracking systems must remain independent: the
+    /// per-venue `Inventory<Usdc>::inflight` (managed by transfer
+    /// lifecycle events) and the location-keyed `inflight_cash` map
+    /// (populated by wallet polls) describe different things and can
+    /// legitimately coexist mid-transfer.
+    #[test]
+    fn venue_inflight_and_inflight_cash_are_tracked_independently() {
+        let now = Utc::now();
+        let view = make_usdc_view(700, 200, 100, 0)
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::EthereumUsdc {
+                    usdc_balance: Usdc::new(float!(50)),
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        // Venue-level inflight remains exactly as constructed
+        assert_eq!(
+            view.usdc_inflight(Venue::MarketMaking),
+            Some(Usdc::new(float!(200))),
+        );
+        // Wallet-level inflight is captured separately
+        assert_eq!(
+            view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+            Some(Usdc::new(float!(50))),
+        );
+    }
+
+    /// Wallet balances must NOT enter the imbalance math. The design
+    /// explicitly keeps `check_usdc_imbalance` operating on venue totals
+    /// only, so wallet readings can never mask or compensate a real venue
+    /// imbalance. Wallet-residue-driven suppression is deferred to a
+    /// broader orphan-state detection mechanism, where distinguishing
+    /// "in-flight" from "settled-with-baseline" requires transfer history.
+    #[test]
+    fn wallet_balances_do_not_enter_imbalance_math() {
+        let now = Utc::now();
+        let imbalance_without_wallet = make_usdc_view(900, 0, 100, 0)
+            .check_usdc_imbalance(&threshold("0.5", "0.3"))
+            .unwrap();
+        assert!(
+            matches!(
+                imbalance_without_wallet,
+                Some(Imbalance::TooMuchOnchain { .. })
+            ),
+            "venue imbalance is detected without wallet noise, got {imbalance_without_wallet:?}",
+        );
+
+        let with_huge_wallet = make_usdc_view(900, 0, 100, 0)
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUsdc {
+                    usdc_balance: Usdc::new(float!(10000)),
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+        let imbalance_with_wallet = with_huge_wallet
+            .check_usdc_imbalance(&threshold("0.5", "0.3"))
+            .unwrap();
+        assert_eq!(
+            imbalance_without_wallet, imbalance_with_wallet,
+            "wallet readings must not alter the imbalance answer",
+        );
+    }
+
+    /// `force_apply_snapshot_event` must wire the same wallet-read events
+    /// so recovery paths produce identical inflight_cash bookkeeping.
+    #[test]
+    fn force_apply_snapshot_event_also_populates_inflight_cash() {
+        let now = Utc::now();
+        let reason = std::sync::Arc::new(InventoryViewError::UsdBalanceConversion(-1));
+        let view = InventoryView::default()
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::EthereumUsdc {
+                    usdc_balance: Usdc::new(float!(7)),
+                    fetched_at: now,
+                },
+                now,
+                reason.clone(),
+            )
+            .unwrap()
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUsdc {
+                    usdc_balance: Usdc::new(float!(8)),
+                    fetched_at: now,
+                },
+                now,
+                reason,
+            )
+            .unwrap();
+
+        assert_eq!(
+            view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+            Some(Usdc::new(float!(7))),
+        );
+        assert_eq!(
+            view.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            Some(Usdc::new(float!(8))),
+        );
+    }
+
+    /// A wallet poll whose `fetched_at` predates the entry already on file
+    /// must not overwrite it. Polls running concurrently against different
+    /// RPC nodes can land out of order; honouring the older one would let
+    /// stale balances replace fresher ones.
+    #[test]
+    fn set_inflight_cash_ignores_stale_fetched_at() {
+        let earlier = Utc::now();
+        let later = earlier + Duration::seconds(30);
+        let fresh_fetched_at = earlier;
+        let stale_fetched_at = earlier - Duration::seconds(10);
+
+        let view = InventoryView::default()
+            .set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                Usdc::new(float!(100)),
+                fresh_fetched_at,
+                earlier,
+            )
+            .set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                Usdc::new(float!(7)),
+                stale_fetched_at,
+                later,
+            );
+
+        assert_eq!(
+            view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+            Some(Usdc::new(float!(100))),
+            "stale snapshot must not overwrite fresher entry",
+        );
+        assert_eq!(
+            view.last_updated, earlier,
+            "dropping a stale snapshot must not advance last_updated",
+        );
+    }
+
+    /// A snapshot whose `fetched_at` matches the existing entry must
+    /// still replace it. Equal timestamps from the same poll cycle should
+    /// not be treated as stale.
+    #[test]
+    fn set_inflight_cash_replaces_when_fetched_at_equals_existing() {
+        let fetched_at = Utc::now();
+        let now = fetched_at;
+
+        let view = InventoryView::default()
+            .set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                Usdc::new(float!(50)),
+                fetched_at,
+                now,
+            )
+            .set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                Usdc::new(float!(75)),
+                fetched_at,
+                now,
+            );
+
+        assert_eq!(
+            view.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            Some(Usdc::new(float!(75))),
         );
     }
 
@@ -2119,7 +2530,13 @@ mod tests {
         let view = InventoryView {
             equities: std::iter::once((tsla, make_inventory(80, 20, 40, 10))).collect(),
             usdc: usdc_make_inventory(5000, 1000, 3000, 500),
-            ..InventoryView::default()
+            last_updated: Utc::now(),
+            buying_power_cents: None,
+            offchain_gross_usd_cents: None,
+            inflight_cash: HashMap::new(),
+            active_usdc_rebalance: None,
+            active_mints: HashMap::new(),
+            active_redemptions: HashMap::new(),
         };
 
         let dto = view.to_dto();
@@ -2159,7 +2576,13 @@ mod tests {
             ))
             .collect(),
             usdc: Inventory::default(),
-            ..InventoryView::default()
+            last_updated: Utc::now(),
+            buying_power_cents: None,
+            offchain_gross_usd_cents: None,
+            inflight_cash: HashMap::new(),
+            active_usdc_rebalance: None,
+            active_mints: HashMap::new(),
+            active_redemptions: HashMap::new(),
         };
 
         let dto = view.to_dto();
@@ -2171,6 +2594,46 @@ mod tests {
 
         assert_eq!(dto.usdc.onchain_available, Usdc::ZERO);
         assert_eq!(dto.usdc.offchain_available, Usdc::ZERO);
+    }
+
+    /// `to_dto` must expose `inflight_cash` so the dashboard can see USDC
+    /// observed in transit between venues. Locations that have not yet
+    /// been polled remain `None`; observed locations expose their amount.
+    #[test]
+    fn to_dto_includes_inflight_cash() {
+        let fetched_at = Utc::now();
+        let view = InventoryView::default()
+            .set_inflight_cash(
+                InFlightCashLocation::EthereumWallet,
+                Usdc::new(float!(250)),
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_cash(
+                InFlightCashLocation::BaseWallet,
+                Usdc::ZERO,
+                fetched_at,
+                fetched_at,
+            );
+
+        let dto = view.to_dto();
+
+        assert_eq!(
+            dto.usdc.inflight_cash.ethereum_wallet,
+            Some(Usdc::new(float!(250)))
+        );
+        assert_eq!(dto.usdc.inflight_cash.base_wallet, Some(Usdc::ZERO));
+    }
+
+    /// Locations that have never been observed must surface as `None` in
+    /// the DTO so the dashboard can distinguish "not polled yet" from
+    /// "observed as zero".
+    #[test]
+    fn to_dto_inflight_cash_is_none_for_unobserved_locations() {
+        let dto = InventoryView::default().to_dto();
+
+        assert_eq!(dto.usdc.inflight_cash.ethereum_wallet, None);
+        assert_eq!(dto.usdc.inflight_cash.base_wallet, None);
     }
 
     #[test]
@@ -2252,5 +2715,141 @@ mod tests {
             shares(40),
             "Available should reflect the transfer (50 - 10 moved to inflight)"
         );
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct SetInflightCashCall {
+        location: InFlightCashLocation,
+        amount: Usdc,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    }
+
+    fn arb_location() -> impl Strategy<Value = InFlightCashLocation> {
+        use InFlightCashLocation::{BaseWallet, EthereumWallet};
+        prop_oneof![Just(EthereumWallet), Just(BaseWallet)]
+    }
+
+    fn arb_usdc() -> impl Strategy<Value = Usdc> {
+        (0i64..1_000_000_000)
+            .prop_map(|cents| Usdc::from_cents(cents).expect("in-range cents are valid Usdc"))
+    }
+
+    /// Bounded so `Utc.timestamp_millis_opt` is always representable.
+    fn arb_timestamp() -> impl Strategy<Value = DateTime<Utc>> {
+        (0i64..i64::from(u32::MAX)).prop_map(|millis| {
+            Utc.timestamp_millis_opt(millis)
+                .single()
+                .expect("bounded millis are representable")
+        })
+    }
+
+    fn arb_call() -> impl Strategy<Value = SetInflightCashCall> {
+        (arb_location(), arb_usdc(), arb_timestamp(), arb_timestamp()).prop_map(
+            |(location, amount, fetched_at, now)| SetInflightCashCall {
+                location,
+                amount,
+                fetched_at,
+                now,
+            },
+        )
+    }
+
+    fn apply_calls(calls: &[SetInflightCashCall]) -> InventoryView {
+        calls.iter().fold(InventoryView::default(), |view, call| {
+            view.set_inflight_cash(call.location, call.amount, call.fetched_at, call.now)
+        })
+    }
+
+    fn dto_slot(dto: &st0x_dto::Inventory, location: InFlightCashLocation) -> Option<Usdc> {
+        use InFlightCashLocation::{BaseWallet, EthereumWallet};
+        match location {
+            EthereumWallet => dto.usdc.inflight_cash.ethereum_wallet,
+            BaseWallet => dto.usdc.inflight_cash.base_wallet,
+        }
+    }
+
+    const LOCATIONS: [InFlightCashLocation; 2] = [
+        InFlightCashLocation::EthereumWallet,
+        InFlightCashLocation::BaseWallet,
+    ];
+
+    proptest! {
+        /// Each slot must equal the amount from the call with the maximum
+        /// `fetched_at` for that location. `max_by_key` keeps the latest
+        /// tie, matching the "equal timestamps replace" semantics.
+        #[test]
+        fn set_inflight_cash_keeps_freshest_per_location(
+            calls in prop::collection::vec(arb_call(), 0..16),
+        ) {
+            let dto = apply_calls(&calls).to_dto();
+
+            for location in LOCATIONS {
+                let expected = calls
+                    .iter()
+                    .filter(|call| call.location == location)
+                    .max_by_key(|call| call.fetched_at)
+                    .map(|call| call.amount);
+
+                prop_assert_eq!(dto_slot(&dto, location), expected);
+            }
+        }
+
+        /// Writes targeting one location must never mutate the other slot.
+        #[test]
+        fn set_inflight_cash_does_not_touch_other_location(
+            mut calls in prop::collection::vec(arb_call(), 1..16),
+            untouched in arb_location(),
+        ) {
+            use InFlightCashLocation::{BaseWallet, EthereumWallet};
+
+            let target = match untouched {
+                EthereumWallet => BaseWallet,
+                BaseWallet => EthereumWallet,
+            };
+            for call in &mut calls {
+                call.location = target;
+            }
+
+            let dto = apply_calls(&calls).to_dto();
+            prop_assert_eq!(dto_slot(&dto, untouched), None);
+        }
+
+        /// `last_updated` must equal the `now` of the most recent accepted
+        /// call. Stale calls (fetched_at strictly older than the entry on
+        /// file) must not advance the clock.
+        #[test]
+        fn set_inflight_cash_last_updated_advances_only_on_accept(
+            calls in prop::collection::vec(arb_call(), 1..16),
+        ) {
+            let mut stored: HashMap<InFlightCashLocation, DateTime<Utc>> = HashMap::new();
+            let mut expected: Option<DateTime<Utc>> = None;
+
+            for call in &calls {
+                if stored.get(&call.location).is_none_or(|seen| *seen <= call.fetched_at) {
+                    stored.insert(call.location, call.fetched_at);
+                    expected = Some(call.now);
+                }
+            }
+
+            prop_assert_eq!(
+                apply_calls(&calls).last_updated,
+                expected.expect("first call always accepts against an empty map"),
+            );
+        }
+
+        /// The DTO slot must equal the view's stored amount at every
+        /// location for any sequence of writes.
+        #[test]
+        fn to_dto_round_trips_inflight_cash(
+            calls in prop::collection::vec(arb_call(), 0..16),
+        ) {
+            let view = apply_calls(&calls);
+            let dto = view.to_dto();
+
+            for location in LOCATIONS {
+                prop_assert_eq!(dto_slot(&dto, location), view.inflight_cash_at(location));
+            }
+        }
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1028,14 +1028,14 @@ impl RebalancingTrigger {
                     })
             }
 
-            OffchainUsd { .. } | OffchainMarginSafeBuyingPower { .. } => {
-                inventory.clone().apply_snapshot_event(&event, now)
-            }
+            OffchainUsd { .. }
+            | OffchainMarginSafeBuyingPower { .. }
+            | EthereumUsdc { .. }
+            | BaseWalletUsdc { .. } => inventory.clone().apply_snapshot_event(&event, now),
 
-            EthereumUsdc { .. }
-            | BaseWalletUsdc { .. }
-            | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
+            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => {
+                Ok(inventory.clone())
+            }
 
             InflightEquity { .. } => {
                 if let Some((mints, redemptions)) = &filtered_inflight {
@@ -1154,14 +1154,18 @@ impl RebalancingTrigger {
                     })
             }
 
-            OffchainUsd { .. } | OffchainMarginSafeBuyingPower { .. } => inventory
-                .clone()
-                .force_apply_snapshot_event(&event, now, recovery_reason),
+            OffchainUsd { .. }
+            | OffchainMarginSafeBuyingPower { .. }
+            | EthereumUsdc { .. }
+            | BaseWalletUsdc { .. } => {
+                inventory
+                    .clone()
+                    .force_apply_snapshot_event(&event, now, recovery_reason)
+            }
 
-            EthereumUsdc { .. }
-            | BaseWalletUsdc { .. }
-            | BaseWalletUnwrappedEquity { .. }
-            | BaseWalletWrappedEquity { .. } => Ok(inventory.clone()),
+            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => {
+                Ok(inventory.clone())
+            }
 
             // Recovery for inflight snapshots: forward the original fetched_at
             // so is_stale_for_symbol still rejects pre-rebalancing polls.
@@ -1205,6 +1209,10 @@ impl RebalancingTrigger {
             OnchainUsdc { .. } | OffchainUsd { .. } => {
                 self.check_and_trigger_usdc().await;
             }
+            // Wallet-read USDC events update `inflight_cash` for visibility
+            // but don't drive triggers here. Suppression-aware
+            // re-triggering will be added once orphan-vs-baseline
+            // detection is in place.
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }


### PR DESCRIPTION
## What

Introduces an `inflight_cash` map on `InventoryView` that tracks USDC observed at intermediate wallet locations (`Ethereum` and `BaseWallet`) between the two venues. `EthereumUsdc` and `BaseWalletUsdc` snapshot events now populate this map instead of being silently discarded. The `RebalancingTrigger` is updated to forward these events through `apply_snapshot_event` and `force_apply_snapshot_event` accordingly.

## Why

Wallet-read USDC balances represent funds in transit between venues (e.g. between an Alpaca withdrawal and a CCTP burn, or between a CCTP mint and a vault deposit). Previously these events were no-ops, meaning the information was thrown away entirely. Capturing them in a dedicated `inflight_cash` map makes the in-transit state visible for observability and lays the groundwork for orphan-state detection without polluting the venue imbalance math.

## How

A new `InFlightCashLocation` enum (`Ethereum`, `BaseWallet`) keys a `HashMap<InFlightCashLocation, InFlightCashEntry>` stored on `InventoryView`. Each entry carries the `amount` and the `fetched_at` timestamp from the originating snapshot.

`set_inflight_cash` enforces a freshness guard: if the incoming `fetched_at` is strictly older than the entry already on file, the update is dropped and a `warn!` is emitted. This prevents concurrent or out-of-order RPC polls from overwriting a fresher reading with a stale one. Equal timestamps are treated as valid replacements.

`check_usdc_imbalance` is intentionally left unchanged — wallet readings never enter the imbalance math. The design keeps imbalance detection strictly venue-scoped so wallet residue cannot mask or compensate a real venue imbalance. Suppression based on wallet residue is deferred to a future orphan-state detection mechanism.

## Testing

- `apply_ethereum_usdc_populates_inflight_cash_only` and `apply_base_wallet_usdc_populates_inflight_cash_only` verify that wallet-read events populate only the correct `inflight_cash` slot and leave venue inventory untouched.
- `apply_wallet_equity_events_remain_noops_on_view` confirms that `BaseWalletUnwrappedEquity` and `BaseWalletWrappedEquity` remain no-ops on both venue equity and `inflight_cash`.
- `venue_inflight_and_inflight_cash_are_tracked_independently` asserts that per-venue transfer inflight and the wallet-level `inflight_cash` map coexist without interfering.
- `wallet_balances_do_not_enter_imbalance_math` verifies that even a very large wallet balance does not alter the result of `check_usdc_imbalance`.
- `force_apply_snapshot_event_also_populates_inflight_cash` ensures the recovery code path produces identical bookkeeping.
- `set_inflight_cash_ignores_stale_fetched_at` and `set_inflight_cash_replaces_when_fetched_at_equals_existing` cover the freshness-guard boundary conditions.

## Anything else

Trigger-level suppression for wallet-residue (i.e. holding off a rebalance when funds are visibly in transit) is explicitly out of scope here. A comment in `RebalancingTrigger::on_snapshot_event` notes that this will be wired once orphan-vs-baseline detection is in place, since distinguishing "in-flight" from "settled with a new baseline" requires transfer history context.

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith` with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tracking and display of USDC balances in intermediate wallet locations (Ethereum and Base wallets), now visible in inventory data and dashboard with location-specific balance details.

* **Tests**
  * Expanded test coverage for wallet-read USDC tracking, event routing, and inventory serialization logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/644)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->