### PR TITLE
feat: graceful shutdown with two-phase drain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6989,6 +6989,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.28.0",
+ "tokio-util",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-appender",
@@ -7532,6 +7533,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ mock = [
 
 [dependencies]
 apalis = "1.0.0-rc.7"
-apalis-sqlite = "1.0.0-rc.6"
+apalis-sqlite = "1.0.0-rc.7"
 apalis-codec = "0.1.0-rc.7"
 apalis-core = "1.0.0-rc.4"
 apalis-cron = { version = "1.0.0-rc.7", default-features = false }
@@ -207,6 +207,7 @@ uuid.workspace = true
 # Force transitive wasm-bindgen to match rain.wasm's expected version
 wasm-bindgen.workspace = true
 tracing-appender = "0.2.5"
+tokio-util = { version = "0.7.18", features = ["rt"] }
 
 [dev-dependencies]
 approx.workspace = true

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -18,8 +18,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use task_supervisor::SupervisorHandle;
 use tokio::sync::{Mutex, broadcast, mpsc};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinError, JoinHandle};
 use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use st0x_dto::Statement;
@@ -117,8 +118,17 @@ pub(crate) struct Conductor {
     executor_maintenance: Option<JoinHandle<()>>,
     /// Periodic rebalancing loop. Absent when rebalancing is not configured.
     rebalancer: Option<JoinHandle<()>>,
+    /// Cancelled during graceful shutdown to stop the rebalancer from
+    /// accepting new operations. The in-flight operation completes before
+    /// the task exits.
+    rebalancer_shutdown_token: CancellationToken,
     /// Periodically removes terminal rows from the persistent job queue.
     job_cleanup: JoinHandle<()>,
+    /// Cancelled by the outer shutdown handler to trigger graceful drain.
+    shutdown_token: CancellationToken,
+    /// Independent token for apalis — cancelled explicitly in Phase 2 after
+    /// producers are stopped.
+    apalis_shutdown_token: CancellationToken,
 }
 
 impl Conductor {
@@ -128,6 +138,7 @@ impl Conductor {
         pool: SqlitePool,
         event_sender: broadcast::Sender<Statement>,
         inventory: Arc<BroadcastingInventory>,
+        shutdown_token: CancellationToken,
     ) -> anyhow::Result<()>
     where
         E: Executor + Clone + Send + 'static,
@@ -171,6 +182,7 @@ impl Conductor {
             position_projection,
             snapshot,
             rebalancer,
+            rebalancer_shutdown_token,
             wallet_polling,
             tokenizer,
             service: rebalancing_service,
@@ -241,6 +253,7 @@ impl Conductor {
             pool,
             wallet_polling,
             tokenizer,
+            shutdown_token: shutdown_token.clone(),
             #[cfg(any(test, feature = "test-support"))]
             failure_injector: ctx.failure_injector.clone(),
         };
@@ -258,33 +271,98 @@ impl Conductor {
             .maybe_rebalancing_service(rebalancing_service)
             .maybe_executor_maintenance(executor_maintenance)
             .maybe_rebalancer(rebalancer)
+            .rebalancer_shutdown_token(rebalancer_shutdown_token)
             .job_cleanup(job_cleanup)
             .call();
 
         info!("Conductor is running");
         let result = conductor.wait_for_completion().await;
-        conductor.abort_all();
+        if result.is_err() {
+            conductor.abort_all();
+        }
         result
     }
 
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
         let exit = tokio::select! {
+            biased;
+            () = self.shutdown_token.cancelled() => ConductorExit::GracefulShutdown,
             result = self.supervisor.wait() => ConductorExit::Supervisor(result),
             result = &mut self.monitor => ConductorExit::Monitor(result),
             result = &mut self.job_cleanup => ConductorExit::JobCleanup(result),
         };
 
-        exit.handle()?;
-        Ok(())
+        match exit {
+            ConductorExit::GracefulShutdown => self.drain_gracefully().await,
+            other => {
+                other.handle()?;
+                Ok(())
+            }
+        }
     }
 
+    /// Two-phase graceful drain: stop producers, then wait for consumers.
+    async fn drain_gracefully(&mut self) -> anyhow::Result<()> {
+        // Phase 1: stop supervised tasks (OrderFillMonitor, PositionMonitor)
+        // so they stop enqueuing new jobs.
+        info!(target: "shutdown", "Phase 1: stopping producers (supervisor)");
+        if let Err(error) = self.supervisor.shutdown() {
+            error!(target: "shutdown", %error, "Failed to shutdown supervisor");
+        }
+
+        // Wait for the supervisor to fully exit so producers are actually
+        // stopped before Phase 2 begins draining consumers.
+        if let Err(error) = self.supervisor.wait().await {
+            warn!(target: "shutdown", %error, "Supervisor exited with error during drain");
+        }
+
+        // Signal the rebalancer to stop accepting new operations, then
+        // wait for the in-flight operation (e.g. a vault deposit) to
+        // finish. This ensures onchain TXs complete and their CQRS events
+        // are persisted before shutdown.
+        self.rebalancer_shutdown_token.cancel();
+
+        if let Some(handle) = self.rebalancer.take() {
+            info!(target: "shutdown", "Draining rebalancer (waiting for in-flight operation)");
+
+            let abort_handle = handle.abort_handle();
+
+            match tokio::time::timeout(std::time::Duration::from_secs(60), handle).await {
+                Ok(Ok(())) => {
+                    info!(target: "shutdown", "Rebalancer drained cleanly");
+                }
+                Ok(Err(join_error)) => {
+                    warn!(target: "shutdown", %join_error, "Rebalancer task panicked during drain");
+                }
+                Err(_timeout) => {
+                    warn!(target: "shutdown", "Rebalancer drain timed out after 60s -- aborting");
+                    abort_handle.abort();
+                }
+            }
+        }
+
+        // Abort remaining non-critical background tasks.
+        self.abort_background_tasks();
+
+        // Phase 2: now that producers are stopped, signal apalis to drain
+        // in-flight jobs. The apalis token is independent of the outer
+        // shutdown token -- we cancel it explicitly after producers stop.
+        info!(target: "shutdown", "Phase 2: draining in-flight jobs");
+        self.apalis_shutdown_token.cancel();
+        check_monitor_drain_result((&mut self.monitor).await)
+    }
+
+    /// Abort all conductor tasks (force shutdown fallback).
     pub(crate) fn abort_all(&self) {
-        info!("Aborting all conductor tasks");
+        info!(target: "shutdown", "Aborting all conductor tasks");
         if let Err(error) = self.supervisor.shutdown() {
             error!(%error, "Failed to shutdown supervisor");
         }
         self.monitor.abort();
+        self.abort_background_tasks();
+    }
 
+    fn abort_background_tasks(&self) {
         if let Some(ref handle) = self.rebalancer {
             handle.abort();
         }
@@ -330,6 +408,31 @@ pub(crate) struct AccumulatedPositionExecutionCtx<'a> {
     pub(crate) counter_trade_submission_lock: &'a Mutex<()>,
     pub(crate) threshold: &'a ExecutionThreshold,
     pub(crate) assets: &'a AssetsConfig,
+}
+
+fn check_monitor_drain_result(
+    join_result: Result<Result<(), MonitorTaskError>, JoinError>,
+) -> anyhow::Result<()> {
+    let monitor_result = match join_result {
+        Ok(inner) => inner,
+        Err(join_error) => {
+            error!(%join_error, "Monitor task panicked during drain");
+            return Err(
+                anyhow::Error::from(join_error).context("Monitor task panicked during drain")
+            );
+        }
+    };
+
+    match monitor_result {
+        Ok(()) => {
+            info!("All jobs drained, shutdown complete");
+            Ok(())
+        }
+        Err(error) => {
+            error!(%error, "Monitor error during drain");
+            Err(error.into())
+        }
+    }
 }
 
 fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> JoinHandle<()> {
@@ -438,6 +541,7 @@ struct RebalancingInfrastructure {
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
     rebalancer: JoinHandle<()>,
+    rebalancer_shutdown_token: CancellationToken,
     tokenizer: Arc<dyn Tokenizer>,
     service: Arc<RebalancingService>,
 }
@@ -463,6 +567,7 @@ struct PositionAndRebalancing {
     position_projection: Arc<Projection<Position>>,
     snapshot: Arc<Store<InventorySnapshot>>,
     rebalancer: Option<JoinHandle<()>>,
+    rebalancer_shutdown_token: CancellationToken,
     wallet_polling: Option<crate::inventory::WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     service: Option<Arc<RebalancingService>>,
@@ -513,6 +618,7 @@ impl PositionAndRebalancing {
                 position_projection: infra.position_projection,
                 snapshot: infra.snapshot,
                 rebalancer: Some(infra.rebalancer),
+                rebalancer_shutdown_token: infra.rebalancer_shutdown_token,
                 wallet_polling: Some(wallet_polling),
                 tokenizer: Some(infra.tokenizer),
                 service: Some(infra.service),
@@ -533,6 +639,7 @@ impl PositionAndRebalancing {
                 position_projection,
                 snapshot,
                 rebalancer: None,
+                rebalancer_shutdown_token: CancellationToken::new(),
                 wallet_polling: None,
                 tokenizer: None,
                 service: None,
@@ -749,7 +856,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .and_then(|cash| cash.vault_ids.first().copied())
             .ok_or(CtxError::MissingCashVaultId)?;
 
-        let handle = services.spawn(
+        let (handle, rebalancer_shutdown_token) = services.spawn(
             market_maker_wallet,
             RaindexVaultId(usdc_vault_id),
             operation_receiver,
@@ -763,6 +870,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             position_projection: built.position_projection,
             snapshot: built.snapshot,
             rebalancer: handle,
+            rebalancer_shutdown_token,
             tokenizer,
             service: rebalancing_service,
         })
@@ -1852,7 +1960,10 @@ mod tests {
             monitor,
             executor_maintenance: None,
             rebalancer: None,
+            rebalancer_shutdown_token: CancellationToken::new(),
             job_cleanup,
+            shutdown_token: CancellationToken::new(),
+            apalis_shutdown_token: CancellationToken::new(),
         }
     }
 
@@ -4710,6 +4821,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn graceful_shutdown_drains_cleanly_when_token_cancelled() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+        let apalis_token_clone = apalis_shutdown_token.clone();
+
+        // Monitor that completes once its shutdown signal fires.
+        let monitor = tokio::spawn(async move {
+            apalis_token_clone.cancelled().await;
+            Ok::<(), MonitorTaskError>(())
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            executor_maintenance: None,
+            rebalancer: None,
+            rebalancer_shutdown_token: CancellationToken::new(),
+
+            job_cleanup,
+            shutdown_token: shutdown_token.clone(),
+            apalis_shutdown_token,
+        };
+
+        shutdown_token.cancel();
+        conductor.wait_for_completion().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_propagates_monitor_error() {
+        let supervisor = SupervisorBuilder::default().build().run();
+        let shutdown_token = CancellationToken::new();
+        let apalis_shutdown_token = CancellationToken::new();
+        let apalis_token_clone = apalis_shutdown_token.clone();
+
+        // Monitor returns an error after shutdown signal.
+        let monitor = tokio::spawn(async move {
+            apalis_token_clone.cancelled().await;
+            Err(MonitorTaskError::TerminalJobFailure)
+        });
+
+        let job_cleanup = tokio::spawn(pending::<()>());
+
+        let mut conductor = Conductor {
+            supervisor,
+            monitor,
+            executor_maintenance: None,
+            rebalancer: None,
+            rebalancer_shutdown_token: CancellationToken::new(),
+
+            job_cleanup,
+            shutdown_token: shutdown_token.clone(),
+            apalis_shutdown_token,
+        };
+
+        shutdown_token.cancel();
+        let result = conductor.wait_for_completion().await;
+        assert!(
+            result.is_err(),
+            "monitor error during drain should propagate"
+        );
+    }
+
+    #[test]
+    fn check_monitor_drain_result_ok() {
+        check_monitor_drain_result(Ok(Ok(()))).unwrap();
+    }
+
+    #[test]
+    fn check_monitor_drain_result_propagates_monitor_error() {
+        let error =
+            check_monitor_drain_result(Ok(Err(MonitorTaskError::TerminalJobFailure))).unwrap_err();
+
+        assert!(
+            error.to_string().contains("Apalis worker failed"),
+            "should propagate MonitorTaskError, got: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn dispatch_post_place_state_filled_clears_position_pending() {
         let pool = setup_test_db().await;
         let (frameworks, _projection) =
@@ -4810,5 +5003,15 @@ mod tests {
             position.pending_offchain_order_id, None,
             "Failed state must clear the position's pending offchain order id"
         );
+    }
+
+    #[tokio::test]
+    async fn check_monitor_drain_result_propagates_join_error() {
+        let handle = tokio::spawn(async { panic!("test panic") });
+        // Abort to get a JoinError::Cancelled.
+        handle.abort();
+        let join_error = handle.await.unwrap_err();
+
+        check_monitor_drain_result(Err(join_error)).unwrap_err();
     }
 }

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -7,6 +7,7 @@ use sqlx::SqlitePool;
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use st0x_event_sorcery::{Projection, Store};
@@ -73,6 +74,7 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) pool: SqlitePool,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
+    pub(crate) shutdown_token: CancellationToken,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) failure_injector: FailureInjector,
 }
@@ -93,6 +95,7 @@ pub(crate) fn spawn<Prov, Exec>(
     job_cleanup: JoinHandle<()>,
     executor_maintenance: Option<JoinHandle<()>>,
     rebalancer: Option<JoinHandle<()>>,
+    rebalancer_shutdown_token: CancellationToken,
 ) -> Conductor
 where
     Prov: Provider + Clone + Send + Sync + 'static,
@@ -206,6 +209,9 @@ where
         job_queue: job_queue.clone(),
     });
 
