### PR TITLE
refactor: import InventorySnapshotEvent variants in fn bodies

### DIFF
--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -103,7 +103,7 @@ mod tests {
     use crate::inventory::snapshot::{
         InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
     };
-    use crate::inventory::view::InFlightCashLocation;
+    use crate::inventory::view::{InFlightCashLocation, InFlightEquityLocation};
     use crate::inventory::{InventoryView, Venue};
     use crate::test_utils::setup_test_db;
 
@@ -134,6 +134,50 @@ mod tests {
     async fn read_usdc_available(inventory: &BroadcastingInventory, venue: Venue) -> Option<Usdc> {
         let view = inventory.read().await;
         view.usdc_available(venue)
+    }
+
+    /// Snapshot of USDC balances at every tracked location for a single
+    /// assertion -- venue inventory plus wallet readings.
+    struct UsdcLocationsSnapshot {
+        mm_available: Option<Usdc>,
+        hedging_available: Option<Usdc>,
+        ethereum_inflight: Option<Usdc>,
+        base_wallet_inflight: Option<Usdc>,
+    }
+
+    impl UsdcLocationsSnapshot {
+        async fn read(inventory: &BroadcastingInventory) -> Self {
+            let view = inventory.read().await;
+            Self {
+                mm_available: view.usdc_available(Venue::MarketMaking),
+                hedging_available: view.usdc_available(Venue::Hedging),
+                ethereum_inflight: view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
+                base_wallet_inflight: view.inflight_cash_at(InFlightCashLocation::BaseWallet),
+            }
+        }
+    }
+
+    /// Snapshot of equity balances at every tracked location for a
+    /// single symbol -- venue inventory plus wallet readings.
+    struct EquityLocationsSnapshot {
+        mm_available: Option<FractionalShares>,
+        hedging_available: Option<FractionalShares>,
+        unwrapped_inflight: Option<FractionalShares>,
+        wrapped_inflight: Option<FractionalShares>,
+    }
+
+    impl EquityLocationsSnapshot {
+        async fn read(inventory: &BroadcastingInventory, symbol: &Symbol) -> Self {
+            let view = inventory.read().await;
+            Self {
+                mm_available: view.equity_available(symbol, Venue::MarketMaking),
+                hedging_available: view.equity_available(symbol, Venue::Hedging),
+                unwrapped_inflight: view
+                    .inflight_equity_at(symbol, InFlightEquityLocation::BaseWalletUnwrapped),
+                wrapped_inflight: view
+                    .inflight_equity_at(symbol, InFlightEquityLocation::BaseWalletWrapped),
+            }
+        }
     }
 
     #[tokio::test]
@@ -187,28 +231,19 @@ mod tests {
 
         projection.apply(&event).await.unwrap();
 
-        let (mm_available, hedging_available, ethereum_inflight, base_wallet_inflight) = {
-            let view = inventory.read().await;
-            (
-                view.usdc_available(Venue::MarketMaking),
-                view.usdc_available(Venue::Hedging),
-                view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
-                view.inflight_cash_at(InFlightCashLocation::BaseWallet),
-            )
-        };
-
+        let snapshot = UsdcLocationsSnapshot::read(&inventory).await;
         assert_eq!(
-            mm_available, None,
+            snapshot.mm_available, None,
             "EthereumUsdc must not touch tracked venue inventory slots",
         );
-        assert_eq!(hedging_available, None);
+        assert_eq!(snapshot.hedging_available, None);
         assert_eq!(
-            ethereum_inflight,
+            snapshot.ethereum_inflight,
             Some(balance),
             "EthereumUsdc must populate the Ethereum inflight cash slot",
         );
         assert_eq!(
-            base_wallet_inflight, None,
+            snapshot.base_wallet_inflight, None,
             "BaseWallet inflight cash must remain untouched",
         );
     }
@@ -225,48 +260,61 @@ mod tests {
 
         projection.apply(&event).await.unwrap();
 
-        let (mm_available, hedging_available, ethereum_inflight, base_wallet_inflight) = {
-            let view = inventory.read().await;
-            (
-                view.usdc_available(Venue::MarketMaking),
-                view.usdc_available(Venue::Hedging),
-                view.inflight_cash_at(InFlightCashLocation::EthereumWallet),
-                view.inflight_cash_at(InFlightCashLocation::BaseWallet),
-            )
-        };
-
+        let snapshot = UsdcLocationsSnapshot::read(&inventory).await;
         assert_eq!(
-            mm_available, None,
+            snapshot.mm_available, None,
             "BaseWalletUsdc must not touch tracked venue inventory slots",
         );
-        assert_eq!(hedging_available, None);
+        assert_eq!(snapshot.hedging_available, None);
         assert_eq!(
-            base_wallet_inflight,
+            snapshot.base_wallet_inflight,
             Some(balance),
             "BaseWalletUsdc must populate the BaseWallet inflight cash slot",
         );
         assert_eq!(
-            ethereum_inflight, None,
+            snapshot.ethereum_inflight, None,
             "Ethereum inflight cash must remain untouched",
         );
     }
 
     #[tokio::test]
-    async fn apply_wallet_equity_events_remain_noops_on_view() {
+    async fn apply_base_wallet_unwrapped_equity_populates_inflight_equity_only() {
         let (projection, inventory) = make_projection();
 
-        let mut balances = std::collections::BTreeMap::new();
+        let mut balances = BTreeMap::new();
         balances.insert(symbol("AAPL"), shares(10));
-
-        let inflight_cash_before = inventory.read().await.inflight_cash_snapshot();
 
         projection
             .apply(&InventorySnapshotEvent::BaseWalletUnwrappedEquity {
-                balances: balances.clone(),
+                balances,
                 fetched_at: Utc::now(),
             })
             .await
             .unwrap();
+
+        let snapshot = EquityLocationsSnapshot::read(&inventory, &symbol("AAPL")).await;
+        assert_eq!(
+            snapshot.mm_available, None,
+            "BaseWalletUnwrappedEquity must not touch tracked venue inventory slots",
+        );
+        assert_eq!(snapshot.hedging_available, None);
+        assert_eq!(
+            snapshot.unwrapped_inflight,
+            Some(shares(10)),
+            "BaseWalletUnwrappedEquity must populate the BaseWalletUnwrapped slot",
+        );
+        assert_eq!(
+            snapshot.wrapped_inflight, None,
+            "BaseWalletWrapped slot must remain untouched",
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_base_wallet_wrapped_equity_populates_inflight_equity_only() {
+        let (projection, inventory) = make_projection();
+
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol("AAPL"), shares(7));
 
         projection
             .apply(&InventorySnapshotEvent::BaseWalletWrappedEquity {
@@ -276,22 +324,20 @@ mod tests {
             .await
             .unwrap();
 
-        let (mm_available, hedging_available, inflight_cash_after) = {
-            let view = inventory.read().await;
-            (
-                view.equity_available(&symbol("AAPL"), Venue::MarketMaking),
-                view.equity_available(&symbol("AAPL"), Venue::Hedging),
-                view.inflight_cash_snapshot(),
-            )
-        };
+        let snapshot = EquityLocationsSnapshot::read(&inventory, &symbol("AAPL")).await;
         assert_eq!(
-            mm_available, None,
-            "BaseWalletUnwrappedEquity / BaseWalletWrappedEquity stay no-ops on venue equity",
+            snapshot.mm_available, None,
+            "BaseWalletWrappedEquity must not touch tracked venue inventory slots",
         );
-        assert_eq!(hedging_available, None);
+        assert_eq!(snapshot.hedging_available, None);
         assert_eq!(
-            inflight_cash_after, inflight_cash_before,
-            "wallet equity events must not mutate inflight_cash either",
+            snapshot.wrapped_inflight,
+            Some(shares(7)),
+            "BaseWalletWrappedEquity must populate the BaseWalletWrapped slot",
+        );
+        assert_eq!(
+            snapshot.unwrapped_inflight, None,
+            "BaseWalletUnwrapped slot must remain untouched",
         );
     }
 

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -662,6 +662,30 @@ pub(crate) struct InFlightCashEntry {
     pub(crate) fetched_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct InFlightEquityEntry {
+    pub(crate) amount: FractionalShares,
+    pub(crate) fetched_at: DateTime<Utc>,
+}
+
+/// Locations where equity tokens may sit in transit between venues.
+///
+/// Like [`InFlightCashLocation`], these slots are populated from
+/// wallet-read snapshots and never enter the imbalance math. They
+/// give visibility into capital that has left one venue but has not
+/// yet landed on the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) enum InFlightEquityLocation {
+    /// Unwrapped equity tokens parked on the Base wallet (issuer
+    /// tokens not yet wrapped into vault shares, or unwrapped tokens
+    /// awaiting redemption journal to Alpaca).
+    BaseWalletUnwrapped,
+    /// Wrapped equity tokens parked on the Base wallet (vault shares
+    /// awaiting deposit into Raindex, or shares withdrawn from the
+    /// vault awaiting unwrapping).
+    BaseWalletWrapped,
+}
+
 /// Cross-aggregate projection tracking inventory across venues.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct InventoryView {
@@ -700,6 +724,17 @@ pub(crate) struct InventoryView {
     /// on terminal redemption events.
     #[serde(default)]
     active_redemptions: HashMap<Symbol, RedemptionAggregateId>,
+    /// Equity tokens observed at intermediate wallet locations between
+    /// the two venues, keyed by `(symbol, location)`. Populated from
+    /// wallet-read snapshots; does not feed the imbalance math.
+    ///
+    /// Wallet readings replace any prior value at the same location only when
+    /// the incoming `fetched_at` is at least as recent as the existing entry's.
+    /// Polls running concurrently against different RPC nodes can land out of
+    /// order, so dropping older snapshots prevents a stale reading from
+    /// overwriting a fresher one.
+    #[serde(default)]
+    inflight_equity: HashMap<(Symbol, InFlightEquityLocation), InFlightEquityEntry>,
 }
 
 impl InventoryView {
@@ -833,6 +868,7 @@ impl Default for InventoryView {
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
+            inflight_equity: HashMap::new(),
         }
     }
 }
@@ -919,13 +955,17 @@ impl InventoryView {
         self.inflight_cash.get(&location).map(|entry| entry.amount)
     }
 
-    /// Returns a clone of the full in-flight cash map for use in tests
-    /// that need to assert no-op semantics across multiple events.
+    /// Returns the in-flight equity tokens observed at the given
+    /// intermediate location for a symbol.
     #[cfg(test)]
-    pub(crate) fn inflight_cash_snapshot(
+    pub(crate) fn inflight_equity_at(
         &self,
-    ) -> HashMap<InFlightCashLocation, InFlightCashEntry> {
-        self.inflight_cash.clone()
+        symbol: &Symbol,
+        location: InFlightEquityLocation,
+    ) -> Option<FractionalShares> {
+        self.inflight_equity
+            .get(&(symbol.clone(), location))
+            .map(|entry| entry.amount)
     }
 
     pub(crate) fn update_equity(
@@ -954,6 +994,7 @@ impl InventoryView {
             active_usdc_rebalance: self.active_usdc_rebalance,
             active_mints: self.active_mints,
             active_redemptions: self.active_redemptions,
+            inflight_equity: self.inflight_equity,
         })
     }
 
@@ -974,6 +1015,7 @@ impl InventoryView {
             active_usdc_rebalance: self.active_usdc_rebalance,
             active_mints: self.active_mints,
             active_redemptions: self.active_redemptions,
+            inflight_equity: self.inflight_equity,
         })
     }
 
@@ -1010,6 +1052,62 @@ impl InventoryView {
         self
     }
 
+    /// Record the latest wallet-read equity balances at an intermediate
+    /// location.
+    ///
+    /// Wallet readings replace any prior value at the same location only when
+    /// the incoming `fetched_at` is at least as recent as the existing entry's.
+    /// Polls running concurrently against different RPC nodes can land out of
+    /// order, so dropping older snapshots prevents a stale reading from
+    /// overwriting a fresher one.
+    ///
+    /// If any existing entry at this location is fresher than `fetched_at`,
+    /// the entire snapshot is rejected without modification.
+    ///
+    /// Otherwise, symbols absent from `balances` are removed from the view,
+    /// matching what the wallet reports.
+    pub(crate) fn set_inflight_equity_at_location(
+        mut self,
+        location: InFlightEquityLocation,
+        balances: &BTreeMap<Symbol, FractionalShares>,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Self {
+        // Check if any existing entries at this location are fresher than the
+        // incoming snapshot. If so, reject it completely.
+        let is_stale = self
+            .inflight_equity
+            .iter()
+            .filter(|((_, existing_location), _)| *existing_location == location)
+            .any(|(_, entry)| entry.fetched_at > fetched_at);
+
+        if is_stale {
+            warn!(
+                target: "inventory",
+                ?location,
+                incoming_fetched_at = ?fetched_at,
+                "ignoring stale inflight_equity snapshot for location",
+            );
+            return self;
+        }
+
+        self.inflight_equity
+            .retain(|(_, existing_location), _| *existing_location != location);
+
+        for (symbol, amount) in balances {
+            self.inflight_equity.insert(
+                (symbol.clone(), location),
+                InFlightEquityEntry {
+                    amount: *amount,
+                    fetched_at,
+                },
+            );
+        }
+
+        self.last_updated = now;
+        self
+    }
+
     pub(crate) fn clear_equity_inflight(
         self,
         symbol: &Symbol,
@@ -1036,6 +1134,7 @@ impl InventoryView {
             active_usdc_rebalance: self.active_usdc_rebalance,
             active_mints: self.active_mints,
             active_redemptions: self.active_redemptions,
+            inflight_equity: self.inflight_equity,
         })
     }
 
@@ -1057,6 +1156,7 @@ impl InventoryView {
             active_usdc_rebalance: self.active_usdc_rebalance,
             active_mints: self.active_mints,
             active_redemptions: self.active_redemptions,
+            inflight_equity: self.inflight_equity,
         })
     }
 
@@ -1327,7 +1427,25 @@ impl InventoryView {
                 now,
             )),
 
-            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => Ok(self),
+            BaseWalletUnwrappedEquity {
+                balances,
+                fetched_at,
+            } => Ok(self.set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                balances,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletWrappedEquity {
+                balances,
+                fetched_at,
+            } => Ok(self.set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                balances,
+                *fetched_at,
+                now,
+            )),
 
             InflightEquity {
                 mints, redemptions, ..
@@ -1436,7 +1554,25 @@ impl InventoryView {
                 now,
             )),
 
-            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => Ok(self),
+            BaseWalletUnwrappedEquity {
+                balances,
+                fetched_at,
+            } => Ok(self.set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                balances,
+                *fetched_at,
+                now,
+            )),
+
+            BaseWalletWrappedEquity {
+                balances,
+                fetched_at,
+            } => Ok(self.set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                balances,
+                *fetched_at,
+                now,
+            )),
 
             InflightEquity {
                 mints,
@@ -1706,6 +1842,7 @@ mod tests {
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
+            inflight_equity: HashMap::new(),
         }
     }
 
