### PR TITLE
docs: fix outdated references in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Current broker support is limited to `alpaca-broker-api` and `dry-run`.
 
 ```bash
 cargo run --bin server -- --config path/to/config.toml --secrets path/to/secrets.toml
-cargo run --bin reporter -- --config path/to/config.toml
 ```
 
 Manual wrap of tokenized equity into wrapped vault shares (requires rebalancing
@@ -158,16 +157,16 @@ and rollbacks without affecting other services.
 
 ### Key Files
 
-| File                 | Purpose                                                |
-| -------------------- | ------------------------------------------------------ |
-| `os.nix`             | NixOS system configuration (services, firewall, users) |
-| `deploy.nix`         | deploy-rs profiles and deployment wrappers             |
-| `rust.nix`           | Nix derivation for Rust binaries                       |
-| `keys.nix`           | SSH public keys and role-based access                  |
-| `config/secrets.nix` | ragenix secret declarations                            |
-| `config/*.toml.age`  | Encrypted service configs (decrypted at deploy)        |
-| `infra/`             | Terraform for DigitalOcean infrastructure              |
-| `disko.nix`          | Disk partitioning for nixos-anywhere bootstrap         |
+| File                | Purpose                                                |
+| ------------------- | ------------------------------------------------------ |
+| `os.nix`            | NixOS system configuration (services, firewall, users) |
+| `deploy.nix`        | deploy-rs profiles and deployment wrappers             |
+| `rust.nix`          | Nix derivation for Rust binaries                       |
+| `keys.nix`          | SSH public keys and role-based access                  |
+| `infra/secrets.nix` | ragenix secret declarations                            |
+| `secret/*.toml.age` | Encrypted service configs (decrypted at deploy)        |
+| `infra/`            | Terraform for DigitalOcean infrastructure              |
+| `disko.nix`         | Disk partitioning for nixos-anywhere bootstrap         |
 
 ### Deploy Commands
 
@@ -220,10 +219,10 @@ using its SSH key, mounting cleartext to `/run/agenix/` (tmpfs).
 
 ```bash
 # Edit an encrypted config
-nix run .#secret config/st0x-hedge.toml.age
+nix run .#secret secret/st0x-hedge.toml.age
 
 # Re-encrypt all secrets after key changes
-ragenix --rules ./config/secrets.nix -r
+ragenix --rules ./infra/secrets.nix -r
 ```
 
 Key access is managed via roles in `keys.nix`:
@@ -297,12 +296,6 @@ the bot cycles liquidity back through hedging and rebalancing.
 
 Open `http://localhost:5173` to watch the dashboard. Press `Ctrl-C` to stop.
 
-## P&L Tracking
-
-The P&L reporter (`cargo run --bin reporter`) calculates realized profit/loss
-using FIFO accounting and writes metrics to the `metrics_pnl` table for Grafana
-visualization. This subsystem is currently being reworked.
-
 ## Project Structure
 
 ### Cargo Workspace
@@ -310,7 +303,7 @@ visualization. This subsystem is currently being reworked.
 Workspace crates:
 
 - **`st0x-hedge`** (root) - Main arbitrage bot: event loop, CQRS/ES aggregates,
-  conductor, reporter, dashboard backend, and CLI
+  conductor, dashboard backend, and CLI
 - **`st0x-dto`** (`crates/dto/`) - Dashboard DTOs and TypeScript binding
   generation
 - **`st0x-event-sorcery`** (`crates/event-sorcery/`) - CQRS/event-sourcing
@@ -323,6 +316,10 @@ Workspace crates:
 - **`st0x-evm`** (`crates/evm/`) - EVM wallet, provider, and test-chain support
 - **`st0x-float-serde`** (`crates/float-serde/`) - Shared Rain Float formatting
   and serde helpers for workspace wire formats
+- **`st0x-finance`** (`crates/finance/`) - Core financial domain types
+  (`Symbol`, `FractionalShares`, `Usdc`, etc.) shared across crates
+- **`st0x-float-macro`** (`crates/float-macro/`) - Proc-macro for compile-time
+  `Float` literals (`float!(1.5)`)
 
 ### Infrastructure
 
@@ -334,10 +331,15 @@ rust.nix                   # Rust package derivation
 disko.nix                  # Disk partitioning for bootstrap
 keys.nix                   # SSH keys and role-based access
 config/
+├── prod/
+│   └── st0x-hedge.toml   # plaintext prod service config
+└── staging/
+    └── st0x-hedge.toml   # plaintext staging service config
+infra/
 ├── secrets.nix            # ragenix secret declarations
-├── st0x-hedge.toml        # plaintext service config
-└── st0x-hedge.toml.age    # encrypted service secrets
-infra/                     # Terraform (DigitalOcean)
+└── ...                    # Terraform (DigitalOcean)
+secret/
+└── st0x-hedge.toml.age   # encrypted service secrets
 dashboard/                 # SvelteKit operations dashboard
 .github/workflows/
 ├── ci.yaml                # Build, test, clippy, dashboard

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -221,24 +221,26 @@ hedging pipeline:
 ### AccountantCtx
 
 Defined in `src/trading/onchain/trade_accountant.rs`. Bundles all dependencies
-the job needs: config, symbol cache, EVM provider, CQRS frameworks, vault
-registry, executor. Wrapped in `Arc` and injected via apalis `Data`.
+the job needs: config, symbol cache, Pyth feed ID cache, EVM provider, orderbook
+address, CQRS frameworks, vault registry, executor, database pool, and job
+queue. Wrapped in `Arc` and injected via apalis `Data`.
 
 ## Conductor assembly
 
 `builder::spawn()` (`src/conductor/builder.rs`) uses `#[bon::builder]` to
-construct a running `Conductor`. Required parameters: `ConductorCtx` (shared
-dependencies), `DexTradeAccountingJobQueue`, `DexEventStreams`. Optional:
-`executor_maintenance`, `rebalancer`.
+construct a running `Conductor`. Takes a `ConductorCtx` (shared dependencies)
+plus per-subsystem job queues, schedulers, and optional handles for rebalancing
+and executor maintenance.
 
 `ConductorCtx` bundles the shared dependencies (config, symbol cache, provider,
-executor, CQRS frameworks, execution threshold, wallet polling config).
+executor, CQRS frameworks, pool, execution threshold, wallet polling config,
+optional `tokenizer: Option<Arc<dyn Tokenizer>>`, shutdown token).
 
 `Conductor` lifecycle:
 