+    let apalis_shutdown_token = CancellationToken::new();
+    let apalis_shutdown_token_for_struct = apalis_shutdown_token.clone();
+
     let order_fill_monitor = OrderFillMonitor::new(
         context.ctx.evm.clone(),
         job_queue.clone(),
@@ -243,6 +249,7 @@ where
         rejection_queue,
         equity_check_scheduler,
         usdc_check_scheduler,
+        apalis_shutdown_token,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: context.failure_injector,
     }
@@ -253,7 +260,10 @@ where
         monitor,
         executor_maintenance,
         rebalancer,
+        rebalancer_shutdown_token,
         job_cleanup,
+        shutdown_token: context.shutdown_token,
+        apalis_shutdown_token: apalis_shutdown_token_for_struct,
     }
 }
 
@@ -282,6 +292,7 @@ where
     rejection_queue: HandleOrderRejectionJobQueue,
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
+    apalis_shutdown_token: CancellationToken,
     #[cfg(any(test, feature = "test-support"))]
     failure_injector: FailureInjector,
 }
@@ -309,6 +320,7 @@ where
             rejection_queue,
             equity_check_scheduler,
             usdc_check_scheduler,
+            apalis_shutdown_token,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         } = self;
@@ -460,11 +472,29 @@ where
                 monitor
             };
 
