### PR TITLE
fix: prevent duplicate mints on post-receipt failure, detect dropped txs

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -160,6 +160,17 @@ pub enum EvmError {
         tx_hash: alloy::primitives::TxHash,
         timeout_secs: u64,
     },
+    /// Transaction was dropped from the mempool (not found via
+    /// `eth_getTransactionByHash` after initial propagation window).
+    #[error(
+        "transaction {tx_hash} dropped from mempool \
+         (not found after {elapsed_secs}s)"
+    )]
+    #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+    TransactionDropped {
+        tx_hash: alloy::primitives::TxHash,
+        elapsed_secs: u64,
+    },
     #[cfg(feature = "local-signer")]
     #[error("invalid private key: {0}")]
     InvalidPrivateKey(#[from] alloy::signers::k256::ecdsa::Error),
@@ -601,6 +612,12 @@ pub(crate) async fn wait_for_receipt(
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 const CONFIRMATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
+/// Number of receipt polls before checking whether the transaction was
+/// dropped from the mempool. Gives the tx time to propagate before
+/// concluding it was never broadcast.
+#[cfg(any(feature = "turnkey", feature = "local-signer"))]
+const DROPPED_TX_CHECK_AFTER_POLLS: u32 = 3;
+
 /// Parameterized version of [`wait_for_receipt`] for testability.
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 pub(crate) async fn wait_for_receipt_with_config(
@@ -614,12 +631,29 @@ pub(crate) async fn wait_for_receipt_with_config(
     let mut poll = interval(poll_interval);
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    let start = std::time::Instant::now();
+
     // Phase 1: wait for inclusion (with timeout).
     let (receipt, receipt_block) = timeout(inclusion_timeout, async {
+        let mut poll_count = 0u32;
+
         loop {
             poll.tick().await;
+            poll_count += 1;
 
             let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? else {
+                // After initial propagation window, check if the tx
+                // still exists in the mempool. If not, it was dropped
+                // and will never mine.
+                if poll_count >= DROPPED_TX_CHECK_AFTER_POLLS
+                    && provider.get_transaction_by_hash(tx_hash).await?.is_none()
+                {
+                    return Err(EvmError::TransactionDropped {
+                        tx_hash,
+                        elapsed_secs: start.elapsed().as_secs(),
+                    });
+                }
+
                 continue;
             };
 
@@ -964,7 +998,7 @@ mod tests {
 
     #[cfg(feature = "local-signer")]
     #[tokio::test]
-    async fn wait_for_receipt_times_out_for_unknown_tx() {
+    async fn wait_for_receipt_detects_dropped_tx() {
         let anvil = Anvil::new().spawn();
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
@@ -977,14 +1011,14 @@ mod tests {
             fake_hash,
             1,
             std::time::Duration::from_millis(50),
-            std::time::Duration::from_millis(200),
+            std::time::Duration::from_secs(30),
             std::time::Duration::from_secs(60),
         )
         .await;
 
         assert!(
-            matches!(result, Err(EvmError::ReceiptTimeout { tx_hash, .. }) if tx_hash == fake_hash),
-            "expected ReceiptTimeout for nonexistent tx, got: {result:?}"
+            matches!(result, Err(EvmError::TransactionDropped { tx_hash, .. }) if tx_hash == fake_hash),
+            "expected TransactionDropped for nonexistent tx, got: {result:?}"
         );
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,8 @@
-//! HTTP API endpoints for health checks, log retrieval, and order status.
+//! HTTP API endpoints for health checks, log retrieval, order status,
+//! and transfer recovery.
 
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 use chrono::{DateTime, Utc};
@@ -10,11 +12,14 @@ use rocket::request::FromParam;
 use rocket::response::content::RawJson;
 use rocket::serde::json::Json;
 use rocket::serde::{Deserialize, Serialize};
-use rocket::{Route, State, get, routes};
+use rocket::{Route, State, get, post, routes};
 use sqlx::SqlitePool;
+use tokio::sync::Mutex;
+use tracing::{error, info};
 
 use crate::config::Ctx;
 use crate::dashboard::transfer_loader::TransferKind;
+use crate::rebalancing::equity::CrossVenueEquityTransfer;
 
 impl<'a> FromParam<'a> for TransferKind {
     type Error = String;
@@ -896,6 +901,154 @@ async fn raindex_orders(ctx: &State<Ctx>) -> RawJson<String> {
     }
 }
 
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+/// Shared handle for resuming interrupted tokenization transfers at
+/// runtime, set by the conductor after startup completes.
+pub(crate) struct RecoveryHandle {
+    pub(crate) transfer: Arc<CrossVenueEquityTransfer>,
+}
+
+/// Prevents concurrent `/transfers/resume` requests from racing through
+/// duplicate mint/redemption recovery flows.
+pub(crate) struct ResumeLock(pub(crate) Mutex<()>);
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InterruptedTransfersResponse {
+    interrupted_mints: Vec<String>,
+    interrupted_redemptions: Vec<String>,
+}
+
+#[get("/transfers/interrupted")]
+async fn interrupted_transfers(
+    pool: &State<SqlitePool>,
+) -> Result<Json<InterruptedTransfersResponse>, (Status, Json<ErrorResponse>)> {
+    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(pool.inner())
+        .await
+        .map_err(|error| {
+            error!(?error, "Failed to query interrupted mints");
+            (
+                Status::InternalServerError,
+                Json(ErrorResponse {
+                    error: "Failed to query interrupted mints".to_string(),
+                }),
+            )
+        })?;
+
+    let redemptions = crate::equity_redemption::interrupted_redemption_ids(pool.inner())
+        .await
+        .map_err(|error| {
+            error!(?error, "Failed to query interrupted redemptions");
+            (
+                Status::InternalServerError,
+                Json(ErrorResponse {
+                    error: "Failed to query interrupted redemptions".to_string(),
+                }),
+            )
+        })?;
+
+    Ok(Json(InterruptedTransfersResponse {
+        interrupted_mints: mints.into_iter().map(|id| id.to_string()).collect(),
+        interrupted_redemptions: redemptions.into_iter().map(|id| id.to_string()).collect(),
+    }))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResumeResponse {
+    mints_attempted: usize,
+    mints_failed: usize,
+    redemptions_attempted: usize,
+    redemptions_failed: usize,
+}
+
+#[post("/transfers/resume")]
+async fn resume_transfers(
+    pool: &State<SqlitePool>,
+    recovery: &State<Arc<tokio::sync::OnceCell<RecoveryHandle>>>,
+    resume_lock: &State<ResumeLock>,
+) -> Result<Json<ResumeResponse>, (Status, Json<ErrorResponse>)> {
+    let _guard = resume_lock.0.try_lock().map_err(|_| {
+        (
+            Status::Conflict,
+            Json(ErrorResponse {
+                error: "A resume operation is already in progress".to_string(),
+            }),
+        )
+    })?;
+
+    let handle = recovery.get().ok_or_else(|| {
+        (
+            Status::ServiceUnavailable,
+            Json(ErrorResponse {
+                error: "Recovery not ready yet (conductor still starting)".to_string(),
+            }),
+        )
+    })?;
+
+    let mints = crate::tokenized_equity_mint::interrupted_mint_ids(pool.inner())
+        .await
+        .map_err(|error| {
+            error!(?error, "Failed to query interrupted mints");
+            (
+                Status::InternalServerError,
+                Json(ErrorResponse {
+                    error: "Failed to query interrupted mints".to_string(),
+                }),
+            )
+        })?;
+
+    let redemptions = crate::equity_redemption::interrupted_redemption_ids(pool.inner())
+        .await
+        .map_err(|error| {
+            error!(?error, "Failed to query interrupted redemptions");
+            (
+                Status::InternalServerError,
+                Json(ErrorResponse {
+                    error: "Failed to query interrupted redemptions".to_string(),
+                }),
+            )
+        })?;
+
+    let mints_attempted = mints.len();
+    let redemptions_attempted = redemptions.len();
+    let mut mints_failed = 0usize;
+    let mut redemptions_failed = 0usize;
+
+    for mint_id in &mints {
+        if let Err(error) = handle.transfer.resume_mint(mint_id).await {
+            error!(%mint_id, ?error, "Failed to resume mint");
+            mints_failed += 1;
+        }
+    }
+
+    for redemption_id in &redemptions {
+        if let Err(error) = handle.transfer.resume_redemption(redemption_id).await {
+            error!(%redemption_id, ?error, "Failed to resume redemption");
+            redemptions_failed += 1;
+        }
+    }
+
+    info!(
+        mints_attempted,
+        mints_failed,
+        redemptions_attempted,
+        redemptions_failed,
+        "Transfer recovery completed via API"
+    );
+
+    Ok(Json(ResumeResponse {
+        mints_attempted,
+        mints_failed,
+        redemptions_attempted,
+        redemptions_failed,
+    }))
+}
+
 pub(crate) fn routes() -> Vec<Route> {
     routes![
         health,
@@ -905,7 +1058,9 @@ pub(crate) fn routes() -> Vec<Route> {
         trade_events,
         transfers_endpoint,
         transfer_events,
-        raindex_orders
+        raindex_orders,
+        interrupted_transfers,
+        resume_transfers
     ]
 }
 
@@ -919,7 +1074,7 @@ mod tests {
     #[test]
     fn test_num_of_routes() {
         let routes_list = routes();
-        assert_eq!(routes_list.len(), 8);
+        assert_eq!(routes_list.len(), 10);
     }
 
     #[tokio::test]
@@ -1303,5 +1458,52 @@ mod tests {
 
         assert_eq!(parsed["unavailable"], true);
         assert!(parsed["reason"].as_str().unwrap().contains("error"));
+    }
+
+    async fn create_test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn interrupted_transfers_returns_empty_on_fresh_db() {
+        let pool = create_test_pool().await;
+        let rocket = rocket::build()
+            .mount("/", routes![interrupted_transfers])
+            .manage(pool);
+        let client = Client::tracked(rocket).await.unwrap();
+
+        let response = client.get("/transfers/interrupted").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+
+        assert_eq!(body["interruptedMints"], serde_json::json!([]));
+        assert_eq!(body["interruptedRedemptions"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn resume_transfers_returns_503_before_conductor_ready() {
+        let pool = create_test_pool().await;
+        let recovery = Arc::new(tokio::sync::OnceCell::<RecoveryHandle>::new());
+        let rocket = rocket::build()
+            .mount("/", routes![resume_transfers])
+            .manage(pool)
+            .manage(recovery)
+            .manage(ResumeLock(Mutex::new(())));
+        let client = Client::tracked(rocket).await.unwrap();
+
+        let response = client.post("/transfers/resume").dispatch().await;
+        assert_eq!(response.status(), Status::ServiceUnavailable);
+
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+
+        assert_eq!(
+            body["error"],
+            "Recovery not ready yet (conductor still starting)"
+        );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -139,6 +139,7 @@ impl Conductor {
         event_sender: broadcast::Sender<Statement>,
         inventory: Arc<BroadcastingInventory>,
         shutdown_token: CancellationToken,
+        recovery_cell: Arc<tokio::sync::OnceCell<crate::api::RecoveryHandle>>,
     ) -> anyhow::Result<()>
     where
         E: Executor + Clone + Send + 'static,
@@ -186,6 +187,7 @@ impl Conductor {
             wallet_polling,
             tokenizer,
             service: rebalancing_service,
+            recovery_transfer,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -274,6 +276,13 @@ impl Conductor {
             .rebalancer_shutdown_token(rebalancer_shutdown_token)
             .job_cleanup(job_cleanup)
             .call();
+
+        // Publish the recovery handle only after all startup work
+        // (inventory hydration, orphan recovery, store builds) completes
+        // so /transfers/resume returns 503 until the conductor is ready.
+        if let Some(transfer) = recovery_transfer {
+            let _ = recovery_cell.set(crate::api::RecoveryHandle { transfer });
+        }
 
         info!("Conductor is running");
         let result = conductor.wait_for_completion().await;
@@ -544,6 +553,7 @@ struct RebalancingInfrastructure {
     rebalancer_shutdown_token: CancellationToken,
     tokenizer: Arc<dyn Tokenizer>,
     service: Arc<RebalancingService>,
+    recovery_transfer: Arc<CrossVenueEquityTransfer>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -571,6 +581,7 @@ struct PositionAndRebalancing {
     wallet_polling: Option<crate::inventory::WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     service: Option<Arc<RebalancingService>>,
+    recovery_transfer: Option<Arc<CrossVenueEquityTransfer>>,
 }
 
 impl PositionAndRebalancing {
@@ -622,6 +633,7 @@ impl PositionAndRebalancing {
                 wallet_polling: Some(wallet_polling),
                 tokenizer: Some(infra.tokenizer),
                 service: Some(infra.service),
+                recovery_transfer: Some(infra.recovery_transfer),
             })
         } else {
             let (position, position_projection) = build_position_cqrs(pool).await?;
@@ -643,6 +655,7 @@ impl PositionAndRebalancing {
                 wallet_polling: None,
                 tokenizer: None,
                 service: None,
+                recovery_transfer: None,
             })
         }
     }
@@ -804,14 +817,14 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .set_stores(built.mint.clone(), built.redemption.clone())
             .await;
 
-        let recovery_transfer = CrossVenueEquityTransfer::new(
+        let recovery_transfer = Arc::new(CrossVenueEquityTransfer::new(
             raindex_service.clone(),
             tokenizer.clone(),
             wrapper.clone(),
             market_maker_wallet,
             built.mint.clone(),
             built.redemption.clone(),
-        );
+        ));
 
         recover_interrupted_tokenization_aggregates(
             &deps.pool,
@@ -873,6 +886,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             rebalancer_shutdown_token,
             tokenizer,
             service: rebalancing_service,
+            recovery_transfer,
         })
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,14 +103,22 @@ pub async fn run_bot_session_with_event_channel(
     ));
 
     let shutdown_token = CancellationToken::new();
+    let recovery_cell = Arc::new(tokio::sync::OnceCell::new());
 
-    let server_task = spawn_server_task(&ctx, &pool, event_sender.clone(), inventory.clone());
+    let server_task = spawn_server_task(
+        &ctx,
+        &pool,
+        event_sender.clone(),
+        inventory.clone(),
+        recovery_cell.clone(),
+    );
     let bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
         pool,
         event_sender,
         inventory,
         shutdown_token.clone(),
+        recovery_cell,
     )));
 
     await_shutdown(server_task, bot_task, shutdown_token).await?;
@@ -124,6 +132,7 @@ fn spawn_server_task(
     pool: &SqlitePool,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
+    recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
 ) -> JoinHandle<Result<Rocket<Ignite>, rocket::Error>> {
     let rocket_config = rocket::Config::figment()
         .merge(("port", ctx.server_port))
@@ -141,7 +150,9 @@ fn spawn_server_task(
             inventory,
             pool: pool.clone(),
             settings: dashboard::settings_from_ctx(ctx),
-        });
+        })
+        .manage(recovery_cell)
+        .manage(api::ResumeLock(tokio::sync::Mutex::new(())));
 
     tokio::spawn(rocket.launch())
 }
@@ -314,6 +325,7 @@ async fn run_conductor_session(
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
     shutdown_token: CancellationToken,
+    recovery_cell: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
 ) -> anyhow::Result<()> {
     let result = match ctx.broker.clone() {
         BrokerCtx::DryRun => {
@@ -325,6 +337,7 @@ async fn run_conductor_session(
                 event_sender,
                 inventory,
                 shutdown_token,
+                recovery_cell,
             ))
             .await
         }
@@ -337,6 +350,7 @@ async fn run_conductor_session(
                 event_sender,
                 inventory,
                 shutdown_token,
+                recovery_cell,
             ))
             .await
         }
@@ -397,6 +411,7 @@ mod tests {
             create_test_event_sender(),
             create_test_inventory(),
             CancellationToken::new(),
+            Arc::new(tokio::sync::OnceCell::new()),
         ))
         .await
         .unwrap_err();
@@ -488,6 +503,7 @@ mod tests {
             create_test_event_sender(),
             create_test_inventory(),
             CancellationToken::new(),
+            Arc::new(tokio::sync::OnceCell::new()),
         ))
         .await
         .unwrap_err();

--- a/src/rebalancing/equity/mock.rs
+++ b/src/rebalancing/equity/mock.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use st0x_execution::{FractionalShares, Symbol};
 
-use super::{Equity, MintError, RedemptionError};
+use super::{Equity, MintTransferError, RedemptionError};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 
 /// Parameters captured from a hedging-to-market-making (mint) call.
@@ -64,7 +64,7 @@ impl MockCrossVenueEquityTransfer {
 #[async_trait]
 impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for MockCrossVenueEquityTransfer {
     type Asset = Equity;
-    type Error = MintError;
+    type Error = MintTransferError;
 
     async fn transfer(&self, asset: Self::Asset) -> Result<(), Self::Error> {
         self.mint_count.fetch_add(1, Ordering::SeqCst);

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -292,6 +292,23 @@ impl From<SendError<TokenizedEquityMint>> for MintError {
     }
 }
 
+/// Distinguishes mint failures before vs after tokens were received from
+/// Alpaca. Post-receipt failures must NOT clear the in-progress guard
+/// because real tokens exist in the wallet and startup recovery will
+/// resume them.
+#[derive(Debug, Error)]
+pub(crate) enum MintTransferError {
+    /// Failure before Alpaca delivered tokens. Safe to clear guard and
+    /// retry from scratch.
+    #[error(transparent)]
+    PreReceipt(MintError),
+
+    /// Failure after tokens were received (verify/wrap/deposit stage).
+    /// Tokens exist in the wallet; guard must stay set for recovery.
+    #[error(transparent)]
+    PostReceipt(MintError),
+}
+
 #[derive(Debug, Error)]
 pub(crate) enum RedemptionError {
     #[error(transparent)]
@@ -960,7 +977,7 @@ impl CrossVenueEquityTransfer {
 #[async_trait]
 impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTransfer {
     type Asset = Equity;
-    type Error = MintError;
+    type Error = MintTransferError;
 
     #[instrument(target = "rebalance", skip_all, fields(symbol = %asset.symbol, quantity = %asset.quantity))]
     async fn transfer(&self, asset: Self::Asset) -> Result<(), Self::Error> {
@@ -969,6 +986,7 @@ impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTra
 
         debug!(target: "rebalance", %issuer_request_id, wallet = %self.wallet, "Requesting mint");
 
+        // Pre-receipt: no tokens exist yet, safe to retry on failure.
         self.mint_store
             .send(
                 &issuer_request_id,
@@ -979,17 +997,25 @@ impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTra
                     wallet: self.wallet,
                 },
             )
-            .await?;
+            .await
+            .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
         info!(target: "rebalance", "Mint request accepted, polling for completion");
 
         self.mint_store
             .send(&issuer_request_id, TokenizedEquityMintCommand::Poll)
-            .await?;
+            .await
+            .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
-        let tokens_received = self.load_tokens_received(&issuer_request_id).await?;
+        // Post-receipt: tokens exist in wallet from this point on.
+        let tokens_received = self
+            .load_tokens_received(&issuer_request_id)
+            .await
+            .map_err(MintTransferError::PostReceipt)?;
+
         self.finalize_received_mint(&issuer_request_id, tokens_received)
             .await
+            .map_err(MintTransferError::PostReceipt)
     }
 }
 
@@ -1323,8 +1349,8 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(error, MintError::Wrapper(_)),
-            "Expected Wrapper error, got: {error:?}"
+            matches!(error, MintTransferError::PostReceipt(MintError::Wrapper(_))),
+            "Expected PostReceipt(Wrapper) error, got: {error:?}"
         );
     }
 
@@ -1348,8 +1374,8 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(error, MintError::Raindex(_)),
-            "Expected Raindex error, got: {error:?}"
+            matches!(error, MintTransferError::PostReceipt(MintError::Raindex(_))),
+            "Expected PostReceipt(Raindex) error, got: {error:?}"
         );
     }
 
@@ -1375,9 +1401,11 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Wrapper(WrapperError::SymbolNotConfigured(_))
+                MintTransferError::PostReceipt(MintError::Wrapper(
+                    WrapperError::SymbolNotConfigured(_)
+                ))
             ),
-            "Expected Wrapper(SymbolNotConfigured) error, got: {error:?}"
+            "Expected PostReceipt(Wrapper(SymbolNotConfigured)) error, got: {error:?}"
         );
     }
 
@@ -1403,9 +1431,11 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Wrapper(WrapperError::SymbolNotConfigured(_))
+                MintTransferError::PostReceipt(MintError::Wrapper(
+                    WrapperError::SymbolNotConfigured(_)
+                ))
             ),
-            "Expected Wrapper(SymbolNotConfigured) error, got: {error:?}"
+            "Expected PostReceipt(Wrapper(SymbolNotConfigured)) error, got: {error:?}"
         );
     }
 