@@ -1730,6 +1867,7 @@ mod tests {
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
+            inflight_equity: HashMap::new(),
         }
     }
 
@@ -2208,6 +2346,315 @@ mod tests {
     }
 
     #[test]
+    fn set_inflight_equity_ignores_stale_fetched_at() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let earlier = Utc::now();
+        let later = earlier + Duration::seconds(30);
+        let fresh_fetched_at = earlier;
+        let stale_fetched_at = earlier - Duration::seconds(10);
+
+        let mut fresh_balances = BTreeMap::new();
+        fresh_balances.insert(symbol_aapl.clone(), shares(100));
+
+        let mut stale_balances = BTreeMap::new();
+        stale_balances.insert(symbol_aapl.clone(), shares(7));
+
+        let view = InventoryView::default()
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &fresh_balances,
+                fresh_fetched_at,
+                earlier,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &stale_balances,
+                stale_fetched_at,
+                later,
+            );
+
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            Some(shares(100)),
+            "stale snapshot must not overwrite fresher entry",
+        );
+        assert_eq!(
+            view.last_updated, earlier,
+            "dropping a stale snapshot must not advance last_updated",
+        );
+    }
+
+    #[test]
+    fn set_inflight_equity_replaces_when_fetched_at_equals_existing() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let fetched_at = Utc::now();
+        let now = fetched_at;
+
+        let mut first_balances = BTreeMap::new();
+        first_balances.insert(symbol_aapl.clone(), shares(50));
+
+        let mut second_balances = BTreeMap::new();
+        second_balances.insert(symbol_aapl.clone(), shares(75));
+
+        let view = InventoryView::default()
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &first_balances,
+                fetched_at,
+                now,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &second_balances,
+                fetched_at,
+                now,
+            );
+
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            Some(shares(75)),
+        );
+    }
+
+    #[test]
+    fn apply_snapshot_event_populates_inflight_equity_for_base_wallet_unwrapped() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol_aapl.clone(), shares(12));
+
+        let view = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                    balances,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            Some(shares(12)),
+            "BaseWalletUnwrappedEquity must populate the BaseWalletUnwrapped slot",
+        );
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletWrapped),
+            None,
+            "BaseWalletWrapped slot must remain untouched",
+        );
+        assert_eq!(
+            view.equity_available(&symbol_aapl, Venue::MarketMaking),
+            None,
+            "wallet read must not initialize venue inventory",
+        );
+        assert_eq!(view.equity_available(&symbol_aapl, Venue::Hedging), None);
+    }
+
+    #[test]
+    fn apply_snapshot_event_populates_inflight_equity_for_base_wallet_wrapped() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol_aapl.clone(), shares(9));
+
+        let view = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletWrappedEquity {
+                    balances,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletWrapped),
+            Some(shares(9)),
+        );
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            None,
+        );
+    }
+
+    /// Wallet readings replace the prior balances at that location:
+    /// symbols absent from the new map drop out of the inflight_equity
+    /// map even if previously seen, because the chain reading is
+    /// authoritative.
+    #[test]
+    fn apply_snapshot_event_replaces_inflight_equity_at_same_location() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let symbol_tsla = Symbol::new("TSLA").unwrap();
+        let now = Utc::now();
+
+        let mut first = BTreeMap::new();
+        first.insert(symbol_aapl.clone(), shares(5));
+        first.insert(symbol_tsla.clone(), shares(3));
+
+        let after_first = InventoryView::default()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                    balances: first,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        let mut second = BTreeMap::new();
+        second.insert(symbol_aapl.clone(), shares(2));
+
+        let after_second = after_first
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                    balances: second,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            after_second
+                .inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            Some(shares(2)),
+            "AAPL balance must reflect the latest wallet read",
+        );
+        assert_eq!(
+            after_second
+                .inflight_equity_at(&symbol_tsla, InFlightEquityLocation::BaseWalletUnwrapped),
+            None,
+            "TSLA must drop out when absent from the latest wallet read",
+        );
+    }
+
+    /// The two equity inflight tracking systems must remain independent:
+    /// `Inventory<FractionalShares>::inflight` (managed by tokenization
+    /// lifecycle events) and the location-keyed `inflight_equity` map
+    /// (populated by wallet polls) describe different things and can
+    /// legitimately coexist mid-transfer.
+    #[test]
+    fn venue_inflight_and_inflight_equity_are_tracked_independently() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let mut mints = BTreeMap::new();
+        mints.insert(symbol_aapl.clone(), shares(15));
+
+        let mut wallet_balances = BTreeMap::new();
+        wallet_balances.insert(symbol_aapl.clone(), shares(4));
+
+        let view = InventoryView::default()
+            .apply_inflight_snapshot(&mints, &BTreeMap::new(), now, now)
+            .unwrap()
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletWrappedEquity {
+                    balances: wallet_balances,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            view.equity_inflight(&symbol_aapl, Venue::Hedging),
+            Some(shares(15)),
+            "venue-level inflight reflects mint snapshot",
+        );
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletWrapped),
+            Some(shares(4)),
+            "location-level inflight reflects the wallet read",
+        );
+    }
+
+    /// Wallet equity balances must NOT enter the imbalance math --
+    /// `check_equity_imbalance` operates on venue totals only, so wallet
+    /// readings can never mask or compensate a real venue imbalance.
+    #[test]
+    fn wallet_equity_balances_do_not_enter_imbalance_math() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let baseline =
+            InventoryView::default().with_equity(symbol_aapl.clone(), shares(90), shares(10));
+
+        let imbalance_without_wallet = baseline
+            .check_equity_imbalance(&symbol_aapl, &threshold("0.5", "0.3"), &one_to_one_ratio())
+            .unwrap();
+        assert!(
+            matches!(
+                imbalance_without_wallet,
+                Some(Imbalance::TooMuchOnchain { .. })
+            ),
+            "venue imbalance is detected without wallet noise, got {imbalance_without_wallet:?}",
+        );
+
+        let mut wallet_balances = BTreeMap::new();
+        wallet_balances.insert(symbol_aapl.clone(), shares(10_000));
+
+        let with_huge_wallet = baseline
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletWrappedEquity {
+                    balances: wallet_balances,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        let imbalance_with_wallet = with_huge_wallet
+            .check_equity_imbalance(&symbol_aapl, &threshold("0.5", "0.3"), &one_to_one_ratio())
+            .unwrap();
+        assert_eq!(
+            imbalance_without_wallet, imbalance_with_wallet,
+            "wallet equity readings must not alter the imbalance answer",
+        );
+    }
+
+    #[test]
+    fn force_apply_snapshot_event_also_populates_inflight_equity() {
+        let symbol_aapl = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let reason = std::sync::Arc::new(InventoryViewError::UsdBalanceConversion(-1));
+
+        let mut unwrapped = BTreeMap::new();
+        unwrapped.insert(symbol_aapl.clone(), shares(2));
+        let mut wrapped = BTreeMap::new();
+        wrapped.insert(symbol_aapl.clone(), shares(3));
+
+        let view = InventoryView::default()
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                    balances: unwrapped,
+                    fetched_at: now,
+                },
+                now,
+                reason.clone(),
+            )
+            .unwrap()
+            .force_apply_snapshot_event(
+                &InventorySnapshotEvent::BaseWalletWrappedEquity {
+                    balances: wrapped,
+                    fetched_at: now,
+                },
+                now,
+                reason,
+            )
+            .unwrap();
+
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletUnwrapped),
+            Some(shares(2)),
+        );
+        assert_eq!(
+            view.inflight_equity_at(&symbol_aapl, InFlightEquityLocation::BaseWalletWrapped),
+            Some(shares(3)),
+        );
+    }
+
+    #[test]
     fn on_snapshot_rejects_stale_snapshot_predating_last_rebalancing() {
         let last_rebalancing = Utc::now();
         let stale_fetched_at = last_rebalancing - Duration::seconds(10);
@@ -2537,6 +2984,7 @@ mod tests {
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
+            inflight_equity: HashMap::new(),
         };
 
         let dto = view.to_dto();
@@ -2583,6 +3031,7 @@ mod tests {
             active_usdc_rebalance: None,
             active_mints: HashMap::new(),
             active_redemptions: HashMap::new(),
+            inflight_equity: HashMap::new(),
         };
 
         let dto = view.to_dto();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1031,11 +1031,9 @@ impl RebalancingTrigger {
             OffchainUsd { .. }
             | OffchainMarginSafeBuyingPower { .. }
             | EthereumUsdc { .. }
-            | BaseWalletUsdc { .. } => inventory.clone().apply_snapshot_event(&event, now),
-
-            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => {
-                Ok(inventory.clone())
-            }
+            | BaseWalletUsdc { .. }
+            | BaseWalletUnwrappedEquity { .. }
+            | BaseWalletWrappedEquity { .. } => inventory.clone().apply_snapshot_event(&event, now),
 
             InflightEquity { .. } => {
                 if let Some((mints, redemptions)) = &filtered_inflight {
@@ -1157,14 +1155,12 @@ impl RebalancingTrigger {
             OffchainUsd { .. }
             | OffchainMarginSafeBuyingPower { .. }
             | EthereumUsdc { .. }
-            | BaseWalletUsdc { .. } => {
+            | BaseWalletUsdc { .. }
+            | BaseWalletUnwrappedEquity { .. }
+            | BaseWalletWrappedEquity { .. } => {
                 inventory
                     .clone()
                     .force_apply_snapshot_event(&event, now, recovery_reason)
-            }
-
-            BaseWalletUnwrappedEquity { .. } | BaseWalletWrappedEquity { .. } => {
-                Ok(inventory.clone())
             }
 
             // Recovery for inflight snapshots: forward the original fetched_at


### PR DESCRIPTION
## What

Adds an `InFlightEquityLocation` enum and an `inflight_equity` map to `InventoryView` to track equity tokens observed at intermediate wallet locations (`BaseWalletUnwrapped` and `BaseWalletWrapped`) between venues. Previously, `BaseWalletUnwrappedEquity` and `BaseWalletWrappedEquity` snapshot events were silently ignored (treated as no-ops) in both `InventoryView` and `RebalancingTrigger`. They now populate the new `inflight_equity` map.

## Why

Equity tokens in transit between venues — unwrapped issuer tokens awaiting wrapping, or vault shares awaiting deposit into Raindex — were invisible to the inventory view. Recording them at their intermediate wallet locations gives observability into capital that has left one venue but has not yet arrived at the other, without affecting imbalance math.

## How

`InFlightEquityLocation` mirrors the existing `InFlightCashLocation` pattern. The `inflight_equity` field is a `HashMap<(Symbol, InFlightEquityLocation), FractionalShares>` keyed by symbol and location. `set_inflight_equity_at_location` replaces all entries for a given location with the latest wallet-read balances, making the chain reading authoritative — symbols absent from the new snapshot drop out of the map entirely.

The `inflight_equity` map is intentionally excluded from imbalance math; it is read-only visibility data. Both `apply_snapshot_event` and `force_apply_snapshot_event` now route `BaseWalletUnwrappedEquity` and `BaseWalletWrappedEquity` through `set_inflight_equity_at_location` instead of returning early. The same change is applied in `RebalancingTrigger` so speculative inventory projections also reflect wallet equity readings.

## Testing

- `apply_snapshot_event_populates_inflight_equity_for_base_wallet_unwrapped` — verifies the `BaseWalletUnwrapped` slot is populated and the `BaseWalletWrapped` slot is untouched.
- `apply_snapshot_event_populates_inflight_equity_for_base_wallet_wrapped` — symmetric test for the wrapped slot.
- `apply_snapshot_event_replaces_inflight_equity_at_same_location` — verifies that a subsequent wallet read replaces prior balances, including dropping symbols absent from the new snapshot.
- `venue_inflight_and_inflight_equity_are_tracked_independently` — verifies that the venue-level inflight system and the location-keyed `inflight_equity` map coexist without interfering.
- `wallet_equity_balances_do_not_enter_imbalance_math` — verifies that even a very large wallet balance cannot mask or compensate a real venue imbalance.
- `force_apply_snapshot_event_also_populates_inflight_equity` — verifies the force-apply path populates both unwrapped and wrapped slots.
- Projection-level tests replaced the single combined `apply_wallet_equity_events_remain_noops_on_view` test with two focused tests (`apply_base_wallet_unwrapped_equity_populates_inflight_equity_only` and `apply_base_wallet_wrapped_equity_populates_inflight_equity_only`) using the new `EquityLocationsSnapshot` helper, mirroring the existing `UsdcLocationsSnapshot` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track wallet in-flight equity separately for unwrapped and wrapped base-wallet locations; inventory now records these in-flight equity snapshots.

* **Bug Fixes**
  * Snapshot handling updated so base-wallet equity snapshot events are applied during normal and recovery flows (no longer ignored).

* **Tests**
  * Refactored inventory projection tests to use aggregated snapshot helpers and simplified assertions for improved coverage and clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/645)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->