### PR TITLE
fix: count only bot-owned pending tokenization requests as inflight

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2000,10 +2000,18 @@ know about cross-venue inventory.
   available (tokens never left our wallet)
 - `EquityRedemptionEvent::TokensSent` - Tokens sent to Alpaca (still inflight)
 - `EquityRedemptionEvent::Completed` - Moves from inflight to Alpaca available
-- `EquityRedemptionEvent::DetectionFailed` - Tokens stranded (manual recovery)
-- `EquityRedemptionEvent::RedemptionRejected` - Token disposition uncertain
-  after rejection; keep inflight until an operator manually resolves the asset
-  location and a subsequent snapshot captures the corrected state
+- `EquityRedemptionEvent::DetectionFailed` - Terminal: tokens may be stranded
+  mid-redemption (sent to the issuance bot's redemption wallet but not yet
+  settled back as broker shares; manual recovery). Inflight is not held
+  indefinitely -- the redemption is dropped from active ownership, so
+  inflight-equity polls stop counting its still-pending provider request as
+  bot-owned and the inflight clears, letting rebalancing resume; the
+  transfer-timeout path also clears inflight explicitly
+- `EquityRedemptionEvent::RedemptionRejected` - Terminal: token disposition
+  uncertain after rejection. Inflight is released the same way as
+  `DetectionFailed` (ownership dropped so polls stop counting the stranded
+  request and rebalancing resumes), while operators resolve the actual asset
+  location manually
 - `UsdcRebalanceEvent::WithdrawalConfirmed` - Moves USDC to inflight (leaving
   source)
 - `UsdcRebalanceEvent::DepositConfirmed` - Terminal success for AlpacaToBase;
@@ -2020,10 +2028,20 @@ know about cross-venue inventory.
   from broker
 - `InventorySnapshotEvent::OffchainCash` - Offchain cash balance fetched from
   broker
-- `InventorySnapshotEvent::InflightEquity` - Pending tokenization requests
-  polled from Alpaca; sets inflight at Hedging (mints) and MarketMaking
-  (redemptions). Available balances are unchanged -- they are set by separate
-  available-balance snapshots
+- `InventorySnapshotEvent::InflightEquity` - Bot-owned pending tokenization
+  requests polled from Alpaca; sets inflight at Hedging (mints) and MarketMaking
+  (redemptions)
+  - **Ownership**: determined by active rebalancing aggregate IDs --
+    `issuer_request_id` / `tokenization_request_id` for mints,
+    `tokenization_request_id` / `redemption_tx` for redemptions -- not by
+    destination wallet alone
+  - **Pre-detection redemptions**: redemptions that sent tokens before Alpaca
+    assigned a `tokenization_request_id` are owned via `redemption_tx` until
+    detection records the provider ID
+  - **External requests**: unknown pending requests targeting the bot wallet are
+    logged for operators but do not count as inflight or block rebalancing
+  - **Available balances**: unchanged -- set by separate available-balance
+    snapshots
 
 ##### Separation of concerns
 

--- a/migrations/20260520180918_backfill_inflight_equity_fetched_at.sql
+++ b/migrations/20260520180918_backfill_inflight_equity_fetched_at.sql
@@ -1,0 +1,18 @@
+-- The `inflight_equity_fetched_at` field was added after the other per-source
+-- fetched-at fields (see 20260518115736). Hydration only replays the
+-- InflightEquity event when this timestamp is set, so compacted snapshot-only
+-- aggregates written before this field existed would silently drop their
+-- inflight mints/redemptions on restart. Backfill from `last_updated` to
+-- preserve the prior hydration behavior, matching the venue fetched-at backfill.
+UPDATE snapshots
+SET payload = json_set(
+    payload,
+    '$.Live.inflight_equity_fetched_at',
+    COALESCE(
+        json_extract(payload, '$.Live.inflight_equity_fetched_at'),
+        json_extract(payload, '$.Live.last_updated'),
+        timestamp
+    )
+)
+WHERE aggregate_type = 'InventorySnapshot'
+  AND json_type(payload, '$.Live') IS NOT NULL;

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -130,7 +130,7 @@ where
         owner: order_owner,
     };
 
-    let polling_service = Arc::new(InventoryPollingService::new(
+    let mut polling_service = InventoryPollingService::new(
         raindex_service,
         context.executor.clone(),
         context.frameworks.vault_registry.clone(),
@@ -139,7 +139,14 @@ where
         context.wallet_polling,
         context.tokenizer,
         reserved_cash,
-    ));
+    );
+
+    if let Some(rebalancing_service) = &rebalancing_service {
+        polling_service =
+            polling_service.with_pending_request_ownership(rebalancing_service.clone());
+    }
+
+    let polling_service = Arc::new(polling_service);
 
     let inventory_monitor = InventoryMonitor {
         poller: polling_service,

--- a/src/inventory/mod.rs
+++ b/src/inventory/mod.rs
@@ -10,7 +10,10 @@ pub(crate) mod view;
 pub(crate) use broadcasting::BroadcastingInventory;
 #[cfg(test)]
 pub(crate) use polling::PollerError;
-pub(crate) use polling::{InventoryPollingService, Poller, WalletPollingCtx};
+pub(crate) use polling::{
+    InventoryPollingService, PendingRequestOwnership, PendingRequestOwnershipSnapshot, Poller,
+    WalletPollingCtx,
+};
 pub(crate) use projection::InventoryProjection;
 pub(crate) use snapshot::{InventorySnapshot, InventorySnapshotId};
 pub(crate) use venue_balance::InventoryError;

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -6,13 +6,14 @@
 //! the fetched values. The InventoryView reacts to these events to reconcile
 //! tracked inventory.
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, TxHash};
 use alloy::providers::RootProvider;
 use async_trait::async_trait;
+use chrono::Utc;
 use futures_util::future::try_join_all;
 use rain_math_float::FloatError;
-use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, Mutex, MutexGuard};
 use tracing::{debug, warn};
 
 use st0x_event_sorcery::{SendError, Store};
@@ -31,12 +32,27 @@ use crate::onchain::raindex::{RaindexError, RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
 use crate::tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};
+use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 
 /// Pending mints and redemptions aggregated by symbol.
 struct PendingRequests {
     mints: BTreeMap<Symbol, FractionalShares>,
     redemptions: BTreeMap<Symbol, FractionalShares>,
+}
+
+/// Active bot-owned tokenization provider request identifiers.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PendingRequestOwnershipSnapshot {
+    pub(crate) mint_issuers: HashSet<IssuerRequestId>,
+    pub(crate) mint_tokenizations: HashSet<TokenizationRequestId>,
+    pub(crate) redemption_tokenizations: HashSet<TokenizationRequestId>,
+    pub(crate) redemption_txs: HashSet<TxHash>,
+}
+
+#[async_trait]
+pub(crate) trait PendingRequestOwnership: Send + Sync {
+    async fn pending_request_ownership(&self) -> PendingRequestOwnershipSnapshot;
 }
 
 /// Error type for inventory polling operations.
@@ -104,6 +120,8 @@ where
     snapshot: Arc<Store<InventorySnapshot>>,
     wallet_polling: Option<WalletPollingCtx>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
+    pending_request_ownership: Option<Arc<dyn PendingRequestOwnership>>,
+    external_pending_warnings: Mutex<HashSet<TokenizationRequestId>>,
     reserved_cash: Usd,
 }
 
@@ -131,8 +149,18 @@ where
             snapshot,
             wallet_polling,
             tokenizer,
+            pending_request_ownership: None,
+            external_pending_warnings: Mutex::new(HashSet::new()),
             reserved_cash,
         }
+    }
+
+    pub(crate) fn with_pending_request_ownership(
+        mut self,
+        pending_request_ownership: Arc<dyn PendingRequestOwnership>,
+    ) -> Self {
+        self.pending_request_ownership = Some(pending_request_ownership);
+        self
     }
 
     /// Polls actual inventory from all venues and emits snapshot commands.
