### PR TITLE
RAI-632 Add dashboard inventory hover values

### DIFF
--- a/dashboard/src/lib/components/available-inventory.svelte
+++ b/dashboard/src/lib/components/available-inventory.svelte
@@ -4,8 +4,10 @@
   import type { UsdcInventory } from '$lib/api/UsdcInventory'
   import type { Position } from '$lib/api/Position'
   import type { Settings } from '$lib/api/Settings'
+  import InventoryHoverValue from '$lib/components/inventory-hover-value.svelte'
   import { decimalAdd, decimalCompare, decimalIsZero, formatDecimal } from '$lib/decimal'
   import { reactive } from '$lib/frp.svelte'
+  import { cashUsdTooltip, equityUsdTooltip, positionSharesTooltip } from '$lib/inventory-value'
 
   interface Props {
     symbols: SymbolInventory[]
@@ -30,7 +32,7 @@
     return {
       display,
       full: value,
-      truncated,
+      truncated
     }
   }
 
@@ -46,7 +48,16 @@
   }
 
   type SortDir = 'asc' | 'desc'
-  type EquityCol = 'asset' | 'alpaca' | 'inflight' | 'unwrapped' | 'wrapped' | 'raindex' | 'total' | 'ratio' | 'exposure'
+  type EquityCol =
+    | 'asset'
+    | 'alpaca'
+    | 'inflight'
+    | 'unwrapped'
+    | 'wrapped'
+    | 'raindex'
+    | 'total'
+    | 'ratio'
+    | 'exposure'
   type EquitySortState = { column: EquityCol; dir: SortDir } | null
 
   const sort = reactive<EquitySortState>(null)
@@ -60,7 +71,10 @@
     })
   }
 
-  const ariaSort = (state: EquitySortState, col: EquityCol): 'ascending' | 'descending' | 'none' => {
+  const ariaSort = (
+    state: EquitySortState,
+    col: EquityCol
+  ): 'ascending' | 'descending' | 'none' => {
     if (state?.column !== col) return 'none'
     return state.dir === 'asc' ? 'ascending' : 'descending'
   }
@@ -80,19 +94,20 @@
     return onchain / total
   }
 
-  const formatRatio = (ratio: number): string =>
-    `${(ratio * 100).toFixed(1)}%`
+  const formatRatio = (ratio: number): string => `${(ratio * 100).toFixed(1)}%`
 
-  type PositionInfo = { net: number; priceUsdc: number }
+  type PositionInfo = { net: string; priceUsdc: string | null }
 
   const positionMap = $derived(
-    new Map(positions.map((position) => [
-      position.symbol,
-      {
-        net: parseFloat(position.net),
-        priceUsdc: position.last_price_usdc ? parseFloat(position.last_price_usdc) : 0,
-      } satisfies PositionInfo,
-    ]))
+    new Map(
+      positions.map((position) => [
+        position.symbol,
+        {
+          net: position.net,
+          priceUsdc: position.last_price_usdc
+        } satisfies PositionInfo
+      ])
+    )
   )
 
   type EquityRow = {
@@ -105,6 +120,8 @@
     total: Formatted
     ratio: number
     exposure: number
+    netShares: string
+    priceUsdc: string | null
     trading: boolean
   }
 
@@ -120,6 +137,8 @@
         inflight
       )
       const stripped = stripPrefix(item.symbol)
+      const pos = positionMap.get(stripped)
+
       return {
         asset: stripped,
         alpaca: fmt(item.offchainAvailable),
@@ -129,12 +148,10 @@
         raindex: fmt(item.onchainAvailable),
         total: fmtValue(totalVal),
         ratio: computeRatio(item.onchainAvailable, item.offchainAvailable),
-        exposure: (() => {
-          const pos = positionMap.get(stripped)
-          if (!pos) return 0
-          return pos.net * pos.priceUsdc
-        })(),
-        trading: tradingSet.has(stripped),
+        exposure: pos?.priceUsdc ? parseFloat(pos.net) * parseFloat(pos.priceUsdc) : 0,
+        netShares: pos?.net ?? '0',
+        priceUsdc: pos?.priceUsdc ?? null,
+        trading: tradingSet.has(stripped)
       }
     })
   )
@@ -155,21 +172,19 @@
     if (!usdc) return null
 
     const inflight = decimalAdd(usdc.onchainInflight, usdc.offchainInflight)
-    const total = decimalAdd(
-      decimalAdd(usdc.onchainAvailable, usdc.offchainAvailable),
-      inflight
-    )
+    const total = decimalAdd(decimalAdd(usdc.onchainAvailable, usdc.offchainAvailable), inflight)
 
     return {
       alpacaAvail: fmt(usdc.offchainAvailable),
       gross: usdc.offchainGross === null ? null : fmt(usdc.offchainGross),
       withdrawable: usdc.withdrawableCash === null ? null : fmt(usdc.withdrawableCash),
       inflight: fmt(inflight),
-      ethWallet: usdc.inflightCash.ethereumWallet === null ? null : fmt(usdc.inflightCash.ethereumWallet),
+      ethWallet:
+        usdc.inflightCash.ethereumWallet === null ? null : fmt(usdc.inflightCash.ethereumWallet),
       baseWallet: usdc.inflightCash.baseWallet === null ? null : fmt(usdc.inflightCash.baseWallet),
       raindex: fmt(usdc.onchainAvailable),
       total: fmtValue(total),
-      ratio: computeRatio(usdc.onchainAvailable, usdc.offchainAvailable),
+      ratio: computeRatio(usdc.onchainAvailable, usdc.offchainAvailable)
     }
   })
 
@@ -182,7 +197,7 @@
     raindex: (lhs, rhs) => decimalCompare(lhs.raindex.full, rhs.raindex.full),
     total: (lhs, rhs) => decimalCompare(lhs.total.full, rhs.total.full),
     ratio: (lhs, rhs) => lhs.ratio - rhs.ratio,
-    exposure: (lhs, rhs) => lhs.exposure - rhs.exposure,
+    exposure: (lhs, rhs) => lhs.exposure - rhs.exposure
   }
 
   const sortedEquities = $derived.by(() => {
@@ -206,7 +221,16 @@
   })
 
   const approxClass = (val: Formatted): string =>
-    val.truncated ? 'cursor-help opacity-80 hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4' : ''
+    val.truncated
+      ? 'cursor-help opacity-80 hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4'
+      : ''
+
+  const valueClass = (val: Formatted): string =>
+    val.truncated
+      ? approxClass(val)
+      : 'cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4'
+
+  const dimClass = (base: string, trading = true): string => (trading ? base : `${base} opacity-40`)
 
   type DeviationStyle = 'normal' | 'high' | 'low'
 
@@ -216,7 +240,9 @@
     if (!settings) return null
 
     const target = isCash ? (settings.usdcTarget ?? settings.equityTarget) : settings.equityTarget
-    const deviation = isCash ? (settings.usdcDeviation ?? settings.equityDeviation) : settings.equityDeviation
+    const deviation = isCash
+      ? (settings.usdcDeviation ?? settings.equityDeviation)
+      : settings.equityDeviation
     const diff = ratio - target
     const sign = diff >= 0 ? '+' : ''
     const text = `${sign}${(diff * 100).toFixed(1)}%`
@@ -242,15 +268,29 @@
   }
 
   const showGross = $derived(cashCells?.gross !== null && cashCells?.gross !== undefined)
-  const showWithdrawable = $derived(cashCells?.withdrawable !== null && cashCells?.withdrawable !== undefined)
-  const showEthWallet = $derived(cashCells?.ethWallet !== null && cashCells?.ethWallet !== undefined)
-  const showBaseWallet = $derived(cashCells?.baseWallet !== null && cashCells?.baseWallet !== undefined)
+  const showWithdrawable = $derived(
+    cashCells?.withdrawable !== null && cashCells?.withdrawable !== undefined
+  )
+  const showEthWallet = $derived(
+    cashCells?.ethWallet !== null && cashCells?.ethWallet !== undefined
+  )
+  const showBaseWallet = $derived(
+    cashCells?.baseWallet !== null && cashCells?.baseWallet !== undefined
+  )
 
   // Visual separator before wallet-observed / info columns to signal they're
   // out-of-band and not part of imbalance math.
   const infoSepClass = 'border-l border-border pl-6'
   const cashFirstInfoCol = $derived<'gross' | 'withdrawable' | 'eth' | 'base' | null>(
-    showGross ? 'gross' : showWithdrawable ? 'withdrawable' : showEthWallet ? 'eth' : showBaseWallet ? 'base' : null,
+    showGross
+      ? 'gross'
+      : showWithdrawable
+        ? 'withdrawable'
+        : showEthWallet
+          ? 'eth'
+          : showBaseWallet
+            ? 'base'
+            : null
   )
   const cashInfoBoundary = (col: 'gross' | 'withdrawable' | 'eth' | 'base'): string =>
     cashFirstInfoCol === col ? infoSepClass : ''
