### PR TITLE
RAI-618 Show all tracked inventory in dashboard

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2583,8 +2583,10 @@ multiple broker-specific contexts.
    1w, 1m, all-time).
 
 2. **Inventory**: Per-symbol equity holdings and cash balances across venues,
-   with available/inflight breakdowns. Includes an "Inventory Transfers" section
-   showing active and recent transfer operations with status.
+   with available/inflight breakdowns. It also shows wallet-observed inventory
+   outside the venues: Ethereum/Base wallet USDC and Base wallet unwrapped
+   (`tSTOCK`) vs wrapped (`wtSTOCK`) equity tokens. Includes an "Inventory
+   Transfers" section showing active and recent transfer operations with status.
 
 3. **Spreads**: Last realized spreads per asset (buy/sell prices, Pyth
    reference, spread bps) and per-symbol price charts over time.

--- a/crates/dto/src/inventory.rs
+++ b/crates/dto/src/inventory.rs
@@ -23,6 +23,20 @@ pub struct SymbolInventory {
     pub offchain_available: FractionalShares,
     #[ts(type = "string")]
     pub offchain_inflight: FractionalShares,
+    /// Equity tokens observed in the Base wallet between venues.
+    pub inflight_equity: InFlightEquity,
+}
+
+/// Equity tokens sitting in wallets between venues, observed by polling.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct InFlightEquity {
+    /// Unwrapped tokenized equity (`tSTOCK`) parked on the Base wallet.
+    #[ts(type = "string")]
+    pub base_wallet_unwrapped: FractionalShares,
+    /// Wrapped equity vault shares (`wtSTOCK`) parked on the Base wallet.
+    #[ts(type = "string")]
+    pub base_wallet_wrapped: FractionalShares,
 }
 
 /// Onchain and offchain USDC balances split by availability.
@@ -40,10 +54,12 @@ pub struct UsdcInventory {
     /// Gross offchain USD balance before cash reserve subtraction.
     #[ts(type = "string | null")]
     pub offchain_gross: Option<Usdc>,
-    /// Cash buying power from the offchain broker (Alpaca's `cash` field --
-    /// includes unsettled T+1 equity-sale proceeds, excludes margin),
-    /// formatted as USD string.
-    pub buying_power: Option<String>,
+    /// Settled cash that can be withdrawn/transferred out of the offchain
+    /// broker (Alpaca's `cash_withdrawable` field -- excludes T+1 unsettled
+    /// equity-sale proceeds). This is what can actually be rebalanced to
+    /// Raindex.
+    #[ts(type = "string | null")]
+    pub withdrawable_cash: Option<Usdc>,
     /// USDC observed at intermediate wallet locations between venues.
     pub inflight_cash: InFlightCash,
 }
@@ -93,7 +109,7 @@ impl Inventory {
                 offchain_available: Usdc::ZERO,
                 offchain_inflight: Usdc::ZERO,
                 offchain_gross: None,
-                buying_power: None,
+                withdrawable_cash: None,
                 inflight_cash: InFlightCash::empty(),
             },
         }
@@ -124,6 +140,10 @@ mod tests {
                 onchain_inflight: FractionalShares::new(float!(5)),
                 offchain_available: FractionalShares::new(float!(45)),
                 offchain_inflight: FractionalShares::ZERO,
+                inflight_equity: InFlightEquity {
+                    base_wallet_unwrapped: FractionalShares::new(float!(3)),
+                    base_wallet_wrapped: FractionalShares::new(float!(2)),
+                },
             }],
             usdc: UsdcInventory {
                 onchain_available: Usdc::new(float!(10000)),
@@ -131,7 +151,7 @@ mod tests {
                 offchain_available: Usdc::new(float!(5000)),
                 offchain_inflight: Usdc::new(float!(500)),
                 offchain_gross: Some(Usdc::new(float!(6000))),
-                buying_power: Some("$4,500.00".to_string()),
+                withdrawable_cash: Some(Usdc::new(float!(4500))),
                 inflight_cash: InFlightCash {
                     ethereum_wallet: Some(Usdc::new(float!(250))),
                     base_wallet: Some(Usdc::ZERO),
@@ -147,6 +167,8 @@ mod tests {
         assert_eq!(symbol["onchainInflight"], json!("5"));
         assert_eq!(symbol["offchainAvailable"], json!("45"));
         assert_eq!(symbol["offchainInflight"], json!("0"));
+        assert_eq!(symbol["inflightEquity"]["baseWalletUnwrapped"], json!("3"));
+        assert_eq!(symbol["inflightEquity"]["baseWalletWrapped"], json!("2"));
 
         let usdc = &json["usdc"];
         assert_eq!(usdc["onchainAvailable"], json!("10000"));
@@ -154,7 +176,7 @@ mod tests {
         assert_eq!(usdc["offchainAvailable"], json!("5000"));
         assert_eq!(usdc["offchainInflight"], json!("500"));
         assert_eq!(usdc["offchainGross"], json!("6000"));
-        assert_eq!(usdc["buyingPower"], json!("$4,500.00"));
+        assert_eq!(usdc["withdrawableCash"], json!("4500"));
         assert_eq!(usdc["inflightCash"]["ethereumWallet"], json!("250"));
         assert_eq!(usdc["inflightCash"]["baseWallet"], json!("0"));
     }

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -54,6 +54,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     Trade::export_all_to(out_dir)?;
     Position::export_all_to(out_dir)?;
     SymbolInventory::export_all_to(out_dir)?;
+    InFlightEquity::export_all_to(out_dir)?;
     Inventory::export_all_to(out_dir)?;
     InventorySnapshot::export_all_to(out_dir)?;
     UsdcInventory::export_all_to(out_dir)?;

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -209,7 +209,7 @@ impl Executor for AlpacaBrokerApi {
                     self.counter_trade_slippage_bps,
                 )?;
 
-                let available_buying_power_cents = account_funds.cash_buying_power_cents;
+                let available_buying_power_cents = account_funds.buying_power;
                 let preflight = buying_power_counter_trade_preflight(
                     estimated_cost_cents,
                     available_buying_power_cents,

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -671,6 +671,7 @@ fn register_account_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>)
                     "id": TEST_ACCOUNT_ID,
                     "status": "ACTIVE",
                     "cash": cash,
+                    "cash_withdrawable": cash,
                     "buying_power": buying_power,
                     "non_marginable_buying_power": buying_power,
                 }),

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -13,10 +13,12 @@ use crate::{
     deserialize_option_float_from_number_or_string,
 };
 
+/// Account-level USD figures from the broker, all denominated in cents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct AccountFunds {
-    pub(super) cash_balance_cents: i64,
-    pub(super) cash_buying_power_cents: i64,
+    pub(super) balance: i64,
+    pub(super) buying_power: i64,
+    pub(super) withdrawable: Option<i64>,
 }
 
 /// Position response from Alpaca Broker API.
@@ -50,12 +52,23 @@ impl std::fmt::Debug for PositionResponse {
 struct AccountDetailsResponse {
     #[serde(deserialize_with = "deserialize_float_from_number_or_string")]
     cash: Float,
+    /// Settled cash that can be withdrawn -- excludes T+1 unsettled
+    /// equity-sale proceeds. `None` if the broker omits the field.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_float_from_number_or_string"
+    )]
+    cash_withdrawable: Option<Float>,
 }
 
 impl std::fmt::Debug for AccountDetailsResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AccountDetailsResponse")
             .field("cash", &DebugFloat(&self.cash))
+            .field(
+                "cash_withdrawable",
+                &DebugOptionFloat(&self.cash_withdrawable),
+            )
             .finish()
     }
 }
@@ -108,8 +121,9 @@ pub(super) async fn fetch_inventory(
 
     Ok(Inventory {
         positions: broker_positions,
-        usd_balance_cents: account_funds.cash_balance_cents,
-        cash_buying_power_cents: Some(account_funds.cash_buying_power_cents),
+        usd_balance_cents: account_funds.balance,
+        cash_buying_power_cents: Some(account_funds.buying_power),
+        cash_withdrawable_cents: account_funds.withdrawable,
     })
 }
 
@@ -117,11 +131,16 @@ pub(super) async fn get_account_funds(
     client: &AlpacaBrokerApiClient,
 ) -> Result<AccountFunds, AlpacaBrokerApiError> {
     let account = get_account_details(client).await?;
-    let cash_balance_cents = to_cash_value_cents(account.cash)?;
+    let balance = to_cash_value_cents(account.cash)?;
+    let withdrawable = account
+        .cash_withdrawable
+        .map(to_cash_value_cents)
+        .transpose()?;
 
     Ok(AccountFunds {
-        cash_balance_cents,
-        cash_buying_power_cents: cash_balance_cents,
+        balance,
+        buying_power: balance,
+        withdrawable,
     })
 }
 
@@ -272,6 +291,72 @@ mod tests {
             aapl.market_value,
             Some(Float::parse("1575.00".to_string()).unwrap())
         ));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_extracts_cash_withdrawable_when_present() {
+        // Alpaca returns `cash_withdrawable` separately from `cash`. The
+        // dashboard displays it as settled cash available to rebalance to
+        // Raindex, distinct from `cash` which includes T+1 unsettled
+        // equity-sale proceeds.
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "50000.00",
+                    "cash_withdrawable": "32000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let state = fetch_inventory(&client).await.unwrap();
+
+        assert_eq!(state.usd_balance_cents, 5_000_000);
+        assert_eq!(state.cash_buying_power_cents, Some(5_000_000));
+        assert_eq!(state.cash_withdrawable_cents, Some(3_200_000));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_leaves_cash_withdrawable_none_when_broker_omits_field() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "50000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let state = fetch_inventory(&client).await.unwrap();
+
+        assert_eq!(state.usd_balance_cents, 5_000_000);
+        assert_eq!(state.cash_withdrawable_cents, None);
     }
 
     #[tokio::test]

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -302,10 +302,15 @@ pub struct Inventory {
     pub usd_balance_cents: i64,
     /// Cash buying power available for equity hedges -- Alpaca's `cash`
     /// field, which includes unsettled T+1 equity-sale proceeds and excludes
-    /// margin. Used for counter-trade preflight and display. `None` when the
-    /// broker omits the field or the value cannot be converted. See
+    /// margin. Used for counter-trade preflight. `None` when the broker
+    /// omits the field or the value cannot be converted. See
     /// adrs/1-cash-bp-for-equity-hedges.md.
     pub cash_buying_power_cents: Option<i64>,
+    /// Settled cash that can be withdrawn or transferred out -- Alpaca's
+    /// `cash_withdrawable` field, excluding T+1 unsettled equity-sale
+    /// proceeds. This is the amount actually movable to Raindex during
+    /// rebalancing. `None` when the broker omits the field.
+    pub cash_withdrawable_cents: Option<i64>,
 }
 
 /// Result of fetching inventory from an executor.

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -366,6 +366,7 @@ mod tests {
             }],
             usd_balance_cents: 5_000_000,
             cash_buying_power_cents: Some(5_000_000),
+            cash_withdrawable_cents: None,
         };
 
         let executor = MockExecutor::new().with_inventory(inventory.clone());
@@ -402,6 +403,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000,
             cash_buying_power_cents: Some(10_000),
+            cash_withdrawable_cents: None,
         };
 
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -416,6 +418,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            cash_withdrawable_cents: None,
         });
 
         let preflight = executor
@@ -446,6 +449,7 @@ mod tests {
             }],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            cash_withdrawable_cents: None,
         });
 
         let preflight = executor
