### PR TITLE
fix: normalize absent Alpaca positions to zero

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2085,7 +2085,10 @@ balances and emitting them as events the system can react to:
   actual balances fetched from onchain vaults and the offchain broker.
 - **InventoryPollingService**: Periodically polls actual balances from both
   venues, emitting InventorySnapshot events. InventoryView reacts to these
-  events to update tracked inventory.
+  events to update tracked inventory. Offchain equity polling normalizes active
+  configured equities omitted by the broker positions response to explicit zero
+  balances, and ignores broker-only symbols that are not configured as active
+  assets.
 - **Polling runs on a 60-second interval** during market hours as a background
   conductor task. Onchain polling uses the `vaultBalance2` contract call;
   offchain polling uses the `Executor::get_inventory()` trait method.
@@ -2100,6 +2103,17 @@ Each asset type (equities per symbol, USDC) is tracked via a generic
 `Inventory<T>` containing `Option<VenueBalance<T>>` per venue. The `Option`
 distinguishes "not yet polled" from "polled with zero balance" — imbalance
 detection requires both venues to have been initialized by snapshot events.
+
+When `InventoryView` applies an equity snapshot (`OnchainEquity` for the
+MarketMaking venue, `OffchainEquity` for the Hedging venue), it treats the
+snapshot as the complete picture of that venue: any symbol already tracked at
+the venue but absent from the snapshot is zeroed at that venue, subject to the
+same staleness guards (snapshot watermark, inflight transfers, last
+rebalancing). This keeps the live view consistent with the fully-replaced
+persisted snapshot rather than retaining a stale balance. It relies on both
+pollers emitting complete venue snapshots: offchain polling seeds an explicit
+zero for every configured symbol (above), and onchain polling emits a balance
+for every discovered vault in the monotonic vault registry.
 
 `InventoryView` listens to trading events (onchain/offchain fills),
 `TokenizedEquityMintEvent`, `EquityRedemptionEvent`, `UsdcRebalanceEvent`, and

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -824,6 +824,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .await?;
 
         rebalancing_service
+            .recover_pending_offchain_order_symbols(&built.position_projection)
+            .await?;
+
+        rebalancing_service
             .set_stores(built.mint.clone(), built.redemption.clone())
             .await;
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -4,6 +4,7 @@ use alloy::providers::Provider;
 use apalis::prelude::Monitor;
 use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
 use sqlx::SqlitePool;
+use std::collections::HashSet;
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
@@ -130,6 +131,18 @@ where
         owner: order_owner,
     };
 
+    let configured_equity_symbols: HashSet<_> = context
+        .ctx
+        .assets
+        .equities
+        .symbols
+        .keys()
+        .filter(|symbol| {
+            context.ctx.is_trading_enabled(symbol) || context.ctx.is_rebalancing_enabled(symbol)
+        })
+        .cloned()
+        .collect();
+
     let mut polling_service = InventoryPollingService::new(
         raindex_service,
         context.executor.clone(),
@@ -139,7 +152,8 @@ where
         context.wallet_polling,
         context.tokenizer,
         reserved_cash,
-    );
+    )
+    .with_configured_equity_symbols(configured_equity_symbols);
 
     if let Some(rebalancing_service) = &rebalancing_service {
         polling_service =

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -122,6 +122,8 @@ where
     tokenizer: Option<Arc<dyn Tokenizer>>,
     pending_request_ownership: Option<Arc<dyn PendingRequestOwnership>>,
     external_pending_warnings: Mutex<HashSet<TokenizationRequestId>>,
+    unconfigured_symbol_warnings: Mutex<HashSet<Symbol>>,
+    configured_equity_symbols: Option<HashSet<Symbol>>,
     reserved_cash: Usd,
 }
 
@@ -151,8 +153,18 @@ where
             tokenizer,
             pending_request_ownership: None,
             external_pending_warnings: Mutex::new(HashSet::new()),
+            unconfigured_symbol_warnings: Mutex::new(HashSet::new()),
+            configured_equity_symbols: None,
             reserved_cash,
         }
+    }
+
+    pub(crate) fn with_configured_equity_symbols(
+        mut self,
+        configured_equity_symbols: HashSet<Symbol>,
+    ) -> Self {
+        self.configured_equity_symbols = Some(configured_equity_symbols);
+        self
     }
 
     pub(crate) fn with_pending_request_ownership(
@@ -455,11 +467,7 @@ where
             return Ok(());
         };
 
