### PR TITLE
deploy: add datasette + generalize service registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ GitHub Actions (CI/CD)
   | deploy-rs over SSH
   v
 NixOS host (DigitalOcean droplet)
-  ├── server           (systemd, hedging bot)
-  ├── reporter         (systemd, P&L reporter)
+  ├── st0x-hedge       (systemd, hedging bot)
+  ├── datasette        (systemd, SQLite database explorer)
   ├── nginx            (dashboard + WebSocket proxy)
   └── grafana          (metrics visualization)
 ```
@@ -163,8 +163,8 @@ nix run .#deployAll
 nix run .#deployNixos
 
 # Deploy a specific service profile
-nix run .#deployService server
-nix run .#deployService reporter
+nix run .#deployService st0x-hedge
+nix run .#deployService datasette
 ```
 
 ### SSH Access
@@ -187,13 +187,13 @@ rollback` is **not compatible** — you must use `nix-env`.
 SSH into the host and run:
 
 ```bash
-# Roll back the server profile to previous deployment
-nix-env --profile /nix/var/nix/profiles/per-service/server --rollback
-systemctl restart server
+# Roll back the bot profile to previous deployment
+nix-env --profile /nix/var/nix/profiles/per-service/st0x-hedge --rollback
+systemctl restart st0x-hedge
 
-# Roll back the reporter profile
-nix-env --profile /nix/var/nix/profiles/per-service/reporter --rollback
-systemctl restart reporter
+# Roll back the Datasette profile
+nix-env --profile /nix/var/nix/profiles/per-service/datasette --rollback
+systemctl restart datasette
 ```
 
 ### Secrets Management
@@ -361,14 +361,14 @@ Pass `-i <path>` to use a different key.
 **Deployment** (requires SSH key for host access and terraform state
 decryption):
 
-| Command         | Usage                               | Notes                                          |
-| --------------- | ----------------------------------- | ---------------------------------------------- |
-| `deployAll`     | `nix run .#deployAll`               | Deploy system config + all services            |
-| `deployNixos`   | `nix run .#deployNixos`             | Deploy NixOS system config only                |
-| `deployService` | `nix run .#deployService <profile>` | Deploy a single service (`server`, `reporter`) |
-| `remote`        | `nix run .#remote [-- <cmd>]`       | SSH into production host                       |
-| `secret`        | `nix run .#secret <file.age>`       | Edit an encrypted config, then re-encrypt all  |
-| `bootstrap`     | `nix run .#bootstrap`               | One-time NixOS install on a new host           |
+| Command         | Usage                               | Notes                                               |
+| --------------- | ----------------------------------- | --------------------------------------------------- |
+| `deployAll`     | `nix run .#deployAll`               | Deploy system config + all services                 |
+| `deployNixos`   | `nix run .#deployNixos`             | Deploy NixOS system config only                     |
+| `deployService` | `nix run .#deployService <profile>` | Deploy a single service (`st0x-hedge`, `datasette`) |
+| `remote`        | `nix run .#remote [-- <cmd>]`       | SSH into production host                            |
+| `secret`        | `nix run .#secret <file.age>`       | Edit an encrypted config, then re-encrypt all       |
+| `bootstrap`     | `nix run .#bootstrap`               | One-time NixOS install on a new host                |
 
 **Infrastructure** (requires SSH key for terraform state decryption):
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -357,18 +357,36 @@ _System configuration_ (deploy-rs `activate.nixos`):
 
 _Per-service profiles_ (deploy-rs `activate.custom`, deployed independently):
 
-- `server` - hedging bot binary
+The set of deployed profiles is declared as a registry in `services.nix`. Each
+entry has a `kind` discriminating how it is activated and whether it has a
+systemd unit:
+
+- `st0x-hedge` (kind = `st0x`) - hedging bot binary. Full pipeline: decrypts
+  agenix secret, installs plaintext config, runs `validate-config`, chowns data
+  files, writes git-rev marker, touches readiness marker, restarts unit.
+- `dashboard` (kind = `static`) - frontend assets served by nginx; the deploy
+  step is `systemctl reload nginx` and there is no managed systemd unit.
+- `datasette` (kind = `plain`) - read-only SQLite explorer over the hedge DB.
+  Has a systemd unit but no secrets/config; activation just touches the
+  readiness marker and restarts. Bound to `127.0.0.1`; access via SSH tunnel.
+
+Activation order within `profilesOrder` is set explicitly by each entry's
+`order` field, so adding a new service forces declaring its slot rather than
+inheriting an alphabetical attribute order.
 
 Each profile is independently deployable and rollback-able without affecting
