### PR TITLE
docs: remove OneToOneTokenizedShares refs and duplicate Event Upcasters section

### DIFF
--- a/docs/cqrs.md
+++ b/docs/cqrs.md
@@ -367,31 +367,6 @@ let entity: Option<Position> = load_aggregate::<Position>(pool, &symbol)
 Gated behind `#[cfg(test)]` / `feature = "test-support"`. Bypasses the CQRS
 framework (no reactors dispatched). Production code reads through `Projection`.
 
-## Event Upcasters
-
-When you MUST change event structure (e.g., adding required fields to existing
-events), use upcasters to transform old events to the new format at load time:
-
-```rust
-use cqrs_es::persist::{EventUpcaster, SemanticVersionEventUpcaster};
-
-fn upcast_v1_to_v2(mut payload: Value) -> Value {
-    payload["new_field"] = json!("default");
-    payload
-}
-
-pub fn create_my_upcaster() -> Box<dyn EventUpcaster> {
-    Box::new(SemanticVersionEventUpcaster::new(
-        "MyAggregate::MyEvent",  // event_type to match
-        "2.0",                    // target version
-        Box::new(upcast_v1_to_v2),
-    ))
-}
-```
-
-Update `event_version()` in your event enum to return the new version for new
-events.
-
 ## Forbidden Patterns
 
 1. **NEVER write directly to the `events` table** -- use `Store::send()`

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -122,16 +122,18 @@ rebalancing), and respects market hours by pausing trading outside open hours.
 A type-safe stock ticker represented as a newtype (`Symbol(String)`). Tokenized
 equities appear onchain in two forms, modeled by `TokenizedSymbol<Form>`:
 
-- `tAAPL` - 1:1 minted tokenized shares (`OneToOneTokenizedShares`)
+- `tAAPL` - 1:1 minted tokenized shares (the unwrapped underlying of the `wt`
+  vault shares; no dedicated Rust type)
 - `wtCOIN` - ERC-4626 vault shares wrapping tokenized equity
   (`WrappedTokenizedShares`)
 - `AAPL` - base equity stock (offchain, at the brokerage)
 - `USDC` - stablecoin used as the quote currency onchain
 
 Both forms resolve to the same base `Symbol` for offchain hedging (e.g. `tAAPL`
-and `wtAAPL` both resolve to `AAPL`). Each context uses the specific form it
-knows: Raindex events use `TokenizedSymbol<WrappedTokenizedShares>`, Alpaca
-tokenization uses `TokenizedSymbol<OneToOneTokenizedShares>`.
+and `wtAAPL` both resolve to `AAPL`). `WrappedTokenizedShares` is the only
+`TokenizationForm` implemented in code: Raindex events parse
+`TokenizedSymbol<WrappedTokenizedShares>` (`wt` prefix), while Alpaca
+tokenization operates on the base `Symbol` directly.
 
 ### Hedge
 


### PR DESCRIPTION
## What

Closes [RAI-862](https://linear.app/makeitrain/issue/RAI-862).

Fix the two stale-doc findings from the docs audit that are still live on
master:

- **docs/domain.md**: `OneToOneTokenizedShares` does not exist anywhere in the
  codebase — `WrappedTokenizedShares` is the only `TokenizationForm`
  implementation, and Alpaca tokenization takes the base `Symbol` directly.
- **docs/cqrs.md**: the "Event Upcasters" section appeared twice; removed the
  first (less complete) copy, keeping the fuller one in the internals
  reference.

## Why

Docs naming types that don't exist mislead contributors and AI agents. The
audit's other findings (reporter binary refs, README crate list, AGENTS.md
core flow, conductor.md paths) have since been fixed on master or by the PRs
below this one in the stack, so this branch was rebuilt to carry only the two
still-live fixes.

## How

Targeted edits verified against `src/onchain/io.rs` (the only
`TokenizationForm` impl) and `crates/tokenization/src/lib.rs` (plain `Symbol`
API).

## Testing

Doc-only change; each correction cross-checked against the current source.

## Anything else

The branch history was reset — the original diff had drifted to a 17k-line
merge-base mess. Now stacked on #617 as part of the stale-docs stack.
