### PR TITLE
fix: refresh dashboard inventory live data

### DIFF
--- a/crates/event-sorcery/src/wire.rs
+++ b/crates/event-sorcery/src/wire.rs
@@ -152,9 +152,15 @@ where
             other => ReconcileError::Persistence(PersistenceError::UnknownError(Box::new(other))),
         })?;
 
-        self.queries.push(Box::new(ReactorBridge {
-            reactor: projection.clone(),
-        }));
+        // The materialized view is the source for reconnect snapshots.
+        // Update it before side-effect reactors emit notifications so a
+        // client that reconnects after a broadcast cannot read a stale view.
+        self.queries.insert(
+            0,
+            Box::new(ReactorBridge {
+                reactor: projection.clone(),
+            }),
+        );
 
         let cqrs = sqlite_snapshot_cqrs(self.pool.clone(), self.queries, services);
         Ok((Arc::new(Store::new(cqrs, self.pool)), projection))
@@ -209,9 +215,34 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct EventB;
 
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct ProjectedAggregate {
+        value: i64,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    enum ProjectedEvent {
+        Created { value: i64 },
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum ProjectedCommand {
+        Create { value: i64 },
+    }
+
     impl DomainEvent for EventB {
         fn event_type(&self) -> String {
             "EventB".to_string()
+        }
+
+        fn event_version(&self) -> String {
+            "1.0".to_string()
+        }
+    }
+
+    impl DomainEvent for ProjectedEvent {
+        fn event_type(&self) -> String {
+            "ProjectedEvent::Created".to_string()
         }
 
         fn event_version(&self) -> String {
@@ -279,6 +310,47 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl EventSourced for ProjectedAggregate {
+        type Id = String;
+        type Event = ProjectedEvent;
+        type Command = ProjectedCommand;
+        type Error = Never;
+        type Services = ();
+        type Materialized = Table;
+
+        const AGGREGATE_TYPE: &'static str = "ProjectedAggregate";
+        const PROJECTION: Table = Table("projected_aggregate_view");
+        const SCHEMA_VERSION: u64 = 1;
+
+        fn originate(event: &ProjectedEvent) -> Option<Self> {
+            match event {
+                ProjectedEvent::Created { value } => Some(Self { value: *value }),
+            }
+        }
+
+        fn evolve(_entity: &Self, _event: &ProjectedEvent) -> Result<Option<Self>, Never> {
+            Ok(None)
+        }
+
+        async fn initialize(
+            command: ProjectedCommand,
+            _services: &(),
+        ) -> Result<Vec<ProjectedEvent>, Never> {
+            match command {
+                ProjectedCommand::Create { value } => Ok(vec![ProjectedEvent::Created { value }]),
+            }
+        }
+
+        async fn transition(
+            &self,
+            _command: ProjectedCommand,
+            _services: &(),
+        ) -> Result<Vec<ProjectedEvent>, Never> {
+            Ok(vec![])
+        }
+    }
+
     struct MultiEntityReactor;
 
     deps!(MultiEntityReactor, [AggregateA, AggregateB]);
@@ -317,10 +389,58 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn single_entity_wiring() {
+    struct ProjectionReadingReactor {
+        pool: SqlitePool,
+        sender: tokio::sync::mpsc::Sender<Option<i64>>,
+    }
+
+    deps!(ProjectionReadingReactor, [ProjectedAggregate]);
+
+    #[async_trait]
+    impl Reactor for ProjectionReadingReactor {
+        type Error = Never;
+
+        async fn react(
+            &self,
+            event: <Self::Dependencies as EntityList>::Event,
+        ) -> Result<(), Self::Error> {
+            event
+                .on(|id, _event| async move {
+                    let value = load_projected_value(&self.pool, &id).await;
+                    self.sender.send(value).await.unwrap();
+                })
+                .exhaustive()
+                .await;
+
+            Ok(())
+        }
+    }
+
+    async fn load_projected_value(pool: &SqlitePool, id: &str) -> Option<i64> {
+        let payload: Option<String> =
+            sqlx::query_scalar("SELECT payload FROM projected_aggregate_view WHERE view_id = ?")
+                .bind(id)
+                .fetch_optional(pool)
+                .await
+                .unwrap();
+
+        payload.and_then(|payload| {
+            match serde_json::from_str::<Lifecycle<ProjectedAggregate>>(&payload).unwrap() {
+                Lifecycle::Live(entity) => Some(entity.value),
+                Lifecycle::Uninitialized | Lifecycle::Failed { .. } => None,
+            }
+        })
+    }
+
+    async fn setup_pool() -> SqlitePool {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn single_entity_wiring() {
+        let pool = setup_pool().await;
 
         let _store = StoreBuilder::<AggregateA>::new(pool.clone())
             .with(Arc::new(SingleEntityReactor))
@@ -331,8 +451,7 @@ mod tests {
 
     #[tokio::test]
     async fn multi_entity_wiring() {
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!("../../migrations").run(&pool).await.unwrap();
+        let pool = setup_pool().await;
 
         let multi = Arc::new(MultiEntityReactor);
         let single = Arc::new(SingleEntityReactor);
@@ -349,5 +468,50 @@ mod tests {
             .build(())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn projected_entities_update_views_before_registered_reactors() {
+        let pool = setup_pool().await;
+        sqlx::query(
+            "CREATE TABLE projected_aggregate_view ( \
+                 view_id TEXT NOT NULL PRIMARY KEY, \
+                 version BIGINT NOT NULL, \
+                 payload TEXT NOT NULL \
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let reactor = Arc::new(ProjectionReadingReactor {
+            pool: pool.clone(),
+            sender,
+        });
+        let (store, _projection) = StoreBuilder::<ProjectedAggregate>::new(pool.clone())
+            .with(reactor)
+            .build(())
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &"projected-1".to_string(),
+                ProjectedCommand::Create { value: 42 },
+            )
+            .await
+            .unwrap();
+
+        let value_seen_by_reactor =
+            tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+                .await
+                .expect("registered reactor should receive the projected event")
+                .expect("registered reactor should receive the projected event");
+        assert_eq!(
+            value_seen_by_reactor,
+            Some(42),
+            "registered reactors must observe the updated projection"
+        );
     }
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -636,7 +636,8 @@ impl PositionAndRebalancing {
                 recovery_transfer: Some(infra.recovery_transfer),
             })
         } else {
-            let (position, position_projection) = build_position_cqrs(pool).await?;
+            let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+            let (position, position_projection) = build_position_cqrs(pool, broadcaster).await?;
 
             // Without the service, the projection is the only subscriber
             // keeping the dashboard view in sync.
@@ -1107,8 +1108,10 @@ async fn recover_single_orphaned_order(
 /// (without rebalancing trigger). Used when rebalancing is disabled.
 async fn build_position_cqrs(
     pool: &SqlitePool,
+    broadcaster: Arc<Broadcaster>,
 ) -> anyhow::Result<(Arc<Store<Position>>, Arc<Projection<Position>>)> {
     Ok(StoreBuilder::<Position>::new(pool.clone())
+        .with(broadcaster)
         .build(())
         .await?)
 }
@@ -1979,6 +1982,11 @@ mod tests {
             shutdown_token: CancellationToken::new(),
             apalis_shutdown_token: CancellationToken::new(),
         }
+    }
+
+    fn test_broadcaster(pool: &SqlitePool) -> (Arc<Broadcaster>, broadcast::Receiver<Statement>) {
+        let (sender, receiver) = broadcast::channel(16);
+        (Arc::new(Broadcaster::new(sender, pool.clone())), receiver)
     }
 
     async fn insert_finished_job(pool: &SqlitePool, id: &str) {
@@ -3960,7 +3968,9 @@ mod tests {
 
         // First "session": create position store, execute commands.
         {
-            let (position_store, position_projection) = build_position_cqrs(&pool).await.unwrap();
+            let (broadcaster, _receiver) = test_broadcaster(&pool);
+            let (position_store, position_projection) =
+                build_position_cqrs(&pool, broadcaster).await.unwrap();
 
             position_store
                 .send(
@@ -3994,7 +4004,9 @@ mod tests {
 
         // Second "session": create NEW position store against the same pool.
         {
-            let (_position_store, position_projection) = build_position_cqrs(&pool).await.unwrap();
+            let (broadcaster, _receiver) = test_broadcaster(&pool);
+            let (_position_store, position_projection) =
+                build_position_cqrs(&pool, broadcaster).await.unwrap();
 
             let position = position_projection
                 .load(&symbol)
@@ -4012,6 +4024,125 @@ mod tests {
                 FractionalShares::new(float!(10)),
                 "Accumulated long should survive restart via persisted view"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn standalone_position_cqrs_broadcasts_live_position_updates() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (broadcaster, mut receiver) = test_broadcaster(&pool);
+        let (position_store, _position_projection) =
+            build_position_cqrs(&pool, broadcaster).await.unwrap();
+
+        position_store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(3)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let message = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("position command should broadcast dashboard update")
+            .expect("position command should broadcast dashboard update");
+
+        match message {
+            Statement::PositionUpdate(position) => {
+                assert_eq!(position.symbol, symbol);
+                assert!(position.net.eq(float!(3)).unwrap());
+                assert!(
+                    position
+                        .last_price_usdc
+                        .expect("position update should include last price")
+                        .eq(float!(150))
+                        .unwrap()
+                );
+            }
+            other => panic!("expected PositionUpdate message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_rebalancing_setup_broadcasts_live_position_updates() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let (event_sender, mut event_receiver) = broadcast::channel(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default(),
+            event_sender.clone(),
+        ));
+        let (vault_registry, vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        let position_and_rebalancing = PositionAndRebalancing::setup(
+            None,
+            &ctx,
+            &pool,
+            inventory,
+            event_sender,
+            vault_registry,
+            vault_registry_projection,
+            RebalancingSchedulers::new(&pool),
+        )
+        .await
+        .unwrap();
+
+        position_and_rebalancing
+            .position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(3)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let message =
+            tokio::time::timeout(std::time::Duration::from_secs(1), event_receiver.recv())
+                .await
+                .expect("position command should broadcast through setup event sender")
+                .expect("position command should broadcast through setup event sender");
+
+        match message {
+            Statement::PositionUpdate(position) => {
+                assert_eq!(position.symbol, symbol);
+                assert!(position.net.eq(float!(3)).unwrap());
+                assert!(
+                    position
+                        .last_price_usdc
+                        .expect("position update should include last price")
+                        .eq(float!(150))
+                        .unwrap()
+                );
+            }
+            other => panic!("expected PositionUpdate message, got {other:?}"),
         }
     }
 

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -74,6 +74,7 @@ impl QueryManifest {
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .with(rebalancing_service.clone())
+            .with(broadcaster.clone())
             .build(())
             .await?;
 
@@ -115,23 +116,33 @@ impl QueryManifest {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Address;
+    use alloy::primitives::{Address, TxHash, fixed_bytes};
     use std::collections::{BTreeMap, HashSet};
     use std::time::Duration;
     use tokio::sync::{broadcast, mpsc};
 
+    use st0x_dto::Statement;
     use st0x_event_sorcery::test_store;
-    use st0x_execution::{FractionalShares, Symbol};
+    use st0x_execution::{Direction, FractionalShares, Symbol};
+    use st0x_finance::Usdc;
     use st0x_float_macro::float;
 
     use super::*;
     use crate::config::{AssetsConfig, EquitiesConfig};
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
-    use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
+    use crate::inventory::{
+        BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Operator, Venue,
+    };
     use crate::onchain::mock::MockRaindex;
-    use crate::rebalancing::{RebalancingSchedulers, RebalancingService, RebalancingServiceConfig};
+    use crate::position::{PositionCommand, TradeId};
+    use crate::rebalancing::{
+        RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, TriggeredOperation,
+        drain_pending_jobs,
+    };
     use crate::test_utils::setup_test_db;
+    use crate::threshold::ExecutionThreshold;
     use crate::tokenization::mock::MockTokenizer;
+    use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
     use crate::wrapper::mock::MockWrapper;
 
     fn test_trigger_config() -> RebalancingServiceConfig {
@@ -264,7 +275,141 @@ mod tests {
             Some(FractionalShares::new(float!(7))),
             "manifest build must wire the InventorySnapshot store so that \
              live commands dispatch through the trigger's projection into \
-             BroadcastingInventory",
+            BroadcastingInventory",
+        );
+    }
+
+    #[tokio::test]
+    async fn build_frameworks_broadcasts_live_position_updates() {
+        let pool = setup_test_db().await;
+        let (operation_sender, mut operation_receiver) = mpsc::channel(10);
+        let (event_sender, mut event_receiver) = broadcast::channel(10);
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let orderbook = Address::repeat_byte(0xAB);
+        let owner = Address::repeat_byte(0xCD);
+        let token = Address::repeat_byte(0xEF);
+        let vault_registry = Arc::new(test_store(pool.clone(), ()));
+        vault_registry
+            .send(
+                &VaultRegistryId { orderbook, owner },
+                VaultRegistryCommand::SeedEquityVaultFromConfig {
+                    token,
+                    vault_id: fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    ),
+                    symbol: symbol.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let initial_inventory = InventoryView::default()
+            .with_equity(
+                symbol.clone(),
+                FractionalShares::ZERO,
+                FractionalShares::ZERO,
+            )
+            .with_usdc(Usdc::new(float!(1000000)), Usdc::new(float!(1000000)))
+            .update_equity(
+                &symbol,
+                Inventory::available(
+                    Venue::MarketMaking,
+                    Operator::Add,
+                    FractionalShares::new(float!(20)),
+                ),
+                chrono::Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                &symbol,
+                Inventory::available(
+                    Venue::Hedging,
+                    Operator::Add,
+                    FractionalShares::new(float!(80)),
+                ),
+                chrono::Utc::now(),
+            )
+            .unwrap();
+        let inventory = Arc::new(BroadcastingInventory::new(
+            initial_inventory,
+            event_sender.clone(),
+        ));
+
+        let rebalancing_service = Arc::new(RebalancingService::new(
+            test_trigger_config(),
+            vault_registry,
+            orderbook,
+            owner,
+            inventory,
+            operation_sender,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
+        ));
+        let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
+        let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster);
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+        let built = manifest.build(pool, services).await.unwrap();
+
+        built
+            .position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(2)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let message = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let message = event_receiver
+                    .recv()
+                    .await
+                    .expect("position command should broadcast dashboard update");
+
+                if matches!(message, Statement::PositionUpdate(_)) {
+                    return message;
+                }
+            }
+        })
+        .await
+        .expect("position command should broadcast dashboard update");
+
+        match message {
+            Statement::PositionUpdate(position) => {
+                assert_eq!(position.symbol, symbol);
+                assert!(position.net.eq(float!(2)).unwrap());
+                assert!(
+                    position
+                        .last_price_usdc
+                        .expect("position update should include last price")
+                        .eq(float!(150))
+                        .unwrap()
+                );
+            }
+            other => panic!("expected PositionUpdate message, got {other:?}"),
+        }
+
+        drain_pending_jobs(&rebalancing_service).await.unwrap();
+        let triggered = operation_receiver.try_recv();
+        assert!(
+            matches!(triggered, Ok(TriggeredOperation::Mint { .. })),
+            "expected rebalancing subscriber to receive position event, got {triggered:?}"
         );
     }
 }

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -12,7 +12,7 @@ use st0x_event_sorcery::{EntityList, Never, Reactor, deps, load_entity};
 use crate::equity_redemption::EquityRedemption;
 use crate::offchain::order::{OffchainOrder, OffchainOrderEvent};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeEvent};
-use crate::position::Position;
+use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 
@@ -88,7 +88,15 @@ impl Reactor for Broadcaster {
                 }
             })
 
-            .on(|id, _event| async move {
+            .on(|id, event| async move {
+                if !matches!(
+                    event,
+                    PositionEvent::OnChainOrderFilled { .. }
+                        | PositionEvent::OffChainOrderFilled { .. }
+                ) {
+                    return;
+                }
+
                 match load_entity::<Position>(&self.pool, &id).await {
                     Ok(Some(position)) => {
                         self.broadcast_position(st0x_dto::Position {
@@ -327,14 +335,21 @@ mod tests {
             .await
             .unwrap();
 
-        let initialized = PositionEvent::Initialized {
-            symbol: symbol.clone(),
-            threshold,
-            initialized_at: now,
-        };
-
         harness
-            .receive::<Position>(symbol.clone(), initialized)
+            .receive::<Position>(
+                symbol.clone(),
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: alloy::primitives::TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(1)),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+            )
             .await
             .unwrap();
 

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -9,10 +9,12 @@ use tokio::sync::broadcast;
 use tracing::{info, trace, warn};
 
 use st0x_dto::{CurrentState, Statement};
+use st0x_event_sorcery::{load_all_ids, load_entity};
 use st0x_finance::Positive;
 
 use crate::config::OperationMode;
 use crate::inventory::BroadcastingInventory;
+use crate::position::Position;
 use crate::threshold::ExecutionThreshold;
 
 mod event;
@@ -229,54 +231,33 @@ fn float_to_f64(value: rain_math_float::Float, fallback: f64) -> f64 {
 }
 
 async fn load_positions(pool: &SqlitePool) -> Vec<st0x_dto::Position> {
-    let rows: Vec<(String, Option<String>, Option<String>)> = match sqlx::query_as(
-        "SELECT symbol, net_position, \
-         json_extract(payload, '$.Live.last_price_usdc') \
-         FROM position_view WHERE symbol IS NOT NULL",
-    )
-    .fetch_all(pool)
-    .await
-    {
-        Ok(rows) => rows,
+    let ids = match load_all_ids::<Position>(pool).await {
+        Ok(ids) => ids,
         Err(error) => {
             warn!(target: "dashboard", %error, "Failed to load positions for dashboard");
             return Vec::new();
         }
     };
 
-    rows.into_iter()
-        .filter_map(|(raw_symbol, net_str, price_str)| {
-            let symbol = st0x_execution::Symbol::new(&raw_symbol)
-                .inspect_err(|error| {
-                    warn!(target: "dashboard", %error, %raw_symbol, "Invalid symbol in position view, skipping");
-                })
-                .ok()?;
+    let mut positions = Vec::with_capacity(ids.len());
 
-            let net = net_str
-                .and_then(|value| match rain_math_float::Float::parse(value) {
-                    Ok(float) => Some(float),
-                    Err(error) => {
-                        warn!(target: "dashboard", %error, %raw_symbol, "Unparseable net_position, skipping");
-                        None
-                    }
-                })
-                .unwrap_or_else(|| st0x_float_macro::float!(0));
+    for id in ids {
+        match load_entity::<Position>(pool, &id).await {
+            Ok(Some(position)) => positions.push(st0x_dto::Position {
+                symbol: position.symbol,
+                net: position.net.inner(),
+                last_price_usdc: position.last_price_usdc,
+            }),
+            Ok(None) => {
+                warn!(target: "dashboard", %id, "Position disappeared while loading dashboard state");
+            }
+            Err(error) => {
+                warn!(target: "dashboard", %id, ?error, "Failed to load position for dashboard");
+            }
+        }
+    }
 
-            let last_price_usdc = price_str.and_then(|value| {
-                rain_math_float::Float::parse(value)
-                    .inspect_err(|error| {
-                        warn!(target: "dashboard", %error, %raw_symbol, "Unparseable last_price_usdc, ignoring");
-                    })
-                    .ok()
-            });
-
-            Some(st0x_dto::Position {
-                symbol,
-                net,
-                last_price_usdc,
-            })
-        })
-        .collect()
+    positions
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves [RAI-602](https://linear.app/makeitrain/issue/RAI-602/refresh-dashboard-inventory-live-data).

## What

Fixes dashboard inventory/position freshness so the inventory tab receives live position updates instead of only reflecting new exposure after a page refresh.

This PR:
- wires `Broadcaster` into the `Position` CQRS store in both standalone and rebalancing-enabled conductor paths
- makes dashboard reconnect snapshots load positions from persisted aggregate state instead of `position_view`
- runs table projections before side-effect reactors in `StoreBuilder`
- filters position broadcasts to fill events so first fills do not emit duplicate updates
- adds regression coverage for standalone, disabled-rebalancing, rebalancing-enabled, and CQRS projection-ordering paths

## Why

The inventory tab could show stale data, for example exposure values that never changed until the page was refreshed. The root cause was that `Position` events were not wired to the dashboard broadcaster in key conductor paths, so live dashboard clients did not receive `PositionUpdate` messages.

Review also found reconnect freshness edge cases: broadcasts could run before materialized projections, and reconnect snapshots relied on `position_view`. This PR makes reconnect snapshots read from the aggregate event-store path so they are not dependent on projection timing.

## How

- `src/conductor.rs`
  - Constructs a `Broadcaster` for the disabled-rebalancing path.
  - Passes the broadcaster into `build_position_cqrs`.
  - Adds regression coverage for standalone position CQRS and `PositionAndRebalancing::setup(None, ...)`.

- `src/conductor/manifest.rs`
  - Registers `Broadcaster` alongside `RebalancingService` for `Position`.
  - Adds coverage that a position fill reaches both dashboard broadcasting and the rebalancing subscriber.

- `src/dashboard/event.rs`
  - Broadcasts `PositionUpdate` only for fill events (`OnChainOrderFilled`, `OffChainOrderFilled`).
  - Avoids duplicate first-fill broadcasts from the initial `Initialized` event.

- `src/dashboard/mod.rs`
  - Changes reconnect initial-state position loading to enumerate persisted `Position` aggregates and replay each with `load_entity`.
  - Builds DTOs from aggregate state rather than parsing `position_view` columns.

- `crates/event-sorcery/src/wire.rs`
  - Inserts auto-wired projections before registered side-effect reactors.
  - Adds a regression test proving registered reactors observe an already-updated projection.

## Testing

Targeted tests run:

```bash
nix develop .#ci-backend --command cargo nextest run -p st0x-hedge \
  position_update_broadcasts_net_position \
  standalone_position_cqrs_broadcasts_live_position_updates \
  disabled_rebalancing_setup_broadcasts_live_position_updates \
  build_frameworks_broadcasts_live_position_updates
```

```bash
nix develop .#ci-backend --command cargo nextest run -p st0x-event-sorcery \
  projected_entities_update_views_before_registered_reactors
```

Earlier full verification before the review-loop changes passed:

```bash
nix develop .#ci-backend --command cargo nextest run --workspace --all-features
```
## Screenshots

Not applicable.

## Anything else

Known follow-up from review-loop:
- `load_positions` currently uses `load_all_ids::<Position>()`, which is all-or-nothing if a malformed position aggregate ID exists. A follow-up should make dashboard position loading skip only malformed IDs instead of returning an empty positions snapshot.
- Additional test hardening was recommended for event-store-backed initial position snapshots, non-fill position events, and more specific rebalancing operation assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position updates now broadcast live to dashboards in real-time, including when rebalancing is disabled.
  * Improved projection update ordering to ensure view updates occur before other operations.

* **Tests**
  * Added tests verifying live position broadcasts in standalone and rebalancing-disabled setups.
  * Extended test support for projected entity broadcasting with integration coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
