### PR TITLE
deploy: bind datasette to 0.0.0.0 for tailnet access

### DIFF
--- a/services.nix
+++ b/services.nix
@@ -47,21 +47,23 @@ builtins.mapAttrs withPaths {
     enabled = true;
     # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
     # before datasette opens it. (--immutable would close the WAL out and serve
-    # stale reads, so we open the DB normally and rely on loopback binding for
-    # access control.)
+    # stale reads, so we open the DB normally and rely on the host firewall +
+    # Tailscale for access control.)
     order = 40;
     kind = "plain";
     package = "datasette";
     bin = "datasette";
     description = "Datasette SQLite explorer";
-    # Bind to loopback; access via SSH tunnel or `tailscale ssh -L 8081:127.0.0.1:8081 <host>`.
+    # Bind to all interfaces so the service is reachable over the tailnet
+    # (e.g. http://<host>.taile5cf8a.ts.net:8081). Public access is blocked
+    # by the host firewall.
     args = [
       "serve"
       "/mnt/data/st0x-hedge.db"
       "-p"
       "8081"
       "-h"
-      "127.0.0.1"
+      "0.0.0.0"
     ];
   };
 }


### PR DESCRIPTION
Closes [RAI-622](https://linear.app/makeitrain/issue/RAI-622/bind-datasette-service-to-0000-for-tailnet-access).

## What

Change the datasette service in `services.nix` to bind to `0.0.0.0` instead of `127.0.0.1`, so it is reachable from a browser over the tailnet at `http://<host>.taile5cf8a.ts.net:8081` without requiring an SSH port-forward. Updates the surrounding comments to reflect the new access-control model (firewall + Tailscale, not loopback).

## Why

Before #674, datasette was running ad-hoc and bound to all interfaces, so the team accessed it directly via its Tailscale URL. #674 codified datasette as a managed NixOS service and chose loopback-only binding as a defense-in-depth measure. In practice this forces every operator to set up an SSH tunnel (`ssh -L 8081:127.0.0.1:8081 ...`) for routine database inspection, which is friction for what is a frequent debugging tool.

Loopback binding is unnecessary on these hosts. Public traffic is already triple-blocked:

1. The DO Cloud Firewall in front of the box only permits Tailscale WireGuard (see `os.nix:234-236`).
2. The NixOS firewall has `allowedTCPPorts = [ ]` — no TCP port is publicly reachable (`os.nix:238`).
3. Only `tailscale0` is in `trustedInterfaces`; all other inbound traffic is dropped (`os.nix:242`).

Binding datasette to `0.0.0.0` therefore only exposes it on `tailscale0`, which is exactly the desired audience.

## How

Single change in `services.nix:64`:

- `-h 127.0.0.1` -> `-h 0.0.0.0` in the datasette `args` list.
- Comments above the service updated: the rationale for opening the DB normally (rather than `--immutable`) is unchanged, but the sentence about relying on loopback for access control is rewritten to point at the firewall + Tailscale layers that now do the job.

No other services, ports, or activation steps are touched. The systemd unit, deploy order (40, after st0x-hedge so the DB exists), and `kind = "plain"` registration are unchanged.

## Testing

No automated test coverage — this is a NixOS service argument change. Verification is by deploying to staging/prod and confirming:

- `curl http://<host>.taile5cf8a.ts.net:8081/` from a tailnet-connected machine returns the datasette UI.
- `curl <public-IP>:8081` from outside the tailnet still fails (firewall drops the connection).
- Existing SSH-tunnel access continues to work for anyone who prefers it.

## Anything else

This unblocks the team's usual datasette browsing workflow without weakening the real security boundary (cloud firewall + NixOS firewall + Tailscale). In the meantime, before this lands, the SSH-tunnel form still works:

```bash
ssh -L 8081:127.0.0.1:8081 root@<host>.taile5cf8a.ts.net
# then open http://localhost:8081
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Datasette service to be reachable across the tailnet (no SSH port forwarding required).
  * Service accessibility is now governed by the host firewall and Tailscale access controls.

* **Documentation**
  * Configuration docs revised to explain the new network access model and recommended access controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
