### PR TITLE
feat: surface stranded equity recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,9 @@ nix develop .#ci-backend -c cargo clippy --workspace --all-targets --all-feature
 
 `nix run .#simulate` launches a full local simulation of the market making
 system using [mprocs](https://github.com/pvolok/mprocs) to run the dashboard and
-the bot side-by-side.
+the bot side-by-side. `nix run .#simulate-failures` starts the same stack, then
+creates failed mint and redemption rebalances whose mock Alpaca provider later
+completes and prints the `recheck-transfer` commands that recover them.
 
 What it does:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2012,6 +2012,19 @@ know about cross-venue inventory.
   `DetectionFailed` (ownership dropped so polls stop counting the stranded
   request and rebalancing resumes), while operators resolve the actual asset
   location manually
+- Failed equity transfer detail views surface the stranded quantity when the
+  terminal failure happened after equity left the bot's normal available
+  balance. Operators can run a targeted re-check command for a specific failed
+  mint or redemption aggregate; if the tokenization provider now reports the
+  request completed, the aggregate records recovery events and transitions to
+  the same success terminal as the normal flow. Pending, rejected, or missing
+  provider requests leave the aggregate unchanged. Recovery runs in-process via
+  the bot's REST API (`POST /transfers/recheck/<kind>/<id>`) so the recovery
+  event dispatches through the inventory reactor (applying the same inventory
+  effect as the successful flow) under the shared resume lock. Mint recovery
+  applies only to acceptance-stage failures (tokens never received); a mint that
+  failed after receiving tokens is reported as not recoverable so recovery never
+  re-wraps tokens that already moved.
 - `UsdcRebalanceEvent::WithdrawalConfirmed` - Moves USDC to inflight (leaving
   source)
 - `UsdcRebalanceEvent::DepositConfirmed` - Terminal success for AlpacaToBase;

--- a/crates/execution/src/alpaca_broker_api/auth.rs
+++ b/crates/execution/src/alpaca_broker_api/auth.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -29,8 +30,7 @@ impl FromStr for AlpacaAccountId {
 }
 
 /// Mode for Alpaca Broker API
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AlpacaBrokerApiMode {
     /// Sandbox environment (paper trading)
     Sandbox,
@@ -38,8 +38,85 @@ pub enum AlpacaBrokerApiMode {
     Production,
     /// Mock mode for testing (available via `mock` feature or in tests)
     #[cfg(any(test, feature = "mock"))]
-    #[serde(skip_deserializing)]
     Mock(String),
+}
+
+impl<'de> Deserialize<'de> for AlpacaBrokerApiMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(AlpacaBrokerApiModeVisitor)
+    }
+}
+
+struct AlpacaBrokerApiModeVisitor;
+
+impl<'de> Visitor<'de> for AlpacaBrokerApiModeVisitor {
+    type Value = AlpacaBrokerApiMode;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .write_str("\"sandbox\", \"production\", or { type = \"mock\", base_url = \"...\" }")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        match value {
+            "sandbox" => Ok(AlpacaBrokerApiMode::Sandbox),
+            "production" => Ok(AlpacaBrokerApiMode::Production),
+            #[cfg(any(test, feature = "mock"))]
+            "mock" => Err(E::custom(
+                "mock mode requires { type = \"mock\", base_url = \"...\" }",
+            )),
+            #[cfg(not(any(test, feature = "mock")))]
+            "mock" => Err(E::custom("mock mode requires the mock feature")),
+            _ => Err(E::unknown_variant(value, &["sandbox", "production"])),
+        }
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut mode_type = None;
+        // `base_url` is only meaningful for the mock variant, which is
+        // feature-gated. Without the mock feature the value is consumed and
+        // discarded so parsing still succeeds (and yields the clearer
+        // "mock mode requires the mock feature" error below).
+        #[cfg(any(test, feature = "mock"))]
+        let mut base_url = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "type" => mode_type = Some(map.next_value::<String>()?),
+                #[cfg(any(test, feature = "mock"))]
+                "base_url" => base_url = Some(map.next_value::<String>()?),
+                #[cfg(not(any(test, feature = "mock")))]
+                "base_url" => {
+                    map.next_value::<de::IgnoredAny>()?;
+                }
+                _ => return Err(de::Error::unknown_field(&key, &["type", "base_url"])),
+            }
+        }
+
+        match mode_type.as_deref() {
+            #[cfg(any(test, feature = "mock"))]
+            Some("mock") => {
+                let base_url = base_url.ok_or_else(|| de::Error::missing_field("base_url"))?;
+                Ok(AlpacaBrokerApiMode::Mock(base_url))
+            }
+            #[cfg(not(any(test, feature = "mock")))]
+            Some("mock") => Err(de::Error::custom("mock mode requires the mock feature")),
+            Some(other) => Err(de::Error::unknown_variant(
+                other,
+                &["sandbox", "production", "mock"],
+            )),
+            None => Err(de::Error::missing_field("type")),
+        }
+    }
 }
 
 impl AlpacaBrokerApiMode {
@@ -193,6 +270,66 @@ mod tests {
         assert_eq!(
             production_ctx.base_url(),
             "https://broker-api.alpaca.markets"
+        );
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_deserializes_mock_table() {
+        let mode: AlpacaBrokerApiMode =
+            serde_json::from_str(r#"{"type":"mock","base_url":"http://127.0.0.1:1234"}"#).unwrap();
+
+        assert_eq!(
+            mode,
+            AlpacaBrokerApiMode::Mock("http://127.0.0.1:1234".to_string())
+        );
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_deserializes_string_forms() {
+        let sandbox: AlpacaBrokerApiMode = serde_json::from_str(r#""sandbox""#).unwrap();
+        assert_eq!(sandbox, AlpacaBrokerApiMode::Sandbox);
+
+        let production: AlpacaBrokerApiMode = serde_json::from_str(r#""production""#).unwrap();
+        assert_eq!(production, AlpacaBrokerApiMode::Production);
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_unknown_string_errors() {
+        let error = serde_json::from_str::<AlpacaBrokerApiMode>(r#""fidelity""#).unwrap_err();
+        assert!(
+            error.to_string().contains("fidelity"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_mock_table_missing_base_url_errors() {
+        let error = serde_json::from_str::<AlpacaBrokerApiMode>(r#"{"type":"mock"}"#).unwrap_err();
+        assert!(
+            error.to_string().contains("base_url"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_unknown_type_errors() {
+        let error =
+            serde_json::from_str::<AlpacaBrokerApiMode>(r#"{"type":"fidelity"}"#).unwrap_err();
+        assert!(
+            error.to_string().contains("fidelity"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_alpaca_broker_api_mode_unknown_field_errors() {
+        let error = serde_json::from_str::<AlpacaBrokerApiMode>(
+            r#"{"type":"mock","base_url":"http://x","extra":"y"}"#,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("extra"),
+            "unexpected error: {error}"
         );
     }
 

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -7,7 +7,12 @@
   import type { Position } from '$lib/api/Position'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
-  import { getApiBaseUrl, getExplorerTxUrl } from '$lib/env'
+  import {
+    getApiBaseUrl,
+    getExplorerTxUrl,
+    getSimulateBackendPort,
+    getSimulateSourceId,
+  } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
   import { formatDecimal } from '$lib/decimal'
   import { cashUsdTooltip, equityUsdTooltip } from '$lib/inventory-value'
@@ -19,9 +24,13 @@
     isTxHash,
     isTransferRef,
     formatFieldName,
+    formatNumericDetailValue,
     extractTimestamp,
     detailFields,
-    apiErrorStatus
+    apiErrorStatus,
+    stuckLocationLabel,
+    stuckReasonLabel,
+    recoveryCommand
   } from '$lib/transfer'
 
   const isNumeric = (value: unknown): boolean =>
@@ -60,6 +69,12 @@
     step: string
     sequence: number
     payload: Record<string, unknown>
+  }
+
+  type StuckTransferInfo = {
+    stuckAmount: string
+    stuckLocation: string
+    stuckReason: string
   }
 
   const PAGE_SIZE = 100
@@ -220,6 +235,7 @@
 
   let detailDialogEl: HTMLDialogElement | undefined = $state()
   const detailEvents = reactive<TransferEvent[]>([])
+  const detailStuck = reactive<StuckTransferInfo | null>(null)
   const detailTransfer = reactive<TransferEntry | null>(null)
   const detailLoading = reactive(false)
   const detailError = reactive<string | null>(null)
@@ -235,6 +251,7 @@
     detailLoading.update(() => true)
     detailError.update(() => null)
     detailEvents.update(() => [])
+    detailStuck.update(() => null)
     detailDialogEl?.showModal()
 
     try {
@@ -250,11 +267,15 @@
         return
       }
 
-      const data = (await response.json()) as { events: TransferEvent[] }
+      const data = (await response.json()) as {
+        events: TransferEvent[]
+        stuck: StuckTransferInfo | null
+      }
 
       if (isAborted()) return
 
       detailEvents.update(() => data.events)
+      detailStuck.update(() => data.stuck)
     } catch (err) {
       if (isAborted()) return
       detailError.update(() => (err instanceof Error ? err.message : 'Unknown error'))
@@ -264,6 +285,7 @@
       }
     }
   }
+
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-purple-500/50">
@@ -560,8 +582,39 @@
           Failed to load events: {detailError.current}
         </div>
       {:else}
+        <svelte:boundary onerror={(error) => console.error('Failed to render transfer detail', error)}>
+        {#if detailStuck.current}
+          {@const recovery = recoveryCommand({
+            simulateSourceId: getSimulateSourceId(),
+            backendPort: getSimulateBackendPort(),
+            kind: transfer.kind,
+            id: transfer.id
+          })}
+          <div class="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs">
+            <div class="font-medium text-destructive">Stranded equity</div>
+            <div class="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono">
+              <span class="text-muted-foreground">Amount</span>
+              <span>{formatDecimal(detailStuck.current.stuckAmount, 3)}</span>
+              <span class="text-muted-foreground">Location</span>
+              <span>{stuckLocationLabel(detailStuck.current.stuckLocation)}</span>
+              <span class="text-muted-foreground">Reason</span>
+              <span>{stuckReasonLabel(detailStuck.current.stuckReason)}</span>
+            </div>
+            {#if recovery}
+              <div class="mt-2 border-t border-destructive/20 pt-2">
+                <div class="font-medium text-destructive">Recovery command</div>
+                {#if recovery.mode === 'production'}
+                  <div class="mt-1 text-muted-foreground">Run on the server (ssh via Tailscale):</div>
+                {/if}
+                <pre class="mt-1 whitespace-pre-wrap break-all rounded bg-background/80 p-2 font-mono text-[11px] text-foreground">{recovery.command}</pre>
+              </div>
+            {/if}
+          </div>
+        {/if}
+
         <div class="relative space-y-0 border-l-2 border-muted pl-4">
           {#each detailEvents.current as event (event.sequence)}
+            <svelte:boundary onerror={(error) => console.error('Failed to render transfer event', error)}>
             {@const stepStyle = statusStyle(event.step)}
             {@const timestamp = extractTimestamp(event.payload)}
             {@const fields = detailFields(event.payload)}
@@ -601,7 +654,7 @@
                                 {JSON.stringify(value)}
                               {/if}
                             {:else if isNumeric(value)}
-                              {formatDecimal(String(value), 3)}
+                              {formatNumericDetailValue(key, String(value))}
                             {:else}
                               {String(value)}
                             {/if}
@@ -660,7 +713,7 @@
                         {:else if typeof value === 'object' && value !== null}
                           {JSON.stringify(value)}
                         {:else if isNumeric(value)}
-                          {formatDecimal(String(value), 3)}
+                          {formatNumericDetailValue(key, String(value))}
                         {:else}
                           {String(value)}
                         {/if}
@@ -670,8 +723,22 @@
                 </div>
               {/if}
             </div>
+
+            {#snippet failed()}
+              <div class="relative pb-4 text-xs text-destructive">
+                Something went wrong rendering this event — check the browser console.
+              </div>
+            {/snippet}
+            </svelte:boundary>
           {/each}
         </div>
+
+        {#snippet failed()}
+          <div class="flex items-center justify-center py-8 text-sm text-destructive">
+            Something went wrong — check the browser console.
+          </div>
+        {/snippet}
+        </svelte:boundary>
       {/if}
     </div>
   {/if}

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { statusStyle, isTxHash, extractTimestamp, detailFields, apiErrorStatus } from './transfer'
+import {
+  statusStyle,
+  isTxHash,
+  formatNumericDetailValue,
+  extractTimestamp,
+  detailFields,
+  apiErrorStatus,
+  stuckLocationLabel,
+  stuckReasonLabel,
+  recoveryCommand,
+} from './transfer'
 
 describe('statusStyle', () => {
   it('matches completed substring case-insensitively', () => {
@@ -47,6 +57,53 @@ describe('isTxHash', () => {
     expect(isTxHash(42)).toBe(false)
     expect(isTxHash(null)).toBe(false)
     expect(isTxHash(undefined)).toBe(false)
+  })
+})
+
+describe('formatNumericDetailValue', () => {
+  it('formats raw wrapped token units as shares', () => {
+    expect(formatNumericDetailValue('wrapped_amount', '31688483870000000000')).toBe('31.688')
+  })
+
+  it('formats raw received token units as shares', () => {
+    expect(formatNumericDetailValue('shares_minted', '12500000000000000000')).toBe('12.500')
+  })
+
+  it('formats decimal-serialized token addresses as hex addresses', () => {
+    expect(
+      formatNumericDetailValue('token', '7973173272142053871140891859049224849605192591')
+    ).toBe('0x0165878a594ca255338adfa4d48449f69242eb8f')
+  })
+
+  it('formats wallet address fields as hex, not comma-separated decimals', () => {
+    // wallet/redemption_wallet are Address fields; without address handling they
+    // fall through to formatDecimal and render as a giant comma-separated number.
+    expect(formatNumericDetailValue('wallet', '0xd8da6bf26964af9d7eed9e03e53415d37aa96045')).toBe(
+      '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
+    )
+    expect(
+      formatNumericDetailValue('redemption_wallet', '0xd8da6bf26964af9d7eed9e03e53415d37aa96045')
+    ).toBe('0xd8da6bf26964af9d7eed9e03e53415d37aa96045')
+  })
+
+  it('keeps regular numeric fields as decimal values', () => {
+    expect(formatNumericDetailValue('poll_count', '1200')).toBe('1,200.000')
+  })
+
+  it('formats hex-encoded U256 token units as shares', () => {
+    // alloy serializes U256 as hex; 0xde0b6b3a7640000 == 1e18 == 1 share.
+    expect(formatNumericDetailValue('shares_minted', '0xde0b6b3a7640000')).toBe('1.000')
+    expect(formatNumericDetailValue('wrapped_amount', '0x1bc16d674ec80000')).toBe('2.000')
+  })
+
+  it('does not throw on a small hex token amount (regression: frozen modal)', () => {
+    // The exact value from the production crash report. decimal.js rejected the
+    // "0x" prefix, throwing during render and stranding the modal on its spinner.
+    expect(formatNumericDetailValue('shares_minted', '0x8ac7230489e8')).toBe('0.000')
+  })
+
+  it('normalizes hex for non-token numeric fields', () => {
+    expect(formatNumericDetailValue('poll_count', '0x10')).toBe('16.000')
   })
 })
 
@@ -138,5 +195,110 @@ describe('apiErrorStatus', () => {
   it('returns null for non-object input', () => {
     expect(apiErrorStatus(null)).toBeNull()
     expect(apiErrorStatus('ApiError')).toBeNull()
+  })
+})
+
+describe('stuckLocationLabel', () => {
+  it('maps known location codes to human labels', () => {
+    expect(stuckLocationLabel('issuer')).toBe('Issuer')
+    expect(stuckLocationLabel('redemption_wallet')).toBe('Redemption wallet')
+    expect(stuckLocationLabel('bot_wallet_unwrapped')).toBe('Bot wallet')
+    expect(stuckLocationLabel('bot_wallet_wrapped')).toBe('Bot wallet (wrapped)')
+  })
+
+  it('passes through unknown codes unchanged', () => {
+    expect(stuckLocationLabel('somewhere_else')).toBe('somewhere_else')
+  })
+})
+
+describe('stuckReasonLabel', () => {
+  it('title-cases snake_case reasons', () => {
+    expect(stuckReasonLabel('redemption_rejected')).toBe('Redemption Rejected')
+    expect(stuckReasonLabel('timeout')).toBe('Timeout')
+  })
+})
+
+describe('recoveryCommand', () => {
+  it('builds the mock recheck command for an equity mint in a simulation build', () => {
+    const command = recoveryCommand({
+      simulateSourceId: 'sim-1',
+      backendPort: '8123',
+      kind: 'equity_mint',
+      id: 'ISS001',
+    })
+    expect(command).toEqual({
+      mode: 'simulation',
+      command:
+        'nix develop --command cargo run --features mock --bin cli -- --config /tmp/st0x-simulate-failures-8123.config.toml --secrets /tmp/st0x-simulate-failures-8123.secrets.toml recheck-transfer --type mint --id ISS001',
+    })
+  })
+
+  it('maps equity_redemption to the redemption transfer type', () => {
+    const command = recoveryCommand({
+      simulateSourceId: 'sim-1',
+      backendPort: '8123',
+      kind: 'equity_redemption',
+      id: 'RED001',
+    })
+    expect(command?.command).toContain('recheck-transfer --type redemption --id RED001')
+  })
+
+  it('builds the stox command for an equity mint on a live deployment', () => {
+    const command = recoveryCommand({
+      simulateSourceId: null,
+      backendPort: '8123',
+      kind: 'equity_mint',
+      id: 'ISS001',
+    })
+    expect(command).toEqual({
+      mode: 'production',
+      command: 'stox recheck-transfer --type mint --id ISS001',
+    })
+  })
+
+  it('builds the stox command for an equity redemption on a live deployment', () => {
+    const command = recoveryCommand({
+      simulateSourceId: null,
+      backendPort: null,
+      kind: 'equity_redemption',
+      id: 'RED001',
+    })
+    expect(command).toEqual({
+      mode: 'production',
+      command: 'stox recheck-transfer --type redemption --id RED001',
+    })
+  })
+
+  it('returns null in a simulation build when the backend port is unknown', () => {
+    expect(
+      recoveryCommand({
+        simulateSourceId: 'sim-1',
+        backendPort: null,
+        kind: 'equity_mint',
+        id: 'ISS001',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null for non-equity transfer kinds in a simulation build', () => {
+    expect(
+      recoveryCommand({
+        simulateSourceId: 'sim-1',
+        backendPort: '8123',
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null for non-equity transfer kinds on a live deployment', () => {
+    expect(
+      recoveryCommand({
+        simulateSourceId: null,
+        backendPort: null,
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+      }),
+    ).toBeNull()
   })
 })

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -1,3 +1,6 @@
+import { formatDecimal } from './decimal'
+import { formatBalance } from './format'
+
 export type StatusStyle = {
   text: string
   dot: string
@@ -45,6 +48,14 @@ export const isTxHash = (value: unknown): value is string =>
   typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value)
 
 const SKIP_FIELDS = new Set(['attestation'])
+const TOKEN_UNIT_FIELDS = new Set([
+  'actual_wrapped_amount',
+  'shares_minted',
+  'unwrapped_amount',
+  'wrapped_amount',
+  'wrapped_shares',
+])
+const ADDRESS_FIELDS = new Set(['token', 'underlying_token', 'wallet', 'redemption_wallet'])
 
 export const isTimestampField = (key: string): boolean => key.endsWith('_at')
 
@@ -53,6 +64,28 @@ export const isTransferRef = (value: unknown): value is Record<string, string> =
 
 export const formatFieldName = (key: string): string =>
   key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+
+const formatDecimalAddress = (value: string): string | null => {
+  try {
+    return `0x${BigInt(value).toString(16).padStart(40, '0')}`
+  } catch {
+    return null
+  }
+}
+
+export const formatNumericDetailValue = (key: string, value: string): string => {
+  const address = ADDRESS_FIELDS.has(key) ? formatDecimalAddress(value) : null
+  if (address !== null) return address
+
+  // alloy serializes U256 fields as hex ("0x.."), but formatBalance and
+  // formatDecimal expect base-10 digit strings. Normalize integer hex to
+  // decimal first so the "0x" prefix doesn't make decimal.js throw (an
+  // unhandled throw here froze the detail modal on "Loading events...").
+  const normalized = /^0x[0-9a-fA-F]+$/.test(value) ? BigInt(value).toString() : value
+
+  const displayValue = TOKEN_UNIT_FIELDS.has(key) ? formatBalance(normalized, 18) : normalized
+  return formatDecimal(displayValue, 3)
+}
 
 export const extractTimestamp = (payload: Record<string, unknown>): string | null => {
   for (const [key, value] of Object.entries(payload)) {
@@ -79,4 +112,80 @@ export const apiErrorStatus = (value: unknown): string | null => {
   if (typeof status === 'string') return status
   if (typeof status === 'number') return String(status)
   return null
+}
+
+/// Human-readable label for a stranded-equity location code.
+export const stuckLocationLabel = (location: string): string => {
+  switch (location) {
+    case 'issuer':
+      return 'Issuer'
+    case 'redemption_wallet':
+      return 'Redemption wallet'
+    case 'bot_wallet_unwrapped':
+      return 'Bot wallet'
+    case 'bot_wallet_wrapped':
+      return 'Bot wallet (wrapped)'
+    default:
+      return location
+  }
+}
+
+/// Title-cases a snake_case stranded-equity reason code.
+export const stuckReasonLabel = (reason: string): string =>
+  reason
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+/// Maps a transfer kind to the `recheck-transfer --type` flag value, or null
+/// for kinds that are not equity transfers (e.g. usdc_bridge).
+const recheckTransferType = (kind: string): string | null => {
+  switch (kind) {
+    case 'equity_mint':
+      return 'mint'
+    case 'equity_redemption':
+      return 'redemption'
+    default:
+      return null
+  }
+}
+
+/// A `recheck-transfer` command for a stranded transfer. The `mode`
+/// distinguishes a local simulation command from one an operator runs on the
+/// deployed server, so the UI can label them differently.
+export type RecoveryCommand =
+  | { mode: 'simulation'; command: string }
+  | { mode: 'production'; command: string }
+
+/// Builds the `recheck-transfer` CLI command shown to operators for a stranded
+/// transfer, or null for kinds with no recovery path (e.g. usdc_bridge).
+///
+/// Simulation builds set `simulateSourceId` (`PUBLIC_SIMULATE_SOURCE_ID`, set
+/// solely by the `simulate-failures` flake apps) and run the mock CLI against
+/// the harness's `/tmp` config, so they also need `backendPort`. Live
+/// deployments invoke the `stox` wrapper, which auto-loads prod config/secrets,
+/// so the production command needs no config paths or port.
+export const recoveryCommand = (params: {
+  simulateSourceId: string | null
+  backendPort: string | null
+  kind: string
+  id: string
+}): RecoveryCommand | null => {
+  const transferType = recheckTransferType(params.kind)
+  if (transferType === null) return null
+
+  if (params.simulateSourceId !== null) {
+    if (params.backendPort === null) return null
+
+    const basePath = `/tmp/st0x-simulate-failures-${params.backendPort}`
+    return {
+      mode: 'simulation',
+      command: `nix develop --command cargo run --features mock --bin cli -- --config ${basePath}.config.toml --secrets ${basePath}.secrets.toml recheck-transfer --type ${transferType} --id ${params.id}`,
+    }
+  }
+
+  return {
+    mode: 'production',
+    command: `stox recheck-transfer --type ${transferType} --id ${params.id}`,
+  }
 }

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -123,3 +123,64 @@ stox alpaca-transfers --pending      # Only pending transfers
 ```
 stox alpaca-tokenization-requests
 ```
+
+### Rechecking Failed Equity Transfers
+
+Use `recheck-transfer` when the bot marked an equity mint or redemption as
+failed, but Alpaca later shows the same provider request as completed.
+
+**The bot must be running.** `recheck-transfer` delegates to the bot's REST API
+(`POST /transfers/recheck/<kind>/<id>` on the configured `server_port`) rather
+than mutating the database directly. Recovery has to run inside the bot process
+so the recovery event dispatches through the in-process inventory reactor (which
+corrects the live inventory view) and shares the bot's resume lock (so it cannot
+race `/transfers/resume` into a double on-chain wrap).
+
+> **Operational guardrail:** like `/transfers/resume`, the `/transfers/recheck`
+> endpoint is currently **unauthenticated** — any caller that can reach
+> `server_port` can recover live transfers and trigger inventory-affecting
+> workflow steps. Until an auth guard is added, the bot's `server_port` **must**
+> be bound to an operator-only/firewalled interface and never exposed publicly.
+
+Recoverable cases:
+
+- Mint failed at acceptance (accepted by Alpaca, but tokens never received),
+  then Alpaca later reports the mint completed.
+  `stox recheck-transfer --type mint --id <issuer-request-id>` records provider
+  completion and resumes wrapping/depositing to Raindex. A mint that already
+  received tokens and then failed while wrapping or depositing is **not**
+  recoverable this way (recovery would re-wrap tokens that already moved); the
+  command reports it as not recoverable.
+- Redemption failed after tokens were sent, with a redemption tx in the
+  aggregate.
+  `stox recheck-transfer --type redemption --id <redemption-aggregate-id>`
+  completes it if Alpaca now reports completed.
+- Non-failed active mints/redemptions can also be passed to `recheck-transfer`;
+  the command resumes the normal workflow instead of forcing recovery.
+
+The command prints the recovery outcome: `recovered`, `resumed`,
+`already_completed`, `left_unchanged`, `not_detected_yet`, or `not_recoverable`.
+
+Not covered by `recheck-transfer` yet:
+
+- Mint requests rejected before Alpaca acceptance. There is no provider
+  completion to discover.
+- Mints that failed after receiving tokens (wrapping/deposit failures). The
+  tokens already left the issuer, so provider-completion recovery does not
+  apply.
+- Redemptions that failed before tokens were sent. The bot has no provider tx or
+  request id to look up, so this needs a retry/resume-send style CLI.
+- Provider rejections. These remain failed unless an operator performs a
+  separate manual reconciliation.
+- USDC rebalancing failures. Those use the USDC/CCTP state machine and need
+  separate recovery commands.
+
+For local dashboard testing, run:
+
+```
+nix run .#simulate-failures
+```
+
+The backend creates failed mint and redemption transfers whose mock Alpaca
+provider later completes, then prints the exact `recheck-transfer` commands for
+that run's generated config, secrets, database, and mock API port.

--- a/flake.nix
+++ b/flake.nix
@@ -311,6 +311,67 @@
               '';
             };
 
+            # Mock infra + bot + dashboard + recoverable failure injection.
+            #
+            # Run with `nix run .#simulate-failures`, press `q` to exit.
+            # Starts the same live dashboard stack as simulate, but first
+            # creates stuck mint and redemption rebalances whose Alpaca mock
+            # provider later completes. The backend logs the recheck-transfer
+            # commands needed to recover them.
+            "simulate-failures" = pkgs.writeShellApplication {
+              name = "simulate-failures";
+              runtimeInputs = [
+                pkgs.mprocs
+                pkgs.bun
+                pkgs.cargo-nextest
+                rainix.rust-toolchain.${system}
+              ];
+              text = ''
+                                port_free() {
+                                  ! (echo >"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+                                }
+
+                                offset=0
+                                max_offset=9
+                                while (( offset <= max_offset )); do
+                                  bot_port=$((8001 + offset))
+                                  vite_port=$((5173 + offset))
+                                  mock_api_port=$((8099 + offset))
+                                  if port_free "$bot_port" \
+                                    && port_free "$vite_port" \
+                                    && port_free "$mock_api_port"; then
+                                    break
+                                  fi
+                                  offset=$((offset + 1))
+                                done
+
+                                if (( offset > max_offset )); then
+                                  echo "simulate-failures: no free port offset in [0..$max_offset]" >&2
+                                  exit 1
+                                fi
+
+                                echo "simulate-failures: offset=$offset (bot=$bot_port \
+                vite=$vite_port mock_api=$mock_api_port)"
+
+                                backend="SIMULATE_BOT_PORT=$bot_port \
+                                  cargo nextest run --test e2e \
+                                  -E 'test(=full_system::simulate_failures)' \
+                                  --run-ignored ignored-only --no-capture"
+
+                                dashboard="cd dashboard && \
+                                  BACKEND_PORT=$bot_port \
+                                  PUBLIC_BACKEND_PORT=$bot_port \
+                                  PUBLIC_SIMULATE_REV=${self.shortRev or self.dirtyShortRev or "unknown"} \
+                                  PUBLIC_SIMULATE_SOURCE_ID=${builtins.substring 0 8 (baseNameOf self.outPath)} \
+                                  bun run dev --port=$vite_port --strictPort --open"
+
+                                mockApi="MOCK_REST_API_PORT=$mock_api_port \
+                                  bun run e2e/mock-rest-api.ts"
+
+                                exec mprocs "$backend" "$dashboard" "$mockApi"
+              '';
+            };
+
             # Sandbox-runnable test for scripts/patch-rain-math-float.nu so
             # the patch logic can't silently rot when upstream drifts.
             test-patch-rain-math-float =

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use alloy::primitives::U256;
 use chrono::{DateTime, Utc};
 use rocket::form::{self, FromFormField, ValueField};
 use rocket::http::Status;
@@ -17,9 +18,14 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info};
 
+use st0x_execution::{FractionalShares, SharesBlockchain};
+
 use crate::config::Ctx;
 use crate::dashboard::transfer_loader::TransferKind;
-use crate::rebalancing::equity::CrossVenueEquityTransfer;
+use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
+use crate::rebalancing::RebalancingService;
+use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
+use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMintEvent};
 
 impl<'a> FromParam<'a> for TransferKind {
     type Error = String;
@@ -89,6 +95,46 @@ struct PendingOrderResponse {
     submitted_at: Option<String>,
     shares_filled: Option<String>,
     avg_price: Option<String>,
+}
+
+/// Where the stranded equity physically sits for a failed transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(crate = "rocket::serde", rename_all = "snake_case")]
+enum StuckLocation {
+    /// At the issuer (Alpaca): a mint was accepted but failed before tokens
+    /// were received on-chain.
+    Issuer,
+    /// In the bot wallet as unwrapped tokenized equity: a mint received tokens
+    /// but failed while wrapping.
+    BotWalletUnwrapped,
+    /// In the bot wallet as wrapped vault shares: a mint wrapped tokens but
+    /// failed depositing into Raindex.
+    BotWalletWrapped,
+    /// In the redemption wallet: a redemption sent tokens but failed during
+    /// detection or was rejected.
+    RedemptionWallet,
+}
+
+/// Why a transfer is stranded, mirroring the terminal failure event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(crate = "rocket::serde", rename_all = "snake_case")]
+enum StuckReason {
+    MintAcceptanceFailed,
+    WrappingFailed,
+    RaindexDepositFailed,
+    DetectionFailed,
+    RedemptionRejected,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(crate = "rocket::serde")]
+struct StuckTransferInfo {
+    #[serde(rename = "stuckAmount")]
+    amount: String,
+    #[serde(rename = "stuckLocation")]
+    location: StuckLocation,
+    #[serde(rename = "stuckReason")]
+    reason: StuckReason,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -773,17 +819,13 @@ async fn transfer_events(
         }
     };
 
-    let events: Vec<serde_json::Value> = rows
-        .into_iter()
-        .map(|(event_type, payload, sequence)| {
-            let step = event_type.split("::").last().unwrap_or("Unknown");
-            let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+    let stuck = stuck_transfer_info(kind, &rows);
 
-            // Unwrap the variant key: {"MintRequested": {fields...}} -> {fields...}
-            let inner = parsed
-                .as_object()
-                .and_then(|obj| obj.get(step).cloned())
-                .unwrap_or(parsed);
+    let events: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|(event_type, payload, sequence)| {
+            let step = event_step(event_type);
+            let inner = event_payload_inner(step, payload);
 
             serde_json::json!({
                 "step": step,
@@ -793,7 +835,216 @@ async fn transfer_events(
         })
         .collect();
 
-    Some(Json(serde_json::json!({ "events": events })))
+    Some(Json(serde_json::json!({
+        "events": events,
+        "stuck": stuck,
+    })))
+}
+
+fn event_step(event_type: &str) -> &str {
+    event_type.split("::").last().unwrap_or("Unknown")
+}
+
+fn event_payload_inner(step: &str, payload: &str) -> serde_json::Value {
+    let parsed: serde_json::Value = serde_json::from_str(payload)
+        .inspect_err(|error| {
+            tracing::warn!(
+                target: "dashboard",
+                %error,
+                step,
+                "Failed to parse event payload for display"
+            );
+        })
+        .unwrap_or_default();
+
+    parsed
+        .as_object()
+        .and_then(|obj| obj.get(step).cloned())
+        .unwrap_or(parsed)
+}
+
+fn stuck_transfer_info(
+    kind: TransferKind,
+    rows: &[(String, String, i64)],
+) -> Option<StuckTransferInfo> {
+    match kind {
+        TransferKind::EquityMint => stuck_mint_info(rows),
+        TransferKind::EquityRedemption => stuck_redemption_info(rows),
+        TransferKind::UsdcBridge => None,
+    }
+}
+
+/// Parses each persisted event payload into the typed mint event so the
+/// terminal-failure classification is checked exhaustively by the compiler:
+/// renaming or adding a variant forces this match to be updated, unlike a
+/// match on raw event-name strings.
+fn stuck_mint_info(rows: &[(String, String, i64)]) -> Option<StuckTransferInfo> {
+    use TokenizedEquityMintEvent::*;
+
+    let mut quantity = None;
+    let mut accepted = false;
+    let mut terminal = None;
+
+    for (event_type, payload, sequence) in rows {
+        let Some(event) = parse_event::<TokenizedEquityMintEvent>(event_type, payload, *sequence)
+        else {
+            continue;
+        };
+
+        match event {
+            MintRequested {
+                quantity: requested,
+                ..
+            } => quantity = Some(FractionalShares::new(requested).to_string()),
+            MintAccepted { .. } => accepted = true,
+            MintAcceptanceFailed { .. } if accepted => {
+                terminal = Some((StuckLocation::Issuer, StuckReason::MintAcceptanceFailed));
+            }
+            WrappingFailed { .. } => {
+                terminal = Some((
+                    StuckLocation::BotWalletUnwrapped,
+                    StuckReason::WrappingFailed,
+                ));
+            }
+            RaindexDepositFailed { .. } => {
+                terminal = Some((
+                    StuckLocation::BotWalletWrapped,
+                    StuckReason::RaindexDepositFailed,
+                ));
+            }
+            // Neither strands equity: a rejected mint never left the issuer,
+            // and a deposited mint completed successfully.
+            MintRejected { .. } | DepositedIntoRaindex { .. } => return None,
+            // Recovery un-failed the mint and put it back on the success path,
+            // so any stuck state observed before it no longer applies; the
+            // mint is re-derived from subsequent events (it may fail again).
+            ProviderCompletionRecovered { .. } => terminal = None,
+            MintAcceptanceFailed { .. }
+            | TokensReceived { .. }
+            | WrapSubmitted { .. }
+            | TokensWrapped { .. }
+            | VaultDepositSubmitted { .. } => {}
+        }
+    }
+
+    let (location, reason) = terminal?;
+    let amount = quantity?;
+
+    Some(StuckTransferInfo {
+        amount,
+        location,
+        reason,
+    })
+}
+
+fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransferInfo> {
+    use EquityRedemptionEvent::*;
+
+    let mut requested_quantity: Option<String> = None;
+    let mut withdrawn_amount: Option<U256> = None;
+    let mut unwrapped_quantity: Option<String> = None;
+    let mut sent = false;
+    let mut terminal = None;
+
+    for (event_type, payload, sequence) in rows {
+        let Some(event) = parse_event::<EquityRedemptionEvent>(event_type, payload, *sequence)
+        else {
+            continue;
+        };
+
+        match event {
+            VaultWithdrawPending { quantity, .. } | VaultWithdrawSubmitted { quantity, .. } => {
+                requested_quantity = requested_quantity
+                    .or_else(|| Some(FractionalShares::new(quantity).to_string()));
+            }
+            WithdrawnFromRaindex {
+                quantity,
+                wrapped_amount,
+                actual_wrapped_amount,
+                ..
+            } => {
+                requested_quantity = requested_quantity
+                    .or_else(|| Some(FractionalShares::new(quantity).to_string()));
+                withdrawn_amount = Some(actual_wrapped_amount.unwrap_or(wrapped_amount));
+            }
+            TokensUnwrapped {
+                quantity,
+                unwrapped_amount,
+                ..
+            } => {
+                // Prefer the recorded share quantity; when absent (older events),
+                // fall back to the actual unwrapped underlying amount -- the tokens
+                // physically stranded in the redemption wallet -- rather than the
+                // wrapped withdrawn amount, which can differ on a non-1:1 ratio.
+                unwrapped_quantity = quantity
+                    .map(|qty| FractionalShares::new(qty).to_string())
+                    .or_else(|| shares_from_u256_18_decimal(unwrapped_amount));
+            }
+            TokensSent { .. } => sent = true,
+            DetectionFailed { .. } if sent => {
+                terminal = Some((
+                    StuckLocation::RedemptionWallet,
+                    StuckReason::DetectionFailed,
+                ));
+            }
+            RedemptionRejected { .. } if sent => {
+                terminal = Some((
+                    StuckLocation::RedemptionWallet,
+                    StuckReason::RedemptionRejected,
+                ));
+            }
+            // A terminal success (including recovery, which evolves straight to
+            // Completed) means nothing is stranded.
+            TransferFailed { .. } | Completed { .. } | ProviderCompletionRecovered { .. } => {
+                return None;
+            }
+            DetectionFailed { .. }
+            | RedemptionRejected { .. }
+            | UnwrapPending { .. }
+            | UnwrapSubmitted { .. }
+            | SendPending { .. }
+            | Detected { .. } => {}
+        }
+    }
+
+    let (location, reason) = terminal?;
+    let amount = unwrapped_quantity
+        .or_else(|| withdrawn_amount.and_then(shares_from_u256_18_decimal))
+        .or(requested_quantity)?;
+
+    Some(StuckTransferInfo {
+        amount,
+        location,
+        reason,
+    })
+}
+
+/// Deserializes a persisted event row into its typed event, logging and
+/// skipping on failure. Persisted events are always well-formed (written by
+/// the framework), so a failure here signals a schema mismatch worth surfacing
+/// rather than silently dropping stuck detection.
+fn parse_event<Event: serde::de::DeserializeOwned>(
+    event_type: &str,
+    payload: &str,
+    sequence: i64,
+) -> Option<Event> {
+    serde_json::from_str(payload)
+        .inspect_err(|error| {
+            tracing::warn!(
+                target: "dashboard",
+                %error,
+                %event_type,
+                sequence,
+                "Failed to parse event for stuck detection"
+            );
+        })
+        .ok()
+}
+
+fn shares_from_u256_18_decimal(amount: U256) -> Option<String> {
+    FractionalShares::from_u256_18_decimals(amount)
+        .ok()
+        .map(|shares| shares.to_string())
 }
 
 /// Returns the full event history for a single trade aggregate.
@@ -920,10 +1171,15 @@ struct ErrorResponse {
     error: String,
 }
 
-/// Shared handle for resuming interrupted tokenization transfers at
-/// runtime, set by the conductor after startup completes.
+/// Shared handle for resuming interrupted tokenization transfers and
+/// re-checking failed ones at runtime, set by the conductor after startup
+/// completes.
 pub(crate) struct RecoveryHandle {
     pub(crate) transfer: Arc<CrossVenueEquityTransfer>,
+    /// Needed by `recheck` recovery to rebuild in-memory tracking before the
+    /// recovery event is dispatched, so the reactor applies its inventory
+    /// effect on the live bot.
+    pub(crate) rebalancing_service: Arc<RebalancingService>,
 }
 
 /// Prevents concurrent `/transfers/resume` requests from racing through
@@ -1063,6 +1319,123 @@ async fn resume_transfers(
     }))
 }
 
+#[derive(Serialize)]
+#[serde(crate = "rocket::serde", rename_all = "camelCase")]
+struct RecheckResponse {
+    outcome: RecheckOutcome,
+}
+
+/// Re-checks a single failed (or active) transfer against the tokenization
+/// provider, recovering it in-process so the live inventory view is corrected.
+///
+/// Runs inside the bot so the recovery event dispatches through the
+/// reactor-wired store; shares `resume_lock` with `/transfers/resume` so the
+/// two cannot race onchain wraps.
+///
+/// TODO(auth): like `/transfers/resume`, this mutation endpoint is currently
+/// unauthenticated. The `/transfers/*` mutation endpoints need an auth guard
+/// before the listener is exposed beyond the operator network -- tracked as a
+/// follow-up. Until then, deployment must keep the bind address firewalled.
+#[post("/transfers/recheck/<kind>/<id>")]
+async fn recheck_transfer(
+    pool: &State<SqlitePool>,
+    recovery: &State<Arc<tokio::sync::OnceCell<RecoveryHandle>>>,
+    resume_lock: &State<ResumeLock>,
+    kind: TransferKind,
+    id: &str,
+) -> Result<Json<RecheckResponse>, (Status, Json<ErrorResponse>)> {
+    let _guard = resume_lock.0.try_lock().map_err(|_| {
+        (
+            Status::Conflict,
+            Json(ErrorResponse {
+                error: "A resume or recheck operation is already in progress".to_string(),
+            }),
+        )
+    })?;
+
+    let handle = recovery.get().ok_or_else(|| {
+        (
+            Status::ServiceUnavailable,
+            Json(ErrorResponse {
+                error: "Recovery not ready yet (conductor still starting)".to_string(),
+            }),
+        )
+    })?;
+
+    let outcome = match kind {
+        TransferKind::EquityMint => {
+            handle
+                .transfer
+                .recover_mint(
+                    &IssuerRequestId::new(id),
+                    pool.inner(),
+                    &handle.rebalancing_service,
+                )
+                .await
+        }
+        TransferKind::EquityRedemption => {
+            let redemption_id = id.parse::<RedemptionAggregateId>().map_err(|error| {
+                (
+                    Status::BadRequest,
+                    Json(ErrorResponse {
+                        error: format!("Invalid redemption ID: {error}"),
+                    }),
+                )
+            })?;
+            handle
+                .transfer
+                .recover_redemption(&redemption_id, &handle.rebalancing_service)
+                .await
+        }
+        TransferKind::UsdcBridge => {
+            return Err((
+                Status::BadRequest,
+                Json(ErrorResponse {
+                    error: "recheck is not supported for USDC bridges".to_string(),
+                }),
+            ));
+        }
+    }
+    .map_err(|error| {
+        error!(?error, %id, "Failed to recheck transfer");
+        let (status, message) = recheck_error_response(&error);
+        (status, Json(ErrorResponse { error: message }))
+    })?;
+
+    info!(%id, ?kind, ?outcome, "Transfer recheck completed via API");
+
+    Ok(Json(RecheckResponse { outcome }))
+}
+
+/// Maps a [`RecheckError`] to an HTTP status and operator-facing message.
+///
+/// Distinguishes not-recoverable conditions (the persisted aggregate state
+/// does not permit provider-completion recovery -- retrying will not help) and
+/// transient upstream failures (the provider was unreachable -- retry later)
+/// from genuinely internal failures, so the operator running `recheck-transfer`
+/// during an incident learns whether to retry without reading bot logs. Bodies
+/// for the not-recoverable variants carry the typed error's message, which only
+/// references aggregate/request ids; internal failures stay generic so they do
+/// not leak internals (the full error is logged at the call site).
+fn recheck_error_response(error: &RecheckError) -> (Status, String) {
+    match error {
+        RecheckError::NoAcceptedRequest(_)
+        | RecheckError::MissingTxHash(_)
+        | RecheckError::MalformedWallet { .. } => (Status::UnprocessableEntity, error.to_string()),
+        RecheckError::Tokenizer(_) => (
+            Status::BadGateway,
+            "Tokenization provider unavailable; retry later".to_string(),
+        ),
+        RecheckError::Mint(_)
+        | RecheckError::Redemption(_)
+        | RecheckError::Rebalancing(_)
+        | RecheckError::Database(_) => (
+            Status::InternalServerError,
+            "Failed to recheck transfer".to_string(),
+        ),
+    }
+}
+
 pub(crate) fn routes() -> Vec<Route> {
     routes![
         health,
@@ -1074,7 +1447,8 @@ pub(crate) fn routes() -> Vec<Route> {
         transfer_events,
         raindex_orders,
         interrupted_transfers,
-        resume_transfers
+        resume_transfers,
+        recheck_transfer
     ]
 }
 
@@ -1086,9 +1460,343 @@ mod tests {
     use crate::config::tests::create_test_ctx_with_order_owner;
 
     #[test]
-    fn test_num_of_routes() {
-        let routes_list = routes();
-        assert_eq!(routes_list.len(), 10);
+    fn routes_include_recheck_transfer_endpoint() {
+        let recheck_routes: Vec<_> = routes()
+            .into_iter()
+            .filter(|route| {
+                route.method == rocket::http::Method::Post
+                    && route.uri.to_string().contains("/transfers/recheck/")
+            })
+            .collect();
+
+        assert_eq!(
+            recheck_routes.len(),
+            1,
+            "exactly one POST /transfers/recheck route must be wired into routes(), found: {:?}",
+            routes()
+                .iter()
+                .map(|route| format!("{} {}", route.method, route.uri))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn stuck_mint_info_reports_accepted_provider_failure() {
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"12.5","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::MintAccepted",
+                r#"{"MintAccepted":{"issuer_request_id":"mint-1","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+                1,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::MintAcceptanceFailed",
+                r#"{"MintAcceptanceFailed":{"reason":"timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                2,
+            ),
+        ];
+
+        let stuck = stuck_transfer_info(TransferKind::EquityMint, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "12.5");
+        assert_eq!(stuck.location, StuckLocation::Issuer);
+        assert_eq!(stuck.reason, StuckReason::MintAcceptanceFailed);
+    }
+
+    #[test]
+    fn stuck_redemption_info_prefers_actual_unwrapped_quantity() {
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensUnwrapped",
+                r#"{"TokensUnwrapped":{"quantity":"9.75","underlying_token":"0x0000000000000000000000000000000000000002","unwrap_tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111","unwrapped_amount":"9750000000000000000","unwrapped_at":"2026-01-01T00:00:01Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:02Z"}}"#,
+                2,
+            ),
+            event_row(
+                "EquityRedemptionEvent::DetectionFailed",
+                r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        let stuck =
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "9.75");
+        assert_eq!(stuck.location, StuckLocation::RedemptionWallet);
+        assert_eq!(stuck.reason, StuckReason::DetectionFailed);
+    }
+
+    #[test]
+    fn stuck_mint_info_reports_wrapping_failure_in_bot_wallet() {
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"7","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::WrappingFailed",
+                r#"{"WrappingFailed":{"symbol":"AAPL","quantity":"7","reason":"revert","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                1,
+            ),
+        ];
+
+        let stuck = stuck_transfer_info(TransferKind::EquityMint, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "7");
+        assert_eq!(stuck.location, StuckLocation::BotWalletUnwrapped);
+        assert_eq!(stuck.reason, StuckReason::WrappingFailed);
+    }
+
+    #[test]
+    fn stuck_mint_info_reports_deposit_failure_as_wrapped_in_bot_wallet() {
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"3.5","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::RaindexDepositFailed",
+                r#"{"RaindexDepositFailed":{"reason":"revert","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                1,
+            ),
+        ];
+
+        let stuck = stuck_transfer_info(TransferKind::EquityMint, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "3.5");
+        assert_eq!(stuck.location, StuckLocation::BotWalletWrapped);
+        assert_eq!(stuck.reason, StuckReason::RaindexDepositFailed);
+    }
+
+    #[test]
+    fn stuck_mint_info_returns_none_for_completed_mint() {
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"7","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::DepositedIntoRaindex",
+                r#"{"DepositedIntoRaindex":{"vault_deposit_tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111","deposited_at":"2026-01-01T00:02:00Z"}}"#,
+                1,
+            ),
+        ];
+
+        assert!(stuck_transfer_info(TransferKind::EquityMint, &rows).is_none());
+    }
+
+    #[test]
+    fn stuck_redemption_info_cleared_after_provider_completion_recovery() {
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:02Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::RedemptionRejected",
+                r#"{"RedemptionRejected":{"reason":"rejected","rejected_at":"2026-01-01T00:01:00Z"}}"#,
+                2,
+            ),
+            event_row(
+                "EquityRedemptionEvent::ProviderCompletionRecovered",
+                r#"{"ProviderCompletionRecovered":{"tokenization_request_id":"tok-1","recovered_at":"2026-01-01T00:02:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        assert!(
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).is_none(),
+            "a recovered redemption must not be reported as stranded"
+        );
+    }
+
+    #[test]
+    fn stuck_transfer_info_serializes_to_dashboard_wire_format() {
+        let info = StuckTransferInfo {
+            amount: "12.5".to_string(),
+            location: StuckLocation::BotWalletWrapped,
+            reason: StuckReason::RaindexDepositFailed,
+        };
+
+        let json = serde_json::to_value(&info).expect("serialize stuck info");
+
+        assert_eq!(json["stuckAmount"], serde_json::json!("12.5"));
+        assert_eq!(
+            json["stuckLocation"],
+            serde_json::json!("bot_wallet_wrapped")
+        );
+        assert_eq!(
+            json["stuckReason"],
+            serde_json::json!("raindex_deposit_failed")
+        );
+    }
+
+    #[test]
+    fn stuck_mint_info_ignores_acceptance_failure_without_acceptance() {
+        // MintAcceptanceFailed without a preceding MintAccepted (the `if
+        // accepted` guard) means equity never left the issuer, so nothing is
+        // stranded.
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"7","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::MintAcceptanceFailed",
+                r#"{"MintAcceptanceFailed":{"reason":"never accepted","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                1,
+            ),
+        ];
+
+        assert!(stuck_transfer_info(TransferKind::EquityMint, &rows).is_none());
+    }
+
+    #[test]
+    fn stuck_redemption_info_falls_back_to_withdrawn_amount_when_not_unwrapped() {
+        // No TokensUnwrapped event, so the amount comes from the withdrawn
+        // wrapped amount (18-decimal U256 -> shares), not the requested
+        // quantity.
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"5","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"5000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::WithdrawnFromRaindex",
+                r#"{"WithdrawnFromRaindex":{"symbol":"AAPL","quantity":"5","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"9000000000000000000","raindex_withdraw_tx":"0x1111111111111111111111111111111111111111111111111111111111111111","withdrawn_at":"2026-01-01T00:00:01Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:02Z"}}"#,
+                2,
+            ),
+            event_row(
+                "EquityRedemptionEvent::DetectionFailed",
+                r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        let stuck =
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "9");
+        assert_eq!(stuck.location, StuckLocation::RedemptionWallet);
+    }
+
+    #[test]
+    fn stuck_redemption_info_uses_unwrapped_amount_when_quantity_absent() {
+        // TokensUnwrapped with no recorded `quantity` but a known
+        // `unwrapped_amount`: the stranded amount must be the actual unwrapped
+        // underlying tokens (9.5), not the larger wrapped withdrawn amount (10).
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::WithdrawnFromRaindex",
+                r#"{"WithdrawnFromRaindex":{"symbol":"AAPL","quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","raindex_withdraw_tx":"0x1111111111111111111111111111111111111111111111111111111111111111","withdrawn_at":"2026-01-01T00:00:01Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensUnwrapped",
+                r#"{"TokensUnwrapped":{"quantity":null,"underlying_token":"0x0000000000000000000000000000000000000002","unwrap_tx_hash":"0x3333333333333333333333333333333333333333333333333333333333333333","unwrapped_amount":"9500000000000000000","unwrapped_at":"2026-01-01T00:00:02Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:03Z"}}"#,
+                2,
+            ),
+            event_row(
+                "EquityRedemptionEvent::DetectionFailed",
+                r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        let stuck =
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "9.5");
+        assert_eq!(stuck.location, StuckLocation::RedemptionWallet);
+        assert_eq!(stuck.reason, StuckReason::DetectionFailed);
+    }
+
+    #[test]
+    fn stuck_redemption_info_falls_back_to_requested_quantity() {
+        // Neither unwrapped nor withdrawn amounts are present, so the requested
+        // quantity is the last-resort amount.
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"5","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"5000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:02Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::RedemptionRejected",
+                r#"{"RedemptionRejected":{"reason":"rejected","rejected_at":"2026-01-01T00:01:00Z"}}"#,
+                2,
+            ),
+        ];
+
+        let stuck =
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).expect("stuck amount");
+
+        assert_eq!(stuck.amount, "5");
+        assert_eq!(stuck.reason, StuckReason::RedemptionRejected);
+    }
+
+    #[test]
+    fn stuck_redemption_info_ignores_detection_failure_before_tokens_sent() {
+        // DetectionFailed before TokensSent (the `sent` guard) means tokens
+        // never left, so nothing is stranded in the redemption wallet.
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"5","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"5000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::DetectionFailed",
+                r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                1,
+            ),
+        ];
+
+        assert!(stuck_transfer_info(TransferKind::EquityRedemption, &rows).is_none());
+    }
+
+    fn event_row(event_type: &str, payload: &str, sequence: i64) -> (String, String, i64) {
+        (event_type.to_string(), payload.to_string(), sequence)
     }
 
     #[tokio::test]
@@ -1626,5 +2334,78 @@ mod tests {
             body["error"],
             "Recovery not ready yet (conductor still starting)"
         );
+    }
+
+    #[tokio::test]
+    async fn recheck_transfer_returns_503_before_conductor_ready() {
+        let pool = create_test_pool().await;
+        let recovery = Arc::new(tokio::sync::OnceCell::<RecoveryHandle>::new());
+        let rocket = rocket::build()
+            .mount("/", routes![recheck_transfer])
+            .manage(pool)
+            .manage(recovery)
+            .manage(ResumeLock(Mutex::new(())));
+        let client = Client::tracked(rocket).await.unwrap();
+
+        let response = client
+            .post("/transfers/recheck/equity_mint/some-id")
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::ServiceUnavailable);
+
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+
+        assert_eq!(
+            body["error"],
+            "Recovery not ready yet (conductor still starting)"
+        );
+    }
+
+    #[test]
+    fn recheck_error_response_distinguishes_recoverability() {
+        use crate::tokenization::{MintVerificationError, TokenizerError};
+        use crate::tokenized_equity_mint::TokenizationRequestId;
+
+        // Not-recoverable: the persisted aggregate state forbids recovery, so
+        // retrying will not help -> 422 carrying the typed reason.
+        let (status, message) = recheck_error_response(&RecheckError::NoAcceptedRequest(
+            IssuerRequestId::new("mint-1"),
+        ));
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(
+            message,
+            "mint mint-1 has no accepted provider request to re-check"
+        );
+
+        let (status, _) = recheck_error_response(&RecheckError::MissingTxHash(
+            TokenizationRequestId("tok-1".to_string()),
+        ));
+        assert_eq!(status, Status::UnprocessableEntity);
+
+        let parse_error = "not-an-address"
+            .parse::<alloy::primitives::Address>()
+            .unwrap_err();
+        let (status, _) = recheck_error_response(&RecheckError::MalformedWallet {
+            id: IssuerRequestId::new("mint-1"),
+            source: parse_error,
+        });
+        assert_eq!(status, Status::UnprocessableEntity);
+
+        // Transient upstream provider failure -> 502 so the operator knows to
+        // retry, with a generic message that does not leak provider internals.
+        let (status, message) = recheck_error_response(&RecheckError::Tokenizer(
+            TokenizerError::MintVerification(MintVerificationError::ReceiptNotFound {
+                tx_hash: alloy::primitives::TxHash::random(),
+            }),
+        ));
+        assert_eq!(status, Status::BadGateway);
+        assert_eq!(message, "Tokenization provider unavailable; retry later");
+
+        // Genuinely internal failure -> 500 with a generic body.
+        let (status, message) =
+            recheck_error_response(&RecheckError::Database(sqlx::Error::RowNotFound));
+        assert_eq!(status, Status::InternalServerError);
+        assert_eq!(message, "Failed to recheck transfer");
     }
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -44,7 +44,7 @@ sol!(
 
 // ERC20 with configurable name, symbol, and decimals via constructor args.
 // Distinct from `TestERC20` (ArbTest Token) which has a no-arg constructor.
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(any(test, feature = "mock", feature = "test-support"))]
 sol!(
     #![sol(all_derives = true, rpc)]
     #[derive(serde::Serialize, serde::Deserialize)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -469,6 +469,20 @@ pub enum Commands {
         reason: String,
     },
 
+    /// Re-check a failed mint or redemption and complete it if the provider settled it
+    ///
+    /// Delegates to the running bot's REST API so recovery dispatches through
+    /// the in-process reactor (correcting live inventory). Requires the bot to
+    /// be running and serving its API on the configured `server_port`.
+    RecheckTransfer {
+        /// Transfer type: "mint" or "redemption"
+        #[arg(short = 't', long = "type")]
+        transfer_type: TransferType,
+        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
+        #[arg(short = 'i', long = "id")]
+        id: String,
+    },
+
     /// Rebuild a materialized view by replaying all events from scratch
     ///
     /// Use as an escape hatch when a view becomes corrupted (e.g., due to
@@ -625,6 +639,31 @@ enum SimpleCommand {
         id: String,
         reason: String,
     },
+    RecheckTransfer {
+        transfer_type: TransferType,
+        id: String,
+    },
+}
+
+#[cfg(feature = "test-support")]
+pub async fn fail_transfer_for_test(
+    pool: &SqlitePool,
+    transfer_type: TransferType,
+    id: &str,
+    reason: &str,
+) -> anyhow::Result<()> {
+    let mut stdout = Vec::new();
+    rebalancing::fail_transfer_command(&mut stdout, pool, transfer_type, id, reason).await
+}
+
+#[cfg(feature = "test-support")]
+pub async fn recheck_transfer_for_test(
+    ctx: &Ctx,
+    transfer_type: TransferType,
+    id: &str,
+) -> anyhow::Result<()> {
+    let mut stdout = Vec::new();
+    rebalancing::recheck_transfer_command(&mut stdout, transfer_type, id, ctx).await
 }
 
 /// Commands that require a WebSocket provider.
@@ -820,6 +859,9 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
             id,
             reason,
         }),
+        Commands::RecheckTransfer { transfer_type, id } => {
+            Ok(SimpleCommand::RecheckTransfer { transfer_type, id })
+        }
     }
 }
 
@@ -977,6 +1019,9 @@ async fn run_simple_command<W: Write>(
             id,
             reason,
         } => rebalancing::fail_transfer_command(stdout, pool, transfer_type, &id, &reason).await,
+        SimpleCommand::RecheckTransfer { transfer_type, id } => {
+            rebalancing::recheck_transfer_command(stdout, transfer_type, &id, ctx).await
+        }
     }
 }
 
@@ -1280,6 +1325,55 @@ mod tests {
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected process-tx provider command"),
             Ok(_) => panic!("expected provider command classification"),
+        }
+    }
+
+    #[test]
+    fn recheck_transfer_command_parses_type_and_id() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "recheck-transfer",
+            "--type",
+            "mint",
+            "--id",
+            "ISS001",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::RecheckTransfer { transfer_type, id } => {
+                assert!(matches!(transfer_type, TransferType::Mint));
+                assert_eq!(id, "ISS001");
+            }
+            other => panic!("expected recheck-transfer command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_recheck_transfer_command_as_simple() {
+        // The recheck-transfer command must route without a WebSocket provider:
+        // it delegates to the running bot's REST API rather than touching chain.
+        let command = Commands::RecheckTransfer {
+            transfer_type: TransferType::Redemption,
+            id: "redemption-1".to_string(),
+        };
+
+        match classify_command(command) {
+            Ok(SimpleCommand::RecheckTransfer { transfer_type, id }) => {
+                assert!(matches!(transfer_type, TransferType::Redemption));
+                assert_eq!(id, "redemption-1");
+            }
+            Ok(_) => panic!("expected recheck-transfer simple command"),
+            Err(
+                ProviderCommand::ProcessTx { .. }
+                | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::CctpBridge { .. }
+                | ProviderCommand::CctpRecover { .. }
+                | ProviderCommand::ResetAllowance { .. }
+                | ProviderCommand::AlpacaTokenize { .. }
+                | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::AlpacaTokenizationRequests,
+            ) => panic!("expected simple command classification, got provider command"),
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -35,11 +35,82 @@ use crate::usdc_rebalance::UsdcRebalance;
 use crate::vault_registry::VaultRegistry;
 use crate::wrapper::{Wrapper, WrapperService};
 
+struct EquityTransferCliServices {
+    transfer: CrossVenueEquityTransfer,
+    wallet: Address,
+}
+
 /// Resolves the redemption wallet address from CLI flag or config.
 ///
 /// CLI flag takes precedence. Falls back to `[tokenization]` config.
 fn resolve_redemption_wallet(flag: Option<Address>, ctx: &Ctx) -> anyhow::Result<Address> {
     flag.map_or_else(|| ctx.redemption_wallet().map_err(Into::into), Ok)
+}
+
+async fn build_equity_transfer_services(
+    redemption_wallet_flag: Option<Address>,
+    ctx: &Ctx,
+    pool: &SqlitePool,
+) -> anyhow::Result<EquityTransferCliServices> {
+    let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
+        anyhow::bail!("transfer-equity requires Alpaca Broker API configuration");
+    };
+
+    let redemption_wallet = resolve_redemption_wallet(redemption_wallet_flag, ctx)?;
+    let wallet_ctx = ctx.wallet()?;
+    let wallet = wallet_ctx.base_wallet().address();
+    let base_caller = wallet_ctx.base_wallet().clone();
+
+    let tokenization_service: Arc<dyn Tokenizer> = Arc::new(AlpacaTokenizationService::new(
+        alpaca_auth.base_url().to_string(),
+        alpaca_auth.account_id,
+        alpaca_auth.api_key.clone(),
+        alpaca_auth.api_secret.clone(),
+        base_caller.clone(),
+        Some(redemption_wallet),
+    ));
+
+    let (_vault_store, vault_registry_projection) =
+        StoreBuilder::<VaultRegistry>::new(pool.clone())
+            .build(())
+            .await?;
+
+    let wrapper: Arc<dyn Wrapper> = Arc::new(WrapperService::new(
+        base_caller.clone(),
+        ctx.assets.equities.symbols.clone(),
+    ));
+
+    let raindex = Arc::new(RaindexService::new(
+        base_caller,
+        ctx.evm.orderbook,
+        vault_registry_projection,
+        wallet,
+    ));
+
+    let services = EquityTransferServices {
+        raindex: raindex.clone(),
+        tokenizer: tokenization_service.clone(),
+        wrapper: wrapper.clone(),
+    };
+
+    let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+        .build(services.clone())
+        .await?;
+
+    let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+        .build(services.clone())
+        .await?;
+
+    let transfer = CrossVenueEquityTransfer::new(
+        raindex,
+        tokenization_service.clone(),
+        wrapper,
+        wallet,
+        mint_store,
+        redemption_store,
+    );
+
+    Ok(EquityTransferCliServices { transfer, wallet })
 }
 
 pub(super) async fn transfer_equity_command<Writer: Write>(
@@ -60,68 +131,13 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
 
-    let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
-        anyhow::bail!("transfer-equity requires Alpaca Broker API configuration");
-    };
-
-    let redemption_wallet = resolve_redemption_wallet(redemption_wallet_flag, ctx)?;
-    let wallet_ctx = ctx.wallet()?;
-    let wallet = wallet_ctx.base_wallet().address();
-    let base_caller = wallet_ctx.base_wallet().clone();
-
-    let tokenization_service = Arc::new(AlpacaTokenizationService::new(
-        alpaca_auth.base_url().to_string(),
-        alpaca_auth.account_id,
-        alpaca_auth.api_key.clone(),
-        alpaca_auth.api_secret.clone(),
-        base_caller.clone(),
-        Some(redemption_wallet),
-    ));
-
-    let (_vault_store, vault_registry_projection) =
-        StoreBuilder::<VaultRegistry>::new(pool.clone())
-            .build(())
-            .await?;
-
-    let wrapper: Arc<dyn Wrapper> = Arc::new(WrapperService::new(
-        base_caller.clone(),
-        ctx.assets.equities.symbols.clone(),
-    ));
-
-    let raindex = Arc::new(RaindexService::new(
-        base_caller.clone(),
-        ctx.evm.orderbook,
-        vault_registry_projection,
-        wallet,
-    ));
-
-    let services = EquityTransferServices {
-        raindex: raindex.clone(),
-        tokenizer: tokenization_service.clone(),
-        wrapper: wrapper.clone(),
-    };
-
-    let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
-        .build(services.clone())
-        .await?;
-
-    let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
-        .build(services)
-        .await?;
-
-    let equity_transfer = CrossVenueEquityTransfer::new(
-        raindex,
-        tokenization_service,
-        wrapper,
-        wallet,
-        mint_store,
-        redemption_store,
-    );
+    let cli_services = build_equity_transfer_services(redemption_wallet_flag, ctx, pool).await?;
+    let equity_transfer = cli_services.transfer;
 
     match direction {
         TransferDirection::ToRaindex => {
             writeln!(stdout, "   Creating mint request...")?;
-            writeln!(stdout, "   Receiving Wallet: {wallet}")?;
+            writeln!(stdout, "   Receiving Wallet: {}", cli_services.wallet)?;
 
             CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
                 &equity_transfer,
@@ -661,6 +677,57 @@ pub(crate) async fn fail_transfer_command<W: Write>(
         }
     }
 
+    Ok(())
+}
+
+/// Re-checks a stuck transfer by calling the running bot's
+/// `/transfers/recheck` endpoint. Recovery must run in the bot process so the
+/// recovery event dispatches through the reactor-wired store (correcting the
+/// live inventory view) and shares the bot's resume lock. Requires the bot to
+/// be running and serving its REST API on the configured `server_port`.
+pub(crate) async fn recheck_transfer_command<W: Write>(
+    stdout: &mut W,
+    transfer_type: TransferType,
+    id: &str,
+    ctx: &Ctx,
+) -> anyhow::Result<()> {
+    let kind = match transfer_type {
+        TransferType::Mint => "equity_mint",
+        TransferType::Redemption => "equity_redemption",
+    };
+
+    let url = format!(
+        "http://127.0.0.1:{}/transfers/recheck/{kind}/{id}",
+        ctx.server_port
+    );
+    writeln!(stdout, "Re-checking {transfer_type:?} {id} via {url}")?;
+
+    // Bound the request so the CLI cannot hang indefinitely if the local bot
+    // stalls after accepting the connection.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
+    let response = client.post(&url).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    if !status.is_success() {
+        anyhow::bail!("recheck-transfer failed ({status}): {body}");
+    }
+
+    // The endpoint returns `{"outcome":"<snake_case>"}`; surface the outcome
+    // name (the operator-facing value documented in docs/cli-ops.md) rather
+    // than the raw JSON envelope, falling back to the body if it can't be parsed.
+    let outcome = serde_json::from_str::<serde_json::Value>(&body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("outcome")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or(body);
+    writeln!(stdout, "recheck-transfer outcome: {outcome}")?;
     Ok(())
 }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -260,6 +260,10 @@ impl Conductor {
             failure_injector: ctx.failure_injector.clone(),
         };
 
+        // Clone before the builder consumes it; the recovery handle needs the
+        // rebalancing service to rebuild tracking during recheck recovery.
+        let recovery_rebalancing_service = rebalancing_service.clone();
+
         let mut conductor = builder::spawn()
             .context(conductor_ctx)
             .job_queue(job_queue)
@@ -280,8 +284,13 @@ impl Conductor {
         // Publish the recovery handle only after all startup work
         // (inventory hydration, orphan recovery, store builds) completes
         // so /transfers/resume returns 503 until the conductor is ready.
-        if let Some(transfer) = recovery_transfer {
-            let _ = recovery_cell.set(crate::api::RecoveryHandle { transfer });
+        if let (Some(transfer), Some(rebalancing_service)) =
+            (recovery_transfer, recovery_rebalancing_service)
+        {
+            let _ = recovery_cell.set(crate::api::RecoveryHandle {
+                transfer,
+                rebalancing_service,
+            });
         }
 
         info!("Conductor is running");

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -240,6 +240,10 @@ pub(crate) enum EquityRedemptionCommand {
     Complete,
     /// Alpaca rejected the redemption.
     RejectRedemption { reason: String },
+    /// Recover provider completion after the aggregate had failed.
+    RecoverProviderCompletion {
+        tokenization_request_id: TokenizationRequestId,
+    },
     /// Operator or timeout-driven failure from `WithdrawnFromRaindex` or
     /// `TokensUnwrapped` states.
     FailTransfer { reason: String },
@@ -367,6 +371,10 @@ pub(crate) enum EquityRedemptionEvent {
 
     Completed {
         completed_at: DateTime<Utc>,
+    },
+    ProviderCompletionRecovered {
+        tokenization_request_id: TokenizationRequestId,
+        recovered_at: DateTime<Utc>,
     },
 }
 
@@ -588,6 +596,16 @@ impl PartialEq for EquityRedemptionEvent {
             (Self::Completed { completed_at: c1 }, Self::Completed { completed_at: c2 }) => {
                 c1 == c2
             }
+            (
+                Self::ProviderCompletionRecovered {
+                    tokenization_request_id: id1,
+                    recovered_at: t1,
+                },
+                Self::ProviderCompletionRecovered {
+                    tokenization_request_id: id2,
+                    recovered_at: t2,
+                },
+            ) => id1 == id2 && t1 == t2,
             _ => false,
         }
     }
@@ -618,6 +636,9 @@ impl DomainEvent for EquityRedemptionEvent {
             Detected { .. } => "EquityRedemptionEvent::Detected".to_string(),
             RedemptionRejected { .. } => "EquityRedemptionEvent::RedemptionRejected".to_string(),
             Completed { .. } => "EquityRedemptionEvent::Completed".to_string(),
+            ProviderCompletionRecovered { .. } => {
+                "EquityRedemptionEvent::ProviderCompletionRecovered".to_string()
+            }
         }
     }
 
@@ -971,7 +992,9 @@ impl EventSourced for EquityRedemption {
 
     const AGGREGATE_TYPE: &'static str = "EquityRedemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    // v3: added the `ProviderCompletionRecovered` event for in-process
+    // failed-transfer recovery.
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use EquityRedemptionEvent::*;
@@ -1431,6 +1454,31 @@ impl EventSourced for EquityRedemption {
                     failed_at: *rejected_at,
                 })
             }
+
+            ProviderCompletionRecovered {
+                tokenization_request_id,
+                recovered_at,
+            } => {
+                let Self::Failed {
+                    symbol,
+                    quantity,
+                    redemption_tx: Some(redemption_tx),
+                    started_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::Completed {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    redemption_tx: *redemption_tx,
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    started_at: *started_at,
+                    completed_at: *recovered_at,
+                })
+            }
         })
     }
 
@@ -1464,6 +1512,7 @@ impl EventSourced for EquityRedemption {
             | FailDetection { .. }
             | Complete
             | RejectRedemption { .. }
+            | RecoverProviderCompletion { .. }
             | FailTransfer { .. } => Err(EquityRedemptionError::NotStarted),
         }
     }
@@ -1787,6 +1836,20 @@ impl EventSourced for EquityRedemption {
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+            },
+
+            RecoverProviderCompletion {
+                tokenization_request_id,
+            } => match self {
+                Self::Failed {
+                    redemption_tx: Some(_),
+                    ..
+                } => Ok(vec![ProviderCompletionRecovered {
+                    tokenization_request_id,
+                    recovered_at: Utc::now(),
+                }]),
+                Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                _ => Err(EquityRedemptionError::TokensNotSent),
             },
 
             FailTransfer { reason } => match self {
@@ -3896,6 +3959,93 @@ mod tests {
         assert_eq!(failed_at, later);
         assert_eq!(op.started_at, now);
         assert_eq!(op.updated_at, later);
+    }
+
+    #[test]
+    fn provider_completion_recovery_moves_failed_redemption_to_completed() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let started_at = Utc::now();
+        let recovered_at = started_at + chrono::Duration::seconds(60);
+        let redemption_tx = TxHash::repeat_byte(1);
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(redemption_tx),
+            tokenization_request_id: None,
+            reason: Some("detection timeout".to_string()),
+            started_at,
+            failed_at: started_at + chrono::Duration::seconds(30),
+        };
+
+        let recovered = EquityRedemptionEvent::ProviderCompletionRecovered {
+            tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            recovered_at,
+        };
+
+        let result = EquityRedemption::evolve(&failed, &recovered)
+            .unwrap()
+            .expect("recovered state");
+
+        assert!(
+            matches!(
+                result,
+                EquityRedemption::Completed {
+                    symbol: ref recovered_symbol,
+                    ref tokenization_request_id,
+                    redemption_tx: recovered_tx,
+                    ..
+                } if *recovered_symbol == symbol
+                    && *tokenization_request_id == TokenizationRequestId("TOK001".to_string())
+                    && recovered_tx == redemption_tx
+            ),
+            "expected recovered redemption to complete, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_provider_completion_rejected_for_active_redemption() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event()])
+            .when(EquityRedemptionCommand::RecoverProviderCompletion {
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::TokensNotSent)
+            ),
+            "active redemptions must not be provider-completion recovered, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_provider_completion_rejected_for_completed_redemption() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                tokens_sent_event(),
+                detected_event(),
+                EquityRedemptionEvent::Completed {
+                    completed_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::RecoverProviderCompletion {
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::AlreadyCompleted)
+            ),
+            "completed redemptions must not be recovered, got {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -949,7 +949,6 @@ impl InventoryView {
     }
 
     /// Returns the equity inflight balance at the given venue for a symbol.
-    #[cfg(test)]
     pub(crate) fn equity_inflight(
         &self,
         symbol: &Symbol,
@@ -1319,13 +1318,11 @@ impl InventoryView {
     }
 
     /// Returns the aggregate ID of the in-flight mint for `symbol`, if any.
-    #[cfg(test)]
     pub(crate) fn active_mint(&self, symbol: &Symbol) -> Option<&IssuerRequestId> {
         self.active_mints.get(symbol)
     }
 
     /// Returns the aggregate ID of the in-flight redemption for `symbol`, if any.
-    #[cfg(test)]
     pub(crate) fn active_redemption(&self, symbol: &Symbol) -> Option<&RedemptionAggregateId> {
         self.active_redemptions.get(symbol)
     }

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -11,20 +11,24 @@
 #[cfg(test)]
 pub(crate) mod mock;
 
+use alloy::hex::FromHexError;
 use alloy::primitives::{Address, TxHash, U256};
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
+use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use uuid::Uuid;
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesBlockchain, SharesConversionError, Symbol};
 
+use super::RebalancingService;
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
+use super::trigger::RecoveryClaim;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
@@ -59,6 +63,114 @@ struct TokensReceivedData {
     tx_hash: TxHash,
     symbol: Symbol,
     wallet: Address,
+}
+
+/// Result of re-checking a stuck transfer against the tokenization provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RecheckOutcome {
+    /// The provider had settled the request; the aggregate was un-failed and
+    /// the workflow resumed (or, for redemption, completed).
+    Recovered,
+    /// The aggregate was active (not failed); the normal workflow was resumed.
+    Resumed,
+    /// The aggregate was already in its terminal success state.
+    AlreadyCompleted,
+    /// The provider request is not yet completed; nothing changed.
+    LeftUnchanged,
+    /// The redemption tx has not been detected by the provider yet.
+    NotDetectedYet,
+    /// Another transfer for the same symbol is currently in progress, so
+    /// recovery was refused: rebuilding tracking would overwrite the live
+    /// transfer's in-flight balance. Retry once the symbol is free.
+    Conflict,
+    /// The failure happened past the recoverable stage (e.g. a mint that
+    /// already received tokens, or a redemption that never sent them).
+    /// Provider-completion recovery does not apply.
+    NotRecoverable,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum RecheckError {
+    #[error(transparent)]
+    Mint(#[from] MintError),
+    #[error(transparent)]
+    Redemption(#[from] RedemptionError),
+    #[error(transparent)]
+    Tokenizer(#[from] TokenizerError),
+    #[error(transparent)]
+    Rebalancing(#[from] super::trigger::RebalancingServiceError),
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    #[error("completed provider request {0} is missing its onchain tx hash")]
+    MissingTxHash(TokenizationRequestId),
+    #[error("mint {0} has no accepted provider request to re-check")]
+    NoAcceptedRequest(IssuerRequestId),
+    #[error("mint {id} has an unparseable wallet address in its event history")]
+    MalformedWallet {
+        id: IssuerRequestId,
+        #[source]
+        source: FromHexError,
+    },
+}
+
+/// Context for re-checking a failed mint: the wallet and provider request
+/// from the aggregate's event history, plus whether the mint progressed past
+/// acceptance (in which case provider-completion recovery does not apply).
+struct MintRecheckContext {
+    wallet: Address,
+    tokenization_request_id: TokenizationRequestId,
+    received_tokens: bool,
+}
+
+async fn load_mint_recheck_context(
+    pool: &SqlitePool,
+    id: &IssuerRequestId,
+) -> Result<MintRecheckContext, RecheckError> {
+    let IssuerRequestId(raw_id) = id;
+
+    let row: Option<(String, String, bool)> = sqlx::query_as(
+        "SELECT \
+             json_extract(requested.payload, '$.MintRequested.wallet'), \
+             json_extract(accepted.payload, '$.MintAccepted.tokenization_request_id'), \
+             EXISTS( \
+                 SELECT 1 FROM events received \
+                 WHERE received.aggregate_type = 'TokenizedEquityMint' \
+                   AND received.aggregate_id = requested.aggregate_id \
+                   AND received.event_type IN ( \
+                       'TokenizedEquityMintEvent::TokensReceived', \
+                       'TokenizedEquityMintEvent::ProviderCompletionRecovered' \
+                   ) \
+             ) \
+         FROM events requested \
+         INNER JOIN events accepted \
+             ON accepted.aggregate_type = requested.aggregate_type \
+            AND accepted.aggregate_id = requested.aggregate_id \
+            AND accepted.event_type = 'TokenizedEquityMintEvent::MintAccepted' \
+         WHERE requested.aggregate_type = 'TokenizedEquityMint' \
+           AND requested.aggregate_id = ?1 \
+           AND requested.event_type = 'TokenizedEquityMintEvent::MintRequested' \
+         ORDER BY accepted.sequence DESC \
+         LIMIT 1",
+    )
+    .bind(raw_id)
+    .fetch_optional(pool)
+    .await?;
+
+    let Some((raw_wallet, raw_tokenization_request_id, received_tokens)) = row else {
+        return Err(RecheckError::NoAcceptedRequest(id.clone()));
+    };
+
+    Ok(MintRecheckContext {
+        wallet: raw_wallet
+            .parse()
+            .map_err(|source| RecheckError::MalformedWallet {
+                id: id.clone(),
+                source,
+            })?,
+        tokenization_request_id: TokenizationRequestId(raw_tokenization_request_id),
+        received_tokens,
+    })
 }
 
 /// Services shared by both equity transfer aggregates.
@@ -162,6 +274,13 @@ impl Tokenizer for PanickingTokenizer {
         unimplemented!("PanickingTokenizer: not available in CLI context")
     }
 
+    async fn get_request(
+        &self,
+        _: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
     fn redemption_wallet(&self) -> Option<Address> {
         unimplemented!("PanickingTokenizer: not available in CLI context")
     }
@@ -171,6 +290,13 @@ impl Tokenizer for PanickingTokenizer {
     }
 
     async fn poll_for_redemption(&self, _: &TxHash) -> Result<TokenizationRequest, TokenizerError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
+    async fn find_redemption_by_tx(
+        &self,
+        _: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
         unimplemented!("PanickingTokenizer: not available in CLI context")
     }
 
@@ -1060,6 +1186,263 @@ impl CrossVenueEquityTransfer {
             EquityRedemption::Completed { .. } | EquityRedemption::Failed { .. }
         ))
     }
+
+    /// Re-checks a stuck mint against the tokenization provider and, if the
+    /// provider has settled it, un-fails the aggregate and resumes the
+    /// wrap/deposit workflow. Active (non-failed) mints simply resume.
+    ///
+    /// Dispatches `RecoverProviderCompletion` through the reactor-wired mint
+    /// store after rebuilding tracking, so the live inventory view is
+    /// corrected. Must run inside the bot process for the reactor to fire.
+    pub(crate) async fn recover_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        pool: &SqlitePool,
+        rebalancing: &RebalancingService,
+    ) -> Result<RecheckOutcome, RecheckError> {
+        let entity = self.load_mint_entity(issuer_request_id).await?;
+
+        let (symbol, quantity) = match &entity {
+            TokenizedEquityMint::DepositedIntoRaindex { .. } => {
+                return Ok(RecheckOutcome::AlreadyCompleted);
+            }
+            TokenizedEquityMint::Failed {
+                symbol, quantity, ..
+            } => (symbol.clone(), FractionalShares::new(*quantity)),
+            _ => {
+                self.resume_mint(issuer_request_id).await?;
+                return Ok(RecheckOutcome::Resumed);
+            }
+        };
+
+        let context = load_mint_recheck_context(pool, issuer_request_id).await?;
+
+        // Provider-completion recovery only applies to mints that failed at
+        // acceptance (tokens never received). A mint that already received
+        // tokens and then failed while wrapping/depositing must not be reset
+        // to TokensReceived and re-wrapped against tokens that already moved.
+        if context.received_tokens {
+            warn!(
+                target: "rebalance",
+                %issuer_request_id,
+                "Mint failed after receiving tokens; provider-completion recovery does not apply"
+            );
+            return Ok(RecheckOutcome::NotRecoverable);
+        }
+
+        let request = match self
+            .tokenizer
+            .get_request(&context.tokenization_request_id)
+            .await
+        {
+            Ok(request) => request,
+            // A missing provider request is "left unchanged", not a hard error:
+            // the request may not exist or may not be visible yet. Other tokenizer
+            // failures (transient, verification) still propagate.
+            Err(TokenizerError::Alpaca(AlpacaTokenizationError::RequestNotFound { id })) => {
+                warn!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    %id,
+                    "Provider request not found; leaving mint unchanged"
+                );
+                return Ok(RecheckOutcome::LeftUnchanged);
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        if request.status != TokenizationRequestStatus::Completed {
+            return Ok(RecheckOutcome::LeftUnchanged);
+        }
+
+        let tx_hash = request
+            .tx_hash
+            .ok_or_else(|| RecheckError::MissingTxHash(request.id.clone()))?;
+
+        // Rebuild tracking (and restore the canonical in-flight inventory shape,
+        // clearing any timeout tombstone) before dispatching so the reactor
+        // applies the ProviderCompletionRecovered inventory effect when it
+        // processes the event below.
+        //
+        // The rollback below covers a *persistence* failure (store.send returns
+        // Err -> the event was never committed and the reactor never ran). It
+        // does NOT cover a reactor-application failure: cqrs-es dispatches the
+        // reactor after persisting, and the bridge logs reactor errors without
+        // propagating them, so send still returns Ok. A reactor failure here
+        // would leave the event persisted but inventory un-completed until the
+        // next inventory poll/restart reconciles it.
+        // Compare-and-claim: refuse recovery while a *different* mint for this
+        // symbol is live (rebuilding would overwrite its in-flight balance, since
+        // `set_inflight` replaces rather than adds). A slot still owned by this
+        // same mint -- e.g. the live process never observed its failure, as with
+        // a reactor-less failure injection -- is not a conflict; that is exactly
+        // the stale state recovery reconciles. The check is atomic with the
+        // in-flight restore so a concurrent mint cannot claim the slot in between.
+        let rollback = match rebalancing
+            .rebuild_mint_tracking_for_recovery(issuer_request_id, &entity, request.id.clone())
+            .await?
+        {
+            RecoveryClaim::Conflict => return Ok(RecheckOutcome::Conflict),
+            RecoveryClaim::Claimed(rollback) => rollback,
+        };
+
+        if let Err(error) = self
+            .mint_store
+            .send(
+                issuer_request_id,
+                TokenizedEquityMintCommand::RecoverProviderCompletion {
+                    issuer_request_id: issuer_request_id.clone(),
+                    wallet: context.wallet,
+                    tokenization_request_id: request.id,
+                    tx_hash,
+                    fees: request.fees,
+                },
+            )
+            .await
+        {
+            // The recovery event was not persisted, so the reactor never ran to
+            // complete the in-flight that the rebuild restored. Undo the rebuild
+            // so the live inventory does not show a phantom in-flight transfer or
+            // a symbol locked in-progress until the next restart.
+            if let Err(rollback_error) = rebalancing
+                .rollback_mint_tracking_for_recovery(issuer_request_id, &symbol, quantity, rollback)
+                .await
+            {
+                error!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    ?rollback_error,
+                    "Failed to roll back mint recovery state after dispatch failure"
+                );
+            }
+
+            return Err(MintError::from(error).into());
+        }
+
+        // The recovery event is committed and the reactor has corrected
+        // inventory. A resume failure now (e.g. a transient RPC error during
+        // wrapping) must not be fatal: the aggregate is recovered and startup
+        // recovery will finish the workflow. Clear the in-progress guard so the
+        // symbol is not locked out of rebalancing until the next restart.
+        if let Err(error) = self.resume_mint(issuer_request_id).await {
+            warn!(
+                target: "rebalance",
+                %issuer_request_id,
+                ?error,
+                "Mint recovered but resume failed; cleared in-progress guard, workflow resumes on next startup"
+            );
+            rebalancing
+                .abandon_mint_recovery_guard(issuer_request_id, &symbol)
+                .await;
+        }
+
+        Ok(RecheckOutcome::Recovered)
+    }
+
+    /// Re-checks a stuck redemption against the tokenization provider and, if
+    /// the provider has settled it, un-fails the aggregate to `Completed`.
+    /// Active (non-failed) redemptions simply resume.
+    ///
+    /// Dispatches `RecoverProviderCompletion` through the reactor-wired
+    /// redemption store after rebuilding tracking, so the in-flight transfer
+    /// is completed in the live inventory view.
+    pub(crate) async fn recover_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        rebalancing: &RebalancingService,
+    ) -> Result<RecheckOutcome, RecheckError> {
+        let entity = self.load_redemption_entity(aggregate_id).await?;
+
+        let (symbol, tokenization_request_id, redemption_tx) = match &entity {
+            EquityRedemption::Completed { .. } => return Ok(RecheckOutcome::AlreadyCompleted),
+            EquityRedemption::Failed {
+                symbol,
+                redemption_tx: Some(redemption_tx),
+                tokenization_request_id,
+                ..
+            } => (
+                symbol.clone(),
+                tokenization_request_id.clone(),
+                *redemption_tx,
+            ),
+            // A redemption that failed before sending tokens has nothing for
+            // the provider to have settled.
+            EquityRedemption::Failed { .. } => return Ok(RecheckOutcome::NotRecoverable),
+            _ => {
+                self.resume_redemption(aggregate_id).await?;
+                return Ok(RecheckOutcome::Resumed);
+            }
+        };
+
+        let request = match &tokenization_request_id {
+            // A missing provider request leaves the redemption unchanged rather
+            // than failing the operator command; transient/other errors propagate.
+            Some(request_id) => match self.tokenizer.get_request(request_id).await {
+                Ok(request) => request,
+                Err(TokenizerError::Alpaca(AlpacaTokenizationError::RequestNotFound { id })) => {
+                    warn!(
+                        target: "rebalance",
+                        %aggregate_id,
+                        %id,
+                        "Provider request not found; leaving redemption unchanged"
+                    );
+                    return Ok(RecheckOutcome::LeftUnchanged);
+                }
+                Err(error) => return Err(error.into()),
+            },
+            None => match self.tokenizer.find_redemption_by_tx(&redemption_tx).await? {
+                Some(request) => request,
+                None => return Ok(RecheckOutcome::NotDetectedYet),
+            },
+        };
+
+        if request.status != TokenizationRequestStatus::Completed {
+            return Ok(RecheckOutcome::LeftUnchanged);
+        }
+
+        // Compare-and-claim: refuse recovery while a *different* redemption for
+        // this symbol is live (see recover_mint for the rationale). A slot still
+        // owned by this same redemption is not a conflict. The check is atomic
+        // with the in-flight restore.
+        let rollback = match rebalancing
+            .rebuild_redemption_tracking_for_recovery(aggregate_id, &entity)
+            .await?
+        {
+            RecoveryClaim::Conflict => return Ok(RecheckOutcome::Conflict),
+            RecoveryClaim::Claimed(rollback) => rollback,
+        };
+
+        if let Err(error) = self
+            .redemption_store
+            .send(
+                aggregate_id,
+                EquityRedemptionCommand::RecoverProviderCompletion {
+                    tokenization_request_id: request.id,
+                },
+            )
+            .await
+        {
+            // The recovery event was not persisted, so the reactor never ran to
+            // complete the in-flight that the rebuild restored. Undo the rebuild
+            // so the live inventory does not show a phantom in-flight transfer or
+            // a symbol locked in-progress until the next restart.
+            if let Err(rollback_error) = rebalancing
+                .rollback_redemption_tracking_for_recovery(aggregate_id, &symbol, rollback)
+                .await
+            {
+                error!(
+                    target: "rebalance",
+                    %aggregate_id,
+                    ?rollback_error,
+                    "Failed to roll back redemption recovery state after dispatch failure"
+                );
+            }
+
+            return Err(RedemptionError::from(error).into());
+        }
+
+        Ok(RecheckOutcome::Recovered)
+    }
 }
 
 /// Hedging -> Market-Making: tokenize equity on Alpaca and deposit into
@@ -1146,20 +1529,31 @@ impl CrossVenueTransfer<MarketMakingVenue, HedgingVenue> for CrossVenueEquityTra
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Address;
+    use alloy::primitives::{Address, address};
+    use chrono::Utc;
     use sqlx::SqlitePool;
+    use std::collections::HashSet;
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::{broadcast, mpsc};
 
-    use st0x_event_sorcery::test_store;
+    use st0x_dto::Statement;
+    use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_execution::{FractionalShares, Symbol};
+    use st0x_float_macro::float;
 
     use super::*;
+    use crate::config::{AssetsConfig, EquitiesConfig};
+    use crate::inventory::{
+        BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
+    };
     use crate::onchain::mock::MockRaindex;
+    use crate::rebalancing::{RebalancingSchedulers, RebalancingServiceConfig};
     use crate::tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
     };
+    use crate::vault_registry::VaultRegistry;
     use crate::wrapper::mock::MockWrapper;
-    use st0x_float_macro::float;
 
     fn mock_services() -> EquityTransferServices {
         EquityTransferServices {
@@ -1167,6 +1561,342 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
         }
+    }
+
+    async fn insert_mint_event(
+        pool: &SqlitePool,
+        id: &IssuerRequestId,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) {
+        let IssuerRequestId(raw) = id;
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES ('TokenizedEquityMint', ?, ?, ?, '1.0', ?, '{}')",
+        )
+        .bind(raw)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn recheck_context_treats_recovered_mint_as_having_received_tokens() {
+        // A mint recovered once via ProviderCompletionRecovered evolves into the
+        // TokensReceived state without writing a literal TokensReceived event. If
+        // it then re-fails at wrapping, a second recheck must NOT recover it again
+        // (which would re-wrap already-moved tokens), so received_tokens must be
+        // true even though no TokensReceived event exists.
+        let pool = crate::test_utils::setup_test_db().await;
+        let id = IssuerRequestId::new("mint-rerecover");
+
+        insert_mint_event(
+            &pool,
+            &id,
+            0,
+            "TokenizedEquityMintEvent::MintRequested",
+            r#"{"MintRequested":{"symbol":"AAPL","quantity":"10","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            1,
+            "TokenizedEquityMintEvent::MintAccepted",
+            r#"{"MintAccepted":{"issuer_request_id":"mint-rerecover","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            2,
+            "TokenizedEquityMintEvent::ProviderCompletionRecovered",
+            r#"{"ProviderCompletionRecovered":{"issuer_request_id":"mint-rerecover","wallet":"0x0000000000000000000000000000000000000001","tokenization_request_id":"tok-1","tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111","shares_minted":"10000000000000000000","fees":null,"recovered_at":"2026-01-01T00:02:00Z"}}"#,
+        )
+        .await;
+
+        let context = load_mint_recheck_context(&pool, &id).await.unwrap();
+
+        assert!(
+            context.received_tokens,
+            "a mint already recovered via ProviderCompletionRecovered must count as having received tokens"
+        );
+    }
+
+    /// Reproduces the production recovery path end to end: a mint that failed
+    /// at acceptance (injected reactor-less, exactly as the simulate-failures
+    /// harness does) is recovered by dispatching `RecoverProviderCompletion`
+    /// through the reactor-wired store. The recovered quantity must leave the
+    /// Hedging in-flight balance (the dashboard's "Inflight" column) and land in
+    /// MarketMaking available -- not stay stuck in-flight forever.
+    #[tokio::test]
+    async fn recover_mint_clears_hedging_inflight() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let id = IssuerRequestId::new("mint-recover-inflight");
+
+        // Reactor-less failure injection: the live reactor never observes these
+        // events, so its inventory holds the full Hedging balance with nothing
+        // in-flight -- the stale state recovery must reconcile.
+        insert_mint_event(
+            &pool,
+            &id,
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            r#"{"MintRequested":{"symbol":"AAPL","quantity":"10","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            2,
+            "TokenizedEquityMintEvent::MintAccepted",
+            r#"{"MintAccepted":{"issuer_request_id":"mint-recover-inflight","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            3,
+            "TokenizedEquityMintEvent::MintAcceptanceFailed",
+            r#"{"MintAcceptanceFailed":{"reason":"simulate: timeout","failed_at":"2026-01-01T00:00:02Z"}}"#,
+        )
+        .await;
+
+        let (operation_sender, _operation_receiver) = mpsc::channel(10);
+        let (event_sender, _event_receiver) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default().with_equity(
+                symbol.clone(),
+                FractionalShares::ZERO,
+                FractionalShares::new(float!(100)),
+            ),
+            event_sender,
+        ));
+
+        let service = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: ImbalanceThreshold {
+                    target: float!(0.5),
+                    deviation: float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(1800),
+                assets: AssetsConfig {
+                    equities: EquitiesConfig::default(),
+                    cash: None,
+                },
+                disabled_assets: HashSet::new(),
+            },
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            address!("0x0000000000000000000000000000000000000001"),
+            address!("0x0000000000000000000000000000000000000002"),
+            inventory.clone(),
+            operation_sender,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
+        ));
+
+        // Reactor-wired stores -- the production wiring that dispatches committed
+        // events to the reactor's `on_mint`.
+        let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        service
+            .set_stores(mint_store.clone(), redemption_store.clone())
+            .await;
+
+        // The provider reports the request settled: get_request must find a
+        // Completed request (with a tx_hash) under the aggregate's
+        // tokenization_request_id ("tok-1").
+        let mut completed_request = TokenizationRequest::mock_completed();
+        completed_request.id = TokenizationRequestId("tok-1".to_string());
+        let tokenizer =
+            Arc::new(MockTokenizer::new().with_pending_requests(vec![completed_request]));
+
+        let transfer = CrossVenueEquityTransfer::new(
+            Arc::new(MockRaindex::new()),
+            tokenizer,
+            Arc::new(MockWrapper::new()),
+            address!("0x0000000000000000000000000000000000000001"),
+            mint_store,
+            redemption_store,
+        );
+
+        let outcome = transfer.recover_mint(&id, &pool, &service).await.unwrap();
+        assert!(
+            matches!(outcome, RecheckOutcome::Recovered),
+            "expected Recovered, got {outcome:?}"
+        );
+
+        let (hedging_inflight, market_making_available) = {
+            let view = inventory.read().await;
+
+            (
+                view.equity_inflight(&symbol, Venue::Hedging),
+                view.equity_available(&symbol, Venue::MarketMaking),
+            )
+        };
+        assert_eq!(
+            hedging_inflight,
+            Some(FractionalShares::ZERO),
+            "recovered mint left its quantity stuck in Hedging in-flight"
+        );
+        assert_eq!(
+            market_making_available,
+            Some(FractionalShares::new(float!(10))),
+            "recovered quantity should land in MarketMaking available"
+        );
+    }
+
+    /// Recovery must not double-count an in-flight that is ALREADY established.
+    ///
+    /// The realistic stuck state -- what the simulate-failures harness and the
+    /// CLI `fail-transfer` ops tool both produce -- is: `MintAccepted` ran
+    /// `start` so the quantity sits in Hedging in-flight, but the failure was
+    /// recorded out-of-process so the reactor never ran `cancel`. Recovery then
+    /// runs against an in-flight already at the mint quantity; re-establishing
+    /// it with a `Start` double-counts (qty -> 2*qty), and the completion
+    /// removes only one copy, leaving the quantity stuck in-flight. Recovery
+    /// must reconcile it to zero idempotently.
+    #[tokio::test]
+    async fn recover_mint_does_not_double_count_existing_inflight() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let id = IssuerRequestId::new("mint-double-count");
+
+        insert_mint_event(
+            &pool,
+            &id,
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            r#"{"MintRequested":{"symbol":"AAPL","quantity":"10","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            2,
+            "TokenizedEquityMintEvent::MintAccepted",
+            r#"{"MintAccepted":{"issuer_request_id":"mint-double-count","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+        )
+        .await;
+        insert_mint_event(
+            &pool,
+            &id,
+            3,
+            "TokenizedEquityMintEvent::MintAcceptanceFailed",
+            r#"{"MintAcceptanceFailed":{"reason":"simulate: timeout","failed_at":"2026-01-01T00:00:02Z"}}"#,
+        )
+        .await;
+
+        let (operation_sender, _operation_receiver) = mpsc::channel(10);
+        let (event_sender, _event_receiver) = broadcast::channel::<Statement>(16);
+
+        // MintAccepted's `start` already moved the quantity into Hedging
+        // in-flight (available 100 -> 90, in-flight 10); the out-of-process
+        // failure never ran `cancel`, so the in-flight is still established.
+        let seeded = InventoryView::default()
+            .with_equity(
+                symbol.clone(),
+                FractionalShares::ZERO,
+                FractionalShares::new(float!(90)),
+            )
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::Hedging, FractionalShares::new(float!(10))),
+                Utc::now(),
+            )
+            .unwrap();
+        let inventory = Arc::new(BroadcastingInventory::new(seeded, event_sender));
+
+        let service = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: ImbalanceThreshold {
+                    target: float!(0.5),
+                    deviation: float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(1800),
+                assets: AssetsConfig {
+                    equities: EquitiesConfig::default(),
+                    cash: None,
+                },
+                disabled_assets: HashSet::new(),
+            },
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            address!("0x0000000000000000000000000000000000000001"),
+            address!("0x0000000000000000000000000000000000000002"),
+            inventory.clone(),
+            operation_sender,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
+        ));
+
+        let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        service
+            .set_stores(mint_store.clone(), redemption_store.clone())
+            .await;
+
+        let mut completed_request = TokenizationRequest::mock_completed();
+        completed_request.id = TokenizationRequestId("tok-1".to_string());
+        let tokenizer =
+            Arc::new(MockTokenizer::new().with_pending_requests(vec![completed_request]));
+
+        let transfer = CrossVenueEquityTransfer::new(
+            Arc::new(MockRaindex::new()),
+            tokenizer,
+            Arc::new(MockWrapper::new()),
+            address!("0x0000000000000000000000000000000000000001"),
+            mint_store,
+            redemption_store,
+        );
+
+        let outcome = transfer.recover_mint(&id, &pool, &service).await.unwrap();
+        assert!(
+            matches!(outcome, RecheckOutcome::Recovered),
+            "expected Recovered, got {outcome:?}"
+        );
+
+        let (hedging_inflight, market_making_available) = {
+            let view = inventory.read().await;
+
+            (
+                view.equity_inflight(&symbol, Venue::Hedging),
+                view.equity_available(&symbol, Venue::MarketMaking),
+            )
+        };
+        assert_eq!(
+            hedging_inflight,
+            Some(FractionalShares::ZERO),
+            "recovery double-counted the already-established in-flight, leaving it stuck"
+        );
+        assert_eq!(
+            market_making_available,
+            Some(FractionalShares::new(float!(10))),
+            "recovered quantity should land in MarketMaking available"
+        );
     }
 
     async fn create_equity_transfer(

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -40,7 +40,7 @@ use tracing::{debug, error, trace, warn};
 use rain_math_float::Float;
 use st0x_event_sorcery::{AggregateError, EntityList, LifecycleError, Reactor, Store, deps};
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
-use st0x_finance::Usdc;
+use st0x_finance::{HasZero, Usdc};
 
 use crate::config::AssetsConfig;
 use crate::equity_redemption::{
@@ -365,6 +365,10 @@ impl MintTracking {
                 self.stage = MintTrackingStage::TokensReceived;
                 self.last_progress_at = *received_at;
             }
+            TokenizedEquityMintEvent::ProviderCompletionRecovered { recovered_at, .. } => {
+                self.stage = MintTrackingStage::TokensReceived;
+                self.last_progress_at = *recovered_at;
+            }
             TokenizedEquityMintEvent::WrapSubmitted { submitted_at, .. } => {
                 self.stage = MintTrackingStage::WrapSubmitted;
                 self.last_progress_at = *submitted_at;
@@ -531,6 +535,7 @@ impl RedemptionTracking {
             | EquityRedemptionEvent::TransferFailed { .. }
             | EquityRedemptionEvent::DetectionFailed { .. }
             | EquityRedemptionEvent::RedemptionRejected { .. }
+            | EquityRedemptionEvent::ProviderCompletionRecovered { .. }
             | EquityRedemptionEvent::Completed { .. } => {}
         }
 
@@ -543,6 +548,10 @@ fn mint_event_tokenization_request_id(
 ) -> Option<&crate::tokenized_equity_mint::TokenizationRequestId> {
     match event {
         TokenizedEquityMintEvent::MintAccepted {
+            tokenization_request_id,
+            ..
+        }
+        | TokenizedEquityMintEvent::ProviderCompletionRecovered {
             tokenization_request_id,
             ..
         } => Some(tokenization_request_id),
@@ -1487,6 +1496,54 @@ impl PendingRequestOwnership for RebalancingService {
     }
 }
 
+/// Describes the inventory/tombstone mutation a `rebuild_*_tracking_for_recovery`
+/// call applied, so the caller can undo it precisely if the recovery dispatch
+/// fails before the reactor completes the restored in-flight transfer. Without
+/// this the live inventory would be left showing a phantom in-flight transfer
+/// (and a symbol locked in-progress) for an aggregate whose recovery event was
+/// never persisted.
+pub(crate) enum RecoveryRollback {
+    /// The rebuild touched no inventory balances (called on a non-failed
+    /// aggregate, or an explicitly-failed redemption whose in-flight was never
+    /// cancelled). Rollback only drops the tracking + in-progress guard.
+    TrackingOnly,
+    /// The rebuild moved available -> in-flight via `Start` (an explicitly
+    /// failed transfer that had cancelled its in-flight back to available).
+    /// Rollback cancels the in-flight back to available.
+    CancelInflight,
+    /// The rebuild re-set the in-flight and dropped the timeout tombstone
+    /// (a timed-out transfer). Rollback clears the in-flight again and restores
+    /// the tombstone + suppressed-inflight markers it removed.
+    RestoreTombstone {
+        timed_out_at: DateTime<Utc>,
+        suppressed_at: Option<DateTime<Utc>>,
+    },
+}
+
+/// Outcome of an atomic recovery claim. `rebuild_*_tracking_for_recovery`
+/// checks symbol ownership and restores the in-flight under a single inventory
+/// write lock, so a concurrent live mint/redemption cannot claim the slot
+/// between the check and the restore (which would silently clobber its
+/// in-flight, since recovery's `set_inflight` *replaces* rather than adds).
+pub(crate) enum RecoveryClaim {
+    /// The recovery claimed the symbol's slot. Carries the rollback needed if
+    /// the recovery dispatch later fails before the reactor runs.
+    Claimed(RecoveryRollback),
+    /// A *different* live mint/redemption for the symbol already owns the slot,
+    /// so recovery must abort without mutating inventory.
+    Conflict,
+}
+
+#[cfg(test)]
+impl RecoveryClaim {
+    fn expect_claimed(self) -> RecoveryRollback {
+        match self {
+            Self::Claimed(rollback) => rollback,
+            Self::Conflict => panic!("expected recovery to claim the slot, got Conflict"),
+        }
+    }
+}
+
 impl RebalancingService {
     async fn expire_stuck_operations_with_logging(&self) {
         if let Err(error) = self.expire_stuck_operations(Utc::now()).await {
@@ -1599,10 +1656,16 @@ impl RebalancingService {
                 Venue::Hedging,
                 quantity,
             )),
-            TokensReceived { .. } => Some(Self::complete_equity_transfer_update(
-                Venue::Hedging,
-                quantity,
-            )),
+            // TokensReceived completes the normal mint; ProviderCompletionRecovered
+            // completes a recovered one. rebuild_mint_tracking_for_recovery restores
+            // the canonical in-flight shape (Hedging in-flight = quantity, available
+            // already debited) before dispatch, so recovery confirms the in-flight
+            // the same way the success path does -- in-flight -> MarketMaking
+            // available, plus last_rebalancing to suppress a redundant rebalance --
+            // regardless of how the mint originally failed.
+            TokensReceived { .. } | ProviderCompletionRecovered { .. } => Some(
+                Self::complete_equity_transfer_update(Venue::Hedging, quantity),
+            ),
             DepositedIntoRaindex { .. } => Some(Self::last_rebalancing_update()),
             MintRequested { .. }
             | MintRejected { .. }
@@ -1687,10 +1750,9 @@ impl RebalancingService {
                 Venue::MarketMaking,
                 quantity,
             )),
-            Completed { .. } => Some(Self::complete_equity_transfer_update(
-                Venue::MarketMaking,
-                quantity,
-            )),
+            Completed { .. } | ProviderCompletionRecovered { .. } => Some(
+                Self::complete_equity_transfer_update(Venue::MarketMaking, quantity),
+            ),
             TransferFailed { .. } => Some(Self::cancel_equity_transfer_update(
                 Venue::MarketMaking,
                 quantity,
@@ -1865,6 +1927,33 @@ impl RebalancingService {
         guard.insert(symbol.clone());
     }
 
+    /// Releases the in-progress guard and tracking for a mint whose recovery
+    /// event was committed (inventory already corrected by the reactor) but
+    /// whose in-process resume failed. The aggregate is left for startup
+    /// recovery to finish; dropping the tracking prevents the timeout sweeper
+    /// from later failing an already-recovered mint, and clearing the guard
+    /// unblocks rebalancing for the symbol.
+    pub(crate) async fn abandon_mint_recovery_guard(&self, id: &IssuerRequestId, symbol: &Symbol) {
+        self.mint_tracking.write().await.remove(id);
+        self.clear_equity_in_progress(symbol);
+
+        // `ProviderCompletionRecovered` is non-terminal for mints, so the
+        // reactor *set* the active-mint slot to this id when it processed the
+        // recovery event. Dropping tracking here means no future event can
+        // clear it (events for an untracked aggregate early-return), so clear
+        // it now to keep `active_mint` mirroring `mint_tracking`'s lifecycle --
+        // otherwise the dashboard shows a phantom active mint until restart.
+        // Clear only if this id still owns the slot: on the dispatch-failure
+        // rollback path the reactor never ran, so a concurrent mint may
+        // legitimately own it and must not be cleared. Re-check ownership under
+        // the write lock so a concurrent mint cannot claim the slot between the
+        // read and the clear.
+        let mut inventory = self.inventory.write().await;
+        if inventory.active_mint(symbol) == Some(id) {
+            *inventory = inventory.clone().clear_active_mint(symbol);
+        }
+    }
+
     /// Clears the in-progress flag for USDC rebalancing.
     pub(crate) fn clear_usdc_in_progress(&self) {
         self.usdc_in_progress.store(false, Ordering::SeqCst);
@@ -1976,6 +2065,347 @@ impl RebalancingService {
             DepositedIntoRaindex { .. } | Failed { .. } => {}
         }
 
+        Ok(())
+    }
+
+    /// Rebuilds in-memory tracking for a failed mint being recovered via
+    /// `recheck-transfer`, so the live reactor applies the
+    /// `ProviderCompletionRecovered` inventory effect and the terminal
+    /// cleanup once the recovery event is dispatched.
+    ///
+    /// Returns [`RecoveryClaim::Conflict`] when a *different* live mint already
+    /// owns the symbol's slot: the ownership check and the in-flight restore run
+    /// under one inventory write lock (compare-and-claim) so a concurrent mint
+    /// cannot claim the slot in between, which would let recovery's `set_inflight`
+    /// (a replace, not an add) clobber its in-flight. A slot still owned by `id`
+    /// itself is not a conflict -- that is the stale state recovery reconciles.
+    pub(crate) async fn rebuild_mint_tracking_for_recovery(
+        &self,
+        id: &IssuerRequestId,
+        entity: &TokenizedEquityMint,
+        tokenization_request_id: crate::tokenized_equity_mint::TokenizationRequestId,
+    ) -> Result<RecoveryClaim, RebalancingServiceError> {
+        let TokenizedEquityMint::Failed {
+            symbol, quantity, ..
+        } = entity
+        else {
+            warn!(target: "rebalance", id = %id, "rebuild_mint_tracking_for_recovery called on non-failed mint; skipping");
+            return Ok(RecoveryClaim::Claimed(RecoveryRollback::TrackingOnly));
+        };
+
+        let quantity = FractionalShares::new(*quantity);
+
+        // Restore a single canonical pre-recovery inventory shape -- the
+        // Hedging in-flight holding `quantity`, with available already debited
+        // -- so the ProviderCompletionRecovered reactor arm can complete it
+        // uniformly regardless of how the mint failed:
+        // - a timeout cleared the in-flight without crediting available and
+        //   tombstoned the aggregate (so the reactor ignores late events), so we
+        //   drop the tombstone and re-set the in-flight (available stays debited);
+        // - an explicit MintAcceptanceFailed cancelled the in-flight back to
+        //   available, so we move it back into the in-flight with a Start.
+        // Peek (don't yet remove) the timeout markers so a failure in the
+        // fallible inventory update below leaves them intact -- a failed rebuild
+        // does not run the caller's rollback, so consuming them up front would
+        // lose the tombstone permanently.
+        let timed_out_at = self.timed_out_mints.read().await.get(id).copied();
+
+        // A third shape the timeout/explicit branches below do not cover: the
+        // failure left the in-flight already established (a `Start` ran but the
+        // failure never cancelled it back to available -- e.g. an out-of-process
+        // `fail-transfer`, or a reactor that recorded the failure without
+        // running `cancel`). That is already the canonical pre-complete shape,
+        // so re-establishing it with another `Start` would double-count
+        // (quantity -> 2*quantity) and strand the quantity in-flight after the
+        // completion. Detect it and set the in-flight idempotently instead.
+        let inflight_already_established = self
+            .inventory
+            .read()
+            .await
+            .equity_inflight(symbol, Venue::Hedging)
+            .map(|amount| amount.is_zero())
+            .transpose()?
+            .is_some_and(|is_zero| !is_zero);
+
+        let (update, rollback): (EquityInventoryUpdate, RecoveryRollback) =
+            if let Some(timed_out_at) = timed_out_at {
+                let suppressed_at = self
+                    .suppressed_inflight_symbols
+                    .read()
+                    .await
+                    .get(symbol)
+                    .copied();
+                (
+                    Box::new(Inventory::set_inflight(Venue::Hedging, quantity)),
+                    RecoveryRollback::RestoreTombstone {
+                        timed_out_at,
+                        suppressed_at,
+                    },
+                )
+            } else if inflight_already_established {
+                (
+                    Box::new(Inventory::set_inflight(Venue::Hedging, quantity)),
+                    RecoveryRollback::TrackingOnly,
+                )
+            } else {
+                (
+                    Self::start_equity_transfer_update(Venue::Hedging, quantity),
+                    RecoveryRollback::CancelInflight,
+                )
+            };
+
+        // Compare-and-claim: refuse if a *different* mint owns the slot, else
+        // restore the in-flight -- both under one write lock so the check and the
+        // claim cannot be interleaved by a concurrent live mint.
+        {
+            let mut inventory = self.inventory.write().await;
+            if matches!(inventory.active_mint(symbol), Some(active) if active != id) {
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    %symbol,
+                    "Refusing mint recovery: a different mint for this symbol is in progress"
+                );
+                return Ok(RecoveryClaim::Conflict);
+            }
+
+            *inventory = inventory
+                .clone()
+                .update_equity(symbol, update, Utc::now())?;
+        }
+
+        // The inventory update succeeded; now consume the timeout markers.
+        if timed_out_at.is_some() {
+            self.timed_out_mints.write().await.remove(id);
+            self.suppressed_inflight_symbols
+                .write()
+                .await
+                .remove(symbol);
+        }
+
+        self.mint_tracking.write().await.insert(
+            id.clone(),
+            MintTracking {
+                symbol: symbol.clone(),
+                quantity,
+                tokenization_request_id: Some(tokenization_request_id),
+                stage: MintTrackingStage::Accepted,
+                last_progress_at: Utc::now(),
+            },
+        );
+        self.mark_equity_in_progress(symbol);
+        Ok(RecoveryClaim::Claimed(rollback))
+    }
+
+    /// Reverses what [`Self::rebuild_mint_tracking_for_recovery`] mutated, for
+    /// when the recovery dispatch fails before the reactor completes the
+    /// restored in-flight transfer. Restores the pre-recovery failed-mint
+    /// state so the live inventory does not show a phantom in-flight transfer,
+    /// a missing timeout tombstone, or a symbol locked in-progress until the
+    /// next bot restart.
+    pub(crate) async fn rollback_mint_tracking_for_recovery(
+        &self,
+        id: &IssuerRequestId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+        rollback: RecoveryRollback,
+    ) -> Result<(), RebalancingServiceError> {
+        match rollback {
+            RecoveryRollback::TrackingOnly => {}
+            RecoveryRollback::CancelInflight => {
+                self.apply_equity_update(
+                    symbol,
+                    Self::cancel_equity_transfer_update(Venue::Hedging, quantity),
+                )
+                .await?;
+            }
+            RecoveryRollback::RestoreTombstone {
+                timed_out_at,
+                suppressed_at,
+            } => {
+                let mut inventory = self.inventory.write().await;
+                *inventory =
+                    inventory
+                        .clone()
+                        .clear_equity_inflight(symbol, Venue::Hedging, Utc::now())?;
+                drop(inventory);
+                self.timed_out_mints
+                    .write()
+                    .await
+                    .insert(id.clone(), timed_out_at);
+                if let Some(suppressed_at) = suppressed_at {
+                    self.suppressed_inflight_symbols
+                        .write()
+                        .await
+                        .insert(symbol.clone(), suppressed_at);
+                }
+            }
+        }
+
+        // Drops the tracking + in-progress guard (and clears active_mint, which
+        // a failed dispatch never set since the reactor did not run).
+        self.abandon_mint_recovery_guard(id, symbol).await;
+        Ok(())
+    }
+
+    /// Rebuilds in-memory tracking for a failed redemption being recovered
+    /// via `recheck-transfer`. See [`Self::rebuild_mint_tracking_for_recovery`]
+    /// for why inventory balances are left untouched on the explicit-failure
+    /// path: a failed redemption never cancelled its in-flight transfer, so the
+    /// recovery event's inventory arm completes that still-pending transfer.
+    ///
+    /// Returns [`RecoveryClaim::Conflict`] when a *different* live redemption
+    /// already owns the symbol's slot. The ownership check runs under the same
+    /// inventory write lock that restores a timed-out in-flight, so it cannot be
+    /// interleaved by a concurrent redemption.
+    pub(crate) async fn rebuild_redemption_tracking_for_recovery(
+        &self,
+        id: &RedemptionAggregateId,
+        entity: &EquityRedemption,
+    ) -> Result<RecoveryClaim, RebalancingServiceError> {
+        let EquityRedemption::Failed {
+            symbol,
+            quantity,
+            tokenization_request_id,
+            redemption_tx,
+            ..
+        } = entity
+        else {
+            warn!(target: "rebalance", id = %id, "rebuild_redemption_tracking_for_recovery called on non-failed redemption; skipping");
+            return Ok(RecoveryClaim::Claimed(RecoveryRollback::TrackingOnly));
+        };
+
+        let quantity = FractionalShares::new(*quantity);
+
+        // A timeout cleared the MarketMaking in-flight and tombstoned the
+        // aggregate; drop the tombstone and re-set the in-flight so the recovery
+        // arm's complete_equity_transfer_update can confirm it. An explicit
+        // DetectionFailed/RedemptionRejected left the in-flight in place (those
+        // events do not touch inventory), so there is nothing to restore.
+        //
+        // Peek (don't yet remove) the timeout markers so a failure in the
+        // fallible inventory update below leaves them intact -- a failed rebuild
+        // does not run the caller's rollback.
+        let timed_out_at = self.timed_out_redemptions.read().await.get(id).copied();
+        let suppressed_at = if timed_out_at.is_some() {
+            self.suppressed_inflight_symbols
+                .read()
+                .await
+                .get(symbol)
+                .copied()
+        } else {
+            None
+        };
+
+        // Compare-and-claim: refuse if a *different* redemption owns the slot.
+        // The check shares the write lock with the timed-out in-flight restore so
+        // a concurrent redemption cannot claim the slot between the two.
+        {
+            let mut inventory = self.inventory.write().await;
+            if matches!(inventory.active_redemption(symbol), Some(active) if active != id) {
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    %symbol,
+                    "Refusing redemption recovery: a different redemption for this symbol is in progress"
+                );
+                return Ok(RecoveryClaim::Conflict);
+            }
+
+            if timed_out_at.is_some() {
+                *inventory = inventory.clone().update_equity(
+                    symbol,
+                    Box::new(Inventory::set_inflight(Venue::MarketMaking, quantity)),
+                    Utc::now(),
+                )?;
+            }
+        }
+
+        let rollback = if let Some(timed_out_at) = timed_out_at {
+            // The inventory update succeeded; now consume the timeout markers.
+            self.timed_out_redemptions.write().await.remove(id);
+            self.suppressed_inflight_symbols
+                .write()
+                .await
+                .remove(symbol);
+
+            RecoveryRollback::RestoreTombstone {
+                timed_out_at,
+                suppressed_at,
+            }
+        } else {
+            RecoveryRollback::TrackingOnly
+        };
+
+        self.redemption_tracking.write().await.insert(
+            id.clone(),
+            RedemptionTracking {
+                symbol: symbol.clone(),
+                quantity,
+                tokenization_request_id: tokenization_request_id.clone(),
+                redemption_tx: *redemption_tx,
+                stage: RedemptionTrackingStage::TokensSent,
+                last_progress_at: Utc::now(),
+            },
+        );
+        self.mark_equity_in_progress(symbol);
+        Ok(RecoveryClaim::Claimed(rollback))
+    }
+
+    /// Reverses what [`Self::rebuild_redemption_tracking_for_recovery`]
+    /// mutated, for when the recovery dispatch fails before the reactor
+    /// completes the restored in-flight transfer. See
+    /// [`Self::rollback_mint_tracking_for_recovery`].
+    pub(crate) async fn rollback_redemption_tracking_for_recovery(
+        &self,
+        id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        rollback: RecoveryRollback,
+    ) -> Result<(), RebalancingServiceError> {
+        match rollback {
+            // Explicit redemption failures never restored an in-flight, and the
+            // `Start`-based variant is mint-only, so there is no balance to undo.
+            RecoveryRollback::TrackingOnly | RecoveryRollback::CancelInflight => {}
+            RecoveryRollback::RestoreTombstone {
+                timed_out_at,
+                suppressed_at,
+            } => {
+                let mut inventory = self.inventory.write().await;
+                *inventory = inventory.clone().clear_equity_inflight(
+                    symbol,
+                    Venue::MarketMaking,
+                    Utc::now(),
+                )?;
+                drop(inventory);
+                self.timed_out_redemptions
+                    .write()
+                    .await
+                    .insert(id.clone(), timed_out_at);
+                if let Some(suppressed_at) = suppressed_at {
+                    self.suppressed_inflight_symbols
+                        .write()
+                        .await
+                        .insert(symbol.clone(), suppressed_at);
+                }
+            }
+        }
+
+        self.redemption_tracking.write().await.remove(id);
+        self.clear_equity_in_progress(symbol);
+
+        // Mirror `abandon_mint_recovery_guard`: a recovery may proceed while the
+        // slot is still self-owned (a reactor-less failure the live process never
+        // observed -- the claim treats that as recoverable, not a conflict). If
+        // the dispatch then fails the reactor never runs to clear it, so dropping
+        // tracking here would strand a phantom `active_redemption` (visible to the
+        // dashboard and future conflict checks) until the next restart. Clear it
+        // now, but only while this id still owns it -- re-checking under the write
+        // lock so a concurrent redemption that claimed the slot is not cleared.
+        let mut inventory = self.inventory.write().await;
+        if inventory.active_redemption(symbol) == Some(id) {
+            *inventory = inventory.clone().clear_active_redemption(symbol);
+        }
+        drop(inventory);
         Ok(())
     }
 
@@ -2113,6 +2543,34 @@ impl RebalancingService {
 
         if let Some(update) = Self::mint_inventory_update(&event, tracking.quantity) {
             self.apply_equity_update(&symbol, update).await?;
+        }
+
+        // Defense-in-depth: a recovered mint must clear its Hedging in-flight via
+        // the completion above. A residual in-flight means recovery double-counted
+        // or otherwise failed to confirm it -- a financial accounting anomaly
+        // worth surfacing rather than stranding silently.
+        if matches!(
+            event,
+            TokenizedEquityMintEvent::ProviderCompletionRecovered { .. }
+        ) {
+            let residual = self
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::Hedging);
+            if residual
+                .map(|amount| amount.is_zero())
+                .transpose()?
+                .is_some_and(|is_zero| !is_zero)
+            {
+                warn!(
+                    target: "rebalance",
+                    id = %id,
+                    %symbol,
+                    ?residual,
+                    "Recovered mint left a non-zero Hedging in-flight; inventory may be inconsistent"
+                );
+            }
         }
 
         // When a new mint transfer starts, clear the previous poll marker
@@ -2258,6 +2716,7 @@ impl RebalancingService {
             MintRequested { .. }
             | MintAccepted { .. }
             | TokensReceived { .. }
+            | ProviderCompletionRecovered { .. }
             | WrapSubmitted { .. }
             | TokensWrapped { .. }
             | VaultDepositSubmitted { .. } => false,
@@ -2277,6 +2736,7 @@ impl RebalancingService {
 
         match event {
             Completed { .. }
+            | ProviderCompletionRecovered { .. }
             | TransferFailed { .. }
             | DetectionFailed { .. }
             | RedemptionRejected { .. } => true,
@@ -2370,7 +2830,7 @@ mod tests {
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionEvent, TradeId};
     use crate::threshold::ExecutionThreshold;
-    use crate::tokenized_equity_mint::{IssuerRequestId, ReceiptId, TokenizationRequestId};
+    use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
     use crate::usdc_rebalance::{
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
@@ -2543,6 +3003,904 @@ mod tests {
             inventory.equity_inflight(&symbol, Venue::MarketMaking)
         };
         assert_eq!(inflight, Some(FractionalShares::new(float!(12))));
+    }
+
+    #[tokio::test]
+    async fn recovery_after_explicit_mint_failure_moves_equity_to_market_making() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-explicit-recovery");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        // An explicit MintAcceptanceFailed cancelled the in-flight back to
+        // Hedging (offchain) available, so available holds the full 100 and
+        // inflight is 0.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(0), shares(100));
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "rejected".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        trigger
+            .rebuild_mint_tracking_for_recovery(&mint_id, &failed, tok.clone())
+            .await
+            .unwrap();
+
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::ProviderCompletionRecovered {
+                    issuer_request_id: mint_id.clone(),
+                    wallet: Address::ZERO,
+                    tokenization_request_id: tok,
+                    tx_hash: TxHash::random(),
+                    shares_minted: U256::from(10u64),
+                    fees: None,
+                    recovered_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (hedging, market_making) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.equity_available(&symbol, Venue::Hedging),
+                inventory.equity_available(&symbol, Venue::MarketMaking),
+            )
+        };
+        assert_eq!(hedging, Some(shares(90)));
+        assert_eq!(market_making, Some(shares(10)));
+    }
+
+    #[tokio::test]
+    async fn recovery_after_timeout_mint_failure_clears_tombstone_and_moves_equity() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-timeout-recovery");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        // A timeout cleared the in-flight without crediting available (Hedging
+        // (offchain) available stays debited at 90) and tombstoned the aggregate
+        // so the reactor ignores late events.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(0), shares(90));
+        trigger
+            .timed_out_mints
+            .write()
+            .await
+            .insert(mint_id.clone(), Utc::now());
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "timeout".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        trigger
+            .rebuild_mint_tracking_for_recovery(&mint_id, &failed, tok.clone())
+            .await
+            .unwrap();
+
+        // The tombstone must be cleared so the reactor stops ignoring events.
+        assert!(!trigger.timed_out_mints.read().await.contains_key(&mint_id));
+
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::ProviderCompletionRecovered {
+                    issuer_request_id: mint_id.clone(),
+                    wallet: Address::ZERO,
+                    tokenization_request_id: tok,
+                    tx_hash: TxHash::random(),
+                    shares_minted: U256::from(10u64),
+                    fees: None,
+                    recovered_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Same end state as the explicit case: the 10 that left Hedging now
+        // sits in MarketMaking. Hedging available is NOT double-debited.
+        let (hedging, market_making) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.equity_available(&symbol, Venue::Hedging),
+                inventory.equity_available(&symbol, Venue::MarketMaking),
+            )
+        };
+        assert_eq!(hedging, Some(shares(90)));
+        assert_eq!(market_making, Some(shares(10)));
+    }
+
+    #[tokio::test]
+    async fn recovery_after_explicit_redemption_failure_moves_equity_to_hedging() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-explicit-recovery");
+
+        // An explicit DetectionFailed/RedemptionRejected does not touch
+        // inventory, so the in-flight is still held at MarketMaking (onchain):
+        // available 90, inflight 10.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("rejected".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap();
+
+        trigger
+            .on_redemption(
+                redemption_id.clone(),
+                EquityRedemptionEvent::ProviderCompletionRecovered {
+                    tokenization_request_id: TokenizationRequestId("TOK-2".to_string()),
+                    recovered_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (market_making, hedging) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.equity_available(&symbol, Venue::MarketMaking),
+                inventory.equity_available(&symbol, Venue::Hedging),
+            )
+        };
+        assert_eq!(market_making, Some(shares(90)));
+        assert_eq!(hedging, Some(shares(10)));
+    }
+
+    #[tokio::test]
+    async fn recovery_after_timeout_redemption_failure_clears_tombstone_and_moves_equity() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-timeout-recovery");
+
+        // A timeout cleared the MarketMaking in-flight and tombstoned the
+        // aggregate; available stays debited at 90.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(90), shares(0));
+        trigger
+            .timed_out_redemptions
+            .write()
+            .await
+            .insert(redemption_id.clone(), Utc::now());
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("timeout".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger
+                .timed_out_redemptions
+                .read()
+                .await
+                .contains_key(&redemption_id)
+        );
+
+        trigger
+            .on_redemption(
+                redemption_id.clone(),
+                EquityRedemptionEvent::ProviderCompletionRecovered {
+                    tokenization_request_id: TokenizationRequestId("TOK-2".to_string()),
+                    recovered_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (market_making, hedging) = {
+            let inventory = trigger.inventory.read().await;
+            (
+                inventory.equity_available(&symbol, Venue::MarketMaking),
+                inventory.equity_available(&symbol, Venue::Hedging),
+            )
+        };
+        assert_eq!(market_making, Some(shares(90)));
+        assert_eq!(hedging, Some(shares(10)));
+    }
+
+    #[tokio::test]
+    async fn abandon_mint_recovery_guard_clears_active_mint() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-resume-failure");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(0), shares(100));
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "rejected".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        trigger
+            .rebuild_mint_tracking_for_recovery(&mint_id, &failed, tok.clone())
+            .await
+            .unwrap();
+
+        // The reactor processed ProviderCompletionRecovered (non-terminal for
+        // mints), which set the active-mint slot.
+        trigger
+            .on_mint(
+                mint_id.clone(),
+                TokenizedEquityMintEvent::ProviderCompletionRecovered {
+                    issuer_request_id: mint_id.clone(),
+                    wallet: Address::ZERO,
+                    tokenization_request_id: tok,
+                    tx_hash: TxHash::random(),
+                    shares_minted: U256::from(10u64),
+                    fees: None,
+                    recovered_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger.inventory.read().await.active_mint(&symbol),
+            Some(&mint_id),
+            "recovery event should have set the active-mint slot"
+        );
+
+        // A failed in-process resume abandons the recovery guard; this must also
+        // clear the active-mint slot. Tracking is dropped here, so no later
+        // event can clear it -- otherwise the dashboard shows a phantom active
+        // mint until the next restart.
+        trigger.abandon_mint_recovery_guard(&mint_id, &symbol).await;
+
+        assert_eq!(trigger.inventory.read().await.active_mint(&symbol), None);
+        assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn mint_recovery_claim_refuses_a_different_mint_without_mutating() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let recovering = IssuerRequestId::new("recovering-mint");
+        let other = IssuerRequestId::new("other-mint");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        // Explicit-failure shape (available 100, in-flight 0) but a *different*
+        // mint owns the slot. The claim must refuse and touch nothing -- the
+        // other mint's in-flight stays intact and recovery installs no tracking.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(100))
+            .set_active_mint(symbol.clone(), other.clone());
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "rejected".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let claim = trigger
+            .rebuild_mint_tracking_for_recovery(&recovering, &failed, tok)
+            .await
+            .unwrap();
+        assert!(matches!(claim, RecoveryClaim::Conflict));
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(0)),
+            "a conflicting claim must not restore the in-flight"
+        );
+        assert_eq!(inventory.active_mint(&symbol), Some(&other));
+        drop(inventory);
+        assert!(!trigger.mint_tracking.read().await.contains_key(&recovering));
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn mint_recovery_claim_succeeds_for_self_owned_slot() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let recovering = IssuerRequestId::new("recovering-mint");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        // The slot is still owned by the recovering mint itself (e.g. a
+        // reactor-less failure injection the live process never observed) -> NOT
+        // a conflict; recovery is what reconciles it.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(100))
+            .set_active_mint(symbol.clone(), recovering.clone());
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "rejected".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let claim = trigger
+            .rebuild_mint_tracking_for_recovery(&recovering, &failed, tok)
+            .await
+            .unwrap();
+        assert!(matches!(claim, RecoveryClaim::Claimed(_)));
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(10)),
+            "claiming a self-owned slot must restore the in-flight"
+        );
+    }
+
+    #[tokio::test]
+    async fn redemption_recovery_claim_refuses_a_different_redemption_without_mutating() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let recovering = RedemptionAggregateId::new("recovering-redemption");
+        let other = RedemptionAggregateId::new("other-redemption");
+        let tombstone_at = Utc::now();
+
+        // Timeout shape with a *different* redemption owning the slot. The claim
+        // must refuse without restoring the in-flight or consuming the tombstone.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .set_active_redemption(symbol.clone(), other.clone());
+        trigger
+            .timed_out_redemptions
+            .write()
+            .await
+            .insert(recovering.clone(), tombstone_at);
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("timeout".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let claim = trigger
+            .rebuild_redemption_tracking_for_recovery(&recovering, &failed)
+            .await
+            .unwrap();
+        assert!(matches!(claim, RecoveryClaim::Conflict));
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(0)),
+            "a conflicting claim must not restore the in-flight"
+        );
+        assert_eq!(inventory.active_redemption(&symbol), Some(&other));
+        drop(inventory);
+        assert!(
+            trigger
+                .timed_out_redemptions
+                .read()
+                .await
+                .contains_key(&recovering),
+            "a conflicting claim must not consume the timeout tombstone"
+        );
+        assert!(
+            !trigger
+                .redemption_tracking
+                .read()
+                .await
+                .contains_key(&recovering)
+        );
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn redemption_recovery_claim_succeeds_for_self_owned_slot() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let recovering = RedemptionAggregateId::new("recovering-redemption");
+        let tombstone_at = Utc::now();
+
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .set_active_redemption(symbol.clone(), recovering.clone());
+        trigger
+            .timed_out_redemptions
+            .write()
+            .await
+            .insert(recovering.clone(), tombstone_at);
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("timeout".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let claim = trigger
+            .rebuild_redemption_tracking_for_recovery(&recovering, &failed)
+            .await
+            .unwrap();
+        assert!(matches!(claim, RecoveryClaim::Claimed(_)));
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(10)),
+            "claiming a self-owned slot must restore the in-flight"
+        );
+    }
+
+    #[tokio::test]
+    async fn abandon_mint_recovery_guard_keeps_active_mint_owned_by_other_id() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let recovering_id = IssuerRequestId::new("recovering-mint");
+        let other_id = IssuerRequestId::new("other-active-mint");
+
+        // A different aggregate owns the symbol's active-mint slot (e.g. a
+        // concurrent mint). Abandoning the recovering mint's guard must NOT clear
+        // a slot it does not own.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(100))
+            .set_active_mint(symbol.clone(), other_id.clone());
+
+        trigger
+            .abandon_mint_recovery_guard(&recovering_id, &symbol)
+            .await;
+
+        assert_eq!(
+            trigger.inventory.read().await.active_mint(&symbol),
+            Some(&other_id),
+            "abandon must not clear an active-mint slot owned by a different aggregate"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_after_explicit_mint_dispatch_failure_restores_available() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-explicit-rollback");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+
+        // Explicit failure cancelled the in-flight back to available: 100/0.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(0), shares(100));
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "rejected".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_mint_tracking_for_recovery(&mint_id, &failed, tok)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        // Rebuild moved available -> in-flight and installed tracking.
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(10))
+        );
+        assert!(trigger.mint_tracking.read().await.contains_key(&mint_id));
+
+        // The dispatch failed before the reactor ran; rolling back must restore
+        // the pre-recovery failed-mint shape.
+        trigger
+            .rollback_mint_tracking_for_recovery(
+                &mint_id,
+                &symbol,
+                FractionalShares::new(float!(10)),
+                rollback,
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::Hedging),
+            Some(shares(100))
+        );
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(0))
+        );
+        assert_eq!(inventory.active_mint(&symbol), None);
+        drop(inventory);
+        assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn rollback_after_timeout_mint_dispatch_failure_restores_tombstone() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mint_id = IssuerRequestId::new("mint-timeout-rollback");
+        let tok = TokenizationRequestId("TOK-1".to_string());
+        let tombstone_at = Utc::now();
+
+        // Timeout shape: available debited to 90, in-flight cleared, tombstoned.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(0), shares(90));
+        trigger
+            .timed_out_mints
+            .write()
+            .await
+            .insert(mint_id.clone(), tombstone_at);
+        trigger
+            .suppressed_inflight_symbols
+            .write()
+            .await
+            .insert(symbol.clone(), tombstone_at);
+
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "timeout".to_string(),
+            requested_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_mint_tracking_for_recovery(&mint_id, &failed, tok)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        // Rebuild dropped the tombstone and re-set the in-flight.
+        assert!(!trigger.timed_out_mints.read().await.contains_key(&mint_id));
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(10))
+        );
+
+        trigger
+            .rollback_mint_tracking_for_recovery(
+                &mint_id,
+                &symbol,
+                FractionalShares::new(float!(10)),
+                rollback,
+            )
+            .await
+            .unwrap();
+
+        // The tombstone + suppressed marker are restored and the in-flight is
+        // re-cleared without crediting available (it stays debited at 90).
+        assert_eq!(
+            trigger.timed_out_mints.read().await.get(&mint_id),
+            Some(&tombstone_at)
+        );
+        assert!(
+            trigger
+                .suppressed_inflight_symbols
+                .read()
+                .await
+                .contains_key(&symbol)
+        );
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::Hedging),
+            Some(shares(90))
+        );
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::Hedging),
+            Some(shares(0))
+        );
+        drop(inventory);
+        assert!(!trigger.mint_tracking.read().await.contains_key(&mint_id));
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn rollback_after_timeout_redemption_dispatch_failure_restores_tombstone() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-timeout-rollback");
+        let tombstone_at = Utc::now();
+
+        // Timeout cleared the MarketMaking in-flight and tombstoned; 90/0.
+        *trigger.inventory.write().await =
+            InventoryView::default().with_equity(symbol.clone(), shares(90), shares(0));
+        trigger
+            .timed_out_redemptions
+            .write()
+            .await
+            .insert(redemption_id.clone(), tombstone_at);
+        trigger
+            .suppressed_inflight_symbols
+            .write()
+            .await
+            .insert(symbol.clone(), tombstone_at);
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("timeout".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        assert!(
+            !trigger
+                .timed_out_redemptions
+                .read()
+                .await
+                .contains_key(&redemption_id)
+        );
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(10))
+        );
+
+        trigger
+            .rollback_redemption_tracking_for_recovery(&redemption_id, &symbol, rollback)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger
+                .timed_out_redemptions
+                .read()
+                .await
+                .get(&redemption_id),
+            Some(&tombstone_at)
+        );
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(90))
+        );
+        assert_eq!(
+            inventory.equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(0))
+        );
+        drop(inventory);
+        assert!(
+            !trigger
+                .redemption_tracking
+                .read()
+                .await
+                .contains_key(&redemption_id)
+        );
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn rollback_after_explicit_redemption_dispatch_failure_keeps_inflight() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-explicit-rollback");
+
+        // An explicit failure left the MarketMaking in-flight in place: 90
+        // available, 10 in-flight. Rebuild does not touch inventory here.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("rejected".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        trigger
+            .rollback_redemption_tracking_for_recovery(&redemption_id, &symbol, rollback)
+            .await
+            .unwrap();
+
+        // The held in-flight is untouched (rebuild never restored it); only the
+        // tracking + in-progress guard are dropped.
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .equity_inflight(&symbol, Venue::MarketMaking),
+            Some(shares(10))
+        );
+        assert!(
+            !trigger
+                .redemption_tracking
+                .read()
+                .await
+                .contains_key(&redemption_id)
+        );
+        assert!(!trigger.equity_in_progress.read().unwrap().contains(&symbol));
+    }
+
+    #[tokio::test]
+    async fn rollback_redemption_clears_self_owned_active_redemption() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-self-owned");
+
+        // Explicit-failure shape with the slot still self-owned (a reactor-less
+        // failure the live process never observed -- the claim treats this as
+        // recoverable). The dispatch then fails, so rollback must clear the now
+        // stale active_redemption rather than strand a phantom.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap()
+            .set_active_redemption(symbol.clone(), redemption_id.clone());
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("rejected".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        trigger
+            .rollback_redemption_tracking_for_recovery(&redemption_id, &symbol, rollback)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger.inventory.read().await.active_redemption(&symbol),
+            None,
+            "rollback must clear the stale self-owned active_redemption slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_redemption_keeps_active_redemption_owned_by_other_id() {
+        let (trigger, _receiver) = make_trigger().await;
+        let symbol = Symbol::new("AAPL").unwrap();
+        let redemption_id = RedemptionAggregateId::new("redemption-rollback");
+        let other_id = RedemptionAggregateId::new("other-redemption");
+
+        // No owner at claim time -> claim succeeds.
+        *trigger.inventory.write().await = InventoryView::default()
+            .with_equity(symbol.clone(), shares(90), shares(0))
+            .update_equity(
+                &symbol,
+                Inventory::set_inflight(Venue::MarketMaking, shares(10)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let failed = EquityRedemption::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            raindex_withdraw_tx: None,
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: Some(TokenizationRequestId("TOK-2".to_string())),
+            reason: Some("rejected".to_string()),
+            started_at: Utc::now(),
+            failed_at: Utc::now(),
+        };
+
+        let rollback = trigger
+            .rebuild_redemption_tracking_for_recovery(&redemption_id, &failed)
+            .await
+            .unwrap()
+            .expect_claimed();
+
+        // A concurrent redemption claims the slot before rollback runs; the
+        // ownership re-check must leave that claim intact.
+        {
+            let mut inventory = trigger.inventory.write().await;
+            *inventory = inventory
+                .clone()
+                .set_active_redemption(symbol.clone(), other_id.clone());
+        }
+
+        trigger
+            .rollback_redemption_tracking_for_recovery(&redemption_id, &symbol, rollback)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            trigger.inventory.read().await.active_redemption(&symbol),
+            Some(&other_id),
+            "rollback must not clear a slot owned by a different redemption"
+        );
     }
 
     #[tokio::test]
