### PR TITLE
fix: correct equity redemption inventory races

### DIFF
--- a/migrations/20260518115736_backfill_inventory_snapshot_fetched_at_fields.sql
+++ b/migrations/20260518115736_backfill_inventory_snapshot_fetched_at_fields.sql
@@ -1,0 +1,33 @@
+-- Existing InventorySnapshot snapshots predate the per-source fetched-at
+-- fields. Hydration used to replay venue snapshots with `last_updated`; keep
+-- that behavior for compacted snapshot-only aggregates.
+UPDATE snapshots
+SET payload = json_set(
+    payload,
+    '$.Live.onchain_equity_fetched_at',
+    COALESCE(
+        json_extract(payload, '$.Live.onchain_equity_fetched_at'),
+        json_extract(payload, '$.Live.last_updated'),
+        timestamp
+    ),
+    '$.Live.onchain_usdc_fetched_at',
+    COALESCE(
+        json_extract(payload, '$.Live.onchain_usdc_fetched_at'),
+        json_extract(payload, '$.Live.last_updated'),
+        timestamp
+    ),
+    '$.Live.offchain_equity_fetched_at',
+    COALESCE(
+        json_extract(payload, '$.Live.offchain_equity_fetched_at'),
+        json_extract(payload, '$.Live.last_updated'),
+        timestamp
+    ),
+    '$.Live.offchain_usd_fetched_at',
+    COALESCE(
+        json_extract(payload, '$.Live.offchain_usd_fetched_at'),
+        json_extract(payload, '$.Live.last_updated'),
+        timestamp
+    )
+)
+WHERE aggregate_type = 'InventorySnapshot'
+  AND json_type(payload, '$.Live') IS NOT NULL;

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -512,6 +512,7 @@ mod tests {
                 quantity: float!(20),
                 token: Address::ZERO,
                 wrapped_amount: alloy::primitives::U256::from(20),
+                actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::ZERO,
                 withdrawn_at: two_days_ago,
             })
@@ -546,6 +547,7 @@ mod tests {
                 quantity: float!(15),
                 token: Address::ZERO,
                 wrapped_amount: alloy::primitives::U256::from(15),
+                actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::ZERO,
                 withdrawn_at: now,
             })

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -56,6 +56,8 @@
 //! - All state transitions are captured as events for complete audit trail
 
 use alloy::primitives::{Address, TxHash, U256};
+use alloy::rpc::types::TransactionReceipt;
+use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
@@ -70,6 +72,7 @@ use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, Id};
 
+use crate::bindings::IERC20;
 use crate::rebalancing::equity::EquityTransferServices;
 use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizationRequestId;
@@ -119,6 +122,33 @@ pub(crate) enum EquityRedemptionError {
     )]
     RaindexWithdrawFailed {
         token: Address,
+        amount: U256,
+        error_message: String,
+    },
+    /// Confirmed Raindex withdrawal receipt did not contain the expected token transfer.
+    #[error(
+        "Raindex withdrawal receipt {tx_hash} did not contain a transfer \
+         for token {token} to recipient {recipient}"
+    )]
+    RaindexWithdrawTransferNotFound {
+        tx_hash: TxHash,
+        token: Address,
+        recipient: Address,
+    },
+    /// Confirmed Raindex withdrawal receipt contained transfer values that overflowed.
+    #[error("Raindex withdrawal transfer amount overflowed for tx {tx_hash}")]
+    RaindexWithdrawTransferOverflow { tx_hash: TxHash },
+    /// Confirmed Raindex withdrawal receipt contained a malformed transfer log.
+    #[error(
+        "Raindex withdrawal receipt {tx_hash} contained malformed transfer log for token {token}"
+    )]
+    RaindexWithdrawTransferDecodeFailed { tx_hash: TxHash, token: Address },
+    /// Actual withdrawal amount could not be converted to fractional shares.
+    #[error(
+        "Raindex withdrawal amount {amount} for tx {tx_hash} could not be converted to shares: {error_message}"
+    )]
+    RaindexWithdrawQuantityConversionFailed {
+        tx_hash: TxHash,
         amount: U256,
         error_message: String,
     },
@@ -267,12 +297,22 @@ pub(crate) enum EquityRedemptionEvent {
         )]
         quantity: Float,
         token: Address,
+        /// Original target amount requested from Raindex.
         wrapped_amount: U256,
+        /// Actual wrapped-token amount transferred to the bot wallet.
+        #[serde(default)]
+        actual_wrapped_amount: Option<U256>,
         raindex_withdraw_tx: TxHash,
         withdrawn_at: DateTime<Utc>,
     },
     /// ERC-4626 wrapped tokens have been unwrapped.
     TokensUnwrapped {
+        #[serde(
+            default,
+            serialize_with = "st0x_float_serde::serialize_option_float",
+            deserialize_with = "st0x_float_serde::deserialize_option_float_from_number_or_string"
+        )]
+        quantity: Option<Float>,
         underlying_token: Address,
         unwrap_tx_hash: TxHash,
         unwrapped_amount: U256,
@@ -328,6 +368,55 @@ pub(crate) enum EquityRedemptionEvent {
     Completed {
         completed_at: DateTime<Utc>,
     },
+}
+
+fn resolve_withdrawn_wrapped_amount(
+    wrapped_amount: U256,
+    actual_wrapped_amount: Option<U256>,
+) -> U256 {
+    actual_wrapped_amount.unwrap_or(wrapped_amount)
+}
+
+fn actual_withdrawn_amount_from_receipt(
+    receipt: &TransactionReceipt,
+    token: Address,
+    recipient: Address,
+) -> Result<U256, EquityRedemptionError> {
+    receipt
+        .inner
+        .logs()
+        .iter()
+        .filter(|log| log.address() == token)
+        .filter(|log| log.topics().first() == Some(&IERC20::Transfer::SIGNATURE_HASH))
+        .try_fold(U256::ZERO, |total: U256, log| {
+            let decoded = log.log_decode_validate::<IERC20::Transfer>().map_err(|_| {
+                EquityRedemptionError::RaindexWithdrawTransferDecodeFailed {
+                    tx_hash: receipt.transaction_hash,
+                    token,
+                }
+            })?;
+
+            if decoded.data().to != recipient {
+                return Ok(total);
+            }
+
+            total.checked_add(decoded.data().value).ok_or(
+                EquityRedemptionError::RaindexWithdrawTransferOverflow {
+                    tx_hash: receipt.transaction_hash,
+                },
+            )
+        })
+        .and_then(|amount: U256| {
+            if amount.is_zero() {
+                Err(EquityRedemptionError::RaindexWithdrawTransferNotFound {
+                    tx_hash: receipt.transaction_hash,
+                    token,
+                    recipient,
+                })
+            } else {
+                Ok(amount)
+            }
+        })
 }
 
 /// Required by `cqrs_es::DomainEvent`.
@@ -395,6 +484,7 @@ impl PartialEq for EquityRedemptionEvent {
                     quantity: q1,
                     token: t1,
                     wrapped_amount: w1,
+                    actual_wrapped_amount: aw1,
                     raindex_withdraw_tx: r1,
                     withdrawn_at: wa1,
                 },
@@ -403,6 +493,7 @@ impl PartialEq for EquityRedemptionEvent {
                     quantity: q2,
                     token: t2,
                     wrapped_amount: w2,
+                    actual_wrapped_amount: aw2,
                     raindex_withdraw_tx: r2,
                     withdrawn_at: wa2,
                 },