@@ -259,224 +299,361 @@
 {#if cashCells}
   {@const dev = ratioDeviation(cashCells.ratio, true)}
   <div class="cash-table">
-  <Table.Root>
-    <Table.Header>
-      <Table.Row>
-        <Table.Head class="text-left">Asset</Table.Head>
-        <Table.Head class="text-left" title="USDC available in Raindex vaults to settle takers.">Raindex</Table.Head>
-        <Table.Head class="text-left" title="USDC the books track as in motion between venues (CCTP transfers, pending settlements). Part of imbalance math.">Inflight</Table.Head>
-        <Table.Head class="text-left" title="USDC available to trade on Alpaca after subtracting the configured cash reserve.">Alpaca Available</Table.Head>
-        <Table.Head class="text-left">Total</Table.Head>
-        <Table.Head class="text-left" title="Proportion of total cash on Raindex (onchain / total).">Ratio</Table.Head>
-        <Table.Head class="w-full" aria-hidden="true"></Table.Head>
-        {#if showGross}
-          <Table.Head class="info-col text-left {cashInfoBoundary('gross')}" title="Full broker USDC balance before subtracting the configured cash reserve.">Gross</Table.Head>
-        {/if}
-        {#if showWithdrawable}
-          <Table.Head class="info-col text-left {cashInfoBoundary('withdrawable')}" title="Settled cash that can be withdrawn or transferred to Raindex. Excludes T+1 unsettled equity-sale proceeds.">Withdrawable</Table.Head>
-        {/if}
-        {#if showEthWallet}
-          <Table.Head class="info-col text-left {cashInfoBoundary('eth')}" title="Wallet-observed USDC on the Ethereum wallet between Alpaca and CCTP. Not part of imbalance math.">Eth Wallet</Table.Head>
-        {/if}
-        {#if showBaseWallet}
-          <Table.Head class="info-col text-left {cashInfoBoundary('base')}" title="Wallet-observed USDC on the Base wallet between CCTP and Raindex vaults. Not part of imbalance math.">Base Wallet</Table.Head>
-        {/if}
-      </Table.Row>
-    </Table.Header>
+    <Table.Root>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head class="text-left">Asset</Table.Head>
+          <Table.Head class="text-left" title="USDC available in Raindex vaults to settle takers."
+            >Raindex</Table.Head
+          >
+          <Table.Head
+            class="text-left"
+            title="USDC the books track as in motion between venues (CCTP transfers, pending settlements). Part of imbalance math."
+            >Inflight</Table.Head
+          >
+          <Table.Head
+            class="text-left"
+            title="USDC available to trade on Alpaca after subtracting the configured cash reserve."
+            >Alpaca Available</Table.Head
+          >
+          <Table.Head class="text-left">Total</Table.Head>
+          <Table.Head
+            class="text-left"
+            title="Proportion of total cash on Raindex (onchain / total).">Ratio</Table.Head
+          >
+          <Table.Head class="w-full" aria-hidden="true"></Table.Head>
+          {#if showGross}
+            <Table.Head
+              class="info-col text-left {cashInfoBoundary('gross')}"
+              title="Full broker USDC balance before subtracting the configured cash reserve."
+              >Gross</Table.Head
+            >
+          {/if}
+          {#if showWithdrawable}
+            <Table.Head
+              class="info-col text-left {cashInfoBoundary('withdrawable')}"
+              title="Settled cash that can be withdrawn or transferred to Raindex. Excludes T+1 unsettled equity-sale proceeds."
+              >Withdrawable</Table.Head
+            >
+          {/if}
+          {#if showEthWallet}
+            <Table.Head
+              class="info-col text-left {cashInfoBoundary('eth')}"
+              title="Wallet-observed USDC on the Ethereum wallet between Alpaca and CCTP. Not part of imbalance math."
+              >Eth Wallet</Table.Head
+            >
+          {/if}
+          {#if showBaseWallet}
+            <Table.Head
+              class="info-col text-left {cashInfoBoundary('base')}"
+              title="Wallet-observed USDC on the Base wallet between CCTP and Raindex vaults. Not part of imbalance math."
+              >Base Wallet</Table.Head
+            >
+          {/if}
+        </Table.Row>
+      </Table.Header>
 
-    <Table.Body>
-      <Table.Row>
-        <Table.Cell class="font-mono font-medium">Cash</Table.Cell>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell class="font-mono font-medium">Cash</Table.Cell>
 
-        <Table.Cell class="text-left font-mono opacity-90">
-          <span class={approxClass(cashCells.raindex)} title={cashCells.raindex.truncated ? cashCells.raindex.full : undefined}>{cashCells.raindex.display}</span>
-        </Table.Cell>
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={cashCells.raindex.display}
+              tooltip={cashUsdTooltip(cashCells.raindex.full)}
+              class={dimClass(valueClass(cashCells.raindex), true)}
+            />
+          </Table.Cell>
 
-        <Table.Cell class="text-left font-mono opacity-50">
-          <span class={approxClass(cashCells.inflight)} title={cashCells.inflight.truncated ? cashCells.inflight.full : undefined}>{cashCells.inflight.display}</span>
-        </Table.Cell>
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={cashCells.inflight.display}
+              tooltip={cashUsdTooltip(cashCells.inflight.full)}
+              class={dimClass(`${valueClass(cashCells.inflight)} opacity-50`, true)}
+            />
+          </Table.Cell>
 
-        <Table.Cell class="text-left font-mono opacity-90">
-          <span class={approxClass(cashCells.alpacaAvail)} title={cashCells.alpacaAvail.truncated ? cashCells.alpacaAvail.full : undefined}>{cashCells.alpacaAvail.display}</span>
-        </Table.Cell>
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={cashCells.alpacaAvail.display}
+              tooltip={cashUsdTooltip(cashCells.alpacaAvail.full)}
+              class={valueClass(cashCells.alpacaAvail)}
+            />
+          </Table.Cell>
 
-        <Table.Cell class="text-left font-mono font-semibold">
-          <span class={approxClass(cashCells.total)} title={cashCells.total.truncated ? cashCells.total.full : undefined}>{cashCells.total.display}</span>
-        </Table.Cell>
+          <Table.Cell class="text-left font-mono font-semibold">
+            <InventoryHoverValue
+              display={cashCells.total.display}
+              tooltip={cashUsdTooltip(cashCells.total.full)}
+              class={valueClass(cashCells.total)}
+            />
+          </Table.Cell>
 
-        <Table.Cell>
-          <div class="flex items-center gap-2">
-            <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-              <div class="h-full rounded-full {dev?.style === 'high' ? 'bg-green-500' : dev?.style === 'low' ? 'bg-red-500' : 'bg-blue-400'}" style="width: {String(Math.min(cashCells.ratio * 100, 100))}%"></div>
+          <Table.Cell>
+            <div class="flex items-center gap-2">
+              <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full {dev?.style === 'high'
+                    ? 'bg-green-500'
+                    : dev?.style === 'low'
+                      ? 'bg-red-500'
+                      : 'bg-blue-400'}"
+                  style="width: {String(Math.min(cashCells.ratio * 100, 100))}%"
+                ></div>
+              </div>
+              <span class="font-mono text-xs">{formatRatio(cashCells.ratio)}</span>
+              {#if dev}
+                <span class="text-xs {deviationColor(dev.style)}">({dev.text})</span>
+              {/if}
             </div>
-            <span class="font-mono text-xs">{formatRatio(cashCells.ratio)}</span>
-            {#if dev}
-              <span class="text-xs {deviationColor(dev.style)}">({dev.text})</span>
-            {/if}
-          </div>
-        </Table.Cell>
-
-        <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
-
-        {#if showGross && cashCells.gross}
-          <Table.Cell class="info-col text-left font-mono opacity-90 {cashInfoBoundary('gross')}">
-            <span class={approxClass(cashCells.gross)} title={cashCells.gross.truncated ? cashCells.gross.full : undefined}>{cashCells.gross.display}</span>
           </Table.Cell>
-        {/if}
 
-        {#if showWithdrawable && cashCells.withdrawable}
-          <Table.Cell class="info-col text-left font-mono opacity-90 {cashInfoBoundary('withdrawable')}">
-            <span class={approxClass(cashCells.withdrawable)} title={cashCells.withdrawable.truncated ? cashCells.withdrawable.full : undefined}>{cashCells.withdrawable.display}</span>
-          </Table.Cell>
-        {/if}
+          <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
 
-        {#if showEthWallet && cashCells.ethWallet}
-          <Table.Cell class="info-col text-left font-mono opacity-50 {cashInfoBoundary('eth')}">
-            <span class={approxClass(cashCells.ethWallet)} title={cashCells.ethWallet.truncated ? cashCells.ethWallet.full : undefined}>{cashCells.ethWallet.display}</span>
-          </Table.Cell>
-        {/if}
+          {#if showGross && cashCells.gross}
+            <Table.Cell class="info-col text-left font-mono {cashInfoBoundary('gross')}">
+              <InventoryHoverValue
+                display={cashCells.gross.display}
+                tooltip={cashUsdTooltip(cashCells.gross.full)}
+                class={valueClass(cashCells.gross)}
+              />
+            </Table.Cell>
+          {/if}
 
-        {#if showBaseWallet && cashCells.baseWallet}
-          <Table.Cell class="info-col text-left font-mono opacity-50 {cashInfoBoundary('base')}">
-            <span class={approxClass(cashCells.baseWallet)} title={cashCells.baseWallet.truncated ? cashCells.baseWallet.full : undefined}>{cashCells.baseWallet.display}</span>
-          </Table.Cell>
-        {/if}
-      </Table.Row>
-    </Table.Body>
-  </Table.Root>
+          {#if showWithdrawable && cashCells.withdrawable}
+            <Table.Cell class="info-col text-left font-mono {cashInfoBoundary('withdrawable')}">
+              <InventoryHoverValue
+                display={cashCells.withdrawable.display}
+                tooltip={cashUsdTooltip(cashCells.withdrawable.full)}
+                class={valueClass(cashCells.withdrawable)}
+              />
+            </Table.Cell>
+          {/if}
+
+          {#if showEthWallet && cashCells.ethWallet}
+            <Table.Cell class="info-col text-left font-mono {cashInfoBoundary('eth')}">
+              <InventoryHoverValue
+                display={cashCells.ethWallet.display}
+                tooltip={cashUsdTooltip(cashCells.ethWallet.full)}
+                class={`${valueClass(cashCells.ethWallet)} opacity-50`}
+              />
+            </Table.Cell>
+          {/if}
+
+          {#if showBaseWallet && cashCells.baseWallet}
+            <Table.Cell class="info-col text-left font-mono {cashInfoBoundary('base')}">
+              <InventoryHoverValue
+                display={cashCells.baseWallet.display}
+                tooltip={cashUsdTooltip(cashCells.baseWallet.full)}
+                class={`${valueClass(cashCells.baseWallet)} opacity-50`}
+              />
+            </Table.Cell>
+          {/if}
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
   </div>
 
   <div class="my-4 h-px bg-border"></div>
 {/if}
 
 <div class="equity-table">
-<Table.Root>
-  <Table.Header>
-    <Table.Row>
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'asset')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('asset')}>
-          Asset{sortIndicator(sort.current, 'asset')}
-        </button>
-      </Table.Head>
+  <Table.Root>
+    <Table.Header>
+      <Table.Row>
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'asset')}>
+          <button class="{sortBtnClass} text-left" onclick={toggleSort('asset')}>
+            Asset{sortIndicator(sort.current, 'asset')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'raindex')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('raindex')} title="Tokens in Raindex vaults.">
-          Raindex{sortIndicator(sort.current, 'raindex')}
-        </button>
-      </Table.Head>
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'raindex')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('raindex')}
+            title="Tokens in Raindex vaults."
+          >
+            Raindex{sortIndicator(sort.current, 'raindex')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'inflight')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('inflight')} title="Shares the books track as in motion between venues (mints, redeems). Part of imbalance math.">
-          Inflight{sortIndicator(sort.current, 'inflight')}
-        </button>
-      </Table.Head>
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'inflight')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('inflight')}
+            title="Shares the books track as in motion between venues (mints, redeems). Part of imbalance math."
+          >
+            Inflight{sortIndicator(sort.current, 'inflight')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'alpaca')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('alpaca')} title="Shares held at Alpaca.">
-          Alpaca{sortIndicator(sort.current, 'alpaca')}
-        </button>
-      </Table.Head>
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'alpaca')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('alpaca')}
+            title="Shares held at Alpaca."
+          >
+            Alpaca{sortIndicator(sort.current, 'alpaca')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'total')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('total')}>
-          Total{sortIndicator(sort.current, 'total')}
-        </button>
-      </Table.Head>
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'total')}>
+          <button class="{sortBtnClass} text-left" onclick={toggleSort('total')}>
+            Total{sortIndicator(sort.current, 'total')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'ratio')}>
-        <button
-          class="{sortBtnClass} text-left"
-          onclick={toggleSort('ratio')}
-          title="Proportion of total holdings on Raindex (onchain / total)."
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'ratio')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('ratio')}
+            title="Proportion of total holdings on Raindex (onchain / total)."
+          >
+            Ratio{sortIndicator(sort.current, 'ratio')}
+          </button>
+        </Table.Head>
+
+        <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'exposure')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('exposure')}
+            title="Net directional exposure from counterparty fills."
+          >
+            Exposure{sortIndicator(sort.current, 'exposure')}
+          </button>
+        </Table.Head>
+
+        <Table.Head class="w-full" aria-hidden="true"></Table.Head>
+
+        <Table.Head
+          class="info-col text-left {infoSepClass}"
+          aria-sort={ariaSort(sort.current, 'unwrapped')}
         >