+            let is_draining = apalis_shutdown_token.clone();
+
+            let shutdown_signal = async {
+                apalis_shutdown_token.cancelled().await;
+                Ok(())
+            };
+
+            // No inner shutdown_timeout — the outer 30s timeout in
+            // drain_bot_with_timeout owns force-abort. This avoids a semantic
+            // gap where apalis reports Ok(()) for both clean drain and timeout,
+            // making the two cases indistinguishable.
+
             tokio::select! {
                 biased;
-                () = failure_notify_for_select.notified() => Err(MonitorTaskError::TerminalJobFailure),
-                result = apalis_monitor.run() => match result {
-                    Ok(()) => Err(MonitorTaskError::UnexpectedExit { source: None }),
+                // During drain, suppress terminal job failures — let remaining
+                // workers finish instead of short-circuiting the drain.
+                () = failure_notify_for_select.notified(),
+                    if !is_draining.is_cancelled() =>
+                {
+                    Err(MonitorTaskError::TerminalJobFailure)
+                }
+                result = apalis_monitor.run_with_signal(shutdown_signal) => match result {
+                    Ok(()) => Ok(()),
                     Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
                 },
             }

--- a/src/conductor/exit.rs
+++ b/src/conductor/exit.rs
@@ -39,11 +39,12 @@ pub(super) enum ConductorExit {
     Supervisor(Result<(), SupervisorError>),
     Monitor(Result<Result<(), MonitorTaskError>, JoinError>),
     JobCleanup(Result<(), JoinError>),
+    GracefulShutdown,
 }
 
 impl ConductorExit {
     pub(super) fn handle(self) -> Result<(), ConductorExitError> {
-        use ConductorExit::{JobCleanup, Monitor, Supervisor};
+        use ConductorExit::{GracefulShutdown, JobCleanup, Monitor, Supervisor};
         match self {
             Supervisor(Ok(())) => {
                 info!("Supervisor finished");
@@ -80,6 +81,9 @@ impl ConductorExit {
                 task: "Job cleanup",
                 source,
             }),
+
+            // Handled directly in wait_for_completion before calling handle().
+            GracefulShutdown => Ok(()),
         }
     }
 }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -583,6 +583,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     // One more onchain sell triggers the CQRS -> trigger -> Mint flow now that
@@ -798,6 +799,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     position_cqrs
@@ -1017,6 +1019,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1097,6 +1100,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1265,6 +1269,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     // Drop all Arc clones holding the trigger so the mpsc channel closes
@@ -1452,6 +1457,7 @@ async fn mint_api_failure_produces_rejected_event() {
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        tokio_util::sync::CancellationToken::new(),
     );
 
     // One more sell triggers the CQRS -> trigger -> Mint flow

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,26 @@
 //! directional exposure by executing offsetting trades on
 //! traditional brokerages.
 
+use anyhow::Context;
 use rocket::{Ignite, Rocket};
 use sqlx::SqlitePool;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio::task::{AbortHandle, JoinError, JoinHandle};
-use tracing::{error, info};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
 
 use st0x_dto::Statement;
 use st0x_execution::MockExecutorCtx;
 
 use crate::config::{BrokerCtx, Ctx};
+
+/// How long to wait for in-flight work to drain before force-aborting.
+/// Outer timeout for the entire graceful shutdown sequence. Must exceed
+/// the rebalancer drain timeout (60s) plus margin for supervisor
+/// shutdown and apalis drain.
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(90);
 
 mod alpaca_wallet;
 pub mod api;
@@ -93,15 +102,18 @@ pub async fn run_bot_session_with_event_channel(
         event_sender.clone(),
     ));
 