-other profiles. The dashboard is served as static files by nginx (part of the
-system configuration).
+others. Units use a `/run/st0x/<name>.ready` marker file gated by
+`ConditionPathExists` so they only start after the per-service profile has
+finished activation, never on a bare `nixos-rebuild switch`.
 
 _Configuration management_:
 
-- Plaintext config per service (`config/*.toml`) baked into Nix closure
-- Encrypted secrets per service (`secret/*.toml.age`) decrypted at activation to
-  `/run/agenix/`
-- Server uses `--config` + `--secrets` flags
+- Plaintext config per `st0x`-kind service (`config/*.toml`) baked into Nix
+  closure
+- Encrypted secrets per `st0x`-kind service (`secret/*.toml.age`) decrypted at
+  activation to `/run/agenix/`
+- `st0x`-kind binaries use `--config` + `--secrets` flags; `plain`-kind units
+  invoke their package binary with declared `args`
 
 _Infrastructure_:
 

--- a/deploy.nix
+++ b/deploy.nix
@@ -9,9 +9,6 @@ let
   inherit (deploy-rs.lib.${system}) activate;
   profileBase = "/nix/var/nix/profiles/per-service";
 
-  st0xPackage = self.packages.${system}.st0x-liquidity;
-  dashboardPackage = self.packages.${system}.st0x-dashboard;
-
   gitRev = self.rev or self.dirtyRev or "unknown";
 
   rage = "/run/current-system/sw/bin/rage";
@@ -23,32 +20,71 @@ let
       builtins.filter (n: !services.${n}.enabled) (builtins.attrNames services)
     )
   );
+  # Explicit ordering: sort enabledServices by each service's declared `order`
+  # field so adding a new entry forces choosing its slot rather than inheriting
+  # the alphabetical attribute order. Duplicate orders would produce a
+  # non-deterministic activation sequence, so assert uniqueness here.
+  enabledOrders = map (n: services.${n}.order) enabledServices;
+  uniqueOrders = builtins.foldl' (
+    acc: o: if builtins.elem o acc then acc else acc ++ [ o ]
+  ) [ ] enabledOrders;
+  orderedServices =
+    if (builtins.length enabledOrders) == (builtins.length uniqueOrders) then
+      builtins.sort (a: b: services.${a}.order < services.${b}.order) enabledServices
+    else
+      throw "services.nix: duplicate `order` values among enabled services: ${builtins.toJSON enabledOrders}";
 
-  # Links latest config, decrypts secrets, and restarts service atomically
+  # Builds the per-service activation command. Branches by service kind so we
+  # don't special-case each new service in this file -- new services land in
+  # services.nix and inherit the correct pipeline.
   mkServiceProfile =
     env: name:
     let
       cfg = services.${name};
-      configFile = ./config/${env}/${name}.toml;
-      secretsFile = ./secret/${cfg.encryptedSecret};
+      pkg = self.packages.${system}.${cfg.package};
     in
