### PR TITLE
fix: recover from stale nonce cache on external wallet usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6845,6 +6845,8 @@ dependencies = [
  "alloy-signer-turnkey",
  "anyhow",
  "async-trait",
+ "dashmap",
+ "futures",
  "httpmock",
  "rain-error-decoding",
  "rand 0.8.6",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -14,6 +14,8 @@ alloy.workspace = true
 alloy-signer-turnkey = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 async-trait.workspace = true
+dashmap = "6.1.0"
+futures = "0.3.32"
 rain-error-decoding.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -32,6 +32,9 @@ pub mod error_decoding;
 pub use error_decoding::{IntoErrorRegistry, NoOpErrorRegistry, OpenChainErrorRegistry};
 use error_decoding::{decode_reverted_receipt, decode_rpc_revert};
 
+pub mod nonce;
+pub use nonce::ResettableNonceManager;
+
 #[cfg(feature = "local-signer")]
 pub mod local;
 #[cfg(feature = "turnkey")]
@@ -163,6 +166,22 @@ pub enum EvmError {
     #[cfg(feature = "turnkey")]
     #[error("Turnkey error: {0}")]
     Turnkey(#[from] turnkey::TurnkeyError),
+}
+
+impl EvmError {
+    /// Returns `true` if this is a "nonce too low" RPC error, which
+    /// occurs when an external process (e.g. CLI) submitted
+    /// transactions from the same wallet, advancing the chain nonce
+    /// past the locally cached value.
+    #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+    pub(crate) fn is_nonce_too_low(&self) -> bool {
+        match self {
+            Self::Transport(rpc_error) => rpc_error
+                .as_error_resp()
+                .is_some_and(|payload| payload.message.contains("nonce too low")),
+            _ => false,
+        }
+    }
 }
 
 impl From<std::convert::Infallible> for EvmError {
@@ -784,6 +803,7 @@ mod tests {
     }
 
     /// Parser that succeeds with a JSON value (`Some`) or fails (`None`).
+    #[allow(dead_code)]
     struct MaybeParser(Option<serde_json::Value>);
 
     impl Parser for MaybeParser {

--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -14,8 +14,9 @@ use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::signers::local::PrivateKeySigner;
 use async_trait::async_trait;
 use serde::Deserialize;
-use tracing::info;
+use tracing::{error, info, warn};
 
+use crate::nonce::ResettableNonceManager;
 use crate::{Evm, EvmError, TryIntoWallet, Wallet, WalletCtx};
 
 /// Secrets needed to construct a [`RawPrivateKeyWallet`].
@@ -24,13 +25,20 @@ pub struct PrivateKeySecrets {
     pub private_key: B256,
 }
 
-/// Provider type produced by wrapping a base provider with default fillers
+/// Provider type produced by wrapping a base provider with fillers
 /// and a [`WalletFiller`].
+///
+/// Uses [`ResettableNonceManager`] instead of alloy's default
+/// `CachedNonceManager` so the nonce cache can be invalidated when
+/// external processes (e.g. CLI commands) advance the chain nonce.
 pub type SignerProvider<P> = FillProvider<
     JoinFill<
         JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+            JoinFill<
+                JoinFill<JoinFill<Identity, GasFiller>, BlobGasFiller>,
+                NonceFiller<ResettableNonceManager>,
+            >,
+            ChainIdFiller,
         >,
         WalletFiller<EthereumWallet>,
     >,
@@ -55,6 +63,10 @@ pub struct RawPrivateKeyWallet<P: Provider> {
     /// Provider wrapped with gas/nonce/chain-id/wallet fillers for
     /// transaction signing and submission.
     signing_provider: SignerProvider<P>,
+    /// Shared nonce manager — cloned from the one inside
+    /// `signing_provider` so we can call [`invalidate()`] on "nonce
+    /// too low" errors without needing to traverse the filler chain.
+    nonce_manager: ResettableNonceManager,
     required_confirmations: u64,
 }
 
@@ -74,8 +86,14 @@ impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = provider.clone();
+        let nonce_manager = ResettableNonceManager::default();
 
         let signing_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .filler(GasFiller)
+            .filler(BlobGasFiller::default())
+            .with_nonce_management(nonce_manager.clone())
+            .filler(ChainIdFiller::default())
             .wallet(eth_wallet)
             .connect_provider(provider);
 
@@ -86,6 +104,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> RawPrivateKeyWallet<P> {
         Ok(Self {
             provider: base_provider,
             signing_provider,
+            nonce_manager,
             required_confirmations,
         })
     }
@@ -130,7 +149,28 @@ where
             .to(contract)
             .input(calldata.into());
 
-        let pending = self.signing_provider.send_transaction(tx).await?;
+        let pending = match self.signing_provider.send_transaction(tx.clone()).await {
+            Ok(pending) => pending,
+            Err(error) => {
+                let error = EvmError::from(error);
+
+                if !error.is_nonce_too_low() {
+                    return Err(error);
+                }
+
+                warn!(target: "wallet", %contract, note, "Nonce too low — \
+                    invalidating cache and retrying (external nonce change detected)");
+                self.nonce_manager.invalidate();
+
+                self.signing_provider
+                    .send_transaction(tx)
+                    .await
+                    .inspect_err(|error| {
+                        error!(target: "wallet", %error, "Nonce-too-low retry also failed");
+                    })?
+            }
+        };
+
         let tx_hash = *pending.tx_hash();
 
         info!(target: "wallet", %tx_hash, note, "Transaction submitted");
@@ -306,6 +346,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(after, amount);
+    }
+
+    #[tokio::test]
+    async fn concurrent_sends_use_distinct_nonces() {
+        let (_anvil, wallet, _token_address, signer_address) = setup_anvil_with_token().await;
+
+        let (receipt_a, receipt_b) = tokio::join!(
+            wallet.send(signer_address, Bytes::new(), "concurrent-a"),
+            wallet.send(signer_address, Bytes::new(), "concurrent-b"),
+        );
+
+        let receipt_a = receipt_a.expect("concurrent send A should succeed");
+        let receipt_b = receipt_b.expect("concurrent send B should succeed");
+
+        assert!(receipt_a.status(), "tx A should succeed");
+        assert!(receipt_b.status(), "tx B should succeed");
+        assert_ne!(
+            receipt_a.transaction_hash, receipt_b.transaction_hash,
+            "transactions must have different hashes (distinct nonces)"
+        );
     }
 
     #[tokio::test]

--- a/crates/evm/src/nonce.rs
+++ b/crates/evm/src/nonce.rs
@@ -1,0 +1,158 @@
+//! Resettable nonce manager for concurrent transaction submission.
+//!
+//! Alloy's [`CachedNonceManager`] caches nonces locally and never
+//! re-fetches from the RPC after initialization. When external
+//! processes (e.g. CLI commands) submit transactions from the same
+//! wallet address, the cache becomes stale and every subsequent send
+//! fails with "nonce too low".
+//!
+//! [`ResettableNonceManager`] behaves identically to
+//! `CachedNonceManager` but exposes [`invalidate()`] to clear the
+//! cache, forcing the next send to re-fetch the nonce from the chain.
+//!
+//! [`CachedNonceManager`]: alloy::providers::fillers::CachedNonceManager
+//! [`invalidate()`]: ResettableNonceManager::invalidate
+
+use alloy::network::Network;
+use alloy::primitives::Address;
+use alloy::providers::Provider;
+use alloy::providers::fillers::NonceManager;
+use alloy::transports::TransportResult;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use futures::lock::Mutex;
+use std::sync::Arc;
+use tracing::trace;
+
+/// Nonce manager that caches nonces locally and supports cache
+/// invalidation for resilience against external nonce changes.
+#[derive(Clone, Debug, Default)]
+pub struct ResettableNonceManager {
+    nonces: Arc<DashMap<Address, Arc<Mutex<u64>>>>,
+}
+
+impl ResettableNonceManager {
+    /// Clears all cached nonces, forcing the next transaction to
+    /// re-fetch the current nonce from the RPC provider.
+    ///
+    /// Race note: if a concurrent `get_next_nonce` has already cloned the
+    /// per-address `Arc<Mutex>` but not yet locked it, it will write to
+    /// an orphaned mutex while a new entry is created for subsequent
+    /// callers. This can cause a one-time nonce collision under concurrent
+    /// sends during invalidation. The window is narrow and only opens
+    /// during an already-degraded state (external nonce change). Acceptable
+    /// for single-address usage; revisit if multi-address support is added.
+    pub fn invalidate(&self) {
+        self.nonces.clear();
+    }
+}
+
+#[async_trait]
+impl NonceManager for ResettableNonceManager {
+    async fn get_next_nonce<TProvider, TNetwork>(
+        &self,
+        provider: &TProvider,
+        address: Address,
+    ) -> TransportResult<u64>
+    where
+        TProvider: Provider<TNetwork>,
+        TNetwork: Network,
+    {
+        // Sentinel marking uninitialized nonces, triggering RPC fetch.
+        const NONE: u64 = u64::MAX;
+
+        let nonce = {
+            let entry = self
+                .nonces
+                .entry(address)
+                .or_insert_with(|| Arc::new(Mutex::new(NONE)));
+            Arc::clone(entry.value())
+        };
+
+        let mut nonce = nonce.lock().await;
+
+        let new_nonce = if *nonce == NONE {
+            trace!(%address, "fetching nonce from RPC");
+            provider.get_transaction_count(address).await?
+        } else {
+            trace!(%address, current_nonce = *nonce, "incrementing cached nonce");
+            *nonce + 1
+        };
+
+        *nonce = new_nonce;
+        drop(nonce);
+
+        Ok(new_nonce)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::providers::ProviderBuilder;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn increments_locally_after_first_fetch() {
+        let manager = ResettableNonceManager::default();
+        let provider = ProviderBuilder::new().connect_anvil();
+        let address = Address::ZERO;
+
+        let first = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(first, 0);
+
+        let second = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(second, 1);
+
+        let third = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(third, 2);
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_rpc_refetch() {
+        let manager = ResettableNonceManager::default();
+        let provider = ProviderBuilder::new().connect_anvil();
+        let address = Address::ZERO;
+
+        let first = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(first, 0);
+
+        let second = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(second, 1);
+
+        manager.invalidate();
+
+        // After invalidation, re-fetches from RPC (still 0 since no
+        // real txs were sent on anvil).
+        let after_invalidate = manager.get_next_nonce(&provider, address).await.unwrap();
+        assert_eq!(after_invalidate, 0);
+    }
+
+    #[tokio::test]
+    async fn cloned_managers_share_cache() {
+        let manager_a = ResettableNonceManager::default();
+        let manager_b = manager_a.clone();
+        let provider = ProviderBuilder::new().connect_anvil();
+        let address = Address::ZERO;
+
+        assert_eq!(
+            manager_a.get_next_nonce(&provider, address).await.unwrap(),
+            0
+        );
+        assert_eq!(
+            manager_b.get_next_nonce(&provider, address).await.unwrap(),
+            1
+        );
+        assert_eq!(
+            manager_a.get_next_nonce(&provider, address).await.unwrap(),
+            2
+        );
+
+        manager_b.invalidate();
+
+        assert_eq!(
+            manager_a.get_next_nonce(&provider, address).await.unwrap(),
+            0
+        );
+    }
+}

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -17,8 +17,9 @@ use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy_signer_turnkey::{TurnkeySigner, TurnkeySignerError};
 use async_trait::async_trait;
 use serde::Deserialize;
-use tracing::info;
+use tracing::{error, info, warn};
 
+use crate::nonce::ResettableNonceManager;
 use crate::{Evm, EvmError, TryIntoWallet, Wallet, WalletCtx};
 
 /// Turnkey organization identifier (non-secret, lives in plaintext
@@ -80,13 +81,20 @@ impl std::fmt::Debug for TurnkeyCredentials {
     }
 }
 
-/// Provider type produced by wrapping a base provider with default
-/// fillers and a [`WalletFiller`] backed by a Turnkey signer.
+/// Provider type produced by wrapping a base provider with fillers
+/// and a [`WalletFiller`] backed by a Turnkey signer.
+///
+/// Uses [`ResettableNonceManager`] instead of alloy's default
+/// `CachedNonceManager` so the nonce cache can be invalidated when
+/// external processes (e.g. CLI commands) advance the chain nonce.
 type SignerProvider<P> = FillProvider<
     JoinFill<
         JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+            JoinFill<
+                JoinFill<JoinFill<Identity, GasFiller>, BlobGasFiller>,
+                NonceFiller<ResettableNonceManager>,
+            >,
+            ChainIdFiller,
         >,
         WalletFiller<EthereumWallet>,
     >,
@@ -108,6 +116,10 @@ pub struct TurnkeyWallet<P: Provider> {
     /// Provider wrapped with gas/nonce/chain-id/wallet fillers for
     /// transaction signing and submission.
     signing_provider: SignerProvider<P>,
+    /// Shared nonce manager — cloned from the one inside
+    /// `signing_provider` so we can call [`invalidate()`] on "nonce
+    /// too low" errors without needing to traverse the filler chain.
+    nonce_manager: ResettableNonceManager,
     address: Address,
     required_confirmations: u64,
 }
@@ -149,7 +161,14 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = ctx.provider.clone();
+        let nonce_manager = ResettableNonceManager::default();
+
         let signing_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .filler(GasFiller)
+            .filler(BlobGasFiller::default())
+            .with_nonce_management(nonce_manager.clone())
+            .filler(ChainIdFiller::default())
             .wallet(eth_wallet)
             .connect_provider(ctx.provider);
 
@@ -160,6 +179,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
         Ok(Self {
             provider: base_provider,
             signing_provider,
+            nonce_manager,
             address,
             required_confirmations,
         })
@@ -184,14 +204,21 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
         let eth_wallet = EthereumWallet::from(signer);
 
         let base_provider = provider.clone();
+        let nonce_manager = ResettableNonceManager::default();
 
         let signing_provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .filler(GasFiller)
+            .filler(BlobGasFiller::default())
+            .with_nonce_management(nonce_manager.clone())
+            .filler(ChainIdFiller::default())
             .wallet(eth_wallet)
             .connect_provider(provider);
 
         Ok(Self {
             provider: base_provider,
             signing_provider,
+            nonce_manager,
             address,
             required_confirmations,
         })
@@ -231,7 +258,28 @@ where
             .to(contract)
             .input(calldata.into());
 
-        let pending = self.signing_provider.send_transaction(tx).await?;
+        let pending = match self.signing_provider.send_transaction(tx.clone()).await {
+            Ok(pending) => pending,
+            Err(error) => {
+                let error = EvmError::from(error);
+
+                if !error.is_nonce_too_low() {
+                    return Err(error);
+                }
+
+                warn!(target: "wallet", %contract, note, "Nonce too low — \
+                    invalidating cache and retrying (external nonce change detected)");
+                self.nonce_manager.invalidate();
+
+                self.signing_provider
+                    .send_transaction(tx)
+                    .await
+                    .inspect_err(|error| {
+                        error!(target: "wallet", %error, "Nonce-too-low retry also failed");
+                    })?
+            }
+        };
+
         let tx_hash = *pending.tx_hash();
 
         info!(target: "wallet", %tx_hash, note, "Transaction submitted");


### PR DESCRIPTION
## What

Introduces a `ResettableNonceManager` that replaces alloy's default
`CachedNonceManager` in both `RawPrivateKeyWallet` and `TurnkeyWallet`,
and adds automatic retry logic when "nonce too low" errors are detected.

## Why

Alloy's `CachedNonceManager` fetches the nonce from the RPC once and
then increments locally forever. When an external process (e.g. the CLI)
submits a transaction from the same wallet, the on-chain nonce advances
past the cached value and every subsequent bot transaction fails with
"nonce too low" — requiring a full restart to recover.

## How

- **New `ResettableNonceManager`** (`crates/evm/src/nonce.rs`): implements
  alloy's `NonceManager` trait with a `DashMap<Address, Arc<Mutex<u64>>>`
  cache. Exposes `invalidate()` to clear all cached nonces, forcing the
  next send to re-fetch from the RPC.
- **Custom filler chain**: both `RawPrivateKeyWallet` and `TurnkeyWallet`
  now call `disable_recommended_fillers()` and manually compose the filler
  stack with `NonceFiller<ResettableNonceManager>` instead of the default
  `NonceFiller` (which uses `CachedNonceManager`).
- **Retry on nonce-too-low**: `Wallet::send()` in both wallet types catches
  the first "nonce too low" error, calls `nonce_manager.invalidate()`, and
  retries once. A shared `nonce_manager` field (cloned `Arc`) is stored
  alongside the signing provider so invalidation doesn't require traversing
  the filler chain.
- **`EvmError::is_nonce_too_low()`**: helper on `EvmError` that inspects
  the RPC error payload for the "nonce too low" message.
- New dependencies: `dashmap` and `futures` (for `futures::lock::Mutex`).

## Testing

- **`ResettableNonceManager` unit tests** (`crates/evm/src/nonce.rs`):
  - `increments_locally_after_first_fetch` — verifies local increment behavior.
  - `invalidate_forces_rpc_refetch` — confirms cache clear triggers RPC re-fetch.
  - `cloned_managers_share_cache` — ensures cloned instances share state.
- **`concurrent_sends_use_distinct_nonces`** (`crates/evm/src/local.rs`):
  integration test using Anvil that sends two concurrent transactions and
  asserts distinct transaction hashes (distinct nonces).

## Anything else

- The `BaseProvider` type alias in `src/rebalancing/spawn.rs` tests was
  updated to reflect the new filler chain shape.
- `MaybeParser` in `crates/evm/src/lib.rs` gained `#[allow(dead_code)]`
  (test-only struct, not used across all test functions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry mechanism for transactions failing due to nonce conflicts, with cache invalidation to ensure proper state synchronization
  * Added resettable nonce caching system that improves reliability and enables better handling of concurrent transaction submissions
  * Enhanced wallet implementations with robust nonce management for more predictable transaction behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/668)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes RAI-562