+    let shutdown_token = CancellationToken::new();
+
     let server_task = spawn_server_task(&ctx, &pool, event_sender.clone(), inventory.clone());
     let bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
         pool,
         event_sender,
         inventory,
+        shutdown_token.clone(),
     )));
 
-    await_shutdown(server_task, bot_task).await?;
+    await_shutdown(server_task, bot_task, shutdown_token).await?;
 
     info!(target: "startup", "Shutdown complete");
     Ok(())
@@ -135,37 +147,126 @@ fn spawn_server_task(
 }
 
 async fn await_shutdown(
-    server_task: JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
-    bot_task: JoinHandle<anyhow::Result<()>>,
+    mut server_task: JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
+    mut bot_task: JoinHandle<anyhow::Result<()>>,
+    shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
     let server_abort = server_task.abort_handle();
     let bot_abort = bot_task.abort_handle();
 
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            info!(
-                target: "startup",
-                "Received shutdown signal, shutting down gracefully..."
-            );
+    let trigger = await_shutdown_trigger(&mut server_task, &mut bot_task).await?;
 
+    match trigger {
+        ShutdownTrigger::Signal(early_exit) => {
+            info!(target: "shutdown", "Initiating graceful shutdown");
+            shutdown_token.cancel();
             abort_task("server", &server_abort);
-            abort_task("bot", &bot_abort);
-
-            Ok(())
+            drain_bot_with_timeout(bot_task, bot_abort, early_exit, GRACEFUL_SHUTDOWN_TIMEOUT).await
         }
-        result = server_task => {
-            abort_task("bot", &bot_abort);
-            check_server_result(result)
-        }
-        result = bot_task => {
+        ShutdownTrigger::BotExited(result) => {
             abort_task("server", &server_abort);
             check_bot_result(result)
         }
     }
 }
 
+enum ShutdownTrigger {
+    /// An OS signal (or server exit) triggered shutdown; includes any
+    /// server error to propagate after the bot drains.
+    Signal(Option<anyhow::Result<()>>),
+    /// The bot task exited on its own before any signal.
+    BotExited(Result<anyhow::Result<()>, JoinError>),
+}
+
+/// Waits for the first shutdown trigger: SIGINT, SIGTERM, or task exit.
+async fn await_shutdown_trigger(
+    server_task: &mut JoinHandle<Result<Rocket<Ignite>, rocket::Error>>,
+    bot_task: &mut JoinHandle<anyhow::Result<()>>,
+) -> anyhow::Result<ShutdownTrigger> {
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .context("failed to register SIGTERM handler")?;
+
+    let trigger = tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            info!(target: "shutdown", "Received SIGINT");
+            ShutdownTrigger::Signal(None)
+        }
+        _ = sigterm.recv() => {
+            info!(target: "shutdown", "Received SIGTERM");
+            ShutdownTrigger::Signal(None)
+        }
+        result = server_task => {
+            ShutdownTrigger::Signal(Some(check_server_result(result)))
+        }
+        result = bot_task => {
+            ShutdownTrigger::BotExited(result)
+        }
+    };
+
+    Ok(trigger)
+}
+
+async fn drain_bot_with_timeout(
+    bot_task: JoinHandle<anyhow::Result<()>>,
+    bot_abort: AbortHandle,
+    early_exit: Option<anyhow::Result<()>>,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    info!(
+        target: "shutdown",
+        "Waiting up to {}s for in-flight work to drain (send signal again to force quit)",
+        timeout.as_secs()
+    );
+
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .context("failed to register SIGTERM handler for drain")?;
+
+    let drain_result = tokio::select! {
+        result = tokio::time::timeout(timeout, bot_task) => result,
+        _ = tokio::signal::ctrl_c() => {
+            warn!(target: "shutdown", "Received second signal, force-aborting immediately");
+            abort_task("bot", &bot_abort);
+            if let Some(server_result) = early_exit {
+                return server_result;
+            }
+            return Ok(());
+        }
+        _ = sigterm.recv() => {
+            warn!(target: "shutdown", "Received second SIGTERM, force-aborting immediately");
+            abort_task("bot", &bot_abort);
+            if let Some(server_result) = early_exit {
+                return server_result;
+            }
+            return Ok(());
+        }
+    };
+
+    match drain_result {
+        Ok(result) => {
+            info!(target: "shutdown", "Bot drained gracefully");
+            let bot_outcome = check_bot_result(result);
+            if let Some(server_result) = early_exit {
+                server_result?;
+            }
+            bot_outcome
+        }
+        Err(_elapsed) => {
+            warn!(
+                target: "shutdown",
+                "Drain timeout expired after {}s, force-aborting bot",
+                timeout.as_secs()
+            );
+            abort_task("bot", &bot_abort);
+            if let Some(server_result) = early_exit {
+                server_result?;
+            }
+            Ok(())
+        }
+    }
+}
+
 fn abort_task(name: &str, handle: &AbortHandle) {
-    info!(target: "startup", name, "Aborting task");
+    info!(target: "shutdown", name, "Aborting task");
     handle.abort();
 }
 