-    activate.custom st0xPackage (
-      builtins.concatStringsSep " && " [
-        "systemctl stop ${name} || true"
-        "rm -f ${cfg.markerFile}"
-        "mkdir -p /run/st0x"
-        "install -D -m 0640 -o root -g st0x ${configFile} ${cfg.configPath}"
-        "${rage} -d -i ${hostKey} ${secretsFile} | install -D -m 0640 -o root -g st0x /dev/stdin ${cfg.decryptedSecretPath}"
-        # Validate config + secrets before restarting. If validation fails,
-        # the activation script exits non-zero and deploy-rs rolls back.
-        "${cfg.profilePath}/bin/validate-config --config ${cfg.configPath} --secrets ${cfg.decryptedSecretPath}"
-        "(chown st0x:st0x /mnt/data/*.db /mnt/data/*.db-wal /mnt/data/*.db-shm /mnt/data/*.db-journal 2>/dev/null || true)"
-        "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
-        "echo '${gitRev}' > /run/st0x/${name}.git-rev"
-        "touch ${cfg.markerFile}"
-        "systemctl restart ${name}"
-      ]
-    );
+    if cfg.kind == "st0x" then
+      let
+        configFile = ./config/${env}/${name}.toml;
+        secretsFile = ./secret/${cfg.encryptedSecret};
+      in
+      activate.custom pkg (
+        builtins.concatStringsSep " && " [
+          "systemctl stop ${name} || true"
+          "rm -f ${cfg.markerFile}"
+          "mkdir -p /run/st0x"
+          "install -D -m 0640 -o root -g st0x ${configFile} ${cfg.configPath}"
+          "${rage} -d -i ${hostKey} ${secretsFile} | install -D -m 0640 -o root -g st0x /dev/stdin ${cfg.decryptedSecretPath}"
+          # Validate config + secrets before restarting. If validation fails,
+          # the activation script exits non-zero and deploy-rs rolls back.
+          "${cfg.profilePath}/bin/validate-config --config ${cfg.configPath} --secrets ${cfg.decryptedSecretPath}"
+          "(chown st0x:st0x /mnt/data/*.db /mnt/data/*.db-wal /mnt/data/*.db-shm /mnt/data/*.db-journal 2>/dev/null || true)"
+          "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
+          "echo '${gitRev}' > /run/st0x/${name}.git-rev"
+          "touch ${cfg.markerFile}"
+          "systemctl restart ${name}"
+        ]
+      )
+    else if cfg.kind == "plain" then
+      # Marker must exist BEFORE systemctl restart, because the unit's
+      # ConditionPathExists is evaluated when systemd processes the start
+      # request -- if the marker is absent, systemd silently skips the unit
+      # (returning exit 0 from `systemctl restart`) and the service never
+      # actually starts. Touch it first, then remove it on restart failure so
+      # a broken unit doesn't satisfy the condition on the next system
+      # activation.
+      activate.custom pkg (
+        builtins.concatStringsSep " && " [
+          "systemctl stop ${name} || true"
+          "mkdir -p /run/st0x"
+          "touch ${cfg.markerFile}"
+          "systemctl restart ${name} || { rm -f ${cfg.markerFile}; exit 1; }"
+        ]
+      )
+    else if cfg.kind == "static" then
+      activate.custom pkg cfg.activation
+    else
+      throw "services.${name}: unknown kind ${cfg.kind}";
 
   mkProfile = env: name: {
     path = mkServiceProfile env name;
@@ -62,25 +98,16 @@ let
       sshUser = "root";
       user = "root";
 
-      profilesOrder = [
-        "system"
-        "dashboard"
-      ]
-      ++ enabledServices;
+      profilesOrder = [ "system" ] ++ orderedServices;
 
       profiles = {
         system.path = activate.nixos nixosConfig;
-
-        dashboard = {
-          path = activate.custom dashboardPackage "systemctl reload nginx";
-          profilePath = "${profileBase}/dashboard";
-        };
       }
       // builtins.listToAttrs (
         map (name: {
           inherit name;
           value = mkProfile env name;
-        }) enabledServices
+        }) orderedServices
       );
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -214,6 +214,7 @@
             st0x-liquidity = st0xRust.package;
             st0x-cli = st0xRust.cli;
             decode-floats = st0xRust.decodeFloats;
