### PR TITLE
fix: hedge equity buys with unsettled USD instead of NM-BP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ markets by providing continuous two-sided liquidity.
 - **Fractional Share Support**: Executes fractional shares on Alpaca; dry-run
   mirrors the same execution model for testing
 - **Alpaca Hedge Preflight**: Checks available offchain shares for sells and
-  margin-safe buying power for buys before submitting Alpaca hedge orders
+  cash buying power for buys (includes unsettled T+1 equity-sale proceeds,
+  excludes margin) before submitting Alpaca hedge orders
 - **Serialized Counter-Trade Submission**: Within one bot process, queued and
   periodic hedge submissions share a lock and reserve budget against active
   offchain orders before placing new Alpaca counter-trades

--- a/adrs/1-cash-bp-for-equity-hedges.md
+++ b/adrs/1-cash-bp-for-equity-hedges.md
@@ -1,0 +1,83 @@
+# ADR 1: Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight
+
+## Status
+
+Accepted
+
+## Context
+
+When a Raindex onchain trade leaves a directional exposure, the bot enqueues a
+hedge order on Alpaca. Before placing the order, the conductor runs a preflight
+check that asks the broker executor: "do we have enough buying power to cover
+this buy?"
+
+PR #562 introduced that preflight. It computed available buying power as:
+
+```rust
+margin_safe_buying_power_cents =
+    min(non_marginable_buying_power, cash)
+```
+
+Intent at the time: never let the bot use leverage.
+`non_marginable_buying_power` (NM-BP) is Alpaca's "buying power that cannot use
+margin" field, and capping it at `cash` was added as belt-and-suspenders against
+any account configuration where Alpaca might fluff NM-BP with credit.
+
+### Why this is wrong for our use case
+
+Per Alpaca's documentation (see
+<https://alpaca.markets/learn/understanding-unsettled-funds>):
+
+> we cover the float between the time equities are purchased and settled. There
+> are no costs associated with this and you don't need to wait for trades to
+> settle before using the proceeds to buy more equities.
+
+> unsettled funds cannot be used to purchase cryptocurrency, nor can they be
+> withdrawn from an account.
+
+`non_marginable_buying_power` is the **crypto-rules** budget: settled cash only,
+because crypto must be fully paid. It's what crypto orders are checked against.
+
+For equity-to-equity trades, Alpaca lets us spend unsettled equity-sale proceeds
+immediately with no margin loan; the broker absorbs the T+1 float at no cost.
+Those unsettled proceeds are tracked in the `cash` field, not in NM-BP. NM-BP
+only picks them up after T+1 settlement.
+
+Concrete failure observed: MSTR hedge skipped with
+`insufficient margin-safe buying power: estimated cost 587881 cents exceeds
+available 3155 cents`,
+while the Alpaca account actually held ~$35,000 in cash from sales executed
+minutes earlier. The old preflight refused to spend that money because NM-BP
+hadn't picked it up yet.
+
+## Decision
+
+Use Alpaca's `cash` field directly for equity hedge preflight. The invariant "do
+not use margin" is enforced by requiring `estimated_cost_cents <= cash`: as long
+as the buy cost does not exceed `cash`, Alpaca settles it from cash +
+unsettled-float, never extending a loan.
+
+`non_marginable_buying_power` is no longer fetched. If we ever add a crypto
+hedge path, that path will introduce its own NM-BP check.
+
+## Consequences
+
+- Hedges fire immediately after equity sales, instead of waiting up to one
+  trading day for settlement.
+- The 1% slippage buffer (`broker.counter_trade_slippage_bps`) continues to
+  cushion against the BP estimate drifting between preflight and order
+  placement.
+- We remain strictly within Alpaca's documented "no margin loan" boundary for
+  equity purchases, so the original PR #562 invariant is preserved.
+- The CQRS event `OffchainMarginSafeBuyingPower` is renamed to
+  `OffchainCashBuyingPower` and a migration rewrites historical events. The
+  historical values were computed with the old formula and are not recalculated
+  -- events are immutable facts about what the system observed at the time.
+
+## Out of scope
+
+- A minimum settled-cash floor for fees or transfers. If we later need to
+  reserve a buffer of settled cash, that is a separate policy on top of this
+  preflight, not a replacement for it.
+- Crypto hedging. If introduced, it must use `non_marginable_buying_power` per
+  Alpaca's rules.