@@ -212,6 +313,7 @@ async fn run_conductor_session(
     pool: SqlitePool,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
+    shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
     let result = match ctx.broker.clone() {
         BrokerCtx::DryRun => {
@@ -222,6 +324,7 @@ async fn run_conductor_session(
                 pool,
                 event_sender,
                 inventory,
+                shutdown_token,
             ))
             .await
         }
@@ -233,6 +336,7 @@ async fn run_conductor_session(
                 pool,
                 event_sender,
                 inventory,
+                shutdown_token,
             ))
             .await
         }
@@ -292,6 +396,7 @@ mod tests {
             pool,
             create_test_event_sender(),
             create_test_inventory(),
+            CancellationToken::new(),
         ))
         .await
         .unwrap_err();
@@ -301,6 +406,72 @@ mod tests {
                 .to_string()
                 .contains("failed to connect websocket provider"),
             "expected websocket provider connection failure, got: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_bot_with_timeout_succeeds_when_bot_drains() {
+        let bot_task = tokio::spawn(async { Ok(()) });
+        let bot_abort = bot_task.abort_handle();
+        drain_bot_with_timeout(bot_task, bot_abort, None, GRACEFUL_SHUTDOWN_TIMEOUT)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_bot_with_timeout_propagates_bot_error() {
+        let bot_task = tokio::spawn(async { Err(anyhow::anyhow!("bot failed")) });
+        let bot_abort = bot_task.abort_handle();
+        let result =
+            drain_bot_with_timeout(bot_task, bot_abort, None, GRACEFUL_SHUTDOWN_TIMEOUT).await;
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("bot failed"),
+            "should propagate bot error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_bot_with_timeout_propagates_server_error_on_success() {
+        let bot_task = tokio::spawn(async { Ok(()) });
+        let bot_abort = bot_task.abort_handle();
+        let early_exit = Some(Err(anyhow::anyhow!("server crashed")));
+        let result =
+            drain_bot_with_timeout(bot_task, bot_abort, early_exit, GRACEFUL_SHUTDOWN_TIMEOUT)
+                .await;
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("server crashed"),
+            "should propagate server error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_bot_with_timeout_force_aborts_on_timeout() {
+        // Bot that never completes, forcing the timeout path
+        let bot_task = tokio::spawn(async { std::future::pending::<anyhow::Result<()>>().await });
+        let bot_abort = bot_task.abort_handle();
+
+        let result =
+            drain_bot_with_timeout(bot_task, bot_abort, None, Duration::from_millis(10)).await;
+
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_bot_with_timeout_force_abort_propagates_server_error() {
+        let bot_task = tokio::spawn(async { std::future::pending::<anyhow::Result<()>>().await });
+        let bot_abort = bot_task.abort_handle();
+        let early_exit = Some(Err(anyhow::anyhow!("server crashed")));
+
+        let result =
+            drain_bot_with_timeout(bot_task, bot_abort, early_exit, Duration::from_millis(10))
+                .await;
+
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("server crashed"),
+            "should propagate server error on force-abort, got: {error}"
         );
     }
 
@@ -316,6 +487,7 @@ mod tests {
             pool,
             create_test_event_sender(),
             create_test_inventory(),
+            CancellationToken::new(),
         ))
         .await
         .unwrap_err();

