### PR TITLE
feat: add db-reset command for prod/staging

### DIFF
--- a/infra/default.nix
+++ b/infra/default.nix
@@ -196,6 +196,7 @@ let
         text = ''
           ${resolveHost}
           trap _cleanup_identity EXIT
+          # shellcheck disable=SC2029
           exec ssh ''${identity:+-i "$identity"} "root@$host_ip" "$@"
         '';
       };
@@ -244,6 +245,65 @@ let
           echo "Restarting st0x-hedge on ${env}..."
           ssh ''${identity:+-i "$identity"} "root@$host_ip" "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl restart st0x-hedge"
           ssh ''${identity:+-i "$identity"} "root@$host_ip" systemctl is-active st0x-hedge
+        '';
+      };
+
+      "${env}DbReset" = pkgs.writeShellApplication {
+        name = "${env}-db-reset";
+        runtimeInputs = sshInputs ++ [ pkgs.curl pkgs.python3 ];
+        text = ''
+          ${resolveHost}
+
+          if [ "''${1:-}" != "--yes" ]; then
+            echo "Refusing destructive reset without --yes" >&2
+            echo "Usage: ${env}-db-reset --yes" >&2
+            exit 1
+          fi
+          shift
+
+          ssh_remote() {
+            # shellcheck disable=SC2029
+            ssh ''${identity:+-i "$identity"} "root@$host_ip" "$@"
+          }
+
+          _restart_service() {
+            echo "Ensuring st0x-hedge is restarted on ${env}..." >&2
+            ssh_remote "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl start st0x-hedge" || true
+            _cleanup_identity
+          }
+          trap _restart_service EXIT
+
+          config="/run/st0x/st0x-hedge.config"
+          db_path="/mnt/data/st0x-hedge.db"
+          backup_dir="/mnt/data/backups/$(date -u +%Y-%m-%d_%H%M%S)"
+
+          echo "Fetching latest Base block..."
+          latest_block=$(curl -sf https://mainnet.base.org \
+            -X POST -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+            | python3 -c "import sys,json; print(int(json.load(sys.stdin)['result'],16))")
+          target_block=$((latest_block - 2))
+          echo "Latest block: $latest_block, will backfill from: $target_block"
+
+          echo "Stopping st0x-hedge on ${env}..."
+          ssh_remote "systemctl stop st0x-hedge && rm -f /run/st0x/st0x-hedge.ready"
+
+          echo "Backing up database to $backup_dir..."
+          ssh_remote "mkdir -p $backup_dir && cp $db_path $db_path-wal $db_path-shm $db_path-journal $backup_dir/ 2>/dev/null; echo 'Backup done'"
+
+          echo "Deleting live database..."
+          ssh_remote "rm -f $db_path $db_path-wal $db_path-shm $db_path-journal"
+
+          echo "Updating deployment_block to $target_block..."
+          ssh_remote "sed -i 's/^deployment_block = .*/deployment_block = $target_block/' $config"
+          ssh_remote "grep -q '^deployment_block = $target_block$' $config"
+          echo "Verified deployment_block=$target_block"
+
+          echo "Starting st0x-hedge on ${env}..."
+          ssh_remote "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl start st0x-hedge"
+          ssh_remote systemctl is-active st0x-hedge
+
+          echo "Database reset complete. Backup at: $backup_dir"
         '';
       };
 


### PR DESCRIPTION
## What

Adds a `{env}DbReset` Nix shell script (exposed as `staging-db-reset` / `prod-db-reset`) that performs a full database reset on a deployed environment: stops the service, backs up the database, deletes it, updates `deployment_block` to a recent Base L1 block, and restarts the service.

## Why

When the bot's SQLite database gets into a bad state (corrupt CQRS projections, stale event history, schema drift after a migration change), the fastest recovery is a clean reset with a fresh backfill from a recent onchain block. This was previously a manual multi-step SSH procedure — automating it reduces operator error and downtime.

## How

- Implemented as a `writeShellApplication` in `infra/default.nix`, following the same pattern as existing `{env}Status`, `{env}Dashboard`, etc.
- Fetches the latest Base block number via the Base mainnet JSON-RPC endpoint (`eth_blockNumber`), then targets `latest - 2` to avoid reorg risk.
- SSHes into the target host to: stop the systemd service, back up all SQLite files (`.db`, `-wal`, `-shm`, `-journal`) to a timestamped directory under `/mnt/data/backups/`, delete the live database files, `sed`-update `deployment_block` in the config, and restart the service.
- Uses the existing `resolveHost`, `sshInputs`, and `identity`/`_cleanup_identity` patterns already established by sibling scripts.

## Testing

No new tests — this is an ops shell script in Nix, tested manually against staging.

## Anything else

- The backup is preserved at `/mnt/data/backups/<timestamp>/` for manual recovery if needed.
- Adds `curl` and `python3` to `runtimeInputs` for the block-number fetch.
- This command is intended for the current deep-development phase where frequent DB resets are needed. It may be removed once the system stabilizes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-environment database reset command to deployment tooling. It creates a timestamped remote DB backup (including auxiliary files), computes a safe backfill target block, updates the deployment block, restarts the service, verifies it is active, and prints the backup location and updated deployment block.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/659)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes RAI-579