@@ -1477,9 +1507,11 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Verification(MintVerificationError::ReceiptNotFound { .. })
+                MintTransferError::PostReceipt(MintError::Verification(
+                    MintVerificationError::ReceiptNotFound { .. }
+                ))
             ),
-            "Expected Verification(ReceiptNotFound) error, got: {error:?}"
+            "Expected PostReceipt(Verification(ReceiptNotFound)) error, got: {error:?}"
         );
     }
 
@@ -1508,9 +1540,11 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Verification(MintVerificationError::TransactionReverted { .. })
+                MintTransferError::PostReceipt(MintError::Verification(
+                    MintVerificationError::TransactionReverted { .. }
+                ))
             ),
-            "Expected Verification(TransactionReverted) error, got: {error:?}"
+            "Expected PostReceipt(Verification(TransactionReverted)) error, got: {error:?}"
         );
     }
 
@@ -1539,9 +1573,11 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Verification(MintVerificationError::NoMatchingTransfer { .. })
+                MintTransferError::PostReceipt(MintError::Verification(
+                    MintVerificationError::NoMatchingTransfer { .. }
+                ))
             ),
-            "Expected Verification(NoMatchingTransfer) error, got: {error:?}"
+            "Expected PostReceipt(Verification(NoMatchingTransfer)) error, got: {error:?}"
         );
     }
 