--- a/src/rebalancing/rebalancer.rs
+++ b/src/rebalancing/rebalancer.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use st0x_execution::{FractionalShares, Symbol};
@@ -38,6 +39,7 @@ pub(crate) struct Rebalancer {
     receiver: mpsc::Receiver<TriggeredOperation>,
     equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
     usdc_in_progress: Arc<AtomicBool>,
+    shutdown_token: CancellationToken,
 }
 
 impl Rebalancer {
@@ -49,6 +51,7 @@ impl Rebalancer {
         receiver: mpsc::Receiver<TriggeredOperation>,
         equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
         usdc_in_progress: Arc<AtomicBool>,
+        shutdown_token: CancellationToken,
     ) -> Self {
         Self {
             equity_to_mm,
@@ -58,19 +61,37 @@ impl Rebalancer {
             receiver,
             equity_in_progress,
             usdc_in_progress,
+            shutdown_token,
         }
     }
 
     /// Runs the rebalancer loop, receiving and executing operations.
-    /// Returns when the sender channel is closed.
+    ///
+    /// Stops accepting new operations when the shutdown token is
+    /// cancelled, but always finishes the in-flight operation before
+    /// returning. Also exits when the sender channel is closed.
     pub(crate) async fn run(mut self) {
         info!(target: "rebalance", "Rebalancer started");
 
-        while let Some(operation) = self.receiver.recv().await {
+        loop {
+            let operation = tokio::select! {
+                biased;
+                () = self.shutdown_token.cancelled() => {
+                    info!(target: "rebalance", "Rebalancer received shutdown signal");
+                    break;
+                }
+                received = self.receiver.recv() => {
+                    match received {
+                        Some(operation) => operation,
+                        None => break,
+                    }
+                }
+            };
+
             self.execute(operation).await;
         }
 
-        info!(target: "rebalance", "Rebalancer stopped (channel closed)");
+        info!(target: "rebalance", "Rebalancer stopped");
     }
 
     async fn execute(&self, operation: TriggeredOperation) {
@@ -180,6 +201,7 @@ mod tests {
             receiver,
             Arc::new(std::sync::RwLock::new(HashSet::new())),
             Arc::new(AtomicBool::new(false)),
+            CancellationToken::new(),
         );
 
         for operation in operations {

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx, CctpError};
@@ -121,7 +122,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         frameworks: RebalancingCqrsFrameworks,
         equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
         usdc_in_progress: Arc<AtomicBool>,
-    ) -> JoinHandle<()> {
+    ) -> (JoinHandle<()>, CancellationToken) {
         let equity = Arc::new(CrossVenueEquityTransfer::new(
             self.raindex.clone(),
             self.tokenizer,
@@ -141,6 +142,8 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             usdc_vault_id,
         ));
 
+        let shutdown_token = CancellationToken::new();
+
         let rebalancer = Rebalancer::new(
             Arc::clone(&equity) as _,
             equity as _,
@@ -149,12 +152,15 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             operation_receiver,
             equity_in_progress,
             usdc_in_progress,
+            shutdown_token.clone(),
         );
 
         info!(target: "rebalance", "Rebalancing infrastructure initialized");
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             rebalancer.run().await;
-        })
+        });
+
+        (handle, shutdown_token)
     }
 }
 
