### PR TITLE
fix: nonce gap from RPC-rejected transactions, idempotent resume_mint (RAI-573, RAI-574)

### DIFF
--- a/crates/evm/src/local.rs
+++ b/crates/evm/src/local.rs
@@ -155,6 +155,9 @@ where
                 let error = EvmError::from(error);
 
                 if !error.is_nonce_too_low() {
+                    warn!(target: "wallet", %contract, note, "Transaction rejected \
+                        by RPC -- invalidating nonce cache to prevent nonce gap");
+                    self.nonce_manager.invalidate();
                     return Err(error);
                 }
 
@@ -165,8 +168,12 @@ where
                 self.signing_provider
                     .send_transaction(tx)
                     .await
-                    .inspect_err(|error| {
-                        error!(target: "wallet", %error, "Nonce-too-low retry also failed");
+                    .map_err(|error| {
+                        let error = EvmError::from(error);
+                        error!(target: "wallet", %error, "Nonce-too-low retry also failed \
+                            -- invalidating nonce cache");
+                        self.nonce_manager.invalidate();
+                        error
                     })?
             }
         };
@@ -366,6 +373,51 @@ mod tests {
             receipt_a.transaction_hash, receipt_b.transaction_hash,
             "transactions must have different hashes (distinct nonces)"
         );
+    }
+
+    /// Verifies that the nonce cache is invalidated when a transaction
+    /// is rejected by the RPC for a reason other than nonce-too-low.
+    ///
+    /// Without invalidation, the nonce manager would hold a stale
+    /// cached nonce (incremented but never consumed on-chain), causing
+    /// all subsequent transactions to use a future nonce and stall.
+    #[tokio::test]
+    async fn nonce_cache_invalidated_on_rpc_rejection() {
+        let (_anvil, wallet, token_address, _signer) = setup_anvil_with_token().await;
+
+        let recipient = Address::random();
+        let excessive_amount = U256::from(999_999_999) * U256::from(10).pow(U256::from(18));
+
+        // First call: reverts at RPC simulation (insufficient balance).
+        // This should invalidate the nonce cache.
+        let _error = wallet
+            .submit::<NoOpErrorRegistry, _>(
+                token_address,
+                IERC20::transferCall {
+                    to: recipient,
+                    amount: excessive_amount,
+                },
+                "should revert",
+            )
+            .await
+            .unwrap_err();
+
+        // Second call: valid transfer. If the nonce cache was not
+        // invalidated, this would use a stale nonce (N+1 instead of N)
+        // and either hang or fail.
+        let receipt = wallet
+            .submit::<NoOpErrorRegistry, _>(
+                token_address,
+                IERC20::transferCall {
+                    to: recipient,
+                    amount: U256::from(1000),
+                },
+                "should succeed after revert",
+            )
+            .await
+            .expect("transaction after revert should succeed (nonce cache was invalidated)");
+
+        assert!(receipt.status(), "valid transfer should succeed");
     }
 
     #[tokio::test]

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -264,6 +264,9 @@ where
                 let error = EvmError::from(error);
 
                 if !error.is_nonce_too_low() {
+                    warn!(target: "wallet", %contract, note, %error, "Transaction \
+                        send failed -- invalidating nonce cache to prevent nonce gap");
+                    self.nonce_manager.invalidate();
                     return Err(error);
                 }
 
@@ -274,8 +277,12 @@ where
                 self.signing_provider
                     .send_transaction(tx)
                     .await
-                    .inspect_err(|error| {
-                        error!(target: "wallet", %error, "Nonce-too-low retry also failed");
+                    .map_err(|error| {
+                        let error = EvmError::from(error);
+                        error!(target: "wallet", %error, "Nonce-too-low retry also failed \
+                            -- invalidating nonce cache");
+                        self.nonce_manager.invalidate();
+                        error
                     })?
             }
         };

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -1,19 +1,32 @@
 //! Mock implementations for onchain services.
 
 use alloy::primitives::{Address, B256, TxHash, U256};
+use alloy::transports::RpcError;
 use async_trait::async_trait;
 use std::sync::Mutex;
 
+use st0x_evm::EvmError;
 use st0x_execution::Symbol;
 
 use super::raindex::{Raindex, RaindexError, RaindexVaultId};
+
+/// Whether `submit_deposit` should succeed, fail generically, or fail
+/// with an "execution reverted" RPC error (simulating a revert during
+/// gas estimation).
+#[derive(Default)]
+enum DepositBehavior {
+    #[default]
+    Succeed,
+    FailGeneric,
+    FailExecutionReverted,
+}
 
 pub(crate) struct MockRaindex {
     vault_id: RaindexVaultId,
     token: Address,
     withdraw_tx: TxHash,
     deposit_tx: TxHash,
-    deposit_fails: bool,
+    deposit_behavior: DepositBehavior,
     deposited_token: Mutex<Option<Address>>,
 }
 