--- a/crates/dto/src/inventory.rs
+++ b/crates/dto/src/inventory.rs
@@ -40,7 +40,9 @@ pub struct UsdcInventory {
     /// Gross offchain USD balance before cash reserve subtraction.
     #[ts(type = "string | null")]
     pub offchain_gross: Option<Usdc>,
-    /// Margin-safe buying power from the offchain broker, formatted as USD string.
+    /// Cash buying power from the offchain broker (Alpaca's `cash` field --
+    /// includes unsettled T+1 equity-sale proceeds, excludes margin),
+    /// formatted as USD string.
     pub buying_power: Option<String>,
     /// USDC observed at intermediate wallet locations between venues.
     pub inflight_cash: InFlightCash,

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -209,7 +209,7 @@ impl Executor for AlpacaBrokerApi {
                     self.counter_trade_slippage_bps,
                 )?;
 
-                let available_buying_power_cents = account_funds.margin_safe_buying_power_cents;
+                let available_buying_power_cents = account_funds.cash_buying_power_cents;
                 let preflight = buying_power_counter_trade_preflight(
                     estimated_cost_cents,
                     available_buying_power_cents,
@@ -349,7 +349,8 @@ mod tests {
     };
     use crate::alpaca_broker_api::order::AlpacaLimitPrice;
     use crate::{
-        CounterTradePreflight, CounterTradeSkipReason, Direction, FractionalShares, Positive, Usd,
+        CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason, Direction,
+        FractionalShares, Positive, Usd,
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -676,7 +677,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_preflight_counter_trade_skips_buy_without_margin_safe_buying_power() {
+    async fn test_preflight_counter_trade_skips_buy_without_cash() {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
@@ -688,8 +689,7 @@ mod tests {
                 .json_body(json!({
                     "id": "904837e3-3b76-47ec-b432-046db621571b",
                     "status": "ACTIVE",
-                    "cash": "1000.00",
-                    "non_marginable_buying_power": "100.00"
+                    "cash": "100.00"
                 }));
         });
         let latest_trade_mock = create_latest_trade_mock(&server, "100.00");
@@ -712,6 +712,52 @@ mod tests {
                 estimated_cost_cents,
                 available_buying_power_cents,
             }) if estimated_cost_cents == 20_200 && available_buying_power_cents == 10_000
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_preflight_counter_trade_allows_buy_using_unsettled_proceeds() {
+        // Verifies the policy from adrs/1-cash-bp-for-equity-hedges.md: cash
+        // (which includes unsettled T+1 equity-sale proceeds) is the budget,
+        // not non_marginable_buying_power. Here NM-BP would have rejected the
+        // buy, but cash covers it -- so the preflight allows it.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        let account_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "status": "ACTIVE",
+                    "cash": "35000.00",
+                    "non_marginable_buying_power": "31.55"
+                }));
+        });
+        let latest_trade_mock = create_latest_trade_mock(&server, "100.00");
+
+        let executor = AlpacaBrokerApi::try_from_ctx(ctx).await.unwrap();
+        let preflight = executor
+            .preflight_counter_trade(MarketOrder {
+                symbol: Symbol::new("AAPL").unwrap(),
+                shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
+                direction: Direction::Buy,
+            })
+            .await
+            .unwrap();
+
+        account_mock.assert_calls(2);
+        latest_trade_mock.assert();
+        assert!(matches!(
+            preflight,
+            CounterTradePreflight::Allowed {
+                reservation: Some(CounterTradeReservation::BuyingPower {
+                    estimated_cost_cents,
+                    available_buying_power_cents,
+                }),
+            } if estimated_cost_cents == 20_200 && available_buying_power_cents == 3_500_000
         ));
     }
 

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -16,7 +16,7 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct AccountFunds {
     pub(super) cash_balance_cents: i64,
-    pub(super) margin_safe_buying_power_cents: i64,
+    pub(super) cash_buying_power_cents: i64,
 }
 
 /// Position response from Alpaca Broker API.
@@ -50,18 +50,12 @@ impl std::fmt::Debug for PositionResponse {
 struct AccountDetailsResponse {
     #[serde(deserialize_with = "deserialize_float_from_number_or_string")]
     cash: Float,
-    #[serde(deserialize_with = "deserialize_float_from_number_or_string")]
-    non_marginable_buying_power: Float,
 }
 
 impl std::fmt::Debug for AccountDetailsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AccountDetailsResponse")
             .field("cash", &DebugFloat(&self.cash))
-            .field(
-                "non_marginable_buying_power",
-                &DebugFloat(&self.non_marginable_buying_power),
-            )
             .finish()
     }
 }
@@ -115,7 +109,7 @@ pub(super) async fn fetch_inventory(
     Ok(Inventory {
         positions: broker_positions,
         usd_balance_cents: account_funds.cash_balance_cents,
-        margin_safe_buying_power_cents: Some(account_funds.margin_safe_buying_power_cents),
+        cash_buying_power_cents: Some(account_funds.cash_buying_power_cents),
     })
 }
 
@@ -124,12 +118,10 @@ pub(super) async fn get_account_funds(
 ) -> Result<AccountFunds, AlpacaBrokerApiError> {
     let account = get_account_details(client).await?;
     let cash_balance_cents = to_cash_value_cents(account.cash)?;
-    let margin_safe_buying_power_cents =
-        to_cash_value_cents(account.non_marginable_buying_power)?.min(cash_balance_cents);
 
     Ok(AccountFunds {
         cash_balance_cents,
-        margin_safe_buying_power_cents,
+        cash_buying_power_cents: cash_balance_cents,
     })
 }
 