@@ -481,6 +485,7 @@ mod tests {
             }],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            cash_withdrawable_cents: None,
         });
 
         let preflight = executor
@@ -508,6 +513,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 10_000,
                 cash_buying_power_cents: Some(10_000),
+                cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
 

--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -4,7 +4,7 @@
   import type { UsdcInventory } from '$lib/api/UsdcInventory'
   import type { Position } from '$lib/api/Position'
   import type { Settings } from '$lib/api/Settings'
-  import { decimalAdd, decimalCompare, decimalIsZero, decimalSub, formatDecimal } from '$lib/decimal'
+  import { decimalAdd, decimalCompare, decimalIsZero, formatDecimal } from '$lib/decimal'
   import { reactive } from '$lib/frp.svelte'
 
   interface Props {
@@ -46,12 +46,12 @@
   }
 
   type SortDir = 'asc' | 'desc'
-  type Col = 'asset' | 'alpaca' | 'inflight' | 'raindex' | 'total' | 'ratio' | 'exposure'
-  type SortState = { column: Col; dir: SortDir } | null
+  type EquityCol = 'asset' | 'alpaca' | 'inflight' | 'unwrapped' | 'wrapped' | 'raindex' | 'total' | 'ratio' | 'exposure'
+  type EquitySortState = { column: EquityCol; dir: SortDir } | null
 
-  const sort = reactive<SortState>(null)
+  const sort = reactive<EquitySortState>(null)
 
-  const toggleSort = (column: Col) => () => {
+  const toggleSort = (column: EquityCol) => () => {
     sort.update((current) => {
       if (current?.column === column) {
         return current.dir === 'asc' ? { column, dir: 'desc' } : null
@@ -60,12 +60,12 @@
     })
   }
 
-  const ariaSort = (state: SortState, col: Col): 'ascending' | 'descending' | 'none' => {
+  const ariaSort = (state: EquitySortState, col: EquityCol): 'ascending' | 'descending' | 'none' => {
     if (state?.column !== col) return 'none'
     return state.dir === 'asc' ? 'ascending' : 'descending'
   }
 
-  const sortIndicator = (state: SortState, col: Col): string => {
+  const sortIndicator = (state: EquitySortState, col: EquityCol): string => {
     if (state?.column !== col) return ''
     return state.dir === 'asc' ? ' ↑' : ' ↓'
   }
@@ -95,15 +95,16 @@
     ]))
   )
 
-  type Row = {
+  type EquityRow = {
     asset: string
     alpaca: Formatted
     inflight: Formatted
+    unwrapped: Formatted
+    wrapped: Formatted
     raindex: Formatted
     total: Formatted
     ratio: number
     exposure: number
-    isCash: boolean
     trading: boolean
   }
 
@@ -111,7 +112,7 @@
     new Set(settings?.assets.filter((asset) => asset.trading).map((asset) => asset.symbol) ?? [])
   )
 
-  const equityRows = $derived<Row[]>(
+  const equityRows = $derived<EquityRow[]>(
     symbols.map((item) => {
       const inflight = decimalAdd(item.onchainInflight, item.offchainInflight)
       const totalVal = decimalAdd(
@@ -123,6 +124,8 @@
         asset: stripped,
         alpaca: fmt(item.offchainAvailable),
         inflight: fmt(inflight),
+        unwrapped: fmt(item.inflightEquity.baseWalletUnwrapped),
+        wrapped: fmt(item.inflightEquity.baseWalletWrapped),
         raindex: fmt(item.onchainAvailable),
         total: fmtValue(totalVal),
         ratio: computeRatio(item.onchainAvailable, item.offchainAvailable),
@@ -131,13 +134,24 @@
           if (!pos) return 0
           return pos.net * pos.priceUsdc
         })(),
-        isCash: false,
         trading: tradingSet.has(stripped),
       }
     })
   )
 
