### PR TITLE
feat: add trace logging for Alpaca and Turnkey API responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,22 +726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer-turnkey"
-version = "1.0.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3528e3fc1294e1706e44e44c855956681b26861758216ad63eb81221223b18"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-signer",
- "async-trait",
- "thiserror 2.0.18",
- "tracing",
- "turnkey_client",
-]
-
-[[package]]
 name = "alloy-sol-macro"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6842,19 +6826,23 @@ name = "st0x-evm"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-signer-turnkey",
  "anyhow",
  "async-trait",
  "dashmap",
  "futures",
  "httpmock",
+ "mime",
  "rain-error-decoding",
  "rand 0.8.6",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-test",
+ "turnkey_api_key_stamper",
+ "turnkey_client",
  "url",
 ]
 
@@ -6894,6 +6882,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-test",
  "url",
  "urlencoding",
  "uuid",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -7,20 +7,30 @@ edition = "2024"
 default = []
 mock = ["local-signer", "dep:url", "dep:anyhow"]
 local-signer = []
-turnkey = ["dep:alloy-signer-turnkey"]
+turnkey = [
+  "dep:reqwest",
+  "dep:serde_json",
+  "dep:turnkey_client",
+  "dep:turnkey_api_key_stamper",
+  "dep:mime",
+]
 
 [dependencies]
 alloy.workspace = true
-alloy-signer-turnkey = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 async-trait.workspace = true
 dashmap = "6.1.0"
 futures = "0.3.32"
+mime = { version = "0.3.17", optional = true }
 rain-error-decoding.workspace = true
+reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
+turnkey_api_key_stamper = { version = "0.4.0", optional = true }
+turnkey_client = { version = "0.4.0", optional = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -28,6 +38,7 @@ httpmock.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -201,13 +201,6 @@ impl From<std::convert::Infallible> for EvmError {
     }
 }
 
-#[cfg(feature = "turnkey")]
-impl From<alloy_signer_turnkey::TurnkeySignerError> for EvmError {
-    fn from(error: alloy_signer_turnkey::TurnkeySignerError) -> Self {
-        Self::Turnkey(turnkey::TurnkeyError::from(error))
-    }
-}
-
 /// Read-only EVM chain access with error-decoded view calls.
 ///
 /// Provides the underlying provider for direct chain queries (balance

--- a/crates/evm/src/turnkey.rs
+++ b/crates/evm/src/turnkey.rs
@@ -7,17 +7,28 @@
 //! the signer: `TurnkeySigner` (remote signing via Turnkey API) instead
 //! of `PrivateKeySigner` (local key).
 
-use alloy::network::{Ethereum, EthereumWallet};
-use alloy::primitives::{Address, Bytes, TxHash};
+use alloy::consensus::SignableTransaction;
+use alloy::network::{Ethereum, EthereumWallet, TxSigner};
+use alloy::primitives::{Address, B256, Bytes, ChainId, Signature, TxHash, U256, hex, normalize_v};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller, WalletFiller,
 };
 use alloy::providers::{Identity, Provider, ProviderBuilder};
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
-use alloy_signer_turnkey::{TurnkeySigner, TurnkeySignerError};
+use alloy::signers::{Error as SignerError, Result as SignerResult, Signer};
 use async_trait::async_trait;
+use reqwest::header::CONTENT_TYPE;
 use serde::Deserialize;
-use tracing::{error, info, warn};
+use serde::Serialize;
+use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use tracing::{error, info, trace, warn};
+use turnkey_api_key_stamper::{Stamp, StampHeader, TurnkeyP256ApiKey};
+use turnkey_client::generated::{
+    Activity, ActivityResponse, ActivityStatus, SignRawPayloadIntentV2, SignRawPayloadRequest,
+    immutable::activity::v1::{SignRawPayloadResult, result},
+    immutable::common::v1::{HashFunction, PayloadEncoding},
+};
+use turnkey_client::{RetryConfig, TurnkeyClientError};
 
 use crate::nonce::ResettableNonceManager;
 use crate::{Evm, EvmError, TryIntoWallet, Wallet, WalletCtx};