-        let positions: BTreeMap<_, _> = inventory
-            .positions
-            .into_iter()
-            .map(|position| (position.symbol, position.quantity))
-            .collect();
+        let positions = self.normalize_offchain_positions(inventory.positions);
 
         self.snapshot
             .send(
@@ -500,6 +508,67 @@ where
             .await?;
 
         Ok(())
+    }
+
+    fn normalize_offchain_positions(
+        &self,
+        broker_positions: Vec<st0x_execution::EquityPosition>,
+    ) -> BTreeMap<Symbol, FractionalShares> {
+        let Some(configured_symbols) = &self.configured_equity_symbols else {
+            return broker_positions
+                .into_iter()
+                .map(|position| (position.symbol, position.quantity))
+                .collect();
+        };
+
+        let mut positions: BTreeMap<_, _> = configured_symbols
+            .iter()
+            .map(|symbol| (symbol.clone(), FractionalShares::ZERO))
+            .collect();
+
+        let mut unconfigured_this_poll = HashSet::new();
+
+        for position in broker_positions {
+            if configured_symbols.contains(&position.symbol) {
+                positions.insert(position.symbol, position.quantity);
+            } else {
+                // Warn once per contiguous appearance, re-warning only if the
+                // symbol disappears and later returns (see the bounding retain
+                // below). The broker may hold positions outside the configured
+                // universe indefinitely, so warning every poll would spam logs.
+                if self
+                    .lock_unconfigured_symbol_warnings()
+                    .insert(position.symbol.clone())
+                {
+                    warn!(
+                        target: "inventory",
+                        symbol = %position.symbol,
+                        "Skipping unconfigured broker equity position"
+                    );
+                }
+
+                unconfigured_this_poll.insert(position.symbol);
+            }
+        }
+
+        // Bound the warn-once set to symbols still seen this poll so it cannot
+        // grow without bound as broker positions appear and disappear.
+        self.lock_unconfigured_symbol_warnings()
+            .retain(|symbol| unconfigured_this_poll.contains(symbol));
+
+        positions
+    }
+
+    fn lock_unconfigured_symbol_warnings(&self) -> MutexGuard<'_, HashSet<Symbol>> {
+        self.unconfigured_symbol_warnings
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                warn!(
+                    target: "inventory",
+                    "Unconfigured symbol warning tracker was poisoned; recovering state"
+                );
+                poisoned.into_inner()
+            })
     }
 
     fn aggregate_pending_requests(
@@ -946,6 +1015,10 @@ mod tests {
         FractionalShares::new(float!(&n.to_string()))
     }
 
+    fn configured_symbols(symbols: &[&str]) -> HashSet<Symbol> {
+        symbols.iter().map(|symbol| test_symbol(symbol)).collect()
+    }
+
     async fn create_test_raindex_service(
         pool: &SqlitePool,
         provider: impl Provider + Clone + 'static,
@@ -1025,6 +1098,131 @@ mod tests {
             positions.get(&test_symbol("MSFT")),
             Some(&test_shares(50)),
             "MSFT position mismatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_and_record_emits_zero_for_configured_position_absent_from_executor() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let inventory = Inventory {
+            positions: vec![EquityPosition {
+                symbol: test_symbol("AAPL"),
+                quantity: test_shares(100),
+                market_value: Some(float!(15000)),
+            }],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            cash_withdrawable_cents: None,
+        };
+        let executor = MockExecutor::new().with_inventory(inventory);
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        )
+        .with_configured_equity_symbols(configured_symbols(&["AAPL", "SPYM"]));
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let offchain_equity_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::OffchainEquity { .. }))
+            .expect("Expected OffchainEquity event to be emitted");
+
+        let InventorySnapshotEvent::OffchainEquity { positions, .. } = offchain_equity_event else {
+            panic!("Expected OffchainEquity event, got {offchain_equity_event:?}");
+        };
+        assert_eq!(
+            positions.get(&test_symbol("AAPL")),
+            Some(&test_shares(100)),
+            "present configured broker position must preserve quantity"
+        );
+        assert_eq!(
+            positions.get(&test_symbol("SPYM")),
+            Some(&FractionalShares::ZERO),
+            "absent configured broker position must be normalized to zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_and_record_ignores_executor_positions_not_in_configured_symbols() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let inventory = Inventory {
+            positions: vec![
+                EquityPosition {
+                    symbol: test_symbol("AAPL"),
+                    quantity: test_shares(100),
+                    market_value: Some(float!(15000)),
+                },
+                EquityPosition {
+                    symbol: test_symbol("UNKNOWN"),
+                    quantity: test_shares(50),
+                    market_value: Some(float!(5000)),
+                },
+            ],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            cash_withdrawable_cents: None,
+        };
+        let executor = MockExecutor::new().with_inventory(inventory);
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            executor,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        )
+        .with_configured_equity_symbols(configured_symbols(&["AAPL"]));
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        let offchain_equity_event = events
+            .iter()
+            .find(|event| matches!(event, InventorySnapshotEvent::OffchainEquity { .. }))
+            .expect("Expected OffchainEquity event to be emitted");
+
+        let InventorySnapshotEvent::OffchainEquity { positions, .. } = offchain_equity_event else {
+            panic!("Expected OffchainEquity event, got {offchain_equity_event:?}");
+        };
+        assert_eq!(
+            positions.len(),
+            1,
+            "Only configured active symbols should be emitted"
+        );
+        assert_eq!(
+            positions.get(&test_symbol("AAPL")),
+            Some(&test_shares(100)),
+            "configured position mismatch"
+        );
+        assert!(
+            !positions.contains_key(&test_symbol("UNKNOWN")),
+            "unconfigured broker-only position must not be added to offchain equity"
         );
     }
 

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -1136,7 +1136,30 @@ impl InventoryView {
         fetched_at: DateTime<Utc>,
         now: DateTime<Utc>,
     ) -> Result<Self, InventoryViewError> {
-        let (view, applied_symbols) = balances.into_iter().try_fold(
+        let snapshot: Vec<(Symbol, FractionalShares)> = balances
+            .into_iter()
+            .map(|(symbol, balance)| (symbol.clone(), *balance))
+            .collect();
+
+        let present: HashSet<&Symbol> = snapshot.iter().map(|(symbol, _)| symbol).collect();
+
+        // A venue snapshot is the complete picture of that venue at `fetched_at`:
+        // a brokerage omits zero-share positions and an onchain poll covers every
+        // discovered vault. Any symbol still tracked at this venue but absent from
+        // the snapshot has therefore gone to zero, so apply an explicit zero
+        // instead of leaving a stale balance behind. The same staleness guards
+        // (`equity_snapshot_would_apply`) protect these zeroes from clobbering
+        // fresher data or inflight transfers.
+        let absent_zeroes: Vec<(Symbol, FractionalShares)> = self
+            .equities
+            .iter()
+            .filter(|(symbol, inventory)| {
+                inventory.get_venue(venue).is_some() && !present.contains(symbol)
+            })
+            .map(|(symbol, _)| (symbol.clone(), FractionalShares::ZERO))
+            .collect();
+
+        let (view, applied_symbols) = snapshot.iter().chain(absent_zeroes.iter()).try_fold(
             (self, Vec::new()),
             |(view, mut applied_symbols), (symbol, snapshot_balance)| {
                 let should_record_watermark =
@@ -3139,6 +3162,199 @@ mod tests {
             inventory.detect_imbalance(&thresh).unwrap(),
             None,
             "Imbalance detection should return None when a venue is uninitialized"
+        );
+    }
+
+    #[test]
+    fn offchain_snapshot_zeroes_symbol_absent_from_complete_snapshot() {
+        // A brokerage omits zero-share positions, so a configured symbol that
+        // dropped to zero is absent from the snapshot. The live view must treat
+        // the snapshot as complete and zero the offchain balance instead of
+        // retaining the stale value, while leaving the onchain venue untouched.
+        let aapl = Symbol::new("AAPL").unwrap();
+        let tsla = Symbol::new("TSLA").unwrap();
+        let now = Utc::now();
+
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(90), shares(10))
+            .with_equity(tsla.clone(), shares(50), shares(20));
+
+        let mut positions = BTreeMap::new();
+        positions.insert(aapl.clone(), shares(10));
+
+        let result = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainEquity {
+                    positions,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.equity_available(&aapl, Venue::Hedging),
+            Some(shares(10)),
+            "present symbol keeps its reported offchain balance",
+        );
+        assert_eq!(
+            result.equity_available(&tsla, Venue::Hedging),
+            Some(shares(0)),
+            "symbol absent from the complete offchain snapshot is zeroed",
+        );
+        assert_eq!(
+            result.equity_available(&tsla, Venue::MarketMaking),
+            Some(shares(50)),
+            "the onchain venue of the absent symbol is untouched",
+        );
+        assert_eq!(
+            result.equity_available(&aapl, Venue::MarketMaking),
+            Some(shares(90)),
+            "the onchain venue of the present symbol is untouched",
+        );
+    }
+
+    #[test]
+    fn onchain_snapshot_zeroes_symbol_absent_from_complete_snapshot() {
+        // The same complete-snapshot semantics apply to the onchain venue: a
+        // symbol tracked onchain but absent from a fresh OnchainEquity snapshot
+        // has gone to zero onchain, leaving its offchain venue untouched.
+        let aapl = Symbol::new("AAPL").unwrap();
+        let tsla = Symbol::new("TSLA").unwrap();
+        let now = Utc::now();
+
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(90), shares(10))
+            .with_equity(tsla.clone(), shares(50), shares(20));
+
+        let mut balances = BTreeMap::new();
+        balances.insert(aapl, shares(90));
+
+        let result = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OnchainEquity {
+                    balances,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.equity_available(&tsla, Venue::MarketMaking),
+            Some(shares(0)),
+            "symbol absent from the complete onchain snapshot is zeroed",
+        );
+        assert_eq!(
+            result.equity_available(&tsla, Venue::Hedging),
+            Some(shares(20)),
+            "the offchain venue of the absent symbol is untouched",
+        );
+    }
+
+    #[test]
+    fn snapshot_does_not_zero_absent_symbol_with_inflight() {
+        // An absent symbol that has an inflight transfer must not be zeroed: the
+        // staleness guard cannot distinguish a completed-but-unconfirmed transfer
+        // from an unrelated change, so the stale balance is preserved.
+        let aapl = Symbol::new("AAPL").unwrap();
+        let tsla = Symbol::new("TSLA").unwrap();
+        let now = Utc::now();
+
+        let view = InventoryView {
+            equities: [
+                (
+                    aapl.clone(),
+                    Inventory {
+                        onchain: Some(VenueBalance::new(shares(90), FractionalShares::ZERO)),
+                        offchain: Some(VenueBalance::new(shares(10), FractionalShares::ZERO)),
+                        last_rebalancing: None,
+                    },
+                ),
+                (
+                    tsla.clone(),
+                    Inventory {
+                        onchain: Some(VenueBalance::new(shares(50), FractionalShares::ZERO)),
+                        offchain: Some(VenueBalance::new(shares(20), shares(5))),
+                        last_rebalancing: None,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            ..InventoryView::default()
+        };
+
+        let mut positions = BTreeMap::new();
+        positions.insert(aapl, shares(10));
+
+        let result = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainEquity {
+                    positions,
+                    fetched_at: now,
+                },
+                now,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.equity_available(&tsla, Venue::Hedging),
+            Some(shares(20)),
+            "absent symbol with inflight is not zeroed",
+        );
+        assert_eq!(
+            result.equity_inflight(&tsla, Venue::Hedging),
+            Some(shares(5)),
+            "absent symbol inflight is preserved",
+        );
+    }
+
+    #[test]
+    fn stale_snapshot_does_not_zero_absent_symbol() {
+        // A snapshot older than a symbol's recorded watermark must not zero it:
+        // out-of-order polls can land late, and a stale complete snapshot would
+        // otherwise wipe a fresher balance.
+        let aapl = Symbol::new("AAPL").unwrap();
+        let tsla = Symbol::new("TSLA").unwrap();
+        let fresh = Utc::now();
+        let stale = fresh - Duration::seconds(60);
+
+        // A fresh snapshot establishes watermarks for both symbols.
+        let mut fresh_positions = BTreeMap::new();
+        fresh_positions.insert(aapl.clone(), shares(10));
+        fresh_positions.insert(tsla.clone(), shares(20));
+
+        let view = InventoryView::default()
+            .with_equity(aapl.clone(), shares(90), shares(0))
+            .with_equity(tsla.clone(), shares(50), shares(0))
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainEquity {
+                    positions: fresh_positions,
+                    fetched_at: fresh,
+                },
+                fresh,
+            )
+            .unwrap();
+
+        // A stale snapshot omitting TSLA arrives late; it must not zero TSLA.
+        let mut stale_positions = BTreeMap::new();
+        stale_positions.insert(aapl, shares(10));
+
+        let result = view
+            .apply_snapshot_event(
+                &InventorySnapshotEvent::OffchainEquity {
+                    positions: stale_positions,
+                    fetched_at: stale,
+                },
+                stale,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.equity_available(&tsla, Venue::Hedging),
+            Some(shares(20)),
+            "stale snapshot must not zero a symbol with a fresher watermark",
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -38,7 +38,9 @@ use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{debug, error, trace, warn};
 
 use rain_math_float::Float;
-use st0x_event_sorcery::{AggregateError, EntityList, LifecycleError, Reactor, Store, deps};
+use st0x_event_sorcery::{
+    AggregateError, EntityList, LifecycleError, Projection, ProjectionError, Reactor, Store, deps,
+};
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usdc};
 
@@ -601,6 +603,7 @@ pub(crate) struct RebalancingService {
     order_owner: Address,
     inventory: Arc<BroadcastingInventory>,
     pub(crate) equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
+    pending_offchain_order_symbols: Arc<RwLock<HashSet<Symbol>>>,
     pub(crate) usdc_in_progress: Arc<AtomicBool>,
     sender: mpsc::Sender<TriggeredOperation>,
     wrapper: Arc<dyn Wrapper>,
@@ -663,6 +666,7 @@ impl RebalancingService {
             order_owner,
             inventory,
             equity_in_progress: Arc::new(std::sync::RwLock::new(HashSet::new())),
+            pending_offchain_order_symbols: Arc::new(RwLock::new(HashSet::new())),
             usdc_in_progress: Arc::new(AtomicBool::new(false)),
             sender,
             wrapper,
@@ -694,6 +698,26 @@ impl RebalancingService {
     ) {
         *self.mint_store.write().await = Some(mint_store);
         *self.redemption_store.write().await = Some(redemption_store);
+    }
+
+    pub(crate) async fn recover_pending_offchain_order_symbols(
+        &self,
+        position_projection: &Projection<Position>,
+    ) -> Result<(), ProjectionError<Position>> {
+        let pending_symbols = position_projection
+            .load_all()
+            .await?
+            .into_iter()
+            .filter_map(|(symbol, position)| {
+                position
+                    .pending_offchain_order_id
+                    .is_some()
+                    .then_some(symbol)
+            })
+            .collect();
+
+        *self.pending_offchain_order_symbols.write().await = pending_symbols;
+        Ok(())
     }
 
     async fn expire_stuck_operations(
@@ -1342,7 +1366,13 @@ impl RebalancingService {
         match event {
             // Per-symbol equity snapshots: fan out into one equity check
             // per symbol so independent retries and parallel work fall
-            // out naturally.
+            // out naturally. Iterating the event map (not the view's full
+            // applied set) is sufficient: `InventoryView::apply_equity_snapshot`
+            // additionally zeroes symbols absent from a complete snapshot, but
+            // both feeders guarantee any such symbol is already a key here --
+            // offchain polling seeds every configured symbol explicitly, and
+            // onchain polling emits a key for every vault in the monotonic
+            // registry.
             OnchainEquity { balances, .. } => {
                 for symbol in balances.keys() {
                     self.equity_scheduler.enqueue_check(symbol.clone()).await;
@@ -1401,6 +1431,7 @@ impl Reactor for RebalancingService {
                 use PositionEvent::*;
 
                 let timestamp = event.timestamp();
+                let mut clear_pending_offchain_order = false;
                 let (equity_update, usdc_update) = match &event {
                     OnChainOrderFilled {
                         amount,
@@ -1426,6 +1457,14 @@ impl Reactor for RebalancingService {
                         price,
                         ..
                     } => {
+                        // Defer clearing the suppression until the fill has been
+                        // applied to inventory below. If that update fails, the
+                        // gate deliberately stays closed: we never resume equity
+                        // rebalancing on inventory we failed to record the fill
+                        // into. It self-heals when the next terminal offchain
+                        // order event for this symbol applies cleanly, or on
+                        // restart via recover_pending_offchain_order_symbols.
+                        clear_pending_offchain_order = true;
                         let equity_op: Operator = (*direction).into();
                         let quantity: Float = shares_filled.inner().into();
                         let price_value = price.inner();
@@ -1439,10 +1478,22 @@ impl Reactor for RebalancingService {
                             ),
                         )
                     }
-                    Initialized { .. }
-                    | OffChainOrderPlaced { .. }
-                    | OffChainOrderFailed { .. }
-                    | ThresholdUpdated { .. } => return Ok(()),
+                    OffChainOrderPlaced { .. } => {
+                        self.pending_offchain_order_symbols
+                            .write()
+                            .await
+                            .insert(symbol);
+                        return Ok(());
+                    }
+                    OffChainOrderFailed { .. } => {
+                        self.pending_offchain_order_symbols
+                            .write()
+                            .await
+                            .remove(&symbol);
+                        self.equity_scheduler.enqueue_check(symbol).await;
+                        return Ok(());
+                    }
+                    Initialized { .. } | ThresholdUpdated { .. } => return Ok(()),
                 };
 
                 let mut inventory = self.inventory.write().await;
@@ -1452,6 +1503,13 @@ impl Reactor for RebalancingService {
                     .update_usdc(usdc_update, timestamp)?;
                 *inventory = updated;
                 drop(inventory);
+
+                if clear_pending_offchain_order {
+                    self.pending_offchain_order_symbols
+                        .write()
+                        .await
+                        .remove(&symbol);
+                }
 
                 self.equity_scheduler.enqueue_check(symbol).await;
                 self.usdc_scheduler.enqueue_check().await;
@@ -1553,6 +1611,13 @@ impl RebalancingService {
 
     fn try_claim_equity_guard(&self, symbol: &Symbol) -> Option<equity::InProgressGuard> {
         equity::InProgressGuard::try_claim(symbol.clone(), Arc::clone(&self.equity_in_progress))
+    }
+
+    async fn has_pending_offchain_order(&self, symbol: &Symbol) -> bool {
+        self.pending_offchain_order_symbols
+            .read()
+            .await
+            .contains(symbol)
     }
 
     async fn build_equity_operation(
@@ -1820,6 +1885,11 @@ impl RebalancingService {
             return Ok(());
         }
 
+        if self.has_pending_offchain_order(symbol).await {
+            debug!(target: "rebalance", %symbol, "Skipped equity trigger: offchain hedge order pending");
+            return Ok(());
+        }
+
         let Some(guard) = self.try_claim_equity_guard(symbol) else {
             debug!(target: "rebalance", %symbol, "Skipped equity trigger: already in progress");
             return Ok(());
@@ -1838,6 +1908,24 @@ impl RebalancingService {
             }
             Err(error) => return Err(error),
         };
+
+        // Re-check immediately before dispatch: an OffChainOrderPlaced for this
+        // symbol may have landed during the awaits in build_equity_operation.
+        // try_send_operation is synchronous, so no await intervenes between this
+        // check and the send, keeping the race window as tight as possible.
+        // This narrows but cannot fully close the gap: the in-memory set is a
+        // reactor-lagged projection of the position aggregate's
+        // pending_offchain_order_id, so a just-committed OffChainOrderPlaced
+        // not yet seen by the reactor is invisible here. Closing that fully
+        // needs a source-side reservation, not a reactor-lagged projection.
+        if self.has_pending_offchain_order(symbol).await {
+            debug!(
+                target: "rebalance",
+                %symbol,
+                "Skipped equity trigger before dispatch: offchain hedge order became pending"
+            );
+            return Ok(());
+        }
 
         if !self.try_send_operation(&operation, "equity") {
             return Ok(());
@@ -2803,7 +2891,7 @@ mod tests {
     use st0x_event_sorcery::{
         EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
     };
-    use st0x_execution::{Direction, ExecutorOrderId, Positive};
+    use st0x_execution::{Direction, ExecutorOrderId, Positive, SupportedExecutor};
     use st0x_finance::{Usd, Usdc};
     use std::collections::{BTreeMap, HashSet};
     use std::sync::Arc;
@@ -2828,7 +2916,7 @@ mod tests {
     use crate::inventory::view::Operator;
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
-    use crate::position::{Position, PositionEvent, TradeId};
+    use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
     use crate::threshold::ExecutionThreshold;
     use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
     use crate::usdc_rebalance::{
@@ -4467,6 +4555,28 @@ mod tests {
             executor_order_id: ExecutorOrderId::new("ORD1"),
             price: Usd::new(float!(150)),
             broker_timestamp,
+        }
+    }
+
+    fn make_offchain_placed(offchain_order_id: OffchainOrderId) -> PositionEvent {
+        PositionEvent::OffChainOrderPlaced {
+            offchain_order_id,
+            shares: Positive::new(shares(10)).unwrap(),
+            direction: Direction::Buy,
+            executor: SupportedExecutor::DryRun,
+            trigger_reason: TriggerReason::SharesThreshold {
+                net_position_shares: float!(10),
+                threshold_shares: float!(1),
+            },
+            placed_at: Utc::now(),
+        }
+    }
+
+    fn make_offchain_failed(offchain_order_id: OffchainOrderId) -> PositionEvent {
+        PositionEvent::OffChainOrderFailed {
+            offchain_order_id,
+            error: "test failure".to_string(),
+            failed_at: Utc::now(),
         }
     }
 
@@ -11144,6 +11254,257 @@ mod tests {
         assert!(
             matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
             "In-progress flag should suppress duplicate equity dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn equity_check_suppresses_dispatch_when_offchain_order_pending() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (reactor, mut receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        trigger
+            .pending_offchain_order_symbols
+            .write()
+            .await
+            .insert(symbol.clone());
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Pending offchain hedge order should suppress equity rebalancing dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn position_offchain_order_lifecycle_blocks_then_releases_equity_check() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.has_pending_offchain_order(&symbol).await,
+            "OffChainOrderPlaced should block equity rebalancing for the symbol"
+        );
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_failed(offchain_order_id))
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.has_pending_offchain_order(&symbol).await,
+            "Terminal offchain order event should release the rebalancing block"
+        );
+    }
+
+    #[tokio::test]
+    async fn offchain_order_filled_releases_equity_rebalancing_block() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.has_pending_offchain_order(&symbol).await,
+            "OffChainOrderPlaced should block equity rebalancing for the symbol"
+        );
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.has_pending_offchain_order(&symbol).await,
+            "A filled offchain order should release the rebalancing block"
+        );
+    }
+
+    #[tokio::test]
+    async fn offchain_order_failed_enqueues_equity_recheck() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        // Balanced venues so the drained recheck evaluates cleanly without
+        // dispatching a rebalance.
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(50))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (trigger, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_failed(offchain_order_id))
+            .await
+            .unwrap();
+
+        let processed = equity::drain_pending_equity_jobs(&trigger).await.unwrap();
+        assert_eq!(
+            processed, 1,
+            "A failed offchain order must enqueue exactly one equity recheck so hedging retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn offchain_order_filled_enqueues_equity_recheck() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        // Sized so the Hedging sell fill leaves both venues balanced (50/50),
+        // letting the drained recheck run to completion without dispatching.
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(50), shares(60))
+            .with_usdc(usdc(500), usdc(500));
+
+        let (trigger, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .unwrap();
+
+        let processed = equity::drain_pending_equity_jobs(&trigger).await.unwrap();
+        assert_eq!(
+            processed, 1,
+            "A filled offchain order must enqueue exactly one equity recheck so hedging re-evaluates"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_pending_offchain_order_symbols_restores_block_from_projection() {
+        let pending_symbol = Symbol::new("AAPL").unwrap();
+        let clear_symbol = Symbol::new("TSLA").unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+
+        // Persist two positions through the real command path: AAPL gets a
+        // pending offchain hedge order; TSLA only has an onchain fill.
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<Position>(pool.clone(), ());
+
+        store
+            .send(
+                &pending_symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: pending_symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: shares(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &pending_symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id: OffchainOrderId::new(),
+                    shares: Positive::new(shares(10)).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    threshold: ExecutionThreshold::whole_share(),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &clear_symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: clear_symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 2,
+                    },
+                    amount: shares(10),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let projection = Projection::<Position>::sqlite(pool);
+        projection.catch_up().await.unwrap();
+
+        // Pre-populate a stale entry to prove recovery replaces the set rather
+        // than merging into it.
+        trigger
+            .pending_offchain_order_symbols
+            .write()
+            .await
+            .insert(clear_symbol.clone());
+
+        trigger
+            .recover_pending_offchain_order_symbols(&projection)
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.has_pending_offchain_order(&pending_symbol).await,
+            "recovery must restore the block for a symbol with a pending offchain order"
+        );
+        assert!(
+            !trigger.has_pending_offchain_order(&clear_symbol).await,
+            "recovery must clear a symbol whose position has no pending offchain order"
         );
     }
 

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -230,7 +230,11 @@ async fn equity_mint_handles_direct_high_precision_sell_price() -> anyhow::Resul
     let broker_fill_price = float!(110);
     let amount_per_trade = float!(7.5);
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!(7.5))],
+    )
+    .await?;
 
     let mut prepared_orders = Vec::new();
     for _ in 0..3 {
@@ -1022,7 +1026,11 @@ async fn usdc_imbalance_triggers_base_to_alpaca() -> anyhow::Result<()> {
     let broker_fill_price = float!(155.00);
     let amount_per_trade = float!(7.5);
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!(7.5))],
+    )
+    .await?;
     let cctp = CctpInfra::start(&infra).await?;
 
     // Pre-fund the USDC vault so the ratio stays below 0.6 before
@@ -1345,7 +1353,11 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
     let broker_fill_price = float!("148.00");
     let amount_per_trade = float!("7.5");
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!(7.5))],
+    )
+    .await?;
 
     // Set up SellEquity orders to create TooMuchOffchain imbalance -> mint.
     let mut prepared_orders = Vec::new();
@@ -1496,7 +1508,8 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
     let onchain_price = float!("150.00");
     let amount_per_trade = float!("5");
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra =
+        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", float!(5))]).await?;
     infra
         .tokenization_service
         .set_polls_until_complete(usize::MAX);
@@ -1609,7 +1622,11 @@ async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
     let broker_fill_price = float!(148.00);
     let amount_per_trade = float!(7.5);
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!(7.5))],
+    )
+    .await?;
     infra.tokenization_service.set_polls_until_complete(4);
 
     let wrapped_token = infra.equity_addresses[0].1;
@@ -2023,7 +2040,8 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
     let onchain_price = float!("150.00");
     let amount_per_trade = float!("5");
 
-    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let infra =
+        TestInfra::start(vec![("AAPL", broker_fill_price)], vec![("AAPL", float!(5))]).await?;
     infra
         .tokenization_service
         .set_polls_until_complete(usize::MAX);


### PR DESCRIPTION
## What

[RAI-648](https://linear.app/makeitrain/issue/RAI-648/normalize-absent-alpaca-positions-to-zero-for-configured-assets)

Normalizes absent Alpaca equity positions to explicit zero balances for configured active assets, and keeps the live inventory view consistent with the persisted snapshot when a symbol drops to zero.

- `InventoryPollingService` now emits zero-share offchain equity positions for configured symbols omitted from Alpaca's positions response.
- Broker-only positions for unconfigured symbols are ignored and warned about (once per contiguous appearance) instead of entering inventory state. This also resolves a prod worker crash loop (2026-05-22): unconfigured Alpaca symbols (CEG/DRAM/TSM) were flowing into the offchain inventory snapshot and reaching the equity rebalance check, which crashed on a vault-registry lookup for the unknown token (`token not in vault registry: CEG`) and put the worker into a restart loop. Filtering them out at the snapshot prevents them from ever reaching that check.
- `InventoryView` now treats an equity snapshot as the complete picture of a venue: symbols tracked at that venue but absent from the snapshot are zeroed, so the live view no longer retains stale balances.
- Rebalancing suppresses equity triggers while an offchain hedge order is pending for the same symbol, recovers that pending state on restart, and re-checks immediately before dispatch.

## Why

Alpaca omits zero-share positions from its positions API. Without normalization, inventory could retain stale offchain equity balances for configured assets that had been reduced to zero, because no new position row arrived to clear the old value.

Configured active assets should always have an explicit offchain balance in inventory snapshots, and symbols outside the bot's configured active universe should not affect inventory or rebalance decisions. The persisted `InventorySnapshot` aggregate already fully replaces its balance map on each poll, but the live in-memory `InventoryView` applied snapshots per-symbol and never cleared omitted symbols -- so a balance reduced to zero (or an unconfigured symbol hydrated from older state) could survive in the live view that the dashboard and rebalancer read. This change makes the two views consistent.

## How

- `SPEC.md` documents both the offchain polling normalization (active configured equities missing from broker positions are treated as zero; broker-only unconfigured symbols are ignored) and the `InventoryView` complete-snapshot semantics for both venues, including the registry-completeness invariant onchain zeroing relies on.
- `src/conductor/builder.rs` collects configured equity symbols where trading or rebalancing is enabled (via the existing `Ctx::is_trading_enabled`/`is_rebalancing_enabled` helpers) and passes them into `InventoryPollingService`.
- `src/inventory/polling.rs` adds `with_configured_equity_symbols` and `normalize_offchain_positions`, seeding all configured symbols at `FractionalShares::ZERO` then overlaying broker-reported quantities; unconfigured broker symbols are dropped with a once-per-symbol warn dedup (`unconfigured_symbol_warnings`).
- `src/inventory/view.rs` changes `apply_equity_snapshot` to zero symbols absent from a complete venue snapshot (both MarketMaking and Hedging), gated by the existing staleness guards (snapshot watermark, inflight transfers, last-rebalancing), so stale balances and out-of-order/inflight cases are preserved correctly.
- `src/rebalancing/trigger/mod.rs` tracks symbols with pending offchain hedge orders from `PositionEvent::OffChainOrderPlaced`, clears them on terminal events (on a fill, only after the inventory update succeeds -- fail-closed), skips equity rebalance dispatch while one is pending (with a pre-dispatch re-check), and adds `recover_pending_offchain_order_symbols` to rebuild that state from the position projection on restart.
- `src/conductor.rs` invokes that recovery before wiring rebalancing stores on startup.
- `tests/e2e/rebalancing/mod.rs` updates fixtures that pre-fund Raindex equity vaults to declare the matching mock Alpaca positions the new explicit-zero semantics require.

## Testing

New unit tests:
- `inventory::view`: `offchain_snapshot_zeroes_symbol_absent_from_complete_snapshot`, `onchain_snapshot_zeroes_symbol_absent_from_complete_snapshot`, `snapshot_does_not_zero_absent_symbol_with_inflight`, `stale_snapshot_does_not_zero_absent_symbol`.
- `inventory::polling`: `poll_and_record_emits_zero_for_configured_position_absent_from_executor`, `poll_and_record_ignores_executor_positions_not_in_configured_symbols`.
- `rebalancing::trigger`: `equity_check_suppresses_dispatch_when_offchain_order_pending`, `position_offchain_order_lifecycle_blocks_then_releases_equity_check`, `offchain_order_filled_releases_equity_rebalancing_block`, `offchain_order_failed_enqueues_equity_recheck`, `offchain_order_filled_enqueues_equity_recheck`, `recover_pending_offchain_order_symbols_restores_block_from_projection`.

Full verification (via `nix develop`):
- `cargo check --workspace`
- `cargo nextest run --workspace --all-features` -- 2047 passed, 5 skipped
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt`

## Screenshots

N/A.

## Anything else

No migrations, config file changes, or new dependencies.

The rebalancing pending-order guard is included because explicit zero Alpaca balances can make startup inventory complete sooner; the guard prevents an equity rebalance from racing a hedge order already pending for the same symbol.

Known, accepted limitation: the in-memory pending-order set is a reactor-lagged projection of the position aggregate's `pending_offchain_order_id`. Between the `PlaceOffChainOrder` commit and the reactor inserting the symbol, an equity check can briefly see an empty set and dispatch. The pre-dispatch re-check narrows this; fully closing it would require a source-side reservation in the hedge dispatch path. Impact is bounded and self-healing (the next 60s poll re-evaluates), so it's left as a follow-up rather than addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inventory consistency by treating venue snapshots as complete pictures—previously omitted symbols are now properly zeroed out.
  * Enhanced rebalancing to prevent conflicting operations when offchain hedge orders are pending.
  * Improved startup recovery of pending offchain orders.

* **Documentation**
  * Clarified inventory polling and view-update semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
