### PR TITLE
feat: recover orphaned offchain orders and add repair CLI

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@
 mod alpaca_wallet;
 mod cctp;
 mod rebalancing;
+mod repair;
 mod submit;
 mod trading;
 mod vault;
@@ -74,6 +75,27 @@ pub enum CctpChain {
     Ethereum,
     /// Base mainnet (destination: Ethereum)
     Base,
+}
+
+/// Manual repair operations for stuck local CQRS state.
+#[derive(Debug, Subcommand)]
+pub enum RepairCommand {
+    /// Fail a position's pending offchain order pointer so normal hedging can retry.
+    FailPendingOffchainOrder {
+        /// Position symbol (e.g., MSTR)
+        #[arg(short = 's', long = "symbol")]
+        symbol: Symbol,
+        /// Pending offchain order ID recorded on the position
+        #[arg(short = 'o', long = "order-id")]
+        order_id: OffchainOrderId,
+        /// Reason to persist on the Position::FailOffChainOrder event
+        #[arg(
+            short = 'r',
+            long = "reason",
+            default_value = "Manually failed pending offchain order via CLI"
+        )]
+        reason: String,
+    },
 }
 
 fn parse_float(input: &str) -> Result<Float, String> {
@@ -501,6 +523,12 @@ pub enum Commands {
         #[arg(long = "all", conflicts_with = "id", required_unless_present = "id")]
         all: bool,
     },
+
+    /// Repair stuck local CQRS state through aggregate commands.
+    Repair {
+        #[command(subcommand)]
+        command: RepairCommand,
+    },
 }
 
 #[derive(Debug, Parser)]