@@ -24,7 +37,7 @@ impl MockRaindex {
             token: Address::ZERO,
             withdraw_tx: TxHash::random(),
             deposit_tx: TxHash::random(),
-            deposit_fails: false,
+            deposit_behavior: DepositBehavior::Succeed,
             deposited_token: Mutex::new(None),
         }
     }
@@ -35,7 +48,22 @@ impl MockRaindex {
             token: Address::ZERO,
             withdraw_tx: TxHash::random(),
             deposit_tx: TxHash::random(),
-            deposit_fails: true,
+            deposit_behavior: DepositBehavior::FailGeneric,
+            deposited_token: Mutex::new(None),
+        }
+    }
+
+    /// Creates a mock that fails `submit_deposit` with an "execution
+    /// reverted" RPC error, simulating a revert during gas estimation
+    /// (e.g., `ERC20InsufficientBalance` when tokens are already in
+    /// the vault from a previous session).
+    pub(crate) fn reverting_deposit() -> Self {
+        Self {
+            vault_id: RaindexVaultId(B256::ZERO),
+            token: Address::ZERO,
+            withdraw_tx: TxHash::random(),
+            deposit_tx: TxHash::random(),
+            deposit_behavior: DepositBehavior::FailExecutionReverted,
             deposited_token: Mutex::new(None),
         }
     }
@@ -81,11 +109,34 @@ impl Raindex for MockRaindex {
         _amount: U256,
         _decimals: u8,
     ) -> Result<TxHash, RaindexError> {
-        if self.deposit_fails {
-            return Err(RaindexError::ZeroAmount);
+        match self.deposit_behavior {
+            DepositBehavior::Succeed => {
+                *self.deposited_token.lock().unwrap() = Some(token);
+                Ok(self.deposit_tx)
+            }
+            DepositBehavior::FailGeneric => Err(RaindexError::ZeroAmount),
+            DepositBehavior::FailExecutionReverted => {
+                // Full ABI-encoded ERC20InsufficientBalance(address,uint256,uint256):
+                // 4-byte selector + 3 x 32-byte zero-padded arguments, matching
+                // what a real RPC node returns on revert.
+                let revert_data = serde_json::value::RawValue::from_string(
+                    "\"0xe450d38c\
+                     0000000000000000000000000000000000000000000000000000000000000000\
+                     0000000000000000000000000000000000000000000000000000000000000000\
+                     0000000000000000000000000000000000000000000000000000000000000000\""
+                        .to_string(),
+                )
+                .expect("valid JSON string");
+
+                Err(RaindexError::Evm(EvmError::Transport(RpcError::ErrorResp(
+                    alloy::rpc::json_rpc::ErrorPayload {
+                        code: 3,
+                        message: "execution reverted".into(),
+                        data: Some(revert_data),
+                    },
+                ))))
+            }
         }
-        *self.deposited_token.lock().unwrap() = Some(token);
-        Ok(self.deposit_tx)
     }
 
     async fn submit_withdraw(

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -20,6 +20,7 @@ use tracing::{debug, info, instrument, warn};
 use uuid::Uuid;
 
 use st0x_event_sorcery::{SendError, Store};
+use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesBlockchain, SharesConversionError, Symbol};
 
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
@@ -286,6 +287,36 @@ pub(crate) enum MintError {
     },
 }
 