@@ -256,8 +248,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00",
-                    "non_marginable_buying_power": "50000.00"
+                    "cash": "50000.00"
                 }));
         });
 
@@ -269,7 +260,7 @@ mod tests {
 
         assert_eq!(state.positions.len(), 2);
         assert_eq!(state.usd_balance_cents, 5_000_000);
-        assert_eq!(state.margin_safe_buying_power_cents, Some(5_000_000));
+        assert_eq!(state.cash_buying_power_cents, Some(5_000_000));
 
         let aapl = state
             .positions
@@ -302,8 +293,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "100000.00",
-                    "non_marginable_buying_power": "100000.00"
+                    "cash": "100000.00"
                 }));
         });
 
@@ -315,7 +305,7 @@ mod tests {
 
         assert!(state.positions.is_empty());
         assert_eq!(state.usd_balance_cents, 10_000_000);
-        assert_eq!(state.margin_safe_buying_power_cents, Some(10_000_000));
+        assert_eq!(state.cash_buying_power_cents, Some(10_000_000));
     }
 
     #[tokio::test]
@@ -343,8 +333,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00",
-                    "non_marginable_buying_power": "50000.00"
+                    "cash": "50000.00"
                 }));
         });
 
@@ -382,8 +371,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00",
-                    "non_marginable_buying_power": "50000.00"
+                    "cash": "50000.00"
                 }));
         });
 
@@ -427,8 +415,7 @@ mod tests {
                 .header("content-type", "application/json")
                 .json_body(json!({
                     // 0.001 fractional cents after multiplying by 100
-                    "cash": "100.001",
-                    "non_marginable_buying_power": "100.001"
+                    "cash": "100.001"
                 }));
         });
 
@@ -466,8 +453,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00",
-                    "non_marginable_buying_power": "50000.00"
+                    "cash": "50000.00"
                 }));
         });
 
@@ -513,8 +499,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00",
-                    "non_marginable_buying_power": "50000.00"
+                    "cash": "50000.00"
                 }));
         });
 
@@ -535,7 +520,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_inventory_requires_non_marginable_buying_power() {
+    async fn fetch_inventory_requires_cash() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({}));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = fetch_inventory(&client).await.unwrap_err();
+
+        assert!(matches!(error, AlpacaBrokerApiError::HttpClient(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_uses_cash_for_buying_power_ignoring_non_marginable() {
+        // Reproduces the production MSTR scenario from
+        // adrs/1-cash-bp-for-equity-hedges.md: NM-BP lags behind cash after a
+        // recent equity sale because the proceeds haven't settled. We now
+        // report `cash` directly as the equity buying power, so the hedge
+        // proceeds without waiting for T+1 settlement.
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
@@ -553,14 +570,16 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "50000.00"
+                    "cash": "35000.00",
+                    "non_marginable_buying_power": "31.55"
                 }));
         });
 
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
-        let error = fetch_inventory(&client).await.unwrap_err();
+        let inventory = fetch_inventory(&client).await.unwrap();
 
-        assert!(matches!(error, AlpacaBrokerApiError::HttpClient(_)));
+        assert_eq!(inventory.usd_balance_cents, 3_500_000);
+        assert_eq!(inventory.cash_buying_power_cents, Some(3_500_000));
     }
 
     #[tokio::test]
@@ -598,8 +617,7 @@ mod tests {
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({
-                    "cash": "10000.00",
-                    "non_marginable_buying_power": "10000.00"
+                    "cash": "10000.00"
                 }));
         });
 

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -300,11 +300,12 @@ pub struct EquityPosition {
 pub struct Inventory {
     pub positions: Vec<EquityPosition>,
     pub usd_balance_cents: i64,
-    /// Margin-safe buying power reported by the broker (`non_marginable_buying_power`
-    /// capped at cash balance). This is the same value used for counter-trade
-    /// preflight checks. Display-only; `None` when the broker omits the field
-    /// or the value cannot be converted.
-    pub margin_safe_buying_power_cents: Option<i64>,
+    /// Cash buying power available for equity hedges -- Alpaca's `cash`
+    /// field, which includes unsettled T+1 equity-sale proceeds and excludes
+    /// margin. Used for counter-trade preflight and display. `None` when the
+    /// broker omits the field or the value cannot be converted. See
+    /// adrs/1-cash-bp-for-equity-hedges.md.
+    pub cash_buying_power_cents: Option<i64>,
 }
 
 /// Result of fetching inventory from an executor.
@@ -333,7 +334,7 @@ pub enum CounterTradeSkipReason {
         available: FractionalShares,
     },
     #[error(
-        "insufficient margin-safe buying power: estimated cost {estimated_cost_cents} cents \
+        "insufficient cash buying power: estimated cost {estimated_cost_cents} cents \
          exceeds available {available_buying_power_cents} cents"
     )]
     InsufficientBuyingPower {

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -365,7 +365,7 @@ mod tests {
                 market_value: Some(Float::parse("15000".to_string()).unwrap()),
             }],
             usd_balance_cents: 5_000_000,
