### PR TITLE
feat: split onchain tx submit/confirm with intermediate persistence (RAI-365)

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -16,7 +16,8 @@
 //! `Wallet::submit` (write transactions), so consumers get
 //! human-readable revert reasons without manual wiring.
 
-use alloy::primitives::{Address, Bytes};
+use alloy::consensus::Transaction;
+use alloy::primitives::{Address, Bytes, TxHash};
 use alloy::providers::Provider;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::sol_types::SolCall;
@@ -229,6 +230,25 @@ pub trait Wallet: Evm {
     /// Returns the address this wallet signs transactions from.
     fn address(&self) -> Address;
 
+    /// Submit a signed transaction and return the tx hash immediately,
+    /// without waiting for confirmation.
+    ///
+    /// Implementations handle signing and submission to the mempool.
+    /// The returned hash can be passed to [`await_receipt`](Wallet::await_receipt)
+    /// to wait for confirmation separately.
+    async fn send_pending(
+        &self,
+        contract: Address,
+        calldata: Bytes,
+        note: &str,
+    ) -> Result<TxHash, EvmError>;
+
+    /// Wait for a previously submitted transaction to be confirmed.
+    ///
+    /// Polls for the receipt and waits for the configured confirmation
+    /// depth before returning.
+    async fn await_receipt(&self, tx_hash: TxHash) -> Result<TransactionReceipt, EvmError>;
+
     /// Send raw calldata as a signed transaction.
     ///
     /// Implementations handle signing, submission, and waiting for the
@@ -284,6 +304,65 @@ pub trait Wallet: Evm {
     {
         let calldata = Bytes::from(call.abi_encode());
         let receipt = self.send(contract, calldata.clone(), note).await?;
+        decode_reverted_receipt::<Registry>(
+            self.provider(),
+            self.address(),
+            contract,
+            calldata,
+            receipt,
+        )
+        .await
+    }
+
+    /// Submit a typed contract call without waiting for confirmation.
+    ///
+    /// Like [`submit`](Wallet::submit), but returns the tx hash
+    /// immediately instead of waiting for the receipt. Use
+    /// [`confirm`](Wallet::confirm) to wait and decode reverts later.
+    async fn submit_pending<Call: SolCall + Send>(
+        &self,
+        contract: Address,
+        call: Call,
+        note: &str,
+    ) -> Result<TxHash, EvmError>
+    where
+        Self: Sized,
+    {
+        let calldata = Bytes::from(call.abi_encode());
+        self.send_pending(contract, calldata, note).await
+    }
+
+    /// Wait for a previously submitted transaction and decode reverts.
+    ///
+    /// Counterpart to [`submit_pending`](Wallet::submit_pending).
+    /// Awaits the receipt, then if the transaction reverted, fetches
+    /// the original transaction from chain to recover `from`,
+    /// `to`, and `input`, and replays as `eth_call` to decode the
+    /// Solidity error via `Registry`.
+    async fn confirm<Registry: IntoErrorRegistry>(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<TransactionReceipt, EvmError>
+    where
+        Self: Sized,
+    {
+        let receipt = self.await_receipt(tx_hash).await?;
+
+        if receipt.status() {
+            return Ok(receipt);
+        }
+
+        // Recover the original calldata from chain so we can replay
+        // the failed call and decode the Solidity revert reason.
+        let original_tx = self
+            .provider()
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or(EvmError::Reverted { tx_hash })?;
+
+        let contract = original_tx.to().unwrap_or_default();
+        let calldata = original_tx.input().clone();
+
         decode_reverted_receipt::<Registry>(
             self.provider(),
             self.address(),
@@ -378,6 +457,19 @@ impl<Inner: Evm + ?Sized> Evm for Arc<Inner> {
 impl<Inner: Wallet + ?Sized> Wallet for Arc<Inner> {
     fn address(&self) -> Address {
         (**self).address()
+    }
+
+    async fn send_pending(
+        &self,
+        contract: Address,
+        calldata: Bytes,
+        note: &str,
+    ) -> Result<TxHash, EvmError> {
+        (**self).send_pending(contract, calldata, note).await
+    }
+
+    async fn await_receipt(&self, tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+        (**self).await_receipt(tx_hash).await
     }
 
     async fn send(

--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -5,7 +5,7 @@
 //! directly.
 
 use alloy::network::{Ethereum, EthereumWallet};
-use alloy::primitives::{Address, B256, Bytes};
+use alloy::primitives::{Address, B256, Bytes, TxHash};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
 };
@@ -118,12 +118,12 @@ where
         self.signing_provider.default_signer_address()
     }
 
-    async fn send(
+    async fn send_pending(
         &self,
         contract: Address,
         calldata: Bytes,
         note: &str,
-    ) -> Result<TransactionReceipt, EvmError> {
+    ) -> Result<TxHash, EvmError> {
         info!(target: "wallet", %contract, note, "Submitting local contract call");
 
         let tx = TransactionRequest::default()
@@ -135,12 +135,26 @@ where
 
         info!(target: "wallet", %tx_hash, note, "Transaction submitted");
 
+        Ok(tx_hash)
+    }
+
+    async fn await_receipt(&self, tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
         let receipt =
             crate::wait_for_receipt(&self.provider, tx_hash, self.required_confirmations).await?;
 
-        info!(target: "wallet", tx_hash = %receipt.transaction_hash, note, "Transaction confirmed");
+        info!(target: "wallet", tx_hash = %receipt.transaction_hash, "Transaction confirmed");
 
         Ok(receipt)
+    }
+
+    async fn send(
+        &self,
+        contract: Address,
+        calldata: Bytes,
+        note: &str,
+    ) -> Result<TransactionReceipt, EvmError> {
+        let tx_hash = self.send_pending(contract, calldata, note).await?;
+        self.await_receipt(tx_hash).await
     }
 }
 

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -8,7 +8,7 @@
 //! of `PrivateKeySigner` (local key).
 
 use alloy::network::{Ethereum, EthereumWallet};
-use alloy::primitives::{Address, Bytes};
+use alloy::primitives::{Address, Bytes, TxHash};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
 };
@@ -219,12 +219,12 @@ where
         self.address
     }
 
-    async fn send(
+    async fn send_pending(
         &self,
         contract: Address,
         calldata: Bytes,
         note: &str,
-    ) -> Result<TransactionReceipt, EvmError> {
+    ) -> Result<TxHash, EvmError> {
         info!(target: "wallet", %contract, note, "Submitting Turnkey contract call");
 
         let tx = TransactionRequest::default()
@@ -236,12 +236,26 @@ where
 
         info!(target: "wallet", %tx_hash, note, "Transaction submitted");
 
+        Ok(tx_hash)
+    }
+
+    async fn await_receipt(&self, tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
         let receipt =
             crate::wait_for_receipt(&self.provider, tx_hash, self.required_confirmations).await?;
 
-        info!(target: "wallet", tx_hash = %receipt.transaction_hash, note, "Transaction confirmed");
+        info!(target: "wallet", tx_hash = %receipt.transaction_hash, "Transaction confirmed");
 
         Ok(receipt)
+    }
+
+    async fn send(
+        &self,
+        contract: Address,
+        calldata: Bytes,
+        note: &str,
+    ) -> Result<TransactionReceipt, EvmError> {
+        let tx_hash = self.send_pending(contract, calldata, note).await?;
+        self.await_receipt(tx_hash).await
     }
 }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -590,10 +590,10 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 MintAccepted { .. } => FailAcceptance {
                     reason: reason.to_string(),
                 },
-                TokensReceived { .. } => FailWrapping {
+                TokensReceived { .. } | WrapSubmitted { .. } => FailWrapping {
                     reason: reason.to_string(),
                 },
-                TokensWrapped { .. } => FailRaindexDeposit {
+                TokensWrapped { .. } | VaultDepositSubmitted { .. } => FailRaindexDeposit {
                     reason: reason.to_string(),
                 },
                 MintRequested { .. } => {
@@ -626,7 +626,13 @@ pub(crate) async fn fail_transfer_command<W: Write>(
 
             use EquityRedemption::*;
             match entity {
-                WithdrawnFromRaindex { .. } | TokensUnwrapped { .. } => {}
+                VaultWithdrawPending { .. }
+                | VaultWithdrawSubmitted { .. }
+                | WithdrawnFromRaindex { .. }
+                | UnwrapPending { .. }
+                | UnwrapSubmitted { .. }
+                | TokensUnwrapped { .. }
+                | SendPending { .. } => {}
                 TokensSent { .. } | Pending { .. } => {
                     anyhow::bail!(
                         "Redemption {id} is past the transfer stage -- \

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -461,6 +461,20 @@ mod tests {
             self.address
         }
 
+        async fn send_pending(
+            &self,
+            contract: Address,
+            calldata: Bytes,
+            _note: &str,
+        ) -> Result<TxHash, EvmError> {
+            self.calls.lock().unwrap().push((contract, calldata));
+            Ok(TxHash::random())
+        }
+
+        async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            self.receipts.lock().unwrap().remove(0)
+        }
+
         async fn send(
             &self,
             contract: Address,

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -183,16 +183,21 @@ pub(crate) enum EquityRedemptionError {
 
 #[derive(Debug, Clone)]
 pub(crate) enum EquityRedemptionCommand {
-    /// Withdraws wrapped tokens from the Raindex vault.
-    /// Emits WithdrawnFromRaindex.
+    /// Submits vault withdrawal tx and emits VaultWithdrawSubmitted.
     Redeem {
         symbol: Symbol,
         quantity: Float,
         token: Address,
         amount: U256,
     },
-    /// Unwrap ERC-4626 wrapped tokens after Raindex withdrawal.
+    /// Waits for a previously submitted withdrawal to confirm.
+    /// Emits WithdrawnFromRaindex.
+    ConfirmWithdraw,
+    /// Submits ERC-4626 unwrap tx and emits UnwrapSubmitted.
     UnwrapTokens,
+    /// Waits for a previously submitted unwrap to confirm.
+    /// Emits TokensUnwrapped.
+    ConfirmUnwrap,
     /// Send unwrapped tokens to Alpaca's redemption wallet.
     SendTokens,
     /// Alpaca detected the token transfer.
@@ -208,6 +213,15 @@ pub(crate) enum EquityRedemptionCommand {
     /// Operator or timeout-driven failure from `WithdrawnFromRaindex` or
     /// `TokensUnwrapped` states.
     FailTransfer { reason: String },
+    /// Performs the actual vault withdrawal (side-effectful).
+    /// Valid from `VaultWithdrawPending`.
+    SubmitWithdraw,
+    /// Performs the actual ERC-4626 unwrap (side-effectful).
+    /// Valid from `UnwrapPending`.
+    SubmitUnwrap,
+    /// Prepares sending tokens (pure, no side effects).
+    /// Valid from `TokensUnwrapped`.
+    PrepareSend,
 }
 
 /// Reason for detection failure when polling Alpaca for redemption detection.
@@ -219,6 +233,31 @@ pub(crate) enum DetectionFailure {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum EquityRedemptionEvent {
+    /// Vault withdrawal requested, awaiting submission.
+    VaultWithdrawPending {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        pending_at: DateTime<Utc>,
+    },
+    /// Vault withdrawal transaction submitted, pending confirmation.
+    VaultWithdrawSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
     /// Tokens withdrawn from Raindex vault to wallet.
     WithdrawnFromRaindex {
         symbol: Symbol,
@@ -238,6 +277,19 @@ pub(crate) enum EquityRedemptionEvent {
         unwrap_tx_hash: TxHash,
         unwrapped_amount: U256,
         unwrapped_at: DateTime<Utc>,
+    },
+    /// Unwrap requested, awaiting submission.
+    UnwrapPending {
+        pending_at: DateTime<Utc>,
+    },
+    /// Unwrap transaction submitted, pending confirmation.
+    UnwrapSubmitted {
+        unwrap_tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+    /// Send requested, awaiting submission.
+    SendPending {
+        pending_at: DateTime<Utc>,
     },
     /// Raindex withdraw succeeded but transfer to redemption wallet failed.
     TransferFailed {
@@ -282,6 +334,61 @@ pub(crate) enum EquityRedemptionEvent {
 impl PartialEq for EquityRedemptionEvent {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (
+                Self::VaultWithdrawPending {
+                    symbol: s1,
+                    quantity: q1,
+                    token: t1,
+                    wrapped_amount: w1,
+                    pending_at: pa1,
+                },
+                Self::VaultWithdrawPending {
+                    symbol: s2,
+                    quantity: q2,
+                    token: t2,
+                    wrapped_amount: w2,
+                    pending_at: pa2,
+                },
+            ) => s1 == s2 && q1.eq(*q2).unwrap_or(false) && t1 == t2 && w1 == w2 && pa1 == pa2,
+            (
+                Self::VaultWithdrawSubmitted {
+                    symbol: s1,
+                    quantity: q1,
+                    token: t1,
+                    wrapped_amount: w1,
+                    tx_hash: h1,
+                    submitted_at: sa1,
+                },
+                Self::VaultWithdrawSubmitted {
+                    symbol: s2,
+                    quantity: q2,
+                    token: t2,
+                    wrapped_amount: w2,
+                    tx_hash: h2,
+                    submitted_at: sa2,
+                },
+            ) => {
+                s1 == s2
+                    && q1.eq(*q2).unwrap_or(false)
+                    && t1 == t2
+                    && w1 == w2
+                    && h1 == h2
+                    && sa1 == sa2
+            }
+            (
+                Self::UnwrapSubmitted {
+                    unwrap_tx_hash: h1,
+                    submitted_at: sa1,
+                },
+                Self::UnwrapSubmitted {
+                    unwrap_tx_hash: h2,
+                    submitted_at: sa2,
+                },
+            ) => h1 == h2 && sa1 == sa2,
+            (Self::UnwrapPending { pending_at: pa1 }, Self::UnwrapPending { pending_at: pa2 })
+            | (Self::SendPending { pending_at: pa1 }, Self::SendPending { pending_at: pa2 }) => {
+                pa1 == pa2
+            }
             (
                 Self::WithdrawnFromRaindex {
                     symbol: s1,
@@ -389,9 +496,18 @@ impl DomainEvent for EquityRedemptionEvent {
     fn event_type(&self) -> String {
         use EquityRedemptionEvent::*;
         match self {
+            VaultWithdrawPending { .. } => {
+                "EquityRedemptionEvent::VaultWithdrawPending".to_string()
+            }
+            VaultWithdrawSubmitted { .. } => {
+                "EquityRedemptionEvent::VaultWithdrawSubmitted".to_string()
+            }
             WithdrawnFromRaindex { .. } => {
                 "EquityRedemptionEvent::WithdrawnFromRaindex".to_string()
             }
+            UnwrapPending { .. } => "EquityRedemptionEvent::UnwrapPending".to_string(),
+            UnwrapSubmitted { .. } => "EquityRedemptionEvent::UnwrapSubmitted".to_string(),
+            SendPending { .. } => "EquityRedemptionEvent::SendPending".to_string(),
             TokensUnwrapped { .. } => "EquityRedemptionEvent::TokensUnwrapped".to_string(),
             TransferFailed { .. } => "EquityRedemptionEvent::TransferFailed".to_string(),
             TokensSent { .. } => "EquityRedemptionEvent::TokensSent".to_string(),
@@ -413,6 +529,33 @@ impl DomainEvent for EquityRedemptionEvent {
 /// Each variant contains exactly the data valid for that state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum EquityRedemption {
+    /// Vault withdrawal requested, awaiting submission
+    VaultWithdrawPending {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        pending_at: DateTime<Utc>,
+    },
+
+    /// Vault withdrawal submitted, awaiting confirmation
+    VaultWithdrawSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+
     /// Tokens withdrawn from Raindex vault to wallet, not yet sent to Alpaca
     WithdrawnFromRaindex {
         symbol: Symbol,
@@ -427,8 +570,54 @@ pub(crate) enum EquityRedemption {
         withdrawn_at: DateTime<Utc>,
     },
 
+    /// Unwrap requested, awaiting submission
+    UnwrapPending {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        raindex_withdraw_tx: TxHash,
+        withdrawn_at: DateTime<Utc>,
+    },
+
+    /// Unwrap transaction submitted, awaiting confirmation
+    UnwrapSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        wrapped_amount: U256,
+        raindex_withdraw_tx: TxHash,
+        unwrap_tx_hash: TxHash,
+        withdrawn_at: DateTime<Utc>,
+    },
+
     /// Wrapped tokens have been unwrapped, ready to send to Alpaca
     TokensUnwrapped {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        token: Address,
+        underlying_token: Address,
+        raindex_withdraw_tx: TxHash,
+        unwrap_tx_hash: TxHash,
+        unwrapped_amount: U256,
+        withdrawn_at: DateTime<Utc>,
+        unwrapped_at: DateTime<Utc>,
+    },
+
+    /// Send requested, awaiting submission
+    SendPending {
         symbol: Symbol,
         #[serde(
             serialize_with = "st0x_float_serde::serialize_float_as_string",
@@ -518,6 +707,34 @@ pub(crate) enum EquityRedemption {
 impl EquityRedemption {
     pub(crate) fn to_dto(&self, id: &RedemptionAggregateId) -> TransferOperation {
         match self {
+            Self::VaultWithdrawPending {
+                symbol,
+                quantity,
+                pending_at,
+                ..
+            } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
+                id: Id::new(id.0.clone()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: EquityRedemptionStatus::Withdrawing,
+                started_at: *pending_at,
+                updated_at: *pending_at,
+            }),
+
+            Self::VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                submitted_at,
+                ..
+            } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
+                id: Id::new(id.0.clone()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: EquityRedemptionStatus::Withdrawing,
+                started_at: *submitted_at,
+                updated_at: *submitted_at,
+            }),
+
             Self::WithdrawnFromRaindex {
                 symbol,
                 quantity,
@@ -532,7 +749,34 @@ impl EquityRedemption {
                 updated_at: *withdrawn_at,
             }),
 
+            Self::UnwrapPending {
+                symbol,
+                quantity,
+                withdrawn_at,
+                ..
+            }
+            | Self::UnwrapSubmitted {
+                symbol,
+                quantity,
+                withdrawn_at,
+                ..
+            } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
+                id: Id::new(id.0.clone()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: EquityRedemptionStatus::Unwrapping,
+                started_at: *withdrawn_at,
+                updated_at: *withdrawn_at,
+            }),
+
             Self::TokensUnwrapped {
+                symbol,
+                quantity,
+                withdrawn_at,
+                unwrapped_at,
+                ..
+            }
+            | Self::SendPending {
                 symbol,
                 quantity,
                 withdrawn_at,
@@ -629,6 +873,36 @@ impl EventSourced for EquityRedemption {
     fn originate(event: &Self::Event) -> Option<Self> {
         use EquityRedemptionEvent::*;
         match event {
+            VaultWithdrawPending {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                pending_at,
+            } => Some(Self::VaultWithdrawPending {
+                symbol: symbol.clone(),
+                quantity: *quantity,
+                token: *token,
+                wrapped_amount: *wrapped_amount,
+                pending_at: *pending_at,
+            }),
+            // Legacy: old aggregates start with VaultWithdrawSubmitted
+            VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                tx_hash,
+                submitted_at,
+            } => Some(Self::VaultWithdrawSubmitted {
+                symbol: symbol.clone(),
+                quantity: *quantity,
+                token: *token,
+                wrapped_amount: *wrapped_amount,
+                tx_hash: *tx_hash,
+                submitted_at: *submitted_at,
+            }),
+            // Legacy: old aggregates start with WithdrawnFromRaindex
             WithdrawnFromRaindex {
                 symbol,
                 quantity,
@@ -648,17 +922,88 @@ impl EventSourced for EquityRedemption {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn evolve(entity: &Self, event: &Self::Event) -> Result<Option<Self>, Self::Error> {
         use EquityRedemptionEvent::*;
 
         Ok(match event {
-            WithdrawnFromRaindex { .. } => None,
+            VaultWithdrawPending { .. } => None,
+            VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                tx_hash,
+                submitted_at,
+            } => match entity {
+                Self::VaultWithdrawPending { .. } => Some(Self::VaultWithdrawSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    wrapped_amount: *wrapped_amount,
+                    tx_hash: *tx_hash,
+                    submitted_at: *submitted_at,
+                }),
+                // Legacy: VaultWithdrawSubmitted is handled as originate
+                _ => None,
+            },
+            WithdrawnFromRaindex {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount,
+                raindex_withdraw_tx,
+                withdrawn_at,
+            } => match entity {
+                Self::VaultWithdrawPending { .. } | Self::VaultWithdrawSubmitted { .. } => {
+                    Some(Self::WithdrawnFromRaindex {
+                        symbol: symbol.clone(),
+                        quantity: *quantity,
+                        token: *token,
+                        wrapped_amount: *wrapped_amount,
+                        raindex_withdraw_tx: *raindex_withdraw_tx,
+                        withdrawn_at: *withdrawn_at,
+                    })
+                }
+                // Legacy: WithdrawnFromRaindex is handled as originate
+                _ => None,
+            },
 
             TransferFailed {
                 tx_hash,
                 reason,
                 failed_at,
             } => match entity {
+                Self::VaultWithdrawPending {
+                    symbol,
+                    quantity,
+                    pending_at,
+                    ..
+                } => Some(Self::Failed {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    raindex_withdraw_tx: None,
+                    redemption_tx: *tx_hash,
+                    tokenization_request_id: None,
+                    reason: reason.clone(),
+                    started_at: *pending_at,
+                    failed_at: *failed_at,
+                }),
+                Self::VaultWithdrawSubmitted {
+                    symbol,
+                    quantity,
+                    submitted_at,
+                    ..
+                } => Some(Self::Failed {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    raindex_withdraw_tx: None,
+                    redemption_tx: *tx_hash,
+                    tokenization_request_id: None,
+                    reason: reason.clone(),
+                    started_at: *submitted_at,
+                    failed_at: *failed_at,
+                }),
                 Self::WithdrawnFromRaindex {
                     symbol,
                     quantity,
@@ -666,7 +1011,28 @@ impl EventSourced for EquityRedemption {
                     withdrawn_at,
                     ..
                 }
+                | Self::UnwrapPending {
+                    symbol,
+                    quantity,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                    ..
+                }
                 | Self::TokensUnwrapped {
+                    symbol,
+                    quantity,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                    ..
+                }
+                | Self::SendPending {
+                    symbol,
+                    quantity,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                    ..
+                }
+                | Self::UnwrapSubmitted {
                     symbol,
                     quantity,
                     raindex_withdraw_tx,
@@ -686,25 +1052,86 @@ impl EventSourced for EquityRedemption {
                 _ => return Ok(None),
             },
 
+            UnwrapPending { pending_at: _ } => match entity {
+                Self::WithdrawnFromRaindex {
+                    symbol,
+                    quantity,
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                } => Some(Self::UnwrapPending {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    wrapped_amount: *wrapped_amount,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    withdrawn_at: *withdrawn_at,
+                }),
+                _ => None,
+            },
+
+            UnwrapSubmitted {
+                unwrap_tx_hash,
+                submitted_at: _,
+            } => match entity {
+                Self::WithdrawnFromRaindex {
+                    symbol,
+                    quantity,
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                }
+                | Self::UnwrapPending {
+                    symbol,
+                    quantity,
+                    token,
+                    wrapped_amount,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                } => Some(Self::UnwrapSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    wrapped_amount: *wrapped_amount,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    unwrap_tx_hash: *unwrap_tx_hash,
+                    withdrawn_at: *withdrawn_at,
+                }),
+                _ => None,
+            },
+
             TokensUnwrapped {
                 underlying_token,
                 unwrap_tx_hash,
                 unwrapped_amount,
                 unwrapped_at,
-            } => {
-                let Self::WithdrawnFromRaindex {
+            } => match entity {
+                Self::WithdrawnFromRaindex {
                     symbol,
                     quantity,
                     token,
                     raindex_withdraw_tx,
                     withdrawn_at,
                     ..
-                } = entity
-                else {
-                    return Ok(None);
-                };
-
-                Some(Self::TokensUnwrapped {
+                }
+                | Self::UnwrapPending {
+                    symbol,
+                    quantity,
+                    token,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                    ..
+                }
+                | Self::UnwrapSubmitted {
+                    symbol,
+                    quantity,
+                    token,
+                    raindex_withdraw_tx,
+                    withdrawn_at,
+                    ..
+                } => Some(Self::TokensUnwrapped {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     token: *token,
@@ -714,8 +1141,34 @@ impl EventSourced for EquityRedemption {
                     unwrapped_amount: *unwrapped_amount,
                     withdrawn_at: *withdrawn_at,
                     unwrapped_at: *unwrapped_at,
-                })
-            }
+                }),
+                _ => None,
+            },
+
+            SendPending { pending_at: _ } => match entity {
+                Self::TokensUnwrapped {
+                    symbol,
+                    quantity,
+                    token,
+                    underlying_token,
+                    raindex_withdraw_tx,
+                    unwrap_tx_hash,
+                    unwrapped_amount,
+                    withdrawn_at,
+                    unwrapped_at,
+                } => Some(Self::SendPending {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    token: *token,
+                    underlying_token: *underlying_token,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    unwrap_tx_hash: *unwrap_tx_hash,
+                    unwrapped_amount: *unwrapped_amount,
+                    withdrawn_at: *withdrawn_at,
+                    unwrapped_at: *unwrapped_at,
+                }),
+                _ => None,
+            },
 
             TokensSent {
                 redemption_wallet,
@@ -739,6 +1192,14 @@ impl EventSourced for EquityRedemption {
                     sent_at: *sent_at,
                 }),
                 Self::TokensUnwrapped {
+                    symbol,
+                    quantity,
+                    underlying_token,
+                    raindex_withdraw_tx,
+                    unwrap_tx_hash,
+                    ..
+                }
+                | Self::SendPending {
                     symbol,
                     quantity,
                     underlying_token,
@@ -863,7 +1324,7 @@ impl EventSourced for EquityRedemption {
 
     async fn initialize(
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         use EquityRedemptionCommand::*;
         use EquityRedemptionEvent::*;
@@ -873,43 +1334,19 @@ impl EventSourced for EquityRedemption {
                 quantity,
                 token,
                 amount,
-            } => {
-                let vault_id = match services.raindex.lookup_vault_id(token).await {
-                    Ok(id) => id,
-                    Err(error) => {
-                        warn!(target: "rebalance", %error, %token, "Raindex vault lookup failed");
-                        return Err(EquityRedemptionError::RaindexVaultNotFound(token));
-                    }
-                };
-
-                info!(target: "rebalance", ?vault_id, %token, %amount, "Withdrawing tokens from Raindex vault");
-
-                let raindex_withdraw_tx = match services
-                    .raindex
-                    .withdraw(token, vault_id, amount, TOKENIZED_EQUITY_DECIMALS)
-                    .await
-                {
-                    Ok(tx) => tx,
-                    Err(error) => {
-                        warn!(target: "rebalance", %error, %token, %amount, "Raindex vault withdrawal failed");
-                        return Err(EquityRedemptionError::RaindexWithdrawFailed {
-                            token,
-                            amount,
-                            error_message: error.to_string(),
-                        });
-                    }
-                };
-
-                Ok(vec![WithdrawnFromRaindex {
-                    symbol,
-                    quantity,
-                    token,
-                    wrapped_amount: amount,
-                    raindex_withdraw_tx,
-                    withdrawn_at: Utc::now(),
-                }])
-            }
-            UnwrapTokens
+            } => Ok(vec![VaultWithdrawPending {
+                symbol,
+                quantity,
+                token,
+                wrapped_amount: amount,
+                pending_at: Utc::now(),
+            }]),
+            SubmitWithdraw
+            | SubmitUnwrap
+            | PrepareSend
+            | ConfirmWithdraw
+            | ConfirmUnwrap
+            | UnwrapTokens
             | SendTokens
             | Detect { .. }
             | FailDetection { .. }
@@ -919,6 +1356,7 @@ impl EventSourced for EquityRedemption {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn transition(
         &self,
         command: Self::Command,
@@ -933,11 +1371,137 @@ impl EventSourced for EquityRedemption {
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
+            SubmitWithdraw => match self {
+                Self::VaultWithdrawPending {
+                    symbol,
+                    quantity,
+                    token,
+                    wrapped_amount,
+                    ..
+                } => {
+                    let vault_id = match services.raindex.lookup_vault_id(*token).await {
+                        Ok(id) => id,
+                        Err(error) => {
+                            warn!(target: "rebalance", %error, %token, "Raindex vault lookup failed");
+                            return Err(EquityRedemptionError::RaindexVaultNotFound(*token));
+                        }
+                    };
+
+                    info!(target: "rebalance", ?vault_id, %token, %wrapped_amount, "Submitting Raindex vault withdrawal");
+
+                    let tx_hash = match services
+                        .raindex
+                        .submit_withdraw(
+                            *token,
+                            vault_id,
+                            *wrapped_amount,
+                            TOKENIZED_EQUITY_DECIMALS,
+                        )
+                        .await
+                    {
+                        Ok(tx) => tx,
+                        Err(error) => {
+                            warn!(target: "rebalance", %error, %token, %wrapped_amount, "Raindex vault withdrawal submission failed");
+                            return Err(EquityRedemptionError::RaindexWithdrawFailed {
+                                token: *token,
+                                amount: *wrapped_amount,
+                                error_message: error.to_string(),
+                            });
+                        }
+                    };
+
+                    Ok(vec![VaultWithdrawSubmitted {
+                        symbol: symbol.clone(),
+                        quantity: *quantity,
+                        token: *token,
+                        wrapped_amount: *wrapped_amount,
+                        tx_hash,
+                        submitted_at: Utc::now(),
+                    }])
+                }
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::AlreadyStarted),
+            },
+
+            ConfirmWithdraw => match self {
+                Self::VaultWithdrawSubmitted {
+                    symbol,
+                    quantity,
+                    token,
+                    wrapped_amount,
+                    tx_hash,
+                    ..
+                } => {
+                    services
+                        .raindex
+                        .confirm_tx(*tx_hash)
+                        .await
+                        .map_err(|error| EquityRedemptionError::RaindexWithdrawFailed {
+                            token: *token,
+                            amount: *wrapped_amount,
+                            error_message: error.to_string(),
+                        })?;
+
+                    Ok(vec![WithdrawnFromRaindex {
+                        symbol: symbol.clone(),
+                        quantity: *quantity,
+                        token: *token,
+                        wrapped_amount: *wrapped_amount,
+                        raindex_withdraw_tx: *tx_hash,
+                        withdrawn_at: Utc::now(),
+                    }])
+                }
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::AlreadyStarted),
+            },
+
             UnwrapTokens => match self {
-                Self::WithdrawnFromRaindex {
+                Self::WithdrawnFromRaindex { .. } => Ok(vec![UnwrapPending {
+                    pending_at: Utc::now(),
+                }]),
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
+            },
+
+            SubmitUnwrap => match self {
+                Self::UnwrapPending {
+                    token,
+                    wrapped_amount,
+                    ..
+                } => {
+                    let owner = services.wrapper.owner();
+                    let unwrap_tx_hash = services
+                        .wrapper
+                        .submit_unwrap(*token, *wrapped_amount, owner, owner)
+                        .await
+                        .inspect_err(|error| {
+                            warn!(target: "rebalance", %error, %token, "Token unwrap submission failed");
+                        })
+                        .map_err(|error| EquityRedemptionError::UnwrapFailed {
+                            token: *token,
+                            wrapped_amount: *wrapped_amount,
+                            error_message: error.to_string(),
+                        })?;
+
+                    Ok(vec![UnwrapSubmitted {
+                        unwrap_tx_hash,
+                        submitted_at: Utc::now(),
+                    }])
+                }
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
+            },
+
+            ConfirmUnwrap => match self {
+                Self::UnwrapSubmitted {
                     symbol,
                     token,
                     wrapped_amount,
+                    unwrap_tx_hash,
                     ..
                 } => {
                     let underlying_token = services
@@ -951,13 +1515,12 @@ impl EventSourced for EquityRedemption {
                             error_message: error.to_string(),
                         })?;
 
-                    let owner = services.wrapper.owner();
-                    let (unwrap_tx_hash, unwrapped_amount) = services
+                    let unwrapped_amount = services
                         .wrapper
-                        .to_underlying(*token, *wrapped_amount, owner, owner)
+                        .confirm_unwrap(*token, *unwrap_tx_hash)
                         .await
                         .inspect_err(|error| {
-                            warn!(target: "rebalance", %error, %token, "Token unwrap failed");
+                            warn!(target: "rebalance", %error, %token, "Token unwrap confirmation failed");
                         })
                         .map_err(|error| EquityRedemptionError::UnwrapFailed {
                             token: *token,
@@ -967,7 +1530,7 @@ impl EventSourced for EquityRedemption {
 
                     Ok(vec![TokensUnwrapped {
                         underlying_token,
-                        unwrap_tx_hash,
+                        unwrap_tx_hash: *unwrap_tx_hash,
                         unwrapped_amount,
                         unwrapped_at: Utc::now(),
                     }])
@@ -977,8 +1540,17 @@ impl EventSourced for EquityRedemption {
                 _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
             },
 
+            PrepareSend => match self {
+                Self::TokensUnwrapped { .. } => Ok(vec![SendPending {
+                    pending_at: Utc::now(),
+                }]),
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                _ => Err(EquityRedemptionError::TokensNotUnwrapped),
+            },
+
             SendTokens => match self {
-                Self::TokensUnwrapped {
+                Self::SendPending {
                     symbol,
                     underlying_token,
                     unwrapped_amount,
@@ -1030,9 +1602,13 @@ impl EventSourced for EquityRedemption {
                     tokenization_request_id,
                     detected_at: Utc::now(),
                 }]),
-                Self::WithdrawnFromRaindex { .. } | Self::TokensUnwrapped { .. } => {
-                    Err(EquityRedemptionError::TokensNotSent)
-                }
+                Self::VaultWithdrawPending { .. }
+                | Self::VaultWithdrawSubmitted { .. }
+                | Self::WithdrawnFromRaindex { .. }
+                | Self::UnwrapPending { .. }
+                | Self::UnwrapSubmitted { .. }
+                | Self::TokensUnwrapped { .. }
+                | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
                 Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
@@ -1043,17 +1619,26 @@ impl EventSourced for EquityRedemption {
                     failure,
                     failed_at: Utc::now(),
                 }]),
-                Self::WithdrawnFromRaindex { .. } | Self::TokensUnwrapped { .. } => {
-                    Err(EquityRedemptionError::TokensNotSent)
-                }
+                Self::VaultWithdrawPending { .. }
+                | Self::VaultWithdrawSubmitted { .. }
+                | Self::WithdrawnFromRaindex { .. }
+                | Self::UnwrapPending { .. }
+                | Self::UnwrapSubmitted { .. }
+                | Self::TokensUnwrapped { .. }
+                | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
                 Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             },
 
             Complete => match self {
-                Self::WithdrawnFromRaindex { .. }
+                Self::VaultWithdrawPending { .. }
+                | Self::VaultWithdrawSubmitted { .. }
+                | Self::WithdrawnFromRaindex { .. }
+                | Self::UnwrapPending { .. }
+                | Self::UnwrapSubmitted { .. }
                 | Self::TokensUnwrapped { .. }
+                | Self::SendPending { .. }
                 | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPending),
                 Self::Pending { .. } => Ok(vec![Completed {
                     completed_at: Utc::now(),
@@ -1063,8 +1648,13 @@ impl EventSourced for EquityRedemption {
             },
 
             RejectRedemption { reason } => match self {
-                Self::WithdrawnFromRaindex { .. }
+                Self::VaultWithdrawPending { .. }
+                | Self::VaultWithdrawSubmitted { .. }
+                | Self::WithdrawnFromRaindex { .. }
+                | Self::UnwrapPending { .. }
+                | Self::UnwrapSubmitted { .. }
                 | Self::TokensUnwrapped { .. }
+                | Self::SendPending { .. }
                 | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPendingForRejection),
                 Self::Pending { .. } => Ok(vec![RedemptionRejected {
                     reason,
@@ -1075,8 +1665,13 @@ impl EventSourced for EquityRedemption {
             },
 
             FailTransfer { reason } => match self {
-                Self::WithdrawnFromRaindex { symbol, .. }
-                | Self::TokensUnwrapped { symbol, .. } => {
+                Self::VaultWithdrawPending { symbol, .. }
+                | Self::VaultWithdrawSubmitted { symbol, .. }
+                | Self::WithdrawnFromRaindex { symbol, .. }
+                | Self::UnwrapPending { symbol, .. }
+                | Self::UnwrapSubmitted { symbol, .. }
+                | Self::TokensUnwrapped { symbol, .. }
+                | Self::SendPending { symbol, .. } => {
                     warn!(
                         target: "rebalance",
                         %symbol, %reason,
@@ -1115,10 +1710,16 @@ pub(crate) async fn symbols_with_stuck_redemptions(
              GROUP BY aggregate_id \
          ) \
          SELECT latest.aggregate_id, \
-                json_extract(first_ev.payload, \
-                '$.WithdrawnFromRaindex.symbol'), \
-                json_extract(first_ev.payload, \
-                '$.WithdrawnFromRaindex.quantity') \
+                COALESCE( \
+                    json_extract(first_ev.payload, '$.VaultWithdrawPending.symbol'), \
+                    json_extract(first_ev.payload, '$.VaultWithdrawSubmitted.symbol'), \
+                    json_extract(first_ev.payload, '$.WithdrawnFromRaindex.symbol') \
+                ), \
+                COALESCE( \
+                    json_extract(first_ev.payload, '$.VaultWithdrawPending.quantity'), \
+                    json_extract(first_ev.payload, '$.VaultWithdrawSubmitted.quantity'), \
+                    json_extract(first_ev.payload, '$.WithdrawnFromRaindex.quantity') \
+                ) \
          FROM events last_ev \
          INNER JOIN latest \
              ON last_ev.aggregate_id = latest.aggregate_id \
@@ -1189,8 +1790,11 @@ pub(crate) async fn symbols_with_active_transfers(
             WHERE aggregate_type = 'EquityRedemption'
             GROUP BY aggregate_id
         )
-        SELECT DISTINCT json_extract(first_ev.payload,
-               '$.WithdrawnFromRaindex.symbol')
+        SELECT DISTINCT COALESCE(
+               json_extract(first_ev.payload, '$.VaultWithdrawPending.symbol'),
+               json_extract(first_ev.payload, '$.VaultWithdrawSubmitted.symbol'),
+               json_extract(first_ev.payload, '$.WithdrawnFromRaindex.symbol')
+        )
         FROM events last_ev
         INNER JOIN latest
             ON last_ev.aggregate_id = latest.aggregate_id
@@ -1201,8 +1805,13 @@ pub(crate) async fn symbols_with_active_transfers(
            AND first_ev.sequence = 0
         WHERE last_ev.aggregate_type = 'EquityRedemption'
           AND last_ev.event_type IN (
+              'EquityRedemptionEvent::VaultWithdrawPending',
+              'EquityRedemptionEvent::VaultWithdrawSubmitted',
               'EquityRedemptionEvent::WithdrawnFromRaindex',
+              'EquityRedemptionEvent::UnwrapPending',
+              'EquityRedemptionEvent::UnwrapSubmitted',
               'EquityRedemptionEvent::TokensUnwrapped',
+              'EquityRedemptionEvent::SendPending',
               'EquityRedemptionEvent::TokensSent',
               'EquityRedemptionEvent::Detected'
           )
@@ -1247,8 +1856,13 @@ pub(crate) async fn interrupted_redemption_ids(
             AND last_ev.sequence = latest.max_seq \
          WHERE last_ev.aggregate_type = 'EquityRedemption' \
            AND last_ev.event_type IN ( \
+               'EquityRedemptionEvent::VaultWithdrawPending', \
+               'EquityRedemptionEvent::VaultWithdrawSubmitted', \
                'EquityRedemptionEvent::WithdrawnFromRaindex', \
+               'EquityRedemptionEvent::UnwrapPending', \
+               'EquityRedemptionEvent::UnwrapSubmitted', \
                'EquityRedemptionEvent::TokensUnwrapped', \
+               'EquityRedemptionEvent::SendPending', \
                'EquityRedemptionEvent::TokensSent', \
                'EquityRedemptionEvent::Detected' \
            ) \
@@ -1354,6 +1968,19 @@ mod tests {
         }
     }
 
+    fn unwrap_pending_event() -> EquityRedemptionEvent {
+        EquityRedemptionEvent::UnwrapPending {
+            pending_at: Utc::now(),
+        }
+    }
+
+    fn unwrap_submitted_event() -> EquityRedemptionEvent {
+        EquityRedemptionEvent::UnwrapSubmitted {
+            unwrap_tx_hash: TxHash::random(),
+            submitted_at: Utc::now(),
+        }
+    }
+
     fn detected_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::Detected {
             tokenization_request_id: TokenizationRequestId("REQ789".to_string()),
@@ -1362,7 +1989,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn redeem_from_uninitialized_produces_withdrawn_from_raindex() {
+    async fn redeem_from_uninitialized_produces_vault_withdraw_pending() {
         let events = TestHarness::<EquityRedemption>::with(mock_services())
             .given_no_previous_events()
             .when(EquityRedemptionCommand::Redeem {
@@ -1377,7 +2004,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0],
-            EquityRedemptionEvent::WithdrawnFromRaindex { .. }
+            EquityRedemptionEvent::VaultWithdrawPending { .. }
         ));
     }
 
@@ -1430,7 +2057,32 @@ mod tests {
             .unwrap();
 
         store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        store
             .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
             .await
             .unwrap();
 
@@ -1486,7 +2138,32 @@ mod tests {
             .unwrap();
 
         store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        store
             .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
             .await
             .unwrap();
 
@@ -1819,7 +2496,32 @@ mod tests {
             .unwrap();
 
         store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        store
             .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
             .await
             .unwrap();
 
@@ -1860,7 +2562,32 @@ mod tests {
             .unwrap();
 
         store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        store
             .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
             .await
             .unwrap();
 
@@ -1884,9 +2611,11 @@ mod tests {
             wrapper: Arc::new(MockWrapper::failing_unwrap()),
         };
 
+        // UnwrapTokens is now pure (emits UnwrapPending).
+        // SubmitUnwrap performs the actual service call and should fail.
         let error = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![withdrawn_from_raindex_event()])
-            .when(EquityRedemptionCommand::UnwrapTokens)
+            .given(vec![withdrawn_from_raindex_event(), unwrap_pending_event()])
+            .when(EquityRedemptionCommand::SubmitUnwrap)
             .await
             .then_expect_error();
 
@@ -1907,9 +2636,14 @@ mod tests {
             wrapper: Arc::new(MockWrapper::failing_lookup()),
         };
 
+        // UnwrapTokens now emits UnwrapSubmitted (no lookup yet).
+        // The lookup happens during ConfirmUnwrap.
         let error = TestHarness::<EquityRedemption>::with(services)
-            .given(vec![withdrawn_from_raindex_event()])
-            .when(EquityRedemptionCommand::UnwrapTokens)
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                unwrap_submitted_event(),
+            ])
+            .when(EquityRedemptionCommand::ConfirmUnwrap)
             .await
             .then_expect_error();
 
@@ -1978,7 +2712,32 @@ mod tests {
             .unwrap();
 
         store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        store
             .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::PrepareSend)
             .await
             .unwrap();
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -464,6 +464,7 @@ async fn build_equity_transfer_with_trigger(
 /// drives the TokenizedEquityMint aggregate to completion via the Alpaca
 /// tokenization API.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn equity_offchain_imbalance_triggers_mint() {
     let EquityTriggerFixture {
         pool,
@@ -672,7 +673,17 @@ async fn equity_offchain_imbalance_triggers_mint() {
             ExpectedEvent::new(
                 "TokenizedEquityMint",
                 &mint_agg_id,
+                "TokenizedEquityMintEvent::WrapSubmitted",
+            ),
+            ExpectedEvent::new(
+                "TokenizedEquityMint",
+                &mint_agg_id,
                 "TokenizedEquityMintEvent::TokensWrapped",
+            ),
+            ExpectedEvent::new(
+                "TokenizedEquityMint",
+                &mint_agg_id,
+                "TokenizedEquityMintEvent::VaultDepositSubmitted",
             ),
             ExpectedEvent::new(
                 "TokenizedEquityMint",
@@ -709,6 +720,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
 /// setting up httpmock responses, so the mock detection endpoint can match
 /// the exact hash produced by the real onchain transfer.
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn equity_onchain_imbalance_triggers_redemption() {
     let EquityTriggerFixture {
         pool,
@@ -870,12 +882,37 @@ async fn equity_onchain_imbalance_triggers_redemption() {
             ExpectedEvent::new(
                 "EquityRedemption",
                 &redemption_agg_id,
+                "EquityRedemptionEvent::VaultWithdrawPending",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
+                "EquityRedemptionEvent::VaultWithdrawSubmitted",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
                 "EquityRedemptionEvent::WithdrawnFromRaindex",
             ),
             ExpectedEvent::new(
                 "EquityRedemption",
                 &redemption_agg_id,
+                "EquityRedemptionEvent::UnwrapPending",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
+                "EquityRedemptionEvent::UnwrapSubmitted",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
                 "EquityRedemptionEvent::TokensUnwrapped",
+            ),
+            ExpectedEvent::new(
+                "EquityRedemption",
+                &redemption_agg_id,
+                "EquityRedemptionEvent::SendPending",
             ),
             ExpectedEvent::new(
                 "EquityRedemption",
@@ -897,21 +934,21 @@ async fn equity_onchain_imbalance_triggers_redemption() {
     .await;
 
     assert_eq!(
-        events[6].payload["WithdrawnFromRaindex"]["symbol"]
+        events[6].payload["VaultWithdrawPending"]["symbol"]
             .as_str()
             .unwrap(),
         "AAPL",
-        "WithdrawnFromRaindex should target the correct symbol"
+        "VaultWithdrawPending should target the correct symbol"
     );
     assert_eq!(
-        events[8].payload["TokensSent"]["redemption_tx"]
+        events[13].payload["TokensSent"]["redemption_tx"]
             .as_str()
             .unwrap(),
         format!("{expected_tx_hash:#x}"),
         "TokensSent redemption_tx should match the deterministic Anvil hash"
     );
     assert_eq!(
-        events[9].payload["Detected"]["tokenization_request_id"]
+        events[14].payload["Detected"]["tokenization_request_id"]
             .as_str()
             .unwrap(),
         "redeem_int_test",
@@ -2275,7 +2312,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
 
     let redemption_id = RedemptionAggregateId::new("redemption-transfer-failed");
 
-    // Redeem: withdraws tokens from Raindex vault -> WithdrawnFromRaindex
+    // Redeem: creates VaultWithdrawPending
     redemption_store
         .send(
             &redemption_id,
@@ -2289,7 +2326,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
         .await
         .unwrap();
 
-    // After WithdrawnFromRaindex, inflight should be set at MarketMaking
+    // After VaultWithdrawPending, inflight should be set at MarketMaking
     let inflight_after_withdraw = inventory
         .read()
         .await
@@ -2297,12 +2334,39 @@ async fn transfer_failed_cancels_redemption_inflight() {
         .unwrap();
     assert!(
         !inflight_after_withdraw.inner().is_zero().unwrap(),
-        "Inflight should be non-zero after WithdrawnFromRaindex, got {inflight_after_withdraw:?}"
+        "Inflight should be non-zero after VaultWithdrawPending, got {inflight_after_withdraw:?}"
     );
 
-    // UnwrapTokens -> TokensUnwrapped (no inventory change)
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::SubmitWithdraw)
+        .await
+        .unwrap();
+
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::ConfirmWithdraw)
+        .await
+        .unwrap();
+
+    // UnwrapTokens -> UnwrapPending, SubmitUnwrap -> UnwrapSubmitted,
+    // ConfirmUnwrap -> TokensUnwrapped
     redemption_store
         .send(&redemption_id, EquityRedemptionCommand::UnwrapTokens)
+        .await
+        .unwrap();
+
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::SubmitUnwrap)
+        .await
+        .unwrap();
+
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::ConfirmUnwrap)
+        .await
+        .unwrap();
+
+    // PrepareSend -> SendPending
+    redemption_store
+        .send(&redemption_id, EquityRedemptionCommand::PrepareSend)
         .await
         .unwrap();
 

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -637,6 +637,19 @@ mod tests {
             self.address
         }
 
+        async fn send_pending(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TxHash, EvmError> {
+            panic!("MockEthereumWallet::send_pending should not be called in polling tests")
+        }
+
+        async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            panic!("MockEthereumWallet::await_receipt should not be called in polling tests")
+        }
+
         async fn send(
             &self,
             _contract: Address,
@@ -660,6 +673,19 @@ mod tests {
     impl Wallet for MockBaseWallet {
         fn address(&self) -> Address {
             self.address
+        }
+
+        async fn send_pending(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TxHash, EvmError> {
+            panic!("MockBaseWallet::send_pending should not be called in polling tests")
+        }
+
+        async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            panic!("MockBaseWallet::await_receipt should not be called in polling tests")
         }
 
         async fn send(

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -64,7 +64,17 @@ impl Raindex for MockRaindex {
         Ok((self.token, self.vault_id))
     }
 
-    async fn deposit(
+    async fn withdraw(
+        &self,
+        _token: Address,
+        _vault_id: RaindexVaultId,
+        _target_amount: U256,
+        _decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        Ok(self.withdraw_tx)
+    }
+
+    async fn submit_deposit(
         &self,
         token: Address,
         _vault_id: RaindexVaultId,
@@ -78,7 +88,7 @@ impl Raindex for MockRaindex {
         Ok(self.deposit_tx)
     }
 
-    async fn withdraw(
+    async fn submit_withdraw(
         &self,
         _token: Address,
         _vault_id: RaindexVaultId,
@@ -86,5 +96,9 @@ impl Raindex for MockRaindex {
         _decimals: u8,
     ) -> Result<TxHash, RaindexError> {
         Ok(self.withdraw_tx)
+    }
+
+    async fn confirm_tx(&self, _tx_hash: TxHash) -> Result<(), RaindexError> {
+        Ok(())
     }
 }

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -205,6 +205,34 @@ impl<W: Wallet> RaindexService<W> {
         Ok(receipt.transaction_hash)
     }
 
+    /// Submit a deposit4 transaction without waiting for confirmation.
+    async fn submit_deposit4_to_vault(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        let amount_float = Float::from_fixed_decimal(amount, decimals)?;
+
+        debug!(target: "orderbook", %token, ?vault_id, %amount, "Sending deposit4");
+
+        let calldata = IOrderBookV6::deposit4Call {
+            token,
+            vaultId: vault_id.0,
+            depositAmount: amount_float.get_inner(),
+            tasks: Vec::new(),
+        };
+
+        let tx_hash = self
+            .evm
+            .submit_pending(self.orderbook_address, calldata, "deposit4 to vault")
+            .await?;
+
+        info!(target: "orderbook", %tx_hash, %token, %amount, "deposit4 submitted");
+        Ok(tx_hash)
+    }
+
     /// Deposits USDC to a Rain OrderBook vault on Base.
     ///
     /// Convenience method that calls `deposit` with the Base USDC address and decimals.
@@ -303,16 +331,7 @@ pub(crate) trait Raindex: Send + Sync {
         symbol: &Symbol,
     ) -> Result<(Address, RaindexVaultId), RaindexError>;
 
-    /// Deposits tokens to a Rain OrderBook vault.
-    async fn deposit(
-        &self,
-        token: Address,
-        vault_id: RaindexVaultId,
-        amount: U256,
-        decimals: u8,
-    ) -> Result<TxHash, RaindexError>;
-
-    /// Withdraws tokens from a Rain OrderBook vault.
+    /// Withdraws tokens from a Rain OrderBook vault (atomic submit + confirm).
     async fn withdraw(
         &self,
         token: Address,
@@ -320,6 +339,34 @@ pub(crate) trait Raindex: Send + Sync {
         target_amount: U256,
         decimals: u8,
     ) -> Result<TxHash, RaindexError>;
+
+    /// Submit a vault deposit without waiting for confirmation.
+    ///
+    /// Handles approval if needed, submits the deposit4 transaction,
+    /// and returns the tx hash immediately. Use
+    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
+    async fn submit_deposit(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError>;
+
+    /// Submit a vault withdrawal without waiting for confirmation.
+    ///
+    /// Returns the tx hash immediately. Use
+    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
+    async fn submit_withdraw(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        target_amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError>;
+
+    /// Wait for a previously submitted transaction to be confirmed.
+    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError>;
 }
 
 #[async_trait]
@@ -344,16 +391,6 @@ impl<W: Wallet> Raindex for RaindexService<W> {
             .primary_vault_id_by_token(token)
             .ok_or(RaindexError::VaultNotFound(token))?;
         Ok((token, RaindexVaultId(vault_id)))
-    }
-
-    async fn deposit(
-        &self,
-        token: Address,
-        vault_id: RaindexVaultId,
-        amount: U256,
-        decimals: u8,
-    ) -> Result<TxHash, RaindexError> {
-        Self::deposit::<OpenChainErrorRegistry>(self, token, vault_id, amount, decimals).await
     }
 
     async fn withdraw(
@@ -385,6 +422,62 @@ impl<W: Wallet> Raindex for RaindexService<W> {
 
         info!(target: "orderbook", tx_hash = %receipt.transaction_hash, %token, %target_amount, "withdraw4 confirmed");
         Ok(receipt.transaction_hash)
+    }
+
+    async fn submit_deposit(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        if amount.is_zero() {
+            return Err(RaindexError::ZeroAmount);
+        }
+
+        self.approve_for_orderbook::<OpenChainErrorRegistry>(token, amount)
+            .await?;
+
+        self.submit_deposit4_to_vault(token, vault_id, amount, decimals)
+            .await
+    }
+
+    async fn submit_withdraw(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        target_amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError> {
+        if target_amount.is_zero() {
+            return Err(RaindexError::ZeroAmount);
+        }
+
+        let amount_float = Float::from_fixed_decimal(target_amount, decimals)?;
+
+        let tx_hash = self
+            .evm
+            .submit_pending(
+                self.orderbook_address,
+                IOrderBookV6::withdraw4Call {
+                    token,
+                    vaultId: vault_id.0,
+                    targetAmount: amount_float.get_inner(),
+                    tasks: Vec::new(),
+                },
+                "withdraw4 from vault",
+            )
+            .await?;
+
+        info!(target: "orderbook", %tx_hash, %token, %target_amount, "withdraw4 submitted");
+        Ok(tx_hash)
+    }
+
+    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError> {
+        let receipt = self.evm.confirm::<OpenChainErrorRegistry>(tx_hash).await?;
+
+        info!(target: "orderbook", tx_hash = %receipt.transaction_hash, "Transaction confirmed");
+        Ok(())
     }
 }
 

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -103,7 +103,7 @@ impl Raindex for PanickingRaindex {
         unimplemented!("PanickingRaindex: not available in CLI context")
     }
 
-    async fn deposit(
+    async fn withdraw(
         &self,
         _: Address,
         _: RaindexVaultId,
@@ -113,13 +113,27 @@ impl Raindex for PanickingRaindex {
         unimplemented!("PanickingRaindex: not available in CLI context")
     }
 
-    async fn withdraw(
+    async fn submit_deposit(
         &self,
         _: Address,
         _: RaindexVaultId,
         _: U256,
         _: u8,
     ) -> Result<TxHash, RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+
+    async fn submit_withdraw(
+        &self,
+        _: Address,
+        _: RaindexVaultId,
+        _: U256,
+        _: u8,
+    ) -> Result<TxHash, RaindexError> {
+        unimplemented!("PanickingRaindex: not available in CLI context")
+    }
+
+    async fn confirm_tx(&self, _: TxHash) -> Result<(), RaindexError> {
         unimplemented!("PanickingRaindex: not available in CLI context")
     }
 }
@@ -213,6 +227,28 @@ impl Wrapper for PanickingWrapper {
         _: Address,
         _: Address,
     ) -> Result<(TxHash, U256), WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn submit_wrap(&self, _: Address, _: U256, _: Address) -> Result<TxHash, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn confirm_wrap(&self, _: Address, _: TxHash) -> Result<U256, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn submit_unwrap(
+        &self,
+        _: Address,
+        _: U256,
+        _: Address,
+        _: Address,
+    ) -> Result<TxHash, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn confirm_unwrap(&self, _: Address, _: TxHash) -> Result<U256, WrapperError> {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
@@ -390,15 +426,27 @@ impl CrossVenueEquityTransfer {
         wrapped_shares: U256,
     ) -> Result<(), MintError> {
         let vault_id = self.raindex.lookup_vault_id(wrapped_token).await?;
+
         let vault_deposit_tx_hash = self
             .raindex
-            .deposit(
+            .submit_deposit(
                 wrapped_token,
                 vault_id,
                 wrapped_shares,
                 TOKENIZED_EQUITY_DECIMALS,
             )
             .await?;
+
+        self.mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::SubmitVaultDeposit {
+                    vault_deposit_tx_hash,
+                },
+            )
+            .await?;
+
+        self.raindex.confirm_tx(vault_deposit_tx_hash).await?;
 
         self.mint_store
             .send(
@@ -447,9 +495,22 @@ impl CrossVenueEquityTransfer {
         info!(target: "rebalance", "Onchain verification passed, wrapping into ERC-4626 shares");
 
         let wrapped_token = self.wrapper.lookup_derivative(&tokens_received.symbol)?;
-        let (wrap_tx_hash, wrapped_shares) = self
+
+        let wrap_tx_hash = self
             .wrapper
-            .to_wrapped(wrapped_token, tokens_received.shares_minted, self.wallet)
+            .submit_wrap(wrapped_token, tokens_received.shares_minted, self.wallet)
+            .await?;
+
+        self.mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash },
+            )
+            .await?;
+
+        let wrapped_shares = self
+            .wrapper
+            .confirm_wrap(wrapped_token, wrap_tx_hash)
             .await?;
 
         self.mint_store
@@ -466,6 +527,7 @@ impl CrossVenueEquityTransfer {
         Ok((wrapped_token, wrapped_shares))
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub(crate) async fn resume_mint(
         &self,
         issuer_request_id: &IssuerRequestId,
@@ -485,6 +547,38 @@ impl CrossVenueEquityTransfer {
                         .finalize_received_mint(issuer_request_id, tokens_received)
                         .await;
                 }
+                TokenizedEquityMint::WrapSubmitted {
+                    wrap_tx_hash,
+                    symbol,
+                    ..
+                } => {
+                    info!(%issuer_request_id, %wrap_tx_hash, "Resuming submitted wrap");
+                    let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
+                    let wrapped_shares = self
+                        .wrapper
+                        .confirm_wrap(wrapped_token, wrap_tx_hash)
+                        .await?;
+
+                    self.mint_store
+                        .send(
+                            issuer_request_id,
+                            TokenizedEquityMintCommand::WrapTokens {
+                                wrap_tx_hash,
+                                wrapped_shares,
+                            },
+                        )
+                        .await?;
+
+                    info!(target: "rebalance", %wrap_tx_hash, %wrapped_shares, "Wrap confirmed on resume, depositing to Raindex vault");
+                    return self
+                        .deposit_wrapped_mint(
+                            issuer_request_id,
+                            &symbol,
+                            wrapped_token,
+                            wrapped_shares,
+                        )
+                        .await;
+                }
                 TokenizedEquityMint::TokensWrapped {
                     symbol,
                     wrapped_shares,
@@ -501,6 +595,26 @@ impl CrossVenueEquityTransfer {
                         )
                         .await;
                 }
+                TokenizedEquityMint::VaultDepositSubmitted {
+                    vault_deposit_tx_hash,
+                    symbol,
+                    ..
+                } => {
+                    info!(%issuer_request_id, %vault_deposit_tx_hash, "Resuming submitted vault deposit");
+                    self.raindex.confirm_tx(vault_deposit_tx_hash).await?;
+
+                    self.mint_store
+                        .send(
+                            issuer_request_id,
+                            TokenizedEquityMintCommand::DepositToVault {
+                                vault_deposit_tx_hash,
+                            },
+                        )
+                        .await?;
+
+                    info!(target: "rebalance", %symbol, %vault_deposit_tx_hash, "Vault deposit confirmed on resume");
+                    return Ok(());
+                }
                 TokenizedEquityMint::DepositedIntoRaindex { .. }
                 | TokenizedEquityMint::Failed { .. } => return Ok(()),
                 entity @ TokenizedEquityMint::MintRequested { .. } => {
@@ -514,7 +628,8 @@ impl CrossVenueEquityTransfer {
         }
     }
 
-    /// Sends the Redeem command to withdraw from Raindex vault.
+    /// Sends the Redeem command to submit vault withdrawal, then
+    /// ConfirmWithdraw to wait for confirmation.
     async fn withdraw_from_raindex(
         &self,
         aggregate_id: &RedemptionAggregateId,
@@ -535,6 +650,14 @@ impl CrossVenueEquityTransfer {
             )
             .await?;
 
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::SubmitWithdraw)
+            .await?;
+
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await?;
+
         Ok(())
     }
 
@@ -548,7 +671,19 @@ impl CrossVenueEquityTransfer {
             .send(aggregate_id, EquityRedemptionCommand::UnwrapTokens)
             .await?;
 
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::SubmitUnwrap)
+            .await?;
+
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await?;
+
         info!(target: "rebalance", %aggregate_id, "Tokens unwrapped, sending to Alpaca");
+
+        self.redemption_store
+            .send(aggregate_id, EquityRedemptionCommand::PrepareSend)
+            .await?;
 
         self.redemption_store
             .send(aggregate_id, EquityRedemptionCommand::SendTokens)
@@ -680,17 +815,48 @@ impl CrossVenueEquityTransfer {
             })
     }
 
+    #[allow(clippy::cognitive_complexity)]
     pub(crate) async fn resume_redemption(
         &self,
         aggregate_id: &RedemptionAggregateId,
     ) -> Result<(), RedemptionError> {
         loop {
             match self.load_redemption_entity(aggregate_id).await? {
+                EquityRedemption::VaultWithdrawPending { .. } => {
+                    info!(%aggregate_id, "Resuming pending vault withdrawal");
+                    self.redemption_store
+                        .send(aggregate_id, EquityRedemptionCommand::SubmitWithdraw)
+                        .await?;
+                }
+                EquityRedemption::VaultWithdrawSubmitted { .. } => {
+                    info!(%aggregate_id, "Resuming submitted vault withdrawal");
+                    self.redemption_store
+                        .send(aggregate_id, EquityRedemptionCommand::ConfirmWithdraw)
+                        .await?;
+                }
                 EquityRedemption::WithdrawnFromRaindex { .. } => {
                     self.resume_withdrawn_redemption(aggregate_id).await?;
                 }
+                EquityRedemption::UnwrapPending { .. } => {
+                    info!(%aggregate_id, "Resuming pending unwrap");
+                    self.redemption_store
+                        .send(aggregate_id, EquityRedemptionCommand::SubmitUnwrap)
+                        .await?;
+                }
+                EquityRedemption::UnwrapSubmitted { .. } => {
+                    info!(%aggregate_id, "Resuming submitted unwrap");
+                    self.redemption_store
+                        .send(aggregate_id, EquityRedemptionCommand::ConfirmUnwrap)
+                        .await?;
+                }
                 EquityRedemption::TokensUnwrapped { .. } => {
                     self.resume_unwrapped_redemption(aggregate_id).await?;
+                }
+                EquityRedemption::SendPending { .. } => {
+                    info!(%aggregate_id, "Resuming pending send");
+                    self.redemption_store
+                        .send(aggregate_id, EquityRedemptionCommand::SendTokens)
+                        .await?;
                 }
                 EquityRedemption::TokensSent { redemption_tx, .. } => {
                     self.resume_sent_redemption(aggregate_id, &redemption_tx)
@@ -728,7 +894,7 @@ impl CrossVenueEquityTransfer {
     ) -> Result<(), RedemptionError> {
         info!(%aggregate_id, "Resuming unwrapped redemption");
         self.redemption_store
-            .send(aggregate_id, EquityRedemptionCommand::SendTokens)
+            .send(aggregate_id, EquityRedemptionCommand::PrepareSend)
             .await?;
         Ok(())
     }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -272,7 +272,9 @@ enum MintTrackingStage {
     Requested,
     Accepted,
     TokensReceived,
+    WrapSubmitted,
     TokensWrapped,
+    VaultDepositSubmitted,
 }
 
 impl std::fmt::Display for MintTrackingStage {
@@ -281,7 +283,9 @@ impl std::fmt::Display for MintTrackingStage {
             Self::Requested => write!(formatter, "MintRequested"),
             Self::Accepted => write!(formatter, "MintAccepted"),
             Self::TokensReceived => write!(formatter, "TokensReceived"),
+            Self::WrapSubmitted => write!(formatter, "WrapSubmitted"),
             Self::TokensWrapped => write!(formatter, "TokensWrapped"),
+            Self::VaultDepositSubmitted => write!(formatter, "VaultDepositSubmitted"),
         }
     }
 }
@@ -324,9 +328,17 @@ impl MintTracking {
                 self.stage = MintTrackingStage::TokensReceived;
                 self.last_progress_at = *received_at;
             }
+            TokenizedEquityMintEvent::WrapSubmitted { submitted_at, .. } => {
+                self.stage = MintTrackingStage::WrapSubmitted;
+                self.last_progress_at = *submitted_at;
+            }
             TokenizedEquityMintEvent::TokensWrapped { wrapped_at, .. } => {
                 self.stage = MintTrackingStage::TokensWrapped;
                 self.last_progress_at = *wrapped_at;
+            }
+            TokenizedEquityMintEvent::VaultDepositSubmitted { submitted_at, .. } => {
+                self.stage = MintTrackingStage::VaultDepositSubmitted;
+                self.last_progress_at = *submitted_at;
             }
             TokenizedEquityMintEvent::MintRequested { .. }
             | TokenizedEquityMintEvent::MintRejected { .. }
@@ -340,8 +352,13 @@ impl MintTracking {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RedemptionTrackingStage {
+    VaultWithdrawPending,
+    VaultWithdrawSubmitted,
     WithdrawnFromRaindex,
+    UnwrapPending,
+    UnwrapSubmitted,
     TokensUnwrapped,
+    SendPending,
     TokensSent,
     Detected,
 }
@@ -349,8 +366,13 @@ enum RedemptionTrackingStage {
 impl std::fmt::Display for RedemptionTrackingStage {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::VaultWithdrawPending => write!(formatter, "VaultWithdrawPending"),
+            Self::VaultWithdrawSubmitted => write!(formatter, "VaultWithdrawSubmitted"),
             Self::WithdrawnFromRaindex => write!(formatter, "WithdrawnFromRaindex"),
+            Self::UnwrapPending => write!(formatter, "UnwrapPending"),
+            Self::UnwrapSubmitted => write!(formatter, "UnwrapSubmitted"),
             Self::TokensUnwrapped => write!(formatter, "TokensUnwrapped"),
+            Self::SendPending => write!(formatter, "SendPending"),
             Self::TokensSent => write!(formatter, "TokensSent"),
             Self::Detected => write!(formatter, "Detected"),
         }
@@ -366,30 +388,70 @@ struct RedemptionTracking {
 }
 
 impl RedemptionTracking {
-    fn from_withdrawn_event(event: &EquityRedemptionEvent) -> Option<Self> {
-        let EquityRedemptionEvent::WithdrawnFromRaindex {
-            symbol,
-            quantity,
-            withdrawn_at,
-            ..
-        } = event
-        else {
-            return None;
-        };
-
-        Some(Self {
-            symbol: symbol.clone(),
-            quantity: FractionalShares::new(*quantity),
-            stage: RedemptionTrackingStage::WithdrawnFromRaindex,
-            last_progress_at: *withdrawn_at,
-        })
+    fn from_genesis_event(event: &EquityRedemptionEvent) -> Option<Self> {
+        match event {
+            EquityRedemptionEvent::VaultWithdrawPending {
+                symbol,
+                quantity,
+                pending_at,
+                ..
+            } => Some(Self {
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                stage: RedemptionTrackingStage::VaultWithdrawPending,
+                last_progress_at: *pending_at,
+            }),
+            EquityRedemptionEvent::VaultWithdrawSubmitted {
+                symbol,
+                quantity,
+                submitted_at,
+                ..
+            } => Some(Self {
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                stage: RedemptionTrackingStage::VaultWithdrawSubmitted,
+                last_progress_at: *submitted_at,
+            }),
+            EquityRedemptionEvent::WithdrawnFromRaindex {
+                symbol,
+                quantity,
+                withdrawn_at,
+                ..
+            } => Some(Self {
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                stage: RedemptionTrackingStage::WithdrawnFromRaindex,
+                last_progress_at: *withdrawn_at,
+            }),
+            _ => None,
+        }
     }
 
     fn track_progress(&mut self, event: &EquityRedemptionEvent) {
         match event {
+            EquityRedemptionEvent::VaultWithdrawSubmitted { submitted_at, .. } => {
+                self.stage = RedemptionTrackingStage::VaultWithdrawSubmitted;
+                self.last_progress_at = *submitted_at;
+            }
+            EquityRedemptionEvent::WithdrawnFromRaindex { withdrawn_at, .. } => {
+                self.stage = RedemptionTrackingStage::WithdrawnFromRaindex;
+                self.last_progress_at = *withdrawn_at;
+            }
+            EquityRedemptionEvent::UnwrapPending { pending_at, .. } => {
+                self.stage = RedemptionTrackingStage::UnwrapPending;
+                self.last_progress_at = *pending_at;
+            }
+            EquityRedemptionEvent::UnwrapSubmitted { submitted_at, .. } => {
+                self.stage = RedemptionTrackingStage::UnwrapSubmitted;
+                self.last_progress_at = *submitted_at;
+            }
             EquityRedemptionEvent::TokensUnwrapped { unwrapped_at, .. } => {
                 self.stage = RedemptionTrackingStage::TokensUnwrapped;
                 self.last_progress_at = *unwrapped_at;
+            }
+            EquityRedemptionEvent::SendPending { pending_at, .. } => {
+                self.stage = RedemptionTrackingStage::SendPending;
+                self.last_progress_at = *pending_at;
             }
             EquityRedemptionEvent::TokensSent { sent_at, .. } => {
                 self.stage = RedemptionTrackingStage::TokensSent;
@@ -399,7 +461,7 @@ impl RedemptionTracking {
                 self.stage = RedemptionTrackingStage::Detected;
                 self.last_progress_at = *detected_at;
             }
-            EquityRedemptionEvent::WithdrawnFromRaindex { .. }
+            EquityRedemptionEvent::VaultWithdrawPending { .. }
             | EquityRedemptionEvent::TransferFailed { .. }
             | EquityRedemptionEvent::DetectionFailed { .. }
             | EquityRedemptionEvent::RedemptionRejected { .. }
@@ -613,10 +675,10 @@ impl RebalancingTrigger {
                     MintTrackingStage::Accepted => {
                         TokenizedEquityMintCommand::FailAcceptance { reason }
                     }
-                    MintTrackingStage::TokensReceived => {
+                    MintTrackingStage::TokensReceived | MintTrackingStage::WrapSubmitted => {
                         TokenizedEquityMintCommand::FailWrapping { reason }
                     }
-                    MintTrackingStage::TokensWrapped => {
+                    MintTrackingStage::TokensWrapped | MintTrackingStage::VaultDepositSubmitted => {
                         TokenizedEquityMintCommand::FailRaindexDeposit { reason }
                     }
                     MintTrackingStage::Requested => continue,
@@ -682,8 +744,13 @@ impl RebalancingTrigger {
                 );
 
                 let command = match tracking.stage {
-                    RedemptionTrackingStage::WithdrawnFromRaindex
-                    | RedemptionTrackingStage::TokensUnwrapped => {
+                    RedemptionTrackingStage::VaultWithdrawPending
+                    | RedemptionTrackingStage::VaultWithdrawSubmitted
+                    | RedemptionTrackingStage::WithdrawnFromRaindex
+                    | RedemptionTrackingStage::UnwrapPending
+                    | RedemptionTrackingStage::UnwrapSubmitted
+                    | RedemptionTrackingStage::TokensUnwrapped
+                    | RedemptionTrackingStage::SendPending => {
                         Some(EquityRedemptionCommand::FailTransfer { reason })
                     }
                     RedemptionTrackingStage::TokensSent => {
@@ -958,7 +1025,7 @@ impl RebalancingTrigger {
             return;
         }
 
-        if let Some(created) = RedemptionTracking::from_withdrawn_event(event) {
+        if let Some(created) = RedemptionTracking::from_genesis_event(event) {
             tracking.insert(id.clone(), created);
         }
     }
@@ -1444,7 +1511,9 @@ impl RebalancingTrigger {
             DepositedIntoRaindex { .. } => Some(Self::last_rebalancing_update()),
             MintRequested { .. }
             | MintRejected { .. }
+            | WrapSubmitted { .. }
             | TokensWrapped { .. }
+            | VaultDepositSubmitted { .. }
             | WrappingFailed { .. }
             | RaindexDepositFailed { .. } => None,
         }
@@ -1519,7 +1588,7 @@ impl RebalancingTrigger {
         use EquityRedemptionEvent::*;
 
         match event {
-            WithdrawnFromRaindex { .. } => Some(Self::start_equity_transfer_update(
+            VaultWithdrawPending { .. } => Some(Self::start_equity_transfer_update(
                 Venue::MarketMaking,
                 quantity,
             )),
@@ -1531,7 +1600,12 @@ impl RebalancingTrigger {
                 Venue::MarketMaking,
                 quantity,
             )),
-            TokensUnwrapped { .. }
+            VaultWithdrawSubmitted { .. }
+            | WithdrawnFromRaindex { .. }
+            | UnwrapPending { .. }
+            | UnwrapSubmitted { .. }
+            | TokensUnwrapped { .. }
+            | SendPending { .. }
             | TokensSent { .. }
             | DetectionFailed { .. }
             | Detected { .. }
@@ -1679,7 +1753,13 @@ impl RebalancingTrigger {
             | TokensReceived {
                 symbol, quantity, ..
             }
+            | WrapSubmitted {
+                symbol, quantity, ..
+            }
             | TokensWrapped {
+                symbol, quantity, ..
+            }
+            | VaultDepositSubmitted {
                 symbol, quantity, ..
             } => {
                 let quantity = FractionalShares::new(*quantity);
@@ -1692,8 +1772,14 @@ impl RebalancingTrigger {
                     TokensReceived { received_at, .. } => {
                         (MintTrackingStage::TokensReceived, *received_at)
                     }
+                    WrapSubmitted { received_at, .. } => {
+                        (MintTrackingStage::WrapSubmitted, *received_at)
+                    }
                     TokensWrapped { wrapped_at, .. } => {
                         (MintTrackingStage::TokensWrapped, *wrapped_at)
+                    }
+                    VaultDepositSubmitted { wrapped_at, .. } => {
+                        (MintTrackingStage::VaultDepositSubmitted, *wrapped_at)
                     }
                     _ => unreachable!(),
                 };
@@ -1734,10 +1820,25 @@ impl RebalancingTrigger {
         use EquityRedemption::*;
 
         match entity {
-            WithdrawnFromRaindex {
+            VaultWithdrawPending {
+                symbol, quantity, ..
+            }
+            | VaultWithdrawSubmitted {
+                symbol, quantity, ..
+            }
+            | WithdrawnFromRaindex {
+                symbol, quantity, ..
+            }
+            | UnwrapPending {
+                symbol, quantity, ..
+            }
+            | UnwrapSubmitted {
                 symbol, quantity, ..
             }
             | TokensUnwrapped {
+                symbol, quantity, ..
+            }
+            | SendPending {
                 symbol, quantity, ..
             }
             | TokensSent {
@@ -1749,11 +1850,27 @@ impl RebalancingTrigger {
                 let quantity = FractionalShares::new(*quantity);
 
                 let (stage, last_progress_at) = match entity {
+                    VaultWithdrawPending { pending_at, .. } => {
+                        (RedemptionTrackingStage::VaultWithdrawPending, *pending_at)
+                    }
+                    VaultWithdrawSubmitted { submitted_at, .. } => (
+                        RedemptionTrackingStage::VaultWithdrawSubmitted,
+                        *submitted_at,
+                    ),
                     WithdrawnFromRaindex { withdrawn_at, .. } => {
                         (RedemptionTrackingStage::WithdrawnFromRaindex, *withdrawn_at)
                     }
+                    UnwrapPending { withdrawn_at, .. } => {
+                        (RedemptionTrackingStage::UnwrapPending, *withdrawn_at)
+                    }
+                    UnwrapSubmitted { withdrawn_at, .. } => {
+                        (RedemptionTrackingStage::UnwrapSubmitted, *withdrawn_at)
+                    }
                     TokensUnwrapped { unwrapped_at, .. } => {
                         (RedemptionTrackingStage::TokensUnwrapped, *unwrapped_at)
+                    }
+                    SendPending { unwrapped_at, .. } => {
+                        (RedemptionTrackingStage::SendPending, *unwrapped_at)
                     }
                     TokensSent { sent_at, .. } => (RedemptionTrackingStage::TokensSent, *sent_at),
                     Pending { detected_at, .. } => {
@@ -1896,7 +2013,9 @@ impl RebalancingTrigger {
             MintRequested { .. }
             | MintAccepted { .. }
             | TokensReceived { .. }
-            | TokensWrapped { .. } => false,
+            | WrapSubmitted { .. }
+            | TokensWrapped { .. }
+            | VaultDepositSubmitted { .. } => false,
         }
     }
 
@@ -1904,7 +2023,7 @@ impl RebalancingTrigger {
     fn extract_redemption_info(
         event: &EquityRedemptionEvent,
     ) -> Option<(Symbol, FractionalShares)> {
-        RedemptionTracking::from_withdrawn_event(event)
+        RedemptionTracking::from_genesis_event(event)
             .map(|tracking| (tracking.symbol, tracking.quantity))
     }
 
@@ -1917,8 +2036,13 @@ impl RebalancingTrigger {
             | DetectionFailed { .. }
             | RedemptionRejected { .. } => true,
 
-            WithdrawnFromRaindex { .. }
+            VaultWithdrawPending { .. }
+            | VaultWithdrawSubmitted { .. }
+            | WithdrawnFromRaindex { .. }
+            | UnwrapPending { .. }
+            | UnwrapSubmitted { .. }
             | TokensUnwrapped { .. }
+            | SendPending { .. }
             | TokensSent { .. }
             | Detected { .. } => false,
         }
@@ -4537,13 +4661,12 @@ mod tests {
     }
 
     fn make_withdrawn_from_raindex(symbol: &Symbol, quantity: Float) -> EquityRedemptionEvent {
-        EquityRedemptionEvent::WithdrawnFromRaindex {
+        EquityRedemptionEvent::VaultWithdrawPending {
             symbol: symbol.clone(),
             quantity,
             token: Address::random(),
             wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
-            raindex_withdraw_tx: TxHash::random(),
-            withdrawn_at: Utc::now(),
+            pending_at: Utc::now(),
         }
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,7 +1,7 @@
 //! Shared test fixtures: database setup, stub orders/logs,
 //! and builders for onchain trades and offchain executions.
 
-use alloy::primitives::{Address, B256, Bytes, LogData, address, bytes, fixed_bytes};
+use alloy::primitives::{Address, B256, Bytes, LogData, TxHash, address, bytes, fixed_bytes};
 use alloy::providers::RootProvider;
 use alloy::rpc::client::RpcClient;
 use alloy::rpc::types::{Log, TransactionReceipt};
@@ -51,6 +51,23 @@ impl Evm for StubWallet {
 impl Wallet for StubWallet {
     fn address(&self) -> Address {
         self.address
+    }
+
+    async fn send_pending(
+        &self,
+        _contract: Address,
+        _calldata: Bytes,
+        _note: &str,
+    ) -> Result<TxHash, EvmError> {
+        panic!(
+            "StubWallet::send_pending called - use a real wallet in tests that need transactions"
+        )
+    }
+
+    async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+        panic!(
+            "StubWallet::await_receipt called - use a real wallet in tests that need transactions"
+        )
     }
 
     async fn send(

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -239,6 +239,14 @@ pub(crate) enum TokenizedEquityMintCommand {
     /// Emits TokensReceived (success)
     ///     or MintAcceptanceFailed (rejection/timeout/error)
     Poll,
+    /// Record that a wrap transaction has been submitted (before confirmation).
+    SubmitWrap {
+        wrap_tx_hash: TxHash,
+    },
+    /// Record that a vault deposit transaction has been submitted (before confirmation).
+    SubmitVaultDeposit {
+        vault_deposit_tx_hash: TxHash,
+    },
     WrapTokens {
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
@@ -305,6 +313,12 @@ pub(crate) enum TokenizedEquityMintEvent {
         received_at: DateTime<Utc>,
     },
 
+    /// Wrap transaction submitted to the blockchain, pending confirmation.
+    WrapSubmitted {
+        wrap_tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
+    },
+
     /// Unwrapped tokens have been wrapped into ERC-4626 vault shares.
     TokensWrapped {
         wrap_tx_hash: TxHash,
@@ -324,6 +338,12 @@ pub(crate) enum TokenizedEquityMintEvent {
         #[serde(default)]
         reason: Option<String>,
         failed_at: DateTime<Utc>,
+    },
+
+    /// Vault deposit transaction submitted, pending confirmation.
+    VaultDepositSubmitted {
+        vault_deposit_tx_hash: TxHash,
+        submitted_at: DateTime<Utc>,
     },
 
     /// Wrapped tokens deposited to Raindex vault.
@@ -461,6 +481,26 @@ impl PartialEq for TokenizedEquityMintEvent {
                     && time_a == time_b
             }
             (
+                Self::WrapSubmitted {
+                    wrap_tx_hash: hash_a,
+                    submitted_at: time_a,
+                },
+                Self::WrapSubmitted {
+                    wrap_tx_hash: hash_b,
+                    submitted_at: time_b,
+                },
+            )
+            | (
+                Self::VaultDepositSubmitted {
+                    vault_deposit_tx_hash: hash_a,
+                    submitted_at: time_a,
+                },
+                Self::VaultDepositSubmitted {
+                    vault_deposit_tx_hash: hash_b,
+                    submitted_at: time_b,
+                },
+            )
+            | (
                 Self::DepositedIntoRaindex {
                     vault_deposit_tx_hash: hash_a,
                     deposited_at: time_a,
@@ -487,7 +527,11 @@ impl DomainEvent for TokenizedEquityMintEvent {
                 "TokenizedEquityMintEvent::MintAcceptanceFailed".to_string()
             }
             Self::TokensReceived { .. } => "TokenizedEquityMintEvent::TokensReceived".to_string(),
+            Self::WrapSubmitted { .. } => "TokenizedEquityMintEvent::WrapSubmitted".to_string(),
             Self::TokensWrapped { .. } => "TokenizedEquityMintEvent::TokensWrapped".to_string(),
+            Self::VaultDepositSubmitted { .. } => {
+                "TokenizedEquityMintEvent::VaultDepositSubmitted".to_string()
+            }
             Self::WrappingFailed { .. } => "TokenizedEquityMintEvent::WrappingFailed".to_string(),
             Self::DepositedIntoRaindex { .. } => {
                 "TokenizedEquityMintEvent::DepositedIntoRaindex".to_string()
@@ -562,6 +606,32 @@ pub(crate) enum TokenizedEquityMint {
         received_at: DateTime<Utc>,
     },
 
+    /// Wrap transaction submitted, awaiting confirmation
+    WrapSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        wallet: Address,
+        issuer_request_id: IssuerRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        tx_hash: TxHash,
+        receipt_id: ReceiptId,
+        shares_minted: U256,
+        #[serde(
+            default,
+            serialize_with = "st0x_float_serde::serialize_option_float",
+            deserialize_with = "st0x_float_serde::deserialize_option_float_from_number_or_string"
+        )]
+        fees: Option<Float>,
+        requested_at: DateTime<Utc>,
+        accepted_at: DateTime<Utc>,
+        received_at: DateTime<Utc>,
+        wrap_tx_hash: TxHash,
+    },
+
     /// Tokens have been wrapped into ERC-4626 vault shares
     TokensWrapped {
         symbol: Symbol,
@@ -582,6 +652,29 @@ pub(crate) enum TokenizedEquityMint {
         accepted_at: DateTime<Utc>,
         received_at: DateTime<Utc>,
         wrapped_at: DateTime<Utc>,
+    },
+
+    /// Vault deposit transaction submitted, awaiting confirmation
+    VaultDepositSubmitted {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        wallet: Address,
+        issuer_request_id: IssuerRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        tx_hash: TxHash,
+        receipt_id: ReceiptId,
+        shares_minted: U256,
+        wrap_tx_hash: TxHash,
+        wrapped_shares: U256,
+        requested_at: DateTime<Utc>,
+        accepted_at: DateTime<Utc>,
+        received_at: DateTime<Utc>,
+        wrapped_at: DateTime<Utc>,
+        vault_deposit_tx_hash: TxHash,
     },
 
     /// Wrapped tokens deposited to Raindex vault
@@ -719,6 +812,56 @@ impl PartialEq for TokenizedEquityMint {
                     && recv_a == recv_b
             }
             (
+                Self::WrapSubmitted {
+                    symbol: sym_a,
+                    quantity: qty_a,
+                    wallet: wal_a,
+                    issuer_request_id: iss_a,
+                    tokenization_request_id: tok_a,
+                    tx_hash: hash_a,
+                    receipt_id: rcpt_a,
+                    shares_minted: mint_a,
+                    fees: fees_a,
+                    requested_at: req_a,
+                    accepted_at: acc_a,
+                    received_at: recv_a,
+                    wrap_tx_hash: wrap_hash_a,
+                },
+                Self::WrapSubmitted {
+                    symbol: sym_b,
+                    quantity: qty_b,
+                    wallet: wal_b,
+                    issuer_request_id: iss_b,
+                    tokenization_request_id: tok_b,
+                    tx_hash: hash_b,
+                    receipt_id: rcpt_b,
+                    shares_minted: mint_b,
+                    fees: fees_b,
+                    requested_at: req_b,
+                    accepted_at: acc_b,
+                    received_at: recv_b,
+                    wrap_tx_hash: wrap_hash_b,
+                },
+            ) => {
+                sym_a == sym_b
+                    && qty_a.eq(*qty_b).unwrap_or(false)
+                    && wal_a == wal_b
+                    && iss_a == iss_b
+                    && tok_a == tok_b
+                    && hash_a == hash_b
+                    && rcpt_a == rcpt_b
+                    && mint_a == mint_b
+                    && match (fees_a, fees_b) {
+                        (Some(a), Some(b)) => a.eq(*b).unwrap_or(false),
+                        (None, None) => true,
+                        _ => false,
+                    }
+                    && req_a == req_b
+                    && acc_a == acc_b
+                    && recv_a == recv_b
+                    && wrap_hash_a == wrap_hash_b
+            }
+            (
                 Self::TokensWrapped {
                     symbol: sym_a,
                     quantity: qty_a,
@@ -766,6 +909,58 @@ impl PartialEq for TokenizedEquityMint {
                     && acc_a == acc_b
                     && recv_a == recv_b
                     && wrap_a == wrap_b
+            }
+            (
+                Self::VaultDepositSubmitted {
+                    symbol: sym_a,
+                    quantity: qty_a,
+                    wallet: wal_a,
+                    issuer_request_id: iss_a,
+                    tokenization_request_id: tok_a,
+                    tx_hash: hash_a,
+                    receipt_id: rcpt_a,
+                    shares_minted: mint_a,
+                    wrap_tx_hash: wrap_hash_a,
+                    wrapped_shares: wrap_shares_a,
+                    requested_at: req_a,
+                    accepted_at: acc_a,
+                    received_at: recv_a,
+                    wrapped_at: wrap_a,
+                    vault_deposit_tx_hash: vault_hash_a,
+                },
+                Self::VaultDepositSubmitted {
+                    symbol: sym_b,
+                    quantity: qty_b,
+                    wallet: wal_b,
+                    issuer_request_id: iss_b,
+                    tokenization_request_id: tok_b,
+                    tx_hash: hash_b,
+                    receipt_id: rcpt_b,
+                    shares_minted: mint_b,
+                    wrap_tx_hash: wrap_hash_b,
+                    wrapped_shares: wrap_shares_b,
+                    requested_at: req_b,
+                    accepted_at: acc_b,
+                    received_at: recv_b,
+                    wrapped_at: wrap_b,
+                    vault_deposit_tx_hash: vault_hash_b,
+                },
+            ) => {
+                sym_a == sym_b
+                    && qty_a.eq(*qty_b).unwrap_or(false)
+                    && wal_a == wal_b
+                    && iss_a == iss_b
+                    && tok_a == tok_b
+                    && hash_a == hash_b
+                    && rcpt_a == rcpt_b
+                    && mint_a == mint_b
+                    && wrap_hash_a == wrap_hash_b
+                    && wrap_shares_a == wrap_shares_b
+                    && req_a == req_b
+                    && acc_a == acc_b
+                    && recv_a == recv_b
+                    && wrap_a == wrap_b
+                    && vault_hash_a == vault_hash_b
             }
             (
                 Self::DepositedIntoRaindex {
@@ -872,6 +1067,13 @@ impl TokenizedEquityMint {
                 requested_at,
                 received_at,
                 ..
+            }
+            | Self::WrapSubmitted {
+                symbol,
+                quantity,
+                requested_at,
+                received_at,
+                ..
             } => TransferOperation::EquityMint(EquityMintOperation {
                 id: Id::new(issuer_request_id.clone()),
                 symbol: symbol.clone(),
@@ -882,6 +1084,13 @@ impl TokenizedEquityMint {
             }),
 
             Self::TokensWrapped {
+                symbol,
+                quantity,
+                requested_at,
+                wrapped_at,
+                ..
+            }
+            | Self::VaultDepositSubmitted {
                 symbol,
                 quantity,
                 requested_at,
@@ -954,7 +1163,9 @@ pub(crate) async fn interrupted_mint_ids(
            AND last_ev.event_type IN ( \
                'TokenizedEquityMintEvent::MintAccepted', \
                'TokenizedEquityMintEvent::TokensReceived', \
-               'TokenizedEquityMintEvent::TokensWrapped' \
+               'TokenizedEquityMintEvent::WrapSubmitted', \
+               'TokenizedEquityMintEvent::TokensWrapped', \
+               'TokenizedEquityMintEvent::VaultDepositSubmitted' \
            ) \
          ORDER BY latest.aggregate_id",
     )
@@ -1018,11 +1229,9 @@ impl EventSourced for TokenizedEquityMint {
                 quantity,
                 reason,
                 failed_at,
-            } => {
-                let Self::TokensReceived { requested_at, .. } = entity else {
-                    return Ok(None);
-                };
-                Some(Self::Failed {
+            } => match entity {
+                Self::TokensReceived { requested_at, .. }
+                | Self::WrapSubmitted { requested_at, .. } => Some(Self::Failed {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     reason: reason
@@ -1030,8 +1239,9 @@ impl EventSourced for TokenizedEquityMint {
                         .unwrap_or_else(|| "ERC-4626 wrapping failed".to_string()),
                     requested_at: *requested_at,
                     failed_at: *failed_at,
-                })
-            }
+                }),
+                _ => None,
+            },
             MintRejected {
                 reason,
                 rejected_at,
@@ -1136,12 +1346,51 @@ impl EventSourced for TokenizedEquityMint {
                 })
             }
 
+            WrapSubmitted {
+                wrap_tx_hash,
+                submitted_at: _,
+            } => {
+                let Self::TokensReceived {
+                    symbol,
+                    quantity,
+                    wallet,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    tx_hash,
+                    receipt_id,
+                    shares_minted,
+                    fees,
+                    requested_at,
+                    accepted_at,
+                    received_at,
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::WrapSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    wallet: *wallet,
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    tx_hash: *tx_hash,
+                    receipt_id: receipt_id.clone(),
+                    shares_minted: *shares_minted,
+                    fees: *fees,
+                    requested_at: *requested_at,
+                    accepted_at: *accepted_at,
+                    received_at: *received_at,
+                    wrap_tx_hash: *wrap_tx_hash,
+                })
+            }
+
             TokensWrapped {
                 wrap_tx_hash,
                 wrapped_shares,
                 wrapped_at,
-            } => {
-                let Self::TokensReceived {
+            } => match entity {
+                Self::TokensReceived {
                     symbol,
                     quantity,
                     wallet,
@@ -1154,12 +1403,21 @@ impl EventSourced for TokenizedEquityMint {
                     accepted_at,
                     received_at,
                     ..
-                } = entity
-                else {
-                    return Ok(None);
-                };
-
-                Some(Self::TokensWrapped {
+                }
+                | Self::WrapSubmitted {
+                    symbol,
+                    quantity,
+                    wallet,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    tx_hash,
+                    receipt_id,
+                    shares_minted,
+                    requested_at,
+                    accepted_at,
+                    received_at,
+                    ..
+                } => Some(Self::TokensWrapped {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     wallet: *wallet,
@@ -1174,14 +1432,58 @@ impl EventSourced for TokenizedEquityMint {
                     accepted_at: *accepted_at,
                     received_at: *received_at,
                     wrapped_at: *wrapped_at,
+                }),
+                _ => None,
+            },
+
+            VaultDepositSubmitted {
+                vault_deposit_tx_hash,
+                submitted_at: _,
+            } => {
+                let Self::TokensWrapped {
+                    symbol,
+                    quantity,
+                    wallet,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    tx_hash,
+                    receipt_id,
+                    shares_minted,
+                    wrap_tx_hash,
+                    wrapped_shares,
+                    requested_at,
+                    accepted_at,
+                    received_at,
+                    wrapped_at,
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::VaultDepositSubmitted {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    wallet: *wallet,
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    tx_hash: *tx_hash,
+                    receipt_id: receipt_id.clone(),
+                    shares_minted: *shares_minted,
+                    wrap_tx_hash: *wrap_tx_hash,
+                    wrapped_shares: *wrapped_shares,
+                    requested_at: *requested_at,
+                    accepted_at: *accepted_at,
+                    received_at: *received_at,
+                    wrapped_at: *wrapped_at,
+                    vault_deposit_tx_hash: *vault_deposit_tx_hash,
                 })
             }
 
             DepositedIntoRaindex {
                 vault_deposit_tx_hash,
                 deposited_at,
-            } => {
-                let Self::TokensWrapped {
+            } => match entity {
+                Self::TokensWrapped {
                     symbol,
                     quantity,
                     issuer_request_id,
@@ -1190,12 +1492,17 @@ impl EventSourced for TokenizedEquityMint {
                     wrap_tx_hash,
                     requested_at,
                     ..
-                } = entity
-                else {
-                    return Ok(None);
-                };
-
-                Some(Self::DepositedIntoRaindex {
+                }
+                | Self::VaultDepositSubmitted {
+                    symbol,
+                    quantity,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    tx_hash,
+                    wrap_tx_hash,
+                    requested_at,
+                    ..
+                } => Some(Self::DepositedIntoRaindex {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     issuer_request_id: issuer_request_id.clone(),
@@ -1205,28 +1512,31 @@ impl EventSourced for TokenizedEquityMint {
                     vault_deposit_tx_hash: *vault_deposit_tx_hash,
                     requested_at: *requested_at,
                     deposited_at: *deposited_at,
-                })
-            }
+                }),
+                _ => None,
+            },
 
-            RaindexDepositFailed { reason, failed_at } => {
-                let Self::TokensWrapped {
+            RaindexDepositFailed { reason, failed_at } => match entity {
+                Self::TokensWrapped {
                     symbol,
                     quantity,
                     requested_at,
                     ..
-                } = entity
-                else {
-                    return Ok(None);
-                };
-
-                Some(Self::Failed {
+                }
+                | Self::VaultDepositSubmitted {
+                    symbol,
+                    quantity,
+                    requested_at,
+                    ..
+                } => Some(Self::Failed {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     reason: reason.clone(),
                     requested_at: *requested_at,
                     failed_at: *failed_at,
-                })
-            }
+                }),
+                _ => None,
+            },
         })
     }
 
@@ -1316,6 +1626,7 @@ impl EventSourced for TokenizedEquityMint {
         ])
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn transition(
         &self,
         command: Self::Command,
@@ -1416,8 +1727,44 @@ impl EventSourced for TokenizedEquityMint {
                 }
                 Self::MintRequested { .. } => Err(TokenizedEquityMintError::NotAccepted),
                 Self::TokensReceived { .. }
+                | Self::WrapSubmitted { .. }
                 | Self::TokensWrapped { .. }
+                | Self::VaultDepositSubmitted { .. }
                 | Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            },
+
+            TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash } => match self {
+                Self::TokensReceived { .. } => Ok(vec![WrapSubmitted {
+                    wrap_tx_hash,
+                    submitted_at: Utc::now(),
+                }]),
+                Self::MintRequested { .. } | Self::MintAccepted { .. } => {
+                    Err(TokenizedEquityMintError::TokensNotReceivedForWrap)
+                }
+                Self::WrapSubmitted { .. }
+                | Self::TokensWrapped { .. }
+                | Self::VaultDepositSubmitted { .. }
+                | Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+            },
+
+            TokenizedEquityMintCommand::SubmitVaultDeposit {
+                vault_deposit_tx_hash,
+            } => match self {
+                Self::TokensWrapped { .. } => Ok(vec![VaultDepositSubmitted {
+                    vault_deposit_tx_hash,
+                    submitted_at: Utc::now(),
+                }]),
+                Self::MintRequested { .. }
+                | Self::MintAccepted { .. }
+                | Self::TokensReceived { .. }
+                | Self::WrapSubmitted { .. } => Err(TokenizedEquityMintError::TokensNotWrapped),
+                Self::VaultDepositSubmitted { .. } | Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
@@ -1427,15 +1774,19 @@ impl EventSourced for TokenizedEquityMint {
                 wrap_tx_hash,
                 wrapped_shares,
             } => match self {
-                Self::TokensReceived { .. } => Ok(vec![TokensWrapped {
-                    wrap_tx_hash,
-                    wrapped_shares,
-                    wrapped_at: Utc::now(),
-                }]),
+                Self::TokensReceived { .. } | Self::WrapSubmitted { .. } => {
+                    Ok(vec![TokensWrapped {
+                        wrap_tx_hash,
+                        wrapped_shares,
+                        wrapped_at: Utc::now(),
+                    }])
+                }
                 Self::MintRequested { .. } | Self::MintAccepted { .. } => {
                     Err(TokenizedEquityMintError::TokensNotReceivedForWrap)
                 }
-                Self::TokensWrapped { .. } | Self::DepositedIntoRaindex { .. } => {
+                Self::TokensWrapped { .. }
+                | Self::VaultDepositSubmitted { .. }
+                | Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
@@ -1444,13 +1795,16 @@ impl EventSourced for TokenizedEquityMint {
             TokenizedEquityMintCommand::DepositToVault {
                 vault_deposit_tx_hash,
             } => match self {
-                Self::TokensWrapped { .. } => Ok(vec![DepositedIntoRaindex {
-                    vault_deposit_tx_hash,
-                    deposited_at: Utc::now(),
-                }]),
+                Self::TokensWrapped { .. } | Self::VaultDepositSubmitted { .. } => {
+                    Ok(vec![DepositedIntoRaindex {
+                        vault_deposit_tx_hash,
+                        deposited_at: Utc::now(),
+                    }])
+                }
                 Self::MintRequested { .. }
                 | Self::MintAccepted { .. }
-                | Self::TokensReceived { .. } => Err(TokenizedEquityMintError::TokensNotWrapped),
+                | Self::TokensReceived { .. }
+                | Self::WrapSubmitted { .. } => Err(TokenizedEquityMintError::TokensNotWrapped),
                 Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
@@ -1471,6 +1825,9 @@ impl EventSourced for TokenizedEquityMint {
 
             TokenizedEquityMintCommand::FailWrapping { reason } => match self {
                 Self::TokensReceived {
+                    symbol, quantity, ..
+                }
+                | Self::WrapSubmitted {
                     symbol, quantity, ..
                 } => {
                     warn!(
@@ -1493,10 +1850,12 @@ impl EventSourced for TokenizedEquityMint {
             },
 
             TokenizedEquityMintCommand::FailRaindexDeposit { reason } => match self {
-                Self::TokensWrapped { .. } => Ok(vec![RaindexDepositFailed {
-                    reason,
-                    failed_at: Utc::now(),
-                }]),
+                Self::TokensWrapped { .. } | Self::VaultDepositSubmitted { .. } => {
+                    Ok(vec![RaindexDepositFailed {
+                        reason,
+                        failed_at: Utc::now(),
+                    }])
+                }
                 Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -77,6 +77,47 @@ pub(crate) trait Wrapper: Send + Sync {
         owner: Address,
     ) -> Result<(TxHash, U256), WrapperError>;
 
+    /// Submit an ERC-4626 deposit without waiting for confirmation.
+    ///
+    /// Handles approval if needed, submits the deposit transaction, and
+    /// returns the tx hash immediately. Use [`confirm_wrap`](Wrapper::confirm_wrap)
+    /// to wait for confirmation and extract the actual shares minted.
+    async fn submit_wrap(
+        &self,
+        wrapped_token: Address,
+        underlying_amount: U256,
+        receiver: Address,
+    ) -> Result<TxHash, WrapperError>;
+
+    /// Wait for a previously submitted wrap transaction to confirm
+    /// and extract the shares minted from the receipt.
+    async fn confirm_wrap(
+        &self,
+        wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError>;
+
+    /// Submit an ERC-4626 redeem without waiting for confirmation.
+    ///
+    /// Returns the tx hash immediately. Use
+    /// [`confirm_unwrap`](Wrapper::confirm_unwrap) to wait for
+    /// confirmation and extract the actual underlying amount received.
+    async fn submit_unwrap(
+        &self,
+        wrapped_token: Address,
+        wrapped_amount: U256,
+        receiver: Address,
+        owner: Address,
+    ) -> Result<TxHash, WrapperError>;
+
+    /// Wait for a previously submitted unwrap transaction to confirm
+    /// and extract the underlying amount received from the receipt.
+    async fn confirm_unwrap(
+        &self,
+        wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError>;
+
     /// Returns the market maker wallet address that owns the wrapped tokens.
     fn owner(&self) -> Address;
 }

--- a/src/wrapper/mock.rs
+++ b/src/wrapper/mock.rs
@@ -2,6 +2,8 @@
 
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 use st0x_execution::Symbol;
 
@@ -26,6 +28,8 @@ pub(crate) struct MockWrapper {
     wrapped_token: Address,
     ratio: U256,
     failure: MockFailure,
+    /// Maps tx hashes to their submitted amounts for confirm methods.
+    submitted_amounts: Mutex<HashMap<TxHash, U256>>,
 }
 
 impl MockWrapper {
@@ -37,6 +41,7 @@ impl MockWrapper {
             wrapped_token: Address::random(),
             ratio: RATIO_ONE,
             failure: MockFailure::None,
+            submitted_amounts: Mutex::new(HashMap::new()),
         }
     }
 
@@ -49,6 +54,7 @@ impl MockWrapper {
             wrapped_token: Address::random(),
             ratio,
             failure: MockFailure::None,
+            submitted_amounts: Mutex::new(HashMap::new()),
         }
     }
 
@@ -67,35 +73,31 @@ impl MockWrapper {
 
     /// Creates a mock wrapper that fails on wrap operations.
     pub(crate) fn failing() -> Self {
-        Self {
-            failure: MockFailure::Wrap,
-            ..Self::new()
-        }
+        let mut mock = Self::new();
+        mock.failure = MockFailure::Wrap;
+        mock
     }
 
     /// Creates a mock wrapper that fails on unwrap operations.
     pub(crate) fn failing_unwrap() -> Self {
-        Self {
-            failure: MockFailure::Unwrap,
-            ..Self::new()
-        }
+        let mut mock = Self::new();
+        mock.failure = MockFailure::Unwrap;
+        mock
     }
 
     /// Creates a mock wrapper that fails on underlying token lookup.
     pub(crate) fn failing_lookup() -> Self {
-        Self {
-            failure: MockFailure::Lookup,
-            ..Self::new()
-        }
+        let mut mock = Self::new();
+        mock.failure = MockFailure::Lookup;
+        mock
     }
 
     /// Creates a mock wrapper that succeeds on underlying token lookup but
     /// fails on derivative token lookup.
     pub(crate) fn failing_derivative_lookup() -> Self {
-        Self {
-            failure: MockFailure::DerivativeLookup,
-            ..Self::new()
-        }
+        let mut mock = Self::new();
+        mock.failure = MockFailure::DerivativeLookup;
+        mock
     }
 }
 
@@ -147,6 +149,70 @@ impl Wrapper for MockWrapper {
         }
         // 1:1 ratio for mock - underlying amount equals wrapped amount
         Ok((self.unwrap_tx, wrapped_amount))
+    }
+
+    async fn submit_wrap(
+        &self,
+        _wrapped_token: Address,
+        underlying_amount: U256,
+        _receiver: Address,
+    ) -> Result<TxHash, WrapperError> {
+        if self.failure == MockFailure::Wrap {
+            return Err(WrapperError::MissingDepositEvent);
+        }
+        let tx_hash = TxHash::random();
+        self.submitted_amounts
+            .lock()
+            .unwrap()
+            .insert(tx_hash, underlying_amount);
+        Ok(tx_hash)
+    }
+
+    async fn confirm_wrap(
+        &self,
+        _wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError> {
+        // 1:1 ratio — return the amount that was submitted for this tx
+        let amount = self
+            .submitted_amounts
+            .lock()
+            .unwrap()
+            .remove(&tx_hash)
+            .expect("confirm called with tx hash that was never submitted");
+        Ok(amount)
+    }
+
+    async fn submit_unwrap(
+        &self,
+        _wrapped_token: Address,
+        wrapped_amount: U256,
+        _receiver: Address,
+        _owner: Address,
+    ) -> Result<TxHash, WrapperError> {
+        if self.failure == MockFailure::Unwrap {
+            return Err(WrapperError::MissingWithdrawEvent);
+        }
+        self.submitted_amounts
+            .lock()
+            .unwrap()
+            .insert(self.unwrap_tx, wrapped_amount);
+        Ok(self.unwrap_tx)
+    }
+
+    async fn confirm_unwrap(
+        &self,
+        _wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError> {
+        // 1:1 ratio — return the amount that was submitted for this tx
+        let amount = self
+            .submitted_amounts
+            .lock()
+            .unwrap()
+            .remove(&tx_hash)
+            .expect("confirm called with tx hash that was never submitted");
+        Ok(amount)
     }
 
     fn owner(&self) -> Address {

--- a/src/wrapper/share.rs
+++ b/src/wrapper/share.rs
@@ -90,6 +90,37 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         underlying_amount: U256,
         receiver: Address,
     ) -> Result<(TxHash, U256), WrapperError> {
+        let tx_hash = self
+            .submit_wrap(wrapped_token, underlying_amount, receiver)
+            .await?;
+
+        let actual_shares = self.confirm_wrap(wrapped_token, tx_hash).await?;
+
+        Ok((tx_hash, actual_shares))
+    }
+
+    async fn to_underlying(
+        &self,
+        wrapped_token: Address,
+        wrapped_amount: U256,
+        receiver: Address,
+        owner: Address,
+    ) -> Result<(TxHash, U256), WrapperError> {
+        let tx_hash = self
+            .submit_unwrap(wrapped_token, wrapped_amount, receiver, owner)
+            .await?;
+
+        let actual_assets = self.confirm_unwrap(wrapped_token, tx_hash).await?;
+
+        Ok((tx_hash, actual_assets))
+    }
+
+    async fn submit_wrap(
+        &self,
+        wrapped_token: Address,
+        underlying_amount: U256,
+        receiver: Address,
+    ) -> Result<TxHash, WrapperError> {
         let underlying_token: Address = self
             .wallet
             .call::<OpenChainErrorRegistry, _>(wrapped_token, IERC4626::assetCall {})
@@ -130,9 +161,9 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         }
 
         info!(target: "orderbook", %wrapped_token, %underlying_amount, "Sending ERC4626 deposit");
-        let receipt = self
+        let tx_hash = self
             .wallet
-            .submit::<OpenChainErrorRegistry, _>(
+            .submit_pending(
                 wrapped_token,
                 IERC4626::depositCall {
                     assets: underlying_amount,
@@ -141,7 +172,21 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
                 "ERC4626 deposit",
             )
             .await?;
-        let tx_hash = receipt.transaction_hash;
+
+        info!(target: "orderbook", %tx_hash, "ERC4626 deposit submitted");
+
+        Ok(tx_hash)
+    }
+
+    async fn confirm_wrap(
+        &self,
+        wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError> {
+        let receipt = self
+            .wallet
+            .confirm::<OpenChainErrorRegistry>(tx_hash)
+            .await?;
 
         let actual_shares = receipt
             .inner
@@ -155,20 +200,20 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             })
             .ok_or(WrapperError::MissingDepositEvent)?;
 
-        Ok((tx_hash, actual_shares))
+        Ok(actual_shares)
     }
 
-    async fn to_underlying(
+    async fn submit_unwrap(
         &self,
         wrapped_token: Address,
         wrapped_amount: U256,
         receiver: Address,
         owner: Address,
-    ) -> Result<(TxHash, U256), WrapperError> {
+    ) -> Result<TxHash, WrapperError> {
         info!(target: "orderbook", %wrapped_token, %wrapped_amount, "Sending ERC4626 redeem");
-        let receipt = self
+        let tx_hash = self
             .wallet
-            .submit::<OpenChainErrorRegistry, _>(
+            .submit_pending(
                 wrapped_token,
                 IERC4626::redeemCall {
                     shares: wrapped_amount,
@@ -178,7 +223,21 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
                 "ERC4626 redeem",
             )
             .await?;
-        let tx_hash = receipt.transaction_hash;
+
+        info!(target: "orderbook", %tx_hash, "ERC4626 redeem submitted");
+
+        Ok(tx_hash)
+    }
+
+    async fn confirm_unwrap(
+        &self,
+        wrapped_token: Address,
+        tx_hash: TxHash,
+    ) -> Result<U256, WrapperError> {
+        let receipt = self
+            .wallet
+            .confirm::<OpenChainErrorRegistry>(tx_hash)
+            .await?;
 
         let actual_assets = receipt
             .inner
@@ -192,7 +251,7 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             })
             .ok_or(WrapperError::MissingWithdrawEvent)?;
 
-        Ok((tx_hash, actual_assets))
+        Ok(actual_assets)
     }
 
     fn owner(&self) -> Address {

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -117,12 +117,12 @@ impl Wallet for TestWallet {
         self.address
     }
 
-    async fn send(
+    async fn send_pending(
         &self,
         contract: Address,
         calldata: alloy::primitives::Bytes,
         note: &str,
-    ) -> Result<TransactionReceipt, EvmError> {
+    ) -> Result<alloy::primitives::TxHash, EvmError> {
         tracing::info!(%contract, note, "Submitting local test wallet call");
 
         let tx = TransactionRequest::default()
@@ -130,12 +130,68 @@ impl Wallet for TestWallet {
             .input(calldata.into());
 
         let pending = self.signing_provider.send_transaction(tx).await?;
-        let receipt = pending
-            .with_required_confirmations(self.required_confirmations)
-            .get_receipt()
-            .await?;
+        Ok(*pending.tx_hash())
+    }
+
+    async fn await_receipt(
+        &self,
+        tx_hash: alloy::primitives::TxHash,
+    ) -> Result<TransactionReceipt, EvmError> {
+        let timeout = Duration::from_secs(60);
+        let poll_interval = Duration::from_secs(1);
+        let start = tokio::time::Instant::now();
+
+        let mut poll = tokio::time::interval(poll_interval);
+
+        let (receipt, receipt_block) = loop {
+            poll.tick().await;
+
+            if start.elapsed() > timeout {
+                return Err(EvmError::ReceiptTimeout {
+                    tx_hash,
+                    timeout_secs: 60,
+                });
+            }
+
+            let Some(receipt) = self.read_provider.get_transaction_receipt(tx_hash).await? else {
+                continue;
+            };
+
+            let Some(block) = receipt.block_number else {
+                continue;
+            };
+
+            break (receipt, block);
+        };
+
+        // Wait for required confirmation depth.
+        loop {
+            let current_block = self.read_provider.get_block_number().await?;
+            if current_block >= receipt_block + self.required_confirmations - 1 {
+                break;
+            }
+
+            poll.tick().await;
+
+            if start.elapsed() > timeout {
+                return Err(EvmError::ReceiptTimeout {
+                    tx_hash,
+                    timeout_secs: 60,
+                });
+            }
+        }
 
         Ok(receipt)
+    }
+
+    async fn send(
+        &self,
+        contract: Address,
+        calldata: alloy::primitives::Bytes,
+        note: &str,
+    ) -> Result<TransactionReceipt, EvmError> {
+        let tx_hash = self.send_pending(contract, calldata, note).await?;
+        self.await_receipt(tx_hash).await
     }
 }
 
@@ -431,8 +487,8 @@ async fn assert_equity_mint_rebalancing<P: Provider>(
 
     assert_eq!(
         mint_events.len(),
-        5,
-        "Expected exactly 5 TokenizedEquityMint events in the completed aggregate, \
+        7,
+        "Expected exactly 7 TokenizedEquityMint events in the completed aggregate, \
          got {} (total across all aggregates: {})",
         mint_events.len(),
         all_mint_events.len(),
@@ -443,7 +499,9 @@ async fn assert_equity_mint_rebalancing<P: Provider>(
             "TokenizedEquityMintEvent::MintRequested",
             "TokenizedEquityMintEvent::MintAccepted",
             "TokenizedEquityMintEvent::TokensReceived",
+            "TokenizedEquityMintEvent::WrapSubmitted",
             "TokenizedEquityMintEvent::TokensWrapped",
+            "TokenizedEquityMintEvent::VaultDepositSubmitted",
             "TokenizedEquityMintEvent::DepositedIntoRaindex",
         ],
     );
@@ -584,14 +642,19 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
     let redeem_events = fetch_events_by_type(pool, "EquityRedemption").await?;
     assert_eq!(
         redeem_events.len(),
-        5,
-        "Expected exactly 5 EquityRedemption success events",
+        10,
+        "Expected exactly 10 EquityRedemption success events",
     );
     assert_event_subsequence(
         &redeem_events,
         &[
+            "EquityRedemptionEvent::VaultWithdrawPending",
+            "EquityRedemptionEvent::VaultWithdrawSubmitted",
             "EquityRedemptionEvent::WithdrawnFromRaindex",
+            "EquityRedemptionEvent::UnwrapPending",
+            "EquityRedemptionEvent::UnwrapSubmitted",
             "EquityRedemptionEvent::TokensUnwrapped",
+            "EquityRedemptionEvent::SendPending",
             "EquityRedemptionEvent::TokensSent",
             "EquityRedemptionEvent::Detected",
             "EquityRedemptionEvent::Completed",
@@ -747,22 +810,21 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
         last_event.event_type,
     );
 
-    // Verify the symbol from the first event (WithdrawnFromRaindex carries
-    // it; the terminal Completed event only has a timestamp).
-    let first_event = &redeem_events[0];
-    let withdrawn = first_event
+    // Verify the symbol from the VaultWithdrawPending event (the terminal
+    // Completed event only has a timestamp). Find by payload key rather
+    // than assuming a fixed index.
+    let pending_event = redeem_events
+        .iter()
+        .find(|event| event.payload.get("VaultWithdrawPending").is_some())
+        .ok_or_else(|| anyhow::anyhow!("No redemption event contains VaultWithdrawPending"))?;
+    let submitted = pending_event
         .payload
-        .get("WithdrawnFromRaindex")
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "First redemption event payload missing WithdrawnFromRaindex, got: {:?}",
-                first_event.payload
-            )
-        })?;
+        .get("VaultWithdrawPending")
+        .expect("checked in find");
     assert_eq!(
-        withdrawn.get("symbol").and_then(|val| val.as_str()),
+        submitted.get("symbol").and_then(|val| val.as_str()),
         Some(symbol),
-        "Redemption should be for {symbol}, got: {withdrawn}"
+        "Redemption should be for {symbol}, got: {submitted:?}"
     );
 
     Ok(())

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -979,11 +979,11 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
         .start_deposit_watcher(eth_deposit_provider, USDC_ETHEREUM, infra.base_chain.owner)
         .await?;
 
-    // Capture the Ethereum USDC balance before spawning the bot, so the
-    // baseline cannot include CCTP mints from a rebalance that fires
-    // shortly after startup. The bot is the only thing that triggers
-    // the CCTP receiveMessage on Ethereum, so its absence here pins the
-    // baseline to the pristine pre-test state.
+    // Snapshot Ethereum USDC balance before the bot starts. Once the
+    // bot detects the USDC surplus from takes it may start the CCTP
+    // bridge immediately, minting USDC on Ethereum. Querying after
+    // takes is racey — the "before" snapshot would capture a
+    // partially-bridged state and double-count the mint.
     let ethereum_usdc_balance_before_rebalance =
         crate::base_chain::IERC20::new(USDC_ETHEREUM, &eth_balance_provider)
             .balanceOf(infra.base_chain.owner)
@@ -1189,7 +1189,10 @@ async fn redemption_rejected_preserves_inflight_via_sticky() -> anyhow::Result<(
         &redeem_events,
         &[
             "EquityRedemptionEvent::WithdrawnFromRaindex",
+            "EquityRedemptionEvent::UnwrapPending",
+            "EquityRedemptionEvent::UnwrapSubmitted",
             "EquityRedemptionEvent::TokensUnwrapped",
+            "EquityRedemptionEvent::SendPending",
             "EquityRedemptionEvent::TokensSent",
             "EquityRedemptionEvent::Detected",
             "EquityRedemptionEvent::RedemptionRejected",
@@ -1323,7 +1326,9 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
             "TokenizedEquityMintEvent::MintRequested",
             "TokenizedEquityMintEvent::MintAccepted",
             "TokenizedEquityMintEvent::TokensReceived",
+            "TokenizedEquityMintEvent::WrapSubmitted",
             "TokenizedEquityMintEvent::TokensWrapped",
+            "TokenizedEquityMintEvent::VaultDepositSubmitted",
             "TokenizedEquityMintEvent::DepositedIntoRaindex",
         ],
     );
@@ -1645,7 +1650,9 @@ async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
             "TokenizedEquityMintEvent::MintRequested",
             "TokenizedEquityMintEvent::MintAccepted",
             "TokenizedEquityMintEvent::TokensReceived",
+            "TokenizedEquityMintEvent::WrapSubmitted",
             "TokenizedEquityMintEvent::TokensWrapped",
+            "TokenizedEquityMintEvent::VaultDepositSubmitted",
             "TokenizedEquityMintEvent::DepositedIntoRaindex",
         ],
     );
@@ -1825,7 +1832,10 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
         &redemption_events_after_restart,
         &[
             "EquityRedemptionEvent::WithdrawnFromRaindex",
+            "EquityRedemptionEvent::UnwrapPending",
+            "EquityRedemptionEvent::UnwrapSubmitted",
             "EquityRedemptionEvent::TokensUnwrapped",
+            "EquityRedemptionEvent::SendPending",
             "EquityRedemptionEvent::TokensSent",
             "EquityRedemptionEvent::Detected",
             "EquityRedemptionEvent::Completed",


### PR DESCRIPTION
## What

[RAI-365](https://linear.app/makeitrain/issue/RAI-365/persist-onchain-tx-hash-before-confirmation-to-prevent-non-idempotent) — Persist onchain tx hash before confirmation to prevent non-idempotent recovery.

Splits every onchain submit+confirm into two phases with an intermediate CQRS event persisted between them. This reduces the crash vulnerability window from minutes (the confirmation wait) to milliseconds (a SQLite write).

## Why

Every onchain operation in the mint/redemption transfer flow follows a non-idempotent pattern: submit tx -> wait minutes for receipt -> persist CQRS event. If the bot shuts down during the confirmation wait, the transaction lands onchain but the event is never persisted. On restart, recovery re-submits the same operation — risking double-minting (`ERC20InsufficientBalance`) or double-withdrawal.

This is not a millisecond race — the confirmation wait window is minutes long on Base via dRPC, making it a high-probability failure mode during deployments or restarts. On staging, mint `b14d1c6f` was stuck at `TokensReceived` for 6 days because a prior boot wrapped tokens but crashed before persisting the event.

## How

### Wallet trait (`crates/evm/src/lib.rs`, `local.rs`, `turnkey.rs`)

Added `send_pending()` and `await_receipt()` to the `Wallet` trait, splitting the existing `send()` into two phases. Added `submit_pending()` as a typed convenience (like `submit()` but returns `TxHash` without waiting). Both `TurnkeyWallet` and `RawPrivateKeyWallet` implement the new methods; `send()` is refactored to compose them.

### Wrapper trait (`src/wrapper.rs`, `src/wrapper/share.rs`)

Added `submit_wrap()`/`confirm_wrap()` and `submit_unwrap()`/`confirm_unwrap()` to the `Wrapper` trait. The existing `to_wrapped()`/`to_underlying()` are refactored to call submit+confirm internally. `confirm_*` methods wait for the receipt and extract event log data (shares minted / assets received).

### Raindex trait (`src/onchain/raindex.rs`)

Added `submit_deposit()`/`submit_withdraw()`/`confirm_tx()` to the `Raindex` trait. The existing `withdraw()` is kept as an atomic submit+confirm for use cases that don't need the split. Submit methods handle approval (for deposits) then submit the main tx without waiting. `confirm_tx()` polls for the receipt.

### TokenizedEquityMint aggregate (`src/tokenized_equity_mint.rs`)

New intermediate states in the state machine (two-phase: submit then confirm):

```
... -> TokensReceived -> [SubmitWrap] -> WrapSubmitted -> [WrapTokens] -> TokensWrapped -> [SubmitVaultDeposit] -> VaultDepositSubmitted -> [DepositToVault] -> DepositedIntoRaindex
```

- **New events:** `WrapSubmitted { wrap_tx_hash, submitted_at }`, `VaultDepositSubmitted { vault_deposit_tx_hash, submitted_at }`
- **New commands:** `SubmitWrap { wrap_tx_hash }`, `SubmitVaultDeposit { vault_deposit_tx_hash }`
- **New state variants:** `WrapSubmitted`, `VaultDepositSubmitted` (carry all parent state fields plus the tx hash)
- Backward compatible: `WrapTokens` accepts both `TokensReceived` (legacy) and `WrapSubmitted`; `DepositToVault` accepts both `TokensWrapped` and `VaultDepositSubmitted`
- Failure commands (`FailWrapping`, `FailRaindexDeposit`) also accept the new intermediate states
- `interrupted_mint_ids()` SQL updated to include new event types

### EquityRedemption aggregate (`src/equity_redemption.rs`)

New intermediate states using a three-step pattern (pending -> submit -> confirm) for each onchain operation:

```
[Redeem] -> VaultWithdrawPending -> [SubmitWithdraw] -> VaultWithdrawSubmitted -> [ConfirmWithdraw] -> WithdrawnFromRaindex
  -> [UnwrapTokens] -> UnwrapPending -> [SubmitUnwrap] -> UnwrapSubmitted -> [ConfirmUnwrap] -> TokensUnwrapped
  -> [PrepareSend] -> SendPending -> [SendTokens] -> TokensSent -> ...
```

- **New events:** `VaultWithdrawPending`, `VaultWithdrawSubmitted { tx_hash }`, `UnwrapPending`, `UnwrapSubmitted { unwrap_tx_hash }`, `SendPending`
- **New commands:** `SubmitWithdraw`, `ConfirmWithdraw`, `SubmitUnwrap`, `ConfirmUnwrap`, `PrepareSend`
- **Modified commands:** `Redeem` is now pure (no side effects) — emits `VaultWithdrawPending`; actual withdrawal moves to `SubmitWithdraw`. `UnwrapTokens` is now pure — emits `UnwrapPending`; actual unwrap moves to `SubmitUnwrap`.
- **New state variants:** `VaultWithdrawPending`, `VaultWithdrawSubmitted`, `UnwrapPending`, `UnwrapSubmitted`, `SendPending`
- Backward compatible: `originate()` handles `VaultWithdrawPending` (new), `VaultWithdrawSubmitted` (legacy), and `WithdrawnFromRaindex` (legacy) as genesis events
- `interrupted_redemption_ids()`, `symbols_with_active_transfers()`, `symbols_with_stuck_redemptions()` SQL updated for new event types; stuck redemptions uses `COALESCE` to extract symbol from any genesis event format

### Orchestration (`src/rebalancing/equity/mod.rs`)

- `wrap_received_mint()`: submit -> `SubmitWrap` command -> confirm -> `WrapTokens` command
- `deposit_wrapped_mint()`: submit -> `SubmitVaultDeposit` command -> confirm -> `DepositToVault` command
- `withdraw_from_raindex()`: `Redeem` command -> `SubmitWithdraw` command -> `ConfirmWithdraw` command
- `unwrap_and_send()`: `UnwrapTokens` command -> `SubmitUnwrap` command -> `ConfirmUnwrap` command -> `PrepareSend` command -> `SendTokens` command
- `resume_mint()`: handles `WrapSubmitted` (confirm wrap -> WrapTokens -> deposit) and `VaultDepositSubmitted` (confirm deposit -> DepositToVault)
- `resume_redemption()`: handles `VaultWithdrawSubmitted` (ConfirmWithdraw) and `UnwrapSubmitted` (ConfirmUnwrap)

### Timeout tracking (`src/rebalancing/trigger/mod.rs`)

- `MintTrackingStage`: added `WrapSubmitted`, `VaultDepositSubmitted`
- `RedemptionTrackingStage`: added `VaultWithdrawPending`, `VaultWithdrawSubmitted`, `UnwrapPending`, `UnwrapSubmitted`, `SendPending`
- Timeout failure commands map new stages to the appropriate failure command
- `restore_tracking_from_entity` and inventory update logic updated for new states
- Genesis event for redemption tracking changed from `WithdrawnFromRaindex` to `VaultWithdrawPending`/`VaultWithdrawSubmitted`

### CLI (`src/cli/rebalancing.rs`)

- `fail-transfer` accepts the new intermediate states (`WrapSubmitted`, `VaultDepositSubmitted`, `VaultWithdrawPending`, `VaultWithdrawSubmitted`, `UnwrapPending`, `UnwrapSubmitted`, `SendPending`)

## Testing

- All lib tests pass (unit, integration, aggregate)
- Updated `equity_redemption::tests` — including `complete_redemption_flow_end_to_end` which now exercises the full three-step flow (`Redeem` -> `SubmitWithdraw` -> `ConfirmWithdraw` -> `UnwrapTokens` -> `SubmitUnwrap` -> `ConfirmUnwrap` -> `PrepareSend` -> `SendTokens` -> ...)
- Updated `rebalancing::trigger::tests` — timeout and tracking tests for new stages
- Updated integration tests — event count assertions and index references adjusted for new intermediate events
- Updated e2e test assertions (`tests/e2e/rebalancing/assertions.rs`) — mint expects 7 events (was 5), redemption expects 12 events (was 5)
- Updated all mock `Wallet` implementations (4 files) with `send_pending`/`await_receipt` stubs
- `MockWrapper` stores submitted amounts via `Mutex<U256>` so `confirm_*` returns the correct value (1:1 ratio mock)

## Anything else

- **Backward compatibility:** Old aggregates persisted in the event store replay correctly. `originate()` and `evolve()` handle both legacy event sequences (starting with `WithdrawnFromRaindex`) and new sequences (starting with `VaultWithdrawPending`). No migration needed — events are stored as JSON blobs.
- **Scope:** Only the 4 onchain operations identified in RAI-365 are split (ERC-4626 wrap, Raindex deposit, Raindex withdrawal, ERC-4626 unwrap). The ERC-20 transfer to Alpaca's redemption wallet (`SendTokens`) is not split but does get a `SendPending` preparation step.
- **Residual risk:** A crash between `send_pending()` returning and the CQRS event being persisted (milliseconds) would still lose the tx hash. This is a dramatic improvement over the current minutes-long window but not zero.