@@ -56,7 +67,35 @@ impl std::fmt::Debug for TurnkeyApiPrivateKey {
 #[derive(Debug, thiserror::Error)]
 pub enum TurnkeyError {
     #[error("Turnkey signer error: {0}")]
-    Signer(#[from] TurnkeySignerError),
+    Signer(#[from] TracingTurnkeySignerError),
+}
+
+/// Component of an ECDSA signature returned by Turnkey.
+#[derive(Debug, Clone, Copy)]
+pub enum SignatureComponent {
+    R,
+    S,
+    V,
+}
+
+/// Errors that can occur when using the traced Turnkey signer.
+#[derive(Debug, thiserror::Error)]
+pub enum TracingTurnkeySignerError {
+    #[error(transparent)]
+    TurnkeyClient(#[from] TurnkeyClientError),
+    #[error("invalid hex string: {0}")]
+    Hex(#[from] hex::FromHexError),
+    #[error("signature component {component:?} has invalid byte length: {len}")]
+    BadComponentLength {
+        component: SignatureComponent,
+        len: usize,
+    },
+    #[error("signature v value {v} is not a valid recovery id")]
+    UnnormalizableV { v: u8 },
+    #[error("transaction is missing a chain id")]
+    MissingTxChainId,
+    #[error("system time is before UNIX epoch: {source}")]
+    SystemTime { source: SystemTimeError },
 }
 
 /// Non-secret Turnkey configuration: wallet address and organization ID.
@@ -153,10 +192,13 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
 
         let chain_id = ctx.provider.get_chain_id().await?;
 
-        let TurnkeyApiPrivateKey(api_key_hex) = &api_private_key;
-        let TurnkeyOrganizationId(org_id) = organization_id;
-
-        let signer = TurnkeySigner::from_api_key(api_key_hex, org_id, address, Some(chain_id))?;
+        let signer = TracingTurnkeySigner::from_api_key(
+            &api_private_key,
+            organization_id,
+            address,
+            Some(chain_id),
+        )
+        .map_err(TurnkeyError::from)?;
 
         let eth_wallet = EthereumWallet::from(signer);
 
@@ -191,15 +233,15 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
     /// base URL. Production code should use [`new`](Self::new).
     #[cfg(test)]
     async fn from_client(
-        client: alloy_signer_turnkey::TurnkeyClient,
-        organization_id: String,
+        client: TracingTurnkeyClient,
+        organization_id: TurnkeyOrganizationId,
         address: Address,
         provider: P,
         required_confirmations: u64,
     ) -> Result<Self, EvmError> {
         let chain_id = provider.get_chain_id().await?;
 
-        let signer = TurnkeySigner::new(client, organization_id, address, Some(chain_id));
+        let signer = TracingTurnkeySigner::new(client, organization_id, address, Some(chain_id));
 
         let eth_wallet = EthereumWallet::from(signer);
 
@@ -222,6 +264,365 @@ impl<P: Provider + Clone + Send + Sync + 'static> TurnkeyWallet<P> {
             address,
             required_confirmations,
         })
+    }
+}
+
+struct TracingTurnkeyClient {
+    http: reqwest::Client,
+    base_url: String,
+    api_key: TurnkeyP256ApiKey,
+    retry_config: RetryConfig,
+}
+
+impl std::fmt::Debug for TracingTurnkeyClient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TracingTurnkeyClient")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TracingTurnkeyClient {
+    fn from_api_key(api_private_key: &TurnkeyApiPrivateKey) -> Result<Self, TurnkeyClientError> {
+        let TurnkeyApiPrivateKey(api_key_hex) = api_private_key;
+        let api_key = TurnkeyP256ApiKey::from_strings(api_key_hex, None)?;
+        Ok(Self::new(
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(20))
+                .user_agent("st0x-turnkey-client")
+                .build()
+                .map_err(TurnkeyClientError::ReqwestBuilder)?,
+            "https://api.turnkey.com".to_string(),
+            api_key,
+            RetryConfig::default(),
+        ))
+    }
+
+    #[cfg(test)]
+    fn for_base_url(
+        base_url: String,
+        api_key: TurnkeyP256ApiKey,
+    ) -> Result<Self, TurnkeyClientError> {
+        Ok(Self::new(
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(20))
+                .user_agent("st0x-turnkey-client")
+                .build()
+                .map_err(TurnkeyClientError::ReqwestBuilder)?,
+            base_url,
+            api_key,
+            RetryConfig::default(),
+        ))
+    }
+
+    fn new(
+        http: reqwest::Client,
+        base_url: String,
+        api_key: TurnkeyP256ApiKey,
+        retry_config: RetryConfig,
+    ) -> Self {
+        Self {
+            http,
+            base_url,
+            api_key,
+            retry_config,
+        }
+    }
+
+    fn current_timestamp() -> Result<u128, TracingTurnkeySignerError> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .map_err(|source| TracingTurnkeySignerError::SystemTime { source })
+    }
+
+    async fn sign_raw_payload(
+        &self,
+        organization_id: TurnkeyOrganizationId,
+        timestamp_ms: u128,
+        params: SignRawPayloadIntentV2,
+    ) -> Result<SignRawPayloadResult, TurnkeyClientError> {
+        let TurnkeyOrganizationId(organization_id) = organization_id;
+        let request = SignRawPayloadRequest {
+            r#type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
+            timestamp_ms: timestamp_ms.to_string(),
+            parameters: Some(params),
+            organization_id,
+        };
+        let activity = self
+            .process_activity(&request, "/public/v1/submit/sign_raw_payload")
+            .await?;
+        let inner = activity
+            .result
+            .ok_or(TurnkeyClientError::MissingResult)?
+            .inner
+            .ok_or(TurnkeyClientError::MissingInnerResult)?;
+
+        match inner {
+            result::Inner::SignRawPayloadResult(result) => Ok(result),
+            other => Err(TurnkeyClientError::UnexpectedInnerActivityResult(
+                serde_json::to_string(&other)?,
+            )),
+        }
+    }
+
+    async fn process_activity<Request: Serialize + Sync>(
+        &self,
+        request: &Request,
+        path: &str,
+    ) -> Result<Activity, TurnkeyClientError> {
+        let mut retry_count = 0;
+
+        loop {
+            let response: ActivityResponse = self.process_request(request, path).await?;
+            let activity = response
+                .activity
+                .ok_or(TurnkeyClientError::MissingActivity)?;
+
+            match activity.status {
+                ActivityStatus::Completed => return Ok(activity),
+                ActivityStatus::Pending => {
+                    if retry_count >= self.retry_config.max_retries {
+                        return Err(TurnkeyClientError::ExceededRetries(retry_count));
+                    }
+
+                    retry_count += 1;
+                    tokio::time::sleep(self.retry_config.compute_delay(retry_count)).await;
+                }
+                ActivityStatus::Failed => {
+                    return Err(TurnkeyClientError::ActivityFailed(activity.failure));
+                }
+                ActivityStatus::ConsensusNeeded => {
+                    return Err(TurnkeyClientError::ActivityRequiresApproval(activity.id));
+                }
+                ActivityStatus::Unspecified
+                | ActivityStatus::Created
+                | ActivityStatus::Rejected => {
+                    return Err(TurnkeyClientError::UnexpectedActivityStatus(
+                        activity.status.as_str_name().to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn process_request<Request, Response>(
+        &self,
+        request: &Request,
+        path: &str,
+    ) -> Result<Response, TurnkeyClientError>
+    where
+        Request: Serialize + Sync,
+        Response: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{}", self.base_url, path);
+        let post_body = serde_json::to_string(request)?;
+        let StampHeader { name, value } = self.api_key.stamp(post_body.as_bytes())?;
+        let response = self
+            .http
+            .post(&url)
+            .header(name, value)
+            .body(post_body)
+            .send()
+            .await?;
+        let status = response.status();
+        let content_type = response.headers().get(CONTENT_TYPE).cloned();
+        // Read raw bytes and parse the success body with `serde_json::from_slice`
+        // so invalid UTF-8 fails fast, matching the fail-fast convention the
+        // Alpaca clients follow. Lossy decoding is used only for the trace line
+        // and the error-body display.
+        let bytes = response.bytes().await?;
+
+        // The successful `sign_raw_payload` body contains the ECDSA signature
+        // components (r/s/v). These are signature material, not key material:
+        // they do not expose the private key, and for transaction signing they
+        // become public on-chain once the tx is broadcast. This signer is only
+        // used for transaction signing (no off-chain raw-hash signing path), so
+        // logging the body does not leak a secret.
+        trace!(
+            target: "wallet",
+            method = "POST",
+            status = %status,
+            url = %url,
+            body = %String::from_utf8_lossy(&bytes),
+            "Turnkey API response body received"
+        );
+
+        // Error mapping below reproduces upstream `turnkey_client`'s handling
+        // (including its String-valued error variants); it is not a new
+        // stringly-typed-error introduction. This client is a deliberate fork
+        // of `turnkey_client` to insert the response-body trace above.
+        let content_type = content_type
+            .ok_or(TurnkeyClientError::MissingContentTypeHeader)?
+            .to_str()
+            .map_err(|error| TurnkeyClientError::HeaderToStrError(error.to_string()))?
+            .parse::<mime::Mime>()
+            .map_err(|error| TurnkeyClientError::HeaderFromStrError(error.to_string()))?;
+
+        if !status.is_success() {
+            return Err(TurnkeyClientError::UnexpectedHttpStatus(
+                status.as_u16(),
+                String::from_utf8_lossy(&bytes).into_owned(),
+            ));
+        }
+
+        // Compare only the MIME essence (type/subtype) so responses that carry
+        // parameters such as `application/json; charset=utf-8` are accepted;
+        // strict equality against `mime::APPLICATION_JSON` rejects them.
+        if content_type.essence_str() != mime::APPLICATION_JSON.essence_str() {
+            return Err(TurnkeyClientError::UnexpectedMimeType(
+                content_type.to_string(),
+            ));
+        }
+
+        serde_json::from_slice(&bytes).map_err(|error| {
+            TurnkeyClientError::Decode(String::from_utf8_lossy(&bytes).into_owned(), error)
+        })
+    }
+}
+
+struct TracingTurnkeySigner {
+    client: TracingTurnkeyClient,
+    organization_id: TurnkeyOrganizationId,
+    address: Address,
+    chain_id: Option<ChainId>,
+}
+
+impl std::fmt::Debug for TracingTurnkeySigner {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TracingTurnkeySigner")
+            .field("organization_id", &self.organization_id)
+            .field("address", &self.address)
+            .field("chain_id", &self.chain_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TracingTurnkeySigner {
+    fn new(
+        client: TracingTurnkeyClient,
+        organization_id: TurnkeyOrganizationId,
+        address: Address,
+        chain_id: Option<ChainId>,
+    ) -> Self {
+        Self {
+            client,
+            organization_id,
+            address,
+            chain_id,
+        }
+    }
+
+    fn from_api_key(
+        api_private_key: &TurnkeyApiPrivateKey,
+        organization_id: TurnkeyOrganizationId,
+        address: Address,
+        chain_id: Option<ChainId>,
+    ) -> Result<Self, TracingTurnkeySignerError> {
+        let client = TracingTurnkeyClient::from_api_key(api_private_key)?;
+        Ok(Self::new(client, organization_id, address, chain_id))
+    }
+
+    fn parse_signature(
+        response: &SignRawPayloadResult,
+    ) -> Result<Signature, TracingTurnkeySignerError> {
+        let r_bytes = hex::decode(&response.r)?;
+        let s_bytes = hex::decode(&response.s)?;
+        let v_bytes = hex::decode(&response.v)?;
+
+        let r_arr: [u8; 32] = r_bytes.try_into().map_err(|bytes: Vec<u8>| {
+            TracingTurnkeySignerError::BadComponentLength {
+                component: SignatureComponent::R,
+                len: bytes.len(),
+            }
+        })?;
+        let r = U256::from_be_bytes(r_arr);
+
+        let s_arr: [u8; 32] = s_bytes.try_into().map_err(|bytes: Vec<u8>| {
+            TracingTurnkeySignerError::BadComponentLength {
+                component: SignatureComponent::S,
+                len: bytes.len(),
+            }
+        })?;
+        let s = U256::from_be_bytes(s_arr);
+
+        let [v_byte]: [u8; 1] = v_bytes.try_into().map_err(|bytes: Vec<u8>| {
+            TracingTurnkeySignerError::BadComponentLength {
+                component: SignatureComponent::V,
+                len: bytes.len(),
+            }
+        })?;
+
+        let parity = normalize_v(u64::from(v_byte))
+            .ok_or(TracingTurnkeySignerError::UnnormalizableV { v: v_byte })?;
+
+        Ok(Signature::new(r, s, parity))
+    }
+}
+
+#[async_trait]
+impl TxSigner<Signature> for TracingTurnkeySigner {
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &mut dyn SignableTransaction<Signature>,
+    ) -> SignerResult<Signature> {
+        if let Some(chain_id) = self.chain_id()
+            && !tx.set_chain_id_checked(chain_id)
+        {
+            // `set_chain_id_checked` only returns false when the tx already
+            // carries a (mismatching) chain id, so `tx.chain_id()` is always
+            // Some here. The `MissingTxChainId` fallback is defensive (avoids
+            // a panic the no-unwrap rule forbids) and is not expected to fire.
+            let tx_chain_id = tx
+                .chain_id()
+                .ok_or_else(|| SignerError::other(TracingTurnkeySignerError::MissingTxChainId))?;
+            return Err(SignerError::TransactionChainIdMismatch {
+                signer: chain_id,
+                tx: tx_chain_id,
+            });
+        }
+
+        self.sign_hash(&tx.signature_hash()).await
+    }
+}
+
+#[async_trait]
+impl Signer for TracingTurnkeySigner {
+    async fn sign_hash(&self, hash: &B256) -> SignerResult<Signature> {
+        let response = self
+            .client
+            .sign_raw_payload(
+                self.organization_id.clone(),
+                TracingTurnkeyClient::current_timestamp().map_err(SignerError::other)?,
+                SignRawPayloadIntentV2 {
+                    sign_with: self.address.to_string(),
+                    payload: hex::encode(hash),
+                    encoding: PayloadEncoding::Hexadecimal,
+                    hash_function: HashFunction::NoOp,
+                },
+            )
+            .await
+            .map_err(|error| SignerError::other(TracingTurnkeySignerError::TurnkeyClient(error)))?;
+
+        Self::parse_signature(&response).map_err(SignerError::other)
+    }
+
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn chain_id(&self) -> Option<ChainId> {
+        self.chain_id
+    }
+
+    fn set_chain_id(&mut self, chain_id: Option<ChainId>) {
+        self.chain_id = chain_id;
     }
 }
 
@@ -334,7 +735,6 @@ mod tests {
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::U256;
     use alloy::providers::ext::AnvilApi;
-    use alloy_signer_turnkey::{TurnkeyClient, TurnkeyClientBuilder, TurnkeyP256ApiKey};
     use httpmock::MockServer;
 
     use super::*;
@@ -344,17 +744,190 @@ mod tests {
         TurnkeyP256ApiKey::generate()
     }
 
-    /// Build a `TurnkeyClient` that sends requests to the mock server.
-    fn mock_client(server: &MockServer) -> TurnkeyClient {
-        let api_key = test_api_key();
-
-        TurnkeyClientBuilder::new()
-            .api_key(api_key)
-            .base_url(server.base_url())
-            .build()
-            .unwrap()
+    /// Build a Turnkey client that sends requests to the mock server.
+    fn mock_client(server: &MockServer) -> TracingTurnkeyClient {
+        TracingTurnkeyClient::for_base_url(server.base_url(), test_api_key()).unwrap()
     }
 
+    /// Build a Turnkey client with a custom retry config so the retry
+    /// loop can be exercised without real backoff delays.
+    fn mock_client_with_retry(
+        server: &MockServer,
+        retry_config: RetryConfig,
+    ) -> TracingTurnkeyClient {
+        TracingTurnkeyClient::new(
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(20))
+                .build()
+                .unwrap(),
+            server.base_url(),
+            test_api_key(),
+            retry_config,
+        )
+    }
+
+    /// 32-byte big-endian hex for the U256 value 1.
+    const VALID_R_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+    /// 32-byte big-endian hex for the U256 value 2.
+    const VALID_S_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000002";
+
+    fn signature_result(r: &str, s: &str, v: &str) -> SignRawPayloadResult {
+        SignRawPayloadResult {
+            r: r.to_string(),
+            s: s.to_string(),
+            v: v.to_string(),
+        }
+    }
+
+    /// JSON body for a COMPLETED `sign_raw_payload` activity carrying the
+    /// given signature components, shaped like a real Turnkey response.
+    fn completed_sign_raw_payload_body(r: &str, s: &str, v: &str) -> serde_json::Value {
+        serde_json::json!({
+            "activity": {
+                "id": "activity-id",
+                "organizationId": "org-test",
+                "status": "ACTIVITY_STATUS_COMPLETED",
+                "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                "fingerprint": "fingerprint",
+                "result": {
+                    "signRawPayloadResult": { "r": r, "s": s, "v": v }
+                }
+            }
+        })
+    }
+
+    /// JSON body for a PENDING activity (no result yet).
+    fn pending_activity_body() -> serde_json::Value {
+        serde_json::json!({
+            "activity": {
+                "id": "activity-id",
+                "organizationId": "org-test",
+                "status": "ACTIVITY_STATUS_PENDING",
+                "type": "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2",
+                "fingerprint": "fingerprint"
+            }
+        })
+    }
+
+    #[test]
+    fn parse_signature_decodes_valid_components() {
+        let result = signature_result(VALID_R_HEX, VALID_S_HEX, "00");
+
+        let signature = TracingTurnkeySigner::parse_signature(&result).unwrap();
+
+        assert_eq!(signature.r(), U256::from(1));
+        assert_eq!(signature.s(), U256::from(2));
+        assert!(!signature.v());
+    }
+
+    #[test]
+    fn parse_signature_rejects_short_r_component() {
+        let result = signature_result("0011", VALID_S_HEX, "00");
+
+        let error = TracingTurnkeySigner::parse_signature(&result).unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::BadComponentLength {
+                component: SignatureComponent::R,
+                len: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_signature_rejects_oversized_v_component() {
+        let result = signature_result(VALID_R_HEX, VALID_S_HEX, "0000");
+
+        let error = TracingTurnkeySigner::parse_signature(&result).unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::BadComponentLength {
+                component: SignatureComponent::V,
+                len: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_signature_rejects_unnormalizable_v() {
+        // v = 2 is not a valid recovery id (not 0/1, 27/28, or >= 35).
+        let result = signature_result(VALID_R_HEX, VALID_S_HEX, "02");
+
+        let error = TracingTurnkeySigner::parse_signature(&result).unwrap_err();
+
+        assert!(matches!(
+            error,
+            TracingTurnkeySignerError::UnnormalizableV { v: 2 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn sign_hash_returns_signature_from_completed_activity() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/submit/sign_raw_payload");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(completed_sign_raw_payload_body(
+                    VALID_R_HEX,
+                    VALID_S_HEX,
+                    "00",
+                ));
+        });
+
+        let signer = TracingTurnkeySigner::new(
+            mock_client(&server),
+            TurnkeyOrganizationId::new("org-test".to_string()),
+            Address::random(),
+            Some(1),
+        );
+
+        let signature = signer.sign_hash(&B256::ZERO).await.unwrap();
+
+        assert_eq!(signature.r(), U256::from(1));
+        assert_eq!(signature.s(), U256::from(2));
+        assert!(!signature.v());
+    }
+
+    #[tokio::test]
+    async fn sign_raw_payload_exhausts_retries_while_activity_stays_pending() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/public/v1/submit/sign_raw_payload");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(pending_activity_body());
+        });
+
+        // `RetryConfig::none()` caps retries at zero, so the first PENDING
+        // response immediately exhausts retries with no backoff sleep.
+        let client = mock_client_with_retry(&server, RetryConfig::none());
+
+        let error = client
+            .sign_raw_payload(
+                TurnkeyOrganizationId::new("org-test".to_string()),
+                0,
+                SignRawPayloadIntentV2 {
+                    sign_with: Address::random().to_string(),
+                    payload: hex::encode(B256::ZERO),
+                    encoding: PayloadEncoding::Hexadecimal,
+                    hash_function: HashFunction::NoOp,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        mock.assert();
+        assert!(matches!(error, TurnkeyClientError::ExceededRetries(0)));
+    }
+
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn send_signing_failure() {
         let server = MockServer::start();
@@ -375,7 +948,7 @@ mod tests {
 
         let wallet = TurnkeyWallet::from_client(
             client,
-            "org-test".to_string(),
+            TurnkeyOrganizationId::new("org-test".to_string()),
             Address::random(),
             provider,
             1,
@@ -400,6 +973,82 @@ mod tests {
             error_str.contains("TurnkeyClient"),
             "expected TurnkeyClient error in chain, got: {error_str}"
         );
+        assert!(logs_contain("Turnkey API response body received"));
+        assert!(logs_contain("internal server error"));
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn process_request_logs_success_response_body() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method("POST").path("/public/v1/test");
+            then.status(200)
+                .header("Content-Type", "application/json")
+                .json_body(serde_json::json!({
+                    "turnkey_marker": "success-body"
+                }));
+        });
+
+        let client = mock_client(&server);
+        let response: serde_json::Value = client
+            .process_request(&serde_json::json!({"request": "body"}), "/public/v1/test")
+            .await
+            .unwrap();
+
+        assert_eq!(response["turnkey_marker"], "success-body");
+        assert!(logs_contain("Turnkey API response body received"));
+        assert!(logs_contain("turnkey_marker"));
+        assert!(logs_contain("success-body"));
+    }
+
+    #[tokio::test]
+    async fn process_request_accepts_json_content_type_with_charset_parameter() {
+        let server = MockServer::start();
+
+        // A `Content-Type` carrying a `charset` parameter must still be accepted:
+        // the essence (`application/json`) is what matters, not exact equality.
+        server.mock(|when, then| {
+            when.method("POST").path("/public/v1/test");
+            then.status(200)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .json_body(serde_json::json!({ "turnkey_marker": "ok" }));
+        });
+
+        let client = mock_client(&server);
+        let response: serde_json::Value = client
+            .process_request(&serde_json::json!({"request": "body"}), "/public/v1/test")
+            .await
+            .unwrap();
+
+        assert_eq!(response["turnkey_marker"], "ok");
+    }
+
+    #[tokio::test]
+    async fn process_request_rejects_non_json_content_type() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method("POST").path("/public/v1/test");
+            then.status(200)
+                .header("Content-Type", "text/html")
+                .body("<html></html>");
+        });
+
+        let client = mock_client(&server);
+        let error = client
+            .process_request::<_, serde_json::Value>(
+                &serde_json::json!({"request": "body"}),
+                "/public/v1/test",
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TurnkeyClientError::UnexpectedMimeType(mime) if mime == "text/html"
+        ));
     }
 
     #[tokio::test]
@@ -412,7 +1061,7 @@ mod tests {
 
         let wallet = TurnkeyWallet::from_client(
             client,
-            "org-test".to_string(),
+            TurnkeyOrganizationId::new("org-test".to_string()),
             expected_address,
             provider,
             1,

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -50,6 +50,7 @@ httpmock.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
 serial_test.workspace = true
+tracing-test.workspace = true
 
 [lints]
 workspace = true

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -2,9 +2,10 @@ use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use reqwest::Method;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 use uuid::Uuid;
 
 use super::AlpacaBrokerApiError;
@@ -234,7 +235,7 @@ impl AlpacaBrokerApiClient {
     ) -> Result<T, AlpacaBrokerApiError> {
         let response = self.http_client.get(url).send().await?;
 
-        self.handle_response(response).await
+        self.handle_response(Method::GET, response).await
     }
 
     /// Perform a POST request with JSON body
@@ -245,24 +246,38 @@ impl AlpacaBrokerApiClient {
     ) -> Result<T, AlpacaBrokerApiError> {
         let response = self.http_client.post(url).json(body).send().await?;
 
-        self.handle_response(response).await
+        self.handle_response(Method::POST, response).await
     }
 
     async fn handle_response<T: serde::de::DeserializeOwned + Send>(
         &self,
+        method: Method,
         response: reqwest::Response,
     ) -> Result<T, AlpacaBrokerApiError> {
         let status = response.status();
+        let url = response.url().clone();
+        // Read raw bytes and parse successful responses with `from_slice` so
+        // invalid UTF-8 fails fast (matching the prior `response.json()`),
+        // rather than being silently replaced by `response.text()`'s lossy
+        // decoding before parse. Lossy decoding is fine for the log line only.
+        let bytes = response.bytes().await?;
+
+        trace!(
+            target: "broker",
+            %method,
+            status = %status,
+            url = %url,
+            body = %String::from_utf8_lossy(&bytes),
+            "Alpaca Broker API response body received"
+        );
 
         if status.is_success() {
-            return Ok(response.json().await?);
+            return Ok(serde_json::from_slice(&bytes)?);
         }
 
-        let error_body = response.text().await.unwrap_or_default();
-
-        let (alpaca_code, message) = match serde_json::from_str::<AlpacaApiErrorBody>(&error_body) {
+        let (alpaca_code, message) = match serde_json::from_slice::<AlpacaApiErrorBody>(&bytes) {
             Ok(parsed) => (parsed.code, parsed.message),
-            Err(_) => (None, error_body),
+            Err(_) => (None, String::from_utf8_lossy(&bytes).into_owned()),
         };
 
         Err(AlpacaBrokerApiError::ApiError {
@@ -382,6 +397,34 @@ mod tests {
         assert_eq!(account.status, super::super::auth::AccountStatus::Active);
     }
 
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn verify_account_logs_success_response_body_at_trace_level() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "status": "ACTIVE",
+                    "currency": "USD",
+                    "buying_power": "100000.00",
+                    "broker_marker": "success-body"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        client.verify_account().await.unwrap();
+
+        assert!(logs_contain("Alpaca Broker API response body received"));
+        assert!(logs_contain("broker_marker"));
+        assert!(logs_contain("success-body"));
+    }
+
     #[tokio::test]
     async fn test_verify_account_unauthorized() {
         let server = MockServer::start();
@@ -405,6 +448,35 @@ mod tests {
         assert!(
             matches!(err, AlpacaBrokerApiError::ApiError { status, .. } if status.as_u16() == 401)
         );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn verify_account_logs_api_error_response_body_at_trace_level() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(401)
+                .header("content-type", "application/json")
+                .json_body(serde_json::json!({
+                    "code": 40_110_000,
+                    "message": "Invalid credentials",
+                    "broker_marker": "error-body"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = client.verify_account().await.unwrap_err();
+
+        assert!(
+            matches!(error, AlpacaBrokerApiError::ApiError { status, .. } if status.as_u16() == 401)
+        );
+        assert!(logs_contain("Alpaca Broker API response body received"));
+        assert!(logs_contain("broker_marker"));
+        assert!(logs_contain("error-body"));
     }
 
     #[tokio::test]

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -109,6 +109,9 @@ pub enum AlpacaBrokerApiError {
     #[error("HTTP client error: {0}")]
     HttpClient(#[from] reqwest::Error),
 
+    #[error("Failed to parse Alpaca API response: {0}")]
+    JsonParse(#[from] serde_json::Error),
+
     #[error("Invalid header value: {0}")]
     InvalidHeader(#[from] reqwest::header::InvalidHeaderValue),
 

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -628,7 +628,7 @@ mod tests {
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let error = fetch_inventory(&client).await.unwrap_err();
 
-        assert!(matches!(error, AlpacaBrokerApiError::HttpClient(_)));
+        assert!(matches!(error, AlpacaBrokerApiError::JsonParse(_)));
     }
 
     #[tokio::test]

--- a/crates/execution/src/alpaca_market_data.rs
+++ b/crates/execution/src/alpaca_market_data.rs
@@ -1,8 +1,9 @@
 //! Shared Alpaca market-data lookups used for hedge preflight checks.
 
 use rain_math_float::Float;
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
 use serde::Deserialize;
+use tracing::trace;
 
 use crate::{Positive, Symbol, deserialize_float_from_number_or_string};
 
@@ -10,6 +11,10 @@ use crate::{Positive, Symbol, deserialize_float_from_number_or_string};
 pub enum AlpacaMarketDataError {
     #[error("HTTP request failed: {0}")]
     Http(#[from] reqwest::Error),
+    #[error("API error (status {status}): {body}")]
+    ApiError { status: StatusCode, body: String },
+    #[error("failed to parse latest trade response: {0}")]
+    JsonParse(#[from] serde_json::Error),
     #[error("latest trade response for {symbol} did not include a price")]
     MissingPrice { symbol: Symbol },
     #[error(
@@ -38,15 +43,36 @@ pub(crate) async fn fetch_latest_trade_price(
     market_data_base_url: &str,
     symbol: &Symbol,
 ) -> Result<Positive<Float>, AlpacaMarketDataError> {
-    let response: LatestTradeEnvelope = client
+    let response = client
         .get(format!(
             "{market_data_base_url}/v2/stocks/{symbol}/trades/latest"
         ))
         .send()
-        .await?
-        .error_for_status()?
-        .json()
         .await?;
+    let status = response.status();
+    let url = response.url().clone();
+    // Parse successful responses from raw bytes with `from_slice` so invalid
+    // UTF-8 fails fast (matching the prior `response.json()`) instead of being
+    // lossily replaced by `response.text()`. Lossy decoding is used only for
+    // the trace line and the error-body display.
+    let bytes = response.bytes().await?;
+
+    trace!(
+        target: "market_data",
+        status = %status,
+        url = %url,
+        body = %String::from_utf8_lossy(&bytes),
+        "Alpaca market data response body received"
+    );
+
+    if !status.is_success() {
+        return Err(AlpacaMarketDataError::ApiError {
+            status,
+            body: String::from_utf8_lossy(&bytes).into_owned(),
+        });
+    }
+
+    let response: LatestTradeEnvelope = serde_json::from_slice(&bytes)?;
 
     response
         .trade
@@ -127,5 +153,64 @@ mod tests {
                 .eq(Float::parse("123.45".to_string()).unwrap())
                 .unwrap()
         );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn fetch_latest_trade_price_logs_success_response_body() {
+        let server = MockServer::start();
+        let client = Client::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/AAPL/trades/latest");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "trade": {
+                        "p": "123.45",
+                        "market_data_marker": "success-body"
+                    }
+                }));
+        });
+
+        fetch_latest_trade_price(&client, &server.base_url(), &symbol)
+            .await
+            .unwrap();
+
+        assert!(logs_contain("Alpaca market data response body received"));
+        assert!(logs_contain("market_data_marker"));
+        assert!(logs_contain("success-body"));
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn fetch_latest_trade_price_logs_error_response_body() {
+        let server = MockServer::start();
+        let client = Client::new();
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v2/stocks/AAPL/trades/latest");
+            then.status(429)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "message": "rate limited",
+                    "market_data_marker": "error-body"
+                }));
+        });
+
+        let error = fetch_latest_trade_price(&client, &server.base_url(), &symbol)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            AlpacaMarketDataError::ApiError { status, .. }
+                if status == StatusCode::TOO_MANY_REQUESTS
+        ));
+        assert!(logs_contain("Alpaca market data response body received"));
+        assert!(logs_contain("market_data_marker"));
+        assert!(logs_contain("error-body"));
     }
 }

--- a/src/alpaca_wallet/asset.rs
+++ b/src/alpaca_wallet/asset.rs
@@ -35,10 +35,9 @@ impl AlpacaWalletClient {
             network.as_ref()
         );
 
-        let response = self.get(&path).await?;
-        let text = response.text().await?;
+        let body = self.get(&path).await?;
 
-        Ok(serde_json::from_str::<WalletAddressResponse>(&text)?.address)
+        Ok(serde_json::from_str::<WalletAddressResponse>(&body)?.address)
     }
 }
 

--- a/src/alpaca_wallet/client.rs
+++ b/src/alpaca_wallet/client.rs
@@ -1,9 +1,11 @@
 //! Authenticated HTTP transport for Alpaca Broker API wallet modules.
 
+use std::borrow::Cow;
+
 use alloy::primitives::{Address, TxHash, hex::FromHexError};
-use reqwest::{Client, Response, StatusCode};
+use reqwest::{Client, Method, Response, StatusCode};
 use thiserror::Error;
-use tracing::trace;
+use tracing::{trace, warn};
 
 use st0x_execution::AlpacaAccountId;
 
@@ -18,6 +20,8 @@ pub enum AlpacaWalletError {
     ApiError { status: StatusCode, message: String },
     #[error("Failed to parse response")]
     ParseError(#[from] serde_json::Error),
+    #[error("response body was not valid UTF-8: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
     #[error(transparent)]
     FromHex(#[from] FromHexError),
     #[error("Transfer not found: {transfer_id}")]
@@ -81,7 +85,7 @@ impl AlpacaWalletClient {
         }
     }
 
-    pub(super) async fn get(&self, path: &str) -> Result<Response, AlpacaWalletError> {
+    pub(super) async fn get(&self, path: &str) -> Result<String, AlpacaWalletError> {
         let url = format!("{}{}", self.base_url, path);
         trace!(target: "wallet", "GET {url}");
 
@@ -94,24 +98,14 @@ impl AlpacaWalletClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-
-            return Err(AlpacaWalletError::ApiError { status, message });
-        }
-
-        Ok(response)
+        read_response_body(Method::GET, response).await
     }
 
     pub(super) async fn post<T: serde::Serialize + Sync>(
         &self,
         path: &str,
         body: &T,
-    ) -> Result<Response, AlpacaWalletError> {
+    ) -> Result<String, AlpacaWalletError> {
         let url = format!("{}{}", self.base_url, path);
         trace!(target: "wallet", "POST {url}");
 
@@ -126,20 +120,10 @@ impl AlpacaWalletClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-
-            return Err(AlpacaWalletError::ApiError { status, message });
-        }
-
-        Ok(response)
+        read_response_body(Method::POST, response).await
     }
 
-    pub(super) async fn delete(&self, path: &str) -> Result<Response, AlpacaWalletError> {
+    pub(super) async fn delete(&self, path: &str) -> Result<String, AlpacaWalletError> {
         let url = format!("{}{}", self.base_url, path);
         trace!(target: "wallet", "DELETE {url}");
 
@@ -152,24 +136,14 @@ impl AlpacaWalletClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-
-            return Err(AlpacaWalletError::ApiError { status, message });
-        }
-
-        Ok(response)
+        read_response_body(Method::DELETE, response).await
     }
 
     pub(super) async fn patch<T: serde::Serialize + Sync>(
         &self,
         path: &str,
         body: &T,
-    ) -> Result<Response, AlpacaWalletError> {
+    ) -> Result<String, AlpacaWalletError> {
         let url = format!("{}{}", self.base_url, path);
         trace!(target: "wallet", "PATCH {url}");
 
@@ -183,17 +157,7 @@ impl AlpacaWalletClient {
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let message = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-
-            return Err(AlpacaWalletError::ApiError { status, message });
-        }
-
-        Ok(response)
+        read_response_body(Method::PATCH, response).await
     }
 
     pub(super) fn account_id(&self) -> &AlpacaAccountId {
@@ -205,8 +169,8 @@ impl AlpacaWalletClient {
     ) -> Result<Vec<WhitelistEntry>, AlpacaWalletError> {
         let path = format!("/v1/accounts/{}/wallets/whitelists", self.account_id);
 
-        let response = self.get(&path).await?;
-        let entries: Vec<WhitelistEntry> = response.json().await?;
+        let body = self.get(&path).await?;
+        let entries: Vec<WhitelistEntry> = serde_json::from_str(&body)?;
 
         Ok(entries)
     }
@@ -259,16 +223,9 @@ impl AlpacaWalletClient {
             travel_rule_info,
         };
 
-        let response = self.post(&path, &request).await?;
-        let text = response.text().await?;
+        let body = self.post(&path, &request).await?;
 
-        trace!(
-            target: "wallet",
-            response_bytes = text.len(),
-            "Whitelist creation response received"
-        );
-
-        Ok(serde_json::from_str::<WhitelistEntry>(&text)?)
+        Ok(serde_json::from_str::<WhitelistEntry>(&body)?)
     }
 
     pub(super) async fn delete_whitelist_entry(
@@ -307,6 +264,114 @@ impl AlpacaWalletClient {
 
         self.patch(&path, &Request { travel_rule_info }).await?;
         Ok(())
+    }
+}
+
+async fn read_response_body(
+    method: Method,
+    response: Response,
+) -> Result<String, AlpacaWalletError> {
+    let status = response.status();
+    let url = response.url().clone();
+    // Read raw bytes and convert the success body with `String::from_utf8` so
+    // invalid UTF-8 fails fast (matching the prior `response.json()` at the call
+    // sites) instead of being silently replaced by `response.text()`'s lossy
+    // decoding. Lossy decoding is used only for the trace line and error body.
+    let bytes = match response.bytes().await {
+        Ok(bytes) => bytes,
+        // Preserve the HTTP status on a non-success response even if the body
+        // stream fails to read, so the poll retry predicate (which only retries
+        // `ApiError { status }` with `status.is_server_error()`) still fires on
+        // a transient 5xx. Mirrors the pre-refactor `.text().unwrap_or_else(..)`.
+        Err(_) if !status.is_success() => {
+            return Err(AlpacaWalletError::ApiError {
+                status,
+                message: "Unknown error".to_string(),
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    trace!(
+        target: "wallet",
+        %method,
+        status = %status,
+        url = %url,
+        body = %redact_beneficiary_for_logging(&String::from_utf8_lossy(&bytes)),
+        "Alpaca wallet API response body received"
+    );
+
+    if !status.is_success() {
+        // Redact the stored body too: `ApiError.message` is surfaced via
+        // Display/Debug and propagated to other log sites, so it must honour the
+        // same beneficiary-redaction boundary as the trace line above.
+        return Err(AlpacaWalletError::ApiError {
+            status,
+            message: redact_beneficiary_for_logging(&String::from_utf8_lossy(&bytes)).into_owned(),
+        });
+    }
+
+    // `bytes` is no longer borrowed here, so consume it without copying.
+    Ok(String::from_utf8(bytes.into())?)
+}
+
+/// Redacts `beneficiary_entity_name` values from a JSON response body for
+/// logging, mirroring the redaction `TravelRuleConfig`'s `Debug` impl applies.
+/// Whitelist responses echo back the Travel Rule beneficiary identity, which
+/// the project deliberately keeps out of logs. The full body is still returned
+/// to callers; only the logged representation is scrubbed.
+fn redact_beneficiary_for_logging(body: &str) -> Cow<'_, str> {
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(mut value) => {
+            redact_beneficiary_in_place(&mut value);
+            match serde_json::to_string(&value) {
+                Ok(redacted) => Cow::Owned(redacted),
+                // Fail closed: never fall back to the raw (unredacted) body, or
+                // a re-serialization failure would leak the beneficiary name.
+                Err(error) => {
+                    warn!(
+                        ?error,
+                        "failed to re-serialize redacted wallet body; omitting body from log"
+                    );
+                    Cow::Owned(format!("<redaction failed, body {} bytes>", body.len()))
+                }
+            }
+        }
+        // Non-JSON bodies (e.g. plain-text gateway errors) carry no structured
+        // travel-rule data, so they are normally safe to log verbatim. Fail
+        // closed if such a body nonetheless references the sensitive field by
+        // name (e.g. a proxy echoing the request), rather than leaking it.
+        Err(_) if body.contains("beneficiary_entity_name") => {
+            warn!("non-JSON wallet body references beneficiary identity; omitting body from log");
+            Cow::Owned(format!(
+                "<redaction failed, non-JSON body {} bytes>",
+                body.len()
+            ))
+        }
+        Err(_) => Cow::Borrowed(body),
+    }
+}
+
+fn redact_beneficiary_in_place(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map.iter_mut() {
+                if key == "beneficiary_entity_name" {
+                    *child = serde_json::Value::String("<redacted>".to_string());
+                } else {
+                    redact_beneficiary_in_place(child);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_beneficiary_in_place(item);
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
     }
 }
 
@@ -365,7 +430,7 @@ mod tests {
 
         let response = client.get("/v1/test").await.unwrap();
 
-        assert!(response.status().is_success());
+        assert_eq!(response, r#"{"success":true}"#);
         test_mock.assert();
     }
 
@@ -444,8 +509,243 @@ mod tests {
         let body = json!({"amount": "10.5", "asset": "USDC"});
         let response = client.post("/v1/test", &body).await.unwrap();
 
-        assert!(response.status().is_success());
+        assert_eq!(response, r#"{"success":true}"#);
         test_mock.assert();
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn get_logs_success_response_body_at_trace_level() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/test");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({"wallet_marker": "success-body"}));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        client.get("/v1/test").await.unwrap();
+
+        assert!(logs_contain("Alpaca wallet API response body received"));
+        assert!(logs_contain("wallet_marker"));
+        assert!(logs_contain("success-body"));
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn get_logs_error_response_body_at_trace_level() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/error");
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(json!({"wallet_marker": "error-body"}));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let error = client.get("/v1/error").await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            AlpacaWalletError::ApiError { status, .. } if status == StatusCode::BAD_REQUEST
+        ));
+        assert!(logs_contain("Alpaca wallet API response body received"));
+        assert!(logs_contain("wallet_marker"));
+        assert!(logs_contain("error-body"));
+    }
+
+    #[test]
+    fn redact_for_logging_passes_through_non_json_bodies() {
+        // Gateway/plain-text error bodies (common during incidents) carry no
+        // structured travel-rule data and are returned verbatim, borrowed.
+        let body = "502 Bad Gateway";
+
+        let redacted = redact_beneficiary_for_logging(body);
+
+        assert!(matches!(redacted, Cow::Borrowed(_)));
+        assert_eq!(redacted, "502 Bad Gateway");
+    }
+
+    #[test]
+    fn redact_for_logging_scrubs_beneficiary_name_nested_in_arrays() {
+        let body = json!({
+            "entries": [
+                {
+                    "travel_rule_info": {
+                        "beneficiary_entity_name": "T0 TRADE (BVI) LTD",
+                        "beneficiary_is_self_hosted": true
+                    }
+                }
+            ]
+        })
+        .to_string();
+
+        let redacted = redact_beneficiary_for_logging(&body);
+
+        assert!(matches!(redacted, Cow::Owned(_)));
+        let parsed: serde_json::Value = serde_json::from_str(&redacted).unwrap();
+        // The key must be present with the redacted value (not deleted), the
+        // non-sensitive sibling preserved, and the original value gone.
+        assert_eq!(
+            parsed["entries"][0]["travel_rule_info"]["beneficiary_entity_name"],
+            "<redacted>"
+        );
+        assert_eq!(
+            parsed["entries"][0]["travel_rule_info"]["beneficiary_is_self_hosted"],
+            true
+        );
+        assert!(!redacted.contains("T0 TRADE (BVI) LTD"));
+    }
+
+    #[test]
+    fn redact_for_logging_fails_closed_on_non_json_body_referencing_beneficiary() {
+        // A non-JSON body that echoes the sensitive field (e.g. a proxy
+        // reflecting the request) must not be logged verbatim.
+        let body = "error: beneficiary_entity_name 'T0 TRADE (BVI) LTD' rejected";
+
+        let redacted = redact_beneficiary_for_logging(body);
+
+        assert!(matches!(redacted, Cow::Owned(_)));
+        assert!(!redacted.contains("T0 TRADE (BVI) LTD"));
+    }
+
+    #[test]
+    fn redact_for_logging_leaves_json_without_beneficiary_field_unchanged() {
+        let body = json!({ "id": "wl-1", "status": "approved" }).to_string();
+
+        let redacted = redact_beneficiary_for_logging(&body);
+
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&redacted).unwrap(),
+            serde_json::from_str::<serde_json::Value>(&body).unwrap()
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn trace_log_redacts_beneficiary_entity_name_but_caller_keeps_full_body() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "wl-1",
+                    "travel_rule_info": {
+                        "beneficiary_is_self_hosted": true,
+                        "beneficiary_entity_name": "T0 TRADE (BVI) LTD"
+                    }
+                }]));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let body = client.get("/v1/whitelists").await.unwrap();
+
+        // The caller still receives the full, unredacted body for parsing.
+        assert!(body.contains("T0 TRADE (BVI) LTD"));
+
+        // The trace log must scrub the beneficiary identity while keeping the
+        // non-sensitive travel-rule fields for debugging.
+        assert!(logs_contain("Alpaca wallet API response body received"));
+        assert!(logs_contain("<redacted>"));
+        assert!(logs_contain("beneficiary_is_self_hosted"));
+        assert!(!logs_contain("T0 TRADE (BVI) LTD"));
+    }
+
+    #[tokio::test]
+    async fn api_error_message_redacts_beneficiary_entity_name() {
+        let server = MockServer::start();
+
+        // A non-2xx body echoing the Travel Rule beneficiary identity must have
+        // that identity scrubbed from `ApiError.message`, which is surfaced via
+        // Display/Debug and re-logged downstream.
+        server.mock(|when, then| {
+            when.method(POST).path("/v1/whitelists");
+            then.status(400)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "message": "invalid travel rule info",
+                    "travel_rule_info": {
+                        "beneficiary_is_self_hosted": true,
+                        "beneficiary_entity_name": "T0 TRADE (BVI) LTD"
+                    }
+                }));
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        let AlpacaWalletError::ApiError { status, message } = client
+            .post("/v1/whitelists", &json!({"any": "body"}))
+            .await
+            .unwrap_err()
+        else {
+            panic!("expected AlpacaWalletError::ApiError");
+        };
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!message.contains("T0 TRADE (BVI) LTD"));
+        let parsed: serde_json::Value = serde_json::from_str(&message).unwrap();
+        assert_eq!(
+            parsed["travel_rule_info"]["beneficiary_entity_name"],
+            "<redacted>"
+        );
+        // Non-sensitive fields must survive redaction for debuggability.
+        assert_eq!(parsed["message"], "invalid travel rule info");
+        assert_eq!(
+            parsed["travel_rule_info"]["beneficiary_is_self_hosted"],
+            true
+        );
+    }
+
+    #[tokio::test]
+    async fn get_returns_utf8_error_for_non_utf8_success_body() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/v1/test");
+            then.status(200)
+                .header("content-type", "application/octet-stream")
+                .body(b"\xFF\xFE not valid utf-8");
+        });
+
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key_id".to_string(),
+            "test_secret_key".to_string(),
+        );
+
+        assert!(matches!(
+            client.get("/v1/test").await.unwrap_err(),
+            AlpacaWalletError::Utf8(_)
+        ));
     }
 
     #[tokio::test]