-          Ratio{sortIndicator(sort.current, 'ratio')}
-        </button>
-      </Table.Head>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('unwrapped')}
+            title="Unwrapped tokenized equity (tSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math."
+          >
+            Unwrapped{sortIndicator(sort.current, 'unwrapped')}
+          </button>
+        </Table.Head>
 
-      <Table.Head class="text-left" aria-sort={ariaSort(sort.current, 'exposure')}>
-        <button
-          class="{sortBtnClass} text-left"
-          onclick={toggleSort('exposure')}
-          title="Net directional exposure from counterparty fills."
-        >
-          Exposure{sortIndicator(sort.current, 'exposure')}
-        </button>
-      </Table.Head>
-
-      <Table.Head class="w-full" aria-hidden="true"></Table.Head>
-
-      <Table.Head class="info-col text-left {infoSepClass}" aria-sort={ariaSort(sort.current, 'unwrapped')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('unwrapped')} title="Unwrapped tokenized equity (tSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math.">
-          Unwrapped{sortIndicator(sort.current, 'unwrapped')}
-        </button>
-      </Table.Head>
-
-      <Table.Head class="info-col text-left" aria-sort={ariaSort(sort.current, 'wrapped')}>
-        <button class="{sortBtnClass} text-left" onclick={toggleSort('wrapped')} title="Wrapped equity vault shares (wtSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math.">
-          Wrapped{sortIndicator(sort.current, 'wrapped')}
-        </button>
-      </Table.Head>
-    </Table.Row>
-  </Table.Header>
-
-  <Table.Body>
-    {#each sortedEquities as row, idx (row.asset)}
-      {@const dev = ratioDeviation(row.ratio, false)}
-      <Table.Row class="{idx % 2 === 0 ? 'bg-muted/40' : ''} {row.trading ? '' : 'opacity-40'}">
-        <Table.Cell class="font-mono font-medium">{row.asset}</Table.Cell>
-
-        <Table.Cell class="text-left font-mono opacity-90">
-          <span class={approxClass(row.raindex)} title={row.raindex.truncated ? row.raindex.full : undefined}>{row.raindex.display}</span>
-        </Table.Cell>
-
-        <Table.Cell class="text-left font-mono opacity-50">
-          <span class={approxClass(row.inflight)} title={row.inflight.truncated ? row.inflight.full : undefined}>{row.inflight.display}</span>
-        </Table.Cell>
-
-        <Table.Cell class="text-left font-mono opacity-90">
-          <span class={approxClass(row.alpaca)} title={row.alpaca.truncated ? row.alpaca.full : undefined}>{row.alpaca.display}</span>
-        </Table.Cell>
-
-        <Table.Cell class="text-left font-mono font-semibold">
-          <span class={approxClass(row.total)} title={row.total.truncated ? row.total.full : undefined}>{row.total.display}</span>
-        </Table.Cell>
-
-        <Table.Cell>
-          <div class="flex items-center gap-2">
-            <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-              <div class="h-full rounded-full {dev?.style === 'high' ? 'bg-green-500' : dev?.style === 'low' ? 'bg-red-500' : 'bg-blue-400'}" style="width: {String(Math.min(row.ratio * 100, 100))}%"></div>
-            </div>
-            <span class="font-mono text-xs">{formatRatio(row.ratio)}</span>
-            {#if dev}
-              <span class="text-xs {deviationColor(dev.style)}">({dev.text})</span>
-            {/if}
-          </div>
-        </Table.Cell>
-
-        <Table.Cell>
-          <div class="flex items-center gap-1.5 font-mono text-xs">
-            {#if !isNegligible(row.exposure) && row.exposure !== 0}
-              <span class="text-base leading-none {row.exposure > 0 ? 'text-green-500' : 'text-red-500'}">{row.exposure > 0 ? '▲' : '▼'}</span>
-            {/if}
-            <span class={row.exposure === 0 || isNegligible(row.exposure) ? 'text-muted-foreground' : row.exposure > 0 ? 'text-green-500' : 'text-red-500'}>
-              {fmtExposure(row.exposure)}
-            </span>
-          </div>
-        </Table.Cell>
-
-        <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
-
-        <Table.Cell class="info-col text-left font-mono opacity-50 {infoSepClass}">
-          <span class={approxClass(row.unwrapped)} title={row.unwrapped.truncated ? row.unwrapped.full : undefined}>{row.unwrapped.display}</span>
-        </Table.Cell>
-
-        <Table.Cell class="info-col text-left font-mono opacity-50">
-          <span class={approxClass(row.wrapped)} title={row.wrapped.truncated ? row.wrapped.full : undefined}>{row.wrapped.display}</span>
-        </Table.Cell>
+        <Table.Head class="info-col text-left" aria-sort={ariaSort(sort.current, 'wrapped')}>
+          <button
+            class="{sortBtnClass} text-left"
+            onclick={toggleSort('wrapped')}
+            title="Wrapped equity vault shares (wtSTOCK) parked on the Base wallet between venues. Wallet-observed, not part of imbalance math."
+          >
+            Wrapped{sortIndicator(sort.current, 'wrapped')}
+          </button>
+        </Table.Head>
       </Table.Row>
-    {/each}
-  </Table.Body>
-</Table.Root>
+    </Table.Header>
+
+    <Table.Body>
+      {#each sortedEquities as row, idx (row.asset)}
+        {@const dev = ratioDeviation(row.ratio, false)}
+        <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
+          <Table.Cell class="font-mono font-medium {row.trading ? '' : 'opacity-40'}"
+            >{row.asset}</Table.Cell
+          >
+
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={row.raindex.display}
+              tooltip={equityUsdTooltip(row.raindex.full, row.priceUsdc)}
+              class={dimClass(valueClass(row.raindex), row.trading)}
+            />
+          </Table.Cell>
+
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={row.inflight.display}
+              tooltip={equityUsdTooltip(row.inflight.full, row.priceUsdc)}
+              class={dimClass(`${valueClass(row.inflight)} opacity-50`, row.trading)}
+            />
+          </Table.Cell>
+
+          <Table.Cell class="text-left font-mono">
+            <InventoryHoverValue
+              display={row.alpaca.display}
+              tooltip={equityUsdTooltip(row.alpaca.full, row.priceUsdc)}
+              class={dimClass(valueClass(row.alpaca), row.trading)}
+            />
+          </Table.Cell>
+
+          <Table.Cell class="text-left font-mono font-semibold">
+            <InventoryHoverValue
+              display={row.total.display}
+              tooltip={equityUsdTooltip(row.total.full, row.priceUsdc)}
+              class={dimClass(valueClass(row.total), row.trading)}
+            />
+          </Table.Cell>
+
+          <Table.Cell>
+            <div class="flex items-center gap-2">
+              <div class="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full {dev?.style === 'high'
+                    ? 'bg-green-500'
+                    : dev?.style === 'low'
+                      ? 'bg-red-500'
+                      : 'bg-blue-400'}"
+                  style="width: {String(Math.min(row.ratio * 100, 100))}%"
+                ></div>
+              </div>
+              <span class="font-mono text-xs {row.trading ? '' : 'opacity-40'}"
+                >{formatRatio(row.ratio)}</span
+              >
+              {#if dev}
+                <span class="text-xs {deviationColor(dev.style)} {row.trading ? '' : 'opacity-40'}"
+                  >({dev.text})</span
+                >
+              {/if}
+            </div>
+          </Table.Cell>
+
+          <Table.Cell>
+            <div class="flex items-center gap-1.5 font-mono text-xs">
+              {#if !isNegligible(row.exposure) && row.exposure !== 0}
+                <span
+                  class="text-base leading-none {row.exposure > 0
+                    ? 'text-green-500'
+                    : 'text-red-500'}">{row.exposure > 0 ? '▲' : '▼'}</span
+                >
+              {/if}
+              <InventoryHoverValue
+                display={fmtExposure(row.exposure)}
+                tooltip={positionSharesTooltip(row.netShares)}
+                class={dimClass(
+                  `cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4 ${row.exposure === 0 || isNegligible(row.exposure) ? 'text-muted-foreground' : row.exposure > 0 ? 'text-green-500' : 'text-red-500'}`,
+                  row.trading
+                )}
+              />
+            </div>
+          </Table.Cell>
+
+          <Table.Cell class="w-full" aria-hidden="true"></Table.Cell>
+
+          <Table.Cell class="info-col text-left font-mono {infoSepClass}">
+            <InventoryHoverValue
+              display={row.unwrapped.display}
+              tooltip={equityUsdTooltip(row.unwrapped.full, row.priceUsdc)}
+              class={dimClass(`${valueClass(row.unwrapped)} opacity-50`, row.trading)}
+            />
+          </Table.Cell>
+
+          <Table.Cell class="info-col text-left font-mono">
+            <InventoryHoverValue
+              display={row.wrapped.display}
+              tooltip={equityUsdTooltip(row.wrapped.full, row.priceUsdc)}
+              class={dimClass(`${valueClass(row.wrapped)} opacity-50`, row.trading)}
+            />
+          </Table.Cell>
+        </Table.Row>
+      {/each}
+    </Table.Body>
+  </Table.Root>
 </div>
 
 <style>

--- a/dashboard/src/lib/components/hover-tooltip.svelte
+++ b/dashboard/src/lib/components/hover-tooltip.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { tick, type Snippet } from 'svelte'
+
+  interface Props {
+    tooltip: string
+    class?: string
+    children?: Snippet
+  }
+
+  let { tooltip, class: className = '', children }: Props = $props()
+  let triggerEl: HTMLButtonElement | undefined = $state()
+  let tooltipEl: HTMLSpanElement | undefined = $state()
+  let open = $state(false)
+  let tooltipLeft = $state(0)
+  let tooltipTop = $state(0)
+
+  const tooltipClass =
+    'pointer-events-none fixed z-50 w-max max-w-72 whitespace-pre-line rounded border border-border bg-background px-2 py-1 text-xs font-normal text-foreground opacity-100 shadow-lg'
+
+  const portal = (node: HTMLElement) => {
+    document.body.appendChild(node)
+
+    return {
+      destroy() {
+        node.remove()
+      }
+    }
+  }
+
+  const positionTooltip = () => {
+    if (!triggerEl) return
+
+    const rect = triggerEl.getBoundingClientRect()
+    const tooltipHeight = tooltipEl?.offsetHeight ?? 0
+    const width = tooltipEl?.offsetWidth ?? 288
+    const left = Math.min(Math.max(rect.left, 8), window.innerWidth - width - 8)
+    const below = rect.bottom + 6
+    const top =
+      below + tooltipHeight > window.innerHeight ? Math.max(rect.top - tooltipHeight - 6, 8) : below
+
+    tooltipLeft = left
+    tooltipTop = top
+  }
+
+  const showTooltip = async () => {
+    open = true
+    await tick()
+    positionTooltip()
+  }
+
+  const hideTooltip = () => {
+    open = false
+  }
+
+  // `position: fixed` keeps the tooltip in viewport coordinates, so it would
+  // drift from its trigger if the page scrolls or resizes while open.
+  const onViewportChange = () => {
+    if (open) positionTooltip()
+  }
+</script>
+
+<svelte:window onscroll={onViewportChange} onresize={onViewportChange} />
+
+<button
+  bind:this={triggerEl}
+  type="button"
+  class="inline-flex appearance-none border-0 bg-transparent p-0 text-inherit {className}"
+  aria-label={tooltip}
+  onmouseenter={showTooltip}
+  onmouseleave={hideTooltip}
+  onfocus={showTooltip}
+  onblur={hideTooltip}
+>
+  {@render children?.()}
+</button>
+
+{#if open}
+  <span
+    bind:this={tooltipEl}
+    use:portal
+    class={tooltipClass}
+    style:left={`${String(tooltipLeft)}px`}
+    style:top={`${String(tooltipTop)}px`}
+  >
+    {tooltip}
+  </span>
+{/if}

--- a/dashboard/src/lib/components/inventory-hover-value.svelte
+++ b/dashboard/src/lib/components/inventory-hover-value.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import HoverTooltip from '$lib/components/hover-tooltip.svelte'
+
+  interface Props {
+    display: string
+    tooltip: string
+    class?: string
+  }
+
+  let { display, tooltip, class: className = '' }: Props = $props()
+</script>
+
+<HoverTooltip {tooltip}>
+  <span class={className}>{display}</span>
+</HoverTooltip>

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
   import { onMount } from 'svelte'
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
+  import HoverTooltip from '$lib/components/hover-tooltip.svelte'
+  import type { Position } from '$lib/api/Position'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
   import { getApiBaseUrl } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
   import { formatDecimal } from '$lib/decimal'
   import { getExplorerTxUrl } from '$lib/env'
+  import { equityUsdTooltip } from '$lib/inventory-value'
 
   type TradeEvent = {
     step: string
@@ -50,21 +54,40 @@
   let sinceInput: HTMLInputElement | undefined
   let untilInput: HTMLInputElement | undefined
 
+  const positionsQuery = createQuery<Position[]>(() => ({
+    queryKey: ['positions'],
+    enabled: false
+  }))
+
+  const positionPrices = $derived(
+    new Map(
+      (positionsQuery.data ?? []).map((position) => [position.symbol, position.last_price_usdc])
+    )
+  )
+
   const venueLabel = (venue: string): string => {
     switch (venue) {
-      case 'raindex': return 'Raindex'
-      case 'alpaca': return 'Alpaca'
-      case 'dry_run': return 'DryRun'
-      default: return venue
+      case 'raindex':
+        return 'Raindex'
+      case 'alpaca':
+        return 'Alpaca'
+      case 'dry_run':
+        return 'DryRun'
+      default:
+        return venue
     }
   }
 
   const venueColor = (venue: string): string => {
     switch (venue) {
-      case 'raindex': return 'text-blue-400'
-      case 'alpaca': return 'text-amber-400'
-      case 'dry_run': return 'text-muted-foreground'
-      default: return ''
+      case 'raindex':
+        return 'text-blue-400'
+      case 'alpaca':
+        return 'text-amber-400'
+      case 'dry_run':
+        return 'text-muted-foreground'
+      default:
+        return ''
     }
   }
 
@@ -74,7 +97,7 @@
   const buildParams = (): URLSearchParams => {
     const params = new URLSearchParams({
       limit: String(PAGE_SIZE),
-      offset: String(offset.current),
+      offset: String(offset.current)
     })
 
     if (selectedVenues.current.size > 0 && selectedVenues.current.size < ALL_VENUES.length) {
@@ -108,17 +131,16 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(
-        `${baseUrl}/trades?${buildParams().toString()}`,
-        { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }
-      )
+      const response = await fetch(`${baseUrl}/trades?${buildParams().toString()}`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+      })
 
       if (!response.ok) {
         error.update(() => `HTTP ${String(response.status)}`)
         return
       }
 
-      const data: TradeResponse = await response.json() as TradeResponse
+      const data: TradeResponse = (await response.json()) as TradeResponse
       total.update(() => data.total)
       hasMore.update(() => data.hasMore)
 
@@ -135,7 +157,7 @@
         return [...merged].sort()
       })
     } catch (fetchError) {
-      error.update(() => fetchError instanceof Error ? fetchError.message : 'Unknown error')
+      error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
     } finally {
       loading.update(() => false)
       loadingMore.update(() => false)
@@ -175,9 +197,9 @@
 
   const hasFilters = $derived(
     since.current !== '' ||
-    until.current !== '' ||
-    selectedVenues.current.size < ALL_VENUES.length ||
-    selectedSymbols.current.size > 0
+      until.current !== '' ||
+      selectedVenues.current.size < ALL_VENUES.length ||
+      selectedSymbols.current.size > 0
   )
 
   onMount(() => {
@@ -185,7 +207,9 @@
     const interval = setInterval(() => {
       if (offset.current === 0) void fetchTrades('replace')
     }, POLL_INTERVAL_MS)
-    return () => { clearInterval(interval) }
+    return () => {
+      clearInterval(interval)
+    }
   })
 
   const handleVenueChange = (selected: Set<string>) => {
@@ -217,6 +241,9 @@
 
   const fmtSize = (value: string): string => formatDecimal(value, 3)
 
+  const shareTooltip = (trade: TradeEntry): string =>
+    equityUsdTooltip(trade.shares, positionPrices.get(trade.symbol) ?? null)
+
   const isNumeric = (value: unknown): boolean =>
     typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))
 
@@ -237,10 +264,9 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(
-        `${baseUrl}/trades/${trade.venue}/${trade.id}/events`,
-        { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
-      )
+      const response = await fetch(`${baseUrl}/trades/${trade.venue}/${trade.id}/events`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+      })
 
       if (!response.ok) {
         detailError.update(() => `HTTP ${String(response.status)}`)
@@ -250,7 +276,7 @@
       const data = (await response.json()) as { events: TradeEvent[] }
       detailEvents.update(() => data.events)
     } catch (err) {
-      detailError.update(() => err instanceof Error ? err.message : 'Unknown error')
+      detailError.update(() => (err instanceof Error ? err.message : 'Unknown error'))
     } finally {
       detailLoading.update(() => false)
     }
@@ -258,8 +284,7 @@
 
   // -- Detail rendering helpers --
 
-  const humanizeStep = (step: string): string =>
-    step.replace(/([A-Z])/g, ' $1').trim()
+  const humanizeStep = (step: string): string => step.replace(/([A-Z])/g, ' $1').trim()
 
   const isTxHash = (value: unknown): value is string =>
     typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value)
@@ -274,6 +299,22 @@
       if (isTimestampField(key) && typeof value === 'string') return value
     }
     return null
+  }
+
+  const formatUnknown = (value: unknown, fallback = ''): string => {
+    if (typeof value === 'string') return value
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+    return fallback
+  }
+
+  const formatPythPrice = (value: unknown): string => {
+    if (typeof value !== 'object' || value === null) return 'unavailable'
+
+    const pyth = value as Record<string, unknown>
+
+    return `$${formatDecimal(formatUnknown(pyth['value'], '0'), 3)} (conf: ${formatUnknown(
+      pyth['conf']
+    )}, expo: ${formatUnknown(pyth['expo'])})`
   }
 
   const stepStyle = (step: string): string => {
@@ -310,18 +351,35 @@
     <Card.Title class="flex items-center justify-between">
       <span class="flex items-center gap-1.5">
         Trade History
-        <span class="group relative cursor-help text-muted-foreground">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
-          <span class="pointer-events-none absolute left-0 top-full z-50 mt-1 hidden w-56 rounded bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg group-hover:block">
-            Onchain fills from Raindex orders and the corresponding Alpaca hedge trades placed to offset exposure.
-          </span>
-        </span>
+        <HoverTooltip
+          tooltip="Onchain fills from Raindex orders and the corresponding Alpaca hedge trades placed to offset exposure."
+          class="cursor-help text-muted-foreground"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            class="h-3.5 w-3.5"
+            ><path
+              fill-rule="evenodd"
+              d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+              clip-rule="evenodd"
+            /></svg
+          >
+        </HoverTooltip>
       </span>
       <div class="flex items-center gap-2">
         {#if hasFilters}
-          <button class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent" onclick={jumpToLatest}>Latest</button>
+          <button
+            class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+            onclick={jumpToLatest}>Latest</button
+          >
         {/if}
-        <button class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent" onclick={refresh} disabled={loading.current}>
+        <button
+          class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+          onclick={refresh}
+          disabled={loading.current}
+        >
           {loading.current ? 'Loading...' : 'Refresh'}
         </button>
         <span class="text-sm font-normal text-muted-foreground">
@@ -331,15 +389,28 @@
     </Card.Title>
 
     <div class="flex flex-wrap items-center gap-2 rounded-md bg-muted/30 px-2 py-1.5 text-xs">
-      <MultiSelect label="Venues" options={venueOptions} selected={selectedVenues.current} onchange={handleVenueChange} />
+      <MultiSelect
+        label="Venues"
+        options={venueOptions}
+        selected={selectedVenues.current}
+        onchange={handleVenueChange}
+      />
 
       {#if symbolOptions.length > 0}
-        <MultiSelect label="Assets" options={symbolOptions} selected={selectedSymbols.current} onchange={handleSymbolChange} />
+        <MultiSelect
+          label="Assets"
+          options={symbolOptions}
+          selected={selectedSymbols.current}
+          onchange={handleSymbolChange}
+        />
       {/if}
 
       <div class="flex items-center gap-1">
         {#each TIME_PRESETS as preset (preset.label)}
-          <button class="rounded border bg-background px-1.5 py-0.5 text-xs hover:bg-accent" onclick={applyPreset(preset.minutes)}>
+          <button
+            class="rounded border bg-background px-1.5 py-0.5 text-xs hover:bg-accent"
+            onclick={applyPreset(preset.minutes)}
+          >
             {preset.label}
           </button>
         {/each}
@@ -347,9 +418,23 @@
 
       <div class="flex items-center gap-1 text-muted-foreground">
         <span>From (UTC)</span>
-        <input bind:this={sinceInput} type="datetime-local" class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground" style="color-scheme: dark" onchange={handleSinceChange} step="1" />
+        <input
+          bind:this={sinceInput}
+          type="datetime-local"
+          class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+          style="color-scheme: dark"
+          onchange={handleSinceChange}
+          step="1"
+        />
         <span>to (UTC)</span>
-        <input bind:this={untilInput} type="datetime-local" class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground" style="color-scheme: dark" onchange={handleUntilChange} step="1" />
+        <input
+          bind:this={untilInput}
+          type="datetime-local"
+          class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+          style="color-scheme: dark"
+          onchange={handleUntilChange}
+          step="1"
+        />
       </div>
     </div>
   </Card.Header>
@@ -360,9 +445,7 @@
         Failed to load trades: {error.current}
       </div>
     {:else if entries.current.length === 0 && !loading.current}
-      <div class="flex h-full items-center justify-center text-muted-foreground">
-        No trades yet
-      </div>
+      <div class="flex h-full items-center justify-center text-muted-foreground">No trades yet</div>
     {:else}
       <Table.Root>
         <Table.Header>
@@ -384,8 +467,17 @@
                   title="View trade details"
                   onclick={() => openDetail(trade)}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-                    <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    class="h-3.5 w-3.5"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+                      clip-rule="evenodd"
+                    />
                   </svg>
                 </button>
               </Table.Cell>
@@ -393,11 +485,20 @@
                 {formatUtc(trade.filledAt)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs font-medium">{trade.symbol}</Table.Cell>
-              <Table.Cell class="text-right text-xs font-medium {venueColor(trade.venue)}">{venueLabel(trade.venue)}</Table.Cell>
+              <Table.Cell class="text-right text-xs font-medium {venueColor(trade.venue)}"
+                >{venueLabel(trade.venue)}</Table.Cell
+              >
               <Table.Cell class="text-right text-xs font-medium {directionColor(trade.direction)}">
                 {trade.direction}
               </Table.Cell>
-              <Table.Cell class="text-center font-mono text-xs">{fmtSize(trade.shares)}</Table.Cell>
+              <Table.Cell class="text-center font-mono text-xs">
+                <HoverTooltip tooltip={shareTooltip(trade)}>
+                  <span
+                    class="cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4"
+                    >{fmtSize(trade.shares)}</span
+                  >
+                </HoverTooltip>
+              </Table.Cell>
             </Table.Row>
           {/each}
         </Table.Body>
@@ -405,13 +506,19 @@
 
       {#if hasMore.current}
         <div class="flex justify-center py-2">
-          <button class="rounded border bg-background px-3 py-1 text-xs hover:bg-accent" onclick={loadMore} disabled={loadingMore.current}>
+          <button
+            class="rounded border bg-background px-3 py-1 text-xs hover:bg-accent"
+            onclick={loadMore}
+            disabled={loadingMore.current}
+          >
             {loadingMore.current ? 'Loading...' : 'Load older trades'}
           </button>
         </div>
       {/if}
 
-      <div class="pointer-events-none sticky bottom-0 h-8 bg-gradient-to-t from-card to-transparent"></div>
+      <div
+        class="pointer-events-none sticky bottom-0 h-8 bg-gradient-to-t from-card to-transparent"
+      ></div>
     {/if}
   </Card.Content>
 </Card.Root>
@@ -419,7 +526,9 @@
 <dialog
   bind:this={detailDialogEl}
   class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
-  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl.close() }}
+  onclick={(event) => {
+    if (event.target === detailDialogEl) detailDialogEl.close()
+  }}
 >
   {#if detailTrade.current}
     {@const trade = detailTrade.current}
@@ -427,7 +536,12 @@
       <div class="flex items-center gap-2 text-sm font-semibold">
         <span class={directionColor(trade.direction)}>{trade.direction}</span>
         <span class="font-mono text-xs font-normal">{trade.symbol}</span>
-        <span class="font-mono text-xs font-normal text-muted-foreground">{fmtSize(trade.shares)} shares</span>
+        <HoverTooltip tooltip={shareTooltip(trade)}>
+          <span
+            class="cursor-help font-mono text-xs font-normal text-muted-foreground hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4"
+            >{fmtSize(trade.shares)} shares</span
+          >
+        </HoverTooltip>
         <span class="text-xs font-normal {venueColor(trade.venue)}">{venueLabel(trade.venue)}</span>
       </div>
       <button
@@ -462,9 +576,18 @@
                 class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
               >
                 {txHash.slice(0, 10)}...{txHash.slice(-8)}
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
-                  <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
-                  <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  class="h-3 w-3"
+                >
+                  <path
+                    d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                  />
+                  <path
+                    d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                  />
                 </svg>
               </a>
               <span class="text-muted-foreground">(log {logIndex})</span>
@@ -483,10 +606,16 @@
         <div class="relative space-y-0 border-l-2 border-muted pl-4">
           {#each detailEvents.current as event (event.sequence)}
             {@const timestamp = extractTimestamp(event.payload)}
-            {@const fields = Object.entries(event.payload).filter(([key]) => !isTimestampField(key))}
+            {@const fields = Object.entries(event.payload).filter(
+              ([key]) => !isTimestampField(key)
+            )}
             <div class="relative pb-4">
               <!-- Timeline dot -->
-              <div class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepDot(event.step)}"></div>
+              <div
+                class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepDot(
+                  event.step
+                )}"
+              ></div>
 
               <div class="text-xs font-medium {stepStyle(event.step)}">
                 {humanizeStep(event.step)}
@@ -514,16 +643,24 @@
                             class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
                           >
                             {value.slice(0, 10)}...{value.slice(-8)}
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
-                              <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
-                              <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 16 16"
+                              fill="currentColor"
+                              class="h-3 w-3"
+                            >
+                              <path
+                                d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                              />
+                              <path
+                                d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                              />
                             </svg>
                           </a>
                         {:else if key === 'executor_order_id' && typeof value === 'object' && value !== null}
                           <span class="text-muted-foreground">{JSON.stringify(value)}</span>
                         {:else if key === 'pyth_price' && typeof value === 'object' && value !== null}
-                          {@const pyth = value as Record<string, string | number>}
-                          <span>${formatDecimal(String(pyth['value'] ?? '0'), 3)} (conf: {String(pyth['conf'] ?? '')}, expo: {String(pyth['expo'] ?? '')})</span>
+                          <span>{formatPythPrice(value)}</span>
                         {:else if typeof value === 'object' && value !== null}
                           {JSON.stringify(value)}
                         {:else if isNumeric(value)}

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query'
   import { onMount } from 'svelte'
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
+  import HoverTooltip from '$lib/components/hover-tooltip.svelte'
+  import type { Position } from '$lib/api/Position'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
   import { getApiBaseUrl, getExplorerTxUrl } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
   import { formatDecimal } from '$lib/decimal'
+  import { cashUsdTooltip, equityUsdTooltip } from '$lib/inventory-value'
   import {
     kindLabel,
     statusStyle,
@@ -17,10 +21,22 @@
     formatFieldName,
     extractTimestamp,
     detailFields,
+    apiErrorStatus
   } from '$lib/transfer'
 
   const isNumeric = (value: unknown): boolean =>
     typeof value === 'string' && value !== '' && !Number.isNaN(Number(value))
+
+  const transferAmount = (transfer: TransferEntry): string | null =>
+    transfer.quantity ?? transfer.amount ?? null
+
+  const transferAmountTooltip = (transfer: TransferEntry): string => {
+    if (transfer.quantity) {
+      return equityUsdTooltip(transfer.quantity, positionPrices.get(transfer.symbol ?? '') ?? null)
+    }
+    if (transfer.amount) return cashUsdTooltip(transfer.amount)
+    return ''
+  }
 
   type TransferEntry = {
     kind: string
@@ -64,12 +80,23 @@
   let sinceInput: HTMLInputElement | undefined
   let untilInput: HTMLInputElement | undefined
 
+  const positionsQuery = createQuery<Position[]>(() => ({
+    queryKey: ['positions'],
+    enabled: false
+  }))
+
+  const positionPrices = $derived(
+    new Map(
+      (positionsQuery.data ?? []).map((position) => [position.symbol, position.last_price_usdc])
+    )
+  )
+
   const kindOptions = ALL_KINDS.map((kind) => ({ value: kind, label: kindLabel(kind) }))
 
   const buildParams = (): URLSearchParams => {
     const params = new URLSearchParams({
       limit: String(PAGE_SIZE),
-      offset: String(offset.current),
+      offset: String(offset.current)
     })
 
     if (selectedKinds.current.size > 0 && selectedKinds.current.size < ALL_KINDS.length) {
@@ -99,17 +126,16 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(
-        `${baseUrl}/transfers?${buildParams().toString()}`,
-        { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }
-      )
+      const response = await fetch(`${baseUrl}/transfers?${buildParams().toString()}`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+      })
 
       if (!response.ok) {
         error.update(() => `HTTP ${String(response.status)}`)
         return
       }
 
-      const data: TransferResponse = await response.json() as TransferResponse
+      const data: TransferResponse = (await response.json()) as TransferResponse
       total.update(() => data.total)
       hasMore.update(() => data.hasMore)
 
@@ -119,7 +145,7 @@
         entries.update(() => data.entries)
       }
     } catch (fetchError) {
-      error.update(() => fetchError instanceof Error ? fetchError.message : 'Unknown error')
+      error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
     } finally {
       loading.update(() => false)
       loadingMore.update(() => false)
@@ -157,9 +183,7 @@
   }
 
   const hasFilters = $derived(
-    since.current !== '' ||
-    until.current !== '' ||
-    selectedKinds.current.size < ALL_KINDS.length
+    since.current !== '' || until.current !== '' || selectedKinds.current.size < ALL_KINDS.length
   )
 
   onMount(() => {
@@ -167,7 +191,9 @@
     const interval = setInterval(() => {
       if (offset.current === 0) void fetchTransfers('replace')
     }, POLL_INTERVAL_MS)
-    return () => { clearInterval(interval) }
+    return () => {
+      clearInterval(interval)
+    }
   })
 
   const handleKindChange = (selected: Set<string>) => {
@@ -213,15 +239,9 @@
 
     try {
       const baseUrl = getApiBaseUrl()
-      const response = await fetch(
-        `${baseUrl}/transfers/${transfer.kind}/${transfer.id}/events`,
-        {
-          signal: AbortSignal.any([
-            controller.signal,
-            AbortSignal.timeout(FETCH_TIMEOUT_MS),
-          ]),
-        },
-      )
+      const response = await fetch(`${baseUrl}/transfers/${transfer.kind}/${transfer.id}/events`, {
+        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
+      })
 
       if (isAborted()) return
 
@@ -237,14 +257,13 @@
       detailEvents.update(() => data.events)
     } catch (err) {
       if (isAborted()) return
-      detailError.update(() => err instanceof Error ? err.message : 'Unknown error')
+      detailError.update(() => (err instanceof Error ? err.message : 'Unknown error'))
     } finally {
       if (!isAborted()) {
         detailLoading.update(() => false)
       }
     }
   }
-
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-purple-500/50">
@@ -252,18 +271,35 @@
     <Card.Title class="flex items-center justify-between">
       <span class="flex items-center gap-1.5">
         Cross-venue Transfers
-        <span class="group relative cursor-help text-muted-foreground">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
-          <span class="pointer-events-none absolute left-0 top-full z-50 mt-1 hidden w-64 rounded bg-popover px-3 py-2 text-xs font-normal text-popover-foreground shadow-lg group-hover:block">
-            Asset movements between venues to rebalance inventory: equity mints (Alpaca to onchain), redemptions (onchain to Alpaca), and USDC bridges (Base/Ethereum via CCTP).
-          </span>
-        </span>
+        <HoverTooltip
+          tooltip="Asset movements between venues to rebalance inventory: equity mints (Alpaca to onchain), redemptions (onchain to Alpaca), and USDC bridges (Base/Ethereum via CCTP)."
+          class="cursor-help text-muted-foreground"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            class="h-3.5 w-3.5"
+            ><path
+              fill-rule="evenodd"
+              d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+              clip-rule="evenodd"
+            /></svg
+          >
+        </HoverTooltip>
       </span>
       <div class="flex items-center gap-2">
         {#if hasFilters}
-          <button class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent" onclick={jumpToLatest}>Latest</button>
+          <button
+            class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+            onclick={jumpToLatest}>Latest</button
+          >
         {/if}
-        <button class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent" onclick={refresh} disabled={loading.current}>
+        <button
+          class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+          onclick={refresh}
+          disabled={loading.current}
+        >
           {loading.current ? 'Loading...' : 'Refresh'}
         </button>
         <span class="text-sm font-normal text-muted-foreground">
@@ -273,11 +309,19 @@
     </Card.Title>
 
     <div class="flex flex-wrap items-center gap-2 rounded-md bg-muted/30 px-2 py-1.5 text-xs">
-      <MultiSelect label="Type" options={kindOptions} selected={selectedKinds.current} onchange={handleKindChange} />
+      <MultiSelect
+        label="Type"
+        options={kindOptions}
+        selected={selectedKinds.current}
+        onchange={handleKindChange}
+      />
 
       <div class="flex items-center gap-1">
         {#each TIME_PRESETS as preset (preset.label)}
-          <button class="rounded border bg-background px-1.5 py-0.5 text-xs hover:bg-accent" onclick={applyPreset(preset.minutes)}>
+          <button
+            class="rounded border bg-background px-1.5 py-0.5 text-xs hover:bg-accent"
+            onclick={applyPreset(preset.minutes)}
+          >
             {preset.label}
           </button>
         {/each}
@@ -285,9 +329,23 @@
 
       <div class="flex items-center gap-1 text-muted-foreground">
         <span>From (UTC)</span>
-        <input bind:this={sinceInput} type="datetime-local" class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground" style="color-scheme: dark" onchange={handleSinceChange} step="1" />
+        <input
+          bind:this={sinceInput}
+          type="datetime-local"
+          class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+          style="color-scheme: dark"
+          onchange={handleSinceChange}
+          step="1"
+        />
         <span>to (UTC)</span>
-        <input bind:this={untilInput} type="datetime-local" class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground" style="color-scheme: dark" onchange={handleUntilChange} step="1" />
+        <input
+          bind:this={untilInput}
+          type="datetime-local"
+          class="rounded border bg-background px-1.5 py-0.5 text-xs text-foreground"
+          style="color-scheme: dark"
+          onchange={handleUntilChange}
+          step="1"
+        />
       </div>
     </div>
   </Card.Header>
@@ -298,9 +356,7 @@
         Failed to load transfers: {error.current}
       </div>
     {:else if entries.current.length === 0 && !loading.current}
-      <div class="flex h-full items-center justify-center text-muted-foreground">
-        No transfers
-      </div>
+      <div class="flex h-full items-center justify-center text-muted-foreground">No transfers</div>
     {:else}
       <Table.Root>
         <Table.Header>
@@ -316,9 +372,21 @@
                 <button
                   class="text-muted-foreground hover:text-foreground"
                   aria-label="Show status legend"
-                  onclick={() => { statusInfoOpen = !statusInfoOpen }}
+                  onclick={() => {
+                    statusInfoOpen = !statusInfoOpen
+                  }}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5"><path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" /></svg>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    class="h-3.5 w-3.5"
+                    ><path
+                      fill-rule="evenodd"
+                      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+                      clip-rule="evenodd"
+                    /></svg
+                  >
                 </button>
               </span>
             </Table.Head>
@@ -336,8 +404,17 @@
                   title="View event history"
                   onclick={() => openDetail(transfer)}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-3.5 w-3.5">
-                    <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    class="h-3.5 w-3.5"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z"
+                      clip-rule="evenodd"
+                    />
                   </svg>
                 </button>
               </Table.Cell>
@@ -348,10 +425,18 @@
                 {kindLabel(transfer.kind)}
               </Table.Cell>
               <Table.Cell class="font-mono text-xs">
-                {transfer.kind === 'usdc_bridge' ? 'USDC' : transfer.symbol ?? ''}
+                {transfer.kind === 'usdc_bridge' ? 'USDC' : (transfer.symbol ?? '')}
               </Table.Cell>
               <Table.Cell class="text-right font-mono text-xs">
-                {#if transfer.quantity}{formatDecimal(transfer.quantity, 3)}{:else if transfer.amount}{formatDecimal(transfer.amount, 3)}{/if}
+                {@const amount = transferAmount(transfer)}
+                {#if amount}
+                  <HoverTooltip tooltip={transferAmountTooltip(transfer)}>
+                    <span
+                      class="cursor-help hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4"
+                      >{formatDecimal(amount, 3)}</span
+                    >
+                  </HoverTooltip>
+                {/if}
               </Table.Cell>
               <Table.Cell class="text-right text-xs {style.text}">
                 <span class="inline-flex items-center gap-1.5">
@@ -369,13 +454,19 @@
 
       {#if hasMore.current}
         <div class="flex justify-center py-2">
-          <button class="rounded border bg-background px-3 py-1 text-xs hover:bg-accent" onclick={loadMore} disabled={loadingMore.current}>
+          <button
+            class="rounded border bg-background px-3 py-1 text-xs hover:bg-accent"
+            onclick={loadMore}
+            disabled={loadingMore.current}
+          >
             {loadingMore.current ? 'Loading...' : 'Load older transfers'}
           </button>
         </div>
       {/if}
 
-      <div class="pointer-events-none sticky bottom-0 h-8 bg-gradient-to-t from-card to-transparent"></div>
+      <div
+        class="pointer-events-none sticky bottom-0 h-8 bg-gradient-to-t from-card to-transparent"
+      ></div>
     {/if}
   </Card.Content>
 </Card.Root>
@@ -384,10 +475,16 @@
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 z-40"
-    onclick={() => { statusInfoOpen = false }}
-    onkeydown={(event) => { if (event.key === 'Escape') statusInfoOpen = false }}
+    onclick={() => {
+      statusInfoOpen = false
+    }}
+    onkeydown={(event) => {
+      if (event.key === 'Escape') statusInfoOpen = false
+    }}
   ></div>
-  <div class="fixed right-8 top-1/3 z-50 w-64 rounded-lg border bg-popover px-4 py-3 text-xs text-popover-foreground shadow-lg">
+  <div
+    class="fixed right-8 top-1/3 z-50 w-64 rounded-lg border bg-popover px-4 py-3 text-xs text-popover-foreground shadow-lg"
+  >
     <div class="mb-2 font-semibold">Status flows by type</div>
 
     <div class="mb-1.5">
@@ -397,39 +494,52 @@
 
     <div class="mb-1.5">
       <div class="mb-0.5 font-medium text-muted-foreground">Redeem</div>
-      <div>Withdrawing → Unwrapping → Sending → Pending Confirmation → <span class="text-green-500">Completed</span></div>
+      <div>
+        Withdrawing → Unwrapping → Sending → Pending Confirmation → <span class="text-green-500"
+          >Completed</span
+        >
+      </div>
     </div>
 
     <div class="mb-1.5">
       <div class="mb-0.5 font-medium text-muted-foreground">USDC Bridge</div>
-      <div>Converting → Withdrawing → Bridging → Depositing → <span class="text-green-500">Completed</span></div>
+      <div>
+        Converting → Withdrawing → Bridging → Depositing → <span class="text-green-500"
+          >Completed</span
+        >
+      </div>
     </div>
 
-    <div class="text-muted-foreground">Any step can transition to <span class="text-destructive">Failed</span></div>
+    <div class="text-muted-foreground">
+      Any step can transition to <span class="text-destructive">Failed</span>
+    </div>
   </div>
 {/if}
 
 <dialog
   bind:this={detailDialogEl}
   class="w-full max-w-lg rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
-  onclick={(event) => { if (event.target === detailDialogEl) detailDialogEl.close() }}
+  onclick={(event) => {
+    if (event.target === detailDialogEl) detailDialogEl.close()
+  }}
 >
   {#if detailTransfer.current}
     {@const transfer = detailTransfer.current}
+    {@const amount = transferAmount(transfer)}
     <div class="flex items-center justify-between border-b px-5 py-3">
       <div class="flex items-center gap-2 text-sm font-semibold">
         <span>{kindLabel(transfer.kind)}</span>
         <span class="font-mono text-xs font-normal text-muted-foreground">
-          {transfer.kind === 'usdc_bridge' ? 'USDC' : transfer.symbol ?? ''}
+          {transfer.kind === 'usdc_bridge' ? 'USDC' : (transfer.symbol ?? '')}
         </span>
-        {#if transfer.quantity}
-          <span class="font-mono text-xs font-normal text-muted-foreground">
-            {formatDecimal(transfer.quantity, 3)}
-          </span>
-        {:else if transfer.amount}
-          <span class="font-mono text-xs font-normal text-muted-foreground">
-            {formatDecimal(transfer.amount, 3)}
-          </span>
+        {#if amount}
+          <HoverTooltip tooltip={transferAmountTooltip(transfer)}>
+            <span
+              class="cursor-help font-mono text-xs font-normal text-muted-foreground hover:underline hover:decoration-dotted hover:decoration-muted-foreground hover:underline-offset-4"
+            >
+              {formatDecimal(amount, 3)}
+            </span>
+          </HoverTooltip>
         {/if}
       </div>
       <button
@@ -457,7 +567,9 @@
             {@const fields = detailFields(event.payload)}
             <div class="relative pb-4">
               <!-- Timeline dot -->
-              <div class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepStyle.dot}"></div>
+              <div
+                class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepStyle.dot}"
+              ></div>
 
               <div class="text-xs font-medium {stepStyle.text}">
                 {humanizeStep(event.step)}
@@ -481,7 +593,8 @@
                           <span class="text-destructive">
                             {#if typeof value === 'object' && value !== null}
                               {#if 'ApiError' in value}
-                                API error{@const apiErr = value as Record<string, unknown>}{#if apiErr['status_code']} (status {apiErr['status_code']}){/if}
+                                API error{@const status = apiErrorStatus(value)}{#if status}
+                                  (status {status}){/if}
                               {:else if 'Timeout' in value}
                                 Timeout
                               {:else}
@@ -501,9 +614,18 @@
                             class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
                           >
                             {value.slice(0, 10)}...{value.slice(-8)}
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
-                              <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
-                              <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 16 16"
+                              fill="currentColor"
+                              class="h-3 w-3"
+                            >
+                              <path
+                                d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                              />
+                              <path
+                                d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                              />
                             </svg>
                           </a>
                         {:else if isTransferRef(value)}
@@ -516,9 +638,18 @@
                               class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
                             >
                               {txHash.slice(0, 10)}...{txHash.slice(-8)}
-                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-3 w-3">
-                                <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
-                                <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                                class="h-3 w-3"
+                              >
+                                <path
+                                  d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                                />
+                                <path
+                                  d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                                />
                               </svg>
                             </a>
                           {:else if 'AlpacaId' in value}

--- a/dashboard/src/lib/inventory-value.test.ts
+++ b/dashboard/src/lib/inventory-value.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { cashUsdTooltip, equityUsdTooltip, positionSharesTooltip } from './inventory-value'
+
+describe('cashUsdTooltip', () => {
+  it('formats cash inventory as USD', () => {
+    expect(cashUsdTooltip('1234.5')).toBe('Current USD value: $1,234.50')
+  })
+
+  it('does not include the full amount when display was truncated', () => {
+    expect(cashUsdTooltip('1.234567')).toBe('Current USD value: $1.23')
+  })
+})
+
+describe('equityUsdTooltip', () => {
+  it('multiplies shares by the latest USDC price', () => {
+    expect(equityUsdTooltip('3.5', '187.25')).toBe('Current USD value: $655.38')
+  })
+
+  it('reports missing price data instead of guessing', () => {
+    expect(equityUsdTooltip('3.5', null)).toBe(
+      'Current USD value unavailable: missing latest price'
+    )
+  })
+})
+
+describe('positionSharesTooltip', () => {
+  it('shows the underlying signed stock amount', () => {
+    expect(positionSharesTooltip('-1.2500')).toBe('Stock amount: -1.25 shares')
+  })
+})

--- a/dashboard/src/lib/inventory-value.ts
+++ b/dashboard/src/lib/inventory-value.ts
@@ -1,0 +1,33 @@
+import Decimal from 'decimal.js'
+
+const toDecimal = (value: string): Decimal => new Decimal(value !== '' ? value : '0')
+
+const withCommas = (value: string): string => value.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+
+const formatUsd = (value: Decimal): string => {
+  const abs = value.abs().toFixed(2)
+  const [intPart = '0', fracPart = '00'] = abs.split('.')
+  const prefix = value.isNegative() ? '-' : ''
+
+  return `${prefix}$${withCommas(intPart)}.${fracPart}`
+}
+
+const trimTrailingZeros = (value: string): string => {
+  if (!value.includes('.')) return value
+
+  return value.replace(/0+$/, '').replace(/\.$/, '')
+}
+
+export const cashUsdTooltip = (amount: string): string =>
+  `Current USD value: ${formatUsd(toDecimal(amount))}`
+
+export const equityUsdTooltip = (shares: string, priceUsdc: string | null): string => {
+  if (priceUsdc === null) {
+    return 'Current USD value unavailable: missing latest price'
+  }
+
+  return `Current USD value: ${formatUsd(toDecimal(shares).mul(toDecimal(priceUsdc)))}`
+}
+
+export const positionSharesTooltip = (shares: string): string =>
+  `Stock amount: ${trimTrailingZeros(toDecimal(shares).toFixed(18))} shares`

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  statusStyle,
-  isTxHash,
-  extractTimestamp,
-  detailFields,
-} from './transfer'
+import { statusStyle, isTxHash, extractTimestamp, detailFields, apiErrorStatus } from './transfer'
 
 describe('statusStyle', () => {
   it('matches completed substring case-insensitively', () => {
@@ -60,16 +55,18 @@ describe('extractTimestamp', () => {
     // Object.entries order matters -- first _at field wins
     const result = extractTimestamp({
       submitted_at: '2024-01-01T00:00:00Z',
-      confirmed_at: '2024-01-02T00:00:00Z',
+      confirmed_at: '2024-01-02T00:00:00Z'
     })
     expect(result).toBe('2024-01-01T00:00:00Z')
   })
 
   it('skips _at fields with non-string values', () => {
-    expect(extractTimestamp({
-      created_at: 1234567890,
-      confirmed_at: '2024-06-15T00:00:00Z',
-    })).toBe('2024-06-15T00:00:00Z')
+    expect(
+      extractTimestamp({
+        created_at: 1234567890,
+        confirmed_at: '2024-06-15T00:00:00Z'
+      })
+    ).toBe('2024-06-15T00:00:00Z')
   })
 
   it('returns null when no _at fields exist', () => {
@@ -88,11 +85,11 @@ describe('detailFields', () => {
       created_at: '2024-01-01T00:00:00Z',
       attestation: 'long-blob',
       tx_hash: '0xabc',
-      confirmed_at: '2024-01-02T00:00:00Z',
+      confirmed_at: '2024-01-02T00:00:00Z'
     })
     expect(result).toEqual([
       ['amount', '100'],
-      ['tx_hash', '0xabc'],
+      ['tx_hash', '0xabc']
     ])
   })
 
@@ -100,15 +97,46 @@ describe('detailFields', () => {
     const result = detailFields({ z_field: '1', a_field: '2' })
     expect(result).toEqual([
       ['z_field', '1'],
-      ['a_field', '2'],
+      ['a_field', '2']
     ])
   })
 
   it('returns empty when all fields are filtered', () => {
-    expect(detailFields({
-      created_at: '2024-01-01',
-      attestation: 'x',
-      submitted_at: 'y',
-    })).toEqual([])
+    expect(
+      detailFields({
+        created_at: '2024-01-01',
+        attestation: 'x',
+        submitted_at: 'y'
+      })
+    ).toEqual([])
+  })
+})
+
+describe('apiErrorStatus', () => {
+  it('reads status_code from the nested ApiError payload', () => {
+    expect(apiErrorStatus({ ApiError: { status_code: 404 } })).toBe('404')
+  })
+
+  it('stringifies a numeric status_code', () => {
+    expect(apiErrorStatus({ ApiError: { status_code: 500 } })).toBe('500')
+  })
+
+  it('passes through a string status_code', () => {
+    expect(apiErrorStatus({ ApiError: { status_code: '403' } })).toBe('403')
+  })
+
+  it('returns null when status_code is absent (None)', () => {
+    expect(apiErrorStatus({ ApiError: { status_code: null } })).toBeNull()
+    expect(apiErrorStatus({ ApiError: {} })).toBeNull()
+  })
+
+  it('returns null when the ApiError payload is missing', () => {
+    expect(apiErrorStatus({ Timeout: null })).toBeNull()
+    expect(apiErrorStatus({ status_code: 404 })).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(apiErrorStatus(null)).toBeNull()
+    expect(apiErrorStatus('ApiError')).toBeNull()
   })
 })

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -5,10 +5,14 @@ export type StatusStyle = {
 
 export const kindLabel = (kind: string): string => {
   switch (kind) {
-    case 'equity_mint': return 'Mint'
-    case 'equity_redemption': return 'Redeem'
-    case 'usdc_bridge': return 'USDC Bridge'
-    default: return kind
+    case 'equity_mint':
+      return 'Mint'
+    case 'equity_redemption':
+      return 'Redeem'
+    case 'usdc_bridge':
+      return 'USDC Bridge'
+    default:
+      return kind
   }
 }
 
@@ -35,8 +39,7 @@ export const humanizeStatus = (status: string): string =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 
-export const humanizeStep = (step: string): string =>
-  step.replace(/([A-Z])/g, ' $1').trim()
+export const humanizeStep = (step: string): string => step.replace(/([A-Z])/g, ' $1').trim()
 
 export const isTxHash = (value: unknown): value is string =>
   typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value)
@@ -46,9 +49,7 @@ const SKIP_FIELDS = new Set(['attestation'])
 export const isTimestampField = (key: string): boolean => key.endsWith('_at')
 
 export const isTransferRef = (value: unknown): value is Record<string, string> =>
-  typeof value === 'object' &&
-  value !== null &&
-  ('AlpacaId' in value || 'OnchainTx' in value)
+  typeof value === 'object' && value !== null && ('AlpacaId' in value || 'OnchainTx' in value)
 
 export const formatFieldName = (key: string): string =>
   key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
@@ -61,6 +62,21 @@ export const extractTimestamp = (payload: Record<string, unknown>): string | nul
 }
 
 export const detailFields = (payload: Record<string, unknown>): Array<[string, unknown]> =>
-  Object.entries(payload).filter(
-    ([key]) => !isTimestampField(key) && !SKIP_FIELDS.has(key),
-  )
+  Object.entries(payload).filter(([key]) => !isTimestampField(key) && !SKIP_FIELDS.has(key))
+
+// `failure` is the externally-tagged DetectionFailure enum, so an ApiError
+// serializes as `{ ApiError: { status_code } }`. The status lives in the nested
+// payload, not on the wrapper, so unwrap before reading it.
+export const apiErrorStatus = (value: unknown): string | null => {
+  if (typeof value !== 'object' || value === null) return null
+
+  const payload = (value as Record<string, unknown>)['ApiError']
+
+  if (typeof payload !== 'object' || payload === null) return null
+
+  const status = (payload as Record<string, unknown>)['status_code']
+
+  if (typeof status === 'string') return status
+  if (typeof status === 'number') return String(status)
+  return null
+}


### PR DESCRIPTION
## What

[RAI-632](https://linear.app/makeitrain/issue/RAI-632/dashboard-inventory-numbers-should-show-alternate-value-on-hover)

Adds hover titles to inventory table numbers so operators can see the alternate unit without adding more columns:

- cash balances show their current USD value
- equity/share balances show current USD value using the latest position price
- exposure, which is already USD-denominated, shows the underlying signed stock amount

![CleanShot 2026-05-25 at 12.11.10@2x.png](https://app.graphite.com/user-attachments/assets/97a79f94-0948-432b-8fee-ae09587cedb2.png)

## Why

The inventory table mixes shares, USDC, and USD-denominated exposure. Hovering should make the alternate interpretation available without increasing table density.

## How

Adds a small Decimal-based dashboard helper for cash, equity, and position hover text. `available-inventory.svelte` now keeps position net and price strings around for tooltip math while preserving the existing displayed values and precision truncation behavior.

## Testing

- `nix develop -c sh -lc 'cd dashboard && bun test:run src/lib/inventory-value.test.ts && bun run check && bun run lint && bunx prettier --check src/lib/inventory-value.ts src/lib/inventory-value.test.ts'`
- `nix develop -c sh -lc 'cd dashboard && bun test:run src'`

Note: `cd dashboard && bun test:run` without a source path currently discovers `.tmp/rain-math-float` upstream tests and fails outside the dashboard source tree.

## Screenshots

Not captured.

## Anything else

The repo-local `nix run .#st0x-dto -- dashboard/src/lib/api` path is currently blocked by a flake input revision lookup for `ST0x-Technology/event-sorcery`; the DTO export test still regenerated the local generated API bindings successfully during verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global hover-tooltips added across dashboard for inventory, positions, trade history, and transfers
  * New compact display component for inventory values and richer USD/share tooltips

* **Bug Fixes**
  * Clearer error/status formatting in transfer and trade flows
  * Safer handling of nullable pricing and position data to avoid display errors

* **Tests**
  * Added tests for cash/equity/share tooltip formatting utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->