### PR TITLE
chore: move imbalance check

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -59,8 +59,8 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::{
-    RebalancerServices, RebalancingCqrsFrameworks, RebalancingCtx, RebalancingTrigger,
-    RebalancingTriggerConfig,
+    RebalancerServices, RebalancingCqrsFrameworks, RebalancingCtx, RebalancingSchedulers,
+    RebalancingService, RebalancingServiceConfig,
 };
 use crate::symbol::cache::SymbolCache;
 use crate::threshold::ExecutionThreshold;
@@ -121,43 +121,6 @@ pub(crate) struct Conductor {
     job_cleanup: JoinHandle<()>,
 }
 
-fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
-    ctx.assets
-        .equities
-        .symbols
-        .iter()
-        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
-        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity))
-        .collect()
-}
-
-fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
-    ctx.assets
-        .equities
-        .symbols
-        .iter()
-        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
-        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
-        .collect()
-}
-
-/// Context for vault discovery operations during trade processing.
-pub(crate) struct VaultDiscoveryCtx<'a> {
-    pub(crate) vault_registry: &'a Store<VaultRegistry>,
-    pub(crate) orderbook: Address,
-    pub(crate) order_owner: Address,
-}
-
-#[cfg(test)]
-pub(crate) struct AccumulatedPositionExecutionCtx<'a> {
-    pub(crate) position: &'a Store<Position>,
-    pub(crate) position_projection: &'a Projection<Position>,
-    pub(crate) offchain_order: &'a Arc<Store<OffchainOrder>>,
-    pub(crate) counter_trade_submission_lock: &'a Mutex<()>,
-    pub(crate) threshold: &'a ExecutionThreshold,
-    pub(crate) assets: &'a AssetsConfig,
-}
-
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -184,6 +147,7 @@ impl Conductor {
         setup_apalis_tables(&pool).await?;
         let job_queue = DexTradeAccountingJobQueue::new(&pool);
         let backfill_queue = BackfillJobQueue::new(&pool);
+        let schedulers = RebalancingSchedulers::new(&pool);
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())
@@ -209,6 +173,7 @@ impl Conductor {
             rebalancer,
             wallet_polling,
             tokenizer,
+            service: rebalancing_service,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -217,6 +182,7 @@ impl Conductor {
             event_sender,
             vault_registry.clone(),
             vault_registry_projection.clone(),
+            schedulers.clone(),
         )
         .await?;
 
@@ -287,6 +253,9 @@ impl Conductor {
             .poll_status_queue(poll_status_queue)
             .reconcile_queue(reconcile_queue)
             .rejection_queue(rejection_queue)
+            .equity_check_scheduler(schedulers.equity)
+            .usdc_check_scheduler(schedulers.usdc)
+            .maybe_rebalancing_service(rebalancing_service)
             .maybe_executor_maintenance(executor_maintenance)
             .maybe_rebalancer(rebalancer)
             .job_cleanup(job_cleanup)
@@ -297,9 +266,7 @@ impl Conductor {
         conductor.abort_all();
         result
     }
-}
 
-impl Conductor {
     pub(crate) async fn wait_for_completion(&mut self) -> anyhow::Result<()> {
         let exit = tokio::select! {
             result = self.supervisor.wait() => ConductorExit::Supervisor(result),
@@ -326,6 +293,43 @@ impl Conductor {
         }
         self.job_cleanup.abort();
     }
+}
+
+fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
+    ctx.assets
+        .equities
+        .symbols
+        .iter()
+        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity))
+        .collect()
+}
+
+fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
+    ctx.assets
+        .equities
+        .symbols
+        .iter()
+        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
+        .collect()
+}
+
+/// Context for vault discovery operations during trade processing.
+pub(crate) struct VaultDiscoveryCtx<'a> {
+    pub(crate) vault_registry: &'a Store<VaultRegistry>,
+    pub(crate) orderbook: Address,
+    pub(crate) order_owner: Address,
+}
+
+#[cfg(test)]
+pub(crate) struct AccumulatedPositionExecutionCtx<'a> {
+    pub(crate) position: &'a Store<Position>,
+    pub(crate) position_projection: &'a Projection<Position>,
+    pub(crate) offchain_order: &'a Arc<Store<OffchainOrder>>,
+    pub(crate) counter_trade_submission_lock: &'a Mutex<()>,
+    pub(crate) threshold: &'a ExecutionThreshold,
+    pub(crate) assets: &'a AssetsConfig,
 }
 
 fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> JoinHandle<()> {
@@ -435,6 +439,7 @@ struct RebalancingInfrastructure {
     snapshot: Arc<Store<InventorySnapshot>>,
     rebalancer: JoinHandle<()>,
     tokenizer: Arc<dyn Tokenizer>,
+    service: Arc<RebalancingService>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -445,6 +450,7 @@ struct RebalancingDeps {
     event_sender: broadcast::Sender<Statement>,
     vault_registry: Arc<Store<VaultRegistry>>,
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
+    schedulers: RebalancingSchedulers,
 }
 
 /// Position + rebalancing-adjacent infrastructure produced during conductor
@@ -459,6 +465,7 @@ struct PositionAndRebalancing {
     rebalancer: Option<JoinHandle<()>>,
     wallet_polling: Option<crate::inventory::WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
+    service: Option<Arc<RebalancingService>>,
 }
 
 impl PositionAndRebalancing {
@@ -470,6 +477,7 @@ impl PositionAndRebalancing {
         event_sender: broadcast::Sender<Statement>,
         vault_registry: Arc<Store<VaultRegistry>>,
         vault_registry_projection: Arc<Projection<VaultRegistry>>,
+        schedulers: RebalancingSchedulers,
     ) -> anyhow::Result<Self> {
         if let Some(rebalancing_ctx) = rebalancing {
             let wallet_ctx = ctx.wallet()?;
@@ -488,6 +496,7 @@ impl PositionAndRebalancing {
                     event_sender,
                     vault_registry,
                     vault_registry_projection,
+                    schedulers,
                 },
             )
             .await?;
@@ -506,11 +515,12 @@ impl PositionAndRebalancing {
                 rebalancer: Some(infra.rebalancer),
                 wallet_polling: Some(wallet_polling),
                 tokenizer: Some(infra.tokenizer),
+                service: Some(infra.service),
             })
         } else {
             let (position, position_projection) = build_position_cqrs(pool).await?;
 
-            // Without the trigger, the projection is the only subscriber
+            // Without the service, the projection is the only subscriber
             // keeping the dashboard view in sync.
             let inventory_projection = Arc::new(InventoryProjection::new(inventory));
             let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
@@ -525,6 +535,7 @@ impl PositionAndRebalancing {
                 rebalancer: None,
                 wallet_polling: None,
                 tokenizer: None,
+                service: None,
             })
         }
     }
@@ -655,8 +666,8 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .cloned()
             .collect();
 
-        let rebalancing_trigger = Arc::new(RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let rebalancing_service = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: rebalancing_ctx.equity,
                 usdc: rebalancing_ctx.usdc,
                 transfer_timeout: rebalancing_ctx.transfer_timeout,
@@ -669,19 +680,20 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             deps.inventory.clone(),
             operation_sender,
             wrapper.clone(),
+            deps.schedulers,
         ));
 
-        let equity_in_progress = Arc::clone(&rebalancing_trigger.equity_in_progress);
-        let usdc_in_progress = Arc::clone(&rebalancing_trigger.usdc_in_progress);
+        let equity_in_progress = Arc::clone(&rebalancing_service.equity_in_progress);
+        let usdc_in_progress = Arc::clone(&rebalancing_service.usdc_in_progress);
 
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_trigger.clone(), broadcaster);
+        let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster);
 
         let built = manifest
             .build(deps.pool.clone(), equity_transfer_services)
             .await?;
 
-        rebalancing_trigger
+        rebalancing_service
             .set_stores(built.mint.clone(), built.redemption.clone())
             .await;
 
@@ -696,7 +708,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         recover_interrupted_tokenization_aggregates(
             &deps.pool,
-            &rebalancing_trigger,
+            &rebalancing_service,
             deps.inventory.as_ref(),
             &recovery_transfer,
             built.mint.clone(),
@@ -752,6 +764,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             snapshot: built.snapshot,
             rebalancer: handle,
             tokenizer,
+            service: rebalancing_service,
         })
     })
 }
@@ -792,7 +805,7 @@ async fn recover_stuck_redemptions(
 
 async fn recover_interrupted_tokenization_aggregates(
     pool: &SqlitePool,
-    rebalancing_trigger: &RebalancingTrigger,
+    rebalancing_service: &RebalancingService,
     inventory: &BroadcastingInventory,
     transfer: &CrossVenueEquityTransfer,
     mint_store: Arc<Store<TokenizedEquityMint>>,
@@ -808,7 +821,7 @@ async fn recover_interrupted_tokenization_aggregates(
             ));
         };
 
-        rebalancing_trigger
+        rebalancing_service
             .recover_mint_state(mint_id, &mint)
             .await?;
     }
@@ -820,7 +833,7 @@ async fn recover_interrupted_tokenization_aggregates(
             ));
         };
 
-        rebalancing_trigger
+        rebalancing_service
             .recover_redemption_state(redemption_id, &redemption)
             .await?;
     }