-  const cashRow = $derived.by<Row | null>(() => {
+  type CashCells = {
+    alpacaAvail: Formatted
+    gross: Formatted | null
+    withdrawable: Formatted | null
+    inflight: Formatted
+    ethWallet: Formatted | null
+    baseWallet: Formatted | null
+    raindex: Formatted
+    total: Formatted
+    ratio: number
+  }
+
+  const cashCells = $derived.by<CashCells | null>(() => {
     if (!usdc) return null
 
     const inflight = decimalAdd(usdc.onchainInflight, usdc.offchainInflight)
@@ -147,22 +161,24 @@
     )
 
     return {
-      asset: 'Cash',
-      alpaca: fmt(usdc.offchainAvailable),
+      alpacaAvail: fmt(usdc.offchainAvailable),
+      gross: usdc.offchainGross === null ? null : fmt(usdc.offchainGross),
+      withdrawable: usdc.withdrawableCash === null ? null : fmt(usdc.withdrawableCash),
       inflight: fmt(inflight),
+      ethWallet: usdc.inflightCash.ethereumWallet === null ? null : fmt(usdc.inflightCash.ethereumWallet),
+      baseWallet: usdc.inflightCash.baseWallet === null ? null : fmt(usdc.inflightCash.baseWallet),
       raindex: fmt(usdc.onchainAvailable),
       total: fmtValue(total),
       ratio: computeRatio(usdc.onchainAvailable, usdc.offchainAvailable),
-      exposure: 0,
-      isCash: true,
-      trading: true,
     }
   })
 
-  const comparators: Record<Col, (lhs: Row, rhs: Row) => number> = {
+  const equityComparators: Record<EquityCol, (lhs: EquityRow, rhs: EquityRow) => number> = {
     asset: (lhs, rhs) => lhs.asset.localeCompare(rhs.asset),
     alpaca: (lhs, rhs) => decimalCompare(lhs.alpaca.full, rhs.alpaca.full),
     inflight: (lhs, rhs) => decimalCompare(lhs.inflight.full, rhs.inflight.full),
+    unwrapped: (lhs, rhs) => decimalCompare(lhs.unwrapped.full, rhs.unwrapped.full),
+    wrapped: (lhs, rhs) => decimalCompare(lhs.wrapped.full, rhs.wrapped.full),
     raindex: (lhs, rhs) => decimalCompare(lhs.raindex.full, rhs.raindex.full),
     total: (lhs, rhs) => decimalCompare(lhs.total.full, rhs.total.full),
     ratio: (lhs, rhs) => lhs.ratio - rhs.ratio,
@@ -178,7 +194,7 @@
 
       if (sort.current) {
         const { column, dir } = sort.current
-        const cmp = comparators[column]
+        const cmp = equityComparators[column]
         const direction = dir === 'desc' ? -1 : 1
         return direction * cmp(lhs, rhs)
       }
@@ -219,149 +235,212 @@
   const isNegligible = (value: number): boolean => Math.abs(value) < 0.01
 
   const fmtExposure = (value: number): string => {
-    if (value === 0) return '$0'
-    if (isNegligible(value)) return '~$0'
+    if (value === 0 || isNegligible(value)) return '$0'
     const sign = value > 0 ? '+' : '-'
     const abs = Math.abs(value)
     return `${sign}$${abs.toFixed(2)}`
   }
 
+  const showGross = $derived(cashCells?.gross !== null && cashCells?.gross !== undefined)
+  const showWithdrawable = $derived(cashCells?.withdrawable !== null && cashCells?.withdrawable !== undefined)
+  const showEthWallet = $derived(cashCells?.ethWallet !== null && cashCells?.ethWallet !== undefined)
+  const showBaseWallet = $derived(cashCells?.baseWallet !== null && cashCells?.baseWallet !== undefined)
+
+  // Visual separator before wallet-observed / info columns to signal they're
+  // out-of-band and not part of imbalance math.
+  const infoSepClass = 'border-l border-border pl-6'
+  const cashFirstInfoCol = $derived<'gross' | 'withdrawable' | 'eth' | 'base' | null>(
+    showGross ? 'gross' : showWithdrawable ? 'withdrawable' : showEthWallet ? 'eth' : showBaseWallet ? 'base' : null,
+  )
+  const cashInfoBoundary = (col: 'gross' | 'withdrawable' | 'eth' | 'base'): string =>
+    cashFirstInfoCol === col ? infoSepClass : ''
 </script>
 
-<Table.Root>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head aria-sort={ariaSort(sort.current, 'asset')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('asset')}>
-          Asset{sortIndicator(sort.current, 'asset')}
-        </button>
-      </Table.Head>
+{#if cashCells}
+  {@const dev = ratioDeviation(cashCells.ratio, true)}
+  <div class="cash-table">
+  <Table.Root>
+    <Table.Header>
+      <Table.Row>
+        <Table.Head class="text-left">Asset</Table.Head>
+        <Table.Head class="text-left" title="USDC available in Raindex vaults to settle takers.">Raindex</Table.Head>
+        <Table.Head class="text-left" title="USDC the books track as in motion between venues (CCTP transfers, pending settlements). Part of imbalance math.">Inflight</Table.Head>
+        <Table.Head class="text-left" title="USDC available to trade on Alpaca after subtracting the configured cash reserve.">Alpaca Available</Table.Head>
+        <Table.Head class="text-left">Total</Table.Head>
+        <Table.Head class="text-left" title="Proportion of total cash on Raindex (onchain / total).">Ratio</Table.Head>
+        <Table.Head class="w-full" aria-hidden="true"></Table.Head>
+        {#if showGross}
+          <Table.Head class="info-col text-left {cashInfoBoundary('gross')}" title="Full broker USDC balance before subtracting the configured cash reserve.">Gross</Table.Head>
+        {/if}
+        {#if showWithdrawable}
+          <Table.Head class="info-col text-left {cashInfoBoundary('withdrawable')}" title="Settled cash that can be withdrawn or transferred to Raindex. Excludes T+1 unsettled equity-sale proceeds.">Withdrawable</Table.Head>
+        {/if}
+        {#if showEthWallet}
+          <Table.Head class="info-col text-left {cashInfoBoundary('eth')}" title="Wallet-observed USDC on the Ethereum wallet between Alpaca and CCTP. Not part of imbalance math.">Eth Wallet</Table.Head>
+        {/if}
+        {#if showBaseWallet}
+          <Table.Head class="info-col text-left {cashInfoBoundary('base')}" title="Wallet-observed USDC on the Base wallet between CCTP and Raindex vaults. Not part of imbalance math.">Base Wallet</Table.Head>
+        {/if}
+      </Table.Row>
+    </Table.Header>
 
-      <Table.Head class="text-right" aria-sort={ariaSort(sort.current, 'alpaca')}>
-        <button class="{sortBtnClass} text-right" onclick={toggleSort('alpaca')}>
-          Alpaca{sortIndicator(sort.current, 'alpaca')}
-        </button>
-      </Table.Head>
-
-      <Table.Head class="text-right" aria-sort={ariaSort(sort.current, 'inflight')}>
-        <button class="{sortBtnClass} text-right" onclick={toggleSort('inflight')}>
-          Inflight{sortIndicator(sort.current, 'inflight')}
-        </button>
-      </Table.Head>
-
-      <Table.Head class="text-right" aria-sort={ariaSort(sort.current, 'raindex')}>
-        <button class="{sortBtnClass} text-right" onclick={toggleSort('raindex')}>
-          Raindex{sortIndicator(sort.current, 'raindex')}
-        </button>
-      </Table.Head>
-
-      <Table.Head class="text-right" aria-sort={ariaSort(sort.current, 'total')}>
-        <button class="{sortBtnClass} text-right" onclick={toggleSort('total')}>
-          Total{sortIndicator(sort.current, 'total')}
-        </button>
-      </Table.Head>
-
-      <Table.Head aria-sort={ariaSort(sort.current, 'ratio')}>
-        <button
-          class="{sortBtnClass} text-left"
-          onclick={toggleSort('ratio')}
-          title="Proportion of total holdings on Raindex (onchain / total)"
-        >
-          Ratio{sortIndicator(sort.current, 'ratio')}
-        </button>
-      </Table.Head>
-
-      <Table.Head aria-sort={ariaSort(sort.current, 'exposure')}>
-        <button
-          class="{sortBtnClass} text-left"
-          onclick={toggleSort('exposure')}
-          title="Net directional exposure from counterparty fills"
-        >
-          Exposure{sortIndicator(sort.current, 'exposure')}
-        </button>
-      </Table.Head>
-    </Table.Row>
-  </Table.Header>
-  {#if cashRow}
-    {@const dev = ratioDeviation(cashRow.ratio, true)}
     <Table.Body>
       <Table.Row>
         <Table.Cell class="font-mono font-medium">Cash</Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-90">
-          <span class={approxClass(cashRow.alpaca)} title={cashRow.alpaca.truncated ? cashRow.alpaca.full : undefined}>{cashRow.alpaca.display}</span>
-          {#if usdc?.offchainGross}
-            {@const gross = fmt(usdc.offchainGross)}
-            {@const reserved = fmt(decimalSub(usdc.offchainGross, usdc.offchainAvailable))}
-            <div class="text-xs text-muted-foreground">
-              Gross: <span class={approxClass(gross)} title={gross.truncated ? gross.full : undefined}>{gross.display}</span>
-              · Rsv: <span class={approxClass(reserved)} title={reserved.truncated ? reserved.full : undefined}>{reserved.display}</span>
-            </div>
-          {/if}
-          {#if usdc?.buyingPower}
-            {@const bp = fmt(usdc.buyingPower.replace(/^\$/, ''))}
-            <div class="text-xs text-muted-foreground">BP: <span class={approxClass(bp)} title={bp.truncated ? bp.full : undefined}>{bp.display}</span></div>
-          {/if}
+
+        <Table.Cell class="text-left font-mono opacity-90">
+          <span class={approxClass(cashCells.raindex)} title={cashCells.raindex.truncated ? cashCells.raindex.full : undefined}>{cashCells.raindex.display}</span>
         </Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-50">
-          <span class={approxClass(cashRow.inflight)} title={cashRow.inflight.truncated ? cashRow.inflight.full : undefined}>{cashRow.inflight.display}</span>
-          {#if usdc?.inflightCash && (usdc.inflightCash.ethereumWallet !== null || usdc.inflightCash.baseWallet !== null)}
-            {@const eth = usdc.inflightCash.ethereumWallet === null ? null : fmt(usdc.inflightCash.ethereumWallet)}
-            {@const base = usdc.inflightCash.baseWallet === null ? null : fmt(usdc.inflightCash.baseWallet)}
-            <div class="text-xs text-muted-foreground" title="Wallet-observed USDC sitting between venues. Not part of imbalance math.">
-              {#if eth}
-                Eth: <span class={approxClass(eth)} title={eth.truncated ? eth.full : undefined}>{eth.display}</span>
-              {/if}
-              {#if eth && base} · {/if}
-              {#if base}
-                Base: <span class={approxClass(base)} title={base.truncated ? base.full : undefined}>{base.display}</span>
-              {/if}
-            </div>
-          {/if}
+
+        <Table.Cell class="text-left font-mono opacity-50">
+          <span class={approxClass(cashCells.inflight)} title={cashCells.inflight.truncated ? cashCells.inflight.full : undefined}>{cashCells.inflight.display}</span>
         </Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-90">
-          <span class={approxClass(cashRow.raindex)} title={cashRow.raindex.truncated ? cashRow.raindex.full : undefined}>{cashRow.raindex.display}</span>
+
+        <Table.Cell class="text-left font-mono opacity-90">
+          <span class={approxClass(cashCells.alpacaAvail)} title={cashCells.alpacaAvail.truncated ? cashCells.alpacaAvail.full : undefined}>{cashCells.alpacaAvail.display}</span>
         </Table.Cell>
-        <Table.Cell class="text-right font-mono font-semibold">
-          <span class={approxClass(cashRow.total)} title={cashRow.total.truncated ? cashRow.total.full : undefined}>{cashRow.total.display}</span>
+
+        <Table.Cell class="text-left font-mono font-semibold">
+          <span class={approxClass(cashCells.total)} title={cashCells.total.truncated ? cashCells.total.full : undefined}>{cashCells.total.display}</span>
         </Table.Cell>
+
         <Table.Cell>
           <div class="flex items-center gap-2">
             <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-              <div class="h-full rounded-full {dev?.style === 'high' ? 'bg-green-500' : dev?.style === 'low' ? 'bg-red-500' : 'bg-blue-400'}" style="width: {String(Math.min(cashRow.ratio * 100, 100))}%"></div>
+              <div class="h-full rounded-full {dev?.style === 'high' ? 'bg-green-500' : dev?.style === 'low' ? 'bg-red-500' : 'bg-blue-400'}" style="width: {String(Math.min(cashCells.ratio * 100, 100))}%"></div>
             </div>
-            <span class="font-mono text-xs">{formatRatio(cashRow.ratio)}</span>
+            <span class="font-mono text-xs">{formatRatio(cashCells.ratio)}</span>
             {#if dev}
               <span class="text-xs {deviationColor(dev.style)}">({dev.text})</span>
             {/if}
           </div>
         </Table.Cell>
-        <Table.Cell class="font-mono text-muted-foreground">—</Table.Cell>
-      </Table.Row>
-      <Table.Row>
-        <Table.Cell colspan={7} class="py-3 px-0">
-          <div class="h-px bg-border"></div>
-        </Table.Cell>
+
+        <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
+
+        {#if showGross && cashCells.gross}
+          <Table.Cell class="info-col text-left font-mono opacity-90 {cashInfoBoundary('gross')}">
+            <span class={approxClass(cashCells.gross)} title={cashCells.gross.truncated ? cashCells.gross.full : undefined}>{cashCells.gross.display}</span>
+          </Table.Cell>
+        {/if}
+
+        {#if showWithdrawable && cashCells.withdrawable}
+          <Table.Cell class="info-col text-left font-mono opacity-90 {cashInfoBoundary('withdrawable')}">
+            <span class={approxClass(cashCells.withdrawable)} title={cashCells.withdrawable.truncated ? cashCells.withdrawable.full : undefined}>{cashCells.withdrawable.display}</span>
+          </Table.Cell>
+        {/if}
+
+        {#if showEthWallet && cashCells.ethWallet}
+          <Table.Cell class="info-col text-left font-mono opacity-50 {cashInfoBoundary('eth')}">
+            <span class={approxClass(cashCells.ethWallet)} title={cashCells.ethWallet.truncated ? cashCells.ethWallet.full : undefined}>{cashCells.ethWallet.display}</span>
+          </Table.Cell>
+        {/if}
+
+        {#if showBaseWallet && cashCells.baseWallet}
+          <Table.Cell class="info-col text-left font-mono opacity-50 {cashInfoBoundary('base')}">
+            <span class={approxClass(cashCells.baseWallet)} title={cashCells.baseWallet.truncated ? cashCells.baseWallet.full : undefined}>{cashCells.baseWallet.display}</span>
+          </Table.Cell>
+        {/if}
       </Table.Row>
     </Table.Body>
-  {/if}
+  </Table.Root>
+  </div>
+
+  <div class="my-4 h-px bg-border"></div>
+{/if}
+
+<div class="equity-table">
+<Table.Root>
+  <Table.Header>
+    <Table.Row>
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'asset')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('asset')}>
+          Asset{sortIndicator(sort.current, 'asset')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'raindex')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('raindex')} title="Tokens in Raindex vaults.">
+          Raindex{sortIndicator(sort.current, 'raindex')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'inflight')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('inflight')} title="Shares the books track as in motion between venues (mints, redeems). Part of imbalance math.">
+          Inflight{sortIndicator(sort.current, 'inflight')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'alpaca')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('alpaca')} title="Shares held at Alpaca.">
+          Alpaca{sortIndicator(sort.current, 'alpaca')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'total')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('total')}>
+          Total{sortIndicator(sort.current, 'total')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'ratio')}>
+        <button
+          class="{sortBtnClass} text-left"
+          onclick={toggleSort('ratio')}
+          title="Proportion of total holdings on Raindex (onchain / total)."
+        >
+          Ratio{sortIndicator(sort.current, 'ratio')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'exposure')}>
+        <button
+          class="{sortBtnClass} text-left"
+          onclick={toggleSort('exposure')}
+          title="Net directional exposure from counterparty fills."
+        >
+          Exposure{sortIndicator(sort.current, 'exposure')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="w-full" aria-hidden="true"></Table.Head>
+
+      <Table.Head class="info-col text-left {infoSepClass}" aria-sort={ariaSort(sort.current, 'unwrapped')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('unwrapped')} title="Unwrapped tokenized equity (tSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math.">
+          Unwrapped{sortIndicator(sort.current, 'unwrapped')}
+        </button>
+      </Table.Head>
+
+      <Table.Head class="info-col text-left" aria-sort={ariaSort(sort.current, 'wrapped')}>
+        <button class="{sortBtnClass} text-left" onclick={toggleSort('wrapped')} title="Wrapped equity vault shares (wtSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math.">
+          Wrapped{sortIndicator(sort.current, 'wrapped')}
+        </button>
+      </Table.Head>
+    </Table.Row>
+  </Table.Header>
 
   <Table.Body>
     {#each sortedEquities as row, idx (row.asset)}
       {@const dev = ratioDeviation(row.ratio, false)}
       <Table.Row class="{idx % 2 === 0 ? 'bg-muted/40' : ''} {row.trading ? '' : 'opacity-40'}">
         <Table.Cell class="font-mono font-medium">{row.asset}</Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-90">
-          <span class={approxClass(row.alpaca)} title={row.alpaca.truncated ? row.alpaca.full : undefined}>{row.alpaca.display}</span>
-        </Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-50">
-          <span class={approxClass(row.inflight)} title={row.inflight.truncated ? row.inflight.full : undefined}>{row.inflight.display}</span>
-        </Table.Cell>
-        <Table.Cell class="text-right font-mono opacity-90">
+
+        <Table.Cell class="text-left font-mono opacity-90">
           <span class={approxClass(row.raindex)} title={row.raindex.truncated ? row.raindex.full : undefined}>{row.raindex.display}</span>
         </Table.Cell>
-        <Table.Cell class="text-right font-mono font-semibold">
+
+        <Table.Cell class="text-left font-mono opacity-50">
+          <span class={approxClass(row.inflight)} title={row.inflight.truncated ? row.inflight.full : undefined}>{row.inflight.display}</span>
+        </Table.Cell>
+
+        <Table.Cell class="text-left font-mono opacity-90">
+          <span class={approxClass(row.alpaca)} title={row.alpaca.truncated ? row.alpaca.full : undefined}>{row.alpaca.display}</span>
+        </Table.Cell>
+
+        <Table.Cell class="text-left font-mono font-semibold">
           <span class={approxClass(row.total)} title={row.total.truncated ? row.total.full : undefined}>{row.total.display}</span>
         </Table.Cell>
+
         <Table.Cell>
           <div class="flex items-center gap-2">
             <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
@@ -373,17 +452,57 @@
             {/if}
           </div>
         </Table.Cell>
+
         <Table.Cell>
           <div class="flex items-center gap-1.5 font-mono text-xs">
             {#if !isNegligible(row.exposure) && row.exposure !== 0}
-              <span class="text-base leading-none {row.exposure > 0 ? 'text-green-500' : 'text-red-500'}">{row.exposure > 0 ? '\u25B2' : '\u25BC'}</span>
+              <span class="text-base leading-none {row.exposure > 0 ? 'text-green-500' : 'text-red-500'}">{row.exposure > 0 ? '▲' : '▼'}</span>
             {/if}
             <span class={row.exposure === 0 || isNegligible(row.exposure) ? 'text-muted-foreground' : row.exposure > 0 ? 'text-green-500' : 'text-red-500'}>
               {fmtExposure(row.exposure)}
             </span>
           </div>
         </Table.Cell>
+
+        <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
+
+        <Table.Cell class="info-col text-left font-mono opacity-50 {infoSepClass}">
+          <span class={approxClass(row.unwrapped)} title={row.unwrapped.truncated ? row.unwrapped.full : undefined}>{row.unwrapped.display}</span>
+        </Table.Cell>
+
+        <Table.Cell class="info-col text-left font-mono opacity-50">
+          <span class={approxClass(row.wrapped)} title={row.wrapped.truncated ? row.wrapped.full : undefined}>{row.wrapped.display}</span>
+        </Table.Cell>
       </Table.Row>
     {/each}
   </Table.Body>
 </Table.Root>
+</div>
+
+<style>
+  /* Cash table: keep headers in normal case, not the default uppercase. */
+  .cash-table :global([data-slot='table-head']) {
+    text-transform: none;
+    letter-spacing: normal;
+    font-size: 0.8rem;
+  }
+
+  /* Widen column padding so cells breathe more and the spacer column between
+     core math and info columns isn't asked to absorb so much slack. Applied
+     to both tables for visual consistency. */
+  .equity-table :global([data-slot='table-head']),
+  .equity-table :global([data-slot='table-cell']),
+  .cash-table :global([data-slot='table-head']),
+  .cash-table :global([data-slot='table-cell']) {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  /* Info columns (right of the divider) get the default tighter padding since
+     the info data is already compact and the wider padding wasted space. */
+  .cash-table :global(.info-col),
+  .equity-table :global(.info-col) {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+</style>

--- a/dashboard/src/lib/components/inventory-panel.svelte
+++ b/dashboard/src/lib/components/inventory-panel.svelte
@@ -26,18 +26,54 @@
   const usdc = $derived(inventory?.usdc)
   const positions = $derived(positionsQuery.data ?? [])
   const settings = $derived(settingsQuery.data)
+
+  let glossaryDialogEl: HTMLDialogElement | undefined = $state()
+
+  const openGlossary = () => {
+    glossaryDialogEl?.showModal()
+  }
+
+  type GlossaryEntry = { name: string; def: string }
+
+  const cashEntries: GlossaryEntry[] = [
+    { name: 'Asset', def: 'Always "Cash" for the USDC row.' },
+    { name: 'Raindex', def: 'USDC available in the Raindex vaults to settle takers.' },
+    { name: 'Inflight', def: 'USDC the books track as in motion between venues (pending CCTP transfers, pending settlements). Already accounted for in imbalance math.' },
+    { name: 'Alpaca Available', def: 'USDC available to trade on Alpaca after subtracting the configured cash reserve. This is what the bot can spend on equity buys.' },
+    { name: 'Total', def: 'Raindex + Inflight + Alpaca Available. Excludes wallet-observed amounts.' },
+    { name: 'Ratio', def: 'Proportion of total cash sitting on Raindex (onchain / total). The bar and percent reflect the current split; the colored offset is the deviation from the configured target.' },
+    { name: 'Gross', def: 'Full broker USDC balance before subtracting the configured cash reserve. Hidden when no reserve is configured. (Reserved = Gross − Alpaca Available.)' },
+    { name: 'Withdrawable', def: 'Settled cash that can actually be withdrawn or transferred to Raindex. Excludes T+1 unsettled equity-sale proceeds. This is what the bot can rebalance.' },
+    { name: 'Eth Wallet', def: 'Wallet-observed USDC sitting on the Ethereum wallet between Alpaca and CCTP. Out-of-band sanity check — NOT part of imbalance math.' },
+    { name: 'Base Wallet', def: 'Wallet-observed USDC sitting on the Base wallet between CCTP and the Raindex vaults. Out-of-band sanity check — NOT part of imbalance math.' },
+  ]
+
+  const equityEntries: GlossaryEntry[] = [
+    { name: 'Asset', def: 'Equity symbol with the t/wt prefix stripped (e.g. AAPL for tAAPL / wtAAPL). Non-trading assets are dimmed.' },
+    { name: 'Raindex', def: 'tSTOCK tokens available in the Raindex vault to settle takers.' },
+    { name: 'Inflight', def: 'Shares the books track as in motion between venues (pending mints, redeems, transfers). Part of imbalance math.' },
+    { name: 'Alpaca', def: 'Shares held at Alpaca (offchain available).' },
+    { name: 'Total', def: 'Raindex + Inflight + Alpaca. Excludes wallet-observed amounts (Unwrapped / Wrapped).' },
+    { name: 'Ratio', def: 'Proportion of total shares sitting on Raindex (onchain / total). Bar and percent reflect the current split; colored offset is deviation from target.' },
+    { name: 'Exposure', def: 'Net directional dollar exposure from counterparty fills (Alpaca-reported net position × last price). ▲ green = long, ▼ red = short. Values under $0.01 render as ~$0.' },
+    { name: 'Unwrapped', def: 'Wallet-observed tSTOCK parked on the Base wallet between a Raindex withdrawal and an Alpaca redemption transfer (or post-mint, pre-vault deposit). Out-of-band — NOT part of imbalance math.' },
+    { name: 'Wrapped', def: 'Wallet-observed wtSTOCK vault shares on the Base wallet (post vault-withdraw, pre-unwrap). Out-of-band — NOT part of imbalance math.' },
+  ]
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-blue-500/50">
   <Card.Header class="shrink-0 pb-3">
     <Card.Title class="flex items-center gap-1.5">
       Inventory
-      <span class="group relative cursor-help text-muted-foreground">
+      <button
+        type="button"
+        class="cursor-pointer text-muted-foreground hover:text-foreground"
+        onclick={openGlossary}
+        title="Column reference"
+        aria-label="Open inventory column reference"
+      >
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
-        <span class="pointer-events-none absolute left-0 top-full z-50 mt-1 hidden w-56 rounded bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg group-hover:block">
-          Asset balances across Alpaca (offchain) and Raindex (onchain), with allocation ratios and directional exposure.
-        </span>
-      </span>
+      </button>
     </Card.Title>
   </Card.Header>
   <Card.Content class="relative min-h-0 flex-1 overflow-auto px-6 pt-0">
@@ -50,3 +86,51 @@
     {/if}
   </Card.Content>
 </Card.Root>
+
+<dialog
+  bind:this={glossaryDialogEl}
+  class="w-full max-w-2xl rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
+  onclick={(event) => { if (event.target === glossaryDialogEl) glossaryDialogEl.close() }}
+>
+  <div class="flex items-center justify-between border-b px-5 py-3">
+    <div class="text-sm font-semibold">Inventory column reference</div>
+    <button
+      type="button"
+      class="text-lg leading-none text-muted-foreground hover:text-foreground"
+      onclick={() => glossaryDialogEl?.close()}
+      aria-label="Close"
+    >
+      &times;
+    </button>
+  </div>
+
+  <div class="max-h-[70vh] space-y-6 overflow-y-auto px-5 py-4 text-sm">
+    <section>
+      <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Cash row</h3>
+      <dl class="space-y-2">
+        {#each cashEntries as entry (entry.name)}
+          <div class="grid grid-cols-[8rem_1fr] gap-3">
+            <dt class="font-mono text-sm font-medium">{entry.name}</dt>
+            <dd class="text-sm text-muted-foreground">{entry.def}</dd>
+          </div>
+        {/each}
+      </dl>
+    </section>
+
+    <section>
+      <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Equity rows</h3>
+      <dl class="space-y-2">
+        {#each equityEntries as entry (entry.name)}
+          <div class="grid grid-cols-[8rem_1fr] gap-3">
+            <dt class="font-mono text-sm font-medium">{entry.name}</dt>
+            <dd class="text-sm text-muted-foreground">{entry.def}</dd>
+          </div>
+        {/each}
+      </dl>
+    </section>
+
+    <section class="rounded border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">
+      <strong class="text-foreground">Wallet-observed</strong> columns (Eth Wallet, Base Wallet, Unwrapped, Wrapped) come from polling the on-chain wallets directly. They are a sanity check for funds in transit between venues and are <strong>NOT</strong> included in Total, Ratio, or imbalance / rebalancing decisions.
+    </section>
+  </div>
+</dialog>

--- a/dashboard/src/lib/components/orders-panel.svelte
+++ b/dashboard/src/lib/components/orders-panel.svelte
@@ -8,6 +8,8 @@
   import { formatDecimal } from '$lib/decimal'
   import { formatTimestamp } from '$lib/format'
 
+  const PAGE_SIZE = 50
+
   type TokenRef = {
     address: string
     symbol: string
@@ -46,35 +48,40 @@
   const isUnavailable = (response: ApiResponse): response is UnavailableResponse =>
     'unavailable' in response && response.unavailable
 
-  const CACHE_KEY = 'orders-panel-cache'
+  const cacheKey = (page: number): string => `orders-panel-cache:${String(page)}`
 
-  const loadCache = (): ApiResponse | null => {
+  const loadCache = (page: number): ApiResponse | null => {
     try {
-      const raw = sessionStorage.getItem(CACHE_KEY)
+      const raw = sessionStorage.getItem(cacheKey(page))
       return raw ? (JSON.parse(raw) as ApiResponse) : null
     } catch {
       return null
     }
   }
 
-  const saveCache = (response: ApiResponse) => {
+  const saveCache = (page: number, response: ApiResponse) => {
     try {
-      sessionStorage.setItem(CACHE_KEY, JSON.stringify(response))
+      sessionStorage.setItem(cacheKey(page), JSON.stringify(response))
     } catch { /* quota exceeded — not critical */ }
   }
 
-  const data = reactive<ApiResponse | null>(loadCache())
+  const currentPage = reactive(1)
+  const data = reactive<ApiResponse | null>(loadCache(currentPage.current))
   const loading = reactive(false)
   const error = reactive<string | null>(null)
 
-  const fetchOrders = async () => {
+  const fetchOrders = async (page = currentPage.current) => {
     loading.update(() => true)
     error.update(() => null)
 
     try {
       const baseUrl = getApiBaseUrl()
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(PAGE_SIZE),
+      })
       const response = await fetch(
-        `${baseUrl}/orders/raindex`,
+        `${baseUrl}/orders/raindex?${params.toString()}`,
         { signal: AbortSignal.timeout(ORDERS_TIMEOUT_MS) },
       )
 
@@ -102,7 +109,7 @@
 
       const orders = result as OrdersListResponse
       data.update(() => orders)
-      saveCache(orders)
+      saveCache(page, orders)
     } catch (fetchError) {
       error.update(() =>
         fetchError instanceof Error ? fetchError.message : 'Unknown error',
@@ -111,6 +118,16 @@
       loading.update(() => false)
     }
   }
+
+  const goToPage = (page: number) => {
+    const nextPage = Math.max(1, page)
+    currentPage.update(() => nextPage)
+    data.update(() => loadCache(nextPage))
+    void fetchOrders(nextPage)
+  }
+
+  const shortHash = (hash: string): string =>
+    hash.length <= 18 ? hash : `${hash.slice(0, 10)}...${hash.slice(-6)}`
 
   onMount(() => {
     void fetchOrders()
@@ -174,51 +191,79 @@
         {data.current.reason}
       </div>
     {:else if data.current && !isUnavailable(data.current)}
-      {#if data.current.orders.length === 0}
+      {#if data.current.orders.length === 0 && data.current.pagination.totalOrders === 0}
         <div class="flex h-full items-center justify-center text-muted-foreground">
           No active orders found for this owner.
         </div>
       {:else}
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="border-b text-left text-xs text-muted-foreground">
-              <th class="pb-2 pr-4 font-medium">Output</th>
-              <th class="pb-2 pr-4 font-medium">Input</th>
-              <th class="pb-2 pr-4 text-right font-medium">Vault Balance</th>
-              <th class="pb-2 pr-4 text-right font-medium">IO Ratio</th>
-              <th class="pb-2 pr-4 font-medium">Order Hash</th>
-              <th class="pb-2 font-medium">Created</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {#each data.current.orders as order (order.orderHash)}
-              <tr class="border-b border-border/30 hover:bg-accent/30">
-                <td class="py-2 pr-4 font-medium">{order.outputToken.symbol}</td>
-
-                <td class="py-2 pr-4 font-medium">{order.inputToken.symbol}</td>
-
-                <td class="py-2 pr-4 text-right font-mono">
-                  {formatDecimal(order.outputVaultBalance, 3)}
-                </td>
-
-                <td class="py-2 pr-4 text-right font-mono">
-                  {formatDecimal(order.ioRatio, 3)}
-                </td>
-
-                <td class="py-2 pr-4">
-                  <span class="font-mono text-xs text-muted-foreground break-all">
-                    {order.orderHash}
-                  </span>
-                </td>
-
-                <td class="py-2 text-xs text-muted-foreground">
-                  {formatTimestamp(order.createdAt)}
-                </td>
+        {#if data.current.orders.length === 0}
+          <div class="flex h-32 items-center justify-center text-muted-foreground">
+            No orders on this page.
+          </div>
+        {:else}
+          <table class="w-full table-fixed text-sm">
+            <thead>
+              <tr class="border-b text-left text-xs text-muted-foreground">
+                <th class="w-24 pb-2 pr-4 font-medium">Output</th>
+                <th class="w-24 pb-2 pr-4 font-medium">Input</th>
+                <th class="w-32 pb-2 pr-4 text-right font-medium">Vault Balance</th>
+                <th class="w-28 pb-2 pr-4 text-right font-medium">IO Ratio</th>
+                <th class="w-44 pb-2 pr-4 font-medium">Order Hash</th>
+                <th class="w-32 pb-2 font-medium">Created</th>
               </tr>
-            {/each}
-          </tbody>
-        </table>
+            </thead>
+
+            <tbody>
+              {#each data.current.orders as order (order.orderHash)}
+                <tr class="border-b border-border/30 hover:bg-accent/30">
+                  <td class="py-2 pr-4 font-medium">{order.outputToken.symbol}</td>
+
+                  <td class="py-2 pr-4 font-medium">{order.inputToken.symbol}</td>
+
+                  <td class="py-2 pr-4 text-right font-mono">
+                    {formatDecimal(order.outputVaultBalance, 3)}
+                  </td>
+
+                  <td class="py-2 pr-4 text-right font-mono">
+                    {formatDecimal(order.ioRatio, 3)}
+                  </td>
+
+                  <td class="py-2 pr-4">
+                    <span class="font-mono text-xs text-muted-foreground" title={order.orderHash}>
+                      {shortHash(order.orderHash)}
+                    </span>
+                  </td>
+
+                  <td class="py-2 text-xs text-muted-foreground">
+                    {formatTimestamp(order.createdAt)}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+
+        <div class="sticky bottom-0 mt-3 flex items-center justify-between border-t bg-card/95 py-2 text-xs text-muted-foreground">
+          <button
+            class="rounded border bg-background px-2 py-1 hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+            onclick={() => { goToPage(currentPage.current - 1); }}
+            disabled={loading.current || currentPage.current <= 1}
+          >
+            Previous
+          </button>
+
+          <span>
+            Page {data.current.pagination.page} of {data.current.pagination.totalPages}
+          </span>
+
+          <button
+            class="rounded border bg-background px-2 py-1 hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+            onclick={() => { goToPage(currentPage.current + 1); }}
+            disabled={loading.current || !data.current.pagination.hasMore}
+          >
+            Next
+          </button>
+        </div>
       {/if}
     {:else}
       <div class="flex h-full items-center justify-center text-muted-foreground">

--- a/dashboard/src/lib/websocket/connection.svelte.test.ts
+++ b/dashboard/src/lib/websocket/connection.svelte.test.ts
@@ -197,7 +197,7 @@ describe('createWebSocket', () => {
               offchainAvailable: '0',
               offchainInflight: '0',
               offchainGross: null,
-              buyingPower: null,
+              withdrawableCash: null,
               inflightCash: { ethereumWallet: null, baseWallet: null }
             }
           },
@@ -297,7 +297,11 @@ describe('createWebSocket', () => {
           onchainAvailable: '10',
           onchainInflight: '0',
           offchainAvailable: '5',
-          offchainInflight: '0'
+          offchainInflight: '0',
+          inflightEquity: {
+            baseWalletUnwrapped: '0',
+            baseWalletWrapped: '0'
+          }
         }],
         usdc: {
           onchainAvailable: '1000',
@@ -305,7 +309,7 @@ describe('createWebSocket', () => {
           offchainAvailable: '500',
           offchainInflight: '0',
           offchainGross: null,
-          buyingPower: null,
+          withdrawableCash: null,
           inflightCash: { ethereumWallet: null, baseWallet: null }
         }
       }

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -4,7 +4,6 @@
   import HeaderBar from '$lib/components/header-bar.svelte'
   import SettingsBar from '$lib/components/settings-bar.svelte'
   import InventoryPanel from '$lib/components/inventory-panel.svelte'
-  import PendingOrders from '$lib/components/pending-orders.svelte'
   import TradeHistoryPanel from '$lib/components/trade-history-panel.svelte'
   import TransferPanel from '$lib/components/transfer-panel.svelte'
   import LogPanel from '$lib/components/log-panel.svelte'
@@ -45,7 +44,7 @@
   })
 
   type Tab = 'dashboard' | 'orders' | 'logs'
-  type MobilePanel = 'inventory' | 'pending' | 'trades' | 'transfers'
+  type MobilePanel = 'inventory' | 'trades' | 'transfers'
 
   const activeTab = reactive<Tab>('dashboard')
   const mobilePanel = reactive<MobilePanel>('inventory')
@@ -76,7 +75,6 @@
   <nav class="flex shrink-0 gap-1 overflow-x-auto border-b bg-card/50 px-2 md:hidden">
     {#if activeTab.current === 'dashboard'}
       <button class={mobilePanelClass('inventory')} onclick={() => { mobilePanel.update(() => 'inventory'); }}>Inventory</button>
-      <button class={mobilePanelClass('pending')} onclick={() => { mobilePanel.update(() => 'pending'); }}>Pending</button>
       <button class={mobilePanelClass('trades')} onclick={() => { mobilePanel.update(() => 'trades'); }}>Trades</button>
       <button class={mobilePanelClass('transfers')} onclick={() => { mobilePanel.update(() => 'transfers'); }}>Transfers</button>
     {/if}
@@ -125,8 +123,6 @@
     <main class="flex-1 overflow-hidden p-2 md:hidden">
       {#if mobilePanel.current === 'inventory'}
         <InventoryPanel />
-      {:else if mobilePanel.current === 'pending'}
-        <PendingOrders />
       {:else if mobilePanel.current === 'trades'}
         <TradeHistoryPanel />
       {:else}
@@ -135,13 +131,10 @@
     </main>
 
     <!-- Desktop: all panels, fixed proportions, internal scrolling -->
-    <main class="hidden min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 md:flex">
-      <div class="grid h-[40%] min-h-0 grid-cols-[2fr_1fr] gap-4">
-        <InventoryPanel />
-        <PendingOrders />
-      </div>
+    <main class="hidden min-h-0 flex-1 grid-cols-[11fr_9fr] gap-4 overflow-hidden p-4 md:grid">
+      <InventoryPanel />
 
-      <div class="grid min-h-0 flex-1 grid-cols-2 gap-4">
+      <div class="grid min-h-0 grid-rows-2 gap-4">
         <TradeHistoryPanel />
         <TransferPanel />
       </div>

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -2,6 +2,10 @@ import tailwindcss from '@tailwindcss/vite'
 import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig } from 'vite'
 
+declare const process: {
+  env: Record<string, string | undefined>
+}
+
 const backendPort = process.env['BACKEND_PORT'] ?? '8001'
 const backendUrl = `http://localhost:${backendPort}`
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -51,6 +51,8 @@ impl<'v> FromFormField<'v> for TransferKindFilter {
 }
 
 static STARTED_AT: LazyLock<DateTime<Utc>> = LazyLock::new(Utc::now);
+const DEFAULT_RAINDEX_ORDERS_PAGE_SIZE: u32 = 50;
+const MAX_RAINDEX_ORDERS_PAGE_SIZE: u32 = 100;
 
 const GIT_COMMIT: &str = match option_env!("ST0X_GIT_COMMIT") {
     Some(val) => val,
@@ -858,9 +860,13 @@ fn unavailable_json(reason: &str) -> RawJson<String> {
 /// Proxies the bot's active Raindex orders from the st0x REST API.
 /// When `[rest_api]` is not configured, returns an unavailable indicator
 /// so the dashboard can show a friendly message instead of an error.
-#[get("/orders/raindex")]
+#[get("/orders/raindex?<page>&<page_size>")]
 #[allow(clippy::cognitive_complexity)]
-async fn raindex_orders(ctx: &State<Ctx>) -> RawJson<String> {
+async fn raindex_orders(
+    ctx: &State<Ctx>,
+    page: Option<u32>,
+    page_size: Option<u32>,
+) -> RawJson<String> {
     let Some(rest_api) = &ctx.rest_api else {
         return unavailable_json("REST API not configured (simulate mode)");
     };
@@ -872,7 +878,15 @@ async fn raindex_orders(ctx: &State<Ctx>) -> RawJson<String> {
         owner
     );
 
-    let mut request = rest_api.http_client.get(&url);
+    let page = page.unwrap_or(1).max(1);
+    let page_size = page_size
+        .unwrap_or(DEFAULT_RAINDEX_ORDERS_PAGE_SIZE)
+        .clamp(1, MAX_RAINDEX_ORDERS_PAGE_SIZE);
+
+    let mut request = rest_api
+        .http_client
+        .get(&url)
+        .query(&[("page", page), ("pageSize", page_size)]);
 
     if let (Some(key_id), Some(key_secret)) = (&rest_api.key_id, &rest_api.key_secret) {
         request = request.basic_auth(key_id, Some(key_secret));
@@ -1398,7 +1412,10 @@ mod tests {
         let expected_path = format!("/v1/orders/owner/{owner:#x}");
 
         mock_server.mock(|when, then| {
-            when.method(httpmock::Method::GET).path(&expected_path);
+            when.method(httpmock::Method::GET)
+                .path(&expected_path)
+                .query_param("page", "1")
+                .query_param("pageSize", "50");
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(upstream_body.clone());
@@ -1424,6 +1441,110 @@ mod tests {
 
         assert_eq!(parsed["orders"][0]["orderHash"], "0xabcd");
         assert_eq!(parsed["pagination"]["totalOrders"], 1);
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_forwards_clamped_pagination_to_upstream() {
+        let mock_server = httpmock::MockServer::start();
+        let upstream_body = serde_json::json!({
+            "orders": [],
+            "pagination": {
+                "page": 3,
+                "pageSize": 100,
+                "totalOrders": 0,
+                "totalPages": 0,
+                "hasMore": false
+            }
+        });
+
+        let owner = alloy::primitives::Address::ZERO;
+        let expected_path = format!("/v1/orders/owner/{owner:#x}");
+
+        mock_server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(&expected_path)
+                .query_param("page", "3")
+                .query_param("pageSize", "100");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(upstream_body.clone());
+        });
+
+        let mut ctx = create_test_ctx_with_order_owner(owner);
+        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+            mock_server.base_url(),
+        ));
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/orders/raindex?page=3&page_size=500")
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
+
+        assert_eq!(parsed["pagination"]["page"], 3);
+        assert_eq!(parsed["pagination"]["pageSize"], 100);
+    }
+
+    #[tokio::test]
+    async fn raindex_orders_clamps_zero_pagination_inputs_to_one() {
+        let mock_server = httpmock::MockServer::start();
+        let upstream_body = serde_json::json!({
+            "orders": [],
+            "pagination": {
+                "page": 1,
+                "pageSize": 1,
+                "totalOrders": 0,
+                "totalPages": 0,
+                "hasMore": false
+            }
+        });
+
+        let owner = alloy::primitives::Address::ZERO;
+        let expected_path = format!("/v1/orders/owner/{owner:#x}");
+
+        mock_server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(&expected_path)
+                .query_param("page", "1")
+                .query_param("pageSize", "1");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(upstream_body.clone());
+        });
+
+        let mut ctx = create_test_ctx_with_order_owner(owner);
+        ctx.rest_api = Some(crate::config::RestApiCtx::unauthenticated(
+            mock_server.base_url(),
+        ));
+
+        let rocket = rocket::build()
+            .mount("/", routes![raindex_orders])
+            .manage(ctx);
+        let client = Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/orders/raindex?page=0&page_size=0")
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body = response.into_string().await.expect("response body");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON response");
+
+        assert_eq!(parsed["pagination"]["page"], 1);
+        assert_eq!(parsed["pagination"]["pageSize"], 1);
     }
 
     #[tokio::test]

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -2766,6 +2766,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            cash_withdrawable_cents: None,
         });
 
         let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -2823,6 +2824,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            cash_withdrawable_cents: None,
         });
 
         let offchain_order_id = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -2885,6 +2887,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            cash_withdrawable_cents: None,
         });
 
         let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
@@ -3121,6 +3124,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 10_000,
                 cash_buying_power_cents: Some(1_000_000),
+                cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
 
@@ -3184,6 +3188,7 @@ mod tests {
                 }],
                 usd_balance_cents: 15_000,
                 cash_buying_power_cents: Some(15_000),
+                cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
 
@@ -3247,6 +3252,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            cash_withdrawable_cents: None,
         });
 
         check_and_execute_accumulated_positions(
@@ -3341,6 +3347,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 15_000,
                 cash_buying_power_cents: Some(15_000),
+                cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -1216,6 +1216,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
         positions: vec![],
         usd_balance_cents: 50_000,
         cash_buying_power_cents: Some(50_000),
+        cash_withdrawable_cents: None,
     });
 
     let asserter = Asserter::new();

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -462,6 +462,15 @@ where
             )
             .await?;
 
+        self.snapshot
+            .send(
+                snapshot_id,
+                InventorySnapshotCommand::OffchainCashWithdrawable {
+                    cash_withdrawable_cents: inventory.cash_withdrawable_cents,
+                },
+            )
+            .await?;
+
         Ok(())
     }
 
@@ -817,6 +826,7 @@ mod tests {
             ],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory.clone());
 
@@ -869,6 +879,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 25_000_000, // $250,000.00
             cash_buying_power_cents: Some(25_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -917,6 +928,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000_000, // $100,000
             cash_buying_power_cents: Some(10_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -975,6 +987,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 3_000_000, // $30,000
             cash_buying_power_cents: Some(3_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1013,6 +1026,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1068,6 +1082,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 5_000_000,
             cash_buying_power_cents: Some(5_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1168,6 +1183,7 @@ mod tests {
             }],
             usd_balance_cents: -5_000_000, // -$50,000 (margin debt)
             cash_buying_power_cents: Some(0),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1209,6 +1225,7 @@ mod tests {
             }],
             usd_balance_cents: 1_000_000,
             cash_buying_power_cents: Some(1_000_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 
@@ -1256,6 +1273,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000,
             cash_buying_power_cents: Some(10_000),
+            cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
 

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -89,6 +89,11 @@ pub(crate) struct InventorySnapshot {
     /// value used for counter-trade preflight checks.) See
     /// adrs/1-cash-bp-for-equity-hedges.md.
     pub(crate) offchain_cash_buying_power_cents: Option<i64>,
+    /// Latest offchain settled (withdrawable) cash in cents (Alpaca's
+    /// `cash_withdrawable` field -- excludes T+1 unsettled equity-sale
+    /// proceeds). What's actually movable to Raindex during rebalancing.
+    #[serde(default)]
+    pub(crate) offchain_cash_withdrawable_cents: Option<i64>,
     /// Latest Ethereum wallet USDC balance
     pub(crate) ethereum_usdc: Option<Usdc>,
     /// Latest Base wallet USDC balance (outside Raindex vaults)
@@ -132,6 +137,7 @@ impl EventSourced for InventorySnapshot {
             offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
             offchain_cash_buying_power_cents: None,
+            offchain_cash_withdrawable_cents: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
             inflight_mints: BTreeMap::new(),
@@ -181,6 +187,12 @@ impl EventSourced for InventorySnapshot {
                 cash_buying_power_cents,
             } => InventorySnapshotEvent::OffchainCashBuyingPower {
                 cash_buying_power_cents,
+                fetched_at: now,
+            },
+            OffchainCashWithdrawable {
+                cash_withdrawable_cents,
+            } => InventorySnapshotEvent::OffchainCashWithdrawable {
+                cash_withdrawable_cents,
                 fetched_at: now,
             },
             EthereumUsdc { usdc_balance } => InventorySnapshotEvent::EthereumUsdc {
@@ -270,6 +282,17 @@ impl EventSourced for InventorySnapshot {
                 }
                 Ok(vec![InventorySnapshotEvent::OffchainCashBuyingPower {
                     cash_buying_power_cents,
+                    fetched_at: now,
+                }])
+            }
+            OffchainCashWithdrawable {
+                cash_withdrawable_cents,
+            } => {
+                if self.offchain_cash_withdrawable_cents == cash_withdrawable_cents {
+                    return Ok(vec![]);
+                }
+                Ok(vec![InventorySnapshotEvent::OffchainCashWithdrawable {
+                    cash_withdrawable_cents,
                     fetched_at: now,
                 }])
             }
@@ -378,6 +401,13 @@ impl InventorySnapshot {
             });
         }
 
+        if self.offchain_cash_withdrawable_cents.is_some() {
+            events.push(InventorySnapshotEvent::OffchainCashWithdrawable {
+                cash_withdrawable_cents: self.offchain_cash_withdrawable_cents,
+                fetched_at,
+            });
+        }
+
         if let Some(usdc_balance) = self.ethereum_usdc {
             events.push(InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance,
@@ -476,6 +506,12 @@ impl InventorySnapshot {
             } => {
                 self.offchain_cash_buying_power_cents = *cash_buying_power_cents;
             }
+            InventorySnapshotEvent::OffchainCashWithdrawable {
+                cash_withdrawable_cents,
+                ..
+            } => {
+                self.offchain_cash_withdrawable_cents = *cash_withdrawable_cents;
+            }
             InventorySnapshotEvent::EthereumUsdc { usdc_balance, .. } => {
                 self.ethereum_usdc = Some(*usdc_balance);
             }
@@ -517,6 +553,9 @@ pub(crate) enum InventorySnapshotCommand {
     },
     OffchainCashBuyingPower {
         cash_buying_power_cents: Option<i64>,
+    },
+    OffchainCashWithdrawable {
+        cash_withdrawable_cents: Option<i64>,
     },
     EthereumUsdc {
         usdc_balance: Usdc,
@@ -567,6 +606,10 @@ pub(crate) enum InventorySnapshotEvent {
         cash_buying_power_cents: Option<i64>,
         fetched_at: DateTime<Utc>,
     },
+    OffchainCashWithdrawable {
+        cash_withdrawable_cents: Option<i64>,
+        fetched_at: DateTime<Utc>,
+    },
     #[serde(alias = "EthereumCash")]
     EthereumUsdc {
         usdc_balance: Usdc,
@@ -602,6 +645,7 @@ impl InventorySnapshotEvent {
             | Self::OffchainEquity { fetched_at, .. }
             | Self::OffchainUsd { fetched_at, .. }
             | Self::OffchainCashBuyingPower { fetched_at, .. }
+            | Self::OffchainCashWithdrawable { fetched_at, .. }
             | Self::EthereumUsdc { fetched_at, .. }
             | Self::BaseWalletUsdc { fetched_at, .. }
             | Self::BaseWalletUnwrappedEquity { fetched_at, .. }
@@ -620,6 +664,9 @@ impl DomainEvent for InventorySnapshotEvent {
             Self::OffchainUsd { .. } => "InventorySnapshotEvent::OffchainUsd".to_string(),
             Self::OffchainCashBuyingPower { .. } => {
                 "InventorySnapshotEvent::OffchainCashBuyingPower".to_string()
+            }
+            Self::OffchainCashWithdrawable { .. } => {
+                "InventorySnapshotEvent::OffchainCashWithdrawable".to_string()
             }
             Self::EthereumUsdc { .. } => "InventorySnapshotEvent::EthereumUsdc".to_string(),
             Self::BaseWalletUsdc { .. } => "InventorySnapshotEvent::BaseWalletUsdc".to_string(),
@@ -1598,6 +1645,7 @@ mod tests {
             offchain_usd_fetched_at: None,
             offchain_gross_usd_cents: None,
             offchain_cash_buying_power_cents: None,
+            offchain_cash_withdrawable_cents: None,
             ethereum_usdc: None,
             base_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
@@ -1629,6 +1677,7 @@ mod tests {
             offchain_usd_fetched_at: Some(now),
             offchain_gross_usd_cents: Some(50_00),
             offchain_cash_buying_power_cents: Some(10_000),
+            offchain_cash_withdrawable_cents: Some(38_00),
             ethereum_usdc: None,
             base_wallet_usdc: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -10,7 +10,7 @@ use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use st0x_dto::{InFlightCash, SymbolInventory, UsdcInventory};
+use st0x_dto::{InFlightCash, InFlightEquity, SymbolInventory, UsdcInventory};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_finance::Usdc;
 use st0x_float_macro::float;
@@ -697,6 +697,11 @@ pub(crate) struct InventoryView {
     /// Margin-safe buying power in cents from the offchain broker.
     #[serde(default)]
     buying_power_cents: Option<i64>,
+    /// Settled (withdrawable) cash in cents from the offchain broker.
+    /// Excludes T+1 unsettled equity-sale proceeds; this is the amount
+    /// actually movable to Raindex during rebalancing.
+    #[serde(default)]
+    withdrawable_cash_cents: Option<i64>,
     /// Gross offchain USD balance in cents (before cash reserve subtraction).
     #[serde(default)]
     offchain_gross_usd_cents: Option<i64>,
@@ -802,11 +807,32 @@ impl InventoryView {
     pub(crate) fn to_dto(&self) -> st0x_dto::Inventory {
         let per_symbol = self
             .equities
-            .iter()
-            .map(|(symbol, inventory)| {
-                let (onchain_available, onchain_inflight) = venue_balances(inventory.onchain);
+            .keys()
+            .chain(self.inflight_equity.keys().map(|(symbol, _)| symbol))
+            .unique()
+            .sorted()
+            .map(|symbol| {
+                let inventory = self.equities.get(symbol);
+                let (onchain_available, onchain_inflight) = inventory
+                    .map_or((FractionalShares::ZERO, FractionalShares::ZERO), |item| {
+                        venue_balances(item.onchain)
+                    });
 
-                let (offchain_available, offchain_inflight) = venue_balances(inventory.offchain);
+                let (offchain_available, offchain_inflight) = inventory
+                    .map_or((FractionalShares::ZERO, FractionalShares::ZERO), |item| {
+                        venue_balances(item.offchain)
+                    });
+
+                let inflight_equity = InFlightEquity {
+                    base_wallet_unwrapped: self
+                        .inflight_equity
+                        .get(&(symbol.clone(), InFlightEquityLocation::BaseWalletUnwrapped))
+                        .map_or(FractionalShares::ZERO, |entry| entry.amount),
+                    base_wallet_wrapped: self
+                        .inflight_equity
+                        .get(&(symbol.clone(), InFlightEquityLocation::BaseWalletWrapped))
+                        .map_or(FractionalShares::ZERO, |entry| entry.amount),
+                };
 
                 SymbolInventory {
                     symbol: symbol.clone(),
@@ -814,22 +840,16 @@ impl InventoryView {
                     onchain_inflight,
                     offchain_available,
                     offchain_inflight,
+                    inflight_equity,
                 }
             })
-            .sorted_by(|left, right| left.symbol.cmp(&right.symbol))
             .collect();
 
         let (usdc_onchain_available, usdc_onchain_inflight) = venue_balances(self.usdc.onchain);
 
         let (usdc_offchain_available, usdc_offchain_inflight) = venue_balances(self.usdc.offchain);
 
-        let buying_power = self.buying_power_cents.map(|cents| {
-            let sign = if cents < 0 { "-" } else { "" };
-            let abs = cents.unsigned_abs();
-            let whole = abs / 100;
-            let frac = abs % 100;
-            format!("{sign}${whole}.{frac:02}")
-        });
+        let withdrawable_cash = self.withdrawable_cash_cents.and_then(Usdc::from_cents);
 
         let offchain_gross = self.offchain_gross_usd_cents.and_then(Usdc::from_cents);
 
@@ -852,7 +872,7 @@ impl InventoryView {
                 offchain_available: usdc_offchain_available,
                 offchain_inflight: usdc_offchain_inflight,
                 offchain_gross,
-                buying_power,
+                withdrawable_cash,
                 inflight_cash,
             },
         }
@@ -879,6 +899,7 @@ impl Default for InventoryView {
             equities: HashMap::new(),
             last_updated: Utc::now(),
             buying_power_cents: None,
+            withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -1009,6 +1030,7 @@ impl InventoryView {
             last_updated: now,
             usdc: self.usdc,
             buying_power_cents: self.buying_power_cents,
+            withdrawable_cash_cents: self.withdrawable_cash_cents,
             offchain_gross_usd_cents: self.offchain_gross_usd_cents,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1034,6 +1056,7 @@ impl InventoryView {
             last_updated: now,
             equities: self.equities,
             buying_power_cents: self.buying_power_cents,
+            withdrawable_cash_cents: self.withdrawable_cash_cents,
             offchain_gross_usd_cents: self.offchain_gross_usd_cents,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1248,6 +1271,7 @@ impl InventoryView {
             last_updated: now,
             usdc: self.usdc,
             buying_power_cents: self.buying_power_cents,
+            withdrawable_cash_cents: self.withdrawable_cash_cents,
             offchain_gross_usd_cents: self.offchain_gross_usd_cents,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1274,6 +1298,7 @@ impl InventoryView {
             last_updated: now,
             equities: self.equities,
             buying_power_cents: self.buying_power_cents,
+            withdrawable_cash_cents: self.withdrawable_cash_cents,
             offchain_gross_usd_cents: self.offchain_gross_usd_cents,
             inflight_cash: self.inflight_cash,
             active_usdc_rebalance: self.active_usdc_rebalance,
@@ -1567,6 +1592,21 @@ impl InventoryView {
                 })
             }
 
+            OffchainCashWithdrawable {
+                cash_withdrawable_cents,
+                ..
+            } => {
+                debug!(
+                    target: "inventory",
+                    ?cash_withdrawable_cents,
+                    "apply_snapshot_event: OffchainCashWithdrawable"
+                );
+                Ok(Self {
+                    withdrawable_cash_cents: *cash_withdrawable_cents,
+                    ..self
+                })
+            }
+
             EthereumUsdc {
                 usdc_balance,
                 fetched_at,
@@ -1707,6 +1747,14 @@ impl InventoryView {
                 ..
             } => Ok(Self {
                 buying_power_cents: *cash_buying_power_cents,
+                ..self
+            }),
+
+            OffchainCashWithdrawable {
+                cash_withdrawable_cents,
+                ..
+            } => Ok(Self {
+                withdrawable_cash_cents: *cash_withdrawable_cents,
                 ..self
             }),
 
@@ -2013,6 +2061,7 @@ mod tests {
             equities: equities.into_iter().collect(),
             last_updated: Utc::now(),
             buying_power_cents: None,
+            withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -2042,6 +2091,7 @@ mod tests {
             equities: HashMap::new(),
             last_updated: Utc::now(),
             buying_power_cents: None,
+            withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -3277,6 +3327,7 @@ mod tests {
             usdc: usdc_make_inventory(5000, 1000, 3000, 500),
             last_updated: Utc::now(),
             buying_power_cents: None,
+            withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -3328,6 +3379,7 @@ mod tests {
             usdc: Inventory::default(),
             last_updated: Utc::now(),
             buying_power_cents: None,
+            withdrawable_cash_cents: None,
             offchain_gross_usd_cents: None,
             inflight_cash: HashMap::new(),
             active_usdc_rebalance: None,
@@ -3380,6 +3432,25 @@ mod tests {
         assert_eq!(dto.usdc.inflight_cash.base_wallet, Some(Usdc::ZERO));
     }
 
+    #[test]
+    fn to_dto_includes_withdrawable_cash() {
+        let view = InventoryView {
+            withdrawable_cash_cents: Some(3_200_000),
+            ..InventoryView::default()
+        };
+
+        let dto = view.to_dto();
+
+        assert_eq!(dto.usdc.withdrawable_cash, Some(Usdc::new(float!(32000))));
+    }
+
+    #[test]
+    fn to_dto_withdrawable_cash_is_none_when_broker_omitted_field() {
+        let dto = InventoryView::default().to_dto();
+
+        assert_eq!(dto.usdc.withdrawable_cash, None);
+    }
+
     /// Locations that have never been observed must surface as `None` in
     /// the DTO so the dashboard can distinguish "not polled yet" from
     /// "observed as zero".
@@ -3389,6 +3460,65 @@ mod tests {
 
         assert_eq!(dto.usdc.inflight_cash.ethereum_wallet, None);
         assert_eq!(dto.usdc.inflight_cash.base_wallet, None);
+    }
+
+    #[test]
+    fn to_dto_includes_inflight_equity() {
+        let fetched_at = Utc::now();
+        let aapl = Symbol::new("AAPL").unwrap();
+        let mut unwrapped = BTreeMap::new();
+        unwrapped.insert(aapl.clone(), shares(3));
+        let mut wrapped = BTreeMap::new();
+        wrapped.insert(aapl.clone(), shares(2));
+
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(100), shares(50))
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletUnwrapped,
+                &unwrapped,
+                fetched_at,
+                fetched_at,
+            )
+            .set_inflight_equity_at_location(
+                InFlightEquityLocation::BaseWalletWrapped,
+                &wrapped,
+                fetched_at,
+                fetched_at,
+            );
+
+        let dto = view.to_dto();
+        let aapl_dto = &dto.per_symbol[0];
+
+        assert_eq!(aapl_dto.symbol, aapl);
+        assert_eq!(aapl_dto.inflight_equity.base_wallet_unwrapped, shares(3));
+        assert_eq!(aapl_dto.inflight_equity.base_wallet_wrapped, shares(2));
+    }
+
+    #[test]
+    fn to_dto_includes_wallet_only_equity_symbols() {
+        let fetched_at = Utc::now();
+        let aapl = Symbol::new("AAPL").unwrap();
+        let mut wrapped = BTreeMap::new();
+        wrapped.insert(aapl.clone(), shares(2));
+
+        let view = InventoryView::default().set_inflight_equity_at_location(
+            InFlightEquityLocation::BaseWalletWrapped,
+            &wrapped,
+            fetched_at,
+            fetched_at,
+        );
+
+        let dto = view.to_dto();
+        let aapl_dto = &dto.per_symbol[0];
+
+        assert_eq!(aapl_dto.symbol, aapl);
+        assert_eq!(aapl_dto.onchain_available, FractionalShares::ZERO);
+        assert_eq!(aapl_dto.offchain_available, FractionalShares::ZERO);
+        assert_eq!(
+            aapl_dto.inflight_equity.base_wallet_unwrapped,
+            FractionalShares::ZERO
+        );
+        assert_eq!(aapl_dto.inflight_equity.base_wallet_wrapped, shares(2));
     }
 
     #[test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1144,6 +1144,7 @@ impl RebalancingService {
 
             OffchainUsd { .. }
             | OffchainCashBuyingPower { .. }
+            | OffchainCashWithdrawable { .. }
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
@@ -1246,6 +1247,7 @@ impl RebalancingService {
             | OffchainEquity { .. }
             | OffchainUsd { .. }
             | OffchainCashBuyingPower { .. }
+            | OffchainCashWithdrawable { .. }
             | EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
@@ -1310,9 +1312,10 @@ impl RebalancingService {
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. }
-            // Buying power is display-only and doesn't feed venue
-            // balances, so it never drives a rebalance.
+            // Buying power and withdrawable cash are display-only and
+            // don't feed venue balances, so they never drive a rebalance.
             | OffchainCashBuyingPower { .. }
+            | OffchainCashWithdrawable { .. }
             // Inflight snapshots don't trigger rebalancing -- they
             // indicate transfers already in progress, not new balances
             // to rebalance.


### PR DESCRIPTION
![image.png](https://app.graphite.com/user-attachments/assets/619c7b32-8ee5-48e2-a5db-9f9aec87d631.png)

## What

Closes [RAI-618](https://linear.app/makeitrain/issue/RAI-618/show-all-tracked-inventory-in-dashboard-and-fix-orders-tab).

- Expose Base-wallet equity (unwrapped `tSTOCK` and wrapped `wtSTOCK`) per
  symbol through `st0x-dto` and surface it in the dashboard inventory table.
- Plumb Alpaca's `cash_withdrawable` (settled cash) end-to-end and replace
  the redundant Buying Power column with a **Withdrawable** column that
  shows what can actually be rebalanced to Raindex.
- Split the inventory panel into two stacked tables — a wide cash row with
  its own conditional columns (Gross / Withdrawable / Eth Wallet / Base
  Wallet) and the per-symbol equity table — and replace the hover tooltip
  with a column glossary dialog.
- Reorder both tables to read **Asset → Raindex → Inflight → Alpaca → Total
  → Ratio → …** so columns mirror flow direction (onchain venue first,
  then in-motion, then offchain venue).
- Restructure the desktop dashboard: drop the `PendingOrders` panel from
  the main layout (and mobile tab bar) and run inventory full-height on
  the left with trades/transfers stacked on the right.
- Paginate the Raindex Orders tab end-to-end (backend proxy + UI) so the
  tab no longer freezes when the upstream returns a large order set.

## Why

The dashboard inventory table did not surface every location the backend
already tracks. In particular, Base-wallet `tSTOCK` / `wtSTOCK` balances —
which sit between a Raindex withdrawal and an Alpaca redemption (or
post-mint before a vault deposit) — were invisible to operators even though
the bot polls them.

The cash row was also misleading: "Gross" and "Buying Power" rendered the
same number because the broker layer set `cash_buying_power_cents = cash_balance_cents`,
and for a cash account Alpaca's `buying_power == cash` anyway. What
operators actually needed was settled cash — the value that excludes T+1
unsettled equity-sale proceeds and is therefore movable to Raindex during
rebalancing. That maps to Alpaca's `cash_withdrawable` field.

The Orders tab was also fetching every active Raindex order in one shot and
rendering them unbounded, which made the tab hang on owners with many
orders. RAI-618 calls out all of this along with the layout cleanup.

## How

### DTO (`crates/dto`)

- New `InFlightEquity { base_wallet_unwrapped, base_wallet_wrapped }` struct
  in `crates/dto/src/inventory.rs`, embedded on `SymbolInventory`. Exported
  via `export_bindings` so the dashboard gets a generated TS type.
- `UsdcInventory.buying_power: Option<String>` removed; replaced with
  `withdrawable_cash: Option<Usdc>` (typed newtype, not a pre-formatted
  string).
- JSON serialization test updated to assert both new fields against
  `json!()` literals.

### Execution crate (`crates/execution`)

- `Inventory` gains `cash_withdrawable_cents: Option<i64>`. `None` when the
  broker omits the field — no silent fallback to cash balance.
- `AccountDetailsResponse` (Alpaca) deserializes `cash_withdrawable` via
  `deserialize_option_float_from_number_or_string`.
- `AccountFunds` fields renamed from `cash_*_cents` to `balance` /
  `buying_power` / `withdrawable` to avoid the `struct_field_names` clippy
  lint after the third field was added. Fields are `pub(super)` so the
  blast radius is the alpaca module only.
- `alpaca_broker_api/mock_api.rs` — the simulate-mode `/account` response
  now includes `cash_withdrawable` (mirroring the existing `buying_power` /
  `cash` fields), so `nix run .#simulate` populates the new column instead
  of leaving it `null`.
- Two new tests in `positions.rs`:
  `fetch_inventory_extracts_cash_withdrawable_when_present` and
  `fetch_inventory_leaves_cash_withdrawable_none_when_broker_omits_field`.

### Snapshot aggregate (`src/inventory/snapshot.rs`)

- New event/command variant `OffchainCashWithdrawable { cash_withdrawable_cents: Option<i64> }`,
  with apply / transition / hydration / `event_type()` / `timestamp()`
  arms.
- New snapshot field `offchain_cash_withdrawable_cents: Option<i64>` with
  `#[serde(default)]` so existing serialized snapshots replay cleanly.
- **Schema-compatible additive change.** `SCHEMA_VERSION` stays at `6`.
  The new event variant and the `#[serde(default)]` field are
  backward-compatible — pre-existing snapshots load fine, and the new
  variant only appears on future polls. (Bumping the version would have
  triggered `CompactedSnapshotClear` since the aggregate uses
  `CompactionPolicy::CompactAfterSnapshot`.)

### Polling + view (`src/inventory/polling.rs`, `src/inventory/view.rs`)

- `InventoryPollingService::poll_offchain` now sends
  `OffchainCashWithdrawable` after `OffchainCashBuyingPower` on every fetch.
- `InventoryView` gains `withdrawable_cash_cents: Option<i64>` (with
  `#[serde(default)]`), populated by both `apply_snapshot_event` and the
  recovery `force_apply_snapshot_event` paths. `clone_with` sites
  (~6 places) propagate the field.
- `to_dto()` drops the formatted `buying_power` string and emits
  `withdrawable_cash` as `Option<Usdc>` derived via `Usdc::from_cents`. The
  matching tests `to_dto_includes_withdrawable_cash` and
  `to_dto_withdrawable_cash_is_none_when_broker_omitted_field` cover both
  paths.

### Rebalancing trigger (`src/rebalancing/trigger/mod.rs`)

- Match arms updated to treat `OffchainCashWithdrawable` exactly like
  `OffchainCashBuyingPower`: display-only, never triggers a rebalance.

### Backend API (`src/api.rs`)

- `InventoryView::to_dto` now iterates the union of `equities` keys and
  `inflight_equity` keys (deduped + sorted) so a symbol that exists *only*
  in the Base wallet polling map still produces a row with zero venue
  balances and the observed wallet amounts. `inflight_equity` is populated
  per symbol from the `(symbol, location)` map. Two new tests cover the
  populated and wallet-only-symbol paths.
- `GET /orders/raindex` now accepts `page` and `page_size` query params,
  clamps them (`page >= 1`, `page_size in [1, 100]`, default 50), and
  forwards the clamped values to the upstream REST API. Three new tests
  cover the happy path, clamped-out-of-range inputs, and zero-input
  fallback to 1.

### Dashboard (`dashboard/src/...`)

- `available-inventory.svelte`: pulled cash out of the equity table into a
  separate `Table.Root` above it. The cash row has conditional columns
  Gross / **Withdrawable** / Eth Wallet / Base Wallet (only shown when the
  backend returns those fields). Equity table gains two new sortable
  `Unwrapped` / `Wrapped` columns wired to `InFlightEquity`. Sort state
  renamed to `EquitySortState` since the cash row is no longer part of
  the sort.
- Column order in both tables reworked to **Asset → Raindex → Inflight →
  Alpaca → Total → Ratio → Exposure → …**, replacing the previous
  Alpaca-first ordering. The new order mirrors the flow direction
  (onchain venue first, in-motion in the middle, offchain last) and keeps
  Raindex and Inflight visually adjacent since they move together during
  rebalancing.
- Cell padding widened to `1rem` for core columns with an `.info-col`
  override (`0.5rem`) for the right-side info columns. A `w-full` spacer
  column between Ratio and the first info column absorbs slack and an
  `infoSepClass` (`border-l border-border pl-6`) marks the visual
  divider. Cash table overrides the default `uppercase tracking-wider`
  header styling with `text-transform: none`.
- `fmtExposure` now collapses values under `$0.01` to `$0` (was `~$0`)
  to declutter the column when fills are tiny.
- `inventory-panel.svelte`: replaced the hover popover on the info icon
  with a full `<dialog>` glossary listing every column (cash + equity)
  with per-column definitions and a callout that wallet-observed columns
  are out-of-band and not part of imbalance math. Glossary entries
  reordered to match the new column order.
- `orders-panel.svelte`: keyed `sessionStorage` cache by page; added
  `currentPage` reactive state, `goToPage`, prev/next buttons,
  table-fixed layout with column widths, truncated order hashes with
  full hash in `title`, and a separate "No orders on this page" empty
  state for paged empties. Sends `page=N&page_size=50` to the new
  backend params.
- `+page.svelte`: removed `PendingOrders` import, mobile tab, and the
  `pending` `MobilePanel` variant. Desktop layout switched from a
  40%-tall inventory/pending grid + bottom row of trades/transfers to a
  single full-height `11fr_9fr` grid with inventory on the left and
  trades stacked over transfers on the right.
- `vite.config.ts`: added a local `declare const process` shim so the
  config typechecks without dragging in `@types/node`.
- `connection.svelte.test.ts`: WS fixture updated for the new
  `inflightEquity` block and the `buyingPower` → `withdrawableCash` field
  rename so the message keeps type-checking against the generated DTO.
- `dashboard/src/lib/api/UsdcInventory.ts` regenerated via
  `cargo run -p st0x-dto -- dashboard/src/lib/api`.

### Spec

- Updated the dashboard section of `SPEC.md` to mention wallet-observed
  USDC (Ethereum/Base) and unwrapped/wrapped equity tokens as part of
  the inventory tab.

## Testing

- `cargo nextest run --workspace --all-features` (1964/1964, 4 skipped).
- `cd dashboard && bun run check` (0 errors).
- `cd dashboard && bun run test:run src/lib/websocket/connection.svelte.test.ts`
  (13/13).
- `cargo clippy --workspace --all-targets --all-features` (clean).
- `cargo fmt`.

## Anything else

- **Schema-compatible deploy.** No DB wipe needed for existing
  deployments — the snapshot field is `#[serde(default)]` and the new
  event variant only appears on polls produced post-upgrade. The
  simulate DB (`/tmp/st0x-liquidity-simulate-*.sqlite`) may need to be
  deleted if you tested an intermediate revision that bumped
  `SCHEMA_VERSION` to 7; otherwise no manual action.
- **Buying Power column removed.** This is a deliberate UI/DTO drop —
  `Inventory.cash_buying_power_cents` still flows in the backend because
  it's used by the counter-trade preflight (`adrs/1-cash-bp-for-equity-hedges.md`).
  Only the redundant display column and the `UsdcInventory.buying_power`
  DTO field are gone.
- **No imbalance-math change.** Wallet-observed columns (Eth Wallet,
  Base Wallet, Unwrapped, Wrapped) and Withdrawable come from polling
  and are explicitly excluded from Total / Ratio and from any
  rebalancing decisions. The glossary dialog calls this out.
- **DTO is partly additive, partly breaking.** `SymbolInventory` gains
  `inflight_equity` (additive). `UsdcInventory` drops `buying_power`
  and adds `withdrawable_cash` (breaking for any external consumer —
  the dashboard is the only known one and is updated in this PR).
- **`PendingOrders` panel is removed from the main layout** but the
  component file is untouched — still reachable through other tabs if
  needed.
- **Raindex order pagination cap is 100 per page**, matching the
  upstream REST API's documented max. Larger requests are silently
  clamped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination for order history with caching.
  * Introduced glossary modal for inventory column definitions.
  * Enhanced inventory tracking with withdrawable cash and wallet-observed equity display.

* **UI Improvements**
  * Refactored equity table with improved sorting and unwrapped/wrapped equity columns.
  * Removed pending orders panel from dashboard.
  * Updated inventory panel descriptions for clarity on wallet-observed values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->