@@ -416,7 +422,7 @@ mod tests {
 
         let (tx, rx) = tokio::sync::mpsc::channel(10);
 
-        let handle = services.spawn(
+        let (handle, _shutdown_token) = services.spawn(
             Address::random(),
             RaindexVaultId(B256::ZERO),
             rx,


### PR DESCRIPTION
## What

Adds graceful shutdown so the bot drains in-flight apalis jobs before
exiting, instead of hard-aborting all tasks on SIGINT/SIGTERM.

## Why

Previously, any shutdown signal immediately aborted all conductor tasks
including in-flight order placement and reconciliation jobs. This could
leave orders in inconsistent states. A graceful drain ensures running
jobs complete before the process exits.

## How

Two-phase shutdown orchestrated via `tokio_util::CancellationToken`:

1. **Phase 1 — stop producers:** Shuts down the supervisor
   (OrderFillMonitor, PositionMonitor) so no new jobs are enqueued,
   then aborts non-critical background tasks (rebalancer, inventory
   poller, job cleanup).
2. **Phase 2 — drain consumers:** Cancels the apalis shutdown token,
   which triggers `run_with_signal` to stop accepting new jobs and
   drain in-flight work with a 25s inner timeout.

Key changes:
- **`src/lib.rs`**: `await_shutdown` refactored into
  `await_shutdown_trigger` (SIGINT, SIGTERM, or task exit) +
  `drain_bot_with_timeout` (30s outer timeout with force-abort
  fallback). SIGTERM handler added alongside SIGINT.
- **`src/conductor.rs`**: New `drain_gracefully()` method implements
  the two-phase drain. `abort_all()` now only called on error paths.
  New `ConductorExit::GracefulShutdown` variant.
- **`src/conductor/builder.rs`**: Apalis monitor wired with
  `run_with_signal` and `shutdown_timeout(25s)`. `CancellationToken`
  threaded through `ConductorCtx` and `MonitorWiring`.
- **`src/conductor/exit.rs`**: `GracefulShutdown` variant added.
- **`Cargo.toml`**: `tokio-util` dependency added for
  `CancellationToken`.

Timeout layering: 25s apalis inner < 30s outer drain timeout, giving
the outer layer time to log and force-abort if apalis hangs.

## Testing

7 new tests added:
- `graceful_shutdown_drains_cleanly_when_token_cancelled` — happy path
- `graceful_shutdown_propagates_monitor_error` — error during drain
- `check_monitor_drain_result_ok` / `_propagates_monitor_error` /
  `_propagates_join_error` — unit tests for drain result handling
- `drain_bot_with_timeout_succeeds_when_bot_drains` /
  `_propagates_bot_error` / `_propagates_server_error_on_success` —
  timeout + error propagation in `await_shutdown`

## Anything else

- The `apalis-cron` crate appears in `Cargo.lock` as a transitive
  dependency of the apalis-core version bump (rc.8 -> rc.9).

RAI-519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated `apalis-sqlite` to version 1.0.0-rc.7
  * Added `tokio-util` dependency for runtime utilities

* **Improvements**
  * Enhanced application shutdown process with graceful draining and configurable timeout-based termination handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/664)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->