+            inherit (pkgs) datasette;
 
             st0x-dashboard = pkgs.callPackage ./dashboard {
               bun2nix = bun2nix.packages.${system}.default;

--- a/os.nix
+++ b/os.nix
@@ -22,6 +22,8 @@ let
 
   services = import ./services.nix;
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
+  # Services with a systemd unit (everything except kind = "static").
+  unitServices = lib.filterAttrs (_: v: v.kind != "static") enabledServices;
 
   cli = pkgs.writeShellApplication {
     name = "stox";
@@ -34,40 +36,52 @@ let
     '';
   };
 
-  mkService = name: cfg: {
-    description = "st0x ${cfg.bin} (${name})";
+  mkService =
+    name: cfg:
+    let
+      execStartArgs =
+        if cfg.kind == "st0x" then
+          [
+            "--config"
+            cfg.configPath
+            "--secrets"
+            cfg.decryptedSecretPath
+          ]
+        else if cfg.kind == "plain" then
+          cfg.args
+        else
+          throw "services.${name}: kind '${cfg.kind}' has no systemd unit";
+    in
+    {
+      description = if cfg.kind == "st0x" then "st0x ${cfg.bin} (${name})" else cfg.description;
 
-    # Service is started by deploy.nix profile, not by systemd on boot.
-    # This avoids coordination issues during deployments.
-    wantedBy = [ ];
+      # Service is started by deploy.nix profile, not by systemd on boot.
+      # This avoids coordination issues during deployments.
+      wantedBy = [ ];
 
-    restartIfChanged = false;
-    stopIfChanged = false;
+      restartIfChanged = false;
+      stopIfChanged = false;
 
-    unitConfig = {
-      "X-OnlyManualStart" = true;
-      StartLimitBurst = 10;
-      StartLimitIntervalSec = 300;
+      unitConfig = {
+        "X-OnlyManualStart" = true;
+        StartLimitBurst = 10;
+        StartLimitIntervalSec = 300;
 
-      # Marker file created ONLY by service profile activation.
-      # Guarantees service is SKIPPED (not failed) during system activation.
-      ConditionPathExists = cfg.markerFile;
+        # Marker file created ONLY by service profile activation.
+        # Guarantees service is SKIPPED (not failed) during system activation.
+        ConditionPathExists = cfg.markerFile;
+      };
+
+      serviceConfig = {
+        User = "st0x";
+        Group = "st0x";
+        ExecStart = builtins.concatStringsSep " " (
+          [ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs
+        );
+        Restart = "always";
+        RestartSec = 30;
+      };
     };
-
-    serviceConfig = {
-      User = "st0x";
-      Group = "st0x";
-      ExecStart = builtins.concatStringsSep " " [
-        "${cfg.profilePath}/bin/${cfg.bin}"
-        "--config"
-        cfg.configPath
-        "--secrets"
-        cfg.decryptedSecretPath
-      ];
-      Restart = "always";
-      RestartSec = 30;
-    };
-  };
 
 in
 {
@@ -266,7 +280,7 @@ in
       "d ${certDir} 0750 nginx nginx -"
     ];
 
-    services = lib.recursiveUpdate (lib.mapAttrs mkService enabledServices) {
+    services = lib.recursiveUpdate (lib.mapAttrs mkService unitServices) {
       # Clean up stale TUN device before tailscaled starts. During NixOS
       # activation the old tailscaled may still hold /dev/net/tun when the
       # new unit starts, causing a crash-loop.
@@ -349,7 +363,7 @@ in
     # before it ever reaches the per-service profile that would install the
     # fix. Stop + reset-failed any managed service that is currently broken
     # so activation can complete; the service profile restarts it afterwards.
-    for svc in ${builtins.concatStringsSep " " (builtins.attrNames enabledServices)}; do
+    for svc in ${builtins.concatStringsSep " " (builtins.attrNames unitServices)}; do
       state=$(${pkgs.systemd}/bin/systemctl show -p ActiveState --value "$svc.service" 2>/dev/null || echo "")
       if [ "$state" = "failed" ] || [ "$state" = "activating" ]; then
         ${pkgs.systemd}/bin/systemctl stop "$svc.service" 2>/dev/null || true

--- a/secret/secrets.nix
+++ b/secret/secrets.nix
@@ -9,11 +9,16 @@ let
   # Service secrets are encrypted to both environments' service roles.
   # Each environment's deploy.nix decrypts with its own host key.
   # When staging needs different secrets, add staging-specific entries below.
+  # Only services with kind = "st0x" carry an encryptedSecret; "plain" and
+  # "static" kinds (e.g. datasette, dashboard) have no secrets to manage.
+  st0xServiceNames = builtins.filter (name: services.${name}.kind == "st0x") (
+    builtins.attrNames services
+  );
   serviceSecrets = builtins.listToAttrs (
     map (name: {
       name = services.${name}.encryptedSecret;
       value.publicKeys = allServiceKeys;
-    }) (builtins.attrNames services)
+    }) st0xServiceNames
   );
 
 in

--- a/services.nix
+++ b/services.nix
@@ -1,15 +1,67 @@
 let
   profileBase = "/nix/var/nix/profiles/per-service";
 
-  paths = name: {
+  baseFields = name: {
     profilePath = "${profileBase}/${name}";
+    markerFile = "/run/st0x/${name}.ready";
+  };
+
+  # st0x-kind services have an encrypted secrets file + plaintext config
+  # installed by deploy.nix before the unit restarts.
+  st0xFields = name: {
     encryptedSecret = "${name}.toml.age";
     configPath = "/run/st0x/${name}.config";
     decryptedSecretPath = "/run/agenix/${name}.toml";
-    markerFile = "/run/st0x/${name}.ready";
   };
+
+  withPaths =
+    name: attrs: attrs // baseFields name // (if attrs.kind == "st0x" then st0xFields name else { });
 in
-builtins.mapAttrs (name: attrs: attrs // paths name) {
-  st0x-hedge.enabled = true;
-  st0x-hedge.bin = "server";
+# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
+#                    chown data dirs, write git-rev, marker file, restart unit.
+# kind = "plain"   -- has a systemd unit, no secrets/config. Marker file gates
+#                    ConditionPathExists; deploy step just touches it and restarts.
+# kind = "static"  -- no systemd unit (e.g. nginx-served static assets). Deploy step
+#                    runs a custom activation command.
+builtins.mapAttrs withPaths {
+  # `order` controls deploy-rs activation sequence within `profilesOrder`. The
+  # system profile always runs first; remaining profiles activate in ascending
+  # `order`. Lower numbers go first.
+  st0x-hedge = {
+    enabled = true;
+    order = 30;
+    kind = "st0x";
+    package = "st0x-liquidity";
+    bin = "server";
+  };
+
+  dashboard = {
+    enabled = true;
+    order = 10;
+    kind = "static";
+    package = "st0x-dashboard";
+    activation = "systemctl reload nginx";
+  };
+
+  datasette = {
+    enabled = true;
+    # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
+    # before datasette opens it. (--immutable would close the WAL out and serve
+    # stale reads, so we open the DB normally and rely on loopback binding for
+    # access control.)
+    order = 40;
+    kind = "plain";
+    package = "datasette";
+    bin = "datasette";
+    description = "Datasette SQLite explorer";
+    # Bind to loopback; access via SSH tunnel or `tailscale ssh -L 8081:127.0.0.1:8081 <host>`.
+    args = [
+      "serve"
+      "/mnt/data/st0x-hedge.db"
+      "-p"
+      "8081"
+      "-h"
+      "127.0.0.1"
+    ];
+  };
 }


### PR DESCRIPTION
## What

Two things land together:

1. **Datasette as a deployed service** for browsing `/mnt/data/st0x-hedge.db` on port 8081, bound to loopback so it's reached via SSH/Tailscale port-forward.
2. **A `services.nix` registry refactor** (`@0xgleb`'s feedback) so the same plumbing handles all per-service profiles. New services land in one place — `services.nix` — and `deploy.nix`/`os.nix` derive the activation pipeline and systemd unit from a `kind` discriminator.

Also updates `README.md` and `SPEC.md` to describe the current profile set and the new kind dispatch.

## Why

Datasette was being started manually with `systemd-run` on the production bot — adding it to the Nix deploy makes it reproducible across rebuilds and survives operator handoffs. Once Datasette became the second non-`st0x-hedge` service (after the dashboard) it became obvious that the hand-written `dashboard` + `datasette` blocks in `deploy.nix`/`os.nix` were the same shape repeated, so this PR collapses them through `services.nix`.

## How

### Registry shape

`services.nix` now declares every per-service profile with a `kind`:

- `kind = "st0x"` — full pipeline: `validate-config`, agenix decrypt, plaintext config install, chown data dirs, git-rev marker, readiness marker, restart. Used by `st0x-hedge`.
- `kind = "plain"` — has a systemd unit with no secrets/config. Activation creates the readiness marker and restarts. Used by `datasette`.
- `kind = "static"` — no systemd unit (nginx-served assets). Activation runs a custom command. Used by `dashboard`.

Each entry declares an explicit `order` integer; `deploy.nix` sorts profiles by it and asserts uniqueness, so adding a new service forces choosing its activation slot rather than inheriting alphabetical attribute order. `secret/secrets.nix` filters to `kind == "st0x"` so ragenix doesn't fail on non-secret-bearing services.

### Datasette specifics

- `datasette serve /mnt/data/st0x-hedge.db -p 8081 -h 127.0.0.1` (loopback).
- `order = 40` — runs after `st0x-hedge` (30), so the DB is created and chowned before datasette opens it.
- No `--immutable` flag — that would tell SQLite to skip WAL recovery, making datasette serve a stale view of the DB while the bot is actively writing. With WAL mode and a live writer, opening the DB normally is the only correct choice; read-only protection comes from the loopback bind and the fact that vanilla `datasette serve` exposes no write endpoints.

### Dispatcher hygiene

- `mkServiceProfile` (in `deploy.nix`) and `mkService` (in `os.nix`) both `throw` on an unknown `kind` instead of silently falling through, so typos surface at eval time.
- The plain-branch activation does `touch marker → systemctl restart || { rm marker; exit 1; }` so `ConditionPathExists` is satisfied when systemd evaluates the start request, and a failed restart removes the marker so future system activations don't try to start a broken unit.

## Testing

This is Nix deployment config — no Rust changes. Verified via:

- `nix eval .#nixosConfigurations.st0x-liquidity.config.systemd.services.{datasette,st0x-hedge}.serviceConfig.ExecStart`
- `nix eval .#deploy.nodes.st0x-liquidity.profilesOrder` → `["system","dashboard","st0x-hedge","datasette"]`
- `nix eval --impure --expr 'import ./secret/secrets.nix'` → only `st0x-hedge.toml.age` mapped (no false attribute errors for dashboard/datasette)
- `cargo check --workspace --all-features`, `cargo clippy --workspace --all-targets --all-features`, `cargo fmt -- --check` — all clean
- `nixfmt --check` on all `*.nix` — clean
- Pre-commit hooks (deadnix, nixfmt, statix, nil, prettier, taplo) — clean

No NixOS realization on this machine (`aarch64-darwin`); CI runs the Linux build path.

## Anything else

### Known follow-ups (deliberately not in this PR)

- **Datasette runs as `st0x` user** with filesystem write access to the DB. The HTTP surface is read-only (vanilla `datasette serve` has no write endpoints), but a defense-in-depth improvement is running it as a dedicated `datasette` user with read-only filesystem perms. Requires adding per-service `user`/`group` fields to the registry — out of scope for the initial landing.
- **Plain services don't survive host reboot** — `wantedBy = []` plus `/run/st0x` marker on tmpfs means a reboot drops Datasette until the next deploy. The same is true of `st0x-hedge` (intentional there because of secrets); for stateless plain services it could be relaxed.
- **`systemctl restart` returns success on "start job submitted," not on healthy** — a service that crashes immediately after fork won't roll back the deploy. Pre-existing pattern across both `st0x` and `plain` branches; worth a separate `--wait` change.
- **First-deploy DB race** — on a fresh host, `st0x-hedge`'s restart returns before its async migrations have created the DB; datasette could activate against a missing file. Practically negligible (migrations run in ms), but worth a `systemd-tmpfiles` rule eventually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `datasette` service alongside existing deployments

* **Documentation**
  * Updated deployment documentation with new service names (`st0x-hedge`, `datasette`)
  * Updated infrastructure specification to clarify service profiles and deployment sequencing

* **Chores**
  * Refactored deployment system to dynamically generate service profiles from configuration metadata

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->