### PR TITLE
feat: track USDC wallet balances in inventory view

### DIFF
--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -225,12 +225,36 @@ impl std::fmt::Display for TransferStatus {
 
 /// Snapshot of a wallet transfer, returned by
 /// [`AlpacaBrokerMock::wallet_transfers`].
+///
+/// Direction-specific counterparty data lives in [`TransferFlow`]; common
+/// metadata stays on the snapshot so consumers don't pay a match cost for
+/// status / amount / id checks. The `flow` discriminant subsumes any
+/// separate "direction" tag, so neither the meaning of an address nor the
+/// invariant linking address-to-direction needs to be reasoned about.
 pub struct MockWalletTransferSnapshot {
     pub transfer_id: String,
-    pub direction: TransferDirection,
     pub amount: Float,
     pub asset: String,
     pub status: TransferStatus,
+    pub flow: TransferFlow,
+}
+
+/// Direction-specific counterparty data attached to a wallet transfer.
+pub enum TransferFlow {
+    /// USDC moving from Alpaca to an on-chain `recipient`.
+    Outgoing { recipient: Address },
+    /// USDC arriving at Alpaca from an on-chain `sender`.
+    Incoming { sender: Address },
+}
+
+impl TransferFlow {
+    #[must_use]
+    pub fn direction(&self) -> TransferDirection {
+        match self {
+            Self::Outgoing { .. } => TransferDirection::Outgoing,
+            Self::Incoming { .. } => TransferDirection::Incoming,
+        }
+    }
 }
 
 /// Owns the `MockServer` and shared state. All endpoints respond dynamically
@@ -407,10 +431,17 @@ impl AlpacaBrokerMock {
             .iter()
             .map(|transfer| MockWalletTransferSnapshot {
                 transfer_id: transfer.transfer_id.clone(),
-                direction: transfer.direction,
                 amount: transfer.amount,
                 asset: transfer.asset.clone(),
                 status: transfer.status,
+                flow: match transfer.direction {
+                    TransferDirection::Outgoing => TransferFlow::Outgoing {
+                        recipient: transfer.to_address,
+                    },
+                    TransferDirection::Incoming => TransferFlow::Incoming {
+                        sender: transfer.from_address,
+                    },
+                },
             })
             .collect()
     }

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -36,7 +36,7 @@ mod mock_api;
 pub use mock_api::{
     AlpacaBrokerMock, MockMode, MockOrderSnapshot, MockPosition, MockPositionSnapshot,
     MockWalletTransferSnapshot, OrderSide, OrderStatus, TEST_ACCOUNT_ID, TEST_API_KEY,
-    TEST_API_SECRET, TransferDirection, TransferStatus, WhitelistStatus,
+    TEST_API_SECRET, TransferDirection, TransferFlow, TransferStatus, WhitelistStatus,
 };
 mod order;
 mod positions;

--- a/tests/e2e/base_chain.rs
+++ b/tests/e2e/base_chain.rs
@@ -366,6 +366,17 @@ impl<P: Provider + Clone> BaseChain<P> {
         Ok(vault_id)
     }
 
+    /// Sets the owner's USDC wallet balance directly (via Anvil storage
+    /// override). Used by tests to model production-like flows where the
+    /// bot's wallet is empty except mid-transfer.
+    pub async fn set_owner_usdc_balance(&self, amount: U256) -> anyhow::Result<()> {
+        let balance_slot = evm_mapping_slot(self.owner, USDC_BALANCES_SLOT);
+        self.provider
+            .anvil_set_storage_at(USDC_BASE, balance_slot, amount.into())
+            .await?;
+        Ok(())
+    }
+
     /// Deposits tokens into an existing Raindex vault.
     ///
     /// `amount` is in raw units (e.g. 18-decimal for equity tokens).

--- a/tests/e2e/cctp.rs
+++ b/tests/e2e/cctp.rs
@@ -2,20 +2,35 @@
 //!
 //! Deploys CCTP V2 contracts on a second (Ethereum) Anvil chain and on the
 //! existing Base chain from [`TestInfra`], links them, replaces USDC bytecode
-//! with mint/burn tokens, mints USDC on both chains, and starts the
-//! attestation watcher.
+//! with mint/burn tokens, and starts the attestation watcher.
+//!
+//! The bot's wallets start with zero USDC. Inbound USDC arrives only through
+//! the rebalance flow itself: CCTP mints (BaseToAlpaca) or the Alpaca
+//! withdrawal executor that mints on Ethereum when the broker mock records
+//! an OUTGOING transfer (AlpacaToBase). This mirrors production semantics
+//! where wallet balances are non-zero only mid-transfer.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
 
 use alloy::node_bindings::{Anvil, AnvilInstance};
 use alloy::primitives::{Address, B256, U256, utils::parse_units};
 use alloy::providers::Provider;
 use alloy::providers::ext::AnvilApi as _;
 use alloy::signers::local::PrivateKeySigner;
+use futures_util::{StreamExt, stream};
+use rain_math_float::Float;
+use task_supervisor::{SupervisedTask, SupervisorBuilder, SupervisorHandle, TaskResult};
 use tokio::task::JoinHandle;
+use tracing::warn;
 
 use st0x_bridge::cctp::{
     TestMintBurnToken, deploy_cctp_on_chain, link_chains, mint_usdc, set_max_burn_amount,
 };
 use st0x_execution::Symbol;
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, TransferFlow};
+use st0x_finance::Usdc;
 
 use crate::base_chain::USDC_BASE;
 use crate::test_infra::TestInfra;