@@ -1570,7 +1606,9 @@ mod tests {
         assert!(
             matches!(
                 error,
-                MintError::Verification(MintVerificationError::InsufficientTransferAmount { .. })
+                MintTransferError::PostReceipt(MintError::Verification(
+                    MintVerificationError::InsufficientTransferAmount { .. }
+                ))
             ),
             "Expected Verification(InsufficientTransferAmount) error, got: {error:?}"
         );

--- a/src/rebalancing/rebalancer.rs
+++ b/src/rebalancing/rebalancer.rs
@@ -11,14 +11,13 @@ use tracing::{error, info, warn};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_finance::Usdc;
 
-use super::equity::{Equity, MintError, RedemptionError};
+use super::equity::{Equity, MintTransferError, RedemptionError};
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use super::trigger::TriggeredOperation;
 use super::usdc::UsdcTransferError;
 
 /// Type-erased equity transfer (hedging -> market-making).
-type EquityToMarketMaking =
-    dyn CrossVenueTransfer<HedgingVenue, MarketMakingVenue, Asset = Equity, Error = MintError>;
+type EquityToMarketMaking = dyn CrossVenueTransfer<HedgingVenue, MarketMakingVenue, Asset = Equity, Error = MintTransferError>;
 
 /// Type-erased equity transfer (market-making -> hedging).
 type EquityToHedging = dyn CrossVenueTransfer<MarketMakingVenue, HedgingVenue, Asset = Equity, Error = RedemptionError>;
@@ -130,8 +129,18 @@ impl Rebalancer {
             .transfer(Equity { symbol, quantity })
             .await
         {
-            error!(target: "rebalance", ?error, symbol = %log_symbol, %quantity, "Equity transfer to market-making venue failed");
-            self.clear_equity_in_progress(&log_symbol);
+            match &error {
+                MintTransferError::PreReceipt(_) => {
+                    error!(target: "rebalance", ?error, symbol = %log_symbol, %quantity,
+                        "Mint failed before tokens received; clearing guard for retry");
+                    self.clear_equity_in_progress(&log_symbol);
+                }
+
+                MintTransferError::PostReceipt(_) => {
+                    error!(target: "rebalance", ?error, symbol = %log_symbol, %quantity,
+                        "Mint failed after tokens received; keeping guard set for recovery");
+                }
+            }
         }
     }
 
@@ -305,5 +314,122 @@ mod tests {
     #[tokio::test]
     async fn run_terminates_when_channel_closes() {
         execute(vec![]).await;
+    }
+
+    /// Mint transfer that always returns the configured error.
+    struct FailingMintTransfer {
+        error: std::sync::Mutex<Option<MintTransferError>>,
+    }
+
+    #[async_trait::async_trait]
+    impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for FailingMintTransfer {
+        type Asset = Equity;
+        type Error = MintTransferError;
+
+        async fn transfer(&self, _asset: Self::Asset) -> Result<(), Self::Error> {
+            Err(self.error.lock().unwrap().take().unwrap())
+        }
+    }
+
+    fn make_pre_receipt_error() -> MintTransferError {
+        use crate::rebalancing::equity::MintError;
+        use crate::tokenized_equity_mint::IssuerRequestId;
+
+        MintTransferError::PreReceipt(MintError::EntityNotFound {
+            issuer_request_id: IssuerRequestId::new("test-pre".to_string()),
+            expected_state: "test",
+        })
+    }
+
+    fn make_post_receipt_error() -> MintTransferError {
+        use crate::rebalancing::equity::MintError;
+        use crate::tokenized_equity_mint::IssuerRequestId;
+
+        MintTransferError::PostReceipt(MintError::EntityNotFound {
+            issuer_request_id: IssuerRequestId::new("test-post".to_string()),
+            expected_state: "test",
+        })
+    }
+
+    #[tokio::test]
+    async fn pre_receipt_mint_failure_clears_guard() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let equity_in_progress = Arc::new(std::sync::RwLock::new(HashSet::from([symbol.clone()])));
+        let usdc_in_progress = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = mpsc::channel(10);
+
+        let failing_mint = Arc::new(FailingMintTransfer {
+            error: std::sync::Mutex::new(Some(make_pre_receipt_error())),
+        });
+        let equity = Arc::new(MockCrossVenueEquityTransfer::new());
+        let usdc = Arc::new(MockUsdcRebalance::new());
+
+        let rebalancer = Rebalancer::new(
+            failing_mint,
+            Arc::clone(&equity) as Arc<EquityToHedging>,
+            Arc::clone(&usdc) as Arc<UsdcToMarketMaking>,
+            Arc::clone(&usdc) as Arc<UsdcToHedging>,
+            receiver,
+            Arc::clone(&equity_in_progress),
+            usdc_in_progress,
+            CancellationToken::new(),
+        );
+
+        sender
+            .send(TriggeredOperation::Mint {
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(float!(10)),
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        rebalancer.run().await;
+
+        assert!(
+            !equity_in_progress.read().unwrap().contains(&symbol),
+            "guard should be cleared after pre-receipt failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_receipt_mint_failure_keeps_guard() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let equity_in_progress = Arc::new(std::sync::RwLock::new(HashSet::from([symbol.clone()])));
+        let usdc_in_progress = Arc::new(AtomicBool::new(false));
+        let (sender, receiver) = mpsc::channel(10);
+
+        let failing_mint = Arc::new(FailingMintTransfer {
+            error: std::sync::Mutex::new(Some(make_post_receipt_error())),
+        });
+        let equity = Arc::new(MockCrossVenueEquityTransfer::new());
+        let usdc = Arc::new(MockUsdcRebalance::new());
+
+        let rebalancer = Rebalancer::new(
+            failing_mint,
+            Arc::clone(&equity) as Arc<EquityToHedging>,
+            Arc::clone(&usdc) as Arc<UsdcToMarketMaking>,
+            Arc::clone(&usdc) as Arc<UsdcToHedging>,
+            receiver,
+            Arc::clone(&equity_in_progress),
+            usdc_in_progress,
+            CancellationToken::new(),
+        );
+
+        sender
+            .send(TriggeredOperation::Mint {
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(float!(10)),
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        rebalancer.run().await;
+
+        assert!(
+            equity_in_progress.read().unwrap().contains(&symbol),
+            "guard should remain set after post-receipt failure"
+        );
     }
 }


### PR DESCRIPTION
## What

Closes RAI-561, RAI-563.

Fixes the rebalancer unconditionally clearing the `equity_in_progress` guard on mint transfer failure, which allowed duplicate mints to pile up when failures occurred after tokens were already received from Alpaca. Adds early detection of dropped transactions to avoid 300s receipt timeouts. Adds runtime API endpoints to resume stuck transfers without restarting the bot.

## Why

Observed in prod (May 13): ~49 tCOIN minted across 6 attempts, none wrapped. When `transfer()` failed at the wrap/deposit stage (after Alpaca had already delivered tokens), the guard was cleared, the trigger immediately fired another mint, and the cycle repeated — each iteration minting real tokens that accumulated unwrapped in the wallet.

Compounding this, timed-out wrap/deposit transactions that were dropped from the mempool (stale nonces) blocked each attempt for 300s before failing, when they could have been detected as dropped in ~6s.

Recovery from stuck transfers previously required a full bot restart.

## How

**Part 1 — Conditional guard clearing (RAI-561):**
- Introduced `MintTransferError` enum with `PreReceipt(MintError)` / `PostReceipt(MintError)` variants in `src/rebalancing/equity/mod.rs`.
- Updated the `CrossVenueTransfer<HedgingVenue, MarketMakingVenue>` impl to wrap errors based on pipeline stage: `RequestMint`/`Poll` → `PreReceipt`, `load_tokens_received`/`finalize_received_mint` → `PostReceipt`.
- `Rebalancer::execute_mint` now clears the guard only on `PreReceipt` (safe to retry). On `PostReceipt`, the guard stays set — startup recovery (`resume_mint`) handles it.

**Part 2 — Dropped transaction detection (RAI-563):**
- Added `EvmError::TransactionDropped` variant in `crates/evm/src/lib.rs`.
- In `wait_for_receipt_with_config`, after 3 polls (~6s), checks `eth_getTransactionByHash`. If the tx doesn't exist, fails immediately with `TransactionDropped` instead of waiting the full 300s `ReceiptTimeout`.

**Part 3 — Recovery API endpoints:**
- Added `GET /transfers/interrupted` — lists all stuck mints and redemptions.
- Added `POST /transfers/resume` — resumes all interrupted transfers at runtime (same logic as startup recovery).
- `RecoveryHandle` is shared between the Rocket server and conductor via `Arc<OnceCell<RecoveryHandle>>`, set after the conductor completes startup. Returns 503 if conductor hasn't finished initializing.

**Bonus:**
- Fixed pre-existing clippy `significant-drop-tightening` lint in `crates/evm/src/nonce.rs`.

## Testing

- 2 new tests in `rebalancer.rs`: `pre_receipt_mint_failure_clears_guard` and `post_receipt_mint_failure_keeps_guard` — verify guard behavior for both error variants using an inline `FailingMintTransfer` mock.
- Updated existing `wait_for_receipt_times_out_for_unknown_tx` test → `wait_for_receipt_detects_dropped_tx` to verify the new `TransactionDropped` behavior.
- Updated 6 existing mint transfer error assertion tests to match on `MintTransferError::PostReceipt(MintError::*)` instead of bare `MintError::*`.
- Updated `test_num_of_routes` to account for 2 new API routes.

## Screenshots

N/A

## Anything else

- The timeout handler in `trigger/mod.rs` also clears the guard unconditionally for post-receipt timeouts, but it explicitly transitions the aggregate to `Failed` first, making the state consistent. This is a separate concern and not addressed here.
- The `POST /transfers/resume` endpoint does not restore the trigger's tracking state (e.g., `recover_mint_state`), only resumes the transfer pipeline. Full state recovery still requires a restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect when a previously-propagated transaction becomes unretrievable and report it as a dropped transaction.
  * HTTP endpoints to list interrupted transfers and to resume them at runtime, with concurrency and availability controls and resumation result reporting.

* **Improvements**
  * Split mint-transfer errors into pre-receipt vs post-receipt categories.
  * Rebalancer now preserves or clears in-progress guards based on failure timing.

* **Tests**
  * Added/updated tests covering dropped transactions, recovery endpoints, and pre/post-receipt behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/669)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->