-            margin_safe_buying_power_cents: Some(5_000_000),
+            cash_buying_power_cents: Some(5_000_000),
         };
 
         let executor = MockExecutor::new().with_inventory(inventory.clone());
@@ -378,7 +378,7 @@ mod tests {
                 assert_eq!(fetched.positions[0].symbol, Symbol::new("AAPL").unwrap());
                 assert_eq!(fetched.positions[0].quantity, shares("100"));
                 assert_eq!(fetched.usd_balance_cents, 5_000_000);
-                assert_eq!(fetched.margin_safe_buying_power_cents, Some(5_000_000));
+                assert_eq!(fetched.cash_buying_power_cents, Some(5_000_000));
             }
             InventoryResult::Unimplemented => {
                 panic!("Expected Fetched, got Unimplemented")
@@ -401,7 +401,7 @@ mod tests {
         let inventory = crate::Inventory {
             positions: vec![],
             usd_balance_cents: 10_000,
-            margin_safe_buying_power_cents: Some(10_000),
+            cash_buying_power_cents: Some(10_000),
         };
 
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -415,7 +415,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(crate::Inventory {
             positions: vec![],
             usd_balance_cents: 50_000,
-            margin_safe_buying_power_cents: Some(50_000),
+            cash_buying_power_cents: Some(50_000),
         });
 
         let preflight = executor
@@ -445,7 +445,7 @@ mod tests {
                 market_value: None,
             }],
             usd_balance_cents: 50_000,
-            margin_safe_buying_power_cents: Some(50_000),
+            cash_buying_power_cents: Some(50_000),
         });
 
         let preflight = executor
@@ -480,7 +480,7 @@ mod tests {
                 market_value: None,
             }],
             usd_balance_cents: 50_000,
-            margin_safe_buying_power_cents: Some(50_000),
+            cash_buying_power_cents: Some(50_000),
         });
 
         let preflight = executor
@@ -507,7 +507,7 @@ mod tests {
             .with_inventory(crate::Inventory {
                 positions: vec![],
                 usd_balance_cents: 10_000,
-                margin_safe_buying_power_cents: Some(10_000),
+                cash_buying_power_cents: Some(10_000),
             })
             .with_preflight_price(float!(100));
 

--- a/migrations/20260518142321_rename_margin_safe_to_cash_buying_power.sql
+++ b/migrations/20260518142321_rename_margin_safe_to_cash_buying_power.sql
@@ -1,0 +1,14 @@
+-- Rename OffchainMarginSafeBuyingPower -> OffchainCashBuyingPower. The
+-- value now reflects Alpaca's `cash` field (settled cash + unsettled T+1
+-- equity-sale proceeds) instead of `min(non_marginable_buying_power, cash)`.
+-- Historical event values were computed with the old formula; only the
+-- variant name and payload key are rewritten, not the numbers.
+UPDATE events
+SET event_type = 'InventorySnapshotEvent::OffchainCashBuyingPower',
+    payload = json_object('OffchainCashBuyingPower', json_object(
+        'cash_buying_power_cents',
+            json_extract(payload, '$.OffchainMarginSafeBuyingPower.margin_safe_buying_power_cents'),
+        'fetched_at',
+            json_extract(payload, '$.OffchainMarginSafeBuyingPower.fetched_at')
+    ))
+WHERE event_type = 'InventorySnapshotEvent::OffchainMarginSafeBuyingPower';

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -2765,7 +2765,7 @@ mod tests {
         let executor = MockExecutor::new().with_inventory(ExecutionInventory {
             positions: vec![],
             usd_balance_cents: 100_000,
-            margin_safe_buying_power_cents: Some(100_000),
+            cash_buying_power_cents: Some(100_000),
         });
 
         let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -2822,7 +2822,7 @@ mod tests {
                 market_value: None,
             }],
             usd_balance_cents: 100_000,
-            margin_safe_buying_power_cents: Some(100_000),
+            cash_buying_power_cents: Some(100_000),
         });
 
         let offchain_order_id = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -2884,7 +2884,7 @@ mod tests {
                 market_value: None,
             }],
             usd_balance_cents: 100_000,
-            margin_safe_buying_power_cents: Some(100_000),
+            cash_buying_power_cents: Some(100_000),
         });
 
         let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -3114,13 +3114,13 @@ mod tests {
 
         acknowledge_fill(&cqrs.position, "AAPL", "1", Direction::Sell, 1).await;
 
-        // margin_safe_buying_power_cents deliberately differs from usd_balance_cents
+        // cash_buying_power_cents deliberately differs from usd_balance_cents
         // to verify buying power is display-only and does not affect trade decisions.
         let executor = MockExecutor::new()
             .with_inventory(ExecutionInventory {
                 positions: vec![],
                 usd_balance_cents: 10_000,
-                margin_safe_buying_power_cents: Some(1_000_000),
+                cash_buying_power_cents: Some(1_000_000),
             })
             .with_preflight_price(float!(100));
 
@@ -3183,7 +3183,7 @@ mod tests {
                     market_value: None,
                 }],
                 usd_balance_cents: 15_000,