@@ -3830,7 +5188,6 @@ mod tests {
     fn make_tokens_received() -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::TokensReceived {
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(789)),
             shares_minted: U256::from(30_000_000_000_000_000_000_u128),
             fees: None,
             received_at: Utc::now(),

--- a/src/tokenization.rs
+++ b/src/tokenization.rs
@@ -83,6 +83,12 @@ pub(crate) trait Tokenizer: Send + Sync {
         id: &TokenizationRequestId,
     ) -> Result<TokenizationRequest, TokenizerError>;
 
+    /// Get a single tokenization provider request by ID.
+    async fn get_request(
+        &self,
+        id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError>;
+
     /// Returns the redemption wallet address where tokens should be sent,
     /// if configured.
     fn redemption_wallet(&self) -> Option<Address>;
@@ -99,6 +105,12 @@ pub(crate) trait Tokenizer: Send + Sync {
         &self,
         tx_hash: &TxHash,
     ) -> Result<TokenizationRequest, TokenizerError>;
+
+    /// Find a redemption request by its onchain token transfer transaction.
+    async fn find_redemption_by_tx(
+        &self,
+        tx_hash: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, TokenizerError>;
 
     /// Poll a redemption request until it reaches a terminal state.
     async fn poll_redemption_until_complete(

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -107,6 +107,13 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
             .await
     }
 
+    pub(crate) async fn get_request(
+        &self,
+        id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, AlpacaTokenizationError> {
+        self.client.get_request(id).await
+    }
+
     /// Returns the redemption wallet address, if configured.
     pub(crate) fn redemption_wallet(&self) -> Option<Address> {
         self.client.redemption_wallet
@@ -131,6 +138,13 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
         self.client
             .poll_for_redemption_detection(tx_hash, &self.polling_config)
             .await
+    }
+
+    pub(crate) async fn find_redemption_by_tx(
+        &self,
+        tx_hash: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, AlpacaTokenizationError> {
+        self.client.find_redemption_by_tx(tx_hash).await
     }
 
     /// Poll a redemption request until it reaches a terminal state.
@@ -874,6 +888,13 @@ impl<W: Wallet> Tokenizer for AlpacaTokenizationService<W> {
         Ok(Self::poll_mint_until_complete(self, id).await?)
     }
 
+    async fn get_request(
+        &self,
+        id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        Ok(Self::get_request(self, id).await?)
+    }
+
     fn redemption_wallet(&self) -> Option<Address> {
         Self::redemption_wallet(self)
     }
@@ -891,6 +912,13 @@ impl<W: Wallet> Tokenizer for AlpacaTokenizationService<W> {
         tx_hash: &TxHash,
     ) -> Result<TokenizationRequest, TokenizerError> {
         Ok(Self::poll_for_redemption(self, tx_hash).await?)
+    }
+
+    async fn find_redemption_by_tx(
+        &self,
+        tx_hash: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
+        Ok(Self::find_redemption_by_tx(self, tx_hash).await?)
     }
 
     async fn poll_redemption_until_complete(

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -222,6 +222,19 @@ impl Tokenizer for MockTokenizer {
         }
     }
 
+    async fn get_request(
+        &self,
+        id: &TokenizationRequestId,
+    ) -> Result<TokenizationRequest, TokenizerError> {
+        self.pending_requests
+            .iter()
+            .find(|request| &request.id == id)
+            .cloned()
+            .ok_or_else(|| {
+                TokenizerError::Alpaca(AlpacaTokenizationError::RequestNotFound { id: id.clone() })
+            })
+    }
+
     fn redemption_wallet(&self) -> Option<Address> {
         self.redemption_wallet
     }
@@ -260,6 +273,17 @@ impl Tokenizer for MockTokenizer {
                 }))
             }
         }
+    }
+
+    async fn find_redemption_by_tx(
+        &self,
+        tx_hash: &TxHash,
+    ) -> Result<Option<TokenizationRequest>, TokenizerError> {
+        Ok(self
+            .pending_requests
+            .iter()
+            .find(|request| request.tx_hash.as_ref() == Some(tx_hash))
+            .cloned())
     }
 
     async fn poll_redemption_until_complete(

--- a/src/tokenization/mock_api.rs
+++ b/src/tokenization/mock_api.rs
@@ -253,6 +253,49 @@ impl AlpacaTokenizationMock {
         lock(&self.state).polls_until_complete = polls_until_complete;
     }
 
+    /// Overrides one existing pending request's poll threshold.
+    pub fn set_request_polls_until_complete(&self, request_id: &str, polls_until_complete: usize) {
+        if let Some(request) = lock(&self.state)
+            .requests
+            .iter_mut()
+            .find(|request| request.tokenization_request_id == request_id)
+        {
+            request.polls_until_complete = polls_until_complete;
+        }
+    }
+
+    /// Overrides one existing request's status for recovery simulations.
+    ///
+    /// Forcing a redemption to `Completed` also returns its shares to the broker
+    /// -- the same side effect the normal poll path applies on completion.
+    /// Without it the provider would report "completed" while the broker position
+    /// still reflected a pending redemption, an inconsistent simulated world that
+    /// could mask or invent recovery bugs in E2E scenarios.
+    pub fn set_request_status(&self, request_id: &str, status: TokenizationStatus) {
+        let mut state = lock(&self.state);
+        let Some(request) = state
+            .requests
+            .iter_mut()
+            .find(|request| request.tokenization_request_id == request_id)
+        else {
+            return;
+        };
+
+        request.status = status;
+        let completed_redemption = request.status == TokenizationStatus::Completed
+            && request.request_type == TokenizationRequestType::Redeem;
+        let underlying_symbol = request.underlying_symbol.clone();
+        let quantity = request.quantity;
+        drop(state);
+
+        if completed_redemption
+            && let Ok(symbol) = Symbol::new(&underlying_symbol)
+            && let Err(error) = self.broker.adjust_position(&symbol, quantity)
+        {
+            warn!(target: "tokenization", %error, "failed to adjust broker position after forced redemption completion");
+        }
+    }
+
     /// Injects a pending tokenization request with an arbitrary wallet
     /// address. Used to simulate requests from other conductors sharing
     /// the same Alpaca account.

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -89,10 +89,6 @@ impl std::fmt::Display for TokenizationRequestId {
     }
 }
 