@@ -1819,7 +1832,7 @@ mod tests {
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::OrderPlacementResult;
     use crate::onchain::trade::OnchainTrade;
-    use crate::rebalancing::{RebalancingTrigger, TriggeredOperation};
+    use crate::rebalancing::{RebalancingSchedulers, RebalancingService, TriggeredOperation};
     use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
     use crate::threshold::ExecutionThreshold;
     use crate::trading::onchain::inclusion::EmittedOnChain;
@@ -3267,7 +3280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn position_events_reach_rebalancing_trigger() {
+    async fn position_events_reach_rebalancing_service() {
         let pool = setup_test_db().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
@@ -3303,8 +3316,8 @@ mod tests {
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
 
-        let trigger = Arc::new(RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: ImbalanceThreshold {
                     target: float!(0.5),
                     deviation: float!(0.2),
@@ -3326,10 +3339,12 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .with(Arc::clone(&trigger))
+            .with(Arc::clone(&reactor))
             .build(())
             .await
             .unwrap();
@@ -3351,6 +3366,9 @@ mod tests {
                     block_timestamp: chrono::Utc::now(),
                 },
             )
+            .await
+            .unwrap();
+        crate::rebalancing::drain_pending_jobs(&reactor)
             .await
             .unwrap();
 
@@ -3399,8 +3417,8 @@ mod tests {
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
 
-        let trigger = Arc::new(RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: threshold,
                 usdc: Some(threshold),
                 transfer_timeout: Duration::from_secs(30 * 60),
@@ -3416,10 +3434,12 @@ mod tests {
             Arc::clone(&inventory),
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .with(Arc::clone(&trigger))
+            .with(Arc::clone(&reactor))
             .build(())
             .await
             .unwrap();
@@ -3512,8 +3532,8 @@ mod tests {
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
 
-        let trigger = Arc::new(RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: ImbalanceThreshold {
                     target: float!(0.5),
                     deviation: float!(0.2),
@@ -3535,10 +3555,12 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .with(trigger.clone())
+            .with(reactor.clone())
             .build(())
             .await
             .unwrap();
@@ -3579,6 +3601,7 @@ mod tests {
         Arc<Store<Position>>,
         mpsc::Receiver<TriggeredOperation>,
         Symbol,
+        Arc<RebalancingService>,
     ) {
         let pool = setup_test_db().await;
         let symbol = Symbol::new("AAPL").unwrap();
@@ -3640,8 +3663,8 @@ mod tests {
 
         let vault_registry = Arc::new(test_store(pool.clone(), ()));
 
-        let trigger = Arc::new(RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: ImbalanceThreshold {
                     target: float!(0.5),
                     deviation: float!(0.2),
@@ -3663,20 +3686,23 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let (position_store, _position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .with(trigger)
+            .with(Arc::clone(&reactor))
             .build(())
             .await
             .unwrap();
 
-        (position_store, receiver, symbol)
+        (position_store, receiver, symbol, reactor)
     }
 
     #[tokio::test]
     async fn position_event_causing_imbalance_triggers_redemption() {
-        let (position_store, mut receiver, symbol) = setup_near_upper_threshold_position().await;
+        let (position_store, mut receiver, symbol, reactor) =
+            setup_near_upper_threshold_position().await;
         let test_token = address!("0x1234567890123456789012345678901234567890");
 
         // No position commands yet -> no triggers fired.
@@ -3708,6 +3734,9 @@ mod tests {
             )
             .await
             .unwrap();
+        crate::rebalancing::drain_pending_jobs(&reactor)
+            .await
+            .unwrap();
 
         let triggered = receiver.try_recv().unwrap();
         let TriggeredOperation::Redemption {
@@ -3726,7 +3755,8 @@ mod tests {
 
     #[tokio::test]
     async fn in_progress_guard_blocks_duplicate_trigger() {
-        let (position_store, mut receiver, symbol) = setup_near_upper_threshold_position().await;
+        let (position_store, mut receiver, symbol, reactor) =
+            setup_near_upper_threshold_position().await;
         let test_token = address!("0x1234567890123456789012345678901234567890");
 
         // First fill pushes over: 85/120 = 70.8% > 70% -> triggers Redemption(25).
@@ -3746,6 +3776,9 @@ mod tests {
                     block_timestamp: chrono::Utc::now(),
                 },
             )
+            .await
+            .unwrap();
+        crate::rebalancing::drain_pending_jobs(&reactor)
             .await
             .unwrap();
 
@@ -3780,6 +3813,9 @@ mod tests {
                     block_timestamp: chrono::Utc::now(),
                 },
             )
+            .await
+            .unwrap();
+        crate::rebalancing::drain_pending_jobs(&reactor)
             .await
             .unwrap();
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -38,6 +38,10 @@ use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::raindex::RaindexService;
 use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
+use crate::rebalancing::{
+    EquityRebalancingCheck, EquityRebalancingCheckScheduler, RebalancingService,
+    UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
+};
 use crate::symbol::cache::SymbolCache;
 use crate::threshold::ExecutionThreshold;
 use crate::tokenization::Tokenizer;
@@ -83,6 +87,9 @@ pub(crate) fn spawn<Prov, Exec>(
     poll_status_queue: PollOrderStatusJobQueue,
     reconcile_queue: ReconcileOrderFillJobQueue,
     rejection_queue: HandleOrderRejectionJobQueue,
+    equity_check_scheduler: EquityRebalancingCheckScheduler,
+    usdc_check_scheduler: UsdcRebalancingCheckScheduler,
+    rebalancing_service: Option<Arc<RebalancingService>>,
     job_cleanup: JoinHandle<()>,
     executor_maintenance: Option<JoinHandle<()>>,
     rebalancer: Option<JoinHandle<()>>,
@@ -221,21 +228,25 @@ where
         .build()
         .run();
 
-    let monitor = spawn_apalis_monitor(MonitorWiring {
+    let monitor = MonitorWiring {
         accountant_ctx,
         hedge_ctx,
         poll_status_ctx,
         reconcile_ctx,
         rejection_ctx,
+        rebalancing_check_ctx: rebalancing_service,
         job_queue,
         hedge_queue,
         backfill_queue,
         poll_status_queue,
         reconcile_queue,
         rejection_queue,
+        equity_check_scheduler,
+        usdc_check_scheduler,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: context.failure_injector,
-    });
+    }
+    .spawn_apalis_monitor();
 
     Conductor {
         supervisor,
@@ -247,8 +258,9 @@ where
 }
 
 /// Owns every queue, ctx and toggle the apalis monitor needs. The wiring is
-/// only meaningful for one call to [`spawn_apalis_monitor`], which moves the
-/// whole struct into a `tokio::spawn` and registers each worker.
+/// only meaningful for one call to [`MonitorWiring::spawn_apalis_monitor`],
+/// which moves the whole struct into a `tokio::spawn` and registers each
+/// worker.
 struct MonitorWiring<Prov, Exec>
 where
     Prov: Provider + Clone + Send + Sync + 'static,
@@ -261,155 +273,203 @@ where
     poll_status_ctx: Arc<PollOrderStatusCtx<Exec>>,
     reconcile_ctx: Arc<ReconcileOrderFillCtx>,
     rejection_ctx: Arc<HandleOrderRejectionCtx>,
+    rebalancing_check_ctx: Option<Arc<RebalancingService>>,
     job_queue: DexTradeAccountingJobQueue,
     hedge_queue: HedgeJobQueue,
     backfill_queue: BackfillJobQueue,
     poll_status_queue: PollOrderStatusJobQueue,
     reconcile_queue: ReconcileOrderFillJobQueue,
     rejection_queue: HandleOrderRejectionJobQueue,
+    equity_check_scheduler: EquityRebalancingCheckScheduler,
+    usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     #[cfg(any(test, feature = "test-support"))]
     failure_injector: FailureInjector,
 }
 
-fn spawn_apalis_monitor<Prov, Exec>(
-    wiring: MonitorWiring<Prov, Exec>,
-) -> JoinHandle<Result<(), MonitorTaskError>>
+impl<Prov, Exec> MonitorWiring<Prov, Exec>
 where
     Prov: Provider + Clone + Send + Sync + 'static,
     Exec: Executor + Clone + Send + Sync + 'static,
     TradeAccountingError: From<Exec::Error>,
     crate::offchain::order::JobError: From<Exec::Error>,
 {
-    let MonitorWiring {
-        accountant_ctx,
-        hedge_ctx,
-        poll_status_ctx,
-        reconcile_ctx,
-        rejection_ctx,
-        job_queue,
-        hedge_queue,
-        backfill_queue,
-        poll_status_queue,
-        reconcile_queue,
-        rejection_queue,
+    fn spawn_apalis_monitor(self) -> JoinHandle<Result<(), MonitorTaskError>> {
+        let Self {
+            accountant_ctx,
+            hedge_ctx,
+            poll_status_ctx,
+            reconcile_ctx,
+            rejection_ctx,
+            rebalancing_check_ctx,
+            job_queue,
+            hedge_queue,
+            backfill_queue,
+            poll_status_queue,
+            reconcile_queue,
+            rejection_queue,
+            equity_check_scheduler,
+            usdc_check_scheduler,
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector,
+        } = self;
+
         #[cfg(any(test, feature = "test-support"))]
-        failure_injector,
-    } = wiring;
+        let failure_injector_for_hedge = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_backfill = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_poll = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_reconcile = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_rejection = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_equity_rebalancing_check = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_usdc_rebalancing_check = failure_injector.clone();
+        let failure_notify = Arc::new(tokio::sync::Notify::new());
+        let failure_notify_for_hedge = failure_notify.clone();
+        let failure_notify_for_backfill = failure_notify.clone();
+        let failure_notify_for_poll = failure_notify.clone();
+        let failure_notify_for_reconcile = failure_notify.clone();
+        let failure_notify_for_rejection = failure_notify.clone();
+        let failure_notify_for_equity_rebalancing_check = failure_notify.clone();
+        let failure_notify_for_usdc_rebalancing_check = failure_notify.clone();
+        let failure_notify_for_select = failure_notify.clone();
 
-    #[cfg(any(test, feature = "test-support"))]
-    let failure_injector_for_hedge = failure_injector.clone();
-    #[cfg(any(test, feature = "test-support"))]
-    let failure_injector_for_backfill = failure_injector.clone();
-    #[cfg(any(test, feature = "test-support"))]
-    let failure_injector_for_poll = failure_injector.clone();
-    #[cfg(any(test, feature = "test-support"))]
-    let failure_injector_for_reconcile = failure_injector.clone();
-    #[cfg(any(test, feature = "test-support"))]
-    let failure_injector_for_rejection = failure_injector.clone();
-    let failure_notify = Arc::new(tokio::sync::Notify::new());
-    let failure_notify_for_hedge = failure_notify.clone();
-    let failure_notify_for_backfill = failure_notify.clone();
-    let failure_notify_for_poll = failure_notify.clone();
-    let failure_notify_for_reconcile = failure_notify.clone();
-    let failure_notify_for_rejection = failure_notify.clone();
-    let failure_notify_for_select = failure_notify.clone();
+        let fail_stop = CircuitBreakerConfig::default()
+            .with_failure_threshold(1)
+            .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+        let fail_stop_for_hedge = fail_stop.clone();
+        let fail_stop_for_backfill = fail_stop.clone();
+        let fail_stop_for_poll = fail_stop.clone();
+        let fail_stop_for_reconcile = fail_stop.clone();
+        let fail_stop_for_rejection = fail_stop.clone();
+        let fail_stop_for_equity_rebalancing_check = fail_stop.clone();
+        let fail_stop_for_usdc_rebalancing_check = fail_stop.clone();
 
-    let fail_stop = CircuitBreakerConfig::default()
-        .with_failure_threshold(1)
-        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
-    let fail_stop_for_hedge = fail_stop.clone();
-    let fail_stop_for_backfill = fail_stop.clone();
-    let fail_stop_for_poll = fail_stop.clone();
-    let fail_stop_for_reconcile = fail_stop.clone();
-    let fail_stop_for_rejection = fail_stop.clone();
+        let accountant_ctx_for_backfill = accountant_ctx.clone();
 
-    let accountant_ctx_for_backfill = accountant_ctx.clone();
+        tokio::spawn(async move {
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<AccountantCtx<Prov, Exec>, AccountForDexTrade>,
+                        index,
+                        job_queue.clone(),
+                        accountant_ctx.clone(),
+                        fail_stop.clone(),
+                        failure_notify.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<HedgeCtx, PlaceHedge>,
+                        index,
+                        hedge_queue.clone(),
+                        hedge_ctx.clone(),
+                        fail_stop_for_hedge.clone(),
+                        failure_notify_for_hedge.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_hedge.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<AccountantCtx<Prov, Exec>, BackfillRange>,
+                        index,
+                        backfill_queue.clone(),
+                        accountant_ctx_for_backfill.clone(),
+                        fail_stop_for_backfill.clone(),
+                        failure_notify_for_backfill.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_backfill.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<PollOrderStatusCtx<Exec>, PollOrderStatus>,
+                        index,
+                        poll_status_queue.clone(),
+                        poll_status_ctx.clone(),
+                        fail_stop_for_poll.clone(),
+                        failure_notify_for_poll.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_poll.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<ReconcileOrderFillCtx, ReconcileOrderFill>,
+                        index,
+                        reconcile_queue.clone(),
+                        reconcile_ctx.clone(),
+                        fail_stop_for_reconcile.clone(),
+                        failure_notify_for_reconcile.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_reconcile.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<HandleOrderRejectionCtx, HandleOrderRejection>,
+                        index,
+                        rejection_queue.clone(),
+                        rejection_ctx.clone(),
+                        fail_stop_for_rejection.clone(),
+                        failure_notify_for_rejection.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_rejection.clone(),
+                    )
+                });
 
-    tokio::spawn(async move {
-        let apalis_monitor = Monitor::new()
-            .should_restart(|_ctx, _error, _attempt| false)
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<AccountantCtx<Prov, Exec>, AccountForDexTrade>,
-                    index,
-                    job_queue.clone(),
-                    accountant_ctx.clone(),
-                    fail_stop.clone(),
-                    failure_notify.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector.clone(),
-                )
-            })
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<HedgeCtx, PlaceHedge>,
-                    index,
-                    hedge_queue.clone(),
-                    hedge_ctx.clone(),
-                    fail_stop_for_hedge.clone(),
-                    failure_notify_for_hedge.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector_for_hedge.clone(),
-                )
-            })
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<AccountantCtx<Prov, Exec>, BackfillRange>,
-                    index,
-                    backfill_queue.clone(),
-                    accountant_ctx_for_backfill.clone(),
-                    fail_stop_for_backfill.clone(),
-                    failure_notify_for_backfill.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector_for_backfill.clone(),
-                )
-            })
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<PollOrderStatusCtx<Exec>, PollOrderStatus>,
-                    index,
-                    poll_status_queue.clone(),
-                    poll_status_ctx.clone(),
-                    fail_stop_for_poll.clone(),
-                    failure_notify_for_poll.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector_for_poll.clone(),
-                )
-            })
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<ReconcileOrderFillCtx, ReconcileOrderFill>,
-                    index,
-                    reconcile_queue.clone(),
-                    reconcile_ctx.clone(),
-                    fail_stop_for_reconcile.clone(),
-                    failure_notify_for_reconcile.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector_for_reconcile.clone(),
-                )
-            })
-            .register(move |index| {
-                build_supervised_worker!(
-                    ::<HandleOrderRejectionCtx, HandleOrderRejection>,
-                    index,
-                    rejection_queue.clone(),
-                    rejection_ctx.clone(),
-                    fail_stop_for_rejection.clone(),
-                    failure_notify_for_rejection.clone(),
-                    #[cfg(any(test, feature = "test-support"))]
-                    failure_injector_for_rejection.clone(),
-                )
-            });
+            let apalis_monitor = if let Some(rebalancing_service) = rebalancing_check_ctx {
+                let equity_service = Arc::clone(&rebalancing_service);
+                let usdc_service = rebalancing_service;
+                let equity_queue = equity_check_scheduler.queue().clone();
+                let usdc_queue = usdc_check_scheduler.queue().clone();
+                monitor
+                    .register(move |index| {
+                        build_supervised_worker!(
+                            ::<RebalancingService, EquityRebalancingCheck>,
+                            index,
+                            equity_queue.clone(),
+                            equity_service.clone(),
+                            fail_stop_for_equity_rebalancing_check.clone(),
+                            failure_notify_for_equity_rebalancing_check.clone(),
+                            #[cfg(any(test, feature = "test-support"))]
+                            failure_injector_for_equity_rebalancing_check.clone(),
+                        )
+                    })
+                    .register(move |index| {
+                        build_supervised_worker!(
+                            ::<RebalancingService, UsdcRebalancingCheck>,
+                            index,
+                            usdc_queue.clone(),
+                            usdc_service.clone(),
+                            fail_stop_for_usdc_rebalancing_check.clone(),
+                            failure_notify_for_usdc_rebalancing_check.clone(),
+                            #[cfg(any(test, feature = "test-support"))]
+                            failure_injector_for_usdc_rebalancing_check.clone(),
+                        )
+                    })
+            } else {
+                monitor
+            };
 
-        tokio::select! {
-            biased;
-            () = failure_notify_for_select.notified() => Err(MonitorTaskError::TerminalJobFailure),
-            result = apalis_monitor.run() => match result {
-                Ok(()) => Err(MonitorTaskError::UnexpectedExit { source: None }),
-                Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
-            },
-        }
-    })
+            tokio::select! {
+                biased;
+                () = failure_notify_for_select.notified() => Err(MonitorTaskError::TerminalJobFailure),
+                result = apalis_monitor.run() => match result {
+                    Ok(()) => Err(MonitorTaskError::UnexpectedExit { source: None }),
+                    Err(source) => Err(MonitorTaskError::UnexpectedExit { source: Some(source) }),
+                },
+            }
+        })
+    }
 }
 
 fn log_optional_task_status(task_name: &str, is_configured: bool) {

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -142,6 +142,34 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
     pub(crate) fn into_storage(self) -> Storage<Task> {
         self.0
     }
+
+    /// Returns the underlying `SqlitePool`. Used by callers that need to
+    /// query or mutate the apalis Jobs table directly.
+    pub(crate) fn pool(&self) -> &SqlitePool {
+        self.0.pool()
+    }
+
+    /// Mark every pending row of this queue's task type as `Done`. Used by
+    /// callers that need to discard stale work after a terminal domain event
+    /// invalidates everything queued before it.
+    pub(crate) async fn cancel_all_pending(&self) {
+        let job_type = std::any::type_name::<Task>();
+        if let Err(error) = sqlx::query(
+            "UPDATE Jobs SET status = 'Done' \
+             WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .execute(self.pool())
+        .await
+        {
+            warn!(
+                target: "rebalance",
+                %error,
+                job_type,
+                "Failed to cancel pending rows for job type",
+            );
+        }
+    }
 }
 
 /// A persistent, retryable unit of work backed by apalis storage.
@@ -279,6 +307,8 @@ pub enum JobKind {
     PollOrderStatus,
     ReconcileOrderFill,
     HandleOrderRejection,
+    EquityRebalancingCheck,
+    UsdcRebalancingCheck,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -309,6 +339,8 @@ pub struct FailureInjector {
     poll_order_status: Arc<Mutex<InjectionState>>,
     reconcile_order_fill: Arc<Mutex<InjectionState>>,
     handle_order_rejection: Arc<Mutex<InjectionState>>,
+    equity_rebalancing_check: Arc<Mutex<InjectionState>>,
+    usdc_rebalancing_check: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -337,6 +369,8 @@ impl FailureInjector {
             poll_order_status: Arc::new(Mutex::new(InjectionState::Idle)),
             reconcile_order_fill: Arc::new(Mutex::new(InjectionState::Idle)),
             handle_order_rejection: Arc::new(Mutex::new(InjectionState::Idle)),
+            equity_rebalancing_check: Arc::new(Mutex::new(InjectionState::Idle)),
+            usdc_rebalancing_check: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -377,6 +411,8 @@ impl FailureInjector {
             JobKind::PollOrderStatus => &self.poll_order_status,
             JobKind::ReconcileOrderFill => &self.reconcile_order_fill,
             JobKind::HandleOrderRejection => &self.handle_order_rejection,
+            JobKind::EquityRebalancingCheck => &self.equity_rebalancing_check,
+            JobKind::UsdcRebalancingCheck => &self.usdc_rebalancing_check,
         };
 
         match mutex.lock() {

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -22,8 +22,7 @@ use crate::dashboard::Broadcaster;
 use crate::equity_redemption::EquityRedemption;
 use crate::inventory::InventorySnapshot;
 use crate::position::Position;
-use crate::rebalancing::RebalancingTrigger;
-use crate::rebalancing::equity::EquityTransferServices;
+use crate::rebalancing::{RebalancingService, equity::EquityTransferServices};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 
@@ -33,7 +32,7 @@ use crate::usdc_rebalance::UsdcRebalance;
 /// Exhaustive destructuring in [`Self::build()`]
 /// ensures every field is handled.
 pub(super) struct QueryManifest {
-    rebalancing_trigger: Arc<RebalancingTrigger>,
+    rebalancing_service: Arc<RebalancingService>,
     broadcaster: Arc<Broadcaster>,
 }
 
@@ -49,11 +48,11 @@ pub(super) struct BuiltFrameworks {
 
 impl QueryManifest {
     pub(super) fn new(
-        rebalancing_trigger: Arc<RebalancingTrigger>,
+        rebalancing_service: Arc<RebalancingService>,
         broadcaster: Arc<Broadcaster>,
     ) -> Self {
         Self {
-            rebalancing_trigger,
+            rebalancing_service,
             broadcaster,
         }
     }
@@ -69,37 +68,37 @@ impl QueryManifest {
         services: EquityTransferServices,
     ) -> anyhow::Result<BuiltFrameworks> {
         let Self {
-            rebalancing_trigger,
+            rebalancing_service,
             broadcaster,
         } = self;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
-            .with(rebalancing_trigger.clone())
+            .with(rebalancing_service.clone())
             .build(())
             .await?;
 
         let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-            .with(rebalancing_trigger.clone())
+            .with(rebalancing_service.clone())
             .with(broadcaster.clone())
             .build(services.clone())
             .await?;
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
-            .with(rebalancing_trigger.clone())
+            .with(rebalancing_service.clone())
             .with(broadcaster.clone())
             .build(services)
             .await?;
 
         let usdc = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-            .with(rebalancing_trigger.clone())
+            .with(rebalancing_service.clone())
             .with(broadcaster)
             .build(())
             .await?;
 
-        // The trigger owns the snapshot projection internally, so it's
-        // the sole subscriber here.
+        // The reactor's underlying trigger owns the snapshot projection
+        // internally, so it's the sole subscriber here.
         let snapshot = StoreBuilder::<InventorySnapshot>::new(pool.clone())
-            .with(rebalancing_trigger)
+            .with(rebalancing_service)
             .build(())
             .await?;
 
@@ -130,13 +129,13 @@ mod tests {
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
     use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::RebalancingTriggerConfig;
+    use crate::rebalancing::{RebalancingSchedulers, RebalancingService, RebalancingServiceConfig};
     use crate::test_utils::setup_test_db;
     use crate::tokenization::mock::MockTokenizer;
     use crate::wrapper::mock::MockWrapper;
 
-    fn test_trigger_config() -> RebalancingTriggerConfig {
-        RebalancingTriggerConfig {
+    fn test_trigger_config() -> RebalancingServiceConfig {
+        RebalancingServiceConfig {
             equity: ImbalanceThreshold {
                 target: float!(0.5),
                 deviation: float!(0.2),
@@ -168,7 +167,7 @@ mod tests {
             event_sender.clone(),
         ));
 
-        let rebalancing_trigger = Arc::new(RebalancingTrigger::new(
+        let rebalancing_service = Arc::new(RebalancingService::new(
             test_trigger_config(),
             vault_registry,
             Address::ZERO,
@@ -176,10 +175,11 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
 
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_trigger, broadcaster);
+        let manifest = QueryManifest::new(rebalancing_service, broadcaster);
 
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
@@ -217,7 +217,7 @@ mod tests {
             event_sender.clone(),
         ));
 
-        let rebalancing_trigger = Arc::new(RebalancingTrigger::new(
+        let rebalancing_service = Arc::new(RebalancingService::new(
             test_trigger_config(),
             vault_registry,
             Address::ZERO,
@@ -225,9 +225,10 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_trigger, broadcaster);
+        let manifest = QueryManifest::new(rebalancing_service, broadcaster);
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
             tokenizer: Arc::new(MockTokenizer::new()),

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -1,5 +1,5 @@
 //! Integration tests for the inventory rebalancing pipeline: position changes
-//! flow through the RebalancingTrigger (wired as a CQRS query processor),
+//! flow through the RebalancingService (wired as a CQRS query processor),
 //! update the InventoryView, detect equity or USDC imbalances, and dispatch
 //! operations through the Rebalancer to drive mints, redemptions, and USDC
 //! transfers to completion.
@@ -44,7 +44,8 @@ use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransfe
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::rebalancing::usdc::mock::MockUsdcRebalance;
 use crate::rebalancing::{
-    Rebalancer, RebalancingTrigger, RebalancingTriggerConfig, TriggeredOperation,
+    Rebalancer, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
+    TriggeredOperation, drain_pending_jobs,
 };
 use crate::test_utils::setup_test_db;
 use crate::threshold::ExecutionThreshold;
@@ -111,8 +112,8 @@ async fn discover_deterministic_tx_hash(
     tx_hash
 }
 
-fn test_trigger_config() -> RebalancingTriggerConfig {
-    RebalancingTriggerConfig {
+fn test_trigger_config() -> RebalancingServiceConfig {
+    RebalancingServiceConfig {
         equity: ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -149,14 +150,15 @@ fn test_trigger_config() -> RebalancingTriggerConfig {
 }
 
 /// Mirrors the private `build_position_cqrs()` from `src/conductor/mod.rs`,
-/// wiring the RebalancingTrigger as a Position CQRS query processor so that
-/// position events flow through trigger.dispatch() -> inventory update.
-async fn build_position_cqrs_with_trigger(
+/// wiring the `RebalancingService` as a Position CQRS query processor so
+/// that position events flow through it into inventory bookkeeping +
+/// follow-up check enqueueing.
+async fn build_position_cqrs_with_service(
     pool: &SqlitePool,
-    trigger: &Arc<RebalancingTrigger>,
+    service: &Arc<RebalancingService>,
 ) -> Arc<Store<Position>> {
     let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
-        .with(Arc::clone(trigger))
+        .with(Arc::clone(service))
         .build(())
         .await
         .unwrap();
@@ -165,12 +167,13 @@ async fn build_position_cqrs_with_trigger(
 }
 
 /// Shared state for equity rebalancing tests (mint and redemption) that
-/// wires up the Position CQRS with a RebalancingTrigger as a query processor.
+/// wires up the Position CQRS with a `RebalancingService` as a query
+/// processor.
 struct EquityTriggerFixture {
     pool: SqlitePool,
     symbol: Symbol,
     aggregate_id: String,
-    trigger: Arc<RebalancingTrigger>,
+    service: Arc<RebalancingService>,
     inventory: Arc<BroadcastingInventory>,
     position_cqrs: Arc<Store<Position>>,
     receiver: mpsc::Receiver<TriggeredOperation>,
@@ -198,7 +201,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
 
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = Arc::new(RebalancingTrigger::new(
+    let service = Arc::new(RebalancingService::new(
         test_trigger_config(),
         vault_registry,
         TEST_ORDERBOOK,
@@ -206,15 +209,16 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     ));
 
-    let position_cqrs = build_position_cqrs_with_trigger(&pool, &trigger).await;
+    let position_cqrs = build_position_cqrs_with_service(&pool, &service).await;
 
     EquityTriggerFixture {
         pool,
         symbol,
         aggregate_id,
-        trigger,
+        service,
         inventory,
         position_cqrs,
         receiver,
@@ -416,16 +420,16 @@ fn build_equity_transfer_with_wrapper(
 }
 
 /// Builds `CrossVenueEquityTransfer` with mint and redemption stores wired to
-/// the `RebalancingTrigger` as a query processor. This mirrors the production
+/// the `RebalancingService` as a query processor. This mirrors the production
 /// wiring in `Conductor` via `QueryManifest::build()`, ensuring mint/redemption
 /// lifecycle events flow through the trigger and update inflight state.
-async fn build_equity_transfer_with_trigger(
+async fn build_equity_transfer_with_service(
     pool: &SqlitePool,
     raindex: Arc<dyn crate::onchain::raindex::Raindex>,
     tokenizer: Arc<dyn Tokenizer>,
     mock_wrapper: MockWrapper,
     wallet: Address,
-    trigger: &Arc<RebalancingTrigger>,
+    service: &Arc<RebalancingService>,
 ) -> Arc<CrossVenueEquityTransfer> {
     let wrapper: Arc<dyn crate::wrapper::Wrapper> = Arc::new(mock_wrapper);
 
@@ -436,13 +440,13 @@ async fn build_equity_transfer_with_trigger(
     };
 
     let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .with(Arc::clone(trigger))
+        .with(Arc::clone(service))
         .build(equity_services.clone())
         .await
         .unwrap();
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-        .with(Arc::clone(trigger))
+        .with(Arc::clone(service))
         .build(equity_services)
         .await
         .unwrap();
@@ -458,7 +462,7 @@ async fn build_equity_transfer_with_trigger(
 }
 
 /// Verifies the full equity mint rebalancing pipeline: position CQRS commands
-/// flow through the RebalancingTrigger (registered as a Query processor),
+/// flow through the RebalancingService (registered as a Query processor),
 /// update the InventoryView, detect an equity imbalance, and dispatch a Mint
 /// operation through the Rebalancer to the CrossVenueEquityTransfer which
 /// drives the TokenizedEquityMint aggregate to completion via the Alpaca
@@ -470,7 +474,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
         pool,
         symbol,
         aggregate_id,
-        trigger,
+        service,
         inventory: _,
         position_cqrs,
         receiver,
@@ -601,11 +605,12 @@ async fn equity_offchain_imbalance_triggers_mint() {
         )
         .await
         .unwrap();
+    drain_pending_jobs(&service).await.unwrap();
 
-    // Both trigger and position_cqrs hold Arc<RebalancingTrigger> which owns the
+    // Both trigger and position_cqrs hold Arc<RebalancingService> which owns the
     // mpsc sender. Both must be dropped to close the channel so rebalancer.run()
     // can exit after processing all queued operations.
-    drop(trigger);
+    drop(service);
     drop(position_cqrs);
 
     rebalancer.run().await;
@@ -710,7 +715,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
 }
 
 /// Verifies the full equity redemption rebalancing pipeline: position CQRS
-/// commands flow through the RebalancingTrigger, detect too much onchain equity,
+/// commands flow through the RebalancingService, detect too much onchain equity,
 /// and dispatch a Redemption operation through the Rebalancer to the real
 /// CrossVenueEquityTransfer. The transfer sends tokens on Anvil, then drives the
 /// EquityRedemption aggregate through TokensSent -> Detected -> Completed via
@@ -726,7 +731,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         pool,
         symbol,
         aggregate_id,
-        trigger,
+        service,
         inventory: _,
         position_cqrs,
         receiver,
@@ -813,8 +818,9 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         )
         .await
         .unwrap();
+    drain_pending_jobs(&service).await.unwrap();
 
-    drop(trigger);
+    drop(service);
     drop(position_cqrs);
     rebalancer.run().await;
 
@@ -962,7 +968,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
 }
 
 /// Verifies USDC rebalancing dispatch: a USDC imbalance triggers the
-/// RebalancingTrigger to send a UsdcAlpacaToBase operation through the channel
+/// RebalancingService to send a UsdcAlpacaToBase operation through the channel
 /// to the Rebalancer, which dispatches to the USDC manager. Uses mocked managers
 /// since the real USDC flow requires CCTP bridge and vault transactions.
 #[tokio::test]
@@ -989,7 +995,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
+    let trigger = RebalancingService::new(
         test_trigger_config(),
         vault_registry,
         TEST_ORDERBOOK,
@@ -997,6 +1003,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
@@ -1068,7 +1075,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
+    let trigger = RebalancingService::new(
         test_trigger_config(),
         vault_registry,
         TEST_ORDERBOOK,
@@ -1076,6 +1083,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
@@ -1155,7 +1163,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = Arc::new(RebalancingTrigger::new(
+    let service = Arc::new(RebalancingService::new(
         test_trigger_config(),
         Arc::clone(&vault_registry),
         TEST_ORDERBOOK,
@@ -1163,11 +1171,13 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     ));
 
-    // Build snapshot store with trigger as reactor — mirrors production wiring
-    // in QueryManifest::build. Snapshot events from polling flow through the
-    // trigger's on_snapshot, updating the BroadcastingInventory.
+    // Build snapshot store with the service as the CQRS subscriber — mirrors
+    // production wiring in QueryManifest::build. Snapshot events from polling
+    // flow through the service's on_snapshot, updating the
+    // BroadcastingInventory and scheduling follow-up imbalance checks.
     let (_, vault_registry_projection) = StoreBuilder::<VaultRegistry>::new(pool.clone())
         .build(())
         .await
@@ -1180,7 +1190,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
 
     let snapshot_store =
         StoreBuilder::<crate::inventory::snapshot::InventorySnapshot>::new(pool.clone())
-            .with(Arc::clone(&trigger))
+            .with(Arc::clone(&service))
             .build(())
             .await
             .unwrap();
@@ -1242,7 +1252,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
     drop(view);
 
     // Trigger checks thresholds against the reserve-shifted inventory.
-    trigger.check_and_trigger_usdc().await;
+    service.check_and_trigger_usdc().await;
 
     let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
     let usdc = Arc::new(MockUsdcRebalance::new());
@@ -1259,9 +1269,9 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
 
     // Drop all Arc clones holding the trigger so the mpsc channel closes
     // and rebalancer.run() terminates after processing queued operations.
-    // The snapshot store (held by polling_service and locally) keeps the
-    // trigger alive via its reactor list.
-    drop(trigger);
+    // The reactor (which wraps the trigger) is also held by the snapshot
+    // store's reactor list.
+    drop(service);
     drop(snapshot_store);
     drop(polling_service);
 
@@ -1314,7 +1324,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
+    let trigger = RebalancingService::new(
         test_trigger_config(),
         vault_registry,
         TEST_ORDERBOOK,
@@ -1322,6 +1332,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1334,7 +1345,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
     );
 }
 
-/// Verifies that setting `usdc: None` in `RebalancingTriggerConfig`
+/// Verifies that setting `usdc: None` in `RebalancingServiceConfig`
 /// disables USDC rebalancing entirely: even with a severe imbalance,
 /// `check_and_trigger_usdc` dispatches no operations.
 #[tokio::test]
@@ -1359,8 +1370,8 @@ async fn usdc_none_disables_usdc_rebalancing() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
-        RebalancingTriggerConfig {
+    let trigger = RebalancingService::new(
+        RebalancingServiceConfig {
             usdc: None,
             ..test_trigger_config()
         },
@@ -1370,6 +1381,7 @@ async fn usdc_none_disables_usdc_rebalancing() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1392,7 +1404,7 @@ async fn mint_api_failure_produces_rejected_event() {
         pool,
         symbol,
         aggregate_id,
-        trigger,
+        service,
         inventory: _,
         position_cqrs,
         receiver,
@@ -1461,8 +1473,9 @@ async fn mint_api_failure_produces_rejected_event() {
         )
         .await
         .unwrap();
+    drain_pending_jobs(&service).await.unwrap();
 
-    drop(trigger);
+    drop(service);
     drop(position_cqrs);
 
     rebalancer.run().await;
@@ -1547,7 +1560,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         }),
     };
 
-    let config = RebalancingTriggerConfig {
+    let config = RebalancingServiceConfig {
         equity: ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -1565,7 +1578,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
+    let trigger = RebalancingService::new(
         config,
         vault_registry,
         TEST_ORDERBOOK,
@@ -1573,6 +1586,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     // Cycle 1: excess = 450, capped to 100
@@ -1678,7 +1692,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
             reserved: None,
         }),
     };
-    let config = RebalancingTriggerConfig {
+    let config = RebalancingServiceConfig {
         equity: ImbalanceThreshold {
             target: float!(0.5),
             deviation: float!(0.2),
@@ -1696,7 +1710,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
-    let trigger = RebalancingTrigger::new(
+    let trigger = RebalancingService::new(
         config,
         vault_registry,
         TEST_ORDERBOOK,
@@ -1704,6 +1718,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         Arc::clone(&inventory),
         sender,
         wrapper,
+        RebalancingSchedulers::new(&pool),
     );
 
     // First trigger fires: excess = 400, capped to 100
@@ -1780,7 +1795,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
         .await;
 
         let (sender, mut receiver) = mpsc::channel(10);
-        let wide_config = RebalancingTriggerConfig {
+        let wide_config = RebalancingServiceConfig {
             equity: ImbalanceThreshold {
                 target: float!(0.5),
                 deviation: float!(0.4),
@@ -1803,7 +1818,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
         };
         let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
         let wrapper = Arc::new(MockWrapper::new());
-        let trigger = RebalancingTrigger::new(
+        let trigger = RebalancingService::new(
             wide_config,
             vault_registry,
             TEST_ORDERBOOK,
@@ -1811,6 +1826,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             sender,
             wrapper,
+            RebalancingSchedulers::new(&pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -1841,7 +1857,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
         .await;
 
         let (sender, mut receiver) = mpsc::channel(10);
-        let tight_config = RebalancingTriggerConfig {
+        let tight_config = RebalancingServiceConfig {
             equity: ImbalanceThreshold {
                 target: float!(0.5),
                 deviation: float!(0.1),
@@ -1864,7 +1880,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
         };
         let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
         let wrapper = Arc::new(MockWrapper::new());
-        let trigger = RebalancingTrigger::new(
+        let trigger = RebalancingService::new(
             tight_config,
             vault_registry,
             TEST_ORDERBOOK,
@@ -1872,6 +1888,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             sender,
             wrapper,
+            RebalancingSchedulers::new(&pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -1906,7 +1923,7 @@ async fn mint_accepted_sets_offchain_inflight() {
         pool,
         symbol,
         aggregate_id: _,
-        trigger,
+        service,
         inventory,
         position_cqrs,
         mut receiver,
@@ -1959,13 +1976,13 @@ async fn mint_accepted_sets_offchain_inflight() {
 
     // Wire mint/redemption stores with trigger so lifecycle events update
     // inflight state through the trigger's Reactor
-    let equity_transfer = build_equity_transfer_with_trigger(
+    let equity_transfer = build_equity_transfer_with_service(
         &pool,
         raindex,
         tokenizer,
         mock_wrapper,
         signer.address(),
-        &trigger,
+        &service,
     )
     .await;
 
@@ -2004,6 +2021,7 @@ async fn mint_accepted_sets_offchain_inflight() {
         )
         .await
         .unwrap();
+    drain_pending_jobs(&service).await.unwrap();
 
     // Receive the dispatched Mint operation and get the quantity
     let operation = receiver
@@ -2102,7 +2120,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
         pool,
         symbol,
         aggregate_id: _,
-        trigger,
+        service,
         inventory,
         position_cqrs,
         mut receiver,
@@ -2151,13 +2169,13 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
     let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
     let mock_wrapper = MockWrapper::new().with_tokenized_shares(token_address);
 
-    let equity_transfer = build_equity_transfer_with_trigger(
+    let equity_transfer = build_equity_transfer_with_service(
         &pool,
         raindex,
         tokenizer,
         mock_wrapper,
         signer.address(),
-        &trigger,
+        &service,
     )
     .await;
 
@@ -2208,6 +2226,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
         )
         .await
         .unwrap();
+    drain_pending_jobs(&service).await.unwrap();
 
     // Receive the dispatched Mint operation
     let operation = receiver
@@ -2277,7 +2296,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
         pool,
         symbol,
         aggregate_id: _,
-        trigger,
+        service,
         inventory,
         position_cqrs,
         receiver: _,
@@ -2305,7 +2324,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
     };
 
     let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-        .with(Arc::clone(&trigger))
+        .with(Arc::clone(&service))
         .build(equity_services)
         .await
         .unwrap();

--- a/src/inventory/projection.rs
+++ b/src/inventory/projection.rs
@@ -2,7 +2,7 @@
 //! [`BroadcastingInventory`] that feeds the dashboard WS.
 //!
 //! When rebalancing is enabled the projection is owned by
-//! `RebalancingTrigger`, which calls [`Self::apply`] before its
+//! `RebalancingService`, which calls [`Self::apply`] before its
 //! threshold checks so rebalancing decisions only run against a
 //! successfully-folded view. When rebalancing is disabled the
 //! projection is registered directly as the sole subscriber on the
@@ -453,7 +453,7 @@ mod tests {
             read_equity_available(&inventory, &symbol("RKLB"), Venue::MarketMaking).await,
             Some(shares(42)),
             "snapshot dispatched through store must reach BroadcastingInventory \
-             via the projection even when no RebalancingTrigger is registered",
+             via the projection even when no RebalancingService is registered",
         );
     }
 }

--- a/src/rebalancing/mod.rs
+++ b/src/rebalancing/mod.rs
@@ -15,5 +15,11 @@ pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks};
 pub(crate) use trigger::RebalancingConfig;
 #[cfg(any(test, feature = "test-support"))]
 pub use trigger::UsdcRebalancing;
+#[cfg(test)]
+pub(crate) use trigger::drain_pending_jobs;
+pub(crate) use trigger::{
+    EquityRebalancingCheck, EquityRebalancingCheckScheduler, RebalancingSchedulers,
+    RebalancingService, RebalancingServiceConfig, TriggeredOperation, UsdcRebalancingCheck,
+    UsdcRebalancingCheckScheduler,
+};
 pub use trigger::{RebalancingCtx, RebalancingCtxError};
-pub(crate) use trigger::{RebalancingTrigger, RebalancingTriggerConfig, TriggeredOperation};

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -185,7 +185,7 @@ mod tests {
     use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::ImbalanceThreshold;
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::RebalancingTriggerConfig;
+    use crate::rebalancing::RebalancingServiceConfig;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::alpaca::AlpacaTokenizationService;
     use crate::tokenization::mock::MockTokenizer;
@@ -221,7 +221,7 @@ mod tests {
     fn trigger_config_uses_equity_from_ctx() {
         let ctx = make_ctx();
 
-        let trigger_config = RebalancingTriggerConfig {
+        let trigger_config = RebalancingServiceConfig {
             equity: ctx.equity,
             usdc: ctx.usdc,
             transfer_timeout: ctx.transfer_timeout,
@@ -240,7 +240,7 @@ mod tests {
     fn trigger_config_uses_usdc_from_ctx() {
         let ctx = make_ctx();
 
-        let trigger_config = RebalancingTriggerConfig {
+        let trigger_config = RebalancingServiceConfig {
             equity: ctx.equity,
             usdc: ctx.usdc,
             transfer_timeout: ctx.transfer_timeout,

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -5,11 +5,15 @@ use std::sync::Arc;
 
 use alloy::primitives::Address;
 use rain_math_float::{Float, FloatError};
-use tracing::{debug, trace};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, trace, warn};
 
 use st0x_execution::{FractionalShares, Positive, Symbol};
 
-use super::{TokenAddressError, TriggeredOperation};
+use super::{RebalancingService, TokenAddressError, TriggeredOperation};
+#[cfg(any(test, feature = "test-support"))]
+use crate::conductor::job::JobKind;
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, EquityImbalanceError, Imbalance, ImbalanceThreshold,
 };
@@ -187,6 +191,122 @@ fn truncate_for_alpaca(
     }
 
     Ok(truncated)
+}
+
+/// Per-symbol equity rebalancing check.
+///
+/// Carries the symbol to evaluate as the payload; every other
+/// dependency the worker needs lives on [`RebalancingService`]. Per-symbol
+/// failures retry/back off independently, and snapshots affecting multiple
+/// symbols fan out into parallel work.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct EquityRebalancingCheck {
+    pub symbol: Symbol,
+}
+
+pub(crate) type EquityRebalancingCheckJobQueue = JobQueue<EquityRebalancingCheck>;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EquityRebalancingCheckJobError {
+    #[error(transparent)]
+    EquityTrigger(#[from] EquityTriggerError),
+}
+
+impl Job<RebalancingService> for EquityRebalancingCheck {
+    type Output = ();
+    type Error = EquityRebalancingCheckJobError;
+
+    const WORKER_NAME: &'static str = "equity-rebalancing-check-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: JobKind = JobKind::EquityRebalancingCheck;
+
+    fn label(&self) -> Label {
+        Label::new(format!("EquityRebalancingCheck({})", self.symbol))
+    }
+
+    async fn perform(&self, trigger: &RebalancingService) -> Result<Self::Output, Self::Error> {
+        trigger.check_and_trigger_equity(&self.symbol).await?;
+        Ok(())
+    }
+}
+
+/// Owns the equity-check queue and the domain-level operations
+/// callers (the reactor, the conductor wiring) want: enqueue a check
+/// for a symbol, cancel pending checks after a terminal event. Keeps
+/// queue plumbing out of [`RebalancingService`] and out of the
+/// conductor wiring.
+#[derive(Clone)]
+pub(crate) struct EquityRebalancingCheckScheduler {
+    queue: EquityRebalancingCheckJobQueue,
+}
+
+impl EquityRebalancingCheckScheduler {
+    pub(crate) fn new(pool: &sqlx::SqlitePool) -> Self {
+        Self {
+            queue: EquityRebalancingCheckJobQueue::new(pool),
+        }
+    }
+
+    pub(crate) fn queue(&self) -> &EquityRebalancingCheckJobQueue {
+        &self.queue
+    }
+
+    /// Best-effort enqueue. Failures are logged: an enqueue miss only
+    /// delays the next imbalance check, which the next snapshot will
+    /// re-trigger.
+    pub(super) async fn enqueue_check(&self, symbol: Symbol) {
+        let mut queue = self.queue.clone();
+        if let Err(QueuePushError(error)) = queue.push(EquityRebalancingCheck { symbol }).await {
+            warn!(target: "rebalance", %error, "Failed to enqueue EquityRebalancingCheck job");
+        }
+    }
+
+    pub(super) async fn cancel_pending(&self) {
+        self.queue.cancel_all_pending().await;
+    }
+}
+
+/// Test helper: synchronously drain every pending equity-check row
+/// the service enqueued, running each job's [`Job::perform`] and
+/// marking the row `Done`.
+#[cfg(test)]
+pub(crate) async fn drain_pending_equity_jobs(
+    service: &std::sync::Arc<RebalancingService>,
+) -> Result<usize, EquityRebalancingCheckJobError> {
+    let pool = service.equity_scheduler.queue().pool().clone();
+    let mut processed = 0usize;
+
+    let job_type = std::any::type_name::<EquityRebalancingCheck>();
+
+    loop {
+        let row: Option<(String, Vec<u8>)> = sqlx::query_as(
+            "SELECT id, job FROM Jobs \
+             WHERE status = 'Pending' AND job_type = ? \
+             ORDER BY run_at LIMIT 1",
+        )
+        .bind(job_type)
+        .fetch_optional(&pool)
+        .await
+        .expect("query pending equity-check jobs");
+
+        let Some((id, payload)) = row else {
+            break;
+        };
+
+        let job: EquityRebalancingCheck =
+            serde_json::from_slice(&payload).expect("deserialize EquityRebalancingCheck payload");
+        job.perform(service).await?;
+
+        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&id)
+            .execute(&pool)
+            .await
+            .expect("mark equity-check job done");
+
+        processed += 1;
+    }
+
+    Ok(processed)
 }
 
 #[cfg(test)]
@@ -689,6 +809,101 @@ mod tests {
         let result = truncate_for_alpaca(&symbol, original).unwrap();
 
         assert_eq!(result, original);
+    }
+
+    #[test]
+    fn cap_shares_returns_input_when_no_limit() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let amount = shares(123);
+        assert_eq!(cap_shares(&symbol, amount, None), amount);
+    }
+
+    #[test]
+    fn cap_shares_returns_input_when_below_limit() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let amount = shares(10);
+        let limit = Some(Positive::new(shares(50)).unwrap());
+        assert_eq!(cap_shares(&symbol, amount, limit), amount);
+    }
+
+    #[test]
+    fn cap_shares_returns_input_when_equal_to_limit() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let amount = shares(50);
+        let limit = Some(Positive::new(shares(50)).unwrap());
+        assert_eq!(cap_shares(&symbol, amount, limit), amount);
+    }
+
+    #[test]
+    fn cap_shares_returns_limit_when_above_limit() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let amount = shares(100);
+        let limit_value = shares(50);
+        assert_eq!(
+            cap_shares(&symbol, amount, Some(Positive::new(limit_value).unwrap())),
+            limit_value
+        );
+    }
+
+    #[test]
+    fn equity_rebalancing_check_label_includes_symbol() {
+        let job = EquityRebalancingCheck {
+            symbol: Symbol::new("RKLB").unwrap(),
+        };
+        assert_eq!(job.label().as_str(), "EquityRebalancingCheck(RKLB)");
+    }
+
+    async fn count_pending_equity_check_jobs(pool: &sqlx::SqlitePool) -> i64 {
+        let job_type = std::any::type_name::<EquityRebalancingCheck>();
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(pool)
+        .await
+        .expect("count pending equity-check jobs")
+    }
+
+    #[tokio::test]
+    async fn equity_scheduler_enqueue_check_inserts_pending_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        scheduler.enqueue_check(symbol).await;
+
+        assert_eq!(count_pending_equity_check_jobs(&pool).await, 1);
+    }
+
+    #[tokio::test]
+    async fn equity_scheduler_cancel_pending_marks_pending_rows_done() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+
+        scheduler.enqueue_check(Symbol::new("AAPL").unwrap()).await;
+        scheduler.enqueue_check(Symbol::new("MSFT").unwrap()).await;
+        assert_eq!(count_pending_equity_check_jobs(&pool).await, 2);
+
+        scheduler.cancel_pending().await;
+
+        assert_eq!(
+            count_pending_equity_check_jobs(&pool).await,
+            0,
+            "cancel_pending must drain all pending rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_scheduler_enqueue_after_cancel_creates_fresh_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        scheduler.enqueue_check(symbol.clone()).await;
+        scheduler.cancel_pending().await;
+        scheduler.enqueue_check(symbol).await;
+
+        assert_eq!(count_pending_equity_check_jobs(&pool).await, 1);
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -3,12 +3,33 @@
 mod equity;
 mod usdc;
 
-pub(crate) use usdc::ALPACA_MINIMUM_WITHDRAWAL;
+pub(crate) use equity::{EquityRebalancingCheck, EquityRebalancingCheckScheduler};
+pub(crate) use usdc::{
+    ALPACA_MINIMUM_WITHDRAWAL, UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
+};
+
+/// Bundle of the equity + USDC schedulers so constructors and plumbing
+/// functions can pass them as a single argument instead of two.
+#[derive(Clone)]
+pub(crate) struct RebalancingSchedulers {
+    pub(crate) equity: EquityRebalancingCheckScheduler,
+    pub(crate) usdc: UsdcRebalancingCheckScheduler,
+}
+
+impl RebalancingSchedulers {
+    pub(crate) fn new(pool: &SqlitePool) -> Self {
+        Self {
+            equity: EquityRebalancingCheckScheduler::new(pool),
+            usdc: UsdcRebalancingCheckScheduler::new(pool),
+        }
+    }
+}
 
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -43,7 +64,7 @@ use crate::wrapper::{Wrapper, WrapperError};
 
 /// Why the rebalancing trigger reactor failed.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum RebalancingTriggerError {
+pub(crate) enum RebalancingServiceError {
     #[error(transparent)]
     Inventory(#[from] InventoryViewError),
     #[error(transparent)]
@@ -259,7 +280,7 @@ impl std::fmt::Debug for RebalancingCtx {
 
 /// Configuration for the rebalancing trigger (runtime).
 #[derive(Debug, Clone)]
-pub(crate) struct RebalancingTriggerConfig {
+pub(crate) struct RebalancingServiceConfig {
     pub(crate) equity: ImbalanceThreshold,
     pub(crate) usdc: Option<ImbalanceThreshold>,
     pub(crate) transfer_timeout: Duration,
@@ -493,9 +514,11 @@ pub(crate) enum TriggeredOperation {
     UsdcBaseToAlpaca { amount: Usdc },
 }
 
-/// Trigger that monitors inventory and sends rebalancing operations.
-pub(crate) struct RebalancingTrigger {
-    config: RebalancingTriggerConfig,
+/// Service that folds CQRS events into rebalancing state and
+/// schedules follow-up imbalance checks. Also serves as the apalis
+/// `Ctx` for the rebalancing-check workers.
+pub(crate) struct RebalancingService {
+    config: RebalancingServiceConfig,
     vault_registry: Arc<Store<VaultRegistry>>,
     orderbook: Address,
     order_owner: Address,
@@ -504,6 +527,8 @@ pub(crate) struct RebalancingTrigger {
     pub(crate) usdc_in_progress: Arc<AtomicBool>,
     sender: mpsc::Sender<TriggeredOperation>,
     wrapper: Arc<dyn Wrapper>,
+    pub(super) equity_scheduler: EquityRebalancingCheckScheduler,
+    pub(super) usdc_scheduler: UsdcRebalancingCheckScheduler,
     /// Tracks symbol/quantity for in-flight mints. The initial `MintRequested`
     /// event carries this data; follow-up events don't.
     mint_tracking: Arc<RwLock<HashMap<IssuerRequestId, MintTracking>>>,
@@ -539,16 +564,21 @@ type EquityInventoryUpdate = Box<
 
 const TIMEOUT_TOMBSTONE_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
-impl RebalancingTrigger {
+impl RebalancingService {
     pub(crate) fn new(
-        config: RebalancingTriggerConfig,
+        config: RebalancingServiceConfig,
         vault_registry: Arc<Store<VaultRegistry>>,
         orderbook: Address,
         order_owner: Address,
         inventory: Arc<BroadcastingInventory>,
         sender: mpsc::Sender<TriggeredOperation>,
         wrapper: Arc<dyn Wrapper>,
+        schedulers: RebalancingSchedulers,
     ) -> Self {
+        let RebalancingSchedulers {
+            equity: equity_scheduler,
+            usdc: usdc_scheduler,
+        } = schedulers;
         Self {
             config,
             vault_registry,
@@ -559,6 +589,8 @@ impl RebalancingTrigger {
             usdc_in_progress: Arc::new(AtomicBool::new(false)),
             sender,
             wrapper,
+            equity_scheduler,
+            usdc_scheduler,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
             usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
@@ -590,7 +622,7 @@ impl RebalancingTrigger {
     async fn expire_stuck_operations(
         &self,
         now: DateTime<Utc>,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         self.prune_timeout_markers(now).await;
         self.expire_stuck_mints(now).await?;
         self.expire_stuck_redemptions(now).await?;
@@ -629,7 +661,7 @@ impl RebalancingTrigger {
             .retain(|_, timed_out_at| !Self::timeout_marker_expired(*timed_out_at, now));
     }
 
-    async fn expire_stuck_mints(&self, now: DateTime<Utc>) -> Result<(), RebalancingTriggerError> {
+    async fn expire_stuck_mints(&self, now: DateTime<Utc>) -> Result<(), RebalancingServiceError> {
         let timed_out_ids = {
             let tracking = self.mint_tracking.read().await;
             tracking
@@ -700,7 +732,7 @@ impl RebalancingTrigger {
     async fn expire_stuck_redemptions(
         &self,
         now: DateTime<Utc>,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let timed_out_ids = {
             let tracking = self.redemption_tracking.read().await;
             tracking
@@ -781,7 +813,7 @@ impl RebalancingTrigger {
     async fn expire_stuck_usdc_rebalances(
         &self,
         now: DateTime<Utc>,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let timed_out_ids = {
             let tracking = self.usdc_tracking.read().await;
             tracking
@@ -880,7 +912,7 @@ impl RebalancingTrigger {
         &self,
         id: &IssuerRequestId,
         now: DateTime<Utc>,
-    ) -> Result<Option<(MintTracking, Duration)>, RebalancingTriggerError> {
+    ) -> Result<Option<(MintTracking, Duration)>, RebalancingServiceError> {
         let _event_sync_guard = self.mint_event_sync.lock().await;
         let mut tracking_guard = self.mint_tracking.write().await;
         let Some(tracking) = tracking_guard.get(id).cloned() else {
@@ -918,7 +950,7 @@ impl RebalancingTrigger {
         &self,
         id: &RedemptionAggregateId,
         now: DateTime<Utc>,
-    ) -> Result<Option<(RedemptionTracking, Duration)>, RebalancingTriggerError> {
+    ) -> Result<Option<(RedemptionTracking, Duration)>, RebalancingServiceError> {
         let _event_sync_guard = self.redemption_event_sync.lock().await;
         let mut tracking_guard = self.redemption_tracking.write().await;
         let Some(tracking) = tracking_guard.get(id).cloned() else {
@@ -959,7 +991,7 @@ impl RebalancingTrigger {
         &self,
         id: &UsdcRebalanceId,
         now: DateTime<Utc>,
-    ) -> Result<Option<(usdc::UsdcRebalanceTracking, Duration)>, RebalancingTriggerError> {
+    ) -> Result<Option<(usdc::UsdcRebalanceTracking, Duration)>, RebalancingServiceError> {
         let _event_sync_guard = self.usdc_event_sync.lock().await;
         let mut tracking_guard = self.usdc_tracking.write().await;
         let Some(tracking) = tracking_guard.get(id).cloned() else {
@@ -1030,19 +1062,22 @@ impl RebalancingTrigger {
         }
     }
 
-    /// Fold the snapshot event into the view, then run threshold
-    /// checks. A failed apply (including recovery) short-circuits the
-    /// checks so rebalancing never runs against a stale view.
+    /// Fold the snapshot event into the view, then enqueue any
+    /// follow-up imbalance checks the event implies. A failed apply
+    /// (including recovery) short-circuits enqueueing so rebalancing
+    /// never runs against a stale view.
     async fn on_snapshot(
         &self,
         event: InventorySnapshotEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
+        use InventorySnapshotEvent::*;
+
         let now = Utc::now();
         let fetched_at = event.timestamp();
         self.expire_stuck_operations(now).await?;
 
         let filtered_inflight = match &event {
-            InventorySnapshotEvent::InflightEquity {
+            InflightEquity {
                 mints, redemptions, ..
             } => {
                 let active_suppressed_symbols = self
@@ -1060,7 +1095,6 @@ impl RebalancingTrigger {
 
         let mut inventory = self.inventory.write().await;
 
-        use InventorySnapshotEvent::*;
         let updated = match &event {
             OnchainEquity { balances, .. } => {
                 balances
@@ -1118,7 +1152,8 @@ impl RebalancingTrigger {
 
         trace!(target: "rebalance", "Applied inventory snapshot event");
 
-        self.check_and_trigger_after_snapshot(&event).await
+        self.enqueue_checks_for_snapshot(&event).await;
+        Ok(())
     }
 
     /// Reprocess a snapshot event after the normal handler failed.
@@ -1128,19 +1163,25 @@ impl RebalancingTrigger {
     /// original failure.
     async fn on_snapshot_recovery(
         &self,
-        error: RebalancingTriggerError,
+        error: RebalancingServiceError,
         event: InventorySnapshotEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
+        use InventorySnapshotEvent::*;
+        use RebalancingServiceError::{
+            EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext, Projection,
+            SettledUsdcExceedsInitiatedAmount,
+        };
+
         self.expire_stuck_operations_with_logging().await;
 
         let inventory_error = match error {
-            RebalancingTriggerError::Inventory(inventory_error) => inventory_error,
-            other @ (RebalancingTriggerError::Projection(_)
-            | RebalancingTriggerError::EquityTrigger(_)
-            | RebalancingTriggerError::Float(_)
-            | RebalancingTriggerError::MissingUsdcTrackingContext { .. }
-            | RebalancingTriggerError::MissingUsdcBridgedAmount { .. }
-            | RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount { .. }) => {
+            RebalancingServiceError::Inventory(inventory_error) => inventory_error,
+            other @ (Projection(_)
+            | EquityTrigger(_)
+            | Float(_)
+            | MissingUsdcTrackingContext { .. }
+            | MissingUsdcBridgedAmount { .. }
+            | SettledUsdcExceedsInitiatedAmount { .. }) => {
                 return Err(other);
             }
         };
@@ -1156,7 +1197,7 @@ impl RebalancingTrigger {
 
         let now = Utc::now();
         let filtered_inflight = match &event {
-            InventorySnapshotEvent::InflightEquity {
+            InflightEquity {
                 mints,
                 redemptions,
                 fetched_at,
@@ -1176,7 +1217,6 @@ impl RebalancingTrigger {
         let mut inventory = self.inventory.write().await;
         *inventory = InventoryView::default();
 
-        use InventorySnapshotEvent::*;
         let updated = match &event {
             OnchainEquity { balances, .. } => {
                 balances
@@ -1248,52 +1288,56 @@ impl RebalancingTrigger {
 
         debug!(target: "rebalance", "Force-applied inventory snapshot after recovery");
 
-        self.check_and_trigger_after_snapshot(&event).await
+        self.enqueue_checks_for_snapshot(&event).await;
+        Ok(())
     }
 
-    /// Trigger rebalancing checks after a snapshot event.
-    async fn check_and_trigger_after_snapshot(
-        &self,
-        event: &InventorySnapshotEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    /// Enqueue the follow-up imbalance checks implied by a snapshot
+    /// event. Events that change tradeable balances (equity / USDC at
+    /// either venue) warrant an imbalance check; wallet-read
+    /// snapshots, inflight snapshots, and buying-power updates do not.
+    async fn enqueue_checks_for_snapshot(&self, event: &InventorySnapshotEvent) {
         use InventorySnapshotEvent::*;
 
         match event {
+            // Per-symbol equity snapshots: fan out into one equity check
+            // per symbol so independent retries and parallel work fall
+            // out naturally.
             OnchainEquity { balances, .. } => {
                 for symbol in balances.keys() {
-                    self.check_and_trigger_equity(symbol).await?;
+                    self.equity_scheduler.enqueue_check(symbol.clone()).await;
                 }
             }
             OffchainEquity { positions, .. } => {
                 for symbol in positions.keys() {
-                    self.check_and_trigger_equity(symbol).await?;
+                    self.equity_scheduler.enqueue_check(symbol.clone()).await;
                 }
             }
+            // Global USDC snapshots: one USDC check.
             OnchainUsdc { .. } | OffchainUsd { .. } => {
-                self.check_and_trigger_usdc().await;
+                self.usdc_scheduler.enqueue_check().await;
             }
-            // Wallet-read USDC events update `inflight_cash` for visibility
-            // but don't drive triggers here. Suppression-aware
-            // re-triggering will be added once orphan-vs-baseline
-            // detection is in place.
+            // Wallet-read USDC events update `inflight_cash` for
+            // visibility but don't drive triggers here.
+            // Suppression-aware re-triggering will be added once
+            // orphan-vs-baseline detection is in place.
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. }
-            // Buying power is display-only and doesn't feed venue balances,
-            // so it never drives a rebalance.
+            // Buying power is display-only and doesn't feed venue
+            // balances, so it never drives a rebalance.
             | OffchainMarginSafeBuyingPower { .. }
-            // Inflight snapshots don't trigger rebalancing -- they indicate
-            // transfers already in progress, not new balances to rebalance.
+            // Inflight snapshots don't trigger rebalancing -- they
+            // indicate transfers already in progress, not new balances
+            // to rebalance.
             | InflightEquity { .. } => {}
         }
-
-        Ok(())
     }
 }
 
 deps!(
-    RebalancingTrigger,
+    RebalancingService,
     [
         Position,
         TokenizedEquityMint,
@@ -1304,8 +1348,8 @@ deps!(
 );
 
 #[async_trait]
-impl Reactor for RebalancingTrigger {
-    type Error = RebalancingTriggerError;
+impl Reactor for RebalancingService {
+    type Error = RebalancingServiceError;
 
     async fn react(
         &self,
@@ -1326,7 +1370,6 @@ impl Reactor for RebalancingTrigger {
                         let equity_op: Operator = (*direction).into();
                         let quantity: Float = (*amount).into();
                         let usdc_value = (*price_usdc * quantity)?;
-
                         (
                             Inventory::available(Venue::MarketMaking, equity_op, *amount),
                             Inventory::available(
@@ -1336,7 +1379,6 @@ impl Reactor for RebalancingTrigger {
                             ),
                         )
                     }
-
                     OffChainOrderFilled {
                         shares_filled,
                         direction,
@@ -1347,7 +1389,6 @@ impl Reactor for RebalancingTrigger {
                         let quantity: Float = shares_filled.inner().into();
                         let price_value = price.inner();
                         let usdc_value = (price_value * quantity)?;
-
                         (
                             Inventory::available(Venue::Hedging, equity_op, shares_filled.inner()),
                             Inventory::available(
@@ -1357,7 +1398,6 @@ impl Reactor for RebalancingTrigger {
                             ),
                         )
                     }
-
                     Initialized { .. }
                     | OffChainOrderPlaced { .. }
                     | OffChainOrderFailed { .. }
@@ -1371,17 +1411,15 @@ impl Reactor for RebalancingTrigger {
                     .update_usdc(usdc_update, timestamp)?;
                 drop(inventory);
 
-                self.check_and_trigger_equity(&symbol).await?;
-                self.check_and_trigger_usdc().await;
-
-                Ok::<(), RebalancingTriggerError>(())
+                self.equity_scheduler.enqueue_check(symbol).await;
+                self.usdc_scheduler.enqueue_check().await;
+                Ok::<(), RebalancingServiceError>(())
             })
             .on(|id, event| async move { self.on_mint(id, event).await })
             .on(|id, event| async move { self.on_redemption(id, event).await })
             .on(|id, event| async move { self.on_usdc_rebalance(id, event).await })
             .on(|_id, event| async move {
                 let recovery_event = event.clone();
-
                 match self.on_snapshot(event).await {
                     Ok(()) => Ok(()),
                     Err(error) => self.on_snapshot_recovery(error, recovery_event).await,
@@ -1392,7 +1430,7 @@ impl Reactor for RebalancingTrigger {
     }
 }
 
-impl RebalancingTrigger {
+impl RebalancingService {
     async fn expire_stuck_operations_with_logging(&self) {
         if let Err(error) = self.expire_stuck_operations(Utc::now()).await {
             error!(target: "rebalance", ?error, "Failed to expire stuck rebalancing operations");
@@ -1523,7 +1561,7 @@ impl RebalancingTrigger {
         &self,
         symbol: &Symbol,
         update: EquityInventoryUpdate,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let now = Utc::now();
         let mut inventory = self.inventory.write().await;
         *inventory = inventory.clone().update_equity(symbol, update, now)?;
@@ -1740,7 +1778,7 @@ impl RebalancingTrigger {
         &self,
         id: &IssuerRequestId,
         entity: &TokenizedEquityMint,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         use TokenizedEquityMint::*;
 
         match entity {
@@ -1816,7 +1854,7 @@ impl RebalancingTrigger {
         &self,
         id: &RedemptionAggregateId,
         entity: &EquityRedemption,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         use EquityRedemption::*;
 
         match entity {
@@ -1908,7 +1946,7 @@ impl RebalancingTrigger {
         &self,
         id: IssuerRequestId,
         event: TokenizedEquityMintEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let event_sync_guard = self.mint_event_sync.lock().await;
 
         if self.mint_timed_out(&id).await {
@@ -1929,7 +1967,7 @@ impl RebalancingTrigger {
 
         self.update_active_mint(&id, &symbol, &event).await;
 
-        let should_check_usdc = if Self::is_terminal_mint_event(&event) {
+        let is_terminal = if Self::is_terminal_mint_event(&event) {
             self.mint_tracking.write().await.remove(&id);
             self.clear_equity_in_progress(&symbol);
             debug!(target: "rebalance", %symbol, "Cleared equity in-progress flag after mint terminal event");
@@ -1940,8 +1978,14 @@ impl RebalancingTrigger {
 
         drop(event_sync_guard);
 
-        if should_check_usdc {
-            self.check_and_trigger_usdc().await;
+        // A terminal mint event freed the USDC reserved for the
+        // just-completed mint, so we cancel any pending checks (they
+        // captured pre-rebalance state) and push a fresh USDC check
+        // against the post-rebalance inventory.
+        if is_terminal {
+            self.equity_scheduler.cancel_pending().await;
+            self.usdc_scheduler.cancel_pending().await;
+            self.usdc_scheduler.enqueue_check().await;
         }
 
         Ok(())
@@ -1951,7 +1995,7 @@ impl RebalancingTrigger {
         &self,
         id: RedemptionAggregateId,
         event: EquityRedemptionEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let event_sync_guard = self.redemption_event_sync.lock().await;
 
         if self.redemption_timed_out(&id).await {
@@ -1972,7 +2016,7 @@ impl RebalancingTrigger {
 
         self.update_active_redemption(&id, &symbol, &event).await;
 
-        let should_check_usdc = if Self::is_terminal_redemption_event(&event) {
+        let is_terminal = if Self::is_terminal_redemption_event(&event) {
             self.redemption_tracking.write().await.remove(&id);
             self.clear_equity_in_progress(&symbol);
             debug!(
@@ -1987,8 +2031,13 @@ impl RebalancingTrigger {
 
         drop(event_sync_guard);
 
-        if should_check_usdc {
-            self.check_and_trigger_usdc().await;
+        // A terminal redemption freed the shares held by the in-flight
+        // transfer, so we cancel pending pre-rebalance checks and push
+        // a fresh USDC check against the post-rebalance inventory.
+        if is_terminal {
+            self.equity_scheduler.cancel_pending().await;
+            self.usdc_scheduler.cancel_pending().await;
+            self.usdc_scheduler.enqueue_check().await;
         }
 
         Ok(())
@@ -2069,13 +2118,35 @@ impl RebalancingTrigger {
     }
 }
 
+/// Test fixture: drain every pending equity- and USDC-check row the service
+/// has enqueued, looping until both queues report zero pending work. Each
+/// asset class drains independently; the loop reconciles the case where a
+/// terminal handler for one asset enqueues a fresh check on the other.
+#[cfg(test)]
+pub(crate) async fn drain_pending_jobs(
+    service: &Arc<RebalancingService>,
+) -> Result<usize, equity::EquityRebalancingCheckJobError> {
+    let mut processed = 0usize;
+    loop {
+        let equity = equity::drain_pending_equity_jobs(service).await?;
+        let usdc = usdc::drain_pending_usdc_jobs(service).await;
+        processed += equity + usdc;
+        if equity == 0 && usdc == 0 {
+            return Ok(processed);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, TxHash, U256, address, fixed_bytes};
+    use async_trait::async_trait;
     use chrono::{Duration as ChronoDuration, Utc};
     use rain_math_float::Float;
     use sqlx::SqlitePool;
-    use st0x_event_sorcery::{EntityList, Never, ReactorHarness, TestStore, deps, test_store};
+    use st0x_event_sorcery::{
+        EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
+    };
     use st0x_execution::{Direction, ExecutorOrderId, Positive};
     use st0x_finance::{Usd, Usdc};
     use std::collections::{BTreeMap, HashSet};
@@ -2092,23 +2163,28 @@ mod tests {
     use super::*;
 
     use crate::alpaca_wallet::AlpacaTransferId;
+    use crate::conductor::job::Job;
     use crate::config::{CashAssetConfig, EquitiesConfig, OperationMode};
     use crate::equity_redemption::DetectionFailure;
-    use crate::inventory::snapshot::{InventorySnapshotEvent, InventorySnapshotId};
+    use crate::inventory::snapshot::{
+        InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
+    };
     use crate::inventory::view::Operator;
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
-    use crate::position::{PositionEvent, TradeId};
+    use crate::position::{Position, PositionEvent, TradeId};
     use crate::threshold::ExecutionThreshold;
     use crate::tokenized_equity_mint::{IssuerRequestId, ReceiptId, TokenizationRequestId};
-    use crate::usdc_rebalance::{TransferRef, UsdcRebalanceCommand, UsdcRebalanceId};
+    use crate::usdc_rebalance::{
+        TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+    };
     use crate::vault_registry::VaultRegistryCommand;
     use crate::wrapper::mock::MockWrapper;
     use st0x_execution::HasZero;
     use st0x_float_macro::float;
 
-    fn test_config() -> RebalancingTriggerConfig {
-        RebalancingTriggerConfig {
+    fn test_config() -> RebalancingServiceConfig {
+        RebalancingServiceConfig {
             equity: ImbalanceThreshold {
                 target: float!(0.5),
                 deviation: float!(0.2),
@@ -2131,14 +2207,14 @@ mod tests {
         }
     }
 
-    fn test_config_with_timeout(timeout: Duration) -> RebalancingTriggerConfig {
-        RebalancingTriggerConfig {
+    fn test_config_with_timeout(timeout: Duration) -> RebalancingServiceConfig {
+        RebalancingServiceConfig {
             transfer_timeout: timeout,
             ..test_config()
         }
     }
 
-    async fn make_trigger() -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+    async fn make_trigger() -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
@@ -2148,18 +2224,17 @@ mod tests {
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
 
-        (
-            Arc::new(RebalancingTrigger::new(
-                test_config(),
-                Arc::new(test_store::<VaultRegistry>(pool, ())),
-                TEST_ORDERBOOK,
-                TEST_ORDER_OWNER,
-                inventory,
-                sender,
-                wrapper,
-            )),
-            receiver,
-        )
+        let service = Arc::new(RebalancingService::new(
+            test_config(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            sender,
+            wrapper,
+            RebalancingSchedulers::new(&pool),
+        ));
+        (service, receiver)
     }
 
     #[tokio::test]
@@ -2249,15 +2324,16 @@ mod tests {
         assert_eq!(inflight, Some(FractionalShares::new(float!(12))));
     }
 
-    /// Mirrors the production wiring where [`InventoryProjection`] writes
-    /// Drives the trigger's production snapshot path: apply then
-    /// threshold checks, short-circuiting if apply fails.
+    /// Drives the production snapshot path end-to-end: applies the
+    /// snapshot via the service (which enqueues follow-up checks
+    /// internally). Skips the entity-list plumbing so tests can drive
+    /// snapshot recovery directly.
     async fn apply_and_dispatch_snapshot(
-        trigger: Arc<RebalancingTrigger>,
+        service: Arc<RebalancingService>,
         _id: InventorySnapshotId,
         event: InventorySnapshotEvent,
-    ) -> Result<(), RebalancingTriggerError> {
-        trigger.on_snapshot(event).await
+    ) -> Result<(), RebalancingServiceError> {
+        service.on_snapshot(event).await
     }
 
     #[tokio::test]
@@ -2313,8 +2389,8 @@ mod tests {
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
 
-        let trigger = RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: test_config().equity,
                 usdc: None,
                 transfer_timeout: test_config().transfer_timeout,
@@ -2324,12 +2400,13 @@ mod tests {
                 },
                 disabled_assets: HashSet::new(),
             },
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
+            RebalancingSchedulers::new(&pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -2355,8 +2432,8 @@ mod tests {
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
 
-        let trigger = RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let trigger = RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: test_config().equity,
                 usdc: test_config().usdc,
                 transfer_timeout: test_config().transfer_timeout,
@@ -2366,12 +2443,13 @@ mod tests {
                 },
                 disabled_assets: HashSet::from([symbol.clone()]),
             },
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
+            RebalancingSchedulers::new(&pool),
         );
 
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -2418,8 +2496,9 @@ mod tests {
     async fn test_balanced_inventory_does_not_trigger() {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default().with_equity(symbol.clone(), shares(0), shares(0));
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
 
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
         trigger.check_and_trigger_usdc().await;
@@ -2491,45 +2570,44 @@ mod tests {
 
     async fn make_trigger_with_inventory(
         inventory: InventoryView,
-    ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+    ) -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         make_trigger_with_inventory_config(inventory, test_config()).await
     }
 
     async fn make_trigger_with_inventory_config(
         inventory: InventoryView,
-        config: RebalancingTriggerConfig,
-    ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+        config: RebalancingServiceConfig,
+    ) -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
         let pool = crate::test_utils::setup_test_db().await;
 
-        (
-            Arc::new(RebalancingTrigger::new(
-                config,
-                Arc::new(test_store::<VaultRegistry>(pool, ())),
-                TEST_ORDERBOOK,
-                TEST_ORDER_OWNER,
-                inventory,
-                sender,
-                Arc::new(MockWrapper::new()),
-            )),
-            receiver,
-        )
+        let service = Arc::new(RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            sender,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
+        ));
+        (service, receiver)
     }
 
     async fn make_trigger_with_inventory_and_registry(
         inventory: InventoryView,
         symbol: &Symbol,
-    ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+    ) -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         make_trigger_with_inventory_and_registry_config(inventory, symbol, test_config()).await
     }
 
     async fn make_trigger_with_inventory_and_registry_config(
         inventory: InventoryView,
         symbol: &Symbol,
-        config: RebalancingTriggerConfig,
-    ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+        config: RebalancingServiceConfig,
+    ) -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         make_trigger_with_inventory_registry_and_wrapper(
             inventory,
             symbol,
@@ -2543,8 +2621,8 @@ mod tests {
         inventory: InventoryView,
         symbol: &Symbol,
         wrapper: Arc<MockWrapper>,
-        config: RebalancingTriggerConfig,
-    ) -> (Arc<RebalancingTrigger>, mpsc::Receiver<TriggeredOperation>) {
+        config: RebalancingServiceConfig,
+    ) -> (Arc<RebalancingService>, mpsc::Receiver<TriggeredOperation>) {
         let (sender, receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
@@ -2552,18 +2630,18 @@ mod tests {
 
         seed_vault_registry(&pool, symbol).await;
 
-        (
-            Arc::new(RebalancingTrigger::new(
-                config,
-                Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-                TEST_ORDERBOOK,
-                TEST_ORDER_OWNER,
-                inventory,
-                sender,
-                wrapper,
-            )),
-            receiver,
-        )
+        let service = Arc::new(RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            sender,
+            wrapper,
+            RebalancingSchedulers::new(&pool),
+        ));
+        let reactor = service;
+        (reactor, receiver)
     }
 
     #[tokio::test]
@@ -2583,8 +2661,9 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let inventory = InventoryView::default().with_equity(symbol.clone(), shares(0), shares(0));
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
 
         let result = trigger.load_token_address(&symbol).await.unwrap();
         assert_eq!(result, Some(TEST_TOKEN));
@@ -2596,8 +2675,9 @@ mod tests {
         let unknown = Symbol::new("MSFT").unwrap();
         let inventory = InventoryView::default().with_equity(known.clone(), shares(0), shares(0));
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &known).await;
+        let trigger = reactor.clone();
 
         let result = trigger.load_token_address(&unknown).await.unwrap();
         assert_eq!(result, None);
@@ -2626,7 +2706,7 @@ mod tests {
 
         seed_vault_registry(&pool, &symbol).await;
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
@@ -2634,9 +2714,11 @@ mod tests {
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
-        let harness = ReactorHarness::new(trigger.clone());
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Simulate production: onchain fills arrive on an empty inventory.
         // 20 onchain buys, 80 offchain buys -> 20% onchain ratio.
@@ -2648,6 +2730,7 @@ mod tests {
                 .receive::<Position>(symbol.clone(), event)
                 .await
                 .unwrap();
+            drain_pending_jobs(&trigger).await.unwrap();
         }
 
         for _ in 0..80 {
@@ -2656,6 +2739,7 @@ mod tests {
                 .receive::<Position>(symbol.clone(), event)
                 .await
                 .unwrap();
+            drain_pending_jobs(&trigger).await.unwrap();
         }
 
         // Drain any intermediate triggers and do a final check.
@@ -2668,6 +2752,7 @@ mod tests {
             .receive::<Position>(symbol.clone(), event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         let triggered = receiver.try_recv();
         assert!(
@@ -2683,9 +2768,10 @@ mod tests {
             .with_equity(symbol.clone(), shares(0), shares(0))
             .with_usdc(usdc(1_000_000), usdc(1_000_000));
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Apply onchain buy - should add to onchain available.
         let event = make_onchain_fill(shares(50), Direction::Buy);
@@ -2734,9 +2820,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Apply a small buy that maintains balance (5 shares onchain).
         // After: 55 onchain, 50 offchain = 52.4% ratio, within 30-70% bounds.
@@ -2785,6 +2871,7 @@ mod tests {
             .receive::<Position>(symbol.clone(), event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // Mint should be triggered because too much offchain.
         let triggered = receiver.try_recv();
@@ -2815,13 +2902,14 @@ mod tests {
         let wrapper = Arc::new(MockWrapper::with_ratio(U256::from(
             1_500_000_000_000_000_000u64,
         )));
-        let (trigger, mut receiver) = make_trigger_with_inventory_registry_and_wrapper(
+        let (reactor, mut receiver) = make_trigger_with_inventory_registry_and_wrapper(
             inventory,
             &symbol,
             wrapper,
             test_config(),
         )
         .await;
+        let trigger = reactor.clone();
 
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
 
@@ -2926,8 +3014,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
 
         // Initially, trigger should detect imbalance (too much offchain).
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -2980,7 +3069,7 @@ mod tests {
         assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
 
         // Check that DepositedIntoRaindex is detected as terminal.
-        assert!(RebalancingTrigger::is_terminal_mint_event(
+        assert!(RebalancingService::is_terminal_mint_event(
             &make_deposited_into_raindex()
         ));
 
@@ -3002,7 +3091,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        assert!(RebalancingTrigger::is_terminal_mint_event(
+        assert!(RebalancingService::is_terminal_mint_event(
             &make_mint_rejected()
         ));
 
@@ -3012,7 +3101,7 @@ mod tests {
 
     #[test]
     fn mint_acceptance_failure_is_terminal() {
-        assert!(RebalancingTrigger::is_terminal_mint_event(
+        assert!(RebalancingService::is_terminal_mint_event(
             &make_mint_acceptance_failed()
         ));
     }
@@ -3023,7 +3112,7 @@ mod tests {
         let event = make_mint_requested(&symbol, float!(42.5));
 
         let (extracted_symbol, extracted_quantity) =
-            RebalancingTrigger::extract_mint_info(&event).unwrap();
+            RebalancingService::extract_mint_info(&event).unwrap();
 
         assert_eq!(extracted_symbol, symbol);
         assert!(extracted_quantity.inner().eq(float!(42.5)).unwrap());
@@ -3031,20 +3120,20 @@ mod tests {
 
     #[test]
     fn extract_mint_info_returns_none_without_mint_requested() {
-        let result = RebalancingTrigger::extract_mint_info(&make_deposited_into_raindex());
+        let result = RebalancingService::extract_mint_info(&make_deposited_into_raindex());
         assert!(result.is_none());
     }
 
     #[test]
     fn non_terminal_mint_events_are_not_terminal() {
         let symbol = Symbol::new("AAPL").unwrap();
-        assert!(!RebalancingTrigger::is_terminal_mint_event(
+        assert!(!RebalancingService::is_terminal_mint_event(
             &make_mint_requested(&symbol, float!(30))
         ));
-        assert!(!RebalancingTrigger::is_terminal_mint_event(
+        assert!(!RebalancingService::is_terminal_mint_event(
             &make_mint_accepted()
         ));
-        assert!(!RebalancingTrigger::is_terminal_mint_event(
+        assert!(!RebalancingService::is_terminal_mint_event(
             &make_tokens_received()
         ));
     }
@@ -3138,8 +3227,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = IssuerRequestId::new("mint-blocks");
 
@@ -3189,8 +3279,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = IssuerRequestId::new("mint-transfer");
 
@@ -3239,8 +3330,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = IssuerRequestId::new("mint-fail");
 
@@ -3287,8 +3379,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         // Set in-progress flag to verify terminal event clears it
@@ -3344,8 +3437,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         {
@@ -3389,8 +3483,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         {
@@ -3428,8 +3523,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         {
@@ -3470,8 +3566,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         {
@@ -3512,8 +3609,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         {
@@ -3584,9 +3682,10 @@ mod tests {
             .with_equity(symbol.clone(), shares(0), shares(0))
             .with_usdc(usdc(10000), usdc(10000));
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Onchain buy of 10 shares at $150 -> adds 10 equity onchain, removes $1500 USDC onchain
         let event = make_onchain_fill(shares(10), Direction::Buy);
@@ -3619,9 +3718,10 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Onchain sell of 10 shares at $150 -> removes 10 equity onchain, adds $1500 USDC onchain
         let event = make_onchain_fill(shares(10), Direction::Sell);
@@ -3648,9 +3748,10 @@ mod tests {
             .with_equity(symbol.clone(), shares(0), shares(0))
             .with_usdc(usdc(10000), usdc(10000));
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Offchain buy of 10 shares at $150 -> adds 10 equity offchain, removes $1500 USDC offchain
         let event = make_offchain_fill(shares(10), Direction::Buy);
@@ -3683,9 +3784,10 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
-        let harness = ReactorHarness::new(trigger.clone());
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor.clone());
 
         // Offchain sell of 10 shares at $150 -> removes 10 equity offchain, adds $1500 USDC offchain
         let event = make_offchain_fill(shares(10), Direction::Sell);
@@ -3724,8 +3826,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -3737,7 +3840,7 @@ mod tests {
         balances.insert(symbol.clone(), shares(40));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OnchainEquity {
                 balances,
@@ -3775,8 +3878,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -3795,7 +3899,7 @@ mod tests {
         positions.insert(symbol.clone(), shares(20));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OffchainEquity {
                 positions,
@@ -3832,8 +3936,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-blocks");
 
@@ -3884,8 +3989,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-rebalances");
 
@@ -3919,7 +4025,8 @@ mod tests {
         // Use 100 onchain, 900 offchain = 10% ratio -> triggers TooMuchOffchain
         let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
 
-        let (trigger, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -3956,7 +4063,8 @@ mod tests {
         // 900 onchain, 100 offchain = 90% ratio -> TooMuchOnchain
         let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
 
-        let (trigger, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -4468,7 +4576,8 @@ mod tests {
 
         for scenario in scenarios {
             let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
-            let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+            let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
+            let trigger = reactor.clone();
             let harness = ReactorHarness::new(Arc::clone(&trigger));
             let id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -4545,7 +4654,8 @@ mod tests {
 
         for scenario in scenarios {
             let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
-            let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+            let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
+            let trigger = reactor.clone();
             let harness = ReactorHarness::new(Arc::clone(&trigger));
             let id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -4574,8 +4684,9 @@ mod tests {
         let inventory = InventoryView::default().with_usdc(usdc(500), usdc(500));
 
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -4590,7 +4701,7 @@ mod tests {
 
         // Snapshot says onchain is actually 900 -> creates imbalance
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance: usdc(900),
@@ -4620,8 +4731,9 @@ mod tests {
         let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
 
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -4641,7 +4753,7 @@ mod tests {
         // Snapshot says offchain is actually 900 (not 100)
         // 95000 cents = $950.00
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OffchainUsd {
                 usd_balance_cents: 90000,
@@ -4719,8 +4831,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
 
         // First trigger detects the imbalance and sends a redemption.
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -4753,7 +4866,7 @@ mod tests {
         assert!(trigger.equity_in_progress.read().unwrap().contains(&symbol));
 
         // Check that Completed is detected as terminal.
-        assert!(RebalancingTrigger::is_terminal_redemption_event(
+        assert!(RebalancingService::is_terminal_redemption_event(
             &make_redemption_completed()
         ));
 
@@ -4764,14 +4877,14 @@ mod tests {
 
     #[test]
     fn detection_failure_is_terminal_redemption_event() {
-        assert!(RebalancingTrigger::is_terminal_redemption_event(
+        assert!(RebalancingService::is_terminal_redemption_event(
             &make_detection_failed()
         ));
     }
 
     #[test]
     fn redemption_rejection_is_terminal() {
-        assert!(RebalancingTrigger::is_terminal_redemption_event(
+        assert!(RebalancingService::is_terminal_redemption_event(
             &make_redemption_rejected()
         ));
     }
@@ -4782,7 +4895,7 @@ mod tests {
         let event = make_withdrawn_from_raindex(&symbol, float!(42.5));
 
         let (extracted_symbol, extracted_quantity) =
-            RebalancingTrigger::extract_redemption_info(&event).unwrap();
+            RebalancingService::extract_redemption_info(&event).unwrap();
 
         assert_eq!(extracted_symbol, symbol);
         assert!(extracted_quantity.inner().eq(float!(42.5)).unwrap());
@@ -4790,17 +4903,17 @@ mod tests {
 
     #[test]
     fn extract_redemption_info_returns_none_without_tokens_sent() {
-        let result = RebalancingTrigger::extract_redemption_info(&make_redemption_completed());
+        let result = RebalancingService::extract_redemption_info(&make_redemption_completed());
         assert!(result.is_none());
     }
 
     #[test]
     fn non_terminal_redemption_events_are_not_terminal() {
         let symbol = Symbol::new("AAPL").unwrap();
-        assert!(!RebalancingTrigger::is_terminal_redemption_event(
+        assert!(!RebalancingService::is_terminal_redemption_event(
             &make_withdrawn_from_raindex(&symbol, float!(30))
         ));
-        assert!(!RebalancingTrigger::is_terminal_redemption_event(
+        assert!(!RebalancingService::is_terminal_redemption_event(
             &make_redemption_detected()
         ));
     }
@@ -4924,7 +5037,7 @@ mod tests {
     }
 
     async fn assert_usdc_tracking_state(
-        trigger: &Arc<RebalancingTrigger>,
+        trigger: &Arc<RebalancingService>,
         id: &UsdcRebalanceId,
         direction: RebalanceDirection,
         initiated_amount: Usdc,
@@ -4946,7 +5059,7 @@ mod tests {
     }
 
     async fn assert_usdc_inventory_balances(
-        trigger: &Arc<RebalancingTrigger>,
+        trigger: &Arc<RebalancingService>,
         market_making_available: Usdc,
         market_making_inflight: Usdc,
         hedging_available: Usdc,
@@ -5016,7 +5129,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            RebalancingTriggerError::MissingUsdcTrackingContext {
+            RebalancingServiceError::MissingUsdcTrackingContext {
                 id: error_id,
                 event: usdc::UsdcTrackingEvent::Bridged,
             } if error_id == id
@@ -5039,7 +5152,7 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            matches!(error, RebalancingTriggerError::Inventory(_)),
+            matches!(error, RebalancingServiceError::Inventory(_)),
             "initiated event should fail through inventory validation, got {error:?}"
         );
         assert!(
@@ -5075,7 +5188,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            RebalancingTriggerError::MissingUsdcBridgedAmount { id: error_id }
+            RebalancingServiceError::MissingUsdcBridgedAmount { id: error_id }
                 if error_id == id
         ));
         assert!(
@@ -5150,11 +5263,12 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        let (trigger, mut receiver) = make_trigger_with_inventory_config(
+        let (reactor, mut receiver) = make_trigger_with_inventory_config(
             inventory,
             test_config_with_timeout(Duration::from_secs(1)),
         )
         .await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -5233,11 +5347,12 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_config(
             inventory,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
         let refreshed_at = Utc::now() - ChronoDuration::seconds(30);
@@ -5299,11 +5414,12 @@ mod tests {
     #[tokio::test]
     async fn usdc_pre_withdrawal_conversion_confirmation_refreshes_timeout_tracking() {
         let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
-        let (trigger, _receiver) = make_trigger_with_inventory_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_config(
             inventory,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
         let initiated_at = Utc::now() - ChronoDuration::minutes(5);
@@ -5419,7 +5535,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            RebalancingTriggerError::MissingUsdcTrackingContext {
+            RebalancingServiceError::MissingUsdcTrackingContext {
                 id: error_id,
                 event: usdc::UsdcTrackingEvent::ConversionConfirmed,
             } if error_id == id
@@ -5457,7 +5573,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount {
+            RebalancingServiceError::SettledUsdcExceedsInitiatedAmount {
                 id: error_id,
                 event: usdc::UsdcTrackingEvent::ConversionConfirmed,
                 initiated_amount,
@@ -5496,32 +5612,32 @@ mod tests {
 
     #[test]
     fn usdc_failure_events_are_terminal() {
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_withdrawal_failed()
         ));
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_bridging_failed()
         ));
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_deposit_failed()
         ));
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_conversion_failed()
         ));
     }
 
     #[test]
     fn non_terminal_usdc_events_are_not_terminal() {
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(1000))
         ));
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_withdrawal_confirmed()
         ));
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_bridging_initiated()
         ));
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_bridged()
         ));
     }
@@ -5529,7 +5645,7 @@ mod tests {
     #[test]
     fn conversion_confirmed_is_terminal_for_base_to_alpaca() {
         // For BaseToAlpaca, ConversionConfirmed IS the terminal event.
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(998))
         ));
     }
@@ -5538,14 +5654,14 @@ mod tests {
     fn conversion_confirmed_is_not_terminal_for_alpaca_to_base() {
         // For AlpacaToBase, ConversionConfirmed is NOT terminal (flow continues
         // to withdrawal).
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(998))
         ));
     }
 
     #[test]
     fn deposit_confirmed_is_terminal_for_alpaca_to_base() {
-        assert!(RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase)
         ));
     }
@@ -5554,7 +5670,7 @@ mod tests {
     fn deposit_confirmed_is_not_terminal_for_base_to_alpaca() {
         // For BaseToAlpaca, DepositConfirmed is NOT terminal because
         // post-deposit conversion (USDC->USD) is still required.
-        assert!(!RebalancingTrigger::is_terminal_usdc_rebalance_event(
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_deposit_confirmed(RebalanceDirection::BaseToAlpaca)
         ));
     }
@@ -5664,8 +5780,9 @@ mod tests {
         let pool = crate::test_utils::setup_test_db().await;
         let wrapper = Arc::new(MockWrapper::new());
 
-        let trigger = RebalancingTrigger::new(
-            RebalancingTriggerConfig {
+        let schedulers = RebalancingSchedulers::new(&pool);
+        let trigger = RebalancingService::new(
+            RebalancingServiceConfig {
                 equity: ImbalanceThreshold {
                     target: float!(0.5),
                     deviation: float!(0.2),
@@ -5690,6 +5807,7 @@ mod tests {
             },
             sender,
             wrapper,
+            schedulers,
         );
 
         assert!(
@@ -5744,7 +5862,7 @@ mod tests {
             let (_id, event) = event.into_inner();
             self.captured_events.lock().await.push(event.clone());
 
-            let is_terminal = RebalancingTrigger::is_terminal_usdc_rebalance_event(&event);
+            let is_terminal = RebalancingService::is_terminal_usdc_rebalance_event(&event);
             self.terminal_detection_results
                 .lock()
                 .await
@@ -6072,7 +6190,7 @@ mod tests {
             event_sender,
         ));
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             Address::ZERO,
@@ -6080,6 +6198,7 @@ mod tests {
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
 
         // Set in_progress flag
@@ -6289,7 +6408,7 @@ mod tests {
         // Seed vault registry so token lookup succeeds
         seed_vault_registry(&pool, &symbol).await;
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
@@ -6297,7 +6416,9 @@ mod tests {
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
@@ -6316,7 +6437,7 @@ mod tests {
 
         // React to the onchain event - this should NOT trigger rebalancing
         // because we don't have offchain data yet
-        apply_and_dispatch_snapshot(trigger.clone(), id.clone(), onchain_event.clone())
+        apply_and_dispatch_snapshot(reactor.clone(), id.clone(), onchain_event.clone())
             .await
             .unwrap();
 
@@ -6352,7 +6473,7 @@ mod tests {
 
         seed_vault_registry(&pool, &symbol).await;
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
@@ -6360,7 +6481,9 @@ mod tests {
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
@@ -6376,9 +6499,10 @@ mod tests {
             fetched_at: Utc::now(),
         };
 
-        apply_and_dispatch_snapshot(trigger.clone(), id.clone(), onchain_event)
+        apply_and_dispatch_snapshot(reactor.clone(), id.clone(), onchain_event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // No trigger yet - only one venue has data
         assert!(
@@ -6395,9 +6519,10 @@ mod tests {
             fetched_at: Utc::now(),
         };
 
-        apply_and_dispatch_snapshot(trigger.clone(), id.clone(), offchain_event)
+        apply_and_dispatch_snapshot(reactor.clone(), id.clone(), offchain_event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // Now both venues have data: 100 onchain, 0 offchain = 100% ratio
         // With target 50% and deviation 10%, ratio 100% > upper bound 60%
@@ -6430,7 +6555,7 @@ mod tests {
 
         seed_vault_registry(&pool, &symbol).await;
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
@@ -6438,7 +6563,9 @@ mod tests {
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
@@ -6454,9 +6581,10 @@ mod tests {
             fetched_at: Utc::now(),
         };
 
-        apply_and_dispatch_snapshot(trigger.clone(), id.clone(), onchain_event)
+        apply_and_dispatch_snapshot(reactor.clone(), id.clone(), onchain_event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // Verify the logs show:
         // 1. The snapshot event was applied
@@ -6490,7 +6618,7 @@ mod tests {
 
         seed_vault_registry(&pool, &symbol).await;
 
-        let trigger = Arc::new(RebalancingTrigger::new(
+        let trigger = Arc::new(RebalancingService::new(
             test_config(),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             TEST_ORDERBOOK,
@@ -6498,7 +6626,9 @@ mod tests {
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
         ));
+        let reactor = trigger.clone();
 
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
@@ -6510,7 +6640,7 @@ mod tests {
         balances.insert(symbol.clone(), shares(100));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OnchainEquity {
                 balances,
@@ -6519,13 +6649,14 @@ mod tests {
         )
         .await
         .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // Now apply offchain data - both venues now have data
         let mut positions = BTreeMap::new();
         positions.insert(symbol.clone(), shares(0));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::OffchainEquity {
                 positions,
@@ -6534,6 +6665,7 @@ mod tests {
         )
         .await
         .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         // Verify the trigger fired after both venues have data
         assert!(
@@ -6563,6 +6695,7 @@ mod tests {
             .receive::<Position>(symbol.clone(), event)
             .await
             .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         let mut operations = Vec::new();
         while let Ok(operation) = receiver.try_recv() {
@@ -6632,8 +6765,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-transfer-cancel");
 
@@ -6700,8 +6834,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -6720,7 +6855,7 @@ mod tests {
         mints.insert(symbol.clone(), shares(10));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::InflightEquity {
                 mints,
@@ -6759,8 +6894,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -6788,7 +6924,7 @@ mod tests {
 
         // Empty InflightEquity snapshot: symbol absent, so inflight preserved
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
@@ -6848,8 +6984,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-rejected-absent-skip");
 
@@ -6875,7 +7012,7 @@ mod tests {
             owner: TEST_ORDER_OWNER,
         };
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             snapshot_id,
             InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
@@ -6916,8 +7053,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-detection-absent-skip");
 
@@ -6940,7 +7078,7 @@ mod tests {
             owner: TEST_ORDER_OWNER,
         };
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             snapshot_id,
             InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
@@ -6981,8 +7119,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("redemption-completed-zeroed");
 
@@ -7006,7 +7145,7 @@ mod tests {
             owner: TEST_ORDER_OWNER,
         };
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             snapshot_id,
             InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
@@ -7047,8 +7186,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
             owner: TEST_ORDER_OWNER,
@@ -7099,7 +7239,7 @@ mod tests {
         balances.insert(symbol.clone(), shares(80));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id,
             InventorySnapshotEvent::OnchainEquity {
                 balances,
@@ -7108,6 +7248,7 @@ mod tests {
         )
         .await
         .unwrap();
+        drain_pending_jobs(&trigger).await.unwrap();
 
         assert!(
             matches!(
@@ -7137,7 +7278,7 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let id = InventorySnapshotId {
             orderbook: TEST_ORDERBOOK,
@@ -7149,7 +7290,7 @@ mod tests {
         mints.insert(symbol.clone(), shares(10));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
@@ -7162,7 +7303,7 @@ mod tests {
 
         // Apply same inflight again -- still present, no recheck
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             id.clone(),
             InventorySnapshotEvent::InflightEquity {
                 mints,
@@ -7203,8 +7344,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         let snapshot_id = InventorySnapshotId {
@@ -7249,7 +7391,7 @@ mod tests {
         stale_mints.insert(symbol.clone(), shares(10));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             snapshot_id,
             InventorySnapshotEvent::InflightEquity {
                 mints: stale_mints,
@@ -7299,8 +7441,9 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (reactor, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
         let snapshot_id = InventorySnapshotId {
@@ -7340,7 +7483,7 @@ mod tests {
         stale_redemptions.insert(symbol.clone(), shares(5));
 
         apply_and_dispatch_snapshot(
-            trigger.clone(),
+            reactor.clone(),
             snapshot_id,
             InventorySnapshotEvent::InflightEquity {
                 mints: BTreeMap::new(),
@@ -7370,12 +7513,13 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        let (trigger, mut receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, mut receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(1)),
         )
         .await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("timed-out-redemption");
 
@@ -7518,12 +7662,13 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        let (trigger, mut receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, mut receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(1)),
         )
         .await;
+        let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = RedemptionAggregateId::new("timed-out-redemption-retrigger");
 
@@ -7609,12 +7754,13 @@ mod tests {
                 now,
             )
             .unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("timed-out-mint-recheck");
 
         trigger.mint_tracking.write().await.insert(
@@ -7673,12 +7819,13 @@ mod tests {
                 now,
             )
             .unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("timed-out-mint-late-request");
 
         trigger.mint_tracking.write().await.insert(
@@ -7748,12 +7895,13 @@ mod tests {
             )
             .unwrap()
             .set_active_mint(symbol.clone(), id.clone());
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
 
         trigger.mint_tracking.write().await.insert(
             id.clone(),
@@ -7780,11 +7928,12 @@ mod tests {
     #[tokio::test]
     async fn mint_event_rechecks_tombstone_after_waiting_for_sync_gate() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("mint-sync-gate-tombstone");
         let sync_guard = trigger.mint_event_sync.lock().await;
         let trigger_for_task = Arc::clone(&trigger);
@@ -7830,12 +7979,13 @@ mod tests {
                 now,
             )
             .unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
         let id = RedemptionAggregateId::new("timed-out-redemption-late-withdrawal");
 
         trigger.redemption_tracking.write().await.insert(
@@ -7908,12 +8058,13 @@ mod tests {
             )
             .unwrap()
             .set_active_redemption(symbol.clone(), id.clone());
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(60)),
         )
         .await;
+        let trigger = reactor.clone();
 
         trigger.redemption_tracking.write().await.insert(
             id.clone(),
@@ -7946,11 +8097,12 @@ mod tests {
     #[tokio::test]
     async fn redemption_event_rechecks_tombstone_after_waiting_for_sync_gate() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = RedemptionAggregateId::new("redemption-sync-gate-tombstone");
         let sync_guard = trigger.redemption_event_sync.lock().await;
         let trigger_for_task = Arc::clone(&trigger);
@@ -8105,9 +8257,10 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_event_rechecks_tombstone_after_waiting_for_sync_gate() {
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(5000), usdc(5000)))
                 .await;
+        let trigger = reactor.clone();
         let id = UsdcRebalanceId(Uuid::new_v4());
         let sync_guard = trigger.usdc_event_sync.lock().await;
         let trigger_for_task = Arc::clone(&trigger);
@@ -8145,11 +8298,12 @@ mod tests {
     #[tokio::test]
     async fn recovery_path_reuses_inflight_suppression_filter() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let cleared_at = Utc::now();
 
         trigger
@@ -8160,7 +8314,7 @@ mod tests {
 
         trigger
             .on_snapshot_recovery(
-                RebalancingTriggerError::Inventory(InventoryViewError::Equity(
+                RebalancingServiceError::Inventory(InventoryViewError::Equity(
                     InventoryError::NegativeInflight {
                         value: FractionalShares::new(float!(-1)),
                     },
@@ -8204,12 +8358,13 @@ mod tests {
                 fetched_at,
             )
             .unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
             inventory,
             &symbol,
             test_config_with_timeout(Duration::from_secs(1)),
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("recovery-timeout-sweep");
 
         trigger.mint_tracking.write().await.insert(
@@ -8224,7 +8379,7 @@ mod tests {
 
         trigger
             .on_snapshot_recovery(
-                RebalancingTriggerError::Inventory(InventoryViewError::Equity(
+                RebalancingServiceError::Inventory(InventoryViewError::Equity(
                     InventoryError::NegativeInflight {
                         value: FractionalShares::new(float!(-1)),
                     },
@@ -8263,11 +8418,12 @@ mod tests {
     #[tokio::test]
     async fn timeout_markers_are_pruned_after_retention_window() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let stale_time = Utc::now()
             - ChronoDuration::from_std(TIMEOUT_TOMBSTONE_RETENTION).unwrap()
             - ChronoDuration::seconds(1);
@@ -8319,10 +8475,11 @@ mod tests {
     #[tokio::test]
     async fn no_active_aggregate_ids_when_idle() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory(
+        let (reactor, _receiver) = make_trigger_with_inventory(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
         )
         .await;
+        let trigger = reactor.clone();
 
         let inventory = trigger.inventory.read().await;
         assert_eq!(inventory.active_usdc_rebalance(), None);
@@ -8334,11 +8491,12 @@ mod tests {
     #[tokio::test]
     async fn mint_accepted_records_active_mint_id() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("mint-active-id");
 
         trigger
@@ -8367,11 +8525,12 @@ mod tests {
     #[tokio::test]
     async fn mint_terminal_event_clears_active_mint_id() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = IssuerRequestId::new("mint-clear-id");
 
         trigger
@@ -8408,11 +8567,12 @@ mod tests {
     #[tokio::test]
     async fn redemption_withdrawn_records_active_redemption_id() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = RedemptionAggregateId::new("redemption-active-id");
 
         trigger
@@ -8436,11 +8596,12 @@ mod tests {
     #[tokio::test]
     async fn redemption_completed_clears_active_redemption_id() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (trigger, _receiver) = make_trigger_with_inventory_and_registry(
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry(
             InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50)),
             &symbol,
         )
         .await;
+        let trigger = reactor.clone();
         let id = RedemptionAggregateId::new("redemption-clear-id");
 
         trigger
@@ -8466,9 +8627,10 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_initiation_records_active_rebalance_id() {
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(500), usdc(500)))
                 .await;
+        let trigger = reactor.clone();
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         trigger
@@ -8494,9 +8656,10 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_terminal_clears_active_rebalance_id() {
-        let (trigger, _receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory(InventoryView::default().with_usdc(usdc(500), usdc(500)))
                 .await;
+        let trigger = reactor.clone();
         let id = UsdcRebalanceId(Uuid::new_v4());
 
         trigger
@@ -8548,6 +8711,402 @@ mod tests {
             trigger.inventory.read().await.active_usdc_rebalance(),
             None,
             "DepositConfirmed (AlpacaToBase terminal) should clear the active USDC rebalance ID",
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_check_dispatches_mint_on_offchain_imbalance() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+
+        let dispatched = receiver.try_recv().unwrap();
+        let TriggeredOperation::Mint { symbol: minted, .. } = dispatched else {
+            panic!("Expected Mint, got {dispatched:?}");
+        };
+        assert_eq!(minted, symbol);
+    }
+
+    #[tokio::test]
+    async fn equity_check_dispatches_redemption_on_onchain_imbalance() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(80), shares(20))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+
+        let dispatched = receiver.try_recv().unwrap();
+        let TriggeredOperation::Redemption {
+            symbol: redeemed, ..
+        } = dispatched
+        else {
+            panic!("Expected Redemption, got {dispatched:?}");
+        };
+        assert_eq!(redeemed, symbol);
+    }
+
+    #[tokio::test]
+    async fn usdc_check_dispatches_transfer_on_imbalance() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+
+        let dispatched = receiver.try_recv().unwrap();
+        assert!(
+            matches!(dispatched, TriggeredOperation::UsdcAlpacaToBase { .. }),
+            "Expected UsdcAlpacaToBase, got {dispatched:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn checks_do_not_dispatch_when_balanced() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (reactor, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+
+        let actual = receiver.try_recv();
+        assert!(
+            matches!(actual, Err(TryRecvError::Empty)),
+            "Balanced inventory should not dispatch a TriggeredOperation, got {actual:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_check_suppresses_duplicate_dispatch_when_in_progress() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (reactor, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        {
+            let mut guard = trigger.equity_in_progress.write().unwrap();
+            guard.insert(symbol.clone());
+        }
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "In-progress flag should suppress duplicate equity dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_check_suppresses_duplicate_dispatch_when_in_progress() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "In-progress flag should suppress duplicate USDC dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_to_alpaca_conversion_confirmed_with_excess_settled_amount_errors() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(100)),
+            )
+            .await
+            .unwrap();
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(200)),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RebalancingServiceError::SettledUsdcExceedsInitiatedAmount {
+                    id: ref error_id,
+                    event: usdc::UsdcTrackingEvent::ConversionConfirmed,
+                    initiated_amount,
+                    settled_amount,
+                } if *error_id == id
+                    && initiated_amount == usdc(100)
+                    && settled_amount == usdc(200)
+            ),
+            "expected SettledUsdcExceedsInitiatedAmount, got {error:?}"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(usdc(100)),
+            "rejected settlement must leave the original inflight amount untouched"
+        );
+        drop(inventory);
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "tracking context must be preserved when settlement is rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_deposit_confirmed_with_excess_bridged_amount_errors() {
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(100)),
+            )
+            .await
+            .unwrap();
+
+        // Bridge reports more USDC arriving than was withdrawn -- impossible
+        // in production, so settlement must reject and inventory must stay
+        // untouched.
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_bridged_with_amounts(usdc(200), Usdc::ZERO),
+            )
+            .await
+            .unwrap();
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                RebalancingServiceError::SettledUsdcExceedsInitiatedAmount {
+                    id: ref error_id,
+                    event: usdc::UsdcTrackingEvent::DepositConfirmed,
+                    initiated_amount,
+                    settled_amount,
+                } if *error_id == id
+                    && initiated_amount == usdc(100)
+                    && settled_amount == usdc(200)
+            ),
+            "expected SettledUsdcExceedsInitiatedAmount, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deposit_confirmed_without_any_tracking_returns_missing_context_error() {
+        let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let error = harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RebalancingServiceError::MissingUsdcTrackingContext {
+                id: error_id,
+                event: usdc::UsdcTrackingEvent::DepositConfirmed,
+            } if error_id == id
+        ));
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_initiated_after_conversion_confirmed_starts_inventory_transfer() {
+        // AlpacaToBase converts USD->USDC BEFORE withdrawal. The Initiated
+        // event arrives *after* the conversion stages have already populated
+        // tracking; track_initiated_usdc_rebalance must detect the existing
+        // tracking entry whose source transfer hasn't started and apply the
+        // inventory transfer Start exactly once.
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(1000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(Usdc::ZERO),
+            "no inventory transfer should occur during conversion stages"
+        );
+        drop(inventory);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(usdc(400)),
+            "Initiated must move source funds into inflight"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(600)),
+            "Initiated must remove source funds from available"
+        );
+        drop(inventory);
+
+        let tracking = trigger
+            .usdc_tracking
+            .read()
+            .await
+            .get(&id)
+            .cloned()
+            .expect("tracking should still exist after Initiated");
+        assert_eq!(tracking.stage, usdc::UsdcRebalanceStage::Initiated);
+        assert_eq!(tracking.initiated_amount, usdc(400));
+    }
+
+    #[tokio::test]
+    async fn check_and_trigger_equity_propagates_token_not_in_registry() {
+        // Registry is initialized (for `seeded`), but the symbol we ask
+        // about is not present. build_equity_operation must surface
+        // TokenNotInRegistry instead of silently returning Ok.
+        let seeded = Symbol::new("AAPL").unwrap();
+        let unknown = Symbol::new("MSFT").unwrap();
+        let inventory = InventoryView::default().with_equity(seeded.clone(), shares(0), shares(0));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &seeded).await;
+        let trigger = reactor.clone();
+
+        let error = trigger
+            .check_and_trigger_equity(&unknown)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                equity::EquityTriggerError::TokenNotInRegistry(ref symbol)
+                    if symbol == &unknown
+            ),
+            "expected TokenNotInRegistry for {unknown}, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_initiated_replay_does_not_double_apply_inventory_transfer() {
+        // After the source transfer has started (Initiated stage), a replayed
+        // Initiated event must update tracking metadata without re-applying
+        // the inventory Start. Otherwise inflight would double-count.
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(1000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+
+        let inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.usdc_inflight(Venue::Hedging)
+        };
+        assert_eq!(
+            inflight,
+            Some(usdc(400)),
+            "replayed Initiated must not double-count inflight"
         );
     }
 }

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -6,13 +6,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
+use serde::{Deserialize, Serialize};
 
 use st0x_float_macro::float;
 use tracing::{debug, trace, warn};
 
 use st0x_finance::Usdc;
 
-use super::{RebalancingTrigger, RebalancingTriggerError, TriggeredOperation};
+use super::{RebalancingService, RebalancingServiceError, TriggeredOperation};
+#[cfg(any(test, feature = "test-support"))]
+use crate::conductor::job::JobKind;
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
 };
@@ -348,12 +352,12 @@ fn truncate_for_transfer(amount: Usdc) -> Result<Usdc, FloatError> {
     Ok(truncated)
 }
 
-impl RebalancingTrigger {
+impl RebalancingService {
     pub(super) async fn on_usdc_rebalance(
         &self,
         id: UsdcRebalanceId,
         event: UsdcRebalanceEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let event_sync_guard = self.usdc_event_sync.lock().await;
 
         if self
@@ -385,8 +389,13 @@ impl RebalancingTrigger {
 
         drop(event_sync_guard);
 
+        // A terminal USDC transfer cleared the in-progress claim, so we
+        // cancel any pre-rebalance checks and push a fresh one against
+        // the post-rebalance inventory.
         if is_terminal {
-            self.check_and_trigger_usdc().await;
+            self.equity_scheduler.cancel_pending().await;
+            self.usdc_scheduler.cancel_pending().await;
+            self.usdc_scheduler.enqueue_check().await;
         }
 
         Ok(())
@@ -396,7 +405,7 @@ impl RebalancingTrigger {
         &self,
         id: &UsdcRebalanceId,
         event: &UsdcRebalanceEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         use UsdcRebalanceEvent::*;
 
         match event {
@@ -467,9 +476,9 @@ impl RebalancingTrigger {
         direction: &RebalanceDirection,
         amount: Usdc,
         event: &UsdcRebalanceEvent,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let stage = UsdcRebalanceStage::from_event(event).ok_or(
-            RebalancingTriggerError::MissingUsdcTrackingContext {
+            RebalancingServiceError::MissingUsdcTrackingContext {
                 id: id.clone(),
                 event: UsdcTrackingEvent::Initiated,
             },
@@ -477,7 +486,7 @@ impl RebalancingTrigger {
         let last_progress_at =
             stage
                 .timestamp(event)
-                .ok_or(RebalancingTriggerError::MissingUsdcTrackingContext {
+                .ok_or(RebalancingServiceError::MissingUsdcTrackingContext {
                     id: id.clone(),
                     event: UsdcTrackingEvent::Initiated,
                 })?;
@@ -589,11 +598,11 @@ impl RebalancingTrigger {
         &self,
         id: &UsdcRebalanceId,
         amount_received: Usdc,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let mut tracking = self.usdc_tracking.write().await;
         let Some(existing) = tracking.get_mut(id) else {
             warn!(target: "rebalance", id = %id, "Bridged event missing USDC tracking context");
-            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
                 id: id.clone(),
                 event: UsdcTrackingEvent::Bridged,
             });
@@ -608,10 +617,10 @@ impl RebalancingTrigger {
     async fn complete_alpaca_to_base_deposit(
         &self,
         id: &UsdcRebalanceId,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             warn!(target: "rebalance", id = %id, "DepositConfirmed event missing USDC tracking context");
-            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
                 id: id.clone(),
                 event: UsdcTrackingEvent::DepositConfirmed,
             });
@@ -623,7 +632,7 @@ impl RebalancingTrigger {
                 id = %id,
                 "DepositConfirmed event missing bridged amount for USDC rebalance"
             );
-            return Err(RebalancingTriggerError::MissingUsdcBridgedAmount { id: id.clone() });
+            return Err(RebalancingServiceError::MissingUsdcBridgedAmount { id: id.clone() });
         };
 
         self.complete_usdc_rebalance(id, UsdcTrackingEvent::DepositConfirmed, amount_received)
@@ -633,7 +642,7 @@ impl RebalancingTrigger {
     async fn cancel_tracked_usdc_rebalance(
         &self,
         id: &UsdcRebalanceId,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             debug!(
                 target: "rebalance",
@@ -668,10 +677,10 @@ impl RebalancingTrigger {
         id: &UsdcRebalanceId,
         event: UsdcTrackingEvent,
         settled_amount: Usdc,
-    ) -> Result<(), RebalancingTriggerError> {
+    ) -> Result<(), RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
             warn!(target: "rebalance", id = %id, "Terminal success event missing USDC tracking context");
-            return Err(RebalancingTriggerError::MissingUsdcTrackingContext {
+            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
                 id: id.clone(),
                 event,
             });
@@ -689,7 +698,7 @@ impl RebalancingTrigger {
                 ?settled_amount,
                 "Settled USDC amount exceeds initiated amount"
             );
-            return Err(RebalancingTriggerError::SettledUsdcExceedsInitiatedAmount {
+            return Err(RebalancingServiceError::SettledUsdcExceedsInitiatedAmount {
                 id: id.clone(),
                 event,
                 initiated_amount,
@@ -728,15 +737,129 @@ impl RebalancingTrigger {
     }
 }
 
+/// USDC rebalancing check. Payload-less because USDC is a single
+/// global balance, not per-symbol.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct UsdcRebalancingCheck;
+
+pub(crate) type UsdcRebalancingCheckJobQueue = JobQueue<UsdcRebalancingCheck>;
+
+/// USDC checks never propagate errors: the trigger logs and skips on
+/// arithmetic/threshold issues, matching the pre-job direct-call
+/// semantics.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum UsdcRebalancingCheckJobError {}
+
+impl Job<RebalancingService> for UsdcRebalancingCheck {
+    type Output = ();
+    type Error = UsdcRebalancingCheckJobError;
+
+    const WORKER_NAME: &'static str = "usdc-rebalancing-check-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: JobKind = JobKind::UsdcRebalancingCheck;
+
+    fn label(&self) -> Label {
+        Label::new("UsdcRebalancingCheck")
+    }
+
+    async fn perform(&self, trigger: &RebalancingService) -> Result<Self::Output, Self::Error> {
+        trigger.check_and_trigger_usdc().await;
+        Ok(())
+    }
+}
+
+/// Owns the USDC-check queue and the domain-level operations
+/// callers (the reactor, the conductor wiring) want: enqueue a check,
+/// cancel pending checks after a terminal event. Keeps queue plumbing
+/// out of [`RebalancingService`] and out of the conductor wiring.
+#[derive(Clone)]
+pub(crate) struct UsdcRebalancingCheckScheduler {
+    queue: UsdcRebalancingCheckJobQueue,
+}
+
+impl UsdcRebalancingCheckScheduler {
+    pub(crate) fn new(pool: &sqlx::SqlitePool) -> Self {
+        Self {
+            queue: UsdcRebalancingCheckJobQueue::new(pool),
+        }
+    }
+
+    pub(crate) fn queue(&self) -> &UsdcRebalancingCheckJobQueue {
+        &self.queue
+    }
+
+    /// Best-effort enqueue. Failures are logged: an enqueue miss only
+    /// delays the next imbalance check, which the next snapshot will
+    /// re-trigger.
+    pub(super) async fn enqueue_check(&self) {
+        let mut queue = self.queue.clone();
+        if let Err(QueuePushError(error)) = queue.push(UsdcRebalancingCheck).await {
+            warn!(target: "rebalance", %error, "Failed to enqueue UsdcRebalancingCheck job");
+        }
+    }
+
+    pub(super) async fn cancel_pending(&self) {
+        self.queue.cancel_all_pending().await;
+    }
+}
+
+/// Test helper: synchronously drain every pending USDC-check row the
+/// service enqueued, running each job's [`Job::perform`] and marking
+/// the row `Done`.
+#[cfg(test)]
+pub(crate) async fn drain_pending_usdc_jobs(service: &Arc<RebalancingService>) -> usize {
+    let pool = service.usdc_scheduler.queue().pool().clone();
+    let mut processed = 0usize;
+
+    let job_type = std::any::type_name::<UsdcRebalancingCheck>();
+
+    loop {
+        let row: Option<(String, Vec<u8>)> = sqlx::query_as(
+            "SELECT id, job FROM Jobs \
+             WHERE status = 'Pending' AND job_type = ? \
+             ORDER BY run_at LIMIT 1",
+        )
+        .bind(job_type)
+        .fetch_optional(&pool)
+        .await
+        .expect("query pending usdc-check jobs");
+
+        let Some((id, payload)) = row else {
+            break;
+        };
+
+        let job: UsdcRebalancingCheck =
+            serde_json::from_slice(&payload).expect("deserialize UsdcRebalancingCheck payload");
+        match job.perform(service).await {
+            Ok(()) => {}
+            Err(never) => match never {},
+        }
+
+        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&id)
+            .execute(&pool)
+            .await
+            .expect("mark usdc-check job done");
+
+        processed += 1;
+    }
+
+    processed
+}
+
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::TxHash;
+    use chrono::TimeZone;
     use tokio::sync::broadcast;
+    use uuid::Uuid;
 
     use st0x_dto::Statement;
     use st0x_float_macro::float;
 
     use super::*;
     use crate::inventory::InventoryView;
+    use crate::usdc_rebalance::TransferRef;
 
     #[test]
     fn test_guard_releases_on_drop() {
@@ -989,5 +1112,557 @@ mod tests {
             ),
             "Cap of $30 should produce BelowMinimumWithdrawal, got {result:?}"
         );
+    }
+
+    fn ts(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(seconds, 0).unwrap()
+    }
+
+    fn initiated_event(direction: RebalanceDirection, amount: Usdc) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::Initiated {
+            direction,
+            amount,
+            withdrawal_ref: TransferRef::OnchainTx(TxHash::ZERO),
+            initiated_at: ts(100),
+        }
+    }
+
+    fn conversion_initiated_event(
+        direction: RebalanceDirection,
+        amount: Usdc,
+    ) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::ConversionInitiated {
+            direction,
+            amount,
+            order_id: Uuid::nil(),
+            initiated_at: ts(101),
+        }
+    }
+
+    fn conversion_confirmed_event(
+        direction: RebalanceDirection,
+        filled_amount: Usdc,
+    ) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::ConversionConfirmed {
+            direction,
+            filled_amount,
+            converted_at: ts(102),
+        }
+    }
+
+    fn withdrawal_confirmed_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::WithdrawalConfirmed {
+            confirmed_at: ts(103),
+        }
+    }
+
+    fn bridging_initiated_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgingInitiated {
+            burn_tx_hash: TxHash::ZERO,
+            burned_at: ts(104),
+        }
+    }
+
+    fn bridge_attestation_received_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgeAttestationReceived {
+            attestation: vec![],
+            cctp_nonce: 0,
+            attested_at: ts(105),
+        }
+    }
+
+    fn bridged_event(amount_received: Usdc) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::Bridged {
+            mint_tx_hash: TxHash::ZERO,
+            amount_received,
+            fee_collected: Usdc::new(float!(0)),
+            minted_at: ts(106),
+        }
+    }
+
+    fn deposit_initiated_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::DepositInitiated {
+            deposit_ref: TransferRef::OnchainTx(TxHash::ZERO),
+            deposit_initiated_at: ts(107),
+        }
+    }
+
+    fn deposit_confirmed_event(direction: RebalanceDirection) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::DepositConfirmed {
+            direction,
+            deposit_confirmed_at: ts(108),
+        }
+    }
+
+    fn conversion_failed_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::ConversionFailed {
+            reason: "boom".into(),
+            failed_at: ts(109),
+        }
+    }
+
+    fn withdrawal_failed_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::WithdrawalFailed {
+            reason: "boom".into(),
+            failed_at: ts(110),
+        }
+    }
+
+    fn bridging_failed_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgingFailed {
+            burn_tx_hash: None,
+            cctp_nonce: None,
+            reason: "boom".into(),
+            failed_at: ts(111),
+        }
+    }
+
+    fn deposit_failed_event() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::DepositFailed {
+            deposit_ref: None,
+            reason: "boom".into(),
+            failed_at: ts(112),
+        }
+    }
+
+    #[test]
+    fn truncate_for_transfer_preserves_value_within_six_decimals() {
+        let original = Usdc::new(float!(123.456789));
+        let result = truncate_for_transfer(original).unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn truncate_for_transfer_drops_seventh_decimal() {
+        let original = Usdc::new(float!(1.1234567));
+        let result = truncate_for_transfer(original).unwrap();
+        assert_eq!(result, Usdc::new(float!(1.123456)));
+    }
+
+    #[test]
+    fn truncate_for_transfer_drops_excess_precision() {
+        let original = Usdc::new(float!(99.123456789012345));
+        let result = truncate_for_transfer(original).unwrap();
+        assert_eq!(result, Usdc::new(float!(99.123456)));
+    }
+
+    #[test]
+    fn truncate_for_transfer_zero_is_zero() {
+        let result = truncate_for_transfer(Usdc::new(float!(0))).unwrap();
+        assert_eq!(result, Usdc::new(float!(0)));
+    }
+
+    #[test]
+    fn truncate_for_transfer_whole_dollar_is_unchanged() {
+        let original = Usdc::new(float!(51));
+        let result = truncate_for_transfer(original).unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn cap_usdc_returns_input_when_no_limit() {
+        let amount = Usdc::new(float!(500));
+        assert_eq!(cap_usdc(amount, None), amount);
+    }
+
+    #[test]
+    fn cap_usdc_returns_input_when_below_limit() {
+        let amount = Usdc::new(float!(100));
+        let limit = Some(Usdc::new(float!(500)));
+        assert_eq!(cap_usdc(amount, limit), amount);
+    }
+
+    #[test]
+    fn cap_usdc_returns_input_when_equal_to_limit() {
+        let amount = Usdc::new(float!(500));
+        let limit = Some(Usdc::new(float!(500)));
+        assert_eq!(cap_usdc(amount, limit), amount);
+    }
+
+    #[test]
+    fn cap_usdc_returns_limit_when_above_limit() {
+        let amount = Usdc::new(float!(1000));
+        let limit_value = Usdc::new(float!(500));
+        assert_eq!(cap_usdc(amount, Some(limit_value)), limit_value);
+    }
+
+    #[test]
+    fn from_event_maps_conversion_initiated_to_stage() {
+        let event =
+            conversion_initiated_event(RebalanceDirection::AlpacaToBase, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&event),
+            Some(UsdcRebalanceStage::ConversionInitiated)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_alpaca_to_base_conversion_confirmed_to_stage() {
+        let event =
+            conversion_confirmed_event(RebalanceDirection::AlpacaToBase, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&event),
+            Some(UsdcRebalanceStage::ConversionConfirmed)
+        );
+    }
+
+    #[test]
+    fn from_event_skips_base_to_alpaca_conversion_confirmed() {
+        let event =
+            conversion_confirmed_event(RebalanceDirection::BaseToAlpaca, Usdc::new(float!(1)));
+        assert_eq!(UsdcRebalanceStage::from_event(&event), None);
+    }
+
+    #[test]
+    fn from_event_maps_initiated_to_stage() {
+        let event = initiated_event(RebalanceDirection::AlpacaToBase, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&event),
+            Some(UsdcRebalanceStage::Initiated)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_withdrawal_confirmed_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&withdrawal_confirmed_event()),
+            Some(UsdcRebalanceStage::WithdrawalConfirmed)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_bridging_initiated_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&bridging_initiated_event()),
+            Some(UsdcRebalanceStage::BridgingInitiated)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_bridge_attestation_received_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&bridge_attestation_received_event()),
+            Some(UsdcRebalanceStage::BridgeAttestationReceived)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_bridged_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&bridged_event(Usdc::new(float!(99)))),
+            Some(UsdcRebalanceStage::Bridged)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_deposit_initiated_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&deposit_initiated_event()),
+            Some(UsdcRebalanceStage::DepositInitiated)
+        );
+    }
+
+    #[test]
+    fn from_event_maps_deposit_confirmed_to_stage() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&deposit_confirmed_event(
+                RebalanceDirection::AlpacaToBase
+            )),
+            Some(UsdcRebalanceStage::DepositConfirmed)
+        );
+    }
+
+    #[test]
+    fn from_event_skips_conversion_failed() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&conversion_failed_event()),
+            None
+        );
+    }
+
+    #[test]
+    fn from_event_skips_withdrawal_failed() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&withdrawal_failed_event()),
+            None
+        );
+    }
+
+    #[test]
+    fn from_event_skips_bridging_failed() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&bridging_failed_event()),
+            None
+        );
+    }
+
+    #[test]
+    fn from_event_skips_deposit_failed() {
+        assert_eq!(
+            UsdcRebalanceStage::from_event(&deposit_failed_event()),
+            None
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_initiated_at_from_conversion_initiated() {
+        let event =
+            conversion_initiated_event(RebalanceDirection::AlpacaToBase, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::ConversionInitiated.timestamp(&event),
+            Some(ts(101))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_converted_at_from_conversion_confirmed() {
+        let event =
+            conversion_confirmed_event(RebalanceDirection::AlpacaToBase, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::ConversionConfirmed.timestamp(&event),
+            Some(ts(102))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_initiated_at_from_initiated() {
+        let event = initiated_event(RebalanceDirection::BaseToAlpaca, Usdc::new(float!(1)));
+        assert_eq!(
+            UsdcRebalanceStage::Initiated.timestamp(&event),
+            Some(ts(100))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_confirmed_at_from_withdrawal_confirmed() {
+        assert_eq!(
+            UsdcRebalanceStage::WithdrawalConfirmed.timestamp(&withdrawal_confirmed_event()),
+            Some(ts(103))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_burned_at_from_bridging_initiated() {
+        assert_eq!(
+            UsdcRebalanceStage::BridgingInitiated.timestamp(&bridging_initiated_event()),
+            Some(ts(104))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_attested_at_from_bridge_attestation_received() {
+        assert_eq!(
+            UsdcRebalanceStage::BridgeAttestationReceived
+                .timestamp(&bridge_attestation_received_event()),
+            Some(ts(105))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_minted_at_from_bridged() {
+        assert_eq!(
+            UsdcRebalanceStage::Bridged.timestamp(&bridged_event(Usdc::new(float!(99)))),
+            Some(ts(106))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_deposit_initiated_at_from_deposit_initiated() {
+        assert_eq!(
+            UsdcRebalanceStage::DepositInitiated.timestamp(&deposit_initiated_event()),
+            Some(ts(107))
+        );
+    }
+
+    #[test]
+    fn timestamp_extracts_deposit_confirmed_at_from_deposit_confirmed() {
+        assert_eq!(
+            UsdcRebalanceStage::DepositConfirmed
+                .timestamp(&deposit_confirmed_event(RebalanceDirection::AlpacaToBase)),
+            Some(ts(108))
+        );
+    }
+
+    #[test]
+    fn timestamp_returns_none_when_stage_does_not_match_event() {
+        let event = withdrawal_confirmed_event();
+        assert_eq!(UsdcRebalanceStage::Initiated.timestamp(&event), None);
+    }
+
+    fn tracking(direction: RebalanceDirection, stage: UsdcRebalanceStage) -> UsdcRebalanceTracking {
+        UsdcRebalanceTracking {
+            direction,
+            initiated_amount: Usdc::new(float!(100)),
+            bridged_amount_received: None,
+            stage,
+            last_progress_at: ts(0),
+        }
+    }
+
+    #[test]
+    fn source_venue_alpaca_to_base_is_hedging() {
+        let entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::Initiated,
+        );
+        assert_eq!(entry.source_venue(), Venue::Hedging);
+    }
+
+    #[test]
+    fn source_venue_base_to_alpaca_is_market_making() {
+        let entry = tracking(
+            RebalanceDirection::BaseToAlpaca,
+            UsdcRebalanceStage::Initiated,
+        );
+        assert_eq!(entry.source_venue(), Venue::MarketMaking);
+    }
+
+    #[test]
+    fn source_transfer_started_alpaca_to_base_false_during_conversion_initiated() {
+        let entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::ConversionInitiated,
+        );
+        assert!(!entry.source_transfer_started());
+    }
+
+    #[test]
+    fn source_transfer_started_alpaca_to_base_false_during_conversion_confirmed() {
+        let entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::ConversionConfirmed,
+        );
+        assert!(!entry.source_transfer_started());
+    }
+
+    #[test]
+    fn source_transfer_started_alpaca_to_base_true_after_initiated() {
+        let entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::Initiated,
+        );
+        assert!(entry.source_transfer_started());
+    }
+
+    #[test]
+    fn source_transfer_started_alpaca_to_base_true_after_bridged() {
+        let entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::Bridged,
+        );
+        assert!(entry.source_transfer_started());
+    }
+
+    #[test]
+    fn source_transfer_started_base_to_alpaca_always_true_during_conversion_initiated() {
+        let entry = tracking(
+            RebalanceDirection::BaseToAlpaca,
+            UsdcRebalanceStage::ConversionInitiated,
+        );
+        assert!(entry.source_transfer_started());
+    }
+
+    #[test]
+    fn source_transfer_started_base_to_alpaca_always_true_during_conversion_confirmed() {
+        let entry = tracking(
+            RebalanceDirection::BaseToAlpaca,
+            UsdcRebalanceStage::ConversionConfirmed,
+        );
+        assert!(entry.source_transfer_started());
+    }
+
+    #[test]
+    fn track_progress_updates_stage_and_timestamp() {
+        let mut entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::Initiated,
+        );
+        entry.track_progress(&withdrawal_confirmed_event());
+        assert_eq!(entry.stage, UsdcRebalanceStage::WithdrawalConfirmed);
+        assert_eq!(entry.last_progress_at, ts(103));
+    }
+
+    #[test]
+    fn track_progress_does_not_change_state_when_event_yields_no_stage() {
+        let mut entry = tracking(
+            RebalanceDirection::AlpacaToBase,
+            UsdcRebalanceStage::Initiated,
+        );
+        entry.track_progress(&withdrawal_failed_event());
+        assert_eq!(entry.stage, UsdcRebalanceStage::Initiated);
+        assert_eq!(entry.last_progress_at, ts(0));
+    }
+
+    #[test]
+    fn usdc_rebalancing_check_label_is_static() {
+        assert_eq!(
+            UsdcRebalancingCheck.label().as_str(),
+            "UsdcRebalancingCheck"
+        );
+    }
+
+    async fn count_pending_usdc_check_jobs(pool: &sqlx::SqlitePool) -> i64 {
+        let job_type = std::any::type_name::<UsdcRebalancingCheck>();
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(pool)
+        .await
+        .expect("count pending usdc-check jobs")
+    }
+
+    #[tokio::test]
+    async fn usdc_scheduler_enqueue_check_inserts_pending_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+
+        scheduler.enqueue_check().await;
+
+        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 1);
+    }
+
+    #[tokio::test]
+    async fn usdc_scheduler_cancel_pending_marks_pending_rows_done() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+
+        scheduler.enqueue_check().await;
+        scheduler.enqueue_check().await;
+        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 2);
+
+        scheduler.cancel_pending().await;
+
+        assert_eq!(
+            count_pending_usdc_check_jobs(&pool).await,
+            0,
+            "cancel_pending must drain all pending rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn usdc_scheduler_enqueue_after_cancel_creates_fresh_row() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+
+        scheduler.enqueue_check().await;
+        scheduler.cancel_pending().await;
+        scheduler.enqueue_check().await;
+
+        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 1);
+    }
+
+    #[test]
+    fn track_progress_skips_base_to_alpaca_conversion_confirmed() {
+        let mut entry = tracking(
+            RebalanceDirection::BaseToAlpaca,
+            UsdcRebalanceStage::DepositConfirmed,
+        );
+        entry.track_progress(&conversion_confirmed_event(
+            RebalanceDirection::BaseToAlpaca,
+            Usdc::new(float!(50)),
+        ));
+        assert_eq!(entry.stage, UsdcRebalanceStage::DepositConfirmed);
+        assert_eq!(entry.last_progress_at, ts(0));
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -147,6 +147,7 @@ pub(crate) fn get_test_log() -> Log {
 pub(crate) async fn setup_test_db() -> SqlitePool {
     let pool = SqlitePool::connect(":memory:").await.unwrap();
     sqlx::migrate!().run(&pool).await.unwrap();
+    crate::conductor::setup_apalis_tables(&pool).await.unwrap();
     pool
 }
 


### PR DESCRIPTION
Closes RAI-387.

## What

Introduces an `EvaluateRebalancing` apalis job that decouples imbalance checks from the CQRS reactor. Instead of calling `check_and_trigger_equity` and `check_and_trigger_usdc` directly inside reactor handlers, the reactor now enqueues an `EvaluateRebalancing` job and returns immediately. The job worker then walks all tracked equity symbols and the USDC inventory to dispatch any `TriggeredOperation`s to the rebalancer.

## Why

Previously, imbalance checks ran synchronously inside the reactor, meaning slow vault-registry or wrapper calls could block event-sourcing throughput. Moving the check into an apalis job lets the framework handle retries, rate-limiting, and back-off independently, and keeps the reactor fast. A missed enqueue only delays the next check — the next snapshot or position event will re-enqueue, and any standing imbalance remains observable in the inventory view.

## How

- Added `EvaluateRebalancing` job, `EvaluateRebalancingCtx`, and `EvaluateRebalancingJobQueue` in a new `rebalancing/trigger/evaluate.rs` module.
- `EvaluateRebalancingCtx` holds an `Arc<RebalancingTrigger>`, giving the job access to inventory, vault registry, and rebalancing config.
- `RebalancingTrigger` now holds an `EvaluateRebalancingJobQueue` and exposes an `enqueue_evaluation` method. All reactor paths that previously called `check_and_trigger_*` directly now call `enqueue_evaluation` instead.
- `RebalancingTrigger::new` accepts the queue as a constructor argument, and it is threaded through `PositionAndRebalancing`, `RebalancingDeps`, `RebalancingInfrastructure`, and the conductor builder.
- The `EvaluateRebalancing` worker is conditionally registered in the apalis monitor only when a `RebalancingTrigger` is present.
- `InventoryView::equity_symbols` was added to allow the job to enumerate all tracked symbols at evaluation time.
- The `trigger` field is now surfaced from `PositionAndRebalancing` so the conductor can pass it to the builder.

## Testing

- Existing tests that relied on synchronous trigger calls were updated to explicitly invoke `check_and_trigger_equity` / `check_and_trigger_usdc` after reactor events, preserving their original assertions.
- New unit tests for `EvaluateRebalancing` cover: mint dispatch on offchain equity imbalance, redemption dispatch on onchain equity imbalance, USDC transfer dispatch on USDC imbalance, no dispatch when balanced, and in-progress flag suppression for both equity and USDC.
- Tests drive `EvaluateRebalancing::perform` directly via `EvaluateRebalancingCtx` without going through apalis storage, isolating job logic from queue plumbing.

## Anything else

Failed enqueues are logged as warnings rather than hard errors. The consequence of a missed enqueue is only a delayed imbalance check, not a lost operation, since the next inventory event will re-trigger evaluation.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebalancing checks (equity and USDC) are now managed through the persistent job queue system, providing improved reliability and monitoring integration.

* **Tests**
  * Enhanced test database setup and integration test coverage for rebalancing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/665)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->