-- `run()` -- the single entry point. Sets up apalis tables, CQRS frameworks,
-  determines cutoff block, backfills historical events, then calls
-  `builder::spawn()` to start the runtime
+- `run()` -- the single entry point. Connects the HTTP provider, sets up apalis
+  tables and CQRS frameworks, seeds the vault registry, requeues orphaned jobs,
+  then calls `builder::spawn()` to start the runtime
 - `wait_for_completion()` -- `tokio::select!` across supervisor, apalis monitor,
   and periodic job cleanup (see periodic cleanup below); returns when any exits
 - `abort_all()` -- shuts down supervisor, aborts all task handles
@@ -246,16 +248,19 @@ executor, CQRS frameworks, execution threshold, wallet polling config).
 ## Startup sequencing
 
 ```
-Phase 1 (parallel):  connect_http | setup_cqrs | setup_apalis_tables
-Phase 2 (parallel):  get_cutoff_block | seed_vaults | setup_rebalancing
-Phase 3 (sequential): backfill checkpoint gap to job queue
-Phase 4:              builder::spawn() starts the runtime
+Phase 1: connect_http (with RPC probe) | setup_apalis_tables | build CQRS stores
+Phase 2: seed_vault_registry (inline) | setup_rebalancing (optional)
+Phase 3: requeue_orphaned jobs | hydrate inventory | recover pending orders
+Phase 4: builder::spawn() starts supervisor + apalis workers
 ```
 
-The trade accounting worker starts only after the initial backfill completes.
-Ingestion is a checkpoint-driven `eth_getLogs` poll, not a live subscription, so
-no events are missed across downtime: the monitor always resumes from the
-persisted checkpoint and re-scans any gap.
+There is no WebSocket and no pre-runtime backfill pass. `Conductor::run()`
+creates a single HTTP provider before spawn; `OrderFillMonitor` clones it and,
+on each tick, derives the confirmation cutoff and enqueues a `BackfillRange` for
+any gap since the persisted checkpoint. The backfill and trade-accounting
+workers start together in Phase 4. Ingestion is checkpoint-driven `eth_getLogs`
+polling, not a live subscription, so no events are missed across downtime: the
+monitor always resumes from the persisted checkpoint and re-scans any gap.
 
 Backfill reads the last successful checkpoint from SQLite. The configured
 `deployment_block` seeds only the first run; subsequent runs start at

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -11,7 +11,7 @@ Types follow a strict naming convention based on their role:
 
 | Suffix     | Meaning                  | Source                               | Example                       |
 | ---------- | ------------------------ | ------------------------------------ | ----------------------------- |