-                margin_safe_buying_power_cents: Some(15_000),
+                cash_buying_power_cents: Some(15_000),
             })
             .with_preflight_price(float!(100));
 
@@ -3246,7 +3246,7 @@ mod tests {
                 market_value: None,
             }],
             usd_balance_cents: 100_000,
-            margin_safe_buying_power_cents: Some(100_000),
+            cash_buying_power_cents: Some(100_000),
         });
 
         check_and_execute_accumulated_positions(
@@ -3340,7 +3340,7 @@ mod tests {
             .with_inventory(ExecutionInventory {
                 positions: vec![],
                 usd_balance_cents: 15_000,
-                margin_safe_buying_power_cents: Some(15_000),
+                cash_buying_power_cents: Some(15_000),
             })
             .with_preflight_price(float!(100));
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -1215,7 +1215,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
     let executor = MockExecutor::new().with_inventory(ExecutorInventory {
         positions: vec![],
         usd_balance_cents: 50_000,
-        margin_safe_buying_power_cents: Some(50_000),
+        cash_buying_power_cents: Some(50_000),
     });
 
     let asserter = Asserter::new();

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -456,8 +456,8 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::OffchainMarginSafeBuyingPower {
-                    margin_safe_buying_power_cents: inventory.margin_safe_buying_power_cents,
+                InventorySnapshotCommand::OffchainCashBuyingPower {
+                    cash_buying_power_cents: inventory.cash_buying_power_cents,
                 },
             )
             .await?;
@@ -816,7 +816,7 @@ mod tests {
                 },
             ],
             usd_balance_cents: 10_000_000,
-            margin_safe_buying_power_cents: Some(10_000_000),
+            cash_buying_power_cents: Some(10_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory.clone());
 
@@ -868,7 +868,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 25_000_000, // $250,000.00
-            margin_safe_buying_power_cents: Some(25_000_000),
+            cash_buying_power_cents: Some(25_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -916,7 +916,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 10_000_000, // $100,000
-            margin_safe_buying_power_cents: Some(10_000_000),
+            cash_buying_power_cents: Some(10_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -974,7 +974,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 3_000_000, // $30,000
-            margin_safe_buying_power_cents: Some(3_000_000),
+            cash_buying_power_cents: Some(3_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1012,7 +1012,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 10_000_000,
-            margin_safe_buying_power_cents: Some(10_000_000),
+            cash_buying_power_cents: Some(10_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1067,7 +1067,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 5_000_000,
-            margin_safe_buying_power_cents: Some(5_000_000),
+            cash_buying_power_cents: Some(5_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1167,7 +1167,7 @@ mod tests {
                 market_value: Some(float!(150000)),
             }],
             usd_balance_cents: -5_000_000, // -$50,000 (margin debt)
-            margin_safe_buying_power_cents: Some(0),
+            cash_buying_power_cents: Some(0),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1208,7 +1208,7 @@ mod tests {
                 market_value: Some(float!(1851.75)),
             }],
             usd_balance_cents: 1_000_000,
-            margin_safe_buying_power_cents: Some(1_000_000),
+            cash_buying_power_cents: Some(1_000_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1255,7 +1255,7 @@ mod tests {
         let inventory = Inventory {
             positions: vec![],
             usd_balance_cents: 10_000,
-            margin_safe_buying_power_cents: Some(10_000),
+            cash_buying_power_cents: Some(10_000),
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -84,9 +84,11 @@ pub(crate) struct InventorySnapshot {
     /// Latest offchain gross USD balance in cents (before reserve subtraction)
     #[serde(default)]
     pub(crate) offchain_gross_usd_cents: Option<i64>,
-    /// Latest offchain margin-safe buying power in cents (`non_marginable_buying_power`
-    /// capped at cash balance -- the same value used for counter-trade preflight checks)
-    pub(crate) offchain_margin_safe_buying_power_cents: Option<i64>,
+    /// Latest offchain cash buying power in cents (Alpaca's `cash` field --
+    /// includes unsettled T+1 equity-sale proceeds, excludes margin. The same
+    /// value used for counter-trade preflight checks.) See
+    /// adrs/1-cash-bp-for-equity-hedges.md.
+    pub(crate) offchain_cash_buying_power_cents: Option<i64>,
     /// Latest Ethereum wallet USDC balance
     pub(crate) ethereum_usdc: Option<Usdc>,
     /// Latest Base wallet USDC balance (outside Raindex vaults)
@@ -114,7 +116,7 @@ impl EventSourced for InventorySnapshot {
 
     const AGGREGATE_TYPE: &'static str = "InventorySnapshot";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 5;
+    const SCHEMA_VERSION: u64 = 6;
     const COMPACTION_POLICY: CompactionPolicy = CompactionPolicy::CompactAfterSnapshot;
     const SNAPSHOT_SIZE: usize = 1;
 
@@ -129,7 +131,7 @@ impl EventSourced for InventorySnapshot {
             offchain_usd_cents: None,
             offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
-            offchain_margin_safe_buying_power_cents: None,
+            offchain_cash_buying_power_cents: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
             inflight_mints: BTreeMap::new(),
@@ -175,10 +177,10 @@ impl EventSourced for InventorySnapshot {
                 gross_usd_cents,
                 fetched_at: now,
             },
-            OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
-            } => InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            OffchainCashBuyingPower {
+                cash_buying_power_cents,
+            } => InventorySnapshotEvent::OffchainCashBuyingPower {
+                cash_buying_power_cents,
                 fetched_at: now,
             },
             EthereumUsdc { usdc_balance } => InventorySnapshotEvent::EthereumUsdc {
@@ -260,18 +262,16 @@ impl EventSourced for InventorySnapshot {
                     fetched_at: now,
                 }])
             }
-            OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            OffchainCashBuyingPower {
+                cash_buying_power_cents,
             } => {
-                if self.offchain_margin_safe_buying_power_cents == margin_safe_buying_power_cents {
+                if self.offchain_cash_buying_power_cents == cash_buying_power_cents {
                     return Ok(vec![]);
                 }
-                Ok(vec![
-                    InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                        margin_safe_buying_power_cents,
-                        fetched_at: now,
-                    },
-                ])
+                Ok(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
+                    cash_buying_power_cents,
+                    fetched_at: now,
+                }])
             }
             EthereumUsdc { usdc_balance } => {
                 if self.ethereum_usdc == Some(usdc_balance) {
@@ -371,9 +371,9 @@ impl InventorySnapshot {
             });
         }
 
-        if self.offchain_margin_safe_buying_power_cents.is_some() {
-            events.push(InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents: self.offchain_margin_safe_buying_power_cents,
+        if self.offchain_cash_buying_power_cents.is_some() {
+            events.push(InventorySnapshotEvent::OffchainCashBuyingPower {
+                cash_buying_power_cents: self.offchain_cash_buying_power_cents,
                 fetched_at,
             });
         }
@@ -470,11 +470,11 @@ impl InventorySnapshot {
             | InventorySnapshotEvent::OnchainUsdc { .. }
             | InventorySnapshotEvent::OffchainEquity { .. }
             | InventorySnapshotEvent::OffchainUsd { .. } => {}
-            InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            InventorySnapshotEvent::OffchainCashBuyingPower {
+                cash_buying_power_cents,
                 ..
             } => {
-                self.offchain_margin_safe_buying_power_cents = *margin_safe_buying_power_cents;
+                self.offchain_cash_buying_power_cents = *cash_buying_power_cents;
             }
             InventorySnapshotEvent::EthereumUsdc { usdc_balance, .. } => {
                 self.ethereum_usdc = Some(*usdc_balance);
@@ -515,8 +515,8 @@ pub(crate) enum InventorySnapshotCommand {
         /// cash reserve is configured, so the dashboard hides the row.
         gross_usd_cents: Option<i64>,
     },
-    OffchainMarginSafeBuyingPower {
-        margin_safe_buying_power_cents: Option<i64>,
+    OffchainCashBuyingPower {
+        cash_buying_power_cents: Option<i64>,
     },
     EthereumUsdc {
         usdc_balance: Usdc,
@@ -563,8 +563,8 @@ pub(crate) enum InventorySnapshotEvent {
         gross_usd_cents: Option<i64>,
         fetched_at: DateTime<Utc>,
     },
-    OffchainMarginSafeBuyingPower {
-        margin_safe_buying_power_cents: Option<i64>,
+    OffchainCashBuyingPower {
+        cash_buying_power_cents: Option<i64>,
         fetched_at: DateTime<Utc>,
     },
     #[serde(alias = "EthereumCash")]
@@ -601,7 +601,7 @@ impl InventorySnapshotEvent {
             | Self::OnchainUsdc { fetched_at, .. }
             | Self::OffchainEquity { fetched_at, .. }
             | Self::OffchainUsd { fetched_at, .. }
-            | Self::OffchainMarginSafeBuyingPower { fetched_at, .. }
+            | Self::OffchainCashBuyingPower { fetched_at, .. }
             | Self::EthereumUsdc { fetched_at, .. }
             | Self::BaseWalletUsdc { fetched_at, .. }
             | Self::BaseWalletUnwrappedEquity { fetched_at, .. }
@@ -618,8 +618,8 @@ impl DomainEvent for InventorySnapshotEvent {
             Self::OnchainUsdc { .. } => "InventorySnapshotEvent::OnchainUsdc".to_string(),
             Self::OffchainEquity { .. } => "InventorySnapshotEvent::OffchainEquity".to_string(),
             Self::OffchainUsd { .. } => "InventorySnapshotEvent::OffchainUsd".to_string(),
-            Self::OffchainMarginSafeBuyingPower { .. } => {
-                "InventorySnapshotEvent::OffchainMarginSafeBuyingPower".to_string()
+            Self::OffchainCashBuyingPower { .. } => {
+                "InventorySnapshotEvent::OffchainCashBuyingPower".to_string()
             }
             Self::EthereumUsdc { .. } => "InventorySnapshotEvent::EthereumUsdc".to_string(),
             Self::BaseWalletUsdc { .. } => "InventorySnapshotEvent::BaseWalletUsdc".to_string(),
@@ -820,25 +820,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn offchain_margin_safe_buying_power_skips_unchanged_value() {
-        let margin_safe_buying_power_cents = Some(3_000_000);
+    async fn offchain_cash_buying_power_skips_unchanged_value() {
+        let cash_buying_power_cents = Some(3_000_000);
 
         let events = TestHarness::<InventorySnapshot>::with(())
-            .given(vec![
-                InventorySnapshotEvent::OffchainMarginSafeBuyingPower {
-                    margin_safe_buying_power_cents,
-                    fetched_at: Utc::now(),
-                },
-            ])
-            .when(InventorySnapshotCommand::OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            .given(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
+                cash_buying_power_cents,
+                fetched_at: Utc::now(),
+            }])
+            .when(InventorySnapshotCommand::OffchainCashBuyingPower {
+                cash_buying_power_cents,
             })
             .await
             .events();
 
         assert!(
             events.is_empty(),
-            "unchanged OffchainMarginSafeBuyingPower should not emit"
+            "unchanged OffchainCashBuyingPower should not emit"
         );
     }
 
@@ -1599,7 +1597,7 @@ mod tests {
             offchain_usd_cents: None,
             offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
-            offchain_margin_safe_buying_power_cents: None,
+            offchain_cash_buying_power_cents: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
@@ -1630,7 +1628,7 @@ mod tests {
             offchain_usd_cents: Some(42_00),
             offchain_usd_fetched_at: Some(now),
             offchain_gross_usd_cents: Some(50_00),
-            offchain_margin_safe_buying_power_cents: Some(10_000),
+            offchain_cash_buying_power_cents: Some(10_000),
             ethereum_usdc: None,
             base_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
@@ -1653,8 +1651,8 @@ mod tests {
             original.offchain_usd_cents
         );
         assert_eq!(
-            reconstructed.offchain_margin_safe_buying_power_cents,
-            original.offchain_margin_safe_buying_power_cents
+            reconstructed.offchain_cash_buying_power_cents,
+            original.offchain_cash_buying_power_cents
         );
         assert_eq!(reconstructed.inflight_mints, original.inflight_mints);
     }

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -1552,17 +1552,17 @@ impl InventoryView {
                 })
             }
 
-            OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            OffchainCashBuyingPower {
+                cash_buying_power_cents,
                 ..
             } => {
                 debug!(
                     target: "inventory",
-                    ?margin_safe_buying_power_cents,
-                    "apply_snapshot_event: OffchainMarginSafeBuyingPower"
+                    ?cash_buying_power_cents,
+                    "apply_snapshot_event: OffchainCashBuyingPower"
                 );
                 Ok(Self {
-                    buying_power_cents: *margin_safe_buying_power_cents,
+                    buying_power_cents: *cash_buying_power_cents,
                     ..self
                 })
             }
@@ -1702,11 +1702,11 @@ impl InventoryView {
                 })
             }
 
-            OffchainMarginSafeBuyingPower {
-                margin_safe_buying_power_cents,
+            OffchainCashBuyingPower {
+                cash_buying_power_cents,
                 ..
             } => Ok(Self {
-                buying_power_cents: *margin_safe_buying_power_cents,
+                buying_power_cents: *cash_buying_power_cents,
                 ..self
             }),
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1143,7 +1143,7 @@ impl RebalancingService {
             ),
 
             OffchainUsd { .. }
-            | OffchainMarginSafeBuyingPower { .. }
+            | OffchainCashBuyingPower { .. }
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
@@ -1245,7 +1245,7 @@ impl RebalancingService {
             OnchainEquity { .. }
             | OffchainEquity { .. }
             | OffchainUsd { .. }
-            | OffchainMarginSafeBuyingPower { .. }
+            | OffchainCashBuyingPower { .. }
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
@@ -1312,7 +1312,7 @@ impl RebalancingService {
             | BaseWalletWrappedEquity { .. }
             // Buying power is display-only and doesn't feed venue
             // balances, so it never drives a rebalance.
-            | OffchainMarginSafeBuyingPower { .. }
+            | OffchainCashBuyingPower { .. }
             // Inflight snapshots don't trigger rebalancing -- they
             // indicate transfers already in progress, not new balances
             // to rebalance.


### PR DESCRIPTION
Resolves [RAI-603](https://linear.app/makeitrain/issue/RAI-603/hedge-equity-buys-with-unsettled-cash-not-non-marginable-buying-power).

## What

Switch the Alpaca hedge-buy preflight from `min(non_marginable_buying_power, cash)` to Alpaca's `cash` field directly, so unsettled T+1 equity-sale proceeds count toward the bot's buying-power budget. Rename the related CQRS event, payload field, and Rust types from `MarginSafe` to `Cash`. New ADR (`adrs/1-cash-bp-for-equity-hedges.md`) records the policy reversal.

## Why

In production, an MSTR hedge was skipped with `insufficient margin-safe buying power: estimated cost 587881 cents exceeds available 3155 cents`, while the Alpaca account actually held ~$35,000 in cash from equity sales executed minutes earlier.

Per Alpaca's docs:
- `non_marginable_buying_power` is the **crypto-rules** budget — settled cash only, because crypto must be fully paid. Unsettled equity-sale proceeds don't appear in NM-BP until T+1.
- For equity-to-equity trades, Alpaca lets us spend unsettled proceeds immediately with **no margin loan** — they cover the float at no cost. Those proceeds are tracked in the `cash` field.

The original guard from #562 picked the strictest possible field (`min(NM-BP, cash)`), which means we were applying crypto-purchase rules to stock purchases. The right rule is: use `cash`, and require `estimated_cost ≤ cash` to avoid pushing into a margin loan. The "no margin" invariant is preserved; the bot just no longer waits up to a trading day for equity proceeds to settle before redeploying them.

See `adrs/1-cash-bp-for-equity-hedges.md` for the full reasoning and the Alpaca docs quoted verbatim.

## How

**Formula change (`crates/execution/src/alpaca_broker_api/positions.rs`):**
- Drop the `non_marginable_buying_power` field from `AccountDetailsResponse` — we no longer read it.
- `get_account_funds` now reports `cash` directly as the cash buying power.

**Rename (preserves intent; no behavioral overlap):**
- `Inventory::margin_safe_buying_power_cents` → `cash_buying_power_cents` (and same on `AccountFunds`, `Mock`, `InventoryView`, `InventorySnapshot`).
- CQRS event variant `InventorySnapshotEvent::OffchainMarginSafeBuyingPower` → `OffchainCashBuyingPower`; payload field `margin_safe_buying_power_cents` → `cash_buying_power_cents`. Command variant renamed in lockstep.
- Error variant text `"insufficient margin-safe buying power..."` → `"insufficient cash buying power..."`.
- Doc comments on `Inventory`, `UsdcInventory` DTO, snapshot field, README updated.

**Migration (`migrations/20260518142321_rename_margin_safe_to_cash_buying_power.sql`):**
- Rewrites historical `event_type` and `payload` JSON in the event store. Historical values were computed with the old formula — only the variant name and payload key are rewritten, not the numbers. Events are immutable facts about what was observed at the time.

**Snapshot schema:**
- `InventorySnapshot::SCHEMA_VERSION` bumped 5 → 6. The framework detects this on startup, clears stale snapshots, and replays from the (now-migrated) event stream — handles the struct field rename automatically.

**Dashboard:** the TS field `usdc.buyingPower` is unchanged (it was already a neutral name, only the auto-generated doc comment updated). Display path keeps working.

## Testing

New tests:
- `crates/execution/src/alpaca_broker_api/positions.rs::fetch_inventory_uses_cash_for_buying_power_ignoring_non_marginable` — reproduces the production MSTR scenario ($35k cash, $31.55 NM-BP) and asserts the reported buying power is `cash`.
- `crates/execution/src/alpaca_broker_api/executor.rs::test_preflight_counter_trade_allows_buy_using_unsettled_proceeds` — preflight allows the buy when NM-BP would have rejected it.

Updated:
- `test_preflight_counter_trade_skips_buy_without_margin_safe_buying_power` → `test_preflight_counter_trade_skips_buy_without_cash` (still verifies insufficient-cash rejection).
- `fetch_inventory_requires_non_marginable_buying_power` → `fetch_inventory_requires_cash` (now asserts `cash` is the required field).

Removed `non_marginable_buying_power` from the rest of the Alpaca test JSON fixtures since we no longer deserialize it.

Verified:
- `cargo nextest run --workspace --all-features` — 1935 passed, 4 skipped.
- `cargo clippy --workspace --all-targets --all-features` — clean.
- `cargo fmt` — clean.
- `cd dashboard && bun run check` — 0 errors.

## Anything else

- The slippage buffer (`broker.counter_trade_slippage_bps`, default 100 bps) is unchanged — continues to cushion against the BP estimate drifting between preflight and order placement.
- Migration is irreversible (no down-migration, matching existing project pattern e.g. `20260411002234_rename_cash_fields_to_usdc.sql`).
- After deploy, the previously-blocked MSTR hedge should fire within ~60s (one `position_check_interval` tick).
- Out of scope: a "minimum settled-cash floor" reserve for fees/transfers. Worth a follow-up if we want belt-and-suspenders on top of the cash-only invariant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

