### PR TITLE
fix: chown log directory during deploy activation

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -43,6 +43,7 @@ let
         # the activation script exits non-zero and deploy-rs rolls back.
         "${cfg.profilePath}/bin/validate-config --config ${cfg.configPath} --secrets ${cfg.decryptedSecretPath}"
         "(chown st0x:st0x /mnt/data/*.db /mnt/data/*.db-wal /mnt/data/*.db-shm /mnt/data/*.db-journal 2>/dev/null || true)"
+        "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
         "echo '${gitRev}' > /run/st0x/${name}.git-rev"
         "touch ${cfg.markerFile}"
         "systemctl restart ${name}"


### PR DESCRIPTION
Fixes RAI-582

## What

Fix the deploy activation script to chown the log directory to `st0x:st0x`, preventing the bot from crash-looping on startup due to a root-owned log file.

## Why

The deploy-rs activation script runs as root. If the log file for the current day is created (or already exists as root-owned) before the `st0x-hedge` service starts, the service panics immediately because the `tracing-appender` rolling file writer cannot open the file. This was observed in production on 2026-05-15 where `st0x-hedge.log.2026-05-15` was owned by `root:root`, causing a crash loop until manually fixed.

## How

Add a `chown -R st0x:st0x /mnt/data/logs` step in the deploy activation sequence in `deploy.nix`, right after the existing `chown` for database files. This ensures all log files have the correct ownership before the service restarts.

## Testing

No new tests — this is a one-line Nix infrastructure change. Verified by inspecting the activation sequence in `deploy.nix` and confirming the existing pattern for database file ownership.

## Anything else

The root cause of *why* the log file gets created as root during activation is still unclear — `validate-config` doesn't initialize tracing. Could be a previous manual intervention or a subtle interaction during the deploy. This fix is defensive: regardless of how the file gets created, the chown ensures correct ownership before the service starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment activation updated to ensure log storage ownership is fixed recursively during service activation (best-effort, errors suppressed); this runs after configuration/secret validation and before service restart.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->