-| `*Env`     | CLI args / env vars      | clap-powered struct                  | `ServerEnv`, `ReporterEnv`    |
+| `*Env`     | CLI args / env vars      | clap-powered struct                  | `Env`, `CliEnv`               |
 | `*Config`  | Non-secret settings      | Plaintext TOML (`config/*.toml`)     | `BrokerConfig`, `EvmConfig`   |
 | `*Secrets` | Secret credentials       | Encrypted TOML (`secret/*.toml.age`) | `BrokerSecrets`, `EvmSecrets` |
 | `*Ctx`     | Combined runtime context | Assembled from runtime state         | `BrokerCtx`, `EvmCtx`         |
@@ -159,13 +159,5 @@ equities:
 - **Redemption**: The reverse - burn onchain tokens to recover broker-held
   shares (e.g., 100 tAAPL tokens -> 100 AAPL shares at Alpaca).
 
-Both operations are tracked as CQRS event-sourced aggregates
-(`TokenizedEquityMint`, `EquityRedemption`) providing an immutable audit trail.
-
-### Reporter
-
-A standalone service (separate binary) that computes P&L metrics from trade
-history. It uses FIFO inventory accounting to calculate realized P&L, cumulative
-P&L, and net position for each symbol. Runs on a polling interval against the
-same SQLite database as the server, but requires no secrets (only a plaintext
-config with the database path).
+Both operations provide an immutable audit trail, tracked as CQRS event-sourced
+aggregates (`TokenizedEquityMint`, `EquityRedemption`).


### PR DESCRIPTION
## What

Closes [RAI-863](https://linear.app/makeitrain/issue/RAI-863).

Fixes factual inaccuracies found during a documentation audit across `README.md`, `docs/domain.md`, and `docs/conductor.md`.

## Why

Several docs had drifted from the actual codebase:
- The `reporter` binary was removed (its `metrics_pnl` table was dropped in migration `20260217103751`) but README and domain.md still described it.
- Secret/config file paths in README pointed at `config/secrets.nix` and `config/*.toml.age`, but the actual files are at `infra/secrets.nix` and `secret/*.toml.age`.
- Two workspace crates (`st0x-finance`, `st0x-float-macro`) were missing from the README crate list.
- `OrderFillMonitor` struct fields in `docs/conductor.md` matched an old version; the current struct uses `evm_ctx`, `backfill_queue`, and `pool` instead of `ws_url` and `orderbook`.
- `builder::spawn()` description referenced a `DexEventStreams` parameter that doesn't exist.

## How

**README.md:**
- Removed `cargo run --bin reporter` line (binary doesn't exist)
- Removed "P&L Tracking" section (subsystem removed, table dropped)
- Removed "reporter" from the `st0x-hedge` crate description
- Fixed `config/secrets.nix` -> `infra/secrets.nix` in the Key Files table, Secrets Management commands, and Infrastructure block
- Fixed `config/*.toml.age` -> `secret/*.toml.age` in the Key Files table
- Corrected the infrastructure directory tree to reflect actual layout (`config/prod/`, `config/staging/`, `infra/`, `secret/`)
- Added `st0x-finance` and `st0x-float-macro` to the workspace crate list

**docs/domain.md:**
- Replaced `ReporterEnv` example with `Env`/`CliEnv` (the types that actually exist)
- Removed the `Reporter` glossary entry (binary removed)

**docs/conductor.md:**
- Updated `OrderFillMonitor` struct definition to match current fields
- Updated `AccountantCtx` description to include all current fields (Pyth feed ID cache, orderbook address, pool, job queue)
- Removed the stale `DexEventStreams` parameter from the `builder::spawn()` description; updated `ConductorCtx` field list

## Testing

Documentation only; no code modified. Verified by reading the actual source files against the updated docs.

## Screenshots

N/A

## Anything else

No SPEC.md, `docs/cqrs.md`, `docs/alloy.md`, `docs/float.md`, or `crates/execution/AGENTS.md` changes were needed -- those files matched the current codebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new run example, revised secrets/config paths and related commands, and reorganized project structure
  * Added new workspace crates and updated workspace listing
  * Expanded conductor docs to document additional runtime dependencies, job context requirements, and revised assembly/initialization procedure
  * Clarified naming conventions and tokenization tracking approach in domain docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->