@@ -411,23 +502,35 @@ impl PartialEq for EquityRedemptionEvent {
                     && q1.eq(*q2).unwrap_or(false)
                     && t1 == t2
                     && w1 == w2
+                    && aw1 == aw2
                     && r1 == r2
                     && wa1 == wa2
             }
             (
                 Self::TokensUnwrapped {
+                    quantity: q1,
                     underlying_token: u1,
                     unwrap_tx_hash: h1,
                     unwrapped_amount: a1,
                     unwrapped_at: t1,
                 },
                 Self::TokensUnwrapped {
+                    quantity: q2,
                     underlying_token: u2,
                     unwrap_tx_hash: h2,
                     unwrapped_amount: a2,
                     unwrapped_at: t2,
                 },
-            ) => u1 == u2 && h1 == h2 && a1 == a2 && t1 == t2,
+            ) => {
+                q1.is_some() == q2.is_some()
+                    && q1
+                        .zip(*q2)
+                        .is_none_or(|(q1, q2)| q1.eq(q2).unwrap_or(false))
+                    && u1 == u2
+                    && h1 == h2
+                    && a1 == a2
+                    && t1 == t2
+            }
             (
                 Self::TransferFailed {
                     tx_hash: h1,
@@ -908,13 +1011,17 @@ impl EventSourced for EquityRedemption {
                 quantity,
                 token,
                 wrapped_amount,
+                actual_wrapped_amount,
                 raindex_withdraw_tx,
                 withdrawn_at,
             } => Some(Self::WithdrawnFromRaindex {
                 symbol: symbol.clone(),
                 quantity: *quantity,
                 token: *token,
-                wrapped_amount: *wrapped_amount,
+                wrapped_amount: resolve_withdrawn_wrapped_amount(
+                    *wrapped_amount,
+                    *actual_wrapped_amount,
+                ),
                 raindex_withdraw_tx: *raindex_withdraw_tx,
                 withdrawn_at: *withdrawn_at,
             }),
@@ -952,6 +1059,7 @@ impl EventSourced for EquityRedemption {
                 quantity,
                 token,
                 wrapped_amount,
+                actual_wrapped_amount,
                 raindex_withdraw_tx,
                 withdrawn_at,
             } => match entity {
@@ -960,7 +1068,10 @@ impl EventSourced for EquityRedemption {
                         symbol: symbol.clone(),
                         quantity: *quantity,
                         token: *token,
-                        wrapped_amount: *wrapped_amount,
+                        wrapped_amount: resolve_withdrawn_wrapped_amount(
+                            *wrapped_amount,
+                            *actual_wrapped_amount,
+                        ),
                         raindex_withdraw_tx: *raindex_withdraw_tx,
                         withdrawn_at: *withdrawn_at,
                     })
@@ -1103,6 +1214,7 @@ impl EventSourced for EquityRedemption {
             },
 
             TokensUnwrapped {
+                quantity: actual_quantity,
                 underlying_token,
                 unwrap_tx_hash,
                 unwrapped_amount,
@@ -1133,7 +1245,7 @@ impl EventSourced for EquityRedemption {
                     ..
                 } => Some(Self::TokensUnwrapped {
                     symbol: symbol.clone(),
-                    quantity: *quantity,
+                    quantity: actual_quantity.unwrap_or(*quantity),
                     token: *token,
                     underlying_token: *underlying_token,
                     raindex_withdraw_tx: *raindex_withdraw_tx,
@@ -1433,21 +1545,24 @@ impl EventSourced for EquityRedemption {
                     tx_hash,
                     ..
                 } => {
-                    services
+                    let receipt = services
                         .raindex
-                        .confirm_tx(*tx_hash)
+                        .confirm_tx_receipt(*tx_hash)
                         .await
                         .map_err(|error| EquityRedemptionError::RaindexWithdrawFailed {
                             token: *token,
                             amount: *wrapped_amount,
                             error_message: error.to_string(),
                         })?;
-
+                    let recipient = services.wrapper.owner();
+                    let actual_wrapped_amount =
+                        actual_withdrawn_amount_from_receipt(&receipt, *token, recipient)?;
                     Ok(vec![WithdrawnFromRaindex {
                         symbol: symbol.clone(),
                         quantity: *quantity,
                         token: *token,
                         wrapped_amount: *wrapped_amount,
+                        actual_wrapped_amount: Some(actual_wrapped_amount),
                         raindex_withdraw_tx: *tx_hash,
                         withdrawn_at: Utc::now(),
                     }])
@@ -1527,8 +1642,18 @@ impl EventSourced for EquityRedemption {
                             wrapped_amount: *wrapped_amount,
                             error_message: error.to_string(),
                         })?;
+                    let quantity =
+                        Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
+                            .map_err(|error| {
+                                EquityRedemptionError::RaindexWithdrawQuantityConversionFailed {
+                                    tx_hash: *unwrap_tx_hash,
+                                    amount: unwrapped_amount,
+                                    error_message: error.to_string(),
+                                }
+                            })?;
 
                     Ok(vec![TokensUnwrapped {
+                        quantity: Some(quantity),
                         underlying_token,
                         unwrap_tx_hash: *unwrap_tx_hash,
                         unwrapped_amount,
@@ -1701,12 +1826,32 @@ impl EventSourced for EquityRedemption {
 /// system does not re-trigger redemptions for tokens it no longer holds.
 pub(crate) async fn symbols_with_stuck_redemptions(
     pool: &SqlitePool,
-) -> Result<HashMap<Symbol, FractionalShares>, sqlx::Error> {
-    let rows: Vec<(String, Option<String>, Option<String>)> = sqlx::query_as(
+) -> Result<HashMap<Symbol, FractionalShares>, StuckRedemptionRecoveryError> {
+    type StuckRedemptionRow = (String, Option<String>, Option<String>, Option<String>);
+
+    let rows: Vec<StuckRedemptionRow> = sqlx::query_as(
         "WITH latest AS ( \
              SELECT aggregate_id, MAX(sequence) AS max_seq \
              FROM events \
              WHERE aggregate_type = 'EquityRedemption' \
+             GROUP BY aggregate_id \
+         ), latest_withdrawn AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'EquityRedemption' \
+               AND event_type = 'EquityRedemptionEvent::WithdrawnFromRaindex' \
+             GROUP BY aggregate_id \
+         ), latest_unwrapped AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'EquityRedemption' \
+               AND event_type = 'EquityRedemptionEvent::TokensUnwrapped' \
+             GROUP BY aggregate_id \
+         ), latest_sent AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'EquityRedemption' \
+               AND event_type = 'EquityRedemptionEvent::TokensSent' \
              GROUP BY aggregate_id \
          ) \
          SELECT latest.aggregate_id, \
@@ -1716,10 +1861,13 @@ pub(crate) async fn symbols_with_stuck_redemptions(
                     json_extract(first_ev.payload, '$.WithdrawnFromRaindex.symbol') \
                 ), \
                 COALESCE( \
+                    json_extract(sent_ev.payload, '$.TokensSent.quantity'), \
+                    json_extract(unwrapped_ev.payload, '$.TokensUnwrapped.quantity'), \
                     json_extract(first_ev.payload, '$.VaultWithdrawPending.quantity'), \
                     json_extract(first_ev.payload, '$.VaultWithdrawSubmitted.quantity'), \
                     json_extract(first_ev.payload, '$.WithdrawnFromRaindex.quantity') \
-                ) \
+                ), \
+                json_extract(unwrapped_ev.payload, '$.TokensUnwrapped.unwrapped_amount') \
          FROM events last_ev \
          INNER JOIN latest \
              ON last_ev.aggregate_id = latest.aggregate_id \
@@ -1728,6 +1876,24 @@ pub(crate) async fn symbols_with_stuck_redemptions(
              ON first_ev.aggregate_type = 'EquityRedemption' \
             AND first_ev.aggregate_id = latest.aggregate_id \
             AND first_ev.sequence = 0 \
+         LEFT JOIN latest_withdrawn \
+             ON latest_withdrawn.aggregate_id = latest.aggregate_id \
+         LEFT JOIN events withdrawn_ev \
+             ON withdrawn_ev.aggregate_type = 'EquityRedemption' \
+            AND withdrawn_ev.aggregate_id = latest.aggregate_id \
+            AND withdrawn_ev.sequence = latest_withdrawn.max_seq \
+         LEFT JOIN latest_unwrapped \
+             ON latest_unwrapped.aggregate_id = latest.aggregate_id \
+         LEFT JOIN events unwrapped_ev \
+             ON unwrapped_ev.aggregate_type = 'EquityRedemption' \
+            AND unwrapped_ev.aggregate_id = latest.aggregate_id \
+            AND unwrapped_ev.sequence = latest_unwrapped.max_seq \
+         LEFT JOIN latest_sent \
+             ON latest_sent.aggregate_id = latest.aggregate_id \
+         LEFT JOIN events sent_ev \
+             ON sent_ev.aggregate_type = 'EquityRedemption' \
+            AND sent_ev.aggregate_id = latest.aggregate_id \
+            AND sent_ev.sequence = latest_sent.max_seq \
          WHERE last_ev.aggregate_type = 'EquityRedemption' \
            AND last_ev.event_type IN ( \
                'EquityRedemptionEvent::DetectionFailed', \
@@ -1739,12 +1905,17 @@ pub(crate) async fn symbols_with_stuck_redemptions(
 
     let mut result: HashMap<Symbol, FractionalShares> = HashMap::new();
 
-    for (aggregate_id, raw_symbol, raw_quantity) in rows {
+    for (aggregate_id, raw_symbol, raw_quantity, raw_wrapped_amount) in rows {
         let Some(symbol) = parse_stuck_symbol(&aggregate_id, raw_symbol) else {
             continue;
         };
 
-        let Some(quantity) = parse_stuck_quantity(&aggregate_id, raw_quantity) else {
+        let Some(quantity) = parse_stuck_quantity(
+            RedemptionAggregateId::new(&aggregate_id),
+            raw_quantity,
+            raw_wrapped_amount,
+        )?
+        else {
             continue;
         };
 
@@ -1763,6 +1934,16 @@ pub(crate) async fn symbols_with_stuck_redemptions(
     }
 
     Ok(result)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StuckRedemptionRecoveryError {
+    #[error(transparent)]
+    Persistence(#[from] sqlx::Error),
+    #[error("stuck redemption {aggregate_id} has invalid actual wrapped amount")]
+    InvalidActualWrappedAmount { aggregate_id: RedemptionAggregateId },
+    #[error("stuck redemption {aggregate_id} has invalid requested quantity")]
+    InvalidRequestedQuantity { aggregate_id: RedemptionAggregateId },
 }
 
 /// Returns the set of symbols that have at least one in-progress
@@ -1896,33 +2077,56 @@ fn parse_stuck_symbol(aggregate_id: &str, raw: Option<String>) -> Option<Symbol>
         .ok()
 }
 
-fn parse_stuck_quantity(aggregate_id: &str, raw: Option<String>) -> Option<FractionalShares> {
-    let value = raw.or_else(|| {
+fn parse_stuck_quantity(
+    aggregate_id: RedemptionAggregateId,
+    raw_quantity: Option<String>,
+    raw_wrapped_amount: Option<String>,
+) -> Result<Option<FractionalShares>, StuckRedemptionRecoveryError> {
+    if raw_quantity.is_some() {
+        return parse_requested_stuck_quantity(aggregate_id, raw_quantity);
+    }
+
+    if let Some(value) = raw_wrapped_amount {
+        let Ok(amount) = U256::from_str(&value) else {
+            return Err(StuckRedemptionRecoveryError::InvalidActualWrappedAmount { aggregate_id });
+        };
+        let Ok(quantity) = Float::from_fixed_decimal(amount, TOKENIZED_EQUITY_DECIMALS) else {
+            return Err(StuckRedemptionRecoveryError::InvalidActualWrappedAmount { aggregate_id });
+        };
+        return Ok(Some(FractionalShares::new(quantity)));
+    }
+
+    parse_requested_stuck_quantity(aggregate_id, raw_quantity)
+}
+
+fn parse_requested_stuck_quantity(
+    aggregate_id: RedemptionAggregateId,
+    raw: Option<String>,
+) -> Result<Option<FractionalShares>, StuckRedemptionRecoveryError> {
+    let Some(value) = raw.or_else(|| {
         warn!(target: "rebalance",
             %aggregate_id,
             "Stuck redemption has NULL quantity in \
              WithdrawnFromRaindex payload, skipping"
         );
         None
-    })?;
+    }) else {
+        return Ok(None);
+    };
 
-    Float::parse(value.clone())
-        .inspect_err(|error| {
-            warn!(target: "rebalance",
-                %error,
-                %aggregate_id,
-                raw_quantity = %value,
-                "Stuck redemption has invalid quantity, skipping"
-            );
-        })
-        .ok()
-        .map(FractionalShares::new)
+    let quantity = Float::parse(value)
+        .map_err(|_| StuckRedemptionRecoveryError::InvalidRequestedQuantity { aggregate_id })?;
+
+    Ok(Some(FractionalShares::new(quantity)))
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
+    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy::primitives::{Bloom, Bytes, Log as PrimitiveLog, LogData};
+    use alloy::rpc::types::Log;
     use st0x_dto::EquityRedemptionStatus;
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
 
@@ -1940,12 +2144,77 @@ mod tests {
         }
     }
 
+    fn receipt_with_logs(logs: Vec<Log>) -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: true.into(),
+                    cumulative_gas_used: 0,
+                    logs,
+                },
+                logs_bloom: Bloom::default(),
+            }),
+            transaction_hash: TxHash::random(),
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: Some(0),
+            gas_used: 21000,
+            effective_gas_price: 1,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    fn transfer_receipt_log(token: Address, recipient: Address, amount: U256) -> Log {
+        let event = IERC20::Transfer {
+            from: Address::ZERO,
+            to: recipient,
+            value: amount,
+        };
+        Log {
+            inner: PrimitiveLog {
+                address: token,
+                data: event.encode_log_data(),
+            },
+            transaction_hash: None,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
+    fn malformed_transfer_receipt_log(token: Address) -> Log {
+        Log {
+            inner: PrimitiveLog {
+                address: token,
+                data: LogData::new_unchecked(
+                    vec![IERC20::Transfer::SIGNATURE_HASH],
+                    Bytes::from_static(&[0x01]),
+                ),
+            },
+            transaction_hash: None,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
     fn withdrawn_from_raindex_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::WithdrawnFromRaindex {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(50.25),
             token: Address::random(),
             wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+            actual_wrapped_amount: None,
             raindex_withdraw_tx: TxHash::random(),
             withdrawn_at: Utc::now(),
         }
@@ -1961,6 +2230,7 @@ mod tests {
 
     fn tokens_unwrapped_event() -> EquityRedemptionEvent {
         EquityRedemptionEvent::TokensUnwrapped {
+            quantity: Some(float!(50.25)),
             underlying_token: Address::random(),
             unwrap_tx_hash: TxHash::random(),
             unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
@@ -2184,6 +2454,197 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn confirm_withdraw_records_actual_transfer_amount_from_receipt() {
+        let requested_amount = U256::from(37_143_292_455_000_000_000_u128);
+        let actual_amount = U256::from(33_681_456_848_531_939_569_u128);
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(actual_amount)),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+        let store = TestStore::<EquityRedemption>::new(services);
+        let id = RedemptionAggregateId::new("partial-withdraw");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("COIN").unwrap(),
+                    quantity: float!(37.143292455),
+                    token: Address::random(),
+                    amount: requested_amount,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let EquityRedemption::WithdrawnFromRaindex { wrapped_amount, .. } = entity else {
+            panic!("Expected WithdrawnFromRaindex state, got: {entity:?}");
+        };
+
+        assert_eq!(
+            wrapped_amount, actual_amount,
+            "Confirmed withdrawal should carry actual receipt transfer amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn unwrap_uses_actual_withdrawn_amount_after_partial_withdraw() {
+        let requested_amount = U256::from(37_143_292_455_000_000_000_u128);
+        let actual_amount = U256::from(33_681_456_848_531_939_569_u128);
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(actual_amount)),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+        let store = TestStore::<EquityRedemption>::new(services);
+        let id = RedemptionAggregateId::new("unwrap-partial-withdraw");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("COIN").unwrap(),
+                    quantity: float!(37.143292455),
+                    token: Address::random(),
+                    amount: requested_amount,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::UnwrapTokens)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .unwrap();
+        store
+            .send(&id, EquityRedemptionCommand::ConfirmUnwrap)
+            .await
+            .unwrap();
+
+        let entity = store.load(&id).await.unwrap().unwrap();
+        let EquityRedemption::TokensUnwrapped {
+            unwrapped_amount, ..
+        } = entity
+        else {
+            panic!("Expected TokensUnwrapped state, got: {entity:?}");
+        };
+
+        assert_eq!(
+            unwrapped_amount, actual_amount,
+            "Unwrap confirmation should reflect the actual withdrawn amount"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_withdraw_fails_without_matching_receipt_transfer() {
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new().with_withdraw_actual_amount(U256::ZERO)),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+        let store = TestStore::<EquityRedemption>::new(services);
+        let id = RedemptionAggregateId::new("missing-withdraw-transfer");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("COIN").unwrap(),
+                    quantity: float!(10),
+                    token: Address::random(),
+                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        let error = store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    EquityRedemptionError::RaindexWithdrawTransferNotFound { .. }
+                ))
+            ),
+            "Expected missing transfer error, got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn actual_withdrawn_amount_sums_only_matching_receipt_transfers() {
+        let token = Address::repeat_byte(0x11);
+        let other_token = Address::repeat_byte(0x22);
+        let recipient = Address::repeat_byte(0x33);
+        let other_recipient = Address::repeat_byte(0x44);
+        let receipt = receipt_with_logs(vec![
+            transfer_receipt_log(other_token, recipient, U256::from(100)),
+            transfer_receipt_log(token, other_recipient, U256::from(200)),
+            transfer_receipt_log(token, recipient, U256::from(30)),
+            transfer_receipt_log(token, recipient, U256::from(12)),
+        ]);
+
+        let amount = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap();
+
+        assert_eq!(
+            amount,
+            U256::from(42),
+            "Only matching token and recipient transfer values should be summed"
+        );
+    }
+
+    #[test]
+    fn actual_withdrawn_amount_errors_on_malformed_matching_transfer_log() {
+        let token = Address::repeat_byte(0x11);
+        let recipient = Address::repeat_byte(0x33);
+        let receipt = receipt_with_logs(vec![malformed_transfer_receipt_log(token)]);
+
+        let error = actual_withdrawn_amount_from_receipt(&receipt, token, recipient).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                EquityRedemptionError::RaindexWithdrawTransferDecodeFailed { .. }
+            ),
+            "Expected decode failure, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn cannot_detect_before_sending_tokens() {
         let error = TestHarness::<EquityRedemption>::with(mock_services())
             .given_no_previous_events()
@@ -2281,6 +2742,7 @@ mod tests {
                 quantity: float!(50.25),
                 token: Address::random(),
                 wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+                actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::random(),
                 withdrawn_at: Utc::now(),
             },
@@ -2804,6 +3266,12 @@ mod tests {
         )
     }
 
+    fn tokens_unwrapped_payload(quantity: &str, unwrapped_amount: &str) -> String {
+        format!(
+            r#"{{"TokensUnwrapped":{{"quantity":"{quantity}","underlying_token":"0x0000000000000000000000000000000000000002","unwrap_tx_hash":"0x0000000000000000000000000000000000000000000000000000000000000002","unwrapped_amount":"{unwrapped_amount}","unwrapped_at":"2026-01-01T00:00:00Z"}}}}"#
+        )
+    }
+
     #[tokio::test]
     async fn stuck_redemptions_returns_detection_failed_symbols() {
         let pool = crate::test_utils::setup_test_db().await;
@@ -2835,6 +3303,82 @@ mod tests {
             "Recovered quantity should be 10, got {:?}",
             result[&aapl]
         );
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_uses_actual_unwrapped_quantity_when_available() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        insert_event(
+            &pool,
+            "partial-redemption",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("COIN"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "partial-redemption",
+            1,
+            "EquityRedemptionEvent::TokensUnwrapped",
+            &tokens_unwrapped_payload("7.5", "7500000000000000000"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "partial-redemption",
+            2,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(result.len(), 1);
+        let coin = Symbol::new("COIN").unwrap();
+        assert!(
+            result[&coin].inner().eq(float!("7.5")).unwrap(),
+            "Recovered quantity should use actual unwrapped quantity, got {:?}",
+            result[&coin]
+        );
+    }
+
+    #[tokio::test]
+    async fn stuck_redemptions_errors_on_invalid_unwrapped_quantity() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        insert_event(
+            &pool,
+            "invalid-actual",
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("COIN"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "invalid-actual",
+            1,
+            "EquityRedemptionEvent::TokensUnwrapped",
+            &tokens_unwrapped_payload("invalid", "invalid"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            "invalid-actual",
+            2,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        let err = symbols_with_stuck_redemptions(&pool).await.unwrap_err();
+        assert!(matches!(
+            err,
+            StuckRedemptionRecoveryError::InvalidRequestedQuantity { .. }
+                | StuckRedemptionRecoveryError::InvalidActualWrappedAmount { .. }
+        ));
     }
 
     #[tokio::test]

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -67,12 +67,20 @@ impl FromStr for InventorySnapshotId {
 pub(crate) struct InventorySnapshot {
     /// Latest onchain equity balances by symbol
     pub(crate) onchain_equity: BTreeMap<Symbol, FractionalShares>,
+    #[serde(default)]
+    pub(crate) onchain_equity_fetched_at: Option<DateTime<Utc>>,
     /// Latest onchain USDC balance
     pub(crate) onchain_usdc: Option<Usdc>,
+    #[serde(default)]
+    pub(crate) onchain_usdc_fetched_at: Option<DateTime<Utc>>,
     /// Latest offchain equity positions by symbol
     pub(crate) offchain_equity: BTreeMap<Symbol, FractionalShares>,
+    #[serde(default)]
+    pub(crate) offchain_equity_fetched_at: Option<DateTime<Utc>>,
     /// Latest offchain USD balance in cents (post-reserve, available for trading)
     pub(crate) offchain_usd_cents: Option<i64>,
+    #[serde(default)]
+    pub(crate) offchain_usd_fetched_at: Option<DateTime<Utc>>,
     /// Latest offchain gross USD balance in cents (before reserve subtraction)
     #[serde(default)]
     pub(crate) offchain_gross_usd_cents: Option<i64>,
@@ -113,9 +121,13 @@ impl EventSourced for InventorySnapshot {
     fn originate(event: &Self::Event) -> Option<Self> {
         let mut snapshot = Self {
             onchain_equity: BTreeMap::new(),
+            onchain_equity_fetched_at: None,
             onchain_usdc: None,
+            onchain_usdc_fetched_at: None,
             offchain_equity: BTreeMap::new(),
+            offchain_equity_fetched_at: None,
             offchain_usd_cents: None,
+            offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
             offchain_margin_safe_buying_power_cents: None,
             ethereum_usdc: None,
@@ -322,28 +334,36 @@ impl InventorySnapshot {
         let fetched_at = self.last_updated;
         let mut events = Vec::new();
 
-        if !self.onchain_equity.is_empty() {
+        if let Some(fetched_at) = self.onchain_equity_fetched_at
+            && !self.onchain_equity.is_empty()
+        {
             events.push(InventorySnapshotEvent::OnchainEquity {
                 balances: self.onchain_equity.clone(),
                 fetched_at,
             });
         }
 
-        if let Some(usdc_balance) = self.onchain_usdc {
+        if let (Some(usdc_balance), Some(fetched_at)) =
+            (self.onchain_usdc, self.onchain_usdc_fetched_at)
+        {
             events.push(InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at,
             });
         }
 
-        if !self.offchain_equity.is_empty() {
+        if let Some(fetched_at) = self.offchain_equity_fetched_at
+            && !self.offchain_equity.is_empty()
+        {
             events.push(InventorySnapshotEvent::OffchainEquity {
                 positions: self.offchain_equity.clone(),
                 fetched_at,
             });
         }
 
-        if let Some(usd_balance_cents) = self.offchain_usd_cents {
+        if let (Some(usd_balance_cents), Some(fetched_at)) =
+            (self.offchain_usd_cents, self.offchain_usd_fetched_at)
+        {
             events.push(InventorySnapshotEvent::OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents: self.offchain_gross_usd_cents,
@@ -398,26 +418,58 @@ impl InventorySnapshot {
     }
 
     fn apply_event(&mut self, event: &InventorySnapshotEvent) {
-        self.last_updated = event.timestamp();
+        let event_timestamp = event.timestamp();
+        if event_timestamp > self.last_updated {
+            self.last_updated = event_timestamp;
+        }
 
         match event {
-            InventorySnapshotEvent::OnchainEquity { balances, .. } => {
+            InventorySnapshotEvent::OnchainEquity {
+                balances,
+                fetched_at,
+            } if self
+                .onchain_equity_fetched_at
+                .is_none_or(|current| *fetched_at >= current) =>
+            {
                 self.onchain_equity = balances.clone();
+                self.onchain_equity_fetched_at = Some(*fetched_at);
             }
-            InventorySnapshotEvent::OnchainUsdc { usdc_balance, .. } => {
+            InventorySnapshotEvent::OnchainUsdc {
+                usdc_balance,
+                fetched_at,
+            } if self
+                .onchain_usdc_fetched_at
+                .is_none_or(|current| *fetched_at >= current) =>
+            {
                 self.onchain_usdc = Some(*usdc_balance);
+                self.onchain_usdc_fetched_at = Some(*fetched_at);
             }
-            InventorySnapshotEvent::OffchainEquity { positions, .. } => {
+            InventorySnapshotEvent::OffchainEquity {
+                positions,
+                fetched_at,
+            } if self
+                .offchain_equity_fetched_at
+                .is_none_or(|current| *fetched_at >= current) =>
+            {
                 self.offchain_equity = positions.clone();
+                self.offchain_equity_fetched_at = Some(*fetched_at);
             }
             InventorySnapshotEvent::OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents,
-                ..
-            } => {
+                fetched_at,
+            } if self
+                .offchain_usd_fetched_at
+                .is_none_or(|current| *fetched_at >= current) =>
+            {
                 self.offchain_usd_cents = Some(*usd_balance_cents);
                 self.offchain_gross_usd_cents = *gross_usd_cents;
+                self.offchain_usd_fetched_at = Some(*fetched_at);
             }
+            InventorySnapshotEvent::OnchainEquity { .. }
+            | InventorySnapshotEvent::OnchainUsdc { .. }
+            | InventorySnapshotEvent::OffchainEquity { .. }
+            | InventorySnapshotEvent::OffchainUsd { .. } => {}
             InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
                 margin_safe_buying_power_cents,
                 ..
@@ -893,6 +945,31 @@ mod tests {
 
         assert_eq!(snapshot.onchain_equity, second_balances);
         assert!(!snapshot.onchain_equity.contains_key(&test_symbol("AAPL")));
+    }
+
+    #[test]
+    fn older_equity_snapshot_event_does_not_replace_newer_persisted_value() {
+        let older_at = Utc::now();
+        let newer_at = older_at + chrono::Duration::seconds(1);
+        let mut older_balances = BTreeMap::new();
+        older_balances.insert(test_symbol("AAPL"), test_shares(100));
+        let mut newer_balances = BTreeMap::new();
+        newer_balances.insert(test_symbol("AAPL"), test_shares(75));
+
+        let snapshot = replay::<InventorySnapshot>(vec![
+            InventorySnapshotEvent::OnchainEquity {
+                balances: newer_balances.clone(),
+                fetched_at: newer_at,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: older_balances,
+                fetched_at: older_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(snapshot.onchain_equity, newer_balances);
     }
 
     #[tokio::test]
@@ -1514,9 +1591,13 @@ mod tests {
     fn hydration_events_empty_snapshot_produces_no_events() {
         let snapshot = InventorySnapshot {
             onchain_equity: BTreeMap::new(),
+            onchain_equity_fetched_at: None,
             onchain_usdc: None,
+            onchain_usdc_fetched_at: None,
             offchain_equity: BTreeMap::new(),
+            offchain_equity_fetched_at: None,
             offchain_usd_cents: None,
+            offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
             offchain_margin_safe_buying_power_cents: None,
             ethereum_usdc: None,
@@ -1541,9 +1622,13 @@ mod tests {
 
         let original = InventorySnapshot {
             onchain_equity: onchain_equity.clone(),
+            onchain_equity_fetched_at: Some(now),
             onchain_usdc: Some(Usdc::from_str("5000").unwrap()),
+            onchain_usdc_fetched_at: Some(now),
             offchain_equity: BTreeMap::new(),
+            offchain_equity_fetched_at: None,
             offchain_usd_cents: Some(42_00),
+            offchain_usd_fetched_at: Some(now),
             offchain_gross_usd_cents: Some(50_00),
             offchain_margin_safe_buying_power_cents: Some(10_000),
             ethereum_usdc: None,

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -31,6 +31,8 @@ pub(crate) enum InventoryViewError {
     Equity(#[from] InventoryError<FractionalShares>),
     #[error(transparent)]
     Usdc(#[from] InventoryError<Usdc>),
+    #[error("float arithmetic error: {0}")]
+    Float(#[from] FloatError),
     #[error("failed to convert USD balance cents {0} to USDC")]
     UsdBalanceConversion(i64),
 }
@@ -743,6 +745,12 @@ pub(crate) struct InventoryView {
     /// Symbols that appeared in the most recent inflight redemption poll.
     #[serde(default)]
     previous_inflight_redemption_symbols: HashSet<Symbol>,
+    /// Latest absolute equity snapshot timestamp by symbol for the onchain venue.
+    #[serde(default)]
+    onchain_equity_snapshot_watermarks: HashMap<Symbol, DateTime<Utc>>,
+    /// Latest absolute equity snapshot timestamp by symbol for the offchain venue.
+    #[serde(default)]
+    offchain_equity_snapshot_watermarks: HashMap<Symbol, DateTime<Utc>>,
 }
 
 impl InventoryView {
@@ -879,6 +887,8 @@ impl Default for InventoryView {
             inflight_equity: HashMap::new(),
             previous_inflight_mint_symbols: HashSet::new(),
             previous_inflight_redemption_symbols: HashSet::new(),
+            onchain_equity_snapshot_watermarks: HashMap::new(),
+            offchain_equity_snapshot_watermarks: HashMap::new(),
         }
     }
 }
@@ -1007,6 +1017,8 @@ impl InventoryView {
             inflight_equity: self.inflight_equity,
             previous_inflight_mint_symbols: self.previous_inflight_mint_symbols,
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
+            onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
+            offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
         })
     }
 
@@ -1030,7 +1042,100 @@ impl InventoryView {
             inflight_equity: self.inflight_equity,
             previous_inflight_mint_symbols: self.previous_inflight_mint_symbols,
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
+            onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
+            offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
         })
+    }
+
+    pub(crate) fn record_equity_snapshot_watermarks<'a>(
+        mut self,
+        venue: Venue,
+        symbols: impl IntoIterator<Item = &'a Symbol>,
+        fetched_at: DateTime<Utc>,
+    ) -> Self {
+        let watermarks = match venue {
+            Venue::MarketMaking => &mut self.onchain_equity_snapshot_watermarks,
+            Venue::Hedging => &mut self.offchain_equity_snapshot_watermarks,
+        };
+
+        for symbol in symbols {
+            let watermark = watermarks.entry(symbol.clone()).or_insert(fetched_at);
+            if fetched_at > *watermark {
+                *watermark = fetched_at;
+            }
+        }
+
+        self
+    }
+
+    fn equity_snapshot_watermark(&self, symbol: &Symbol, venue: Venue) -> Option<DateTime<Utc>> {
+        let watermarks = match venue {
+            Venue::MarketMaking => &self.onchain_equity_snapshot_watermarks,
+            Venue::Hedging => &self.offchain_equity_snapshot_watermarks,
+        };
+
+        watermarks.get(symbol).copied()
+    }
+
+    fn equity_snapshot_would_apply(
+        &self,
+        symbol: &Symbol,
+        venue: Venue,
+        fetched_at: DateTime<Utc>,
+    ) -> Result<bool, InventoryViewError> {
+        if self
+            .equity_snapshot_watermark(symbol, venue)
+            .is_some_and(|watermark| fetched_at <= watermark)
+        {
+            return Ok(false);
+        }
+
+        let Some(inventory) = self.equities.get(symbol) else {
+            return Ok(true);
+        };
+
+        if inventory.has_inflight()? {
+            return Ok(false);
+        }
+
+        if let Some(last_rebalancing) = inventory.last_rebalancing()
+            && fetched_at < last_rebalancing
+        {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    pub(crate) fn apply_equity_snapshot<'a>(
+        self,
+        venue: Venue,
+        balances: impl IntoIterator<Item = (&'a Symbol, &'a FractionalShares)>,
+        fetched_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<Self, InventoryViewError> {
+        let (view, applied_symbols) = balances.into_iter().try_fold(
+            (self, Vec::new()),
+            |(view, mut applied_symbols), (symbol, snapshot_balance)| {
+                let should_record_watermark =
+                    view.equity_snapshot_would_apply(symbol, venue, fetched_at)?;
+                if !should_record_watermark {
+                    return Ok::<_, InventoryViewError>((view, applied_symbols));
+                }
+
+                let view = view.update_equity(
+                    symbol,
+                    Inventory::on_snapshot(venue, *snapshot_balance, fetched_at),
+                    now,
+                )?;
+
+                applied_symbols.push(symbol.clone());
+
+                Ok::<_, InventoryViewError>((view, applied_symbols))
+            },
+        )?;
+
+        Ok(view.record_equity_snapshot_watermarks(venue, applied_symbols.iter(), fetched_at))
     }
 
     /// Record the latest wallet-read USDC balance at an intermediate location.
@@ -1151,6 +1256,8 @@ impl InventoryView {
             inflight_equity: self.inflight_equity,
             previous_inflight_mint_symbols: self.previous_inflight_mint_symbols,
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
+            onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
+            offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
         })
     }
 
@@ -1175,6 +1282,8 @@ impl InventoryView {
             inflight_equity: self.inflight_equity,
             previous_inflight_mint_symbols: self.previous_inflight_mint_symbols,
             previous_inflight_redemption_symbols: self.previous_inflight_redemption_symbols,
+            onchain_equity_snapshot_watermarks: self.onchain_equity_snapshot_watermarks,
+            offchain_equity_snapshot_watermarks: self.offchain_equity_snapshot_watermarks,
         })
     }
 
@@ -1414,19 +1523,7 @@ impl InventoryView {
         let fetched_at = event.timestamp();
         match event {
             OnchainEquity { balances, .. } => {
-                balances
-                    .iter()
-                    .try_fold(self, |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::on_snapshot(
-                                Venue::MarketMaking,
-                                *snapshot_balance,
-                                fetched_at,
-                            ),
-                            now,
-                        )
-                    })
+                self.apply_equity_snapshot(Venue::MarketMaking, balances.iter(), fetched_at, now)
             }
 
             OnchainUsdc { usdc_balance, .. } => self.update_usdc(
@@ -1435,15 +1532,7 @@ impl InventoryView {
             ),
 
             OffchainEquity { positions, .. } => {
-                positions
-                    .iter()
-                    .try_fold(self, |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::on_snapshot(Venue::Hedging, *snapshot_balance, fetched_at),
-                            now,
-                        )
-                    })
+                self.apply_equity_snapshot(Venue::Hedging, positions.iter(), fetched_at, now)
             }
 
             OffchainUsd {
@@ -1543,42 +1632,58 @@ impl InventoryView {
         use InventorySnapshotEvent::*;
 
         match event {
-            OnchainEquity { balances, .. } => {
-                balances
-                    .iter()
-                    .try_fold(self, |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::force_on_snapshot(
-                                Venue::MarketMaking,
-                                *snapshot_balance,
-                                reason.clone(),
-                            ),
-                            now,
-                        )
-                    })
-            }
+            OnchainEquity {
+                balances,
+                fetched_at,
+            } => balances
+                .iter()
+                .try_fold(self, |view, (symbol, snapshot_balance)| {
+                    view.update_equity(
+                        symbol,
+                        Inventory::force_on_snapshot(
+                            Venue::MarketMaking,
+                            *snapshot_balance,
+                            reason.clone(),
+                        ),
+                        now,
+                    )
+                })
+                .map(|view| {
+                    view.record_equity_snapshot_watermarks(
+                        Venue::MarketMaking,
+                        balances.keys(),
+                        *fetched_at,
+                    )
+                }),
 
             OnchainUsdc { usdc_balance, .. } => self.update_usdc(
                 Inventory::force_on_snapshot(Venue::MarketMaking, *usdc_balance, reason),
                 now,
             ),
 
-            OffchainEquity { positions, .. } => {
-                positions
-                    .iter()
-                    .try_fold(self, |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::force_on_snapshot(
-                                Venue::Hedging,
-                                *snapshot_balance,
-                                reason.clone(),
-                            ),
-                            now,
-                        )
-                    })
-            }
+            OffchainEquity {
+                positions,
+                fetched_at,
+            } => positions
+                .iter()
+                .try_fold(self, |view, (symbol, snapshot_balance)| {
+                    view.update_equity(
+                        symbol,
+                        Inventory::force_on_snapshot(
+                            Venue::Hedging,
+                            *snapshot_balance,
+                            reason.clone(),
+                        ),
+                        now,
+                    )
+                })
+                .map(|view| {
+                    view.record_equity_snapshot_watermarks(
+                        Venue::Hedging,
+                        positions.keys(),
+                        *fetched_at,
+                    )
+                }),
 
             OffchainUsd {
                 usd_balance_cents,
@@ -1916,6 +2021,8 @@ mod tests {
             inflight_equity: HashMap::new(),
             previous_inflight_mint_symbols: HashSet::new(),
             previous_inflight_redemption_symbols: HashSet::new(),
+            onchain_equity_snapshot_watermarks: HashMap::new(),
+            offchain_equity_snapshot_watermarks: HashMap::new(),
         }
     }
 
@@ -1943,6 +2050,8 @@ mod tests {
             inflight_equity: HashMap::new(),
             previous_inflight_mint_symbols: HashSet::new(),
             previous_inflight_redemption_symbols: HashSet::new(),
+            onchain_equity_snapshot_watermarks: HashMap::new(),
+            offchain_equity_snapshot_watermarks: HashMap::new(),
         }
     }
 
@@ -3176,6 +3285,8 @@ mod tests {
             inflight_equity: HashMap::new(),
             previous_inflight_mint_symbols: HashSet::new(),
             previous_inflight_redemption_symbols: HashSet::new(),
+            onchain_equity_snapshot_watermarks: HashMap::new(),
+            offchain_equity_snapshot_watermarks: HashMap::new(),
         };
 
         let dto = view.to_dto();
@@ -3225,6 +3336,8 @@ mod tests {
             inflight_equity: HashMap::new(),
             previous_inflight_mint_symbols: HashSet::new(),
             previous_inflight_redemption_symbols: HashSet::new(),
+            onchain_equity_snapshot_watermarks: HashMap::new(),
+            offchain_equity_snapshot_watermarks: HashMap::new(),
         };
 
         let dto = view.to_dto();

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -1,6 +1,9 @@
 //! Mock implementations for onchain services.
 
-use alloy::primitives::{Address, B256, TxHash, U256};
+use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+use alloy::primitives::{Address, B256, Bloom, Log as PrimitiveLog, TxHash, U256};
+use alloy::rpc::types::{Log, TransactionReceipt};
+use alloy::sol_types::SolEvent;
 use alloy::transports::RpcError;
 use async_trait::async_trait;
 use std::sync::Mutex;
@@ -9,6 +12,7 @@ use st0x_evm::EvmError;
 use st0x_execution::Symbol;
 
 use super::raindex::{Raindex, RaindexError, RaindexVaultId};
+use crate::bindings::IERC20;
 
 /// Whether `submit_deposit` should succeed, fail generically, or fail
 /// with an "execution reverted" RPC error (simulating a revert during
@@ -28,6 +32,55 @@ pub(crate) struct MockRaindex {
     deposit_tx: TxHash,
     deposit_behavior: DepositBehavior,
     deposited_token: Mutex<Option<Address>>,
+    withdraw_transfer: Mutex<Option<(Address, U256)>>,
+    withdraw_actual_amount: Option<U256>,
+}
+
+fn successful_receipt(tx_hash: TxHash, logs: Vec<Log>) -> TransactionReceipt {
+    TransactionReceipt {
+        inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+            receipt: Receipt {
+                status: true.into(),
+                cumulative_gas_used: 0,
+                logs,
+            },
+            logs_bloom: Bloom::default(),
+        }),
+        transaction_hash: tx_hash,
+        transaction_index: Some(0),
+        block_hash: None,
+        block_number: Some(0),
+        gas_used: 21000,
+        effective_gas_price: 1,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from: Address::ZERO,
+        to: Some(Address::ZERO),
+        contract_address: None,
+    }
+}
+
+fn transfer_log(token: Address, to: Address, amount: U256) -> Log {
+    let event = IERC20::Transfer {
+        from: Address::ZERO,
+        to,
+        value: amount,
+    };
+    let inner = PrimitiveLog {
+        address: token,
+        data: event.encode_log_data(),
+    };
+
+    Log {
+        inner,
+        transaction_hash: None,
+        transaction_index: None,
+        block_hash: None,
+        block_number: None,
+        block_timestamp: None,
+        log_index: None,
+        removed: false,
+    }
 }
 
 impl MockRaindex {
@@ -39,6 +92,8 @@ impl MockRaindex {
             deposit_tx: TxHash::random(),
             deposit_behavior: DepositBehavior::Succeed,
             deposited_token: Mutex::new(None),
+            withdraw_transfer: Mutex::new(None),
+            withdraw_actual_amount: None,
         }
     }
 
@@ -50,6 +105,8 @@ impl MockRaindex {
             deposit_tx: TxHash::random(),
             deposit_behavior: DepositBehavior::FailGeneric,
             deposited_token: Mutex::new(None),
+            withdraw_transfer: Mutex::new(None),
+            withdraw_actual_amount: None,
         }
     }
 
@@ -65,6 +122,8 @@ impl MockRaindex {
             deposit_tx: TxHash::random(),
             deposit_behavior: DepositBehavior::FailExecutionReverted,
             deposited_token: Mutex::new(None),
+            withdraw_transfer: Mutex::new(None),
+            withdraw_actual_amount: None,
         }
     }
 
@@ -75,6 +134,11 @@ impl MockRaindex {
 
     pub(crate) fn with_token(mut self, token: Address) -> Self {
         self.token = token;
+        self
+    }
+
+    pub(crate) fn with_withdraw_actual_amount(mut self, amount: U256) -> Self {
+        self.withdraw_actual_amount = Some(amount);
         self
     }
 }
@@ -141,15 +205,29 @@ impl Raindex for MockRaindex {
 
     async fn submit_withdraw(
         &self,
-        _token: Address,
+        token: Address,
         _vault_id: RaindexVaultId,
-        _target_amount: U256,
+        target_amount: U256,
         _decimals: u8,
     ) -> Result<TxHash, RaindexError> {
+        *self.withdraw_transfer.lock().unwrap() = Some((token, target_amount));
         Ok(self.withdraw_tx)
     }
 
-    async fn confirm_tx(&self, _tx_hash: TxHash) -> Result<(), RaindexError> {
-        Ok(())
+    async fn confirm_tx_receipt(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<TransactionReceipt, RaindexError> {
+        let logs = self
+            .withdraw_transfer
+            .lock()
+            .unwrap()
+            .map(|(token, amount)| {
+                let amount = self.withdraw_actual_amount.unwrap_or(amount);
+                vec![transfer_log(token, Address::ZERO, amount)]
+            })
+            .unwrap_or_default();
+
+        Ok(successful_receipt(tx_hash, logs))
     }
 }

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -12,6 +12,7 @@
 //! standard fixed-point amounts (U256) and the float format MUST use rain-math-float.
 
 use alloy::primitives::{Address, B256, TxHash, U256, address};
+use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use rain_math_float::Float;
 use std::sync::Arc;
@@ -366,7 +367,13 @@ pub(crate) trait Raindex: Send + Sync {
     ) -> Result<TxHash, RaindexError>;
 
     /// Wait for a previously submitted transaction to be confirmed.
-    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError>;
+    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError> {
+        self.confirm_tx_receipt(tx_hash).await.map(|_| ())
+    }
+
+    /// Wait for a previously submitted transaction to be confirmed and return the receipt.
+    async fn confirm_tx_receipt(&self, tx_hash: TxHash)
+    -> Result<TransactionReceipt, RaindexError>;
 }
 
 #[async_trait]
@@ -473,11 +480,14 @@ impl<W: Wallet> Raindex for RaindexService<W> {
         Ok(tx_hash)
     }
 
-    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError> {
+    async fn confirm_tx_receipt(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<TransactionReceipt, RaindexError> {
         let receipt = self.evm.confirm::<OpenChainErrorRegistry>(tx_hash).await?;
 
         info!(target: "orderbook", tx_hash = %receipt.transaction_hash, "Transaction confirmed");
-        Ok(())
+        Ok(receipt)
     }
 }
 

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -12,6 +12,7 @@
 pub(crate) mod mock;
 
 use alloy::primitives::{Address, TxHash, U256};
+use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use std::fmt;
 use std::sync::Arc;
@@ -134,7 +135,7 @@ impl Raindex for PanickingRaindex {
         unimplemented!("PanickingRaindex: not available in CLI context")
     }
 
-    async fn confirm_tx(&self, _: TxHash) -> Result<(), RaindexError> {
+    async fn confirm_tx_receipt(&self, _: TxHash) -> Result<TransactionReceipt, RaindexError> {
         unimplemented!("PanickingRaindex: not available in CLI context")
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -39,7 +39,7 @@ use tracing::{debug, error, trace, warn};
 
 use rain_math_float::Float;
 use st0x_event_sorcery::{AggregateError, EntityList, LifecycleError, Reactor, Store, deps};
-use st0x_execution::{FractionalShares, Positive, Symbol};
+use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
 use st0x_finance::Usdc;
 
 use crate::config::AssetsConfig;
@@ -73,6 +73,8 @@ pub(crate) enum RebalancingServiceError {
     EquityTrigger(#[from] equity::EquityTriggerError),
     #[error("float arithmetic error: {0}")]
     Float(#[from] rain_math_float::FloatError),
+    #[error(transparent)]
+    SharesConversion(#[from] SharesConversionError),
     #[error("missing USDC tracking context for rebalance {id} at {event}")]
     MissingUsdcTrackingContext {
         id: UsdcRebalanceId,
@@ -89,6 +91,14 @@ pub(crate) enum RebalancingServiceError {
         event: usdc::UsdcTrackingEvent,
         initiated_amount: Usdc,
         settled_amount: Usdc,
+    },
+    #[error(
+        "redemption {id} unwrapped {actual_quantity} shares, exceeding tracked quantity {tracked_quantity}"
+    )]
+    RedemptionUnwrappedExceedsTracked {
+        id: RedemptionAggregateId,
+        tracked_quantity: FractionalShares,
+        actual_quantity: FractionalShares,
     },
 }
 
@@ -448,7 +458,10 @@ impl RedemptionTracking {
         }
     }
 
-    fn track_progress(&mut self, event: &EquityRedemptionEvent) {
+    fn track_progress(
+        &mut self,
+        event: &EquityRedemptionEvent,
+    ) -> Result<(), SharesConversionError> {
         match event {
             EquityRedemptionEvent::VaultWithdrawSubmitted { submitted_at, .. } => {
                 self.stage = RedemptionTrackingStage::VaultWithdrawSubmitted;
@@ -466,7 +479,16 @@ impl RedemptionTracking {
                 self.stage = RedemptionTrackingStage::UnwrapSubmitted;
                 self.last_progress_at = *submitted_at;
             }
-            EquityRedemptionEvent::TokensUnwrapped { unwrapped_at, .. } => {
+            EquityRedemptionEvent::TokensUnwrapped {
+                quantity,
+                unwrapped_amount,
+                unwrapped_at,
+                ..
+            } => {
+                self.quantity = match quantity {
+                    Some(quantity) => FractionalShares::new(*quantity),
+                    None => FractionalShares::from_u256_18_decimals(*unwrapped_amount)?,
+                };
                 self.stage = RedemptionTrackingStage::TokensUnwrapped;
                 self.last_progress_at = *unwrapped_at;
             }
@@ -488,6 +510,8 @@ impl RedemptionTracking {
             | EquityRedemptionEvent::RedemptionRejected { .. }
             | EquityRedemptionEvent::Completed { .. } => {}
         }
+
+        Ok(())
     }
 }
 
@@ -1049,17 +1073,20 @@ impl RebalancingService {
         &self,
         id: &RedemptionAggregateId,
         event: &EquityRedemptionEvent,
-    ) {
+    ) -> Result<(), RebalancingServiceError> {
         let mut tracking = self.redemption_tracking.write().await;
 
         if let Some(existing) = tracking.get_mut(id) {
-            existing.track_progress(event);
-            return;
+            existing.track_progress(event)?;
+            return Ok(());
         }
 
         if let Some(created) = RedemptionTracking::from_genesis_event(event) {
             tracking.insert(id.clone(), created);
         }
+        drop(tracking);
+
+        Ok(())
     }
 
     /// Fold the snapshot event into the view, then enqueue any
@@ -1096,38 +1123,24 @@ impl RebalancingService {
         let mut inventory = self.inventory.write().await;
 
         let updated = match &event {
-            OnchainEquity { balances, .. } => {
-                balances
-                    .iter()
-                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::on_snapshot(
-                                Venue::MarketMaking,
-                                *snapshot_balance,
-                                fetched_at,
-                            ),
-                            now,
-                        )
-                    })
-            }
+            OnchainEquity { balances, .. } => inventory.clone().apply_equity_snapshot(
+                Venue::MarketMaking,
+                balances.iter(),
+                fetched_at,
+                now,
+            ),
 
             OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
                 Inventory::on_snapshot(Venue::MarketMaking, *usdc_balance, fetched_at),
                 now,
             ),
 
-            OffchainEquity { positions, .. } => {
-                positions
-                    .iter()
-                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::on_snapshot(Venue::Hedging, *snapshot_balance, fetched_at),
-                            now,
-                        )
-                    })
-            }
+            OffchainEquity { positions, .. } => inventory.clone().apply_equity_snapshot(
+                Venue::Hedging,
+                positions.iter(),
+                fetched_at,
+                now,
+            ),
 
             OffchainUsd { .. }
             | OffchainMarginSafeBuyingPower { .. }
@@ -1169,7 +1182,7 @@ impl RebalancingService {
         use InventorySnapshotEvent::*;
         use RebalancingServiceError::{
             EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext, Projection,
-            SettledUsdcExceedsInitiatedAmount,
+            RedemptionUnwrappedExceedsTracked, SettledUsdcExceedsInitiatedAmount, SharesConversion,
         };
 
         self.expire_stuck_operations_with_logging().await;
@@ -1179,9 +1192,11 @@ impl RebalancingService {
             other @ (Projection(_)
             | EquityTrigger(_)
             | Float(_)
+            | SharesConversion(_)
             | MissingUsdcTrackingContext { .. }
             | MissingUsdcBridgedAmount { .. }
-            | SettledUsdcExceedsInitiatedAmount { .. }) => {
+            | SettledUsdcExceedsInitiatedAmount { .. }
+            | RedemptionUnwrappedExceedsTracked { .. }) => {
                 return Err(other);
             }
         };
@@ -1218,22 +1233,6 @@ impl RebalancingService {
         *inventory = InventoryView::default();
 
         let updated = match &event {
-            OnchainEquity { balances, .. } => {
-                balances
-                    .iter()
-                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::force_on_snapshot(
-                                Venue::MarketMaking,
-                                *snapshot_balance,
-                                recovery_reason.clone(),
-                            ),
-                            now,
-                        )
-                    })
-            }
-
             OnchainUsdc { usdc_balance, .. } => inventory.clone().update_usdc(
                 Inventory::force_on_snapshot(
                     Venue::MarketMaking,
@@ -1243,23 +1242,9 @@ impl RebalancingService {
                 now,
             ),
 
-            OffchainEquity { positions, .. } => {
-                positions
-                    .iter()
-                    .try_fold(inventory.clone(), |view, (symbol, snapshot_balance)| {
-                        view.update_equity(
-                            symbol,
-                            Inventory::force_on_snapshot(
-                                Venue::Hedging,
-                                *snapshot_balance,
-                                recovery_reason.clone(),
-                            ),
-                            now,
-                        )
-                    })
-            }
-
-            OffchainUsd { .. }
+            OnchainEquity { .. }
+            | OffchainEquity { .. }
+            | OffchainUsd { .. }
             | OffchainMarginSafeBuyingPower { .. }
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
@@ -1405,10 +1390,11 @@ impl Reactor for RebalancingService {
                 };
 
                 let mut inventory = self.inventory.write().await;
-                *inventory = inventory
+                let updated = inventory
                     .clone()
                     .update_equity(&symbol, equity_update, timestamp)?
                     .update_usdc(usdc_update, timestamp)?;
+                *inventory = updated;
                 drop(inventory);
 
                 self.equity_scheduler.enqueue_check(symbol).await;
@@ -1651,6 +1637,45 @@ impl RebalancingService {
         }
     }
 
+    fn redemption_actual_unwrapped_quantity(
+        event: &EquityRedemptionEvent,
+    ) -> Result<Option<FractionalShares>, SharesConversionError> {
+        match event {
+            EquityRedemptionEvent::TokensUnwrapped {
+                quantity,
+                unwrapped_amount,
+                ..
+            } => Ok(Some(match quantity {
+                Some(quantity) => FractionalShares::new(*quantity),
+                None => FractionalShares::from_u256_18_decimals(*unwrapped_amount)?,
+            })),
+            _ => Ok(None),
+        }
+    }
+
+    fn recovered_redemption_quantity(
+        entity: &EquityRedemption,
+    ) -> Result<FractionalShares, SharesConversionError> {
+        use EquityRedemption::*;
+
+        match entity {
+            VaultWithdrawPending { quantity, .. }
+            | VaultWithdrawSubmitted { quantity, .. }
+            | WithdrawnFromRaindex { quantity, .. }
+            | UnwrapPending { quantity, .. }
+            | UnwrapSubmitted { quantity, .. }
+            | TokensSent { quantity, .. }
+            | Pending { quantity, .. } => Ok(FractionalShares::new(*quantity)),
+            TokensUnwrapped {
+                unwrapped_amount, ..
+            }
+            | SendPending {
+                unwrapped_amount, ..
+            } => FractionalShares::from_u256_18_decimals(*unwrapped_amount),
+            Completed { .. } | Failed { .. } => Ok(FractionalShares::ZERO),
+        }
+    }
+
     /// Checks inventory for equity imbalance and triggers operation if needed.
     pub(crate) async fn check_and_trigger_equity(
         &self,
@@ -1858,35 +1883,16 @@ impl RebalancingService {
         use EquityRedemption::*;
 
         match entity {
-            VaultWithdrawPending {
-                symbol, quantity, ..
-            }
-            | VaultWithdrawSubmitted {
-                symbol, quantity, ..
-            }
-            | WithdrawnFromRaindex {
-                symbol, quantity, ..
-            }
-            | UnwrapPending {
-                symbol, quantity, ..
-            }
-            | UnwrapSubmitted {
-                symbol, quantity, ..
-            }
-            | TokensUnwrapped {
-                symbol, quantity, ..
-            }
-            | SendPending {
-                symbol, quantity, ..
-            }
-            | TokensSent {
-                symbol, quantity, ..
-            }
-            | Pending {
-                symbol, quantity, ..
-            } => {
-                let quantity = FractionalShares::new(*quantity);
-
+            VaultWithdrawPending { symbol, .. }
+            | VaultWithdrawSubmitted { symbol, .. }
+            | WithdrawnFromRaindex { symbol, .. }
+            | UnwrapPending { symbol, .. }
+            | UnwrapSubmitted { symbol, .. }
+            | TokensUnwrapped { symbol, .. }
+            | SendPending { symbol, .. }
+            | TokensSent { symbol, .. }
+            | Pending { symbol, .. } => {
+                let quantity = Self::recovered_redemption_quantity(entity)?;
                 let (stage, last_progress_at) = match entity {
                     VaultWithdrawPending { pending_at, .. } => {
                         (RedemptionTrackingStage::VaultWithdrawPending, *pending_at)
@@ -2013,7 +2019,33 @@ impl RebalancingService {
             return Ok(());
         }
 
-        self.track_redemption_progress(&id, &event).await;
+        if let Some(actual_quantity) = Self::redemption_actual_unwrapped_quantity(&event)?
+            && let Some(existing) = self.load_redemption_tracking(&id).await
+        {
+            if actual_quantity.inner().lt(existing.quantity.inner())? {
+                let shortfall = (existing.quantity - actual_quantity)?;
+                self.apply_equity_update(
+                    &existing.symbol,
+                    Self::cancel_equity_transfer_update(Venue::MarketMaking, shortfall),
+                )
+                .await?;
+            } else if existing.quantity.inner().lt(actual_quantity.inner())? {
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    expected_quantity = %existing.quantity,
+                    actual_quantity = %actual_quantity,
+                    "Redemption unwrapped more than tracked quantity"
+                );
+                return Err(RebalancingServiceError::RedemptionUnwrappedExceedsTracked {
+                    id,
+                    tracked_quantity: existing.quantity,
+                    actual_quantity,
+                });
+            }
+        }
+
+        self.track_redemption_progress(&id, &event).await?;
 
         let Some(tracking) = self.load_redemption_tracking(&id).await else {
             return Ok(());
@@ -2344,6 +2376,55 @@ mod tests {
         assert_eq!(inflight, Some(FractionalShares::new(float!(12))));
     }
 
+    #[tokio::test]
+    async fn recover_redemption_state_keeps_requested_quantity_until_unwrap_confirms() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("COIN").unwrap();
+        let redemption_id = RedemptionAggregateId::new("partial-redemption-recovery");
+        let requested_quantity = float!(37.143292455);
+        let actual_wrapped_amount = U256::from(33_681_456_848_531_939_569_u128);
+        let requested_fractional = FractionalShares::new(requested_quantity);
+        let withdrawn_at = Utc::now();
+
+        trigger
+            .recover_redemption_state(
+                &redemption_id,
+                &EquityRedemption::WithdrawnFromRaindex {
+                    symbol: symbol.clone(),
+                    quantity: requested_quantity,
+                    token: Address::random(),
+                    wrapped_amount: actual_wrapped_amount,
+                    raindex_withdraw_tx: TxHash::random(),
+                    withdrawn_at,
+                },
+            )
+            .await
+            .unwrap();
+
+        let tracking = trigger
+            .redemption_tracking
+            .read()
+            .await
+            .get(&redemption_id)
+            .cloned()
+            .unwrap();
+        assert_eq!(tracking.quantity, requested_fractional);
+        assert_eq!(
+            tracking.stage,
+            RedemptionTrackingStage::WithdrawnFromRaindex
+        );
+
+        let inflight = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_inflight(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(
+            inflight,
+            Some(requested_fractional),
+            "Recovery keeps requested underlying quantity until unwrap confirms actual underlying shares"
+        );
+    }
+
     /// Drives the production snapshot path end-to-end: applies the
     /// snapshot via the service (which enqueues follow-up checks
     /// internally). Skips the entity-list plumbing so tests can drive
@@ -2537,6 +2618,14 @@ mod tests {
     }
 
     fn make_onchain_fill(amount: FractionalShares, direction: Direction) -> PositionEvent {
+        make_onchain_fill_at(amount, direction, Utc::now())
+    }
+
+    fn make_onchain_fill_at(
+        amount: FractionalShares,
+        direction: Direction,
+        block_timestamp: DateTime<Utc>,
+    ) -> PositionEvent {
         PositionEvent::OnChainOrderFilled {
             trade_id: TradeId {
                 tx_hash: TxHash::random(),
@@ -2545,19 +2634,27 @@ mod tests {
             amount,
             direction,
             price_usdc: float!(150),
-            block_timestamp: Utc::now(),
+            block_timestamp,
             seen_at: Utc::now(),
         }
     }
 
     fn make_offchain_fill(shares_filled: FractionalShares, direction: Direction) -> PositionEvent {
+        make_offchain_fill_at(shares_filled, direction, Utc::now())
+    }
+
+    fn make_offchain_fill_at(
+        shares_filled: FractionalShares,
+        direction: Direction,
+        broker_timestamp: DateTime<Utc>,
+    ) -> PositionEvent {
         PositionEvent::OffChainOrderFilled {
             offchain_order_id: OffchainOrderId::new(),
             shares_filled: Positive::new(shares_filled).unwrap(),
             direction,
             executor_order_id: ExecutorOrderId::new("ORD1"),
             price: Usd::new(float!(150)),
-            broker_timestamp: Utc::now(),
+            broker_timestamp,
         }
     }
 
@@ -2818,6 +2915,304 @@ mod tests {
                 mpsc::error::TryRecvError::Empty
             ),
             "Expected channel to be empty (no message sent)"
+        );
+    }
+
+    #[tokio::test]
+    async fn fill_delta_before_snapshot_timestamp_is_still_applied() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let snapshot_at = Utc::now();
+        let stale_fill_at = snapshot_at - chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor);
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(50))]),
+                fetched_at: snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let event = make_onchain_fill_at(shares(10), Direction::Buy, stale_fill_at);
+        harness
+            .receive::<Position>(symbol.clone(), event)
+            .await
+            .unwrap();
+
+        let onchain_available = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_available(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(
+            onchain_available,
+            Some(shares(60)),
+            "Fill deltas are applied because snapshot timestamps are not causal watermarks"
+        );
+    }
+
+    #[tokio::test]
+    async fn older_onchain_equity_snapshot_does_not_overwrite_newer_snapshot() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let newer_snapshot_at = Utc::now();
+        let older_snapshot_at = newer_snapshot_at - chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(80))]),
+                fetched_at: newer_snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(10))]),
+                fetched_at: older_snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let onchain_available = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_available(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(
+            onchain_available,
+            Some(shares(80)),
+            "Older onchain snapshot should not overwrite newer onchain balance"
+        );
+    }
+
+    #[tokio::test]
+    async fn older_offchain_equity_snapshot_does_not_overwrite_newer_snapshot() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let newer_snapshot_at = Utc::now();
+        let older_snapshot_at = newer_snapshot_at - chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OffchainEquity {
+                positions: BTreeMap::from([(symbol.clone(), shares(80))]),
+                fetched_at: newer_snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OffchainEquity {
+                positions: BTreeMap::from([(symbol.clone(), shares(10))]),
+                fetched_at: older_snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let offchain_available = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_available(&symbol, Venue::Hedging)
+        };
+        assert_eq!(
+            offchain_available,
+            Some(shares(80)),
+            "Older offchain snapshot should not overwrite newer offchain balance"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_onchain_fill_delta_after_snapshot_is_applied() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let snapshot_at = Utc::now();
+        let fresh_fill_at = snapshot_at + chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor);
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(50))]),
+                fetched_at: snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let event = make_onchain_fill_at(shares(10), Direction::Buy, fresh_fill_at);
+        harness
+            .receive::<Position>(symbol.clone(), event)
+            .await
+            .unwrap();
+
+        let onchain_available = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_available(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(
+            onchain_available,
+            Some(shares(60)),
+            "Fresh fill newer than the snapshot should update onchain inventory"
+        );
+    }
+
+    #[tokio::test]
+    async fn offchain_fill_delta_before_snapshot_timestamp_updates_equity_and_cash() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let snapshot_at = Utc::now();
+        let stale_fill_at = snapshot_at - chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor);
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OffchainEquity {
+                positions: BTreeMap::from([(symbol.clone(), shares(50))]),
+                fetched_at: snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let event = make_offchain_fill_at(shares(10), Direction::Buy, stale_fill_at);
+        harness
+            .receive::<Position>(symbol.clone(), event)
+            .await
+            .unwrap();
+
+        let (offchain_available, hedging_usdc) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.equity_available(&symbol, Venue::Hedging),
+                inventory.usdc_available(Venue::Hedging),
+            )
+        };
+        assert_eq!(
+            offchain_available,
+            Some(shares(60)),
+            "Offchain fill should update equity because snapshot timestamps are not causal watermarks"
+        );
+        assert_ne!(
+            hedging_usdc,
+            Some(usdc(1_000_000)),
+            "Cash leg applies atomically with equity"
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_snapshot_does_not_suppress_later_fill_delta() {
+        let symbol = Symbol::new("COIN").unwrap();
+        let snapshot_at = Utc::now();
+        let stale_fill_at = snapshot_at - chrono::Duration::seconds(1);
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000))
+            .update_equity(
+                &symbol,
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, shares(5)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(reactor);
+
+        apply_and_dispatch_snapshot(
+            trigger.clone(),
+            InventorySnapshotId {
+                orderbook: TEST_ORDERBOOK,
+                owner: TEST_ORDER_OWNER,
+            },
+            InventorySnapshotEvent::OnchainEquity {
+                balances: BTreeMap::from([(symbol.clone(), shares(100))]),
+                fetched_at: snapshot_at,
+            },
+        )
+        .await
+        .unwrap();
+
+        let event = make_onchain_fill_at(shares(10), Direction::Buy, stale_fill_at);
+        harness
+            .receive::<Position>(symbol.clone(), event)
+            .await
+            .unwrap();
+
+        let onchain_available = {
+            let inventory = trigger.inventory.read().await;
+            inventory.equity_available(&symbol, Venue::MarketMaking)
+        };
+        assert_eq!(
+            onchain_available,
+            Some(shares(55)),
+            "Fill must apply when the newer snapshot was skipped due to inflight inventory"
         );
     }
 

--- a/src/wrapper/mock.rs
+++ b/src/wrapper/mock.rs
@@ -35,7 +35,7 @@ pub(crate) struct MockWrapper {
 impl MockWrapper {
     pub(crate) fn new() -> Self {
         Self {
-            owner: Address::random(),
+            owner: Address::ZERO,
             unwrap_tx: TxHash::random(),
             tokenized_shares: Address::random(),
             wrapped_token: Address::random(),
@@ -48,7 +48,7 @@ impl MockWrapper {
     /// Creates a mock wrapper with a custom ratio.
     pub(crate) fn with_ratio(ratio: U256) -> Self {
         Self {
-            owner: Address::random(),
+            owner: Address::ZERO,
             unwrap_tx: TxHash::random(),
             tokenized_shares: Address::random(),
             wrapped_token: Address::random(),


### PR DESCRIPTION
## What

Addresses [RAI-583](https://linear.app/makeitrain/issue/RAI-583/use-actual-withdraw4-received-amount-before-unwrapping-equity) and [RAI-584](https://linear.app/makeitrain/issue/RAI-584/prevent-stale-onchain-fill-deltas-from-inflating-inventory-after).

Fixes equity redemption and inventory accounting races that could leave the rebalancing view tracking the wrong quantity.

This PR records actual Raindex withdrawal amounts from transaction receipts, carries actual unwrapped quantities through redemption state, and prevents stale inventory snapshots from overwriting newer absolute balances while still allowing fill deltas to apply.

## Why

Raindex withdrawals can return less than the requested wrapped-token amount. The redemption flow previously kept using the requested quantity after confirmation, which could overstate in-flight equity and make stuck-redemption recovery re-trigger work for inventory the bot no longer holds.

Inventory snapshots also used timestamps like causal watermarks for all updates. That let stale snapshots overwrite newer snapshot values, and could suppress legitimate fill deltas whose exchange timestamp was earlier than a later snapshot fetch.

## How

- `Raindex::confirm_tx_receipt` now returns the confirmed transaction receipt, while `confirm_tx` remains a convenience wrapper.
- `EquityRedemptionEvent::WithdrawnFromRaindex` stores `actual_wrapped_amount`, decoded from matching ERC-20 `Transfer` logs in the withdrawal receipt.
- `EquityRedemptionEvent::TokensUnwrapped` stores the actual fractional `quantity` derived from the unwrapped amount.
- `EquityRedemption` uses the actual withdrawn/unwrapped amount for later redemption states, while keeping event fields backward-compatible with `serde(default)`.
- `symbols_with_stuck_redemptions` recovers quantities from the latest sent/unwrapped/withdrawn event instead of blindly using the originally requested quantity, and now errors on invalid recovered amounts instead of silently skipping bad financial data.
- `InventorySnapshot` persists per-snapshot fetched timestamps for onchain equity, onchain USDC, offchain equity, and offchain USD, and ignores older snapshot events for the same snapshot kind.
- `InventoryView` tracks per-symbol equity snapshot watermarks, applies absolute equity snapshots only when they are newer and safe to apply, and continues applying position fill deltas independently of snapshot timestamps.
- `RebalancingService` adjusts in-flight market-making equity downward when a redemption unwrap confirms fewer shares than originally tracked, and errors if an unwrap reports more shares than tracked.
- `migrations/20260518115736_backfill_inventory_snapshot_fetched_at_fields.sql` backfills the new `InventorySnapshot` fetched-at fields from existing snapshot `last_updated` values so compacted snapshot-only aggregates still hydrate correctly after deploy.
- Test mocks for Raindex and wrapper ownership were updated so receipt-transfer decoding can be exercised deterministically.

## Testing

Added unit and async coverage for:

- decoding actual withdrawal transfer amounts from receipts
- using actual withdrawn amounts during unwrap confirmation
- failing withdrawal confirmation when no matching transfer exists
- rejecting malformed transfer logs
- stuck-redemption recovery using actual unwrapped quantities
- stuck-redemption recovery errors on invalid recovered quantities
- preserving newer persisted inventory snapshots over older events
- preventing older onchain/offchain equity snapshots from overwriting newer balances
- applying onchain and offchain fill deltas even when their timestamps precede snapshot fetch timestamps
- ensuring skipped snapshots do not suppress later fill deltas
- recovering redemption tracking with requested quantity until unwrap confirms the actual quantity

Additional verification:

- Verified the migration path on a throwaway SQLite database: applied all migrations through `20260506235955`, seeded a pre-migration `InventorySnapshot` snapshot, ran `sqlx migrate run`, confirmed `20260518115736` applied successfully, and checked all four fetched-at fields were backfilled from `last_updated`.

## Screenshots

Not applicable.

## Anything else

There is no table/schema migration. The included data migration updates existing `InventorySnapshot` snapshot JSON so the newly persisted fetched-at fields are present for old compacted snapshots. The redemption event payload shape changes are backward-compatible through optional/defaulted fields. No config changes or new dependencies are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-source fetch timestamp tracking for inventory snapshots (onchain equity, onchain USDC, offchain equity, offchain USD).

* **Bug Fixes**
  * Fixed stale snapshot data overwriting newer inventory states.
  * Improved handling of partial equity redemptions with accurate quantity tracking.

* **Improvements**
  * Enhanced error reporting for failed withdrawal operations.
  * Strengthened redemption recovery logic with better quantity validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->