@@ -36,8 +51,14 @@ pub struct CctpOverrides {
 ///
 /// Deploys CCTP V2 contracts on a second (Ethereum) Anvil chain and on
 /// the existing Base chain from `TestInfra`, links them, replaces Base
-/// USDC with a mint/burn token, mints USDC on both chains, registers
-/// broker wallet endpoints, and starts the attestation watcher.
+/// USDC with a mint/burn token, registers broker wallet endpoints, starts
+/// the attestation watcher, and starts the Alpaca-withdrawal executor that
+/// mints USDC on Ethereum when the broker mock records an OUTGOING wallet
+/// transfer (simulating Alpaca actually sending USDC on completion).
+///
+/// The bot's wallets begin with zero USDC; balances arise only mid-transfer
+/// (Alpaca withdrawal -> Ethereum -> CCTP burn / CCTP mint -> Base wallet
+/// or Ethereum wallet -> Alpaca deposit), matching production semantics.
 pub struct CctpInfra {
     pub ethereum_endpoint: String,
     attestation_base_url: String,
@@ -47,6 +68,7 @@ pub struct CctpInfra {
     // Kept alive so resources aren't dropped while the test runs.
     _ethereum_anvil: AnvilInstance,
     _attestation_watcher: JoinHandle<()>,
+    _supervisor: SupervisorHandle,
 }
 
 impl CctpInfra {
@@ -145,30 +167,25 @@ impl CctpInfra {
         )
         .await?;
 
-        // MockMintBurnToken.mint() has no access control, so any key works.
-        let mint_amount = U256::from(1_000_000_000_000u64); // 1M USDC
-
-        mint_usdc(
-            &infra.base_chain.endpoint(),
-            &cctp_deployer_key,
-            USDC_BASE,
-            infra.base_chain.owner,
-            mint_amount,
-        )
-        .await?;
-
-        mint_usdc(
-            &ethereum_endpoint,
-            &cctp_deployer_key,
-            USDC_ETHEREUM,
-            infra.base_chain.owner,
-            mint_amount,
-        )
-        .await?;
-
         infra
             .broker_service
             .register_wallet_endpoints(infra.base_chain.owner);
+
+        // Simulate Alpaca's withdrawal-side leg: when the broker mock
+        // records an OUTGOING wallet transfer, mint USDC on Ethereum to
+        // the recipient. Without this, AlpacaToBase tests would have
+        // nothing to burn during the CCTP step.
+        let supervisor = SupervisorBuilder::default()
+            .with_task(
+                "alpaca-withdrawal-executor",
+                AlpacaWithdrawalExecutor {
+                    broker: Arc::clone(&infra.broker_service),
+                    ethereum_endpoint: ethereum_endpoint.clone(),
+                    deployer_key: cctp_deployer_key,
+                },
+            )
+            .build()
+            .run();
 
         // USDC/USD conversion is a 1:1 stablecoin pair on Alpaca
         infra
@@ -193,6 +210,7 @@ impl CctpInfra {
             message_transmitter: base_cctp.message_transmitter,
             _ethereum_anvil: ethereum_anvil,
             _attestation_watcher: attestation_watcher,
+            _supervisor: supervisor,
         })
     }
 
@@ -201,6 +219,103 @@ impl CctpInfra {
             attestation_base_url: self.attestation_base_url.clone(),
             token_messenger: self.token_messenger,
             message_transmitter: self.message_transmitter,
+        }
+    }
+}
+
+/// Simulates Alpaca's withdrawal-side leg by polling the broker mock for
+/// OUTGOING wallet transfers and minting USDC on Ethereum to the recipient.
+///
+/// Mints on first observation so the bot's CCTP burn finds USDC available
+/// before the mock flips the transfer's status to `Complete`. The
+/// per-transfer dedupe set is task-local; if `task-supervisor` restarts the
+/// task after a panic, we re-walk all transfers but the on-chain mint
+/// behaves idempotently per `transfer_id` only within a single run -- a
+/// restart could double-mint, which is acceptable for tests.
+#[derive(Clone)]
+struct AlpacaWithdrawalExecutor {
+    broker: Arc<AlpacaBrokerMock>,
+    ethereum_endpoint: String,
+    deployer_key: B256,
+}
+
+/// Outcome of a single mint attempt for an outgoing transfer.
+enum MintAttempt {
+    /// Terminal outcome (success or permanent validation failure). The
+    /// transfer_id should be recorded so we don't re-attempt next tick.
+    Done,
+    /// Transient failure -- leave the transfer_id off the handled set so
+    /// the outer loop re-attempts on the next tick.
+    Retry,
+}
+
+impl AlpacaWithdrawalExecutor {
+    async fn try_mint(&self, transfer_id: &str, recipient: Address, amount: Float) -> MintAttempt {
+        let raw_amount = match Usdc::new(amount).to_u256_6_decimals() {
+            Ok(raw) => raw,
+            Err(error) => {
+                warn!(
+                    %transfer_id,
+                    ?error,
+                    "withdrawal executor: invalid USDC amount, skipping"
+                );
+                return MintAttempt::Done;
+            }
+        };
+
+        match mint_usdc(
+            &self.ethereum_endpoint,
+            &self.deployer_key,
+            USDC_ETHEREUM,
+            recipient,
+            raw_amount,
+        )
+        .await
+        {
+            Ok(()) => MintAttempt::Done,
+            Err(error) => {
+                warn!(
+                    %transfer_id,
+                    ?error,
+                    "withdrawal executor: mint_usdc failed, will retry"
+                );
+                MintAttempt::Retry
+            }
+        }
+    }
+}
+
+impl SupervisedTask for AlpacaWithdrawalExecutor {
+    async fn run(&mut self) -> TaskResult {
+        let this = &*self;
+        let mut minted: HashSet<String> = HashSet::new();
+
+        loop {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            let seen = &minted;
+            let newly_handled: HashSet<String> = stream::iter(this.broker.wallet_transfers())
+                .filter_map(|transfer| async move {
+                    let TransferFlow::Outgoing { recipient } = transfer.flow else {
+                        return None;
+                    };
+
+                    (!seen.contains(&transfer.transfer_id)).then_some((
+                        transfer.transfer_id,
+                        recipient,
+                        transfer.amount,
+                    ))
+                })
+                .filter_map(|(transfer_id, recipient, amount)| async move {
+                    match this.try_mint(&transfer_id, recipient, amount).await {
+                        MintAttempt::Done => Some(transfer_id),
+                        MintAttempt::Retry => None,
+                    }
+                })
+                .collect()
+                .await;
+
+            minted.extend(newly_handled);
         }
     }
 }

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -945,8 +945,6 @@ struct UsdcRebalanceExpectations<'a> {
 struct UsdcRebalanceEventAmounts {
     initiated_amount: U256,
     bridged_amount_received: U256,
-    /// Full amount burned on source chain = amount_received + fee_collected
-    bridged_amount_burned: U256,
 }
 
 fn usdc_rebalance_expectations(
@@ -1041,20 +1039,10 @@ async fn assert_usdc_rebalancing_db_state(
         .get("amount_received")
         .and_then(|val| val.as_str())
         .ok_or_else(|| anyhow::anyhow!("Bridged event missing amount_received"))?;
-    let fee_collected = bridged_payload
-        .get("fee_collected")
-        .and_then(|val| val.as_str())
-        .ok_or_else(|| anyhow::anyhow!("Bridged event missing fee_collected"))?;
-
-    let received_units: U256 = parse_units(amount_received, 6)?.into();
-    let fee_units: U256 = parse_units(fee_collected, 6)?.into();
 
     Ok(UsdcRebalanceEventAmounts {
         initiated_amount: parse_units(initiated_amount_str, 6)?.into(),
-        bridged_amount_received: received_units,
-        bridged_amount_burned: received_units
-            .checked_add(fee_units)
-            .ok_or_else(|| anyhow::anyhow!("burned amount overflow"))?,
+        bridged_amount_received: parse_units(amount_received, 6)?.into(),
     })
 }
 
@@ -1089,7 +1077,7 @@ fn assert_usdc_rebalancing_broker_state(
     let transfers: Vec<_> = broker
         .wallet_transfers()
         .into_iter()
-        .filter(|transfer| transfer.direction == expectations.expected_transfer_direction)
+        .filter(|transfer| transfer.flow.direction() == expectations.expected_transfer_direction)
         .collect();
     assert_eq!(
         transfers.len(),
@@ -1227,15 +1215,15 @@ async fn assert_usdc_rebalancing_onchain_state<P: Provider>(
 
     let expected_ethereum_post_units = match rebalance_type {
         UsdcRebalanceType::AlpacaToBase => {
-            // In production, the Alpaca withdrawal deposits USDC on
-            // Ethereum and the CCTP burn removes the same amount (net
-            // zero). The mock broker records the transfer but does NOT
-            // mint USDC on-chain, so only the burn is reflected. The
-            // burn amount is the full source-chain amount (received +
-            // fee), not just the amount received on the destination.
-            ethereum_usdc_balance_before_rebalance
-                .checked_sub(event_amounts.bridged_amount_burned)
-                .ok_or_else(|| anyhow::anyhow!("Ethereum USDC underflow on AlpacaToBase burn"))?
+            // The Alpaca withdrawal mints USDC to the bot's Ethereum wallet
+            // (via the test fixture's withdrawal executor) and the CCTP
+            // burn removes the same amount, so the wallet returns to its
+            // pre-test baseline of zero. We can't compare against
+            // `ethereum_usdc_balance_before_rebalance` because the test
+            // captures it after the bot starts -- if the watcher has
+            // already minted by that point, the "before" reading reflects
+            // mid-flight state, not baseline.
+            U256::ZERO
         }
         UsdcRebalanceType::BaseToAlpaca => ethereum_usdc_balance_before_rebalance
             .checked_add(event_amounts.bridged_amount_received)

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -799,6 +799,13 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
         );
     }
 
+    // Drain residual owner-wallet USDC after vault + order setup so wallet
+    // polling sees the production-like baseline (0). Without this, the
+    // `BaseWalletUsdc` snapshot would carry the leftover from
+    // `deploy_usdc_at`'s 1B-USDC seeding and trip the wallet-inflight
+    // suppression even though no transfer is in flight.
+    infra.base_chain.set_owner_usdc_balance(U256::ZERO).await?;
+
     let current_block = infra.base_chain.provider.get_block_number().await?;
 
     let ctx = build_usdc_rebalancing_ctx()
@@ -928,6 +935,13 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
     // add ~3.6k USDC (148.6k / 245k = 0.61 > 0.6 threshold).
     let usdc_amount: U256 = parse_units("145000", 6)?.into();
     let usdc_vault_id = infra.base_chain.create_usdc_vault(usdc_amount).await?;
+
+    // Drain residual owner-wallet USDC so wallet polling sees the
+    // production-like baseline (0). Without this, `BaseWalletUsdc`
+    // snapshots would carry the leftover from `deploy_usdc_at`'s
+    // 1B-USDC seeding and trip the wallet-inflight suppression even
+    // though no transfer is in flight.
+    infra.base_chain.set_owner_usdc_balance(U256::ZERO).await?;
 
     // Set up SellEquity orders BEFORE bot starts.
     // All orders share the same USDC input vault as the pre-funded vault


### PR DESCRIPTION
Closes RAI-82.

## What

Tracks USDC balances observed in intermediate wallet locations (Ethereum mainnet, Base wallet) as `inflight_cash` on `InventoryView`, and uses that signal to suppress USDC rebalance re-triggers while a transfer is mid-flight past the source venue's inflight slot.

## Why

After a USDC transfer leaves the source venue, the existing `active_usdc_rebalance` inflight slot is cleared but the capital hasn't yet arrived at the destination. During this window — e.g. while USDC is sitting on Ethereum waiting for CCTP attestation, or in the Base wallet before being deposited into a Raindex vault — the imbalance check still sees a venue imbalance and would fire a duplicate rebalance. The wallet-read snapshots (`EthereumUsdc`, `BaseWalletUsdc`) are the only signal available that a transfer is genuinely in progress at this stage.

## How

- Introduces `InFlightCashLocation` (`Ethereum`, `BaseWallet`) to identify where mid-transit USDC can sit.
- Adds an `inflight_cash: HashMap<InFlightCashLocation, Usdc>` field to `InventoryView`, populated by `EthereumUsdc` and `BaseWalletUsdc` snapshot events via `set_inflight_cash`. The field is excluded from imbalance math.
- `has_inflight_cash()` returns `true` when any location holds a non-zero balance.
- `RebalancingTrigger::check_and_trigger_usdc` calls `wallet_usdc_blocks_trigger()` before claiming the USDC guard; if any wallet location is non-zero the trigger is skipped. Wallet USDC snapshot events are also wired into the post-apply trigger path so the suppression lifts as soon as the wallet drains.
- The `RebalancingTrigger`'s snapshot-apply path now forwards `EthereumUsdc` and `BaseWalletUsdc` events to `apply_snapshot_event` / `force_apply_snapshot_event` instead of treating them as no-ops.
- `MockWalletTransferSnapshot` gains a `to_address` field so the e2e withdrawal executor knows where to mint Ethereum USDC.
- The CCTP e2e fixture no longer pre-mints USDC into the bot's wallets. Instead, a new `start_alpaca_withdrawal_executor` task polls the broker mock for `OUTGOING` transfers and mints Ethereum USDC to the recipient on first observation, matching production semantics where wallet balances are non-zero only mid-transfer. Tests zero out any residual owner wallet USDC left over from vault setup before starting the bot.
- E2e `AlpacaToBase` post-rebalance assertions now expect the Ethereum wallet to return to `U256::ZERO` (mint + burn net to zero) rather than computing a delta from a potentially mid-flight "before" snapshot.

## Testing

- Unit tests in `view.rs`: `ethereum_usdc_event_populates_inflight_cash`, `base_wallet_usdc_event_populates_inflight_cash`, `force_apply_snapshot_event_populates_inflight_cash_for_wallet_usdc_events`, `has_inflight_cash_distinguishes_zero_from_unset`, `check_usdc_imbalance_ignores_inflight_cash`, `wallet_usdc_event_does_not_disturb_venue_inventory`.
- Integration tests in `projection.rs`: `apply_ethereum_usdc_event_records_inflight_cash`, `apply_base_wallet_usdc_event_records_inflight_cash`, `apply_wallet_equity_events_are_noops_on_view`.
- Trigger-level tests: `non_zero_inflight_cash_suppresses_usdc_trigger` verifies suppression fires when a wallet balance is recorded; `cleared_inflight_cash_lifts_usdc_trigger_suppression` verifies the trigger resumes once the wallet drains to zero.
- Existing `usdc_imbalance_triggers_alpaca_to_base` and `usdc_imbalance_triggers_base_to_alpaca` e2e tests updated to reflect the new zero-baseline wallet setup.

## Anything else

Equity wallet-read events (`BaseWalletUnwrappedEquity`, `BaseWalletWrappedEquity`) remain no-ops in this PR; tracking them is deferred to follow-up work noted in the test comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Wallet transfer data structures now expose counterparty-aware transfer flow information, replacing directional-only representations.

* **Tests**
  * Updated end-to-end test infrastructure to simulate production USDC rebalancing behavior with dynamic minting tied to outgoing broker transfers.
  * Revised test assertions and setup to align with updated accounting model and wallet balance handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/647)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->