@@ -479,15 +507,26 @@ where
     ) -> Result<PendingRequests, FloatError> {
         let mut mints: BTreeMap<Symbol, FractionalShares> = BTreeMap::new();
         let mut redemptions: BTreeMap<Symbol, FractionalShares> = BTreeMap::new();
+        let mut seen = HashSet::new();
 
         for request in requests {
+            if !seen.insert(request.id.clone()) {
+                warn!(
+                    target: "inventory",
+                    request_id = %request.id,
+                    symbol = %request.underlying_symbol,
+                    "Duplicate pending tokenization request from provider, skipping"
+                );
+                continue;
+            }
+
             let target = match request.r#type {
                 Some(TokenizationRequestType::Mint) => &mut mints,
                 Some(TokenizationRequestType::Redeem) => &mut redemptions,
                 None => {
                     warn!(
                         target: "inventory",
-                        request_id = %request.id.0,
+                        request_id = %request.id,
                         symbol = %request.underlying_symbol,
                         "Pending tokenization request has no type, skipping"
                     );
@@ -505,20 +544,84 @@ where
         Ok(PendingRequests { mints, redemptions })
     }
 
-    fn is_own_request(&self, request: &crate::tokenization::TokenizationRequest) -> bool {
-        match request.wallet {
-            Some(wallet) if wallet != self.snapshot_id.owner => {
+    fn lock_external_pending_warnings(&self) -> MutexGuard<'_, HashSet<TokenizationRequestId>> {
+        self.external_pending_warnings
+            .lock()
+            .unwrap_or_else(|poisoned| {
                 warn!(
                     target: "inventory",
-                    request_id = %request.id.0,
-                    ?wallet,
-                    expected = ?self.snapshot_id.owner,
-                    "Skipping pending request from different wallet"
+                    "External pending warning tracker was poisoned; recovering state"
                 );
-                false
+                poisoned.into_inner()
+            })
+    }
+
+    fn is_own_request(
+        &self,
+        request: &crate::tokenization::TokenizationRequest,
+        ownership: &PendingRequestOwnershipSnapshot,
+    ) -> bool {
+        let is_owned = match request.r#type {
+            Some(TokenizationRequestType::Mint) => {
+                request
+                    .issuer_request_id
+                    .as_ref()
+                    .is_some_and(|id| ownership.mint_issuers.contains(id))
+                    || ownership.mint_tokenizations.contains(&request.id)
             }
-            _ => true,
+            Some(TokenizationRequestType::Redeem) => {
+                ownership.redemption_tokenizations.contains(&request.id)
+                    || request
+                        .tx_hash
+                        .is_some_and(|tx_hash| ownership.redemption_txs.contains(&tx_hash))
+            }
+            None => {
+                // Dedup through the same warn-once set as external requests so a
+                // persistently typeless provider row does not warn on every poll.
+                if self
+                    .lock_external_pending_warnings()
+                    .insert(request.id.clone())
+                {
+                    warn!(
+                        target: "inventory",
+                        request_id = %request.id,
+                        symbol = %request.underlying_symbol,
+                        "Pending tokenization request has no type, skipping"
+                    );
+                }
+
+                return false;
+            }
+        };
+
+        if is_owned {
+            return true;
         }
+
+        if request
+            .wallet
+            .is_none_or(|wallet| wallet == self.snapshot_id.owner)
+        {
+            let should_warn = self
+                .lock_external_pending_warnings()
+                .insert(request.id.clone());
+
+            if should_warn {
+                warn!(
+                    target: "inventory",
+                    request_id = %request.id,
+                    issuer_request_id = ?request.issuer_request_id,
+                    request_type = ?request.r#type,
+                    symbol = %request.underlying_symbol,
+                    quantity = %request.quantity,
+                    wallet = ?request.wallet,
+                    expected_wallet = ?self.snapshot_id.owner,
+                    "Ignoring external pending tokenization request"
+                );
+            }
+        }
+
+        false
     }
 
     async fn poll_inflight_equity(
@@ -530,12 +633,31 @@ where
             return Ok(());
         };
 
+        let fetched_at = Utc::now();
         let pending = tokenizer.list_pending_requests().await?;
+        let ownership = if let Some(pending_request_ownership) = &self.pending_request_ownership {
+            pending_request_ownership.pending_request_ownership().await
+        } else {
+            warn!(
+                target: "inventory",
+                "No pending request ownership source configured; treating provider pending requests as external"
+            );
+            PendingRequestOwnershipSnapshot::default()
+        };
+
+        let current_request_ids: HashSet<TokenizationRequestId> =
+            pending.iter().map(|request| request.id.clone()).collect();
+
         let PendingRequests { mints, redemptions } = Self::aggregate_pending_requests(
             pending
                 .into_iter()
-                .filter(|request| self.is_own_request(request)),
+                .filter(|request| self.is_own_request(request, &ownership)),
         )?;
+
+        // Bound the warn-once dedup set to requests still present this poll so it
+        // cannot grow without bound as external requests appear and complete.
+        self.lock_external_pending_warnings()
+            .retain(|id| current_request_ids.contains(id));
 
         debug!(
             target: "inventory",
@@ -547,7 +669,11 @@ where
         self.snapshot
             .send(
                 snapshot_id,
-                InventorySnapshotCommand::InflightEquity { mints, redemptions },
+                InventorySnapshotCommand::InflightEquity {
+                    mints,
+                    redemptions,
+                    fetched_at,
+                },
             )
             .await?;
 
@@ -629,8 +755,42 @@ mod tests {
     use super::*;
     use crate::inventory::snapshot::InventorySnapshotEvent;
     use crate::test_utils::setup_test_db;
-    use crate::tokenized_equity_mint::TokenizationRequestId;
     use crate::vault_registry::{VaultRegistry, VaultRegistryCommand};
+
+    #[derive(Clone, Default)]
+    struct TestPendingRequestOwnership(PendingRequestOwnershipSnapshot);
+
+    #[async_trait]
+    impl PendingRequestOwnership for TestPendingRequestOwnership {
+        async fn pending_request_ownership(&self) -> PendingRequestOwnershipSnapshot {
+            self.0.clone()
+        }
+    }
+
+    fn ownership(
+        mint_issuer_request_ids: impl IntoIterator<Item = &'static str>,
+        mint_tokenization_request_ids: impl IntoIterator<Item = &'static str>,
+        redemption_tokenization_request_ids: impl IntoIterator<Item = &'static str>,
+        redemption_txs: impl IntoIterator<Item = TxHash>,
+    ) -> Arc<dyn PendingRequestOwnership> {
+        Arc::new(TestPendingRequestOwnership(
+            PendingRequestOwnershipSnapshot {
+                mint_issuers: mint_issuer_request_ids
+                    .into_iter()
+                    .map(IssuerRequestId::new)
+                    .collect(),
+                mint_tokenizations: mint_tokenization_request_ids
+                    .into_iter()
+                    .map(|id| TokenizationRequestId(id.to_string()))
+                    .collect(),
+                redemption_tokenizations: redemption_tokenization_request_ids
+                    .into_iter()
+                    .map(|id| TokenizationRequestId(id.to_string()))
+                    .collect(),
+                redemption_txs: redemption_txs.into_iter().collect(),
+            },
+        ))
+    }
 
     struct MockEthereumWallet {
         address: Address,
@@ -2474,6 +2634,32 @@ mod tests {
         }
     }
 
+    fn mock_pending_request_with_issuer_id(
+        request_type: crate::tokenization::TokenizationRequestType,
+        symbol: &str,
+        quantity: i64,
+        issuer_request_id: &str,
+        wallet: Option<Address>,
+    ) -> crate::tokenization::TokenizationRequest {
+        crate::tokenization::TokenizationRequest {
+            issuer_request_id: Some(IssuerRequestId::new(issuer_request_id)),
+            ..mock_pending_request_with_wallet(request_type, symbol, quantity, wallet)
+        }
+    }
+
+    fn mock_pending_request_with_tx_hash(
+        request_type: crate::tokenization::TokenizationRequestType,
+        symbol: &str,
+        quantity: i64,
+        tx_hash: TxHash,
+        wallet: Option<Address>,
+    ) -> crate::tokenization::TokenizationRequest {
+        crate::tokenization::TokenizationRequest {
+            tx_hash: Some(tx_hash),
+            ..mock_pending_request_with_wallet(request_type, symbol, quantity, wallet)
+        }
+    }
+
     #[tokio::test]
     async fn poll_inflight_equity_emits_mints_and_redemptions() {
         let pool = setup_test_db().await;
@@ -2510,7 +2696,8 @@ mod tests {
             None,
             Some(tokenizer),
             Usd::ZERO,
-        );
+        )
+        .with_pending_request_ownership(ownership([], ["REQ_AAPL_10"], ["REQ_MSFT_5"], []));
 
         service.poll_and_record().await.unwrap();
 
@@ -2569,7 +2756,13 @@ mod tests {
             None,
             Some(tokenizer),
             Usd::ZERO,
-        );
+        )
+        .with_pending_request_ownership(ownership(
+            [],
+            ["REQ_AAPL_10", "REQ_AAPL_25"],
+            [],
+            [],
+        ));
 
         service.poll_and_record().await.unwrap();
 
@@ -2669,7 +2862,66 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_inflight_equity_filters_by_wallet() {
+    async fn poll_inflight_equity_treats_requests_as_external_without_ownership_source() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    10,
+                    Some(order_owner),
+                ),
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Redeem,
+                    "TSLA",
+                    5,
+                    Some(order_owner),
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            Some(tokenizer),
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity {
+            mints, redemptions, ..
+        } = inflight_event
+        else {
+            panic!("Expected InflightEquity event");
+        };
+
+        assert!(mints.is_empty(), "No pending mints expected");
+        assert!(redemptions.is_empty(), "No pending redemptions expected");
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_ignores_external_requests_even_for_matching_wallet() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2713,7 +2965,8 @@ mod tests {
             None,
             Some(tokenizer),
             Usd::ZERO,
-        );
+        )
+        .with_pending_request_ownership(ownership([], [], [], []));
 
         service.poll_and_record().await.unwrap();
 
@@ -2730,15 +2983,137 @@ mod tests {
             panic!("Expected InflightEquity event");
         };
 
-        assert_eq!(mints.len(), 1, "Only matching wallet should be included");
-        assert_eq!(mints.get(&test_symbol("AAPL")), Some(&test_shares(10)));
-
-        assert_eq!(
-            redemptions.len(),
-            1,
-            "No-wallet requests should be included"
+        assert!(
+            mints.is_empty(),
+            "Matching wallet must not imply bot ownership"
         );
-        assert_eq!(redemptions.get(&test_symbol("TSLA")), Some(&test_shares(5)));
+        assert!(
+            redemptions.is_empty(),
+            "Absent wallet must not imply bot ownership"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_includes_owned_mint_by_issuer_request_id() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                mock_pending_request_with_issuer_id(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    10,
+                    "owned-issuer-request",
+                    Some(order_owner),
+                ),
+                mock_pending_request_with_wallet(
+                    crate::tokenization::TokenizationRequestType::Mint,
+                    "AAPL",
+                    20,
+                    Some(order_owner),
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            Some(tokenizer),
+            Usd::ZERO,
+        )
+        .with_pending_request_ownership(ownership(["owned-issuer-request"], [], [], []));
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity { mints, .. } = inflight_event else {
+            panic!("Expected InflightEquity event");
+        };
+
+        assert_eq!(mints.len(), 1);
+        assert_eq!(mints.get(&test_symbol("AAPL")), Some(&test_shares(10)));
+    }
+
+    #[tokio::test]
+    async fn poll_inflight_equity_includes_pending_redemption_intent_before_detection() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+        let redemption_tx = TxHash::random();
+        let external_tx = TxHash::random();
+
+        let tokenizer = Arc::new(
+            crate::tokenization::mock::MockTokenizer::new().with_pending_requests(vec![
+                mock_pending_request_with_tx_hash(
+                    crate::tokenization::TokenizationRequestType::Redeem,
+                    "AAPL",
+                    5,
+                    redemption_tx,
+                    Some(order_owner),
+                ),
+                // Distinct quantity so the external row gets a distinct provider
+                // id (REQ_AAPL_7); otherwise dedup-by-id would mask a leaked
+                // external request and the assertion could pass even on regression.
+                mock_pending_request_with_tx_hash(
+                    crate::tokenization::TokenizationRequestType::Redeem,
+                    "AAPL",
+                    7,
+                    external_tx,
+                    Some(order_owner),
+                ),
+            ]),
+        );
+
+        let executor = MockExecutor::new();
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            Some(tokenizer),
+            Usd::ZERO,
+        )
+        .with_pending_request_ownership(ownership([], [], [], [redemption_tx]));
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let inflight_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("Expected InflightEquity event");
+
+        let InventorySnapshotEvent::InflightEquity { redemptions, .. } = inflight_event else {
+            panic!("Expected InflightEquity event");
+        };
+
+        // Only the owned redemption (5 shares) is counted; the external 7-share
+        // request must be excluded. If it leaked through, AAPL would total 12.
+        assert_eq!(redemptions.get(&test_symbol("AAPL")), Some(&test_shares(5)));
     }
 
     #[test]
@@ -2784,5 +3159,36 @@ mod tests {
 
         assert_eq!(mints.len(), 1);
         assert_eq!(redemptions.len(), 1);
+    }
+
+    #[test]
+    fn aggregate_pending_requests_deduplicates_provider_request_ids() {
+        let requests = vec![
+            mock_pending_request(
+                crate::tokenization::TokenizationRequestType::Mint,
+                "AAPL",
+                10,
+            ),
+            mock_pending_request(
+                crate::tokenization::TokenizationRequestType::Mint,
+                "AAPL",
+                10,
+            ),
+        ];
+
+        let PendingRequests { mints, redemptions } = InventoryPollingService::<
+            ReadOnlyEvm<RootProvider>,
+            MockExecutor,
+        >::aggregate_pending_requests(
+            requests.into_iter()
+        )
+        .unwrap();
+
+        assert_eq!(
+            mints.get(&test_symbol("AAPL")),
+            Some(&test_shares(10)),
+            "Duplicate provider rows should only count once"
+        );
+        assert!(redemptions.is_empty());
     }
 }

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -106,6 +106,9 @@ pub(crate) struct InventorySnapshot {
     pub(crate) inflight_mints: BTreeMap<Symbol, FractionalShares>,
     /// Equity currently in-flight via redemptions (tokens sent to Alpaca)
     pub(crate) inflight_redemptions: BTreeMap<Symbol, FractionalShares>,
+    /// Time the current inflight equity provider snapshot was fetched.
+    #[serde(default)]
+    pub(crate) inflight_equity_fetched_at: Option<DateTime<Utc>>,
     /// When this snapshot was last updated
     pub(crate) last_updated: DateTime<Utc>,
 }
@@ -142,6 +145,7 @@ impl EventSourced for InventorySnapshot {
             base_wallet_usdc: None,
             inflight_mints: BTreeMap::new(),
             inflight_redemptions: BTreeMap::new(),
+            inflight_equity_fetched_at: None,
             base_wallet_unwrapped_equity: BTreeMap::new(),
             base_wallet_wrapped_equity: BTreeMap::new(),
             last_updated: event.timestamp(),
@@ -203,10 +207,14 @@ impl EventSourced for InventorySnapshot {
                 usdc_balance,
                 fetched_at: now,
             },
-            InflightEquity { mints, redemptions } => InventorySnapshotEvent::InflightEquity {
+            InflightEquity {
                 mints,
                 redemptions,
-                fetched_at: now,
+                fetched_at,
+            } => InventorySnapshotEvent::InflightEquity {
+                mints,
+                redemptions,
+                fetched_at,
             },
             BaseWalletUnwrappedEquity { balances } => {
                 InventorySnapshotEvent::BaseWalletUnwrappedEquity {
@@ -314,14 +322,31 @@ impl EventSourced for InventorySnapshot {
                     fetched_at: now,
                 }])
             }
-            InflightEquity { mints, redemptions } => {
-                if self.inflight_mints == mints && self.inflight_redemptions == redemptions {
+            InflightEquity {
+                mints,
+                redemptions,
+                fetched_at,
+            } => {
+                // Suppress when the inflight maps are unchanged and either there
+                // is nothing inflight (empty maps carry no signal worth a per-poll
+                // event) or the new fetch is not newer than the stored one. When
+                // something IS inflight, a strictly newer `fetched_at` still emits
+                // even with identical maps so observers know the provider was
+                // re-polled and the in-transit balance is still confirmed.
+                let maps_unchanged =
+                    self.inflight_mints == mints && self.inflight_redemptions == redemptions;
+                let nothing_inflight = mints.is_empty() && redemptions.is_empty();
+                let fetch_not_newer = self
+                    .inflight_equity_fetched_at
+                    .is_some_and(|current| fetched_at <= current);
+
+                if maps_unchanged && (nothing_inflight || fetch_not_newer) {
                     return Ok(vec![]);
                 }
                 Ok(vec![InventorySnapshotEvent::InflightEquity {
                     mints,
                     redemptions,
-                    fetched_at: now,
+                    fetched_at,
                 }])
             }
             BaseWalletUnwrappedEquity { balances } => {
@@ -436,7 +461,9 @@ impl InventorySnapshot {
             });
         }
 
-        if !self.inflight_mints.is_empty() || !self.inflight_redemptions.is_empty() {
+        if let Some(fetched_at) = self.inflight_equity_fetched_at
+            && (!self.inflight_mints.is_empty() || !self.inflight_redemptions.is_empty())
+        {
             events.push(InventorySnapshotEvent::InflightEquity {
                 mints: self.inflight_mints.clone(),
                 redemptions: self.inflight_redemptions.clone(),
@@ -519,10 +546,13 @@ impl InventorySnapshot {
                 self.base_wallet_usdc = Some(*usdc_balance);
             }
             InventorySnapshotEvent::InflightEquity {
-                mints, redemptions, ..
+                mints,
+                redemptions,
+                fetched_at,
             } => {
                 self.inflight_mints = mints.clone();
                 self.inflight_redemptions = redemptions.clone();
+                self.inflight_equity_fetched_at = Some(*fetched_at);
             }
             InventorySnapshotEvent::BaseWalletUnwrappedEquity { balances, .. } => {
                 self.base_wallet_unwrapped_equity = balances.clone();
@@ -576,6 +606,8 @@ pub(crate) enum InventorySnapshotCommand {
         mints: BTreeMap<Symbol, FractionalShares>,
         /// Pending redemptions by symbol (tokens sent to Alpaca).
         redemptions: BTreeMap<Symbol, FractionalShares>,
+        /// Time the provider pending-request response was observed.
+        fetched_at: DateTime<Utc>,
     },
 }
 
@@ -1409,6 +1441,7 @@ mod tests {
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: mints.clone(),
                 redemptions: redemptions.clone(),
+                fetched_at: Utc::now(),
             })
             .await
             .events();
@@ -1445,6 +1478,7 @@ mod tests {
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: mints.clone(),
                 redemptions: updated_redemptions.clone(),
+                fetched_at: Utc::now(),
             })
             .await
             .events();
@@ -1464,16 +1498,18 @@ mod tests {
     async fn inflight_equity_skips_when_unchanged() {
         let mut mints = BTreeMap::new();
         mints.insert(test_symbol("AAPL"), test_shares(10));
+        let fetched_at = Utc::now();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given(vec![InventorySnapshotEvent::InflightEquity {
                 mints: mints.clone(),
                 redemptions: BTreeMap::new(),
-                fetched_at: Utc::now(),
+                fetched_at,
             }])
             .when(InventorySnapshotCommand::InflightEquity {
                 mints,
                 redemptions: BTreeMap::new(),
+                fetched_at,
             })
             .await
             .events();
@@ -1482,6 +1518,124 @@ mod tests {
             events.is_empty(),
             "Should not emit event when inflight unchanged"
         );
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_emits_when_only_fetched_at_advances() {
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+        let first_fetched_at = Utc::now();
+        let second_fetched_at = first_fetched_at + chrono::Duration::seconds(30);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: mints.clone(),
+                redemptions: BTreeMap::new(),
+                fetched_at: first_fetched_at,
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints,
+                redemptions: BTreeMap::new(),
+                fetched_at: second_fetched_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = &events[0] else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+        assert_eq!(*fetched_at, second_fetched_at);
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_skips_empty_unchanged_even_when_fetched_at_advances() {
+        let first_fetched_at = Utc::now();
+        let second_fetched_at = first_fetched_at + chrono::Duration::seconds(30);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: BTreeMap::new(),
+                redemptions: BTreeMap::new(),
+                fetched_at: first_fetched_at,
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: BTreeMap::new(),
+                redemptions: BTreeMap::new(),
+                fetched_at: second_fetched_at,
+            })
+            .await
+            .events();
+
+        assert!(
+            events.is_empty(),
+            "Empty unchanged inflight must not emit a per-poll event even on a newer fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_skips_stale_fetch_when_unchanged() {
+        let mut mints = BTreeMap::new();
+        mints.insert(test_symbol("AAPL"), test_shares(10));
+        let current_fetched_at = Utc::now();
+        let stale_fetched_at = current_fetched_at - chrono::Duration::seconds(30);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: mints.clone(),
+                redemptions: BTreeMap::new(),
+                fetched_at: current_fetched_at,
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints,
+                redemptions: BTreeMap::new(),
+                fetched_at: stale_fetched_at,
+            })
+            .await
+            .events();
+
+        assert!(
+            events.is_empty(),
+            "An out-of-order (older) fetch with unchanged inflight must not emit"
+        );
+    }
+
+    #[tokio::test]
+    async fn inflight_equity_emits_on_change_even_with_stale_fetch() {
+        let mut initial_mints = BTreeMap::new();
+        initial_mints.insert(test_symbol("AAPL"), test_shares(10));
+
+        let mut updated_mints = BTreeMap::new();
+        updated_mints.insert(test_symbol("AAPL"), test_shares(5));
+
+        let current_fetched_at = Utc::now();
+        let stale_fetched_at = current_fetched_at - chrono::Duration::seconds(30);
+
+        let events = TestHarness::<InventorySnapshot>::with(())
+            .given(vec![InventorySnapshotEvent::InflightEquity {
+                mints: initial_mints,
+                redemptions: BTreeMap::new(),
+                fetched_at: current_fetched_at,
+            }])
+            .when(InventorySnapshotCommand::InflightEquity {
+                mints: updated_mints.clone(),
+                redemptions: BTreeMap::new(),
+                fetched_at: stale_fetched_at,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let InventorySnapshotEvent::InflightEquity {
+            mints: event_mints,
+            fetched_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected InflightEquity event, got {:?}", events[0]);
+        };
+        assert_eq!(event_mints, &updated_mints);
+        assert_eq!(*fetched_at, stale_fetched_at);
     }
 
     #[tokio::test]
@@ -1501,6 +1655,7 @@ mod tests {
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: updated_mints.clone(),
                 redemptions: BTreeMap::new(),
+                fetched_at: Utc::now(),
             })
             .await
             .events();
@@ -1537,44 +1692,36 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_inflight_equity_preserves_fetched_at() {
-        // The aggregate's initialize() generates fetched_at from Utc::now().
-        // This test pins that the emitted event carries a fetched_at close to
-        // the wall-clock time at command submission -- proving the aggregate
-        // threads a real timestamp rather than e.g. a stale default.
-        let before = Utc::now();
+        let fetched_at = Utc::now();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given_no_previous_events()
             .when(InventorySnapshotCommand::InflightEquity {
                 mints: BTreeMap::new(),
                 redemptions: BTreeMap::new(),
+                fetched_at,
             })
             .await
             .events();
 
-        let after = Utc::now();
-
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = &events[0] else {
+        let InventorySnapshotEvent::InflightEquity {
+            fetched_at: event_fetched_at,
+            ..
+        } = &events[0]
+        else {
             panic!("Expected InflightEquity event, got {:?}", events[0]);
         };
 
-        assert!(
-            *fetched_at >= before && *fetched_at <= after,
-            "fetched_at ({fetched_at:?}) should be between \
-             before ({before:?}) and after ({after:?})"
-        );
+        assert_eq!(*event_fetched_at, fetched_at);
     }
 
     #[tokio::test]
     async fn transition_inflight_equity_preserves_fetched_at() {
-        // Same as above but for the transition path (existing aggregate).
-        // The aggregate deduplicates unchanged inflight, so we must provide
-        // data different from the prior state to get an emitted event.
         let mut mints = BTreeMap::new();
         mints.insert(test_symbol("AAPL"), test_shares(10));
 
-        let before = Utc::now();
+        let fetched_at = Utc::now();
 
         let events = TestHarness::<InventorySnapshot>::with(())
             .given(vec![InventorySnapshotEvent::OnchainUsdc {
@@ -1584,22 +1731,21 @@ mod tests {
             .when(InventorySnapshotCommand::InflightEquity {
                 mints,
                 redemptions: BTreeMap::new(),
+                fetched_at,
             })
             .await
             .events();
 
-        let after = Utc::now();
-
         assert_eq!(events.len(), 1);
-        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = &events[0] else {
+        let InventorySnapshotEvent::InflightEquity {
+            fetched_at: event_fetched_at,
+            ..
+        } = &events[0]
+        else {
             panic!("Expected InflightEquity event, got {:?}", events[0]);
         };
 
-        assert!(
-            *fetched_at >= before && *fetched_at <= after,
-            "transition fetched_at ({fetched_at:?}) should be between \
-             before ({before:?}) and after ({after:?})"
-        );
+        assert_eq!(*event_fetched_at, fetched_at);
     }
 
     #[test]
@@ -1652,6 +1798,7 @@ mod tests {
             base_wallet_wrapped_equity: BTreeMap::new(),
             inflight_mints: BTreeMap::new(),
             inflight_redemptions: BTreeMap::new(),
+            inflight_equity_fetched_at: None,
             last_updated: Utc::now(),
         };
 
@@ -1684,6 +1831,7 @@ mod tests {
             base_wallet_wrapped_equity: BTreeMap::new(),
             inflight_mints: inflight_mints.clone(),
             inflight_redemptions: BTreeMap::new(),
+            inflight_equity_fetched_at: Some(now),
             last_updated: now,
         };
 
@@ -1704,5 +1852,36 @@ mod tests {
             original.offchain_cash_buying_power_cents
         );
         assert_eq!(reconstructed.inflight_mints, original.inflight_mints);
+    }
+
+    #[test]
+    fn hydration_events_preserve_inflight_provider_fetch_time() {
+        let inflight_fetched_at = Utc::now();
+        let later_balance_fetched_at = inflight_fetched_at + chrono::Duration::seconds(30);
+
+        let mut snapshot =
+            replay::<InventorySnapshot>(vec![InventorySnapshotEvent::InflightEquity {
+                mints: BTreeMap::from([(test_symbol("AAPL"), test_shares(10))]),
+                redemptions: BTreeMap::new(),
+                fetched_at: inflight_fetched_at,
+            }])
+            .unwrap()
+            .unwrap();
+        snapshot.apply_event(&InventorySnapshotEvent::OnchainUsdc {
+            usdc_balance: Usdc::from_str("1000").unwrap(),
+            fetched_at: later_balance_fetched_at,
+        });
+
+        let inflight_event = snapshot
+            .hydration_events()
+            .into_iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::InflightEquity { .. }))
+            .expect("expected inflight hydration event");
+
+        let InventorySnapshotEvent::InflightEquity { fetched_at, .. } = inflight_event else {
+            panic!("Expected InflightEquity event");
+        };
+
+        assert_eq!(fetched_at, inflight_fetched_at);
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -25,7 +25,7 @@ impl RebalancingSchedulers {
     }
 }
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -50,7 +50,7 @@ use crate::inventory::projection::InventoryProjectionError;
 use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
 use crate::inventory::{
     BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, InventoryViewError,
-    Operator, TransferOp, Venue,
+    Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
 };
 use crate::position::{Position, PositionEvent};
 use crate::tokenized_equity_mint::{
@@ -325,6 +325,7 @@ impl std::fmt::Display for MintTrackingStage {
 struct MintTracking {
     symbol: Symbol,
     quantity: FractionalShares,
+    tokenization_request_id: Option<crate::tokenized_equity_mint::TokenizationRequestId>,
     stage: MintTrackingStage,
     last_progress_at: DateTime<Utc>,
 }
@@ -344,12 +345,17 @@ impl MintTracking {
         Some(Self {
             symbol: symbol.clone(),
             quantity: FractionalShares::new(*quantity),
+            tokenization_request_id: None,
             stage: MintTrackingStage::Requested,
             last_progress_at: *requested_at,
         })
     }
 
     fn track_progress(&mut self, event: &TokenizedEquityMintEvent) {
+        if let Some(tokenization_request_id) = mint_event_tokenization_request_id(event) {
+            self.tokenization_request_id = Some(tokenization_request_id.clone());
+        }
+
         match event {
             TokenizedEquityMintEvent::MintAccepted { accepted_at, .. } => {
                 self.stage = MintTrackingStage::Accepted;
@@ -414,6 +420,8 @@ impl std::fmt::Display for RedemptionTrackingStage {
 struct RedemptionTracking {
     symbol: Symbol,
     quantity: FractionalShares,
+    tokenization_request_id: Option<crate::tokenized_equity_mint::TokenizationRequestId>,
+    redemption_tx: Option<TxHash>,
     stage: RedemptionTrackingStage,
     last_progress_at: DateTime<Utc>,
 }
@@ -429,6 +437,8 @@ impl RedemptionTracking {
             } => Some(Self {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
+                tokenization_request_id: None,
+                redemption_tx: None,
                 stage: RedemptionTrackingStage::VaultWithdrawPending,
                 last_progress_at: *pending_at,
             }),
@@ -440,6 +450,8 @@ impl RedemptionTracking {
             } => Some(Self {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
+                tokenization_request_id: None,
+                redemption_tx: None,
                 stage: RedemptionTrackingStage::VaultWithdrawSubmitted,
                 last_progress_at: *submitted_at,
             }),
@@ -451,6 +463,8 @@ impl RedemptionTracking {
             } => Some(Self {
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
+                tokenization_request_id: None,
+                redemption_tx: None,
                 stage: RedemptionTrackingStage::WithdrawnFromRaindex,
                 last_progress_at: *withdrawn_at,
             }),
@@ -496,11 +510,20 @@ impl RedemptionTracking {
                 self.stage = RedemptionTrackingStage::SendPending;
                 self.last_progress_at = *pending_at;
             }
-            EquityRedemptionEvent::TokensSent { sent_at, .. } => {
+            EquityRedemptionEvent::TokensSent {
+                redemption_tx,
+                sent_at,
+                ..
+            } => {
+                self.redemption_tx = Some(*redemption_tx);
                 self.stage = RedemptionTrackingStage::TokensSent;
                 self.last_progress_at = *sent_at;
             }
-            EquityRedemptionEvent::Detected { detected_at, .. } => {
+            EquityRedemptionEvent::Detected {
+                tokenization_request_id,
+                detected_at,
+            } => {
+                self.tokenization_request_id = Some(tokenization_request_id.clone());
                 self.stage = RedemptionTrackingStage::Detected;
                 self.last_progress_at = *detected_at;
             }
@@ -512,6 +535,27 @@ impl RedemptionTracking {
         }
 
         Ok(())
+    }
+}
+
+fn mint_event_tokenization_request_id(
+    event: &TokenizedEquityMintEvent,
+) -> Option<&crate::tokenized_equity_mint::TokenizationRequestId> {
+    match event {
+        TokenizedEquityMintEvent::MintAccepted {
+            tokenization_request_id,
+            ..
+        } => Some(tokenization_request_id),
+        TokenizedEquityMintEvent::MintRequested { .. }
+        | TokenizedEquityMintEvent::MintRejected { .. }
+        | TokenizedEquityMintEvent::MintAcceptanceFailed { .. }
+        | TokenizedEquityMintEvent::TokensReceived { .. }
+        | TokenizedEquityMintEvent::WrapSubmitted { .. }
+        | TokenizedEquityMintEvent::TokensWrapped { .. }
+        | TokenizedEquityMintEvent::WrappingFailed { .. }
+        | TokenizedEquityMintEvent::VaultDepositSubmitted { .. }
+        | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
+        | TokenizedEquityMintEvent::RaindexDepositFailed { .. } => None,
     }
 }
 
@@ -1419,6 +1463,30 @@ impl Reactor for RebalancingService {
     }
 }
 
+#[async_trait]
+impl PendingRequestOwnership for RebalancingService {
+    async fn pending_request_ownership(&self) -> PendingRequestOwnershipSnapshot {
+        let mint_tracking = self.mint_tracking.read().await;
+        let redemption_tracking = self.redemption_tracking.read().await;
+
+        PendingRequestOwnershipSnapshot {
+            mint_issuers: mint_tracking.keys().cloned().collect(),
+            mint_tokenizations: mint_tracking
+                .values()
+                .filter_map(|tracking| tracking.tokenization_request_id.clone())
+                .collect(),
+            redemption_tokenizations: redemption_tracking
+                .values()
+                .filter_map(|tracking| tracking.tokenization_request_id.clone())
+                .collect(),
+            redemption_txs: redemption_tracking
+                .values()
+                .filter_map(|tracking| tracking.redemption_tx)
+                .collect(),
+        }
+    }
+}
+
 impl RebalancingService {
     async fn expire_stuck_operations_with_logging(&self) {
         if let Err(error) = self.expire_stuck_operations(Utc::now()).await {
@@ -1830,23 +1898,55 @@ impl RebalancingService {
             } => {
                 let quantity = FractionalShares::new(*quantity);
 
-                let (stage, last_progress_at) = match entity {
+                let (stage, last_progress_at, tokenization_request_id) = match entity {
                     MintRequested { requested_at, .. } => {
-                        (MintTrackingStage::Requested, *requested_at)
+                        (MintTrackingStage::Requested, *requested_at, None)
                     }
-                    MintAccepted { accepted_at, .. } => (MintTrackingStage::Accepted, *accepted_at),
-                    TokensReceived { received_at, .. } => {
-                        (MintTrackingStage::TokensReceived, *received_at)
-                    }
-                    WrapSubmitted { received_at, .. } => {
-                        (MintTrackingStage::WrapSubmitted, *received_at)
-                    }
-                    TokensWrapped { wrapped_at, .. } => {
-                        (MintTrackingStage::TokensWrapped, *wrapped_at)
-                    }
-                    VaultDepositSubmitted { wrapped_at, .. } => {
-                        (MintTrackingStage::VaultDepositSubmitted, *wrapped_at)
-                    }
+                    MintAccepted {
+                        accepted_at,
+                        tokenization_request_id,
+                        ..
+                    } => (
+                        MintTrackingStage::Accepted,
+                        *accepted_at,
+                        Some(tokenization_request_id.clone()),
+                    ),
+                    TokensReceived {
+                        received_at,
+                        tokenization_request_id,
+                        ..
+                    } => (
+                        MintTrackingStage::TokensReceived,
+                        *received_at,
+                        Some(tokenization_request_id.clone()),
+                    ),
+                    WrapSubmitted {
+                        received_at,
+                        tokenization_request_id,
+                        ..
+                    } => (
+                        MintTrackingStage::WrapSubmitted,
+                        *received_at,
+                        Some(tokenization_request_id.clone()),
+                    ),
+                    TokensWrapped {
+                        wrapped_at,
+                        tokenization_request_id,
+                        ..
+                    } => (
+                        MintTrackingStage::TokensWrapped,
+                        *wrapped_at,
+                        Some(tokenization_request_id.clone()),
+                    ),
+                    VaultDepositSubmitted {
+                        wrapped_at,
+                        tokenization_request_id,
+                        ..
+                    } => (
+                        MintTrackingStage::VaultDepositSubmitted,
+                        *wrapped_at,
+                        Some(tokenization_request_id.clone()),
+                    ),
                     _ => unreachable!(),
                 };
 
@@ -1855,6 +1955,7 @@ impl RebalancingService {
                     MintTracking {
                         symbol: symbol.clone(),
                         quantity,
+                        tokenization_request_id,
                         stage,
                         last_progress_at,
                     },
@@ -1896,33 +1997,71 @@ impl RebalancingService {
             | TokensSent { symbol, .. }
             | Pending { symbol, .. } => {
                 let quantity = Self::recovered_redemption_quantity(entity)?;
-                let (stage, last_progress_at) = match entity {
-                    VaultWithdrawPending { pending_at, .. } => {
-                        (RedemptionTrackingStage::VaultWithdrawPending, *pending_at)
-                    }
+                let (stage, last_progress_at, tokenization_request_id, redemption_tx) = match entity
+                {
+                    VaultWithdrawPending { pending_at, .. } => (
+                        RedemptionTrackingStage::VaultWithdrawPending,
+                        *pending_at,
+                        None,
+                        None,
+                    ),
                     VaultWithdrawSubmitted { submitted_at, .. } => (
                         RedemptionTrackingStage::VaultWithdrawSubmitted,
                         *submitted_at,
+                        None,
+                        None,
                     ),
-                    WithdrawnFromRaindex { withdrawn_at, .. } => {
-                        (RedemptionTrackingStage::WithdrawnFromRaindex, *withdrawn_at)
-                    }
-                    UnwrapPending { withdrawn_at, .. } => {
-                        (RedemptionTrackingStage::UnwrapPending, *withdrawn_at)
-                    }
-                    UnwrapSubmitted { withdrawn_at, .. } => {
-                        (RedemptionTrackingStage::UnwrapSubmitted, *withdrawn_at)
-                    }
-                    TokensUnwrapped { unwrapped_at, .. } => {
-                        (RedemptionTrackingStage::TokensUnwrapped, *unwrapped_at)
-                    }
-                    SendPending { unwrapped_at, .. } => {
-                        (RedemptionTrackingStage::SendPending, *unwrapped_at)
-                    }
-                    TokensSent { sent_at, .. } => (RedemptionTrackingStage::TokensSent, *sent_at),
-                    Pending { detected_at, .. } => {
-                        (RedemptionTrackingStage::Detected, *detected_at)
-                    }
+                    WithdrawnFromRaindex { withdrawn_at, .. } => (
+                        RedemptionTrackingStage::WithdrawnFromRaindex,
+                        *withdrawn_at,
+                        None,
+                        None,
+                    ),
+                    UnwrapPending { withdrawn_at, .. } => (
+                        RedemptionTrackingStage::UnwrapPending,
+                        *withdrawn_at,
+                        None,
+                        None,
+                    ),
+                    UnwrapSubmitted { withdrawn_at, .. } => (
+                        RedemptionTrackingStage::UnwrapSubmitted,
+                        *withdrawn_at,
+                        None,
+                        None,
+                    ),
+                    TokensUnwrapped { unwrapped_at, .. } => (
+                        RedemptionTrackingStage::TokensUnwrapped,
+                        *unwrapped_at,
+                        None,
+                        None,
+                    ),
+                    SendPending { unwrapped_at, .. } => (
+                        RedemptionTrackingStage::SendPending,
+                        *unwrapped_at,
+                        None,
+                        None,
+                    ),
+                    TokensSent {
+                        sent_at,
+                        redemption_tx,
+                        ..
+                    } => (
+                        RedemptionTrackingStage::TokensSent,
+                        *sent_at,
+                        None,
+                        Some(*redemption_tx),
+                    ),
+                    Pending {
+                        detected_at,
+                        tokenization_request_id,
+                        redemption_tx,
+                        ..
+                    } => (
+                        RedemptionTrackingStage::Detected,
+                        *detected_at,
+                        Some(tokenization_request_id.clone()),
+                        Some(*redemption_tx),
+                    ),
                     _ => unreachable!(),
                 };
 
@@ -1931,6 +2070,8 @@ impl RebalancingService {
                     RedemptionTracking {
                         symbol: symbol.clone(),
                         quantity,
+                        tokenization_request_id,
+                        redemption_tx,
                         stage,
                         last_progress_at,
                     },
@@ -2326,8 +2467,20 @@ mod tests {
             .unwrap();
         assert_eq!(tracking.symbol, symbol);
         assert_eq!(tracking.quantity, FractionalShares::new(float!(10)));
+        assert_eq!(
+            tracking.tokenization_request_id,
+            Some(TokenizationRequestId("TOK-1".to_string()))
+        );
         assert_eq!(tracking.stage, MintTrackingStage::Accepted);
         assert_eq!(tracking.last_progress_at, accepted_at);
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(ownership.mint_issuers.contains(&mint_id));
+        assert!(
+            ownership
+                .mint_tokenizations
+                .contains(&TokenizationRequestId("TOK-1".to_string()))
+        );
 
         let inflight = {
             let inventory = trigger.inventory.read().await;
@@ -2342,6 +2495,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let redemption_id = RedemptionAggregateId::new("redemption-recovery");
         let detected_at = Utc::now();
+        let redemption_tx = TxHash::random();
 
         trigger
             .recover_redemption_state(
@@ -2349,7 +2503,7 @@ mod tests {
                 &EquityRedemption::Pending {
                     symbol: symbol.clone(),
                     quantity: float!(12),
-                    redemption_tx: TxHash::random(),
+                    redemption_tx,
                     tokenization_request_id: TokenizationRequestId("TOK-2".to_string()),
                     sent_at: Utc::now(),
                     detected_at,
@@ -2369,14 +2523,308 @@ mod tests {
             .unwrap();
         assert_eq!(tracking.symbol, symbol);
         assert_eq!(tracking.quantity, FractionalShares::new(float!(12)));
+        assert_eq!(
+            tracking.tokenization_request_id,
+            Some(TokenizationRequestId("TOK-2".to_string()))
+        );
         assert_eq!(tracking.stage, RedemptionTrackingStage::Detected);
         assert_eq!(tracking.last_progress_at, detected_at);
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(
+            ownership
+                .redemption_tokenizations
+                .contains(&TokenizationRequestId("TOK-2".to_string()))
+        );
+        assert!(ownership.redemption_txs.contains(&redemption_tx));
 
         let inflight = {
             let inventory = trigger.inventory.read().await;
             inventory.equity_inflight(&symbol, Venue::MarketMaking)
         };
         assert_eq!(inflight, Some(FractionalShares::new(float!(12))));
+    }
+
+    #[tokio::test]
+    async fn pending_request_ownership_exposes_active_mint_ids() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("owned-mint");
+        let tokenization_request_id = TokenizationRequestId("owned-tokenization".to_string());
+
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50));
+
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::MintRequested {
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                    requested_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::MintAccepted {
+                    issuer_request_id: mint_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    accepted_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+
+        assert!(ownership.mint_issuers.contains(&mint_id));
+        assert!(
+            ownership
+                .mint_tokenizations
+                .contains(&tokenization_request_id)
+        );
+
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::MintAcceptanceFailed {
+                    reason: "test terminal".to_string(),
+                    failed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(!ownership.mint_issuers.contains(&mint_id));
+        assert!(
+            !ownership
+                .mint_tokenizations
+                .contains(&tokenization_request_id)
+        );
+
+        let success_mint_id = IssuerRequestId::new("owned-success-mint");
+        let success_tokenization_request_id =
+            TokenizationRequestId("owned-success-tokenization".to_string());
+
+        trigger
+            .on_mint(
+                success_mint_id.clone(),
+                TokenizedEquityMintEvent::MintRequested {
+                    symbol: symbol.clone(),
+                    quantity: float!(2),
+                    wallet: Address::ZERO,
+                    requested_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        trigger
+            .on_mint(
+                success_mint_id.clone(),
+                TokenizedEquityMintEvent::MintAccepted {
+                    issuer_request_id: success_mint_id.clone(),
+                    tokenization_request_id: success_tokenization_request_id.clone(),
+                    accepted_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+        trigger
+            .on_mint(
+                success_mint_id.clone(),
+                TokenizedEquityMintEvent::DepositedIntoRaindex {
+                    vault_deposit_tx_hash: TxHash::random(),
+                    deposited_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(!ownership.mint_issuers.contains(&success_mint_id));
+        assert!(
+            !ownership
+                .mint_tokenizations
+                .contains(&success_tokenization_request_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_request_ownership_exposes_active_redemption_request_id() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("owned-redemption");
+        let tokenization_request_id = TokenizationRequestId("owned-redemption-request".to_string());
+        let redemption_tx = TxHash::random();
+
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50));
+
+        trigger
+            .on_redemption(
+                redemption_id.clone(),
+                EquityRedemptionEvent::VaultWithdrawPending {
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    token: Address::ZERO,
+                    wrapped_amount: U256::from(10),
+                    pending_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(ownership.redemption_txs.is_empty());
+
+        trigger
+            .on_redemption(
+                redemption_id.clone(),
+                EquityRedemptionEvent::TokensSent {
+                    redemption_wallet: Address::ZERO,
+                    redemption_tx,
+                    sent_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(ownership.redemption_txs.contains(&redemption_tx));
+
+        trigger
+            .on_redemption(
+                redemption_id.clone(),
+                EquityRedemptionEvent::Detected {
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    detected_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+
+        assert!(
+            ownership
+                .redemption_tokenizations
+                .contains(&tokenization_request_id)
+        );
+        assert!(ownership.redemption_txs.contains(&redemption_tx));
+
+        trigger
+            .on_redemption(
+                redemption_id,
+                EquityRedemptionEvent::Completed {
+                    completed_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(
+            !ownership
+                .redemption_tokenizations
+                .contains(&tokenization_request_id)
+        );
+        assert!(!ownership.redemption_txs.contains(&redemption_tx));
+    }
+
+    #[tokio::test]
+    async fn pending_request_ownership_drops_on_redemption_failure_terminals() {
+        let terminal_events = [
+            EquityRedemptionEvent::RedemptionRejected {
+                reason: "test rejection".to_string(),
+                rejected_at: Utc::now(),
+            },
+            EquityRedemptionEvent::TransferFailed {
+                tx_hash: Some(TxHash::random()),
+                reason: None,
+                failed_at: Utc::now(),
+            },
+            EquityRedemptionEvent::DetectionFailed {
+                failure: DetectionFailure::Timeout,
+                failed_at: Utc::now(),
+            },
+        ];
+
+        for terminal_event in terminal_events {
+            let (trigger, _receiver) = make_trigger().await;
+            let symbol = Symbol::new("AAPL").unwrap();
+            let redemption_id = RedemptionAggregateId::new("failing-redemption");
+            let tokenization_request_id =
+                TokenizationRequestId("failing-redemption-request".to_string());
+            let redemption_tx = TxHash::random();
+
+            *trigger.inventory.write().await =
+                InventoryView::default().with_equity(symbol.clone(), shares(50), shares(50));
+
+            trigger
+                .on_redemption(
+                    redemption_id.clone(),
+                    EquityRedemptionEvent::VaultWithdrawPending {
+                        symbol: symbol.clone(),
+                        quantity: float!(10),
+                        token: Address::ZERO,
+                        wrapped_amount: U256::from(10),
+                        pending_at: Utc::now(),
+                    },
+                )
+                .await
+                .unwrap();
+            trigger
+                .on_redemption(
+                    redemption_id.clone(),
+                    EquityRedemptionEvent::TokensSent {
+                        redemption_wallet: Address::ZERO,
+                        redemption_tx,
+                        sent_at: Utc::now(),
+                    },
+                )
+                .await
+                .unwrap();
+            trigger
+                .on_redemption(
+                    redemption_id.clone(),
+                    EquityRedemptionEvent::Detected {
+                        tokenization_request_id: tokenization_request_id.clone(),
+                        detected_at: Utc::now(),
+                    },
+                )
+                .await
+                .unwrap();
+
+            let ownership = trigger.pending_request_ownership().await;
+            assert!(ownership.redemption_txs.contains(&redemption_tx));
+            assert!(
+                ownership
+                    .redemption_tokenizations
+                    .contains(&tokenization_request_id)
+            );
+
+            trigger
+                .on_redemption(redemption_id, terminal_event.clone())
+                .await
+                .unwrap();
+
+            let ownership = trigger.pending_request_ownership().await;
+            assert!(
+                !ownership.redemption_txs.contains(&redemption_tx),
+                "redemption_tx must drop after terminal event {terminal_event:?}"
+            );
+            assert!(
+                !ownership
+                    .redemption_tokenizations
+                    .contains(&tokenization_request_id),
+                "redemption tokenization id must drop after terminal event {terminal_event:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -2416,6 +2864,9 @@ mod tests {
             tracking.stage,
             RedemptionTrackingStage::WithdrawnFromRaindex
         );
+
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(ownership.redemption_txs.is_empty());
 
         let inflight = {
             let inventory = trigger.inventory.read().await;
@@ -7951,6 +8402,8 @@ mod tests {
             RedemptionTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
+                redemption_tx: Some(TxHash::random()),
                 stage: RedemptionTrackingStage::TokensSent,
                 last_progress_at: Utc::now() - ChronoDuration::minutes(31),
             },
@@ -8100,6 +8553,8 @@ mod tests {
             RedemptionTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
+                redemption_tx: Some(TxHash::random()),
                 stage: RedemptionTrackingStage::TokensSent,
                 last_progress_at: Utc::now() - ChronoDuration::minutes(31),
             },
@@ -8161,6 +8616,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timed_out_redemption_drops_ownership_so_stuck_provider_request_is_external() {
+        // Core lifecycle of this PR: when a redemption times out, cleanup clears
+        // its inflight AND removes it from tracking. Because ownership is derived
+        // from live tracking, the still-pending provider request is no longer
+        // recognized as the bot's own -- the next poll classifies it as external
+        // and excludes it, so a stuck Alpaca request can no longer block
+        // rebalancing (which the old wallet-based matching would have done).
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(80), shares(20))
+            .update_equity(
+                &symbol,
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+        let (reactor, _receiver) = make_trigger_with_inventory_and_registry_config(
+            inventory,
+            &symbol,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = RedemptionAggregateId::new("timed-out-still-pending");
+        let redemption_tx = TxHash::random();
+        let tokenization_request_id = TokenizationRequestId("stuck-at-alpaca".to_string());
+
+        trigger.redemption_tracking.write().await.insert(
+            id.clone(),
+            RedemptionTracking {
+                symbol: symbol.clone(),
+                quantity: shares(10),
+                tokenization_request_id: Some(tokenization_request_id.clone()),
+                redemption_tx: Some(redemption_tx),
+                stage: RedemptionTrackingStage::Detected,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        // Before timeout the redemption is owned, so a poll would count it.
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(ownership.redemption_txs.contains(&redemption_tx));
+        assert!(
+            ownership
+                .redemption_tokenizations
+                .contains(&tokenization_request_id)
+        );
+
+        trigger.expire_stuck_operations(Utc::now()).await.unwrap();
+
+        // After timeout it is no longer owned: a provider poll that STILL lists
+        // this request treats it as external and does not re-introduce inflight.
+        let ownership = trigger.pending_request_ownership().await;
+        assert!(!ownership.redemption_txs.contains(&redemption_tx));
+        assert!(
+            !ownership
+                .redemption_tokenizations
+                .contains(&tokenization_request_id)
+        );
+
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::MarketMaking),
+            Some(FractionalShares::ZERO),
+            "timeout cleanup should clear the stuck redemption's inflight so rebalancing can resume"
+        );
+    }
+
+    #[tokio::test]
     async fn timed_out_mint_cleanup_rechecks_progress_before_clearing() {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
@@ -8186,6 +8713,7 @@ mod tests {
             MintTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
                 stage: MintTrackingStage::Accepted,
                 last_progress_at: now - ChronoDuration::minutes(5),
             },
@@ -8251,6 +8779,7 @@ mod tests {
             MintTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
                 stage: MintTrackingStage::Accepted,
                 last_progress_at: now - ChronoDuration::minutes(5),
             },
@@ -8326,6 +8855,7 @@ mod tests {
             MintTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
                 stage: MintTrackingStage::Accepted,
                 last_progress_at: now - ChronoDuration::minutes(5),
             },
@@ -8411,6 +8941,8 @@ mod tests {
             RedemptionTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
+                redemption_tx: Some(TxHash::random()),
                 stage: RedemptionTrackingStage::TokensSent,
                 last_progress_at: now - ChronoDuration::minutes(5),
             },
@@ -8489,6 +9021,8 @@ mod tests {
             RedemptionTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
+                redemption_tx: Some(TxHash::random()),
                 stage: RedemptionTrackingStage::TokensSent,
                 last_progress_at: now - ChronoDuration::minutes(5),
             },
@@ -8790,6 +9324,7 @@ mod tests {
             MintTracking {
                 symbol: symbol.clone(),
                 quantity: shares(10),
+                tokenization_request_id: None,
                 stage: MintTrackingStage::Accepted,
                 last_progress_at: fetched_at - ChronoDuration::minutes(5),
             },

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -80,7 +80,7 @@ impl FromStr for IssuerRequestId {
 }
 
 /// Alpaca tokenization request identifier used to track the mint operation through their API.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub(crate) struct TokenizationRequestId(pub(crate) String);
 
 impl std::fmt::Display for TokenizationRequestId {

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -95,6 +95,101 @@ fn snapshot_has_inflight_mint(snapshot: &StoredSnapshot, symbol: &str) -> anyhow
     Ok(has_symbol)
 }
 
+fn snapshot_inflight_mint(
+    snapshot: &StoredSnapshot,
+    symbol: &str,
+) -> anyhow::Result<Option<FractionalShares>> {
+    let payload: serde_json::Value = serde_json::from_str(&snapshot.payload)?;
+    let live = payload.get("Live").unwrap_or(&payload);
+    let quantity = live
+        .get("inflight_mints")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|mints| mints.get(symbol))
+        .and_then(serde_json::Value::as_str)
+        .map(str::parse::<FractionalShares>)
+        .transpose()?;
+
+    Ok(quantity)
+}
+
+fn single_pending_request_quantity(
+    requests: &[st0x_hedge::mock_api::MockTokenizationRequestSnapshot],
+    request_type: TokenizationRequestType,
+    symbol: &str,
+) -> FractionalShares {
+    let quantities: Vec<_> = requests
+        .iter()
+        .filter(|request| {
+            request.request_type == request_type
+                && request.symbol == symbol
+                && request.status == st0x_hedge::mock_api::TokenizationStatus::Pending
+        })
+        .map(|request| FractionalShares::new(request.quantity))
+        .collect();
+
+    assert_eq!(
+        quantities.len(),
+        1,
+        "Expected exactly one pending {request_type:?} request for {symbol}, got {quantities:?}",
+    );
+
+    quantities[0]
+}
+
+fn inflight_mint_quantities(
+    events: &[crate::assert::StoredEvent],
+    symbol: &str,
+) -> anyhow::Result<Vec<FractionalShares>> {
+    events
+        .iter()
+        .filter(|event| event.event_type == "InventorySnapshotEvent::InflightEquity")
+        .filter_map(|event| {
+            event
+                .payload
+                .get("InflightEquity")?
+                .get("mints")?
+                .get(symbol)?
+                .as_str()
+        })
+        .map(|quantity| quantity.parse::<FractionalShares>().map_err(Into::into))
+        .collect()
+}
+
+async fn poll_for_inflight_mint_event_count_after(
+    bot: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    symbol: &str,
+    expected_quantity: FractionalShares,
+    previous_count: usize,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("new InflightEquity event for {symbol} quantity {expected_quantity}");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        if let Ok(pool) = connect_db(db_path).await {
+            let events = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+            pool.close().await;
+
+            let matching_count = inflight_mint_quantities(&events, symbol)?
+                .into_iter()
+                .filter(|quantity| *quantity == expected_quantity)
+                .count();
+
+            if matching_count > previous_count {
+                return Ok(());
+            }
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
 async fn poll_for_inflight_mint_snapshot(
     bot: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
     db_path: &std::path::Path,
@@ -1389,30 +1484,22 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Inflight polling picks up pending tokenization requests end-to-end.
+/// Inflight polling picks up bot-owned pending tokenization requests end-to-end.
 ///
 /// The conductor's inventory poller calls `list_pending_requests()` on
-/// every poll cycle. When pending requests exist (matching the conductor's
-/// wallet), the poller aggregates them into an `InflightEquity` snapshot
-/// command, which the CQRS aggregate turns into an `InflightEquity` event.
-///
-/// This test injects a pending mint request into the tokenization mock,
-/// starts the bot, and verifies that `InflightEquity` events are emitted
-/// with non-empty mint data -- proving the full pipeline from HTTP poll
-/// through CQRS event emission works end-to-end.
+/// every poll cycle. When pending requests match an active mint aggregate,
+/// the poller aggregates them into an `InflightEquity` snapshot command,
+/// which the CQRS aggregate turns into an `InflightEquity` event.
 #[test_log::test(tokio::test)]
 async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<()> {
     let broker_fill_price = float!("150.00");
     let onchain_price = float!("150.00");
+    let amount_per_trade = float!("5");
 
-    let infra = TestInfra::start(
-        vec![("AAPL", broker_fill_price)],
-        // No offchain positions — avoids rebalancing triggering a real
-        // mint that could satisfy the assertion instead of the injected
-        // pending request.
-        vec![],
-    )
-    .await?;
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    infra
+        .tokenization_service
+        .set_polls_until_complete(usize::MAX);
 
     // We need at least one order set up so the vault registry gets seeded
     // and the inventory poller has valid vault IDs to query.
@@ -1420,20 +1507,11 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
         .base_chain
         .setup_order()
         .symbol("AAPL")
-        .amount(float!("5"))
+        .amount(amount_per_trade)
         .price(onchain_price)
         .direction(TakeDirection::SellEquity)
         .call()
         .await?;
-
-    // Inject a pending mint request with the bot's wallet address BEFORE
-    // starting the bot. The first inventory poll should pick this up.
-    infra.tokenization_service.inject_pending_request(
-        "AAPL",
-        float!("25"),
-        infra.base_chain.owner,
-        TokenizationRequestType::Mint,
-    );
 
     let current_block = infra.base_chain.provider.get_block_number().await?;
     let cash_vault_id = prepared.input_vault_id;
@@ -1453,9 +1531,33 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
 
     let mut bot = spawn_bot(ctx);
 
-    // Poll the snapshot table for inflight data instead of the events
-    // table, because compaction may delete the event before we observe
-    // it. The snapshot is the durable record.
+    infra.base_chain.take_prepared_order(&prepared).await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAccepted",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let expected_quantity = single_pending_request_quantity(
+        &infra.tokenization_service.tokenization_requests(),
+        TokenizationRequestType::Mint,
+        "AAPL",
+    );
+
+    poll_for_inflight_mint_event_count_after(
+        &mut bot,
+        &infra.db_path,
+        "AAPL",
+        expected_quantity,
+        0,
+        Duration::from_secs(30),
+    )
+    .await?;
+
     poll_for_snapshot_field(
         &mut bot,
         &infra.db_path,
@@ -1467,8 +1569,7 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
 
     let pool = connect_db(&infra.db_path).await?;
 
-    // Verify the snapshot contains the injected pending mint for AAPL
-    // with the exact quantity we injected (25 shares).
+    // Verify the snapshot contains the bot-owned pending mint for AAPL.
     let snapshot_payload: (String,) = sqlx::query_as(
         "SELECT payload FROM snapshots \
          WHERE aggregate_type = 'InventorySnapshot' LIMIT 1",
@@ -1485,12 +1586,15 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
         .expect("Snapshot should contain inflight_mints");
     let aapl_quantity = mints
         .get("AAPL")
-        .expect("inflight_mints should contain AAPL from the injected pending request");
+        .expect("inflight_mints should contain AAPL from the bot-owned pending request");
+    let aapl_quantity = aapl_quantity
+        .as_str()
+        .expect("AAPL inflight mint quantity should be serialized as a string")
+        .parse::<FractionalShares>()?;
     assert_eq!(
-        aapl_quantity.as_str().unwrap(),
-        "25",
-        "inflight_mints quantity for AAPL should match the injected \
-         pending request (25 shares), got: {aapl_quantity}"
+        aapl_quantity, expected_quantity,
+        "inflight_mints quantity for AAPL should match the bot-owned \
+         pending request"
     );
 
     pool.close().await;
@@ -1917,33 +2021,22 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
 async fn inflight_state_survives_restart() -> anyhow::Result<()> {
     let broker_fill_price = float!("150.00");
     let onchain_price = float!("150.00");
+    let amount_per_trade = float!("5");
 
-    let infra = TestInfra::start(
-        vec![("AAPL", broker_fill_price)],
-        // No offchain positions: the test focuses on inflight polling
-        // and restart behavior, not rebalancing decisions.
-        vec![],
-    )
-    .await?;
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    infra
+        .tokenization_service
+        .set_polls_until_complete(usize::MAX);
 
     let prepared = infra
         .base_chain
         .setup_order()
         .symbol("AAPL")
-        .amount(float!("5"))
+        .amount(amount_per_trade)
         .price(onchain_price)
         .direction(TakeDirection::SellEquity)
         .call()
         .await?;
-
-    // Inject a pending mint request that will persist across restarts
-    // (the mock server stays alive).
-    infra.tokenization_service.inject_pending_request(
-        "AAPL",
-        float!("25"),
-        infra.base_chain.owner,
-        TokenizationRequestType::Mint,
-    );
 
     let current_block = infra.base_chain.provider.get_block_number().await?;
     let cash_vault_id = prepared.input_vault_id;
@@ -1965,11 +2058,47 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
 
     let mut bot1 = spawn_bot(ctx1);
 
+    infra.base_chain.take_prepared_order(&prepared).await?;
+
+    poll_for_events_with_timeout(
+        &mut bot1,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAccepted",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let expected_quantity = single_pending_request_quantity(
+        &infra.tokenization_service.tokenization_requests(),
+        TokenizationRequestType::Mint,
+        "AAPL",
+    );
+
+    poll_for_inflight_mint_event_count_after(
+        &mut bot1,
+        &infra.db_path,
+        "AAPL",
+        expected_quantity,
+        0,
+        Duration::from_secs(30),
+    )
+    .await?;
+
     // Wait for the first bot to persist inflight state. InventorySnapshot
     // events are compactable, so the durable assertion is the snapshot row.
     let snapshot_before_restart =
         poll_for_inflight_mint_snapshot(&mut bot1, &infra.db_path, "AAPL", Duration::from_secs(30))
             .await?;
+    let pool = connect_db(&infra.db_path).await?;
+    let events_before_restart = fetch_events_by_type(&pool, "InventorySnapshot").await?;
+    pool.close().await;
+    let observed_before_restart = inflight_mint_quantities(&events_before_restart, "AAPL")?;
+    assert!(
+        observed_before_restart.contains(&expected_quantity),
+        "First bot should persist exact inflight mint quantity before restart: \
+         {observed_before_restart:?}",
+    );
 
     // Stop the first bot.
     bot1.abort();
@@ -1992,8 +2121,9 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
 
     let bot2 = spawn_bot(ctx2);
 
-    // Wait for the second bot to start polling. This proves snapshot
-    // restoration succeeded and the bot is functional after restart.
+    // Recovery resumes the accepted mint before the inventory monitor starts.
+    // Keep the provider request pending and assert the compacted snapshot is
+    // still present while startup is in that recovery phase.
     tokio::time::sleep(Duration::from_secs(15)).await;
 
     // Verify the second bot is still alive (didn't crash on replay).
@@ -2014,8 +2144,9 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
         snapshot_before_restart.last_sequence,
         snapshot_after_restart.last_sequence
     );
-    assert!(
-        snapshot_has_inflight_mint(&snapshot_after_restart, "AAPL")?,
+    assert_eq!(
+        snapshot_inflight_mint(&snapshot_after_restart, "AAPL")?,
+        Some(expected_quantity),
         "Inflight mint state should survive restart via the compacted snapshot"
     );
 


### PR DESCRIPTION
## What

Scopes inflight-equity accounting to the bot's **own** in-progress tokenization operations. The inventory poller now decides whether a pending mint/redemption from the tokenization provider counts as inflight by matching it against the bot's active rebalancing aggregates (`issuer_request_id` / `tokenization_request_id` / `redemption_tx`), instead of by destination wallet. Also threads a `fetched_at` timestamp through the `InflightEquity` snapshot, adds a backfill migration, and de-duplicates provider request rows.

## Why

Tokenized equity moves through an **issuance-bot** intermediary (liquidity bot ↔ issuance bot burn/mint ↔ Alpaca), so a pending tokenization request hitting the bot's wallet is not necessarily one the bot initiated. The poller previously counted any pending request matching the bot's wallet (or with no wallet) as bot-owned inflight. External or manually-triggered requests were therefore miscounted as inflight, skewing the inventory snapshot and rebalancing decisions and leaving funds stuck — the "stuck funds on external rebalance" this branch is named for.

## How

- **Ownership by aggregate identity.** New `PendingRequestOwnership` trait (implemented by `RebalancingService`) exposes a `PendingRequestOwnershipSnapshot` of active `IssuerRequestId` / `TokenizationRequestId` / `redemption_tx`, built from live mint/redemption tracking. `polling.rs::is_own_request` matches mints by `issuer_request_id` or `tokenization_request_id`, and redemptions by `tokenization_request_id` or `redemption_tx` (so a redemption that has sent tokens but not yet observed the provider id stays owned). `conductor/builder.rs` wires the rebalancing service as the ownership source; with no source configured, all provider requests are treated as external (logged, not counted).
- **Bounded operator logging.** Unknown wallet-matching requests warn once via a set that is pruned to the current poll's request ids each cycle.
- **Provider-row dedup.** `aggregate_pending_requests` de-duplicates by request id.
- **`fetched_at` threading.** Captured at poll time and threaded through the `InflightEquity` command/event into the snapshot (`inflight_equity_fetched_at`). Dedup re-emits when `fetched_at` advances *only* when inflight is non-empty (idle polls stay quiet); hydration gates on `fetched_at` being set, with migration `20260520180918_backfill_inflight_equity_fetched_at.sql` backfilling legacy compacted snapshots from `last_updated` (mirrors the #675 venue-field backfill; runs at startup before hydration).
- **Recovery.** Mint/redemption tracking records `tokenization_request_id` and `redemption_tx`, including during restart state recovery, so ownership survives restarts.
- **SPEC.** Documents the bot-owned ownership rule and the failed-redemption inflight lifecycle (timeout/cleanup clears inflight so rebalancing resumes; a still-pending provider request becomes external once the aggregate is dropped).

## Testing

- **Unit:** ownership by `issuer_request_id`; redemption owned by `redemption_tx` before detection (distinct external row excluded via distinct quantity so dedup can't mask it); provider-id dedup; external-without-ownership-source; matching-wallet-but-not-owned excluded; `fetched_at` dedup boundaries (stale / advance / empty-unchanged); ownership drops on `RedemptionRejected`/`TransferFailed`/`DetectionFailed`; timed-out redemption drops ownership so a still-pending provider request is treated as external.
- **e2e:** `inflight_polling_emits_events_for_pending_requests` and `inflight_state_survives_restart` rewritten to drive real mint flows (instead of injected fake requests) and assert exact bot-owned quantities, including across restart.
- Affected-crate test suites pass; local CI (check / clippy / fmt / nixfmt) green.

## Anything else

- **Migration:** `migrations/20260520180918_backfill_inflight_equity_fetched_at.sql` — backfills `inflight_equity_fetched_at` on existing `InventorySnapshot` rows so compacted snapshots still hydrate inflight after deploy.
- **Follow-up:** [RAI-629](https://linear.app/makeitrain/issue/RAI-629/surface-stuckstranded-inflight-balance-for-failed-rebalances-cli-to-re) — surface the stranded inflight amount in the dashboard's failed-rebalance modal, and add a CLI command to re-check/resolve a stuck mint/redemption (today only `FailTransfer` to close it and `AlpacaTokenizationRequests` to list exist).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inflight equity now includes ownership detection to accurately distinguish bot-owned pending requests from external ones.
  * Enhanced redemption failure handling with terminal stranded-asset classification.

* **Improvements**
  * Added timestamp tracking for inflight equity snapshots to enable proper event deduplication.
  * Improved pending request deduplication to eliminate duplicate entries before aggregation.
  * Better state preservation across system restarts and replays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->