-/// Onchain receipt identifier (U256) for the token transfer transaction.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct ReceiptId(pub(crate) U256);
-
 /// Errors that can occur during tokenized equity mint operations.
 ///
 /// These errors enforce state machine constraints and prevent
@@ -262,6 +258,14 @@ pub(crate) enum TokenizedEquityMintCommand {
     FailRaindexDeposit {
         reason: String,
     },
+    /// Recover a failed mint after the provider reports completion later.
+    RecoverProviderCompletion {
+        issuer_request_id: IssuerRequestId,
+        wallet: Address,
+        tokenization_request_id: TokenizationRequestId,
+        tx_hash: TxHash,
+        fees: Option<Float>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -297,7 +301,6 @@ pub(crate) enum TokenizedEquityMintEvent {
 
     TokensReceived {
         tx_hash: TxHash,
-        receipt_id: ReceiptId,
         shares_minted: U256,
         /// Tokenization fees charged by Alpaca (if reported).
         #[serde(
@@ -352,6 +355,21 @@ pub(crate) enum TokenizedEquityMintEvent {
     RaindexDepositFailed {
         reason: String,
         failed_at: DateTime<Utc>,
+    },
+    ProviderCompletionRecovered {
+        issuer_request_id: IssuerRequestId,
+        wallet: Address,
+        tokenization_request_id: TokenizationRequestId,
+        tx_hash: TxHash,
+        shares_minted: U256,
+        /// Tokenization fees charged by Alpaca (if reported).
+        #[serde(
+            default,
+            serialize_with = "st0x_float_serde::serialize_option_float",
+            deserialize_with = "st0x_float_serde::deserialize_option_float_from_number_or_string"
+        )]
+        fees: Option<Float>,
+        recovered_at: DateTime<Utc>,
     },
 }
 
@@ -422,21 +440,18 @@ impl PartialEq for TokenizedEquityMintEvent {
             (
                 Self::TokensReceived {
                     tx_hash: hash_a,
-                    receipt_id: rcpt_a,
                     shares_minted: mint_a,
                     fees: fees_a,
                     received_at: time_a,
                 },
                 Self::TokensReceived {
                     tx_hash: hash_b,
-                    receipt_id: rcpt_b,
                     shares_minted: mint_b,
                     fees: fees_b,
                     received_at: time_b,
                 },
             ) => {
                 hash_a == hash_b
-                    && rcpt_a == rcpt_b
                     && mint_a == mint_b
                     && match (fees_a, fees_b) {
                         (Some(a), Some(b)) => a.eq(*b).unwrap_or(false),
@@ -506,6 +521,38 @@ impl PartialEq for TokenizedEquityMintEvent {
                     deposited_at: time_b,
                 },
             ) => hash_a == hash_b && time_a == time_b,
+            (
+                Self::ProviderCompletionRecovered {
+                    issuer_request_id: issuer_a,
+                    wallet: wallet_a,
+                    tokenization_request_id: id_a,
+                    tx_hash: hash_a,
+                    shares_minted: shares_a,
+                    fees: fees_a,
+                    recovered_at: time_a,
+                },
+                Self::ProviderCompletionRecovered {
+                    issuer_request_id: issuer_b,
+                    wallet: wallet_b,
+                    tokenization_request_id: id_b,
+                    tx_hash: hash_b,
+                    shares_minted: shares_b,
+                    fees: fees_b,
+                    recovered_at: time_b,
+                },
+            ) => {
+                issuer_a == issuer_b
+                    && wallet_a == wallet_b
+                    && id_a == id_b
+                    && hash_a == hash_b
+                    && shares_a == shares_b
+                    && match (fees_a, fees_b) {
+                        (Some(a), Some(b)) => a.eq(*b).unwrap_or(false),
+                        (None, None) => true,
+                        _ => false,
+                    }
+                    && time_a == time_b
+            }
             _ => false,
         }
     }
@@ -534,6 +581,9 @@ impl DomainEvent for TokenizedEquityMintEvent {
             }
             Self::RaindexDepositFailed { .. } => {
                 "TokenizedEquityMintEvent::RaindexDepositFailed".to_string()
+            }
+            Self::ProviderCompletionRecovered { .. } => {
+                "TokenizedEquityMintEvent::ProviderCompletionRecovered".to_string()
             }
         }
     }