--- a/src/alpaca_wallet/transfer.rs
+++ b/src/alpaca_wallet/transfer.rs
@@ -189,9 +189,8 @@ pub(super) async fn initiate_withdrawal(
 
     let path = format!("/v1/accounts/{}/wallets/transfers", client.account_id());
 
-    let response = client.post(&path, &request).await?;
-
-    let transfer: Transfer = response.json().await?;
+    let body = client.post(&path, &request).await?;
+    let transfer: Transfer = serde_json::from_str(&body)?;
 
     Ok(transfer)
 }
@@ -204,9 +203,8 @@ pub(super) async fn get_transfer_status(
     // The API's transfer_id query param appears to be unreliable.
     let path = format!("/v1/accounts/{}/wallets/transfers", client.account_id());
 
-    let response = client.get(&path).await?;
-
-    let transfers: Vec<Transfer> = response.json().await?;
+    let body = client.get(&path).await?;
+    let transfers: Vec<Transfer> = serde_json::from_str(&body)?;
 
     transfers
         .into_iter()
@@ -222,9 +220,9 @@ pub(super) async fn list_all_transfers(
 ) -> Result<Vec<Transfer>, AlpacaWalletError> {
     let path = format!("/v1/accounts/{}/wallets/transfers", client.account_id());
 
-    let response = client.get(&path).await?;
+    let body = client.get(&path).await?;
 
-    Ok(response.json().await?)
+    Ok(serde_json::from_str(&body)?)
 }
 
 /// Finds a transfer by its transaction hash.
@@ -237,9 +235,8 @@ pub(super) async fn find_transfer_by_tx_hash(
 ) -> Result<Option<Transfer>, AlpacaWalletError> {
     let path = format!("/v1/accounts/{}/wallets/transfers", client.account_id());
 
-    let response = client.get(&path).await?;
-
-    let transfers: Vec<Transfer> = response.json().await?;
+    let body = client.get(&path).await?;
+    let transfers: Vec<Transfer> = serde_json::from_str(&body)?;
 
     Ok(transfers
         .into_iter()
@@ -743,7 +740,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error, AlpacaWalletError::Reqwest(_)));
+        assert!(matches!(error, AlpacaWalletError::ParseError(_)));
 
         status_mock.assert();
     }

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -403,6 +403,9 @@ pub(crate) enum AlpacaTokenizationError {
     #[error("Failed to parse API response: {0}")]
     JsonParse(#[from] serde_json::Error),
 
+    #[error("response body was not valid UTF-8: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
+
     #[error("API error (status {status}): {message}")]
     ApiError { status: StatusCode, message: String },
 
@@ -528,12 +531,22 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         let status = response.status();
 
         if status.is_success() {
-            let body = response.text().await?;
-            let tokenization_request: TokenizationRequest = serde_json::from_str(&body)
+            // Read raw bytes and parse with `from_slice` so invalid UTF-8 fails
+            // fast (matching the other Alpaca clients) instead of being lossily
+            // replaced. Lossy decoding is used only for the trace line.
+            let bytes = response.bytes().await?;
+            trace!(
+                target: "tokenization",
+                status = %status,
+                body = %String::from_utf8_lossy(&bytes),
+                "Alpaca tokenization mint response body received"
+            );
+
+            let tokenization_request: TokenizationRequest = serde_json::from_slice(&bytes)
                 .inspect_err(|error| {
                     error!(
                         target: "tokenization",
-                        body_len = body.len(),
+                        body_len = bytes.len(),
                         error = %error,
                         symbol = %request.underlying_symbol,
                         issuer_request_id = %request.issuer_request_id.0,
@@ -545,7 +558,13 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
             return Ok(tokenization_request);
         }
 
-        let message = response.text().await?;
+        let message = String::from_utf8_lossy(&response.bytes().await?).into_owned();
+        trace!(
+            target: "tokenization",
+            status = %status,
+            body = %message,
+            "Alpaca tokenization mint error response body received"
+        );
         warn!(target: "tokenization", status = %status, message = %message, "Tokenization request failed");
         Err(map_mint_error(status, message, request.underlying_symbol))
     }
@@ -561,11 +580,6 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         params: ListRequestsParams,
     ) -> Result<Vec<TokenizationRequest>, AlpacaTokenizationError> {
         let body = self.fetch_requests_body(&params).await?;
-        trace!(
-            target: "tokenization",
-            body_len = body.len(),
-            "List requests response body received"
-        );
 
         let requests = parse_request_list(&body).inspect_err(|error| {
             error!(
@@ -815,15 +829,27 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         let response = request.send().await?;
 
         let status = response.status();
-        let body = response.text().await?;
+        // Read raw bytes; convert the success body with strict `String::from_utf8`
+        // so invalid UTF-8 fails fast for the caller's parse. Lossy decoding is
+        // used only for the trace line and the error-body message.
+        let bytes = response.bytes().await?;
+        trace!(
+            target: "tokenization",
+            status = %status,
+            request_type = ?params.request_type,
+            request_status = ?params.status,
+            underlying_symbol = ?params.underlying_symbol,
+            body = %String::from_utf8_lossy(&bytes),
+            "Alpaca tokenization requests response body received"
+        );
 
         if status.is_success() {
-            return Ok(body);
+            return Ok(String::from_utf8(bytes.into())?);
         }
 
         Err(AlpacaTokenizationError::ApiError {
             status,
-            message: body,
+            message: String::from_utf8_lossy(&bytes).into_owned(),
         })
     }
 }
@@ -1063,6 +1089,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_request_mint_success() {
         let server = MockServer::start();
@@ -1115,10 +1142,16 @@ pub(crate) mod tests {
             result.issuer_request_id,
             Some(IssuerRequestId("iss_req_456".to_string()))
         );
+        assert!(logs_contain(
+            "Alpaca tokenization mint response body received"
+        ));
+        assert!(logs_contain("tok_req_123"));
+        assert!(logs_contain("pending"));
 
         mint_mock.assert();
     }
 
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_request_mint_insufficient_position() {
         let server = MockServer::start();
@@ -1131,7 +1164,8 @@ pub(crate) mod tests {
                 .header("content-type", "application/json")
                 .json_body(json!({
                     "code": 40_310_000,
-                    "message": "insufficient position for AAPL"
+                    "message": "insufficient position for AAPL",
+                    "tokenization_marker": "mint-error-body"
                 }));
         });
 
@@ -1142,6 +1176,11 @@ pub(crate) mod tests {
             matches!(&err, AlpacaTokenizationError::InsufficientPosition { symbol } if symbol.to_string() == "AAPL"),
             "expected InsufficientPosition for AAPL, got: {err:?}"
         );
+        assert!(logs_contain(
+            "Alpaca tokenization mint error response body received"
+        ));
+        assert!(logs_contain("tokenization_marker"));
+        assert!(logs_contain("mint-error-body"));
 
         mint_mock.assert();
     }
@@ -1238,6 +1277,32 @@ pub(crate) mod tests {
         assert_eq!(result[1].r#type, Some(TokenizationRequestType::Redeem));
 
         list_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn fetch_requests_body_returns_utf8_error_for_non_utf8_success_body() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, key) = setup_anvil();
+        let client = create_test_client(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
+
+        // A successful (2xx) response whose body is not valid UTF-8 must fail
+        // fast via the dedicated `Utf8` path, not be conflated with JSON parse
+        // failures or silently lossy-decoded.
+        let body_mock = server.mock(|when, then| {
+            when.method(GET).path(tokenization_requests_path());
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(b"\xFF\xFE not valid utf-8");
+        });
+
+        let error = client
+            .fetch_requests_body(&ListRequestsParams::default())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, AlpacaTokenizationError::Utf8(_)));
+
+        body_mock.assert();
     }
 
     #[tokio::test]
@@ -1730,6 +1795,7 @@ pub(crate) mod tests {
         list_mock.assert();
     }
 
+    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_poll_until_terminal_rejected() {
         let server = MockServer::start();
@@ -1755,6 +1821,11 @@ pub(crate) mod tests {
         let result = client.poll_until_terminal(&id, &config).await.unwrap();
 
         assert_eq!(result.status, TokenizationRequestStatus::Rejected);
+        assert!(logs_contain(
+            "Alpaca tokenization requests response body received"
+        ));
+        assert!(logs_contain("req_1"));
+        assert!(logs_contain("rejected"));
         list_mock.assert();
     }
 


### PR DESCRIPTION
## What

Closes [RAI-650](https://linear.app/makeitrain/issue/RAI-650/trace-log-raw-alpaca-and-turnkey-api-response-bodies-for-incident).

Adds trace-level logging for raw HTTP response bodies across Alpaca and Turnkey wallet integrations used by the liquidity service:

- Alpaca tokenization mint and request polling responses, including rejected terminal states.
- Alpaca Broker API responses for account, asset, order, crypto order, position, and journal calls through the shared broker client.
- Alpaca wallet responses for whitelist, wallet address, transfer creation, transfer status, and transfer search flows through the shared wallet client.
- Alpaca market-data latest-trade responses, including non-2xx bodies that were previously lost.
- Turnkey wallet responses through the EVM Turnkey client used for wallet signing flows.

## Why

Tokenization mint requests can be accepted and later become rejected. We were logging parsed status only, which made incident diagnosis harder because any extra response fields returned by Alpaca were discarded before they reached logs. Turnkey wallet failures have the same operational debugging need, so this PR traces those response bodies too.

## How

The HTTP clients now read each response body once (as raw bytes), emit method/status/url/body at `trace` level, and then parse successful responses with `serde_json::from_slice` (or `String::from_utf8`) so invalid UTF-8 fails fast instead of being silently lossy-decoded. Lossy decoding (`from_utf8_lossy`) is used only for the trace line and error-body display. The logs avoid request headers, auth headers, API keys, request stamps, and secrets; they only include response metadata, URL, status, method, body, and existing safe context.

The shared client helpers (`handle_response` for the broker API, `read_response_body` for the wallet client) gained a `Method` parameter so the trace line records the verb. `read_response_body` also preserves the HTTP status on a body-stream read failure for non-2xx responses, so the transfer poll retry predicate (which retries only `ApiError` with a server-error status) keeps firing on transient 5xxs.

Wallet response bodies echo back Travel Rule beneficiary identity. To honour the same redaction boundary the `TravelRuleConfig` `Debug` impl applies, `redact_beneficiary_for_logging` scrubs `beneficiary_entity_name` from the logged representation (recursively, including inside arrays) while still returning the full unredacted body to callers for parsing. It fails closed: re-serialization failures and non-JSON bodies that nonetheless reference the field are logged as a placeholder rather than leaked.

For Turnkey, the wallet now uses a local traced client/signer wrapper (`TracingTurnkeyClient` / `TracingTurnkeySigner`) around the Turnkey API flow so response bodies can be logged before the existing response parsing and error behavior is reproduced (activity polling with configurable retry/backoff, signature component decoding, and error mapping).

New error variants were added where the body is now parsed explicitly: `JsonParse` on the broker and market-data errors, `Utf8` on the wallet and tokenization errors, and a structured `ApiError { status, body }` on the market-data error (replacing the prior `error_for_status()` that discarded the body).

## Testing

- `nix develop -c cargo check -p st0x-execution`
- `nix develop -c cargo check -p st0x-hedge`
- `nix develop -c cargo nextest run -p st0x-execution alpaca_broker_api::client`
- `nix develop -c cargo nextest run -p st0x-execution alpaca_market_data`
- `nix develop -c cargo nextest run -p st0x-hedge alpaca_wallet`
- `nix develop -c cargo nextest run -p st0x-hedge tokenization::alpaca`
- `nix develop -c cargo check -p st0x-evm --features turnkey`
- `nix develop -c cargo nextest run -p st0x-evm --features turnkey turnkey`
- `nix develop -c cargo clippy -p st0x-evm --all-targets --features turnkey`
- `nix develop -c cargo check -p st0x-hedge`
- `nix develop -c cargo fmt`
- `nix develop -c cargo clippy -p st0x-execution --all-targets --all-features`
- `nix develop -c cargo clippy -p st0x-hedge --all-targets --all-features`

New tests cover: success/error body logging for each client (broker, market-data, wallet, tokenization, Turnkey), beneficiary redaction (nested arrays, non-JSON fail-closed, pass-through, caller keeps full body), strict UTF-8 rejection, and Turnkey signature parsing + retry-exhaustion paths.

## Screenshots

N/A.

## Anything else

- Logs remain trace-level only because full response bodies are useful for incident debugging but too noisy for normal operation.
- This PR replaces the `alloy-signer-turnkey` dependency with a local traced Turnkey client/signer in `st0x-evm` (built on `reqwest` + `turnkey_client` + `turnkey_api_key_stamper` + `mime`). The upstream crate does not expose response bodies for logging, so signing, signature parsing, retry, and error-mapping behavior are reimplemented and preserved, covered by the existing Turnkey tests plus new logging tests. The Turnkey signature body (r/s/v) is signature material, not key material -- it becomes public on-chain once the tx is broadcast -- and this signer is only used for transaction signing, so logging it does not leak a secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracing-enabled Turnkey signing with activity polling and configurable retry behavior for more reliable transaction signing.
  * Response-body tracing with redaction of sensitive wallet fields to preserve privacy in logs.

* **Bug Fixes**
  * Clearer error distinctions for JSON parse and UTF‑8 decoding failures.
  * More robust HTTP response handling and improved error mapping across API clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
