### PR TITLE
refactor: convert vault registry seeding to apalis job

### DIFF
--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -170,11 +170,6 @@ impl Executor for AlpacaBrokerApi {
         Ok(order_id_str.to_string())
     }
 
-    async fn run_executor_maintenance(&self) -> Option<tokio::task::JoinHandle<()>> {
-        // Alpaca uses API keys, no token refresh needed
-        None
-    }
-
     async fn get_inventory(&self) -> Result<crate::InventoryResult, Self::Error> {
         let inventory = super::positions::fetch_inventory(&self.client).await?;
         Ok(InventoryResult::Fetched(inventory))
@@ -604,7 +599,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_executor_maintenance_returns_none() {
+    async fn test_maintenance_interval_returns_none() {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
@@ -614,7 +609,7 @@ mod tests {
 
         account_mock.assert();
 
-        assert!(executor.run_executor_maintenance().await.is_none());
+        assert!(executor.maintenance_interval().is_none());
     }
 
     #[tokio::test]

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -6,7 +6,7 @@ use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use std::sync::LazyLock;
-use tokio::task::JoinHandle;
+use std::time::Duration;
 use tracing::{debug, info};
 
 pub(crate) use st0x_float_serde::{
@@ -159,11 +159,26 @@ pub trait Executor: Send + Sync + 'static {
     /// This is needed for converting database-stored order IDs back to executor types
     fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error>;
 
-    /// Run executor-specific maintenance tasks (token refresh, connection health, etc.)
-    /// Returns None if no maintenance needed, Some(handle) if maintenance task spawned
-    /// Tasks should run indefinitely and be aborted by the caller when shutdown is needed
-    /// Errors are logged inside the task and do not propagate to the caller
-    async fn run_executor_maintenance(&self) -> Option<JoinHandle<()>>;
+    /// Tick interval for executor-specific background maintenance work
+    /// (token refresh, connection health, etc.).
+    ///
+    /// Returning `None` means this executor has no maintenance work; the
+    /// conductor skips registering the supervised maintenance task entirely.
+    /// Returning `Some(interval)` causes the conductor to register a
+    /// supervised task that calls [`maintenance_tick`](Self::maintenance_tick)
+    /// on every tick.
+    fn maintenance_interval(&self) -> Option<Duration> {
+        None
+    }
+
+    /// One iteration of executor maintenance. Invoked by the supervised
+    /// maintenance task on every [`maintenance_interval`](Self::maintenance_interval)
+    /// tick. Transient errors are logged by the supervisor wrapper and do not
+    /// halt the loop; a panic inside this method is caught by task-supervisor
+    /// and triggers a restart.
+    async fn maintenance_tick(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 
     /// Fetches current inventory (positions and cash balance) from the broker.
     ///

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -7,7 +7,6 @@ use std::sync::{
 use async_trait::async_trait;
 use rain_math_float::Float;
 use st0x_float_macro::float;
-use tokio::task::JoinHandle;
 use tracing::{debug, info};
 
 /// Hardcoded mock price returned by `MockExecutor::get_order_status`.
@@ -176,10 +175,6 @@ impl Executor for MockExecutor {
     fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
         // For MockExecutor, OrderId is String, so just clone the input
         Ok(order_id_str.to_string())
-    }
-
-    async fn run_executor_maintenance(&self) -> Option<JoinHandle<()>> {
-        None
     }
 
     async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {

--- a/flake.nix
+++ b/flake.nix
@@ -474,6 +474,11 @@
                     packages.secret
                     packages.rekey
                     packages.ci
+                    # foundry exposes anvil for cargo tests that spawn a local
+                    # EVM (e.g. cctp + hedging e2e). Pinned rainix doesn't ship
+                    # it in rust-shell, so add it here so cargo nextest from
+                    # the default shell mirrors the ci-backend shell.
+                    foundryBin
                   ]
                   ++ builtins.attrValues infraPkgs.packages
                   ++ builtins.attrValues deployScripts

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -70,7 +70,10 @@ use crate::tokenization::alpaca::AlpacaTokenizationService;
 use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{DexTradeAccountingJobQueue, TradeAccountingError};
-use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
+use crate::vault_registry::{
+    SeedVaultRegistry, SeedVaultRegistryCtx, SeedVaultRegistryJobQueue, VaultRegistry,
+    VaultRegistryCommand, VaultRegistryId,
+};
 use crate::wrapper::WrapperService;
 
 pub(crate) use builder::CqrsFrameworks;
@@ -108,14 +111,11 @@ pub(crate) struct TradeProcessingCqrs {
 /// accounting) into a unified lifecycle. Waits for either the supervisor or
 /// the apalis monitor to exit, then aborts all remaining tasks.
 pub(crate) struct Conductor {
-    /// Manages long-running tasks (order fill monitor, position monitor)
-    /// with automatic restart.
+    /// Manages long-running tasks (order fill monitor, position monitor,
+    /// executor maintenance) with automatic restart.
     supervisor: SupervisorHandle,
     /// Runs the apalis job queue workers that process trade accounting jobs.
     monitor: JoinHandle<Result<(), MonitorTaskError>>,
-    /// Periodic executor upkeep (e.g. Schwab token refresh). Absent when
-    /// the executor requires no background maintenance.
-    executor_maintenance: Option<JoinHandle<()>>,
     /// Periodic rebalancing loop. Absent when rebalancing is not configured.
     rebalancer: Option<JoinHandle<()>>,
     /// Cancelled during graceful shutdown to stop the rebalancer from
@@ -147,7 +147,6 @@ impl Conductor {
         crate::offchain::order::JobError: From<E::Error>,
     {
         let executor = executor_ctx.try_into_executor().await?;
-        let executor_maintenance = executor.run_executor_maintenance().await;
 
         let ws = WsConnect::new(ctx.evm.ws_rpc_url.as_str());
         let provider = ProviderBuilder::new()
@@ -170,7 +169,18 @@ impl Conductor {
                 .build(())
                 .await?;
 
-        seed_vault_registry_from_config(&vault_registry, &ctx).await?;
+        let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&pool);
+        let seed_vault_registry_ctx = Arc::new(SeedVaultRegistryCtx::from_config(
+            vault_registry.clone(),
+            &ctx,
+        )?);
+
+        // Run the seeding logic inline at startup so downstream wiring
+        // (RaindexService, trade accounting, inventory polling) starts
+        // with a populated registry. The same code path is registered
+        // below as an apalis worker so the queue retries on failure if
+        // seeding is re-triggered later (e.g. from a recovery flow).
+        crate::conductor::job::Job::perform(&SeedVaultRegistry, &seed_vault_registry_ctx).await?;
 
         let rebalancing = match ctx.rebalancing_ctx() {
             Ok(ctx) => Some(ctx.clone()),
@@ -275,7 +285,8 @@ impl Conductor {
             .equity_check_scheduler(schedulers.equity)
             .usdc_check_scheduler(schedulers.usdc)
             .maybe_rebalancing_service(rebalancing_service)
-            .maybe_executor_maintenance(executor_maintenance)
+            .seed_vault_registry_queue(seed_vault_registry_queue)
+            .seed_vault_registry_ctx(seed_vault_registry_ctx)
             .maybe_rebalancer(rebalancer)
             .rebalancer_shutdown_token(rebalancer_shutdown_token)
             .job_cleanup(job_cleanup)
@@ -382,9 +393,6 @@ impl Conductor {
 
     fn abort_background_tasks(&self) {
         if let Some(ref handle) = self.rebalancer {
-            handle.abort();
-        }
-        if let Some(ref handle) = self.executor_maintenance {
             handle.abort();
         }
         self.job_cleanup.abort();
@@ -669,71 +677,6 @@ impl PositionAndRebalancing {
             })
         }
     }
-}
-
-/// Pre-seeds the vault registry with vault IDs from config.
-///
-/// Assets with a `vault_id` in config get their vaults registered
-/// immediately at startup, so rebalancing can work even before any
-/// onchain trades have been observed.
-async fn seed_vault_registry_from_config(
-    vault_registry: &Store<VaultRegistry>,
-    ctx: &Ctx,
-) -> anyhow::Result<()> {
-    // Pre-flight validation: ensure every rebalancing-enabled equity has at
-    // least one vault_id before performing any writes to the vault registry.
-    for (symbol, equity_config) in &ctx.assets.equities.symbols {
-        if equity_config.vault_ids.is_empty() && ctx.is_rebalancing_enabled(symbol) {
-            return Err(CtxError::MissingEquityVaultId {
-                symbol: symbol.clone(),
-            }
-            .into());
-        }
-    }
-
-    let vault_registry_id = VaultRegistryId {
-        orderbook: ctx.evm.orderbook,
-        owner: ctx.order_owner(),
-    };
-
-    for (symbol, equity_config) in &ctx.assets.equities.symbols {
-        for vault_id in &equity_config.vault_ids {
-            debug!(
-                %symbol,
-                %vault_id,
-                token = %equity_config.tokenized_equity_derivative,
-                "Seeding equity vault from config"
-            );
-
-            vault_registry
-                .send(
-                    &vault_registry_id,
-                    VaultRegistryCommand::SeedEquityVaultFromConfig {
-                        token: equity_config.tokenized_equity_derivative,
-                        vault_id: *vault_id,
-                        symbol: symbol.clone(),
-                    },
-                )
-                .await?;
-        }
-    }
-
-    if let Some(cash) = &ctx.assets.cash {
-        for vault_id in &cash.vault_ids {
-            info!(%vault_id, "Seeding USDC vault from config");
-
-            vault_registry
-                .send(
-                    &vault_registry_id,
-                    VaultRegistryCommand::SeedUsdcVaultFromConfig {
-                        vault_id: *vault_id,
-                    },
-                )
-                .await?;
-        }
-    }
-
-    Ok(())
 }
 
 fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
@@ -1998,7 +1941,6 @@ mod tests {
         Conductor {
             supervisor,
             monitor,
-            executor_maintenance: None,
             rebalancer: None,
             rebalancer_shutdown_token: CancellationToken::new(),
             job_cleanup,
@@ -4464,73 +4406,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_vault_registry_rejects_missing_vault_id_without_side_effects() {
-        let pool = setup_test_db().await;
-        let vault_registry: Store<VaultRegistry> = test_store(pool.clone(), ());
-
-        // Two equities with rebalancing enabled: one has a vault_id, one does not.
-        // The pre-flight validation must reject before any seeds are applied.
-        let mut symbols = HashMap::new();
-
-        symbols.insert(
-            Symbol::new("AAPL").unwrap(),
-            EquityAssetConfig {
-                tokenized_equity: Address::ZERO,
-                tokenized_equity_derivative: Address::ZERO,
-                vault_ids: vec![fixed_bytes!(
-                    "0x0000000000000000000000000000000000000000000000000000000000000001"
-                )],
-                trading: OperationMode::Disabled,
-                rebalancing: OperationMode::Enabled,
-                operational_limit: None,
-            },
-        );
-
-        symbols.insert(
-            Symbol::new("TSLA").unwrap(),
-            EquityAssetConfig {
-                tokenized_equity: Address::ZERO,
-                tokenized_equity_derivative: Address::ZERO,
-                vault_ids: Vec::new(),
-                trading: OperationMode::Disabled,
-                rebalancing: OperationMode::Enabled,
-                operational_limit: None,
-            },
-        );
-
-        let ctx = Ctx {
-            assets: AssetsConfig {
-                equities: EquitiesConfig {
-                    operational_limit: None,
-                    symbols,
-                },
-                cash: None,
-            },
-            ..create_test_ctx_with_order_owner(Address::ZERO)
-        };
-
-        let error = seed_vault_registry_from_config(&vault_registry, &ctx)
-            .await
-            .expect_err("should fail when vault_id is missing for TSLA");
-
-        let ctx_error = error
-            .downcast_ref::<CtxError>()
-            .expect("error should be CtxError");
-
-        assert!(
-            matches!(ctx_error, CtxError::MissingEquityVaultId { symbol } if symbol.to_string() == "TSLA"),
-            "expected MissingEquityVaultId for TSLA, got: {ctx_error:?}"
-        );
-
-        let registry = load_vault_registry(&vault_registry).await;
-
-        assert!(
-            registry.is_none(),
-            "Vault registry should have no state after validation failure"
-        );
-    }
-
-    #[tokio::test]
     async fn recover_orphaned_pending_clears_filled_order() {
         let pool = setup_test_db().await;
         let order_placer = crate::offchain::order::noop_order_placer();
@@ -5090,7 +4965,6 @@ mod tests {
         let mut conductor = Conductor {
             supervisor,
             monitor,
-            executor_maintenance: None,
             rebalancer: None,
             rebalancer_shutdown_token: CancellationToken::new(),
 
@@ -5121,7 +4995,6 @@ mod tests {
         let mut conductor = Conductor {
             supervisor,
             monitor,
-            executor_maintenance: None,
             rebalancer: None,
             rebalancer_shutdown_token: CancellationToken::new(),
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -21,6 +21,7 @@ use super::exit::MonitorTaskError;
 #[cfg(any(test, feature = "test-support"))]
 use super::job::FailureInjector;
 use super::job::{FAIL_STOP_RECOVERY_TIMEOUT, build_supervised_worker};
+use super::monitor::executor_maintenance::ExecutorMaintenance;
 use super::monitor::inventory::InventoryMonitor;
 use super::monitor::order_fills::OrderFillMonitor;
 use super::monitor::positions::PositionMonitor;
@@ -51,7 +52,9 @@ use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue, PlaceHedge};
 use crate::trading::onchain::trade_accountant::{
     AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
 };
-use crate::vault_registry::VaultRegistry;
+use crate::vault_registry::{
+    SeedVaultRegistry, SeedVaultRegistryCtx, SeedVaultRegistryJobQueue, VaultRegistry,
+};
 
 pub(crate) struct CqrsFrameworks {
     pub(crate) onchain_trade: Arc<Store<OnChainTrade>>,
@@ -93,8 +96,9 @@ pub(crate) fn spawn<Prov, Exec>(
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     rebalancing_service: Option<Arc<RebalancingService>>,
+    seed_vault_registry_queue: SeedVaultRegistryJobQueue,
+    seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
     job_cleanup: JoinHandle<()>,
-    executor_maintenance: Option<JoinHandle<()>>,
     rebalancer: Option<JoinHandle<()>>,
     rebalancer_shutdown_token: CancellationToken,
 ) -> Conductor
@@ -106,7 +110,6 @@ where
 {
     info!("Starting conductor orchestration");
 
-    log_optional_task_status("executor maintenance", executor_maintenance.is_some());
     log_optional_task_status("rebalancer", rebalancer.is_some());
 
     let order_owner = context.ctx.order_owner();
@@ -220,6 +223,8 @@ where
         poll_status_queue: poll_status_queue.clone(),
     };
 
+    let maintenance_interval = context.executor.maintenance_interval();
+
     let accountant_ctx = Arc::new(AccountantCtx {
         orderbook: context.ctx.evm.orderbook,
         ctx: context.ctx.clone(),
@@ -228,7 +233,7 @@ where
         evm: ReadOnlyEvm::new(context.provider),
         cqrs: trade_cqrs,
         vault_registry: context.frameworks.vault_registry,
-        executor: context.executor,
+        executor: context.executor.clone(),
         pool: context.pool.clone(),
         job_queue: job_queue.clone(),
     });
@@ -247,16 +252,25 @@ where
     // In test builds, use aggressive timeouts so a flaky WebSocket doesn't
     // stall e2e tests for ~13 minutes of exponential backoff.
     let is_test = cfg!(any(test, feature = "test-support"));
-    let supervisor = SupervisorBuilder::default()
+    let mut supervisor_builder = SupervisorBuilder::default()
         .with_max_restart_attempts(if is_test { 2 } else { 10 })
         .with_max_backoff_exponent(if is_test { 2 } else { 8 })
         .with_base_restart_delay(std::time::Duration::from_secs(1))
         .with_dead_tasks_threshold(Some(0.0))
         .with_task("order-fill-monitor", order_fill_monitor)
         .with_task("position-monitor", position_monitor)
-        .with_task("inventory-monitor", inventory_monitor)
-        .build()
-        .run();
+        .with_task("inventory-monitor", inventory_monitor);
+
+    log_optional_task_status("executor maintenance", maintenance_interval.is_some());
+
+    if let Some(interval) = maintenance_interval {
+        supervisor_builder = supervisor_builder.with_task(
+            "executor-maintenance",
+            ExecutorMaintenance::new(context.executor, interval),
+        );
+    }
+
+    let supervisor = supervisor_builder.build().run();
 
     let monitor = MonitorWiring {
         accountant_ctx,
@@ -265,6 +279,7 @@ where
         reconcile_ctx,
         rejection_ctx,
         rebalancing_check_ctx: rebalancing_service,
+        seed_vault_registry_ctx,
         job_queue,
         hedge_queue,
         backfill_queue,
@@ -274,6 +289,7 @@ where
         equity_check_scheduler,
         usdc_check_scheduler,
         apalis_shutdown_token,
+        seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
         failure_injector: context.failure_injector,
     }
@@ -282,7 +298,6 @@ where
     Conductor {
         supervisor,
         monitor,
-        executor_maintenance,
         rebalancer,
         rebalancer_shutdown_token,
         job_cleanup,
@@ -308,6 +323,7 @@ where
     reconcile_ctx: Arc<ReconcileOrderFillCtx>,
     rejection_ctx: Arc<HandleOrderRejectionCtx>,
     rebalancing_check_ctx: Option<Arc<RebalancingService>>,
+    seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
     job_queue: DexTradeAccountingJobQueue,
     hedge_queue: HedgeJobQueue,
     backfill_queue: BackfillJobQueue,
@@ -317,6 +333,7 @@ where
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     apalis_shutdown_token: CancellationToken,
+    seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
     failure_injector: FailureInjector,
 }
@@ -336,6 +353,7 @@ where
             reconcile_ctx,
             rejection_ctx,
             rebalancing_check_ctx,
+            seed_vault_registry_ctx,
             job_queue,
             hedge_queue,
             backfill_queue,
@@ -345,6 +363,7 @@ where
             equity_check_scheduler,
             usdc_check_scheduler,
             apalis_shutdown_token,
+            seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
             failure_injector,
         } = self;
@@ -363,6 +382,8 @@ where
         let failure_injector_for_equity_rebalancing_check = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_usdc_rebalancing_check = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_seed_vault_registry = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -371,6 +392,7 @@ where
         let failure_notify_for_rejection = failure_notify.clone();
         let failure_notify_for_equity_rebalancing_check = failure_notify.clone();
         let failure_notify_for_usdc_rebalancing_check = failure_notify.clone();
+        let failure_notify_for_seed_vault_registry = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -383,6 +405,7 @@ where
         let fail_stop_for_rejection = fail_stop.clone();
         let fail_stop_for_equity_rebalancing_check = fail_stop.clone();
         let fail_stop_for_usdc_rebalancing_check = fail_stop.clone();
+        let fail_stop_for_seed_vault_registry = fail_stop.clone();
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -459,6 +482,18 @@ where
                         failure_notify_for_rejection.clone(),
                         #[cfg(any(test, feature = "test-support"))]
                         failure_injector_for_rejection.clone(),
+                    )
+                })
+                .register(move |index| {
+                    build_supervised_worker!(
+                        ::<SeedVaultRegistryCtx, SeedVaultRegistry>,
+                        index,
+                        seed_vault_registry_queue.clone(),
+                        seed_vault_registry_ctx.clone(),
+                        fail_stop_for_seed_vault_registry.clone(),
+                        failure_notify_for_seed_vault_registry.clone(),
+                        #[cfg(any(test, feature = "test-support"))]
+                        failure_injector_for_seed_vault_registry.clone(),
                     )
                 });
 

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -309,6 +309,7 @@ pub enum JobKind {
     HandleOrderRejection,
     EquityRebalancingCheck,
     UsdcRebalancingCheck,
+    SeedVaultRegistry,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -341,6 +342,7 @@ pub struct FailureInjector {
     handle_order_rejection: Arc<Mutex<InjectionState>>,
     equity_rebalancing_check: Arc<Mutex<InjectionState>>,
     usdc_rebalancing_check: Arc<Mutex<InjectionState>>,
+    seed_vault_registry: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -371,6 +373,7 @@ impl FailureInjector {
             handle_order_rejection: Arc::new(Mutex::new(InjectionState::Idle)),
             equity_rebalancing_check: Arc::new(Mutex::new(InjectionState::Idle)),
             usdc_rebalancing_check: Arc::new(Mutex::new(InjectionState::Idle)),
+            seed_vault_registry: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -413,6 +416,7 @@ impl FailureInjector {
             JobKind::HandleOrderRejection => &self.handle_order_rejection,
             JobKind::EquityRebalancingCheck => &self.equity_rebalancing_check,
             JobKind::UsdcRebalancingCheck => &self.usdc_rebalancing_check,
+            JobKind::SeedVaultRegistry => &self.seed_vault_registry,
         };
 
         match mutex.lock() {

--- a/src/conductor/monitor.rs
+++ b/src/conductor/monitor.rs
@@ -1,5 +1,6 @@
 //! Supervised monitors: long-running tasks registered with the supervisor.
 
+pub(crate) mod executor_maintenance;
 pub(crate) mod inventory;
 pub(crate) mod order_fills;
 pub(crate) mod positions;

--- a/src/conductor/monitor/executor_maintenance.rs
+++ b/src/conductor/monitor/executor_maintenance.rs
@@ -1,0 +1,199 @@
+//! Supervised executor maintenance loop.
+//!
+//! [`ExecutorMaintenance`] is a long-running [`SupervisedTask`] that ticks
+//! at the executor's [`Executor::maintenance_interval`] and invokes
+//! [`Executor::maintenance_tick`]. Tick errors are transient (token refresh
+//! failures, transient broker connectivity) -- they are logged and swallowed
+//! so a hiccup never halts the loop; the supervisor restarts the task only
+//! if the tick loop itself panics.
+//!
+//! The previous implementation spawned a raw `tokio::spawn` from inside the
+//! executor and returned the `JoinHandle` to the conductor. That handle was
+//! aborted on shutdown but never restarted: if token refresh died, the
+//! executor silently stopped working. Wrapping the tick in a supervised
+//! task closes that gap.
+
+use std::time::Duration;
+use task_supervisor::{SupervisedTask, TaskResult};
+use tokio::time::MissedTickBehavior;
+use tracing::{info, warn};
+
+use st0x_execution::Executor;
+
+#[derive(Clone)]
+pub(crate) struct ExecutorMaintenance<Exec> {
+    executor: Exec,
+    interval: Duration,
+}
+
+impl<Exec: Executor + Clone> ExecutorMaintenance<Exec> {
+    pub(crate) fn new(executor: Exec, interval: Duration) -> Self {
+        Self { executor, interval }
+    }
+}
+
+impl<Exec: Executor + Clone> SupervisedTask for ExecutorMaintenance<Exec> {
+    async fn run(&mut self) -> TaskResult {
+        info!(
+            interval_secs = self.interval.as_secs(),
+            "Executor maintenance started"
+        );
+
+        let mut ticker = tokio::time::interval(self.interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            ticker.tick().await;
+
+            if let Err(error) = self.executor.maintenance_tick().await {
+                warn!(?error, "Executor maintenance tick failed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+
+    use st0x_execution::{
+        CounterTradePreflight, ExecutionError, InventoryResult, MarketOrder, OrderPlacement,
+        OrderState, SupportedExecutor, TryIntoExecutor,
+    };
+
+    use super::*;
+
+    /// Executor that pulses on `tx` for every maintenance tick. `fail`
+    /// toggles whether tick returns an error so the test can prove the
+    /// loop survives transient failures.
+    #[derive(Clone)]
+    struct NotifyingExecutor {
+        tx: UnboundedSender<()>,
+        fail: Arc<AtomicBool>,
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct NotifyingExecutorCtx;
+
+    #[async_trait]
+    impl TryIntoExecutor for NotifyingExecutorCtx {
+        type Executor = NotifyingExecutor;
+        async fn try_into_executor(
+            self,
+        ) -> Result<Self::Executor, <Self::Executor as Executor>::Error> {
+            unreachable!("test executor is constructed directly")
+        }
+    }
+
+    #[async_trait]
+    impl Executor for NotifyingExecutor {
+        type Error = ExecutionError;
+        type OrderId = String;
+        type Ctx = NotifyingExecutorCtx;
+
+        async fn try_from_ctx(_ctx: Self::Ctx) -> Result<Self, Self::Error> {
+            unreachable!("test executor is constructed directly")
+        }
+
+        async fn is_market_open(&self) -> Result<bool, Self::Error> {
+            Ok(true)
+        }
+
+        async fn place_market_order(
+            &self,
+            _order: MarketOrder,
+        ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        async fn get_order_status(
+            &self,
+            _order_id: &Self::OrderId,
+        ) -> Result<OrderState, Self::Error> {
+            unreachable!("not used in maintenance tests")
+        }
+
+        fn to_supported_executor(&self) -> SupportedExecutor {
+            SupportedExecutor::DryRun
+        }
+
+        fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+            Ok(order_id_str.to_string())
+        }
+
+        async fn maintenance_tick(&self) -> Result<(), Self::Error> {
+            self.tx.send(()).unwrap();
+
+            if self.fail.load(Ordering::SeqCst) {
+                Err(ExecutionError::MockFailure {
+                    message: "forced maintenance failure".to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+            Ok(InventoryResult::Unimplemented)
+        }
+
+        async fn preflight_counter_trade(
+            &self,
+            _order: MarketOrder,
+        ) -> Result<CounterTradePreflight, Self::Error> {
+            Ok(CounterTradePreflight::Allowed { reservation: None })
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ticks_at_configured_interval() {
+        let (tx, mut rx) = unbounded_channel();
+        let mut maintenance = ExecutorMaintenance::new(
+            NotifyingExecutor {
+                tx,
+                fail: Arc::new(AtomicBool::new(false)),
+            },
+            Duration::from_secs(10),
+        );
+
+        let handle = tokio::spawn(async move { maintenance.run().await });
+
+        for tick in 0..4 {
+            rx.recv()
+                .await
+                .unwrap_or_else(|| panic!("maintenance failed to tick on iteration {tick}"));
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn keeps_ticking_after_tick_error() {
+        let (tx, mut rx) = unbounded_channel();
+        let mut maintenance = ExecutorMaintenance::new(
+            NotifyingExecutor {
+                tx,
+                fail: Arc::new(AtomicBool::new(true)),
+            },
+            Duration::from_secs(10),
+        );
+
+        let handle = tokio::spawn(async move { maintenance.run().await });
+
+        for tick in 0..3 {
+            rx.recv()
+                .await
+                .unwrap_or_else(|| panic!("maintenance stopped ticking after error on {tick}"));
+        }
+
+        assert!(
+            !handle.is_finished(),
+            "maintenance must keep running after a tick error"
+        );
+
+        handle.abort();
+    }
+}

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -687,10 +687,6 @@ mod tests {
                 self.inner.parse_order_id(order_id_str)
             }
 
-            async fn run_executor_maintenance(&self) -> Option<tokio::task::JoinHandle<()>> {
-                self.inner.run_executor_maintenance().await
-            }
-
             async fn get_inventory(&self) -> Result<st0x_execution::InventoryResult, Self::Error> {
                 self.inner.get_inventory().await
             }

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -14,11 +14,18 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
+use tracing::{debug, info};
 
 use st0x_execution::Symbol;
 
-use st0x_event_sorcery::{DomainEvent, EventSourced, Never, Projection, Table};
+use st0x_event_sorcery::{DomainEvent, EventSourced, Never, Projection, SendError, Store, Table};
+
+#[cfg(any(test, feature = "test-support"))]
+use crate::conductor::job::JobKind;
+use crate::conductor::job::{Job, JobQueue, Label};
+use crate::config::{Ctx, CtxError};
 
 /// Typed identifier for VaultRegistry aggregates, keyed by
 /// orderbook and owner address pair.
@@ -442,6 +449,155 @@ impl DomainEvent for VaultRegistryEvent {
 
     fn event_version(&self) -> String {
         "1.0".to_string()
+    }
+}
+
+/// A single equity vault to seed from config.
+#[derive(Debug, Clone)]
+pub(crate) struct EquityVaultSeed {
+    pub(crate) token: Address,
+    pub(crate) vault_id: B256,
+    pub(crate) symbol: Symbol,
+}
+
+/// Apalis job that seeds the [`VaultRegistry`] aggregate from config.
+///
+/// Stateless payload: the registry id, store handle, and seed list all
+/// live in [`SeedVaultRegistryCtx`]. Carries no data so the job survives
+/// restarts without serializing config (which is reloaded at startup).
+///
+/// Idempotent: each seed command is a no-op if the vault is already
+/// registered with the same id (see [`VaultRegistry::transition`]).
+/// Re-running the job after a partial failure replays only the missing
+/// seeds.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct SeedVaultRegistry;
+
+pub(crate) type SeedVaultRegistryJobQueue = JobQueue<SeedVaultRegistry>;
+
+/// Bundled dependencies for [`SeedVaultRegistry`].
+///
+/// Only constructable via [`Self::from_config`], which performs the
+/// pre-flight config validation. Holding an instance of this type is
+/// proof that validation succeeded -- callers cannot bypass the check
+/// by hand-rolling the fields.
+pub(crate) struct SeedVaultRegistryCtx {
+    vault_registry: Arc<Store<VaultRegistry>>,
+    id: VaultRegistryId,
+    equity_seeds: Vec<EquityVaultSeed>,
+    usdc_vault_ids: Vec<B256>,
+}
+
+impl SeedVaultRegistryCtx {
+    /// Builds a seeding context from configuration.
+    ///
+    /// Validates that every rebalancing-enabled equity has at least
+    /// one configured `vault_id`. Returns [`CtxError::MissingEquityVaultId`]
+    /// if any rebalancing-enabled equity lacks a vault, so config errors
+    /// fail fast at construction rather than being retried by apalis.
+    pub(crate) fn from_config(
+        vault_registry: Arc<Store<VaultRegistry>>,
+        ctx: &Ctx,
+    ) -> Result<Self, CtxError> {
+        for (symbol, equity_config) in &ctx.assets.equities.symbols {
+            if equity_config.vault_ids.is_empty() && ctx.is_rebalancing_enabled(symbol) {
+                return Err(CtxError::MissingEquityVaultId {
+                    symbol: symbol.clone(),
+                });
+            }
+        }
+
+        let id = VaultRegistryId {
+            orderbook: ctx.evm.orderbook,
+            owner: ctx.order_owner(),
+        };
+
+        let equity_seeds = ctx
+            .assets
+            .equities
+            .symbols
+            .iter()
+            .flat_map(|(symbol, equity_config)| {
+                equity_config
+                    .vault_ids
+                    .iter()
+                    .map(move |vault_id| EquityVaultSeed {
+                        token: equity_config.tokenized_equity_derivative,
+                        vault_id: *vault_id,
+                        symbol: symbol.clone(),
+                    })
+            })
+            .collect();
+
+        let usdc_vault_ids = ctx
+            .assets
+            .cash
+            .as_ref()
+            .map(|cash| cash.vault_ids.clone())
+            .unwrap_or_default();
+
+        Ok(Self {
+            vault_registry,
+            id,
+            equity_seeds,
+            usdc_vault_ids,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SeedVaultRegistryError {
+    #[error("VaultRegistry command failed: {0}")]
+    VaultRegistry(#[from] SendError<VaultRegistry>),
+}
+
+impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
+    type Output = ();
+    type Error = SeedVaultRegistryError;
+
+    const WORKER_NAME: &'static str = "seed-vault-registry-worker";
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: JobKind = JobKind::SeedVaultRegistry;
+
+    fn label(&self) -> Label {
+        Label::new("SeedVaultRegistry")
+    }
+
+    async fn perform(&self, ctx: &SeedVaultRegistryCtx) -> Result<Self::Output, Self::Error> {
+        for seed in &ctx.equity_seeds {
+            debug!(
+                symbol = %seed.symbol,
+                vault_id = %seed.vault_id,
+                token = %seed.token,
+                "Seeding equity vault from config",
+            );
+
+            ctx.vault_registry
+                .send(
+                    &ctx.id,
+                    VaultRegistryCommand::SeedEquityVaultFromConfig {
+                        token: seed.token,
+                        vault_id: seed.vault_id,
+                        symbol: seed.symbol.clone(),
+                    },
+                )
+                .await?;
+        }
+
+        for vault_id in &ctx.usdc_vault_ids {
+            info!(%vault_id, "Seeding USDC vault from config");
+
+            ctx.vault_registry
+                .send(
+                    &ctx.id,
+                    VaultRegistryCommand::SeedUsdcVaultFromConfig {
+                        vault_id: *vault_id,
+                    },
+                )
+                .await?;
+        }
+
+        Ok(())
     }
 }
 
@@ -1011,6 +1167,270 @@ mod tests {
             counter.load(Ordering::SeqCst),
             1,
             "Reactor should only see events emitted after construction, not historical ones"
+        );
+    }
+
+    fn test_usdc_vault_id() -> B256 {
+        b256!("0x0000000000000000000000000000000000000000000000000000000000000002")
+    }
+
+    /// Builds a [`Ctx`] populated with the seeding fixtures defined at
+    /// the top of this module so [`SeedVaultRegistryCtx::from_config`]
+    /// can exercise the production construction path.
+    fn ctx_with_seeded_assets() -> Ctx {
+        use crate::config::tests::create_test_ctx_with_order_owner;
+        use crate::config::{
+            AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, OperationMode,
+        };
+        use std::collections::HashMap;
+
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            test_symbol(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: TEST_TOKEN,
+                vault_ids: vec![TEST_VAULT_ID],
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        Ctx {
+            assets: AssetsConfig {
+                equities: EquitiesConfig {
+                    operational_limit: None,
+                    symbols,
+                },
+                cash: Some(CashAssetConfig {
+                    vault_ids: vec![test_usdc_vault_id()],
+                    rebalancing: OperationMode::Disabled,
+                    operational_limit: None,
+                    reserved: None,
+                }),
+            },
+            ..create_test_ctx_with_order_owner(TEST_OWNER)
+        }
+    }
+
+    async fn seed_ctx_from(pool: sqlx::SqlitePool, ctx: &Ctx) -> Arc<SeedVaultRegistryCtx> {
+        let (store, _projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+
+        Arc::new(SeedVaultRegistryCtx::from_config(store, ctx).unwrap())
+    }
+
+    async fn loaded_registry(store: &Store<VaultRegistry>, id: &VaultRegistryId) -> VaultRegistry {
+        store
+            .load(id)
+            .await
+            .unwrap()
+            .expect("registry should be initialized after seeding")
+    }
+
+    #[tokio::test]
+    async fn from_config_rejects_missing_vault_id() {
+        use crate::config::tests::create_test_ctx_with_order_owner;
+        use crate::config::{AssetsConfig, EquitiesConfig, EquityAssetConfig, OperationMode};
+        use std::collections::HashMap;
+
+        // Two equities with rebalancing enabled: one has a vault_id, one
+        // does not. The smart constructor must reject before any state
+        // is built, leaving callers with no way to skip the check.
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                vault_ids: vec![TEST_VAULT_ID],
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+        symbols.insert(
+            Symbol::new("TSLA").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        let ctx = Ctx {
+            assets: AssetsConfig {
+                equities: EquitiesConfig {
+                    operational_limit: None,
+                    symbols,
+                },
+                cash: None,
+            },
+            ..create_test_ctx_with_order_owner(Address::ZERO)
+        };
+
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+
+        let error = SeedVaultRegistryCtx::from_config(store, &ctx)
+            .err()
+            .expect("should fail when vault_id is missing for TSLA");
+
+        assert!(
+            matches!(&error, CtxError::MissingEquityVaultId { symbol } if symbol.to_string() == "TSLA"),
+            "expected MissingEquityVaultId for TSLA, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_seeds_configured_equity_and_usdc_vaults() {
+        let pool = setup_test_db().await;
+        let ctx = ctx_with_seeded_assets();
+        let seed_ctx = seed_ctx_from(pool, &ctx).await;
+
+        SeedVaultRegistry.perform(&seed_ctx).await.unwrap();
+
+        let registry = loaded_registry(&seed_ctx.vault_registry, &seed_ctx.id).await;
+
+        assert_eq!(
+            registry.primary_vault_id_by_token(TEST_TOKEN),
+            Some(TEST_VAULT_ID),
+            "equity vault should be seeded as primary for the token",
+        );
+        assert_eq!(
+            registry.primary_usdc_vault_id(),
+            Some(test_usdc_vault_id()),
+            "usdc vault should be seeded as primary",
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_is_idempotent_across_reruns() {
+        let pool = setup_test_db().await;
+        let ctx = ctx_with_seeded_assets();
+        let seed_ctx = seed_ctx_from(pool, &ctx).await;
+
+        SeedVaultRegistry.perform(&seed_ctx).await.unwrap();
+        // Re-running with the same seeds must be a no-op: the transition
+        // function returns `vec![]` for already-seeded vaults, so no
+        // duplicate events accrue.
+        SeedVaultRegistry.perform(&seed_ctx).await.unwrap();
+
+        let registry = loaded_registry(&seed_ctx.vault_registry, &seed_ctx.id).await;
+        assert_eq!(
+            registry.all_vault_ids_by_token(TEST_TOKEN),
+            vec![TEST_VAULT_ID]
+        );
+    }
+
+    async fn job_attempts_for_seed(pool: &sqlx::SqlitePool) -> i64 {
+        use sqlx::Row;
+        let queue_name = std::any::type_name::<SeedVaultRegistry>();
+        sqlx::query("SELECT attempts FROM Jobs WHERE job_type = ?")
+            .bind(queue_name)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+            .get::<i64, _>("attempts")
+    }
+
+    // Proves the gap is closed: enqueuing a SeedVaultRegistry job and
+    // forcing the job to fail (via the FailureInjector armed for this
+    // JobKind, which short-circuits before reaching the aggregate
+    // command) results in apalis retrying the job before halting. The
+    // `attempts` column on the Jobs row shows >1 when retries actually
+    // happened.
+    #[tokio::test]
+    async fn enqueued_job_retries_on_aggregate_command_failure() {
+        use apalis::layers::WorkerBuilderExt;
+        use apalis::layers::retry::RetryPolicy;
+        use apalis::prelude::{Monitor, WorkerBuilder};
+        use apalis_core::worker::event::Event;
+        use apalis_core::worker::ext::circuit_breaker::{
+            CircuitBreaker, config::CircuitBreakerConfig,
+        };
+        use apalis_core::worker::ext::event_listener::EventListenerExt;
+        use std::time::Duration;
+
+        use crate::conductor::job::{
+            FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobKind, JobQueue, work,
+        };
+        use crate::conductor::setup_apalis_tables;
+
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let ctx = ctx_with_seeded_assets();
+        let seed_ctx = seed_ctx_from(pool.clone(), &ctx).await;
+
+        let mut queue: JobQueue<SeedVaultRegistry> = JobQueue::new(&pool);
+        queue.push(SeedVaultRegistry).await.unwrap();
+
+        let injector = FailureInjector::new();
+        injector.arm(JobKind::SeedVaultRegistry);
+
+        let queue_for_worker = queue.clone();
+        let ctx_for_worker = seed_ctx.clone();
+        let injector_for_worker = injector.clone();
+
+        let monitor_handle = tokio::spawn(async move {
+            let monitor = Monitor::new()
+                .should_restart(|_ctx, _error, _attempt| false)
+                .register(move |index| {
+                    let fail_stop = CircuitBreakerConfig::default()
+                        .with_failure_threshold(1)
+                        .with_recovery_timeout(FAIL_STOP_RECOVERY_TIMEOUT);
+
+                    WorkerBuilder::new(format!("seed-vault-registry-test-{index}"))
+                        .backend(queue_for_worker.clone().into_storage())
+                        .data(ctx_for_worker.clone())
+                        .data(injector_for_worker.clone())
+                        .data(JobKind::SeedVaultRegistry)
+                        .concurrency(1)
+                        .retry(RetryPolicy::retries(3))
+                        .break_circuit_with(fail_stop)
+                        .on_event(|ctx, event| {
+                            if let Event::Error(_) = event {
+                                let _ = ctx.stop();
+                            }
+                        })
+                        .build(work::<SeedVaultRegistryCtx, SeedVaultRegistry>)
+                });
+
+            monitor.run().await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), monitor_handle)
+            .await
+            .expect("Monitor should halt within 5s after retries exhaust")
+            .expect("Monitor task should not panic")
+            .ok();
+
+        let attempts = job_attempts_for_seed(&pool).await;
+        assert!(
+            attempts > 1,
+            "Job should have been retried at least once; attempts={attempts}",
+        );
+
+        // The retries never produced events because every attempt was
+        // injected to fail before reaching the aggregate command.
+        assert!(
+            seed_ctx
+                .vault_registry
+                .load(&seed_ctx.id)
+                .await
+                .unwrap()
+                .is_none(),
+            "registry must remain empty when every retry attempt failed",
         );
     }
 }


### PR DESCRIPTION
Closes RAI-79.

## What

Extracts vault registry seeding into a dedicated `SeedVaultRegistry` apalis job with its own context type (`SeedVaultRegistryCtx`), job queue (`SeedVaultRegistryJobQueue`), and worker registration. Config validation is split into a synchronous `validate_vault_registry_config` function that runs at startup before any seeding work begins.

## Why

The previous `seed_vault_registry_from_config` function mixed config validation with aggregate writes in a single async function that ran inline at startup with no retry capability. If seeding failed partway through, there was no mechanism to replay the missing seeds. Moving seeding into an apalis job gives it the same retry and circuit-breaker guarantees as other background jobs, and separating validation from execution means config errors still fail fast at startup without being swallowed by the job machinery.

## How

Config validation (`validate_vault_registry_config`) runs synchronously at startup and returns a typed `CtxError` directly rather than boxing it. If validation passes, `build_seed_vault_registry_ctx` materializes a `SeedVaultRegistryCtx` from the validated config, collecting equity seeds into `Vec<EquityVaultSeed>` and USDC vault IDs into a plain `Vec<B256>`.

The `SeedVaultRegistry` job is then run inline at startup via `Job::perform` so that downstream services (RaindexService, trade accounting, inventory polling) start with a populated registry. The same job is also registered as an apalis worker so that if seeding is re-triggered later (e.g. from a recovery flow), the queue handles retries automatically.

The job is idempotent: each `SeedEquityVaultFromConfig` and `SeedUsdcVaultFromConfig` command is a no-op if the vault is already registered, so replaying the job after a partial failure only applies the missing seeds.

## Testing

- `validate_vault_registry_config_rejects_missing_vault_id` — verifies that a missing vault ID for a rebalancing-enabled equity returns `CtxError::MissingEquityVaultId` before any seeding work begins. The test no longer needs a database or vault registry store since validation is now synchronous.
- `perform_seeds_configured_equity_and_usdc_vaults` — verifies that running the job populates the registry with the configured equity and USDC vaults.
- `perform_is_idempotent_across_reruns` — verifies that running the job twice with the same seeds does not produce duplicate events.
- `enqueued_job_retries_on_aggregate_command_failure` — verifies that when the `FailureInjector` is armed for `JobKind::SeedVaultRegistry`, apalis retries the job before the circuit breaker halts the worker, and that the registry remains empty when every attempt fails.

## Anything else

The `FailureInjector` gains a `seed_vault_registry` slot so failure injection works consistently with all other job kinds.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal improvements to vault registry initialization and executor maintenance architectures for enhanced system reliability
  * Added Foundry tooling to development environment to support contract testing workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->