@@ -589,7 +639,6 @@ pub(crate) enum TokenizedEquityMint {
         issuer_request_id: IssuerRequestId,
         tokenization_request_id: TokenizationRequestId,
         tx_hash: TxHash,
-        receipt_id: ReceiptId,
         shares_minted: U256,
         #[serde(
             default,
@@ -614,7 +663,6 @@ pub(crate) enum TokenizedEquityMint {
         issuer_request_id: IssuerRequestId,
         tokenization_request_id: TokenizationRequestId,
         tx_hash: TxHash,
-        receipt_id: ReceiptId,
         shares_minted: U256,
         #[serde(
             default,
@@ -640,7 +688,6 @@ pub(crate) enum TokenizedEquityMint {
         issuer_request_id: IssuerRequestId,
         tokenization_request_id: TokenizationRequestId,
         tx_hash: TxHash,
-        receipt_id: ReceiptId,
         shares_minted: U256,
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
@@ -662,7 +709,6 @@ pub(crate) enum TokenizedEquityMint {
         issuer_request_id: IssuerRequestId,
         tokenization_request_id: TokenizationRequestId,
         tx_hash: TxHash,
-        receipt_id: ReceiptId,
         shares_minted: U256,
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
@@ -768,7 +814,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_a,
                     tokenization_request_id: tok_a,
                     tx_hash: hash_a,
-                    receipt_id: rcpt_a,
                     shares_minted: mint_a,
                     fees: fees_a,
                     requested_at: req_a,
@@ -782,7 +827,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_b,
                     tokenization_request_id: tok_b,
                     tx_hash: hash_b,
-                    receipt_id: rcpt_b,
                     shares_minted: mint_b,
                     fees: fees_b,
                     requested_at: req_b,
@@ -796,7 +840,6 @@ impl PartialEq for TokenizedEquityMint {
                     && iss_a == iss_b
                     && tok_a == tok_b
                     && hash_a == hash_b
-                    && rcpt_a == rcpt_b
                     && mint_a == mint_b
                     && match (fees_a, fees_b) {
                         (Some(a), Some(b)) => a.eq(*b).unwrap_or(false),
@@ -815,7 +858,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_a,
                     tokenization_request_id: tok_a,
                     tx_hash: hash_a,
-                    receipt_id: rcpt_a,
                     shares_minted: mint_a,
                     fees: fees_a,
                     requested_at: req_a,
@@ -830,7 +872,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_b,
                     tokenization_request_id: tok_b,
                     tx_hash: hash_b,
-                    receipt_id: rcpt_b,
                     shares_minted: mint_b,
                     fees: fees_b,
                     requested_at: req_b,
@@ -845,7 +886,6 @@ impl PartialEq for TokenizedEquityMint {
                     && iss_a == iss_b
                     && tok_a == tok_b
                     && hash_a == hash_b
-                    && rcpt_a == rcpt_b
                     && mint_a == mint_b
                     && match (fees_a, fees_b) {
                         (Some(a), Some(b)) => a.eq(*b).unwrap_or(false),
@@ -865,7 +905,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_a,
                     tokenization_request_id: tok_a,
                     tx_hash: hash_a,
-                    receipt_id: rcpt_a,
                     shares_minted: mint_a,
                     wrap_tx_hash: wrap_hash_a,
                     wrapped_shares: wrap_shares_a,
@@ -881,7 +920,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_b,
                     tokenization_request_id: tok_b,
                     tx_hash: hash_b,
-                    receipt_id: rcpt_b,
                     shares_minted: mint_b,
                     wrap_tx_hash: wrap_hash_b,
                     wrapped_shares: wrap_shares_b,
@@ -897,7 +935,6 @@ impl PartialEq for TokenizedEquityMint {
                     && iss_a == iss_b
                     && tok_a == tok_b
                     && hash_a == hash_b
-                    && rcpt_a == rcpt_b
                     && mint_a == mint_b
                     && wrap_hash_a == wrap_hash_b
                     && wrap_shares_a == wrap_shares_b
@@ -914,7 +951,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_a,
                     tokenization_request_id: tok_a,
                     tx_hash: hash_a,
-                    receipt_id: rcpt_a,
                     shares_minted: mint_a,
                     wrap_tx_hash: wrap_hash_a,
                     wrapped_shares: wrap_shares_a,
@@ -931,7 +967,6 @@ impl PartialEq for TokenizedEquityMint {
                     issuer_request_id: iss_b,
                     tokenization_request_id: tok_b,
                     tx_hash: hash_b,
-                    receipt_id: rcpt_b,
                     shares_minted: mint_b,
                     wrap_tx_hash: wrap_hash_b,
                     wrapped_shares: wrap_shares_b,
@@ -948,7 +983,6 @@ impl PartialEq for TokenizedEquityMint {
                     && iss_a == iss_b
                     && tok_a == tok_b
                     && hash_a == hash_b
-                    && rcpt_a == rcpt_b
                     && mint_a == mint_b
                     && wrap_hash_a == wrap_hash_b
                     && wrap_shares_a == wrap_shares_b
@@ -1158,6 +1192,7 @@ pub(crate) async fn interrupted_mint_ids(
          WHERE last_ev.aggregate_type = 'TokenizedEquityMint' \
            AND last_ev.event_type IN ( \
                'TokenizedEquityMintEvent::MintAccepted', \
+               'TokenizedEquityMintEvent::ProviderCompletionRecovered', \
                'TokenizedEquityMintEvent::TokensReceived', \
                'TokenizedEquityMintEvent::WrapSubmitted', \
                'TokenizedEquityMintEvent::TokensWrapped', \
@@ -1195,7 +1230,9 @@ impl EventSourced for TokenizedEquityMint {
 
     const AGGREGATE_TYPE: &'static str = "TokenizedEquityMint";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    // v3: removed the vestigial `receipt_id` field and added the
+    // `ProviderCompletionRecovered` event for in-process failed-transfer recovery.
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use TokenizedEquityMintEvent::*;
@@ -1308,7 +1345,6 @@ impl EventSourced for TokenizedEquityMint {
 
             TokensReceived {
                 tx_hash,
-                receipt_id,
                 shares_minted,
                 fees,
                 received_at,
@@ -1333,12 +1369,45 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     tx_hash: *tx_hash,
-                    receipt_id: receipt_id.clone(),
                     shares_minted: *shares_minted,
                     fees: *fees,
                     requested_at: *requested_at,
                     accepted_at: *accepted_at,
                     received_at: *received_at,
+                })
+            }
+
+            ProviderCompletionRecovered {
+                issuer_request_id,
+                wallet,
+                tokenization_request_id,
+                tx_hash,
+                shares_minted,
+                fees,
+                recovered_at,
+            } => {
+                let Self::Failed {
+                    symbol,
+                    quantity,
+                    requested_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::TokensReceived {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    wallet: *wallet,
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    tx_hash: *tx_hash,
+                    shares_minted: *shares_minted,
+                    fees: *fees,
+                    requested_at: *requested_at,
+                    accepted_at: *recovered_at,
+                    received_at: *recovered_at,
                 })
             }
 
@@ -1353,7 +1422,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id,
                     tokenization_request_id,
                     tx_hash,
-                    receipt_id,
                     shares_minted,
                     fees,
                     requested_at,
@@ -1371,7 +1439,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     tx_hash: *tx_hash,
-                    receipt_id: receipt_id.clone(),
                     shares_minted: *shares_minted,
                     fees: *fees,
                     requested_at: *requested_at,
@@ -1393,7 +1460,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id,
                     tokenization_request_id,
                     tx_hash,
-                    receipt_id,
                     shares_minted,
                     requested_at,
                     accepted_at,
@@ -1407,7 +1473,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id,
                     tokenization_request_id,
                     tx_hash,
-                    receipt_id,
                     shares_minted,
                     requested_at,
                     accepted_at,
@@ -1420,7 +1485,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     tx_hash: *tx_hash,
-                    receipt_id: receipt_id.clone(),
                     shares_minted: *shares_minted,
                     wrap_tx_hash: *wrap_tx_hash,
                     wrapped_shares: *wrapped_shares,
@@ -1443,7 +1507,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id,
                     tokenization_request_id,
                     tx_hash,
-                    receipt_id,
                     shares_minted,
                     wrap_tx_hash,
                     wrapped_shares,
@@ -1463,7 +1526,6 @@ impl EventSourced for TokenizedEquityMint {
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     tx_hash: *tx_hash,
-                    receipt_id: receipt_id.clone(),
                     shares_minted: *shares_minted,
                     wrap_tx_hash: *wrap_tx_hash,
                     wrapped_shares: *wrapped_shares,
@@ -1691,7 +1753,6 @@ impl EventSourced for TokenizedEquityMint {
 
                             Ok(vec![TokensReceived {
                                 tx_hash,
-                                receipt_id: ReceiptId(U256::ZERO),
                                 shares_minted,
                                 fees: completed.fees,
                                 received_at: Utc::now(),
@@ -1858,6 +1919,28 @@ impl EventSourced for TokenizedEquityMint {
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
                 _ => Err(TokenizedEquityMintError::AlreadyInProgress),
             },
+
+            TokenizedEquityMintCommand::RecoverProviderCompletion {
+                issuer_request_id,
+                wallet,
+                tokenization_request_id,
+                tx_hash,
+                fees,
+            } => match self {
+                Self::Failed { quantity, .. } => Ok(vec![ProviderCompletionRecovered {
+                    issuer_request_id,
+                    wallet,
+                    tokenization_request_id,
+                    tx_hash,
+                    shares_minted: quantity_to_u256_18_decimals(*quantity)?,
+                    fees,
+                    recovered_at: Utc::now(),
+                }]),
+                Self::DepositedIntoRaindex { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyCompleted)
+                }
+                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
         }
     }
 }
@@ -1913,7 +1996,6 @@ mod tests {
     fn tokens_received_event() -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::TokensReceived {
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(789)),
             shares_minted: U256::from(100_500_000_000_000_000_000_u128),
             fees: None,
             received_at: Utc::now(),
@@ -2151,7 +2233,6 @@ mod tests {
 
         let event = TokenizedEquityMintEvent::TokensReceived {
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(789)),
             shares_minted: U256::from(100_500_000_000_000_000_000_u128),
             fees: None,
             received_at: Utc::now(),
@@ -2412,7 +2493,6 @@ mod tests {
             issuer_request_id: IssuerRequestId::new("ISS001"),
             tokenization_request_id: TokenizationRequestId("REQ001".to_string()),
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(1)),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
             fees: None,
             requested_at: Utc::now(),
@@ -2626,7 +2706,6 @@ mod tests {
             issuer_request_id: IssuerRequestId::new("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(1)),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
             fees: None,
             requested_at: now,
@@ -2651,7 +2730,6 @@ mod tests {
             issuer_request_id: IssuerRequestId::new("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::random(),
-            receipt_id: ReceiptId(U256::from(1)),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
             wrap_tx_hash: TxHash::random(),
             wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
@@ -2720,6 +2798,132 @@ mod tests {
         }
         assert_eq!(op.started_at, now);
         assert_eq!(op.updated_at, later);
+    }
+
+    #[test]
+    fn provider_completion_recovery_reopens_failed_mint_as_tokens_received() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let requested_at = Utc::now();
+        let recovered_at = requested_at + chrono::Duration::seconds(60);
+        let failed = TokenizedEquityMint::Failed {
+            symbol: symbol.clone(),
+            quantity: float!(10),
+            reason: "poll timeout".to_string(),
+            requested_at,
+            failed_at: requested_at + chrono::Duration::seconds(30),
+        };
+
+        let recovered = TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: IssuerRequestId::new("ISS001"),
+            wallet: Address::ZERO,
+            tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            tx_hash: TxHash::ZERO,
+            shares_minted: U256::from(10) * U256::from(10).pow(U256::from(18)),
+            fees: None,
+            recovered_at,
+        };
+
+        let result = TokenizedEquityMint::evolve(&failed, &recovered)
+            .unwrap()
+            .expect("recovered state");
+
+        assert!(
+            matches!(
+                result,
+                TokenizedEquityMint::TokensReceived {
+                    symbol: ref recovered_symbol,
+                    ref tokenization_request_id,
+                    ..
+                } if *recovered_symbol == symbol
+                    && *tokenization_request_id == TokenizationRequestId("TOK001".to_string())
+            ),
+            "expected recovered mint to move to TokensReceived, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn provider_completion_recovered_fees_serialize_as_decimal_string() {
+        use st0x_float_macro::float;
+
+        // Regression: without the custom Float serde annotation, `fees` would
+        // serialize via Float's default representation -- diverging from
+        // `TokensReceived.fees` and breaking event replay from the events
+        // table. Assert the decimal-string form (independent of the type under
+        // test) and a clean round-trip.
+        let event = TokenizedEquityMintEvent::ProviderCompletionRecovered {
+            issuer_request_id: IssuerRequestId::new("ISS001"),
+            wallet: Address::ZERO,
+            tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            tx_hash: TxHash::ZERO,
+            shares_minted: U256::from(10),
+            fees: Some(float!("0.25")),
+            recovered_at: Utc::now(),
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            serialized["ProviderCompletionRecovered"]["fees"],
+            serde_json::json!("0.25")
+        );
+
+        let deserialized: TokenizedEquityMintEvent = serde_json::from_value(serialized).unwrap();
+        let TokenizedEquityMintEvent::ProviderCompletionRecovered { fees, .. } = deserialized
+        else {
+            panic!("expected ProviderCompletionRecovered, got {deserialized:?}");
+        };
+        assert!(fees.unwrap().eq(float!("0.25")).unwrap());
+    }
+
+    #[tokio::test]
+    async fn recover_provider_completion_rejected_for_active_mint() {
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![mint_requested_event()])
+            .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
+                issuer_request_id: IssuerRequestId::new("ISS001"),
+                wallet: Address::ZERO,
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+                tx_hash: TxHash::ZERO,
+                fees: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::AlreadyInProgress)
+            ),
+            "active mints must not be provider-completion recovered, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_provider_completion_rejected_for_completed_mint() {
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![
+                mint_requested_event(),
+                mint_accepted_event(),
+                tokens_received_event(),
+                tokens_wrapped_event(),
+                vault_deposited_event(),
+            ])
+            .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
+                issuer_request_id: IssuerRequestId::new("ISS001"),
+                wallet: Address::ZERO,
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+                tx_hash: TxHash::ZERO,
+                fees: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::AlreadyCompleted)
+            ),
+            "completed mints must not be recovered, got {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -11,6 +11,11 @@
 //!   The bot counter-trades, mints/redeems, and bridges USDC to maintain
 //!   liquidity — if it works correctly, the vaults never drain permanently.
 //!   Run via `nix run .#simulate` (mprocs with dashboard). Ctrl-C to stop.
+//!
+//! - [`simulate_failures`]: Same live simulation, but first creates stuck
+//!   mint and redemption rebalances where the local aggregate failed while
+//!   the mock provider later completed, so `recheck-transfer` can recover them.
+//!   Run via `nix run .#simulate-failures`.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -28,14 +33,19 @@ use tracing::{debug, info};
 use st0x_dto::Statement;
 use st0x_event_sorcery::Projection;
 use st0x_evm::Wallet;
-use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, TEST_API_KEY, TEST_API_SECRET};
+use st0x_execution::alpaca_broker_api::{
+    AlpacaBrokerMock, TEST_ACCOUNT_ID, TEST_API_KEY, TEST_API_SECRET,
+};
 use st0x_execution::{
     AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
     DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS, FractionalShares, Symbol, TimeInForce,
 };
 use st0x_finance::{Positive, Usd};
+use st0x_hedge::cli::TransferType;
 use st0x_hedge::config::{BrokerCtx, Ctx};
-use st0x_hedge::mock_api::REDEMPTION_WALLET;
+use st0x_hedge::mock_api::{
+    REDEMPTION_WALLET, RedemptionOutcome, TokenizationRequestType, TokenizationStatus,
+};
 use st0x_hedge::{
     AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, ImbalanceThreshold,
     OperationMode, Position, RebalancingCtx, TradingMode, UsdcRebalancing,
@@ -152,6 +162,300 @@ fn build_full_system_ctx<P: Provider + Clone>(
         .redemption_wallet(REDEMPTION_WALLET)
         .call()
         .map_err(Into::into)
+}
+
+struct AcceptedMintIds {
+    issuer_request_id: String,
+    tokenization_request_id: String,
+}
+
+struct RejectedRedemptionIds {
+    redemption_id: String,
+    tokenization_request_id: String,
+}
+
+async fn latest_accepted_mint_ids(pool: &sqlx::SqlitePool) -> anyhow::Result<AcceptedMintIds> {
+    let (issuer_request_id, tokenization_request_id): (String, String) = sqlx::query_as(
+        "SELECT accepted.aggregate_id, \
+                json_extract(accepted.payload, '$.MintAccepted.tokenization_request_id') \
+         FROM events accepted \
+         WHERE accepted.aggregate_type = 'TokenizedEquityMint' \
+           AND accepted.event_type = 'TokenizedEquityMintEvent::MintAccepted' \
+         ORDER BY accepted.rowid DESC \
+         LIMIT 1",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(AcceptedMintIds {
+        issuer_request_id,
+        tokenization_request_id,
+    })
+}
+
+async fn latest_accepted_mint_ids_for_symbol(
+    pool: &sqlx::SqlitePool,
+    symbol: &str,
+) -> anyhow::Result<AcceptedMintIds> {
+    let (issuer_request_id, tokenization_request_id): (String, String) = sqlx::query_as(
+        "SELECT accepted.aggregate_id, \
+                json_extract(accepted.payload, '$.MintAccepted.tokenization_request_id') \
+         FROM events accepted \
+         INNER JOIN events requested \
+             ON requested.aggregate_type = accepted.aggregate_type \
+            AND requested.aggregate_id = accepted.aggregate_id \
+            AND requested.event_type = 'TokenizedEquityMintEvent::MintRequested' \
+         WHERE accepted.aggregate_type = 'TokenizedEquityMint' \
+           AND accepted.event_type = 'TokenizedEquityMintEvent::MintAccepted' \
+           AND json_extract(requested.payload, '$.MintRequested.symbol') = ?1 \
+         ORDER BY accepted.rowid DESC \
+         LIMIT 1",
+    )
+    .bind(symbol)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(AcceptedMintIds {
+        issuer_request_id,
+        tokenization_request_id,
+    })
+}
+
+async fn latest_rejected_redemption_ids(
+    pool: &sqlx::SqlitePool,
+) -> anyhow::Result<RejectedRedemptionIds> {
+    let (redemption_id, tokenization_request_id): (String, String) = sqlx::query_as(
+        "SELECT rejected.aggregate_id, \
+                json_extract(detected.payload, '$.Detected.tokenization_request_id') \
+         FROM events rejected \
+         INNER JOIN events detected \
+             ON detected.aggregate_type = rejected.aggregate_type \
+            AND detected.aggregate_id = rejected.aggregate_id \
+            AND detected.event_type = 'EquityRedemptionEvent::Detected' \
+         WHERE rejected.aggregate_type = 'EquityRedemption' \
+           AND rejected.event_type = 'EquityRedemptionEvent::RedemptionRejected' \
+         ORDER BY rejected.rowid DESC \
+         LIMIT 1",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(RejectedRedemptionIds {
+        redemption_id,
+        tokenization_request_id,
+    })
+}
+
+async fn complete_mock_mint_provider<P: Sync>(
+    infra: &TestInfra<P>,
+    tokenization_request_id: &str,
+) -> anyhow::Result<()> {
+    infra
+        .tokenization_service
+        .set_request_polls_until_complete(tokenization_request_id, 1);
+
+    let url = format!(
+        "{}/v1/accounts/{TEST_ACCOUNT_ID}/tokenization/requests",
+        infra.broker_service.base_url()
+    );
+    reqwest::get(url).await?.error_for_status()?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let completed = infra
+            .tokenization_service
+            .tokenization_requests()
+            .into_iter()
+            .any(|request| {
+                request.request_id == tokenization_request_id
+                    && request.request_type == TokenizationRequestType::Mint
+                    && request.status == TokenizationStatus::Completed
+            });
+
+        if completed {
+            return Ok(());
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "Timed out waiting for mock provider to complete mint {tokenization_request_id}"
+            );
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+fn complete_mock_redemption_provider<P: Sync>(
+    infra: &TestInfra<P>,
+    tokenization_request_id: &str,
+) -> anyhow::Result<()> {
+    // `set_request_status` mutates the mock synchronously, so -- unlike the mint
+    // helper, which drives an async poll counter via an HTTP request -- there is
+    // nothing to wait for. Set the status and assert the flip took effect.
+    infra
+        .tokenization_service
+        .set_request_status(tokenization_request_id, TokenizationStatus::Completed);
+
+    let completed = infra
+        .tokenization_service
+        .tokenization_requests()
+        .into_iter()
+        .any(|request| {
+            request.request_id == tokenization_request_id
+                && request.request_type == TokenizationRequestType::Redeem
+                && request.status == TokenizationStatus::Completed
+        });
+
+    anyhow::ensure!(
+        completed,
+        "mock provider did not mark redemption {tokenization_request_id} completed"
+    );
+
+    Ok(())
+}
+
+fn write_simulate_failure_cli_files<P: Provider + Clone>(
+    infra: &TestInfra<P>,
+    cctp: &CctpInfra,
+    server_port: u16,
+    current_block: u64,
+    usdc_vault_id: B256,
+    equity_vault_ids: &HashMap<String, B256>,
+) -> anyhow::Result<(std::path::PathBuf, std::path::PathBuf)> {
+    let config_path = std::path::PathBuf::from(format!(
+        "/tmp/st0x-simulate-failures-{server_port}.config.toml"
+    ));
+    let secrets_path = std::path::PathBuf::from(format!(
+        "/tmp/st0x-simulate-failures-{server_port}.secrets.toml"
+    ));
+
+    let (aapl_wrapped, aapl_unwrapped) = find_equity_addresses(infra, "AAPL")?;
+    let (tsla_wrapped, tsla_unwrapped) = find_equity_addresses(infra, "TSLA")?;
+
+    let config = format!(
+        r#"server_port = {server_port}
+log_level = "debug"
+database_url = "{database_url}"
+apalis_finished_job_cleanup_interval_secs = 3600
+hyperdx.service_name = "st0x-simulate-failures"
+
+[broker]
+counter_trade_slippage_bps = 100
+
+[broker.travel_rule]
+beneficiary_entity_name = "Simulate Failures"
+
+[raindex]
+orderbook = "{orderbook}"
+deployment_block = {current_block}
+required_confirmations = 0
+
+[wallet]
+kind = "private-key"
+address = "{owner}"
+
+[tokenization]
+redemption_wallet = "{redemption_wallet}"
+
+[rebalancing]
+transfer_timeout_secs = 1800
+equity = {{ target = 0.5, deviation = 0.1 }}
+usdc = {{ mode = "enabled", target = 0.5, deviation = 0.1 }}
+
+[assets.equities.AAPL]
+tokenized_equity = "{aapl_unwrapped}"
+tokenized_equity_derivative = "{aapl_wrapped}"
+vault_ids = ["{aapl_vault_id:#x}"]
+trading = "enabled"
+rebalancing = "enabled"
+
+[assets.equities.TSLA]
+tokenized_equity = "{tsla_unwrapped}"
+tokenized_equity_derivative = "{tsla_wrapped}"
+vault_ids = ["{tsla_vault_id:#x}"]
+trading = "enabled"
+rebalancing = "enabled"
+
+[assets.cash]
+vault_ids = ["{usdc_vault_id:#x}"]
+rebalancing = "enabled"
+"#,
+        database_url = infra.db_path.display(),
+        orderbook = infra.base_chain.orderbook,
+        owner = infra.base_chain.owner,
+        redemption_wallet = REDEMPTION_WALLET,
+        aapl_vault_id = equity_vault_ids["AAPL"],
+        tsla_vault_id = equity_vault_ids["TSLA"],
+    );
+
+    let secrets = format!(
+        r#"hyperdx.api_key = "simulate-failures"
+
+[evm]
+ws_rpc_url = "{ws_rpc_url}"
+base_rpc_url = "{base_rpc_url}"
+ethereum_rpc_url = "{ethereum_rpc_url}"
+
+[broker]
+type = "alpaca-broker-api"
+mode = {{ type = "mock", base_url = "{broker_base_url}" }}
+api_key = "{api_key}"
+api_secret = "{api_secret}"
+account_id = "{account_id}"
+
+[wallet]
+private_key = "{private_key:#x}"
+"#,
+        ws_rpc_url = infra.base_chain.ws_endpoint()?,
+        base_rpc_url = infra.base_chain.endpoint(),
+        ethereum_rpc_url = cctp.ethereum_endpoint,
+        broker_base_url = infra.broker_service.base_url(),
+        api_key = TEST_API_KEY,
+        api_secret = TEST_API_SECRET,
+        account_id = TEST_ACCOUNT_ID,
+        private_key = infra.base_chain.owner_key,
+    );
+
+    std::fs::write(&config_path, config)?;
+    std::fs::write(&secrets_path, secrets)?;
+
+    Ok((config_path, secrets_path))
+}
+
+fn find_equity_addresses<P>(
+    infra: &TestInfra<P>,
+    symbol: &str,
+) -> anyhow::Result<(Address, Address)> {
+    infra
+        .equity_addresses
+        .iter()
+        .find(|(candidate, _, _)| candidate == symbol)
+        .map(|(_, wrapped, unwrapped)| (*wrapped, *unwrapped))
+        .ok_or_else(|| anyhow::anyhow!("missing test equity addresses for {symbol}"))
+}
+
+fn log_recheck_command(
+    config_path: &Path,
+    secrets_path: &Path,
+    transfer_type: TransferType,
+    id: &str,
+) {
+    let transfer_type_arg = match transfer_type {
+        TransferType::Mint => "mint",
+        TransferType::Redemption => "redemption",
+    };
+    let command = format!(
+        "nix develop --command cargo run --features mock --bin cli -- \
+         --config {} --secrets {} recheck-transfer --type {} --id {}",
+        config_path.display(),
+        secrets_path.display(),
+        transfer_type_arg,
+        id
+    );
+
+    println!("\nRecover stuck {transfer_type_arg} with:\n{command}\n");
+    info!(transfer_type = transfer_type_arg, %id, %command, "Recover stuck transfer with CLI");
 }
 
 /// Asserts correctness of the full hedging + rebalancing pipeline across
@@ -608,6 +912,368 @@ async fn simulate() -> anyhow::Result<()> {
 
         if started.elapsed() >= trade_duration && round > 0 {
             // Only log once when transitioning to idle
+            info!("Trade phase complete. Bot still running — observe the system settling.");
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                if bot.is_finished() {
+                    let result = (&mut bot).await;
+                    panic!("Bot exited during idle phase: {result:?}");
+                }
+            }
+        }
+
+        let (order, symbol, direction) = orders[usize::try_from(round).unwrap() % orders.len()];
+        round += 1;
+
+        let mut rng = rand::thread_rng();
+        let amount: f64 = rng.gen_range(1.0..10.0);
+        let amount_str = format!("{amount:.3}");
+        let max_amount = Float::parse(amount_str.clone()).ok();
+
+        info!(round, symbol, direction, amount = %amount_str, "Simulating user trade");
+
+        match infra
+            .base_chain
+            .take_prepared_order_with_max(order, max_amount)
+            .await
+        {
+            Ok(_) => info!(round, symbol, direction, amount = %amount_str, "Trade executed"),
+            Err(error) => {
+                info!(
+                    round, symbol, direction, %error,
+                    "Trade reverted (vault drained, waiting for rebalance)",
+                );
+            }
+        }
+    }
+}
+
+/// Failure-injection simulation: starts the full system, performs normal trades
+/// to create recoverable AAPL mint and TSLA redemption failures, then advances
+/// the mock issuer/provider to Completed. The dashboard should show the failed
+/// transfers until `recheck-transfer` recovers them.
+///
+/// Run via `nix run .#simulate-failures`. Set
+/// `SIMULATE_EXIT_AFTER_SELF_HEAL=1` when running under automated verification
+/// to run the same recheck path in-process and stop after recovery.
+#[tokio::test]
+#[ignore = "failure simulation -- run via nix run .#simulate-failures"]
+#[allow(clippy::too_many_lines)]
+async fn simulate_failures() -> anyhow::Result<()> {
+    let server_port: u16 = std::env::var("SIMULATE_BOT_PORT")
+        .expect("SIMULATE_BOT_PORT must be set (run via `nix run .#simulate-failures`)")
+        .parse()
+        .expect("SIMULATE_BOT_PORT must be a valid u16 port number");
+
+    let log_dir =
+        std::path::PathBuf::from(format!("/tmp/st0x-simulate-failures-logs-{server_port}"));
+    std::fs::create_dir_all(&log_dir)?;
+    let _log_guard = crate::test_infra::init_tracing_with_log_dir(&log_dir);
+
+    let aapl_broker_price = float!(150.25);
+    let tsla_broker_price = float!(245.00);
+
+    let db_path = std::path::PathBuf::from(format!(
+        "/tmp/st0x-liquidity-simulate-failures-{server_port}.sqlite"
+    ));
+    let _ = std::fs::remove_file(&db_path);
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("sqlite-wal"));
+
+    let infra = TestInfra::start_with_cash(
+        vec![("AAPL", aapl_broker_price), ("TSLA", tsla_broker_price)],
+        vec![("AAPL", float!(400)), ("TSLA", float!(40))],
+        Some(float!(20000)),
+        Some(db_path),
+    )
+    .await?;
+    infra
+        .tokenization_service
+        .set_polls_until_complete(usize::MAX);
+
+    debug!("Starting CCTP mock infrastructure");
+    let cctp = CctpInfra::start(&infra).await?;
+
+    debug!("Creating USDC vault");
+    let usdc_amount: U256 = parse_units("80000", 6)?.into();
+    let usdc_vault_id = infra.base_chain.create_usdc_vault(usdc_amount).await?;
+
+    debug!("Setting up Raindex orders");
+    let aapl_sell = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!(67))
+        .price(float!(155.00))
+        .direction(TakeDirection::SellEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .call()
+        .await?;
+
+    let aapl_equity_vault_id = aapl_sell.output_vault_id;
+
+    let aapl_buy = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!(67))
+        .price(float!(155.00))
+        .direction(TakeDirection::BuyEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .equity_vault_id(aapl_equity_vault_id)
+        .call()
+        .await?;
+
+    let tsla_sell = infra
+        .base_chain
+        .setup_order()
+        .symbol("TSLA")
+        .amount(float!(20))
+        .price(float!(250.00))
+        .direction(TakeDirection::SellEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .call()
+        .await?;
+
+    let tsla_equity_vault_id = tsla_sell.output_vault_id;
+
+    let tsla_buy = infra
+        .base_chain
+        .setup_order()
+        .symbol("TSLA")
+        .amount(float!(20))
+        .price(float!(250.00))
+        .direction(TakeDirection::BuyEquity)
+        .usdc_vault_id(usdc_vault_id)
+        .equity_vault_id(tsla_equity_vault_id)
+        .call()
+        .await?;
+
+    let equity_vault_ids = HashMap::from([
+        ("AAPL".to_owned(), aapl_equity_vault_id),
+        ("TSLA".to_owned(), tsla_equity_vault_id),
+    ]);
+
+    debug!("Starting deposit watcher");
+    let eth_deposit_provider = alloy::providers::ProviderBuilder::new()
+        .connect(&cctp.ethereum_endpoint)
+        .await?;
+    let _deposit_watcher = infra
+        .broker_service
+        .start_deposit_watcher(eth_deposit_provider, USDC_ETHEREUM, infra.base_chain.owner)
+        .await?;
+
+    debug!("Building bot context");
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let (event_sender, _) = broadcast::channel::<Statement>(256);
+
+    let mut ctx = build_full_system_ctx()
+        .chain(&infra.base_chain)
+        .ethereum_endpoint(&cctp.ethereum_endpoint)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(usdc_vault_id)
+        .cctp(cctp.cctp_overrides())
+        .cash_reserved(Positive::new(Usd::new(float!(50000)))?)
+        .server_port(server_port)
+        .call()?;
+    ctx.log_dir = Some(log_dir.display().to_string());
+    let cli_ctx = ctx.clone();
+
+    let (config_path, secrets_path) = write_simulate_failure_cli_files(
+        &infra,
+        &cctp,
+        server_port,
+        current_block,
+        usdc_vault_id,
+        &equity_vault_ids,
+    )?;
+
+    debug!("Starting bot");
+    let mut bot = spawn_bot_with_event_channel(ctx, event_sender);
+
+    poll_for_ready(&mut bot, server_port).await;
+    info!("Bot ready. Creating recoverable provider-completion failures.");
+
+    infra
+        .base_chain
+        .take_prepared_order_with_max(&aapl_sell, Some(float!(67)))
+        .await?;
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+    poll_for_events(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAccepted",
+        1,
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let accepted_mint = latest_accepted_mint_ids(&pool).await?;
+
+    st0x_hedge::cli::fail_transfer_for_test(
+        &pool,
+        TransferType::Mint,
+        &accepted_mint.issuer_request_id,
+        "simulate: local workflow timed out while provider kept processing",
+    )
+    .await?;
+    poll_for_events(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAcceptanceFailed",
+        1,
+    )
+    .await;
+
+    complete_mock_mint_provider(&infra, &accepted_mint.tokenization_request_id).await?;
+    info!(
+        mint_id = %accepted_mint.issuer_request_id,
+        tokenization_request_id = %accepted_mint.tokenization_request_id,
+        "Injected stuck mint: local aggregate failed, mock provider completed later"
+    );
+    log_recheck_command(
+        &config_path,
+        &secrets_path,
+        TransferType::Mint,
+        &accepted_mint.issuer_request_id,
+    );
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::MintAccepted",
+        2,
+        Duration::from_secs(180),
+    )
+    .await;
+    let settling_mint = latest_accepted_mint_ids_for_symbol(&pool, "TSLA").await?;
+    complete_mock_mint_provider(&infra, &settling_mint.tokenization_request_id).await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "TokenizedEquityMintEvent::DepositedIntoRaindex",
+        1,
+        Duration::from_secs(180),
+    )
+    .await;
+
+    infra
+        .tokenization_service
+        .set_redemption_outcome(RedemptionOutcome::Reject);
+    infra.tokenization_service.set_polls_until_complete(1);
+
+    infra.base_chain.take_prepared_order(&tsla_buy).await?;
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "EquityRedemptionEvent::TokensSent",
+        1,
+        Duration::from_secs(180),
+    )
+    .await;
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "EquityRedemptionEvent::RedemptionRejected",
+        1,
+        Duration::from_secs(180),
+    )
+    .await;
+
+    let rejected_redemption = latest_rejected_redemption_ids(&pool).await?;
+    complete_mock_redemption_provider(&infra, &rejected_redemption.tokenization_request_id)?;
+    infra
+        .tokenization_service
+        .set_redemption_outcome(RedemptionOutcome::Complete);
+    info!(
+        redemption_id = %rejected_redemption.redemption_id,
+        tokenization_request_id = %rejected_redemption.tokenization_request_id,
+        "Injected stuck redemption: local aggregate failed, mock provider completed later"
+    );
+    log_recheck_command(
+        &config_path,
+        &secrets_path,
+        TransferType::Redemption,
+        &rejected_redemption.redemption_id,
+    );
+
+    if std::env::var_os("SIMULATE_EXIT_AFTER_SELF_HEAL").is_some() {
+        st0x_hedge::cli::recheck_transfer_for_test(
+            &cli_ctx,
+            TransferType::Mint,
+            &accepted_mint.issuer_request_id,
+        )
+        .await?;
+
+        // A first DepositedIntoRaindex was already observed for the settling
+        // mint above, so this must wait for a *second* deposit -- the one the
+        // recovered mint produces -- otherwise the count is already satisfied
+        // and the assertion passes without verifying mint recovery at all.
+        poll_for_events_with_timeout(
+            &mut bot,
+            &infra.db_path,
+            "TokenizedEquityMintEvent::DepositedIntoRaindex",
+            2,
+            Duration::from_secs(180),
+        )
+        .await;
+
+        st0x_hedge::cli::recheck_transfer_for_test(
+            &cli_ctx,
+            TransferType::Redemption,
+            &rejected_redemption.redemption_id,
+        )
+        .await?;
+
+        // `ProviderCompletionRecovered` is the terminal recovery event: the
+        // redemption aggregate evolves straight to the `Completed` state from
+        // it (no separate `Completed` event is ever written), so its presence
+        // is the end-to-end proof that recheck-transfer completed the redemption.
+        poll_for_events_with_timeout(
+            &mut bot,
+            &infra.db_path,
+            "EquityRedemptionEvent::ProviderCompletionRecovered",
+            1,
+            Duration::from_secs(60),
+        )
+        .await;
+        info!(
+            "Recovery verified: recheck-transfer completed stuck mint and redemption rebalances."
+        );
+        bot.abort();
+        return Ok(());
+    }
+
+    info!(
+        "Stuck mint and redemption left visible for dashboard/CLI testing. Starting continuous trade simulation."
+    );
+
+    let orders = [
+        (&aapl_sell, "AAPL", "SellEquity"),
+        (&aapl_buy, "AAPL", "BuyEquity"),
+        (&tsla_sell, "TSLA", "SellEquity"),
+        (&tsla_buy, "TSLA", "BuyEquity"),
+    ];
+
+    let trade_onchain_minutes = 10;
+    let trade_duration = Duration::from_secs(trade_onchain_minutes * 60);
+    let started = tokio::time::Instant::now();
+    let mut round = 0u64;
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        if bot.is_finished() {
+            let result = (&mut bot).await;
+            panic!("Bot exited during simulation: {result:?}");
+        }
+
+        if started.elapsed() >= trade_duration && round > 0 {
             info!("Trade phase complete. Bot still running — observe the system settling.");
             loop {
                 tokio::time::sleep(Duration::from_secs(30)).await;


### PR DESCRIPTION
## What

[RAI-629](https://linear.app/makeitrain/issue/RAI-629/surface-stuckstranded-inflight-balance-for-failed-rebalances-cli-to-re)

![CleanShot 2026-05-25 at 12.32.25@2x.png](https://app.graphite.com/user-attachments/assets/f2bbe155-6093-4ef0-be15-ddac08d32de8.png)

Surfaces stranded equity for failed mint/redemption rebalances in the dashboard, and recovers transfers whose tokenization provider later settled — **in-process**, so the live inventory view is corrected, not just the persisted aggregate.

- `GET /transfers/<kind>/<aggregate_id>/events` returns event history plus optional `stuck` metadata (stranded amount, location, reason).
- The dashboard transfer detail modal renders a "Stranded equity" block.
- New `POST /transfers/recheck/<kind>/<id>` endpoint performs recovery inside the running bot; the `recheck-transfer` CLI is now a thin HTTP client of it.
- Mint/redemption CQRS aggregates gain `RecoverProviderCompletion` -> `ProviderCompletionRecovered`, and the rebalancing reactor applies the same inventory effect a successful flow would.
- Recovery is concurrency-safe and self-undoing: it refuses (returns a `conflict` outcome) when a *different* transfer for the same symbol is already live, and rolls back its in-memory rebuild if the recovery event fails to persist.
- Removes the vestigial `receipt_id` field from the mint aggregate (always zero, never read).

## Why

Some rebalances fail locally after equity has already left the normal available balance — most commonly a redemption that times out into `DetectionFailed`, or a mint that fails after Alpaca accepted it. Operators need to see where the equity is stranded and need a deterministic way to re-check the provider without hand-mutating aggregate state.

Recovery must run **in the bot process**: the in-memory inventory tally is only updated by the `RebalancingService` reactor, which fires for events produced in-process. A standalone CLI writing the recovery event via a reactor-less framework would persist the event but leave live inventory uncorrected (dead-code reactor arms). [ADR 2](adrs/2-in-process-recovery-for-failed-transfers.md) records this decision.

## How

- **[ADR 2](adrs/2-in-process-recovery-for-failed-transfers.md)** documents the in-process design and why the standalone-CLI approach was rejected.
- **[ADR 3](adrs/3-deterministic-recovery-inventory-reconciliation.md)** records a known, self-healing inventory edge case in the explicit-failure rebuild and why the deterministic fix is deferred (see "Anything else").
- `src/api.rs`: `POST /transfers/recheck/<kind>/<id>` runs recovery under the existing `resume_lock` (shared with `/transfers/resume`, so the two can't race an on-chain wrap). `stuck_mint_info`/`stuck_redemption_info` deserialize persisted payloads into the typed event enums and match exhaustively (was string-matched event names); `StuckLocation`/`StuckReason` are enums; the redemption stranded amount prefers the actual unwrapped underlying amount over the wrapped withdrawn amount. `recheck_transfer` maps recovery errors to meaningful HTTP statuses — `422` for not-recoverable states (no accepted request / missing tx / malformed wallet), `502` for a transient provider failure, `500` for internal — instead of one opaque 500. Recovered transfers clear their stuck state.
- `src/rebalancing/equity/mod.rs`: `CrossVenueEquityTransfer::recover_mint`/`recover_redemption` query the provider and, if completed, dispatch `RecoverProviderCompletion` through the **reactor-wired** store, then resume. Guards: recovery returns `RecheckOutcome::Conflict` when a *different* aggregate owns the symbol's in-flight (rebuilding would overwrite it); a missing/not-yet-visible provider request returns `LeftUnchanged` rather than erroring; mint recovery is restricted to acceptance-stage failures (a mint that already received tokens is `NotRecoverable`). If `store.send` fails the rebuild is rolled back so inventory isn't left with a phantom in-flight; a post-dispatch `resume_mint` failure is non-fatal (clears the in-progress guard and the symbol's active-mint slot; startup recovery finishes the workflow).
- `src/rebalancing/trigger/mod.rs`: `rebuild_*_tracking_for_recovery` rebuild reactor tracking before dispatch and restore a canonical in-flight inventory shape so the recovery arm completes uniformly whether the transfer failed explicitly (cancelled to available) or by timeout (in-flight cleared); they apply the inventory update *before* consuming the timeout tombstone (so a failed rebuild can't lose it) and return a `RecoveryRollback` token the caller uses to undo the rebuild on dispatch failure. The symbol-conflict checks (`mint_recovery_conflicts`/`redemption_recovery_conflicts`) are owner-aware, so an aggregate can always recover its own stale slot.
- `src/cli/{mod,rebalancing}.rs`: `recheck-transfer` POSTs to the bot and prints the outcome; the old direct-DB recovery path is removed.
- `src/tokenized_equity_mint.rs` / `src/equity_redemption.rs`: add the recovery command/event, delete the dead `receipt_id` field + `ReceiptId` type, bump `SCHEMA_VERSION` to 3.
- `src/tokenization.rs` / `alpaca.rs` / `mock.rs`: provider lookup by request id and by redemption tx hash.
- `crates/execution/.../auth.rs`: mock Alpaca mode in config (for the simulation); also fixes a feature-gated `base_url` compile error.
- `flake.nix` / `README.md` / `tests/e2e/full_system.rs`: `nix run .#simulate-failures` boots the stack against a failure scenario the printed `recheck-transfer` command recovers.
- `docs/cli-ops.md`: documents that `recheck-transfer` now requires the bot running, and what it can/can't recover.

## Testing

- `cargo check --workspace`, `cargo clippy --workspace --all-targets --all-features`, `cargo fmt` — all clean.
- `cargo nextest run -p st0x-hedge -p st0x-execution` — reactor-level recovery inventory tests (explicit + timeout × mint + redemption); the dispatch-failure **rollback** (explicit + timeout × mint + redemption); the **owner-aware symbol-conflict** guard; the `recheck_error_response` status mapping; the `received_tokens` re-recovery guard; the redemption `unwrapped_amount` stuck-amount fallback; the recheck endpoint (503-before-ready, route registration); and the `AlpacaBrokerApiMode` deserializer error paths.
- `env SIMULATE_EXIT_AFTER_SELF_HEAL=1 cargo nextest run --test e2e -E 'test(=full_system::simulate_failures)' --run-ignored ignored-only --features mock,test-support` (via `nix run .#simulate-failures`) — recovers a stuck mint and redemption end-to-end through the endpoint.
- Dashboard `bun run check` and `bunx vitest run src` — pass (90 tests); the stuck-info wire contract (`stuckAmount`/`stuckLocation`/`stuckReason`) is unchanged and locked with a serialization test.

## Screenshots

Not captured.

## Anything else

- **Behavioral change:** recovery now requires the bot to be running (it goes through the live process via the REST API), trading the ability to recover against a stopped bot for correct in-process inventory.
- **Known transient inventory window ([ADR 3](adrs/3-deterministic-recovery-inventory-reconciliation.md)):** the explicit-failure rebuild assumes Hedging `available` still holds the cancelled amount; if a balance poll already reconciled the post-settlement balance, recovery momentarily under-reports `available` by the recovered quantity. It self-corrects on the next offchain poll (never double-spends; at worst a brief mis-sized rebalance), so the deterministic fix (authoritative offchain re-fetch under the recovery lock) is deferred, not added here.
- The `/transfers/recheck` endpoint is unauthenticated, matching the existing `/transfers/resume`. The auth boundary for `/transfers/*` mutation endpoints is pre-existing debt and should be a separate follow-up, not addressed here.
- Recovery stays operator-driven. It does not add automatic recovery for loose wrapped equity in the bot wallet; that is covered by Gleb's WrappedEquityRecovery work in #678 / RAI-87.
- Follow-up [RAI-636](https://linear.app/makeitrain/issue/RAI-636/recover-rpc-timed-out-transfers-by-reconciling-txprovider-state) tracks RPC-timeout/unknown-tx recovery — a separate class that must reconcile submitted tx hashes, receipts, logs, and balances before retrying so we never double send/unwrap/deposit/mint/burn.
- `cd dashboard && bun run test:run` still discovers generated `.tmp/rain-math-float` upstream tests and fails outside the dashboard source tree on missing Hardhat/Rain modules; the scoped run (`bunx vitest run src`) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added transfer recovery via new `POST /transfers/recheck/` API endpoint and `recheck-transfer` CLI command for failed equity mints and redemptions.
  * Enhanced dashboard to display stranded equity detail views with recovery information.
  * Added `simulate-failures` testing tool for local failure injection and recovery validation.

* **Documentation**
  * Updated guides for transfer recovery workflows and local simulation.
  * Added architectural decision records covering in-process recovery and inventory reconciliation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->