@@ -633,6 +661,9 @@ enum SimpleCommand {
         aggregate: AggregateView,
         id: Option<String>,
         all: bool,
+    },
+    Repair {
+        command: RepairCommand,
     },
     FailTransfer {
         transfer_type: TransferType,
@@ -850,6 +881,7 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::RebuildView { aggregate, id, all } => {
             Ok(SimpleCommand::RebuildView { aggregate, id, all })
         }
+        Commands::Repair { command } => Ok(SimpleCommand::Repair { command }),
         Commands::FailTransfer {
             transfer_type,
             id,
@@ -1014,6 +1046,7 @@ async fn run_simple_command<W: Write>(
         SimpleCommand::RebuildView { aggregate, id, all } => {
             rebuild_view(stdout, pool, aggregate, id, all).await
         }
+        SimpleCommand::Repair { command } => run_repair_command(stdout, pool, command).await,
         SimpleCommand::FailTransfer {
             transfer_type,
             id,
@@ -1072,6 +1105,23 @@ async fn rebuild_view<W: Write>(
     }
 
     Ok(())
+}
+
+async fn run_repair_command<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    command: RepairCommand,
+) -> anyhow::Result<()> {
+    match command {
+        RepairCommand::FailPendingOffchainOrder {
+            symbol,
+            order_id,
+            reason,
+        } => {
+            repair::fail_pending_offchain_order_command(stdout, pool, &symbol, order_id, reason)
+                .await
+        }
+    }
 }
 
 async fn run_provider_command<W: Write>(
@@ -1374,6 +1424,77 @@ mod tests {
                 | ProviderCommand::AlpacaRedeem { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification, got provider command"),
+        }
+    }
+
+    #[test]
+    fn repair_fail_pending_offchain_order_parses() {
+        let order_id = OffchainOrderId::new();
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "fail-pending-offchain-order",
+            "--symbol",
+            "MSTR",
+            "--order-id",
+            &order_id.to_string(),
+            "--reason",
+            "operator repair",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Repair {
+                command:
+                    RepairCommand::FailPendingOffchainOrder {
+                        symbol,
+                        order_id: parsed_order_id,
+                        reason,
+                    },
+            } => {
+                assert_eq!(symbol, Symbol::new("MSTR").unwrap());
+                assert_eq!(parsed_order_id, order_id);
+                assert_eq!(reason, "operator repair");
+            }
+            other => panic!("expected repair command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_repair_command_as_simple() {
+        let order_id = OffchainOrderId::new();
+        let command = Commands::Repair {
+            command: RepairCommand::FailPendingOffchainOrder {
+                symbol: Symbol::new("MSTR").unwrap(),
+                order_id,
+                reason: "operator repair".to_string(),
+            },
+        };
+
+        match classify_command(command) {
+            Ok(SimpleCommand::Repair {
+                command:
+                    RepairCommand::FailPendingOffchainOrder {
+                        symbol,
+                        order_id: parsed_order_id,
+                        reason,
+                    },
+            }) => {
+                assert_eq!(symbol, Symbol::new("MSTR").unwrap());
+                assert_eq!(parsed_order_id, order_id);
+                assert_eq!(reason, "operator repair");
+            }
+            Ok(_) => panic!("expected repair simple command"),
+            Err(
+                ProviderCommand::ProcessTx { .. }
+                | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::CctpBridge { .. }
+                | ProviderCommand::CctpRecover { .. }
+                | ProviderCommand::ResetAllowance { .. }
+                | ProviderCommand::AlpacaTokenize { .. }
+                | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::AlpacaTokenizationRequests,
+            ) => panic!("expected simple command classification"),
         }
     }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -1,0 +1,224 @@
+//! Repair CLI commands for manually recovering stuck local CQRS state.
+
+use anyhow::{Context, bail};
+use sqlx::SqlitePool;
+use std::io::Write;
+
+use st0x_event_sorcery::StoreBuilder;
+use st0x_execution::Symbol;
+
+use crate::offchain::order::OffchainOrderId;
+use crate::position::{Position, PositionCommand};
+
+pub(super) async fn fail_pending_offchain_order_command<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    symbol: &Symbol,
+    offchain_order_id: OffchainOrderId,
+    reason: String,
+) -> anyhow::Result<()> {
+    let (position, projection) = StoreBuilder::<Position>::new(pool.clone())
+        .build(())
+        .await
+        .context("failed to build position store")?;
+
+    let Some(view) = projection
+        .load(symbol)
+        .await
+        .context("failed to load position view")?
+    else {
+        bail!("position {symbol} not found");
+    };
+
+    match view.pending_offchain_order_id {
+        Some(pending) if pending == offchain_order_id => {}
+        Some(pending) => {
+            bail!("position {symbol} pending offchain order is {pending}, not {offchain_order_id}");
+        }
+        None => bail!("position {symbol} has no pending offchain order"),
+    }
+
+    position
+        .send(
+            symbol,
+            PositionCommand::FailOffChainOrder {
+                offchain_order_id,
+                error: reason,
+            },
+        )
+        .await
+        .context("failed to fail pending offchain order")?;
+
+    writeln!(
+        stdout,
+        "Failed pending offchain order {offchain_order_id} for {symbol}"
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::TxHash;
+
+    use st0x_execution::{Direction, FractionalShares};
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::position::TradeId;
+    use crate::test_utils::{positive_shares, setup_test_db};
+    use crate::threshold::ExecutionThreshold;
+
+    async fn seed_pending_position(
+        pool: &SqlitePool,
+        symbol: &Symbol,
+        offchain_order_id: OffchainOrderId,
+    ) {
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(420),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares: positive_shares("0.5"),
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fail_pending_offchain_order_clears_matching_pending_order() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("MSTR").unwrap();
+        let order_id = OffchainOrderId::new();
+        seed_pending_position(&pool, &symbol, order_id).await;
+
+        let mut stdout_buffer = Vec::new();
+        fail_pending_offchain_order_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            order_id,
+            "operator repair".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.pending_offchain_order_id, None);
+        let output = String::from_utf8(stdout_buffer).unwrap();
+        assert!(
+            output.contains(&order_id.to_string()),
+            "unexpected output: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_pending_offchain_order_rejects_mismatched_order_id() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("MSTR").unwrap();
+        let pending_order_id = OffchainOrderId::new();
+        let requested_order_id = OffchainOrderId::new();
+        seed_pending_position(&pool, &symbol, pending_order_id).await;
+
+        let mut stdout_buffer = Vec::new();
+        let error = fail_pending_offchain_order_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            requested_order_id,
+            "operator repair".to_string(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("not"),
+            "unexpected error: {error}"
+        );
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.pending_offchain_order_id, Some(pending_order_id));
+    }
+
+    #[tokio::test]
+    async fn fail_pending_offchain_order_rejects_position_without_pending_order() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("MSTR").unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(420),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut stdout_buffer = Vec::new();
+        let error = fail_pending_offchain_order_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            OffchainOrderId::new(),
+            "operator repair".to_string(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("no pending offchain order"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1070,7 +1070,17 @@ async fn recover_single_orphaned_order(
     order_id: OffchainOrderId,
 ) -> anyhow::Result<()> {
     let Some(order) = offchain_order.load(&order_id).await? else {
-        warn!(%symbol, %order_id, "Pending offchain order not found in store -- skipping");
+        warn!(%symbol, %order_id, "Pending offchain order not found in store -- recovering");
+        position
+            .send(
+                symbol,
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: order_id,
+                    error: "pending offchain order has no offchain order aggregate".to_string(),
+                },
+            )
+            .await?;
+        info!(%symbol, %order_id, "Orphaned missing pending order recovered");
         return Ok(());
     };
 
@@ -4609,6 +4619,76 @@ mod tests {
         assert_eq!(
             pos.pending_offchain_order_id, None,
             "Recovery should clear pending_offchain_order_id for filled orders"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_orphaned_pending_clears_missing_order_aggregate() {
+        let pool = setup_test_db().await;
+        let order_placer = crate::offchain::order::noop_order_placer();
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(order_placer)
+                .await
+                .unwrap();
+
+        let symbol = Symbol::new("MSTR").unwrap();
+        let threshold = ExecutionThreshold::whole_share();
+        let offchain_order_id = OffchainOrderId::new();
+        let shares = Positive::new(st0x_execution::FractionalShares::new(float!(0.5))).unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: fixed_bytes!(
+                            "0000000000000000000000000000000000000000000000000000000000000004"
+                        ),
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(float!(1)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(420),
+                    block_timestamp: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::PlaceOffChainOrder {
+                    offchain_order_id,
+                    shares,
+                    direction: Direction::Sell,
+                    executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    threshold,
+                },
+            )
+            .await
+            .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(pos.pending_offchain_order_id, Some(offchain_order_id));
+
+        recover_orphaned_pending_offchain_orders(&position, &position_projection, &offchain_order)
+            .await
+            .unwrap();
+
+        let pos = position_projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            pos.pending_offchain_order_id, None,
+            "Recovery should clear a pending order id when the offchain order aggregate is missing"
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1906,6 +1906,14 @@ impl RebalancingService {
                 );
                 return Ok(());
             }
+            Err(equity::EquityTriggerError::TokenNotInRegistry(symbol)) => {
+                warn!(
+                    target: "rebalance",
+                    %symbol,
+                    "Skipped equity trigger: symbol not in vault registry"
+                );
+                return Ok(());
+            }
             Err(error) => return Err(error),
         };
 
@@ -11717,10 +11725,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_and_trigger_equity_propagates_token_not_in_registry() {
-        // Registry is initialized (for `seeded`), but the symbol we ask
-        // about is not present. build_equity_operation must surface
-        // TokenNotInRegistry instead of silently returning Ok.
+    async fn check_and_trigger_equity_skips_token_not_in_registry() {
         let seeded = Symbol::new("AAPL").unwrap();
         let unknown = Symbol::new("MSFT").unwrap();
         let inventory = InventoryView::default().with_equity(seeded.clone(), shares(0), shares(0));
@@ -11729,19 +11734,10 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &seeded).await;
         let trigger = reactor.clone();
 
-        let error = trigger
+        trigger
             .check_and_trigger_equity(&unknown)
             .await
-            .unwrap_err();
-
-        assert!(
-            matches!(
-                error,
-                equity::EquityTriggerError::TokenNotInRegistry(ref symbol)
-                    if symbol == &unknown
-            ),
-            "expected TokenNotInRegistry for {unknown}, got {error:?}"
-        );
+            .expect("stale queued checks for unregistered symbols should no-op");
     }
 
     #[tokio::test]


### PR DESCRIPTION
RAI-690

## What

Closes the remaining "stuck pending offchain order" recovery gaps so a
position's `pending_offchain_order_id` can no longer wedge hedging:

- `recover_single_orphaned_order` in `src/conductor.rs` now actively clears
  a position's pending pointer when the referenced offchain order
  aggregate is missing from the store, instead of just logging a warning
  and bailing.
- New `repair fail-pending-offchain-order` CLI subcommand
  (`src/cli/repair.rs`, wired through `src/cli/mod.rs`) lets an operator
  manually fail a position's pending offchain order pointer through the
  CQRS aggregate, so normal hedging can retry.
- `RebalancingService::trigger_equity_rebalance` in
  `src/rebalancing/trigger/mod.rs` now treats
  `EquityTriggerError::TokenNotInRegistry` as a soft skip (warn + `Ok`)
  rather than propagating it.

## Why

Follow-up to #683 ("surface stranded equity recovery"). In production we
hit two classes of stuck state that the existing automatic recovery did
not handle:

1. A position recorded `pending_offchain_order_id = Some(_)` while the
   corresponding `OffchainOrder` aggregate was absent (event store /
   aggregate mismatch). The old code path logged and skipped, leaving
   the position permanently unable to place a new offchain order.
2. The rebalancer's queued equity checks could outlive a token being
   removed from the vault registry. Surfacing
   `TokenNotInRegistry` as an error spammed the failure path even
   though the only correct response is to drop the stale check.

The repair CLI exists for any residual cases where automatic recovery
can't decide on its own — operators get a one-shot, audited way to
emit `PositionCommand::FailOffChainOrder` without poking the database.

## How

**Auto-recovery (`src/conductor.rs`):** the `Some(view) = projection.load(...) else`
branch in `recover_single_orphaned_order` now sends
`PositionCommand::FailOffChainOrder { offchain_order_id, error: "pending
offchain order has no offchain order aggregate" }` before returning. This
goes through the existing CQRS framework, so the position state transition
and event are atomic — no direct DB writes.

**Repair CLI (`src/cli/repair.rs` + `src/cli/mod.rs`):**
- New `RepairCommand::FailPendingOffchainOrder { symbol, order_id, reason }`
  subcommand under a top-level `repair` group, threaded through
  `SimpleCommand` and `classify_command` like the other local-state CLI
  commands.
- `fail_pending_offchain_order_command` loads the position view, validates
  that `pending_offchain_order_id == Some(order_id)` (refuses to act if
  the position has no pending order, or if the IDs don't match), then
  emits `PositionCommand::FailOffChainOrder` and prints a confirmation
  line.
- Reason text defaults to "Manually failed pending offchain order via
  CLI" but is operator-overridable for audit context.

**Rebalancer (`src/rebalancing/trigger/mod.rs`):** added a
`TokenNotInRegistry` arm to the `match` in `trigger_equity_rebalance` that
logs `target: "rebalance"` and returns `Ok(())`. The existing test was
asserting the old propagation behavior; it's been renamed and updated to
assert the no-op semantics instead.

## Testing

- `repair_fail_pending_offchain_order_parses` — clap parsing of the new
  subcommand.
- `classify_repair_command_as_simple` — `repair` classifies as a
  `SimpleCommand` (no provider needed).
- `repair_fail_pending_offchain_order_clears_matching_pending_order` —
  end-to-end seed → repair → assert `pending_offchain_order_id == None`.
- `repair_fail_pending_offchain_order_rejects_mismatched_order_id` —
  refuses to act when the supplied ID doesn't match the pending pointer;
  state is unchanged.
- `repair_fail_pending_offchain_order_rejects_position_without_pending_order` —
  errors out cleanly when there is no pending order.
- `recover_orphaned_pending_clears_missing_order_aggregate` (conductor) —
  exercises the new auto-recovery path: pending pointer set, aggregate
  missing, recovery clears the pointer.
- `check_and_trigger_equity_skips_token_not_in_registry` — replaces the
  prior `..._propagates_token_not_in_registry` test to assert the new
  skip-and-`Ok` behavior.

## Anything else

- No schema migrations, no new dependencies, no config changes.
- The repair CLI goes through the standard `CqrsFramework` write path,
  so it inherits the same idempotency / event-sourcing guarantees as
  every other position command — no direct table writes.
- The rebalancer behavior change is operator-visible only via logs
  (`target: "rebalance"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repair CLI command to manually clear stuck pending orders with symbol, order ID, and reason parameters.

* **Bug Fixes**
  * Startup recovery now clears pending state when a referenced order record is missing (recovers orphaned pending orders).
  * Rebalancing now treats unregistered symbols as non-fatal warnings instead of failures.

* **Tests**
  * Added and updated unit tests covering the new repair command, orphan recovery, and rebalancing no-op behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->