+/// Selector for `ERC20InsufficientBalance(address,uint256,uint256)`.
+const ERC20_INSUFFICIENT_BALANCE_SELECTOR: &str = "0xe450d38c";
+
+impl MintError {
+    /// Returns `true` if the underlying error is an RPC-level
+    /// `ERC20InsufficientBalance` revert, indicating the wallet has
+    /// zero tokens because they were already deposited in a previous
+    /// session.
+    ///
+    /// Matches both `Raindex` and `Wrapper` variants: currently only
+    /// `Raindex` is reachable from `try_deposit_or_recover`, but the
+    /// broader match keeps this predicate correct for any `MintError`
+    /// regardless of call site.
+    fn is_insufficient_balance_revert(&self) -> bool {
+        let (Self::Raindex(RaindexError::Evm(EvmError::Transport(rpc_error)))
+        | Self::Wrapper(WrapperError::Evm(EvmError::Transport(rpc_error)))) = self
+        else {
+            return false;
+        };
+
+        rpc_error.as_error_resp().is_some_and(|payload| {
+            payload.data.as_ref().is_some_and(|data| {
+                data.get()
+                    .trim_matches('"')
+                    .starts_with(ERC20_INSUFFICIENT_BALANCE_SELECTOR)
+            })
+        })
+    }
+}
+
 impl From<SendError<TokenizedEquityMint>> for MintError {
     fn from(error: SendError<TokenizedEquityMint>) -> Self {
         Self::Aggregate(Box::new(error))
@@ -478,6 +509,63 @@ impl CrossVenueEquityTransfer {
         Ok(())
     }
 
+    /// Attempts vault deposit; if it reverts with `ERC20InsufficientBalance`,
+    /// the deposit already landed in a previous session -- advance the
+    /// aggregate to terminal state. Used by both the `TokensWrapped` and
+    /// `WrapSubmitted` resume paths.
+    ///
+    /// # Invariant: tokens only leave the wallet via vault deposit
+    ///
+    /// This recovery assumes that the *only* way wrapped tokens leave the
+    /// wallet is through a successful Raindex vault deposit. Under this
+    /// invariant, a zero balance at retry time proves the deposit landed
+    /// in a prior session that crashed before persisting the CQRS event.
+    ///
+    /// If this invariant is violated (e.g. manual token transfer, bug in
+    /// another code path), the recovery would incorrectly mark the mint
+    /// complete while tokens are lost. The invariant holds today because
+    /// the wrap -> deposit lifecycle is the sole consumer of these tokens
+    /// and runs atomically within a single task.
+    async fn try_deposit_or_recover(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        wrapped_token: Address,
+        wrapped_shares: U256,
+    ) -> Result<(), MintError> {
+        match self
+            .deposit_wrapped_mint(issuer_request_id, symbol, wrapped_token, wrapped_shares)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(error) if error.is_insufficient_balance_revert() => {
+                warn!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    %symbol,
+                    ?error,
+                    "Vault deposit reverted on resume -- deposit likely \
+                    already landed in a previous session; closing operation"
+                );
+
+                // TxHash::ZERO signals that the real deposit TX hash is
+                // unknown -- the deposit succeeded in a previous session
+                // that crashed before persisting the CQRS event.
+                self.mint_store
+                    .send(
+                        issuer_request_id,
+                        TokenizedEquityMintCommand::DepositToVault {
+                            vault_deposit_tx_hash: TxHash::ZERO,
+                        },
+                    )
+                    .await?;
+
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     async fn verify_received_mint(
         &self,
         tokens_received: &TokensReceivedData,
@@ -588,7 +676,7 @@ impl CrossVenueEquityTransfer {
 
                     info!(target: "rebalance", %wrap_tx_hash, %wrapped_shares, "Wrap confirmed on resume, depositing to Raindex vault");
                     return self
-                        .deposit_wrapped_mint(
+                        .try_deposit_or_recover(
                             issuer_request_id,
                             &symbol,
                             wrapped_token,
@@ -603,8 +691,9 @@ impl CrossVenueEquityTransfer {
                 } => {
                     info!(%issuer_request_id, "Resuming wrapped mint");
                     let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
+
                     return self
-                        .deposit_wrapped_mint(
+                        .try_deposit_or_recover(
                             issuer_request_id,
                             &symbol,
                             wrapped_token,
@@ -1611,6 +1700,169 @@ mod tests {
                 ))
             ),
             "Expected Verification(InsufficientTransferAmount) error, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_recovers_when_deposit_reverts() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::reverting_deposit()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = IssuerRequestId::new("ISS-REVERT-RECOVERY");
+
+        // Advance the aggregate to TokensWrapped state manually:
+        // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted
+        // -> TokensWrapped
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Poll advances to TokensReceived
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        let wrap_tx = TxHash::random();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let wrapped_shares = U256::from(10_000_000_000_000_000_000u128);
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: wrap_tx,
+                    wrapped_shares,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Verify we're in TokensWrapped state
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensWrapped { .. }),
+            "Expected TokensWrapped, got: {entity:?}"
+        );
+
+        // Resume should detect zero balance and advance to terminal
+        transfer.resume_mint(&id).await.unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::DepositedIntoRaindex {
+            vault_deposit_tx_hash,
+            ..
+        } = entity
+        else {
+            panic!("Expected DepositedIntoRaindex after revert recovery, got: {entity:?}");
+        };
+        assert_eq!(
+            vault_deposit_tx_hash,
+            TxHash::ZERO,
+            "Recovered deposit must use TxHash::ZERO sentinel"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_from_wrap_submitted_recovers_when_deposit_reverts() {
+        let mock_wrapper = MockWrapper::new();
+        let wrap_tx = TxHash::random();
+
+        // Pre-seed the mock so confirm_wrap recognises the tx hash that the
+        // aggregate will store in WrapSubmitted state.
+        mock_wrapper.seed_submitted_amount(wrap_tx, U256::from(10_000_000_000_000_000_000u128));
+
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::reverting_deposit()),
+            Arc::new(mock_wrapper),
+        )
+        .await;
+
+        let id = IssuerRequestId::new("ISS-WRAP-SUBMITTED-RECOVERY");
+
+        // Advance aggregate to WrapSubmitted state:
+        // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::WrapSubmitted { .. }),
+            "Expected WrapSubmitted, got: {entity:?}"
+        );
+
+        // Resume from WrapSubmitted: confirms wrap, then deposit reverts,
+        // recovery should advance to terminal state.
+        transfer.resume_mint(&id).await.unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        let TokenizedEquityMint::DepositedIntoRaindex {
+            vault_deposit_tx_hash,
+            ..
+        } = entity
+        else {
+            panic!(
+                "Expected DepositedIntoRaindex after WrapSubmitted revert recovery, got: {entity:?}"
+            );
+        };
+        assert_eq!(
+            vault_deposit_tx_hash,
+            TxHash::ZERO,
+            "Recovered deposit must use TxHash::ZERO sentinel"
         );
     }
 }

--- a/src/wrapper/mock.rs
+++ b/src/wrapper/mock.rs
@@ -99,6 +99,16 @@ impl MockWrapper {
         mock.failure = MockFailure::DerivativeLookup;
         mock
     }
+
+    /// Pre-seeds a tx hash into `submitted_amounts` so that `confirm_wrap`
+    /// recognises it. Used by tests that manually advance the aggregate to
+    /// `WrapSubmitted` without going through `submit_wrap`.
+    pub(crate) fn seed_submitted_amount(&self, tx_hash: TxHash, amount: U256) {
+        self.submitted_amounts
+            .lock()
+            .unwrap()
+            .insert(tx_hash, amount);
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## What

Closes RAI-573, RAI-574.

Fixes two bugs that together caused all onchain operations to permanently stall after a single RPC-rejected transaction.

## Why

Observed in prod (May 14): the startup recovery for an MSTR mint tried `deposit4` on tokens that were already in the vault (from a previous session's TX that landed but wasn't recorded in CQRS). The RPC rejected the TX with `execution reverted: ERC20InsufficientBalance`. This consumed a nonce in the cache without submitting to the chain, creating a nonce gap. Every subsequent TX used a future nonce — accepted by the RPC but never mined — blocking all onchain operations for the rest of the session.

## How

**Part 1 — Invalidate nonce cache on RPC rejection (RAI-573):**

In `TurnkeyWallet::send_pending` and `RawPrivateKeyWallet::send_pending`, when `send_transaction` fails with any error other than "nonce too low", call `nonce_manager.invalidate()` before returning the error. This ensures the next transaction re-fetches the nonce from the chain, preventing a nonce gap.

Previously, only "nonce too low" errors triggered invalidation. All other RPC rejections (simulation reverts, gas estimation failures) silently consumed a nonce in the cache. This fix prevents the nonce gap regardless of the revert reason.

**Part 2 — Handle already-completed deposits on resume (RAI-574):**

When `resume_mint` retries `deposit_wrapped_mint` from `TokensWrapped` state and the deposit reverts with `ERC20InsufficientBalance` (selector `0xe450d38c`), this specifically means the wallet has zero wrapped tokens — they were already deposited in a previous session. The aggregate is advanced to terminal state (`DepositToVault` with `TxHash::ZERO`).

Only `ERC20InsufficientBalance` triggers this recovery. Other reverts (paused vault, orderbook validation, etc.) propagate normally — the nonce cache invalidation from Part 1 prevents the nonce gap, and the next restart retries recovery.

## Testing

- `resume_mint_recovers_when_deposit_reverts` — configures `MockRaindex::reverting_deposit()` to return an `ERC20InsufficientBalance` revert on `submit_deposit`. Verifies that resume from `TokensWrapped` catches the revert and advances to `DepositedIntoRaindex`.
- `MockRaindex` extended with `reverting_deposit()` constructor and `DepositBehavior` enum.
- `MintError::is_insufficient_balance_revert()` helper matches the specific `0xe450d38c` selector in the RPC error payload data.
- Existing `resume_mint_from_accepted_completes_workflow` still passes.

## Screenshots

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always invalidate nonce cache and log when RPC transaction submissions are rejected (improves wallet reliability and retry behavior).
  * Improve error logging for retry failures to aid diagnostics.
  * Detect ERC20 insufficient-balance reverts during deposit flows and automatically advance/resume deposit state to recover from interrupted deposits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/670)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->