### PR TITLE
docs: add ADR process and ADR 0002 for axum+tower

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   nix-source-cache:
     name: nix source cache
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
   backend-validation:
     name: backend ${{ matrix.name }}
     needs: nix-source-cache
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -157,9 +157,15 @@ jobs:
             .tmp/nix-ci-cache
             .tmp/nix-ci-cache-paths.txt
           key: nix-source-abi-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/*.nix') }}
-          fail-on-cache-miss: true
+          # A miss must not fail the job. GitHub's 10GB cache can evict the
+          # nix-source-abi entry between the populate job saving it and this
+          # restore (especially under concurrent load), so on a miss we skip the
+          # import below and let `nix develop .#ci-backend` build the ABIs from
+          # source. Slower, but the build stays green instead of hard-failing.
+          fail-on-cache-miss: false
 
       - name: Import Nix source cache
+        if: steps.nix-source-cache.outputs.cache-hit == 'true'
         run: |
           nix copy \
             --from "file://$GITHUB_WORKSPACE/.tmp/nix-ci-cache" \
@@ -195,7 +201,7 @@ jobs:
           fi
 
   dashboard:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -230,7 +236,7 @@ jobs:
         run: nix build .#st0x-dashboard
 
   hooks:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -25,7 +25,7 @@ jobs:
     concurrency:
       group: deploy-prod
       cancel-in-progress: false
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -26,7 +26,7 @@ jobs:
     concurrency:
       group: deploy-staging
       cancel-in-progress: false
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   tf-rekey:
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ permission to do the obvious corrective work.
   already told you what to do wastes their time and signals you weren't
   listening. Only stop and ask when you are actually blocked on a decision the
   user must make, not as a polite checkpoint.
+- **When you need user input, use the structured input prompt your tooling
+  exposes -- not prose at the end of a long response.** Wall-of-text questions
+  get missed. Batch all open decisions in one prompt, not a trickle.
 
 ## Planning Hierarchy
 
@@ -136,6 +139,8 @@ An epic is a roadmap subsection grouping related issues toward a single goal.
   progresses.
 - Clear completed tasks from the active list so the remaining work is always
   obvious.
+- **Questions awaiting user answers are tasks: track them.** Untracked prose
+  questions get lost when the user replies about something else.
 
 ### While implementing
 
@@ -270,24 +275,19 @@ binary).
 
 **CRITICAL: If Rust build fails with sqlx macro errors like "unable to open
 database file" or "(code: 14)", run `sqlx db reset -y` to fix the database.**
-This is the proper solution - NEVER try workarounds like
-`DATABASE_URL=sqlite://:memory:` or other hacks.
+NEVER use workarounds like `DATABASE_URL=sqlite://:memory:`.
 
-**CRITICAL: NEVER manually create migration files.** Always use
-`sqlx migrate add
-<migration_name>` to create migrations. This ensures proper
-timestamping and sequencing.
+**CRITICAL: NEVER manually create migration files.** Use
+`sqlx migrate add <migration_name>` for proper timestamping and sequencing.
 
-**CRITICAL: New worktrees require database setup.** When working in a new git
-worktree, you will encounter sqlx compile errors like "unable to open database
-file". Fix this by running `sqlx db reset -y` to create and migrate the local
-database before running any cargo commands.
+**CRITICAL: New worktrees require database setup.** A new worktree will hit sqlx
+compile errors like "unable to open database file". Run `sqlx db reset -y` to
+create and migrate the local database before any cargo commands.
 
 ### Dependency Management
 
-**CRITICAL: NEVER manually edit `Cargo.toml` to add dependencies.** Always use
-`cargo add <crate_name>` to add dependencies. This ensures proper version
-resolution and feature selection.
+**CRITICAL: NEVER manually edit `Cargo.toml` to add dependencies.** Use
+`cargo add <crate_name>` for proper version resolution and feature selection.
 
 - `cargo add <crate_name>` - Add a dependency to the current crate
 - `cargo add <crate_name> --dev` - Add a dev-dependency
@@ -350,6 +350,25 @@ convention -- new generated paths should not extend that list.
 - When handling clippy errors about function lengths or cognitive complexity,
   don't split up the functions more than necessary to get below the limit.
   Instead ask the user if we can add a clippy allow for that error.
+
+### Push policy
+
+master is protected (PR + CI + 2 approvals), so mistakes can't publish to
+master. For feature branches, push is part of the work.
+
+- **Default: `gt ss`** to submit the whole stack. Plain `git push` leaves
+  restacked descendants stale.
+- **In-flight CI:** pushing cancels in-progress CI; hold if you don't want it
+  restarted.
+- **Shared stacks:** `gt ss` would clobber upstack work; use `gt submit` on
+  current + downstack only. If unsure, ask.
+
+### Commit message hygiene
+
+Set the message at `gt create` time. After that, use `gt modify` without `-m` so
+the existing message stays. If amended work has different scope than the
+branch's message, it belongs on a different branch -- don't rewrite the message
+to absorb it.
 
 ### Updating ROADMAP.md
 
@@ -610,12 +629,6 @@ reviewing code that uses configuration instead of reading secrets directly.
     input regardless of surrounding bytes)
   - Numeric operations where edge cases are hard to enumerate manually
 
-#### Writing Meaningful Tests
-
-Tests must verify application logic, not language features. Testing struct field
-assignments is useless; test actual behavior like
-`config.calculate_next_poll_delay()` returning expected values.
-
 ### Workflow Best Practices
 
 - **Incremental verification during development** -- scope checks to the package
@@ -626,23 +639,19 @@ assignments is useless; test actual behavior like
   3. `cargo clippy -p <crate>` only after all substantive edits to that crate
      are done
   4. Reserve `--workspace` variants for the final verification pass
-- **Final verification before handing over** (skip if only
-  documentation/markdown files were changed). The simplest path is
-  `nix run .#ci` -- it enters the right dev shells (`ci-backend`,
-  `ci-dashboard`) and runs the full check matrix end-to-end: backend
-  `cargo check` (with and without `--all-features`), `cargo nextest run`,
-  `cargo clippy`, `cargo fmt --check`, plus the dashboard's `bun.nix` freshness
-  check, DTO regeneration, lint, and `svelte-check`. This is what local
-  verification should look like before pushing, and what CI mirrors.
+- **Final verification before handing over** (skip for doc-only changes):
+  `nix run .#ci` enters the right dev shells (`ci-backend`, `ci-dashboard`) and
+  runs the full matrix end-to-end -- backend `cargo check` (with and without
+  `--all-features`), `cargo nextest run`, `cargo clippy`, `cargo fmt --check`,
+  plus dashboard `bun.nix` freshness check, DTO regeneration, lint,
+  `svelte-check`. Mirrors CI.
 
-  If you need to break it down for iteration (e.g. only the backend changed),
-  run the individual steps from inside the corresponding shell:
-  1. `cargo check --workspace` - catches compilation errors across all crates
-  2. `cargo nextest run --workspace --all-features` - full test suite including
-     e2e. **Spawns anvil** for CCTP integration tests; only the `ci-backend`
-     shell exposes the foundry binary needed for this. Run via
-     `nix develop .#ci-backend -c cargo nextest run ...`, not the default dev
-     shell.
+  For iteration (e.g. backend-only), run individual steps in the corresponding
+  shell:
+  1. `cargo check --workspace`
+  2. `cargo nextest run --workspace --all-features` -- spawns anvil for CCTP
+     integration tests; only the `ci-backend` shell exposes the foundry binary.
+     Run via `nix develop .#ci-backend -c cargo nextest run ...`.
   3. `cargo clippy --workspace --all-targets --all-features` - full linting
   4. `cargo fmt` - always run last to ensure clean formatting
   5. **Diff review** - after all checks pass, review staged changes and revert

--- a/adrs/0002-axum-and-tower.md
+++ b/adrs/0002-axum-and-tower.md
@@ -1,0 +1,168 @@
+# ADR 0002: Adopt Axum and lean on Tower for both transport and business logic
+
+- Status: Accepted
+  ([#651](https://github.com/ST0x-Technology/st0x.liquidity/pull/651))
+- Date: 2026-05-08
+
+## Context
+
+The HTTP surface of `st0x.liquidity` (dashboard backend, internal control
+endpoints, health/metrics, future operator APIs) is currently served by Rocket.
+Rocket was originally picked for its ergonomics — declarative routing, request
+guards, attribute-driven handlers — and it served that purpose. The project has
+since stalled: 0.5.1 shipped in May 2024 and there has been no published release
+since, maintainership has shifted, and a 0.6 release candidate has been "in
+progress" for over a year. Meanwhile our needs have moved in a direction Rocket
+does not serve well:
+
+- Structured tracing per request, with span propagation across async work,
+  background jobs, and outbound calls.
+- Composable cross-cutting policy (timeouts, concurrency limits, rate limits,
+  retries, auth, idempotency) applied uniformly to HTTP handlers and worker
+  pipelines.
+- Tight integration with the rest of our async stack: Tokio, Hyper,
+  `tower-http`, `tracing`, `governor`, `apalis` workers, and the CQRS
+  command/handler pipeline.
+- Free per-job and per-worker observability via `apalis-board`'s web UI.
+  `apalis-board` ships first-class Axum integration; Rocket is not a supported
+  host framework, so staying on Rocket would mean either reimplementing the
+  board or running a second HTTP stack just to host it.
+- Strong compile-time guarantees on application state wiring so that missing
+  managed resources fail at build time, not as a 500 in production.
+
+We evaluated Axum, Actix-web, and Rocket. Summary of the relevant differences:
+
+| Dimension                    | Rocket                                | Axum                                       | Actix-web                             |
+| ---------------------------- | ------------------------------------- | ------------------------------------------ | ------------------------------------- |
+| Latest release (May 2026)    | 0.5.1 (May 2024)                      | 0.8.x active                               | 4.13.x active                         |
+| Maintenance                  | Stalled                               | Tokio org, monthly cadence                 | Active under @robjtede                |
+| Middleware model             | Fairings (isolated)                   | `tower::Layer` (universal)                 | Custom `Transform` (isolated)         |
+| Tower / `tower-http` interop | None                                  | Native                                     | None                                  |
+| Compile-time state wiring    | Sentinels (runtime fail-fast at boot) | `State<T>` + `FromRef` (true compile-time) | Runtime                               |
+| Generic handlers             | No                                    | Yes                                        | Yes                                   |
+| Tracing-span hooks           | Weak                                  | Best of the three                          | Comparable to Axum                    |
+| Performance vs. Axum         | -20-40% on most workloads             | Baseline                                   | +5-15% on saturated synthetic benches |
+
+Performance and release-cadence figures are informal community-benchmark / repo
+observations as of May 2026 (TechEmpower rounds, GitHub release history); they
+are not load-bearing for this decision. The discriminators are interop and
+modularity, not throughput.
+
+Performance is not the discriminator for this service. Our hot paths are bound
+by RPC, broker latency, database, and serde — not framework overhead. The
+discriminators are **interop** and **modularity**: the framework should plug
+straight into the rest of our async stack (Tokio, Hyper, `tower-http`,
+`tracing`, `apalis`) and let cross-cutting policy compose around both HTTP
+handlers and our internal command pipelines without re-implementation. Tower
+gives us that; Rocket and Actix do not.
+
+## Decision
+
+1. **Replace Rocket with Axum** as the HTTP framework across the workspace. The
+   immediate upstack PRs in this stack carry out that migration.
+
+2. **Adopt Tower (`tower::Service` / `tower::Layer`) as the primary composition
+   primitive across the codebase, not just at the HTTP edge.** Cross-cutting
+   concerns — tracing spans, structured logging, timeouts, concurrency limits,
+   rate limits, retries, idempotency keys, authorization, metrics — are written
+   once as Tower layers and applied to:
+
+   - Inbound HTTP handlers (via Axum's `Router::layer`).
+   - Outbound HTTP clients built on Hyper / `reqwest`.
+   - Internal command pipelines and `apalis` workers, by modeling each command
+     handler as a `Service<Command>` and stacking the same layer types we use
+     for HTTP.
+
+   This means our business-logic boundaries (e.g. CQRS command handlers, broker
+   call wrappers, rebalancer steps) are expressed as `Service`s where it pays
+   for itself, so a single `TimeoutLayer` / `TraceLayer` /
+   `ConcurrencyLimitLayer` implementation is shared across the system rather
+   than reimplemented per surface.
+
+3. **Encode application state via Axum's `State<T>` + `FromRef`** so that any
+   handler that depends on a resource (DB pool, broker client, CQRS framework,
+   rebalancer, conductor handle) is impossible to wire up incorrectly.
+   Forgetting to register a resource becomes a compile error, consistent with
+   the project's "make invalid states unrepresentable" stance.
+
+4. **Standardize error handling on `IntoResponse` for HTTP and on a single
+   `Service` error type per pipeline for non-HTTP surfaces**, so the same
+   `TraceLayer::on_failure` and structured-logging conventions apply uniformly.
+
+## Consequences
+
+### Positive
+
+- One mental model and one set of layer implementations across HTTP handlers and
+  worker pipelines. Cross-cutting policy lives in one place per concern.
+- Compile-time wiring of state eliminates a class of "forgot to register the
+  pool" runtime 500s.
+- Direct access to the `tower-http` ecosystem (compression, CORS, request IDs,
+  trace, timeouts, decompression, sensitive-headers) without bespoke
+  re-implementations.
+- Testing improves: `Router` is a `Service`, so handler tests become
+  `oneshot(Request::builder()...)` calls — no socket, no server, no fixtures
+  beyond the state struct.
+- Aligns with the rest of our async stack (Tokio, Hyper, `tracing`, `apalis`)
+  maintained by overlapping authors, reducing cross-version surprise.
+
+### Negative / costs
+
+- **Pre-1.0.** Axum is on 0.8.x with 0.9 in development. Plan for one moderate
+  migration every 12-18 months. Mitigation: keep Axum-specific code thin and
+  centralized; treat handlers as `async fn` over our own extractors where
+  practical.
+- **Error messages around the `Handler` trait can be cryptic** when handler
+  signatures are wrong. Mitigation: use `#[axum::debug_handler]` on non-generic
+  handlers; prefer a small set of conventional handler shapes.
+- **Tower fluency is now a team requirement.** Writing a custom `Layer` /
+  `Service` is more involved than writing a Rocket fairing. Mitigation: document
+  the layer authoring pattern in `docs/`, prefer `axum::middleware::from_fn` and
+  `tower::ServiceBuilder` for the common cases, and reserve hand-written
+  `Service` impls for layers whose state or back-pressure semantics genuinely
+  require it.
+- **Treating non-HTTP code as `Service`s is a discipline, not a free lunch.**
+  Over-Service-ifying small synchronous helpers is worse than leaving them as
+  functions. We apply the Tower pattern only where a cross-cutting concern is
+  actually shared across surfaces, or where back-pressure / load-shedding /
+  timeout semantics are part of the contract.
+- **Structured-error logging has the same global-hook gap on Axum that it has on
+  every Rust web framework today**: `tower_http::trace::TraceLayer::on_failure`
+  sees the response, not the original error. Mitigation: wrap a per-codebase
+  `ApiError` enum with explicit span attachment at the conversion site.
+
+### Neutral
+
+- Performance is not expected to change meaningfully in either direction for
+  this service.
+- Existing Rocket-specific request guards translate to Axum extractors
+  (`FromRequestParts` / `FromRequest`) one-to-one.
+
+## Alternatives considered
+
+- **Stay on Rocket.** Rejected: stalled release cadence, no Tower interop,
+  weaker tracing hooks. The ergonomic features that made Rocket the original
+  choice (declarative routing, request guards, attribute-driven handlers) have
+  one-to-one analogues in Axum extractors and `axum::routing`, so the ergonomic
+  loss is small relative to the modularity and interop wins.
+- **Adopt Actix-web.** Rejected: its middleware ecosystem is a parallel universe
+  to Tower, which would force us to write or import every cross-cutting policy
+  twice (once for HTTP, once for everything else). The thread-per-core runtime
+  model also adds friction to sharing async resources (broker clients, DB pools,
+  the CQRS framework) across handlers. The performance margin Actix offers is
+  irrelevant to a service whose hot path is broker / RPC / DB bound.
+- **Adopt a combinator framework (Warp) or an emerging one (Pavex, xitca-web).**
+  Rejected for now: insufficient production gravity and ecosystem fit.
+  Reconsider if Pavex matures; the Tower-centric design here ports forward
+  cleanly.
+
+## Follow-ups
+
+- Migration PRs: `fix/replace-rocket-with-axum` (this stack) and any downstream
+  feature branches that touch the HTTP surface.
+- Document the Tower layer authoring conventions and the standard layer stack
+  (trace, timeout, concurrency limit, request id, sensitive-header redaction) in
+  `docs/`.
+- Audit existing CQRS command handlers and broker wrappers for places where
+  promoting them to `Service` would let us delete bespoke timeout / retry /
+  tracing code, and convert opportunistically — not as a flag-day refactor.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -1,0 +1,124 @@
+# adrs/
+
+Architecture Decision Records (ADRs) for `st0x.liquidity`. Each ADR captures a
+single significant architectural decision: the context that forced a choice, the
+options considered, the option taken, and the consequences accepted.
+
+## What an ADR is
+
+An ADR is an **immutable historical record** of a decision at the moment it was
+made. It is not a living document. Once accepted, the body of an ADR is not
+edited to reflect later developments — instead, a new ADR either supersedes the
+old one or amends it, and the old one's status is updated to point at the
+successor.
+
+Treat ADRs the way you treat git history: append-only, dated, signed by context.
+
+## When to write one
+
+Write an ADR when a decision is:
+
+- **Architectural** — affects how components fit together, what responsibilities
+  a layer has, or what the public contract of a subsystem is.
+- **Non-obvious** — a future contributor (human or agent) would reasonably
+  wonder "why did we do it this way?" without it.
+- **Costly to reverse** — replacing a framework, switching a serialization
+  format, restructuring a workspace, picking a domain modeling pattern.
+
+If a decision is local, easily reversible, or fully captured by the code itself,
+it does not need an ADR. Naming conventions, domain terminology, and how-to
+guides belong in [`/docs`](../docs/) instead.
+
+The repository root [`AGENTS.md`](../AGENTS.md) gives the standing rule: when an
+architectural decision is not already answered by existing docs, write an ADR
+here, summarize it briefly for review, and stop for approval before proceeding
+with that direction.
+
+## Approval workflow
+
+ADRs follow the same review path as code: a contributor opens a PR with the new
+ADR file, the rest of the team reviews on GitHub, and the ADR moves to
+**Accepted** when the PR is approved and merged. There is no separate approval
+channel — the merge IS the approval, and the merge commit IS the dated record.
+
+While a PR is open, the ADR's `Status:` header stays **Proposed**. The author
+flips it to **Accepted** in the same PR once reviewers approve, before merging.
+
+## File layout
+
+```
+adrs/
+  README.md                     # this file
+  NNNN-short-kebab-name.md      # one ADR per decision
+```
+
+- `NNNN` is a zero-padded four-digit index, allocated sequentially. The next ADR
+  is the highest existing index plus one. Indices are never reused, even if an
+  ADR is superseded.
+- The kebab name should be terse and decision-shaped (e.g.
+  `0002-axum-and-tower.md`, not `0002-web-framework.md`).
+
+  ADRs written before this convention landed (e.g.
+  `1-cash-bp-for-equity-hedges.md`) keep their original filenames — the README
+  rule is "indices are never reused, even if an ADR is superseded," and that
+  applies to filenames too. That earlier ADR sits at index `1`; the first ADR
+  written under this convention is ADR `0002`.
+
+## ADR template
+
+```markdown
+# ADR NNNN: <decision in one line>
+
+- Status: Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+- Date: YYYY-MM-DD
+
+## Context
+
+What forced the decision? What constraints, requirements, or pain points are in
+play? What did we know at the time?
+
+## Decision
+
+What we decided, stated affirmatively. If the decision has multiple parts,
+enumerate them.
+
+## Consequences
+
+### Positive
+
+What we gain.
+
+### Negative / costs
+
+What we accept as the price. Be honest — an ADR with no costs section is
+suspicious.
+
+### Neutral
+
+Side effects that are neither wins nor losses.
+
+## Alternatives considered
+
+The options we rejected, with one or two sentences each on why.
+
+## Follow-ups
+
+Concrete migration work, documentation tasks, or audits that fall out of the
+decision.
+```
+
+## Statuses
+
+- **Proposed** — drafted, awaiting review. Do not act on the decision yet.
+- **Accepted** — approved by the team. The decision is in force.
+- **Superseded by ADR-XXXX** — overridden by a later ADR. The body stays as
+  written; only the status header changes, and the superseding ADR links back.
+- **Deprecated** — the decision no longer applies but no replacement was
+  recorded.
+
+## Index
+
+| #                                   | Title                                                                            | Status   |
+| ----------------------------------- | -------------------------------------------------------------------------------- | -------- |
+| [1](1-cash-bp-for-equity-hedges.md) | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
+| [0002](0002-axum-and-tower.md)      | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# docs/
+
+Living reference documentation for `st0x.liquidity`. Read when relevant to your
+current task; update when you discover something a future contributor (human or
+agent) would benefit from knowing.
+
+## What belongs here
+
+- **How-to guides** — concrete procedures (e.g.
+  [how-to-add-new-asset.md](how-to-add-new-asset.md), [cli-ops.md](cli-ops.md)).
+- **Domain references** — naming, terminology, conceptual models (e.g.
+  [domain.md](domain.md), [float.md](float.md)).
+- **Subsystem deep-dives** — non-obvious behavior of internal components (e.g.
+  [conductor.md](conductor.md), [cqrs.md](cqrs.md)).
+- **Framework / library notes** — gotchas, idioms, integration pitfalls for the
+  external dependencies we use heavily (e.g. [alloy.md](alloy.md),
+  [sqlx.md](sqlx.md), [ttdd.md](ttdd.md), [feature-flags.md](feature-flags.md),
+  [observability.md](observability.md)).
+
+## File organization
+
+- **Naming**: kebab-case (e.g. `how-to-add-new-asset.md`, `feature-flags.md`).
+- **Granularity**: new file when the topic is a standalone how-to, domain
+  reference, subsystem deep-dive, or framework note that another doc would not
+  reasonably absorb. Otherwise extend an existing doc with a new section.
+
+## What does NOT belong here
+
+- **Architectural decisions.** Those go in [`/adrs`](../adrs/) at the repo root.
+  ADRs are immutable historical records of _why_ we chose one option over
+  others; `docs/` entries are mutable references describing _what_ the system
+  currently does and _how_ to work with it.
+- **The product specification.** That lives in [SPEC.md](../SPEC.md).
+- **The roadmap.** That lives in [ROADMAP.md](../ROADMAP.md).
+
+## Lifecycle
+
+These documents are expected to drift unless maintained. When research or
+trial-and-error reveals a non-obvious pattern, pitfall, or framework behavior,
+document it here (in the relevant existing file or a new one) so the next person
+does not have to rediscover it. Prioritize: framework-specific idioms,
+integration gotchas, and "X doesn't work because Y" findings.
+
+If a doc here describes behavior that has changed, update it in the same PR that
+changes the behavior. If you delete a feature, delete or revise the doc.
+
+## Index
+
+| File                                               | Purpose                                                                    |
+| -------------------------------------------------- | -------------------------------------------------------------------------- |
+| [alloy.md](alloy.md)                               | Alloy types, `FixedBytes` aliases, mocks, encoding                         |
+| [cli-ops.md](cli-ops.md)                           | CLI operational procedures                                                 |
+| [conductor.md](conductor.md)                       | Conductor orchestration layer (task supervisor, apalis workers, lifecycle) |
+| [cqrs.md](cqrs.md)                                 | Event sourcing with `st0x-event-sorcery`                                   |
+| [domain.md](domain.md)                             | Domain terminology and naming conventions (source of truth for names)      |
+| [feature-flags.md](feature-flags.md)               | Cargo feature flags, `test-support` vs `cfg(test)`                         |
+| [float.md](float.md)                               | `Float` type, precision-safe financial arithmetic                          |
+| [how-to-add-new-asset.md](how-to-add-new-asset.md) | Procedure for onboarding a new tokenized equity                            |
+| [observability.md](observability.md)               | Tracing, metrics, logging conventions                                      |
+| [sqlx.md](sqlx.md)                                 | sqlx usage notes and pitfalls                                              |
+| [ttdd.md](ttdd.md)                                 | Type-driven TDD workflow                                                   |


### PR DESCRIPTION
## Stack Context

This stack is the Rocket -> Axum migration ([RAI-69](https://linear.app/makeitrain/issue/RAI-69)). Before the actual code migration lands upstack, this PR establishes the ADR process and records the architectural decision behind it.

Tracked under [RAI-393](https://linear.app/makeitrain/issue/RAI-393/establish-adr-process-and-record-axumtower-architectural-decision), which is the parent of RAI-69.

## What

- New top-level `adrs/` directory (sibling to `docs/`, not nested -- ADRs are immutable historical records with a different lifecycle from the living reference docs).
- `adrs/README.md` -- purpose, when to write an ADR, file layout (`NNNN-kebab-name.md`), template, approval workflow, statuses, index. Acknowledges the existing `1-cash-bp-for-equity-hedges.md` (already on master) which predates this convention and keeps its original filename per the "indices are never reused" rule.
- `adrs/0002-axum-and-tower.md` -- first ADR written under the new convention (`1-cash-bp-for-equity-hedges.md` is index `1` from before the convention; this is index `0002`). Decision goes beyond "use Axum": adopt Tower (`Service` / `Layer`) as the primary composition primitive across HTTP, outbound clients, and `apalis` / CQRS pipelines, so cross-cutting policy (trace, timeout, concurrency, retry, auth) is written once and reused everywhere.
- `docs/README.md` -- purpose, what belongs / does not belong, lifecycle, index of existing docs. Clarifies that architectural decisions go in `adrs/`, not here.

## Why

We've been making architectural decisions implicitly through PRs and conversation. That makes it hard for new contributors (human or agent) to answer "why did we do it this way?" without spelunking through git history. ADRs give us an append-only, dated record of significant decisions -- context, options, choice, consequences -- separate from the living `docs/` reference set.

The Rocket -> Axum migration is the immediate forcing function and ADR 0002 records its rationale. Rocket was originally picked for ergonomics; the discriminators driving the move are **interop** (plug straight into Tokio / Hyper / `tower-http` / `tracing` / `apalis`) and **modularity** (one Tower stack reused across HTTP handlers and worker pipelines, instead of fairings reimplemented per surface). The honest costs are called out: pre-1.0 churn, cryptic `Handler` trait errors, the Tower fluency requirement, and the discipline needed to *not* over-Service-ify trivial helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Record (ADR) process documentation with templates and guidelines.
  * Added living reference documentation structure and index.
  * Documented framework adoption plan for HTTP and service standardization.
  * Updated developer agent guidance for task tracking and commit practices.

* **Chores**
  * Updated CI and deployment workflows to use standard Ubuntu runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->