### PR TITLE
feat: enable production USDC rebalancing

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -49,7 +49,9 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 transfer_timeout_secs = 1800
 
 [rebalancing.usdc]
-mode = "disabled"
+mode = "enabled"
+target = 0.5
+deviation = 0.2
 
 [rebalancing.equity]
 target = 0.6
@@ -61,10 +63,13 @@ url = "https://api.st0x.io"
 # USDC vault and rebalancing settings.
 [assets.cash]
 # Raindex vault ID for USDC deposits/withdrawals.
-vault_id = "0xfab2"
+vault_id = "0xfab4"
 # Whether automatic USDC rebalancing between venues is active.
 rebalancing = "enabled"
-# operational_limit = 0.01
+# Maximum USDC moved per rebalance operation.
+operational_limit = 1000
+# USD cash kept offchain and unavailable for rebalancing.
+reserved = 25000
 
 # Per-equity asset configuration.
 # - trading: whether the bot hedges fills for this asset.

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -380,9 +380,14 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
             onchain,
             offchain,
         } => {
+            let withdrawable_cash_cents = Usd::new(offchain.inner())
+                .to_cents()
+                .expect("test USDC balances should be cent-denominated");
             let mut guard = inventory.write().await;
             let taken = std::mem::take(&mut *guard);
-            *guard = taken.with_usdc(onchain, offchain);
+            *guard = taken
+                .with_usdc(onchain, offchain)
+                .with_withdrawable_cash_cents(withdrawable_cash_cents);
         }
     }
 }
@@ -1131,18 +1136,18 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
     );
 }
 
-/// Verifies that cash reserve shifts the effective offchain balance by
-/// wiring up the actual `InventoryPollingService` with `reserved_cash`.
+/// Verifies that the configured cash reserve does NOT shift the rebalancing
+/// ratio. Polling subtracts the reserve from `OffchainUsd` for dashboard and
+/// spending-cap purposes, but the imbalance check uses gross offchain cash
+/// (`offchain_gross_usd_cents`) so the reserve cannot make the system look
+/// artificially onchain-heavy and pull cash onchain unnecessarily.
 ///
-/// The broker reports $500, reserve is $300, so polling's
-/// `compute_available_cash` subtracts the reserve -> effective offchain = $200.
-///
-/// Without reserve: 500 onchain / 500 offchain = 50% ratio -> balanced.
-/// With $300 reserve: effective offchain = 200, ratio = 500/700 = 71.4%
-/// -> above 70% upper bound -> TooMuchOnchain -> base_to_alpaca.
-/// Excess = 500 - 350 (target = 0.5 * 700) = $150.
+/// The broker reports $500 gross, reserve is $300. Polling emits
+/// `OffchainUsd` with available = $200 and `gross_usd_cents = Some(50000)`.
+/// Rebalancing uses gross: 500 onchain / 500 gross offchain = 50% -> balanced
+/// -> no operation triggered.
 #[tokio::test]
-async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
+async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     use alloy::providers::{ProviderBuilder, mock::Asserter};
 
     use st0x_event_sorcery::StoreBuilder;
@@ -1167,8 +1172,15 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
+    // Trigger config mirrors prod: reserved is configured here so the
+    // imbalance check exercises the (reserved=Some, gross=Some) path
+    // end-to-end, matching what the polling side will write.
+    let mut trigger_config = test_trigger_config();
+    if let Some(cash) = trigger_config.assets.cash.as_mut() {
+        cash.reserved = Some(Positive::new(Usd::new(float!(300))).unwrap());
+    }
     let service = Arc::new(RebalancingService::new(
-        test_trigger_config(),
+        trigger_config,
         Arc::clone(&vault_registry),
         TEST_ORDERBOOK,
         TEST_ORDER_OWNER,
@@ -1256,7 +1268,9 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
     );
     drop(view);
 
-    // Trigger checks thresholds against the reserve-shifted inventory.
+    // Trigger checks thresholds. The reserve subtraction lives in
+    // `usdc_available`; the imbalance check uses gross offchain cash so the
+    // ratio stays balanced (500/500) despite the reserve.
     service.check_and_trigger_usdc().await;
 
     let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
@@ -1285,17 +1299,9 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
 
     assert_eq!(
         usdc.base_to_alpaca_calls(),
-        1,
-        "Reserve-shifted imbalance should trigger base_to_alpaca"
-    );
-
-    let call = usdc
-        .last_base_to_alpaca_call()
-        .expect("Expected a captured call");
-    assert_eq!(
-        call.amount,
-        Usdc::new(float!(150)),
-        "Expected excess of $150 (actual $500 - target $350)"
+        0,
+        "Gross offchain cash is used for the rebalancing ratio, so a $300 \
+         reserve must not trigger base_to_alpaca on a balanced 500/500 split"
     );
 
     assert_eq!(
@@ -1307,7 +1313,7 @@ async fn cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca() {
 
 /// Verifies that without reserve, the same 500/500 split is balanced
 /// and no rebalancing triggers. This is the counterpart to
-/// `cash_reserve_shifts_offchain_balance_triggering_base_to_alpaca`.
+/// `cash_reserve_does_not_shift_rebalancing_ratio`.
 #[tokio::test]
 async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
     let pool = setup_test_db().await;
@@ -1348,6 +1354,65 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
     assert!(
         matches!(receiver.try_recv(), Err(TryRecvError::Disconnected)),
         "Balanced 500/500 split should not trigger any USDC rebalancing"
+    );
+}
+
+/// Verifies that when a reserve is configured and the broker stops
+/// reporting `cash_withdrawable_cents` (e.g. transient Alpaca outage), an
+/// existing offchain imbalance does not trigger an Alpaca-to-Base
+/// transfer: the system refuses to act because reserve-safety cannot be
+/// proven. Companion to `cash_reserve_does_not_shift_rebalancing_ratio`
+/// which covers the balanced case.
+#[tokio::test]
+async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve() {
+    let pool = setup_test_db().await;
+
+    let (event_sender, _) = broadcast::channel::<Statement>(16);
+    let inventory = Arc::new(BroadcastingInventory::new(
+        InventoryView::default(),
+        event_sender,
+    ));
+
+    // Imbalanced 100 onchain / 500 offchain (17% / 83%) is well outside the
+    // 30%-70% band. gross is set (production invariant after first poll
+    // when a reserve is configured), but the broker did not report
+    // withdrawable cash.
+    {
+        let mut guard = inventory.write().await;
+        let taken = std::mem::take(&mut *guard);
+        *guard = taken
+            .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+            .with_offchain_gross_usd_cents(50_000);
+    }
+
+    let mut config = test_trigger_config();
+    if let Some(cash) = config.assets.cash.as_mut() {
+        cash.reserved = Some(Positive::new(Usd::new(float!(100))).unwrap());
+    }
+
+    let (sender, mut receiver) = mpsc::channel(10);
+
+    let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
+    let wrapper = Arc::new(MockWrapper::new());
+
+    let trigger = RebalancingService::new(
+        config,
+        vault_registry,
+        TEST_ORDERBOOK,
+        TEST_ORDER_OWNER,
+        Arc::clone(&inventory),
+        sender,
+        wrapper,
+        RebalancingSchedulers::new(&pool),
+    );
+
+    trigger.check_and_trigger_usdc().await;
+
+    drop(trigger);
+
+    assert!(
+        matches!(receiver.try_recv(), Err(TryRecvError::Disconnected)),
+        "Missing withdrawable cash + reserve configured must suppress Alpaca-to-Base rebalancing even with a real imbalance"
     );
 }
 
@@ -1395,7 +1460,7 @@ async fn usdc_none_disables_usdc_rebalancing() {
     drop(trigger);
 
     assert!(
-        receiver.try_recv().is_err(),
+        matches!(receiver.try_recv(), Err(TryRecvError::Disconnected)),
         "No USDC operation should be dispatched when usdc threshold is None"
     );
 }
@@ -1553,7 +1618,9 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     // Excess to reach 50% target = 500 - 50 = 450 USDC
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
-        InventoryView::default().with_usdc(Usdc::new(float!(50)), Usdc::new(float!(950))),
+        InventoryView::default()
+            .with_usdc(Usdc::new(float!(50)), Usdc::new(float!(950)))
+            .with_withdrawable_cash_cents(95_000),
         event_sender,
     ));
 
@@ -1616,7 +1683,9 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc::new(float!(150)), Usdc::new(float!(850)));
+        *guard = taken
+            .with_usdc(Usdc::new(float!(150)), Usdc::new(float!(850)))
+            .with_withdrawable_cash_cents(85_000);
     }
 
     // Cycle 2: excess = 350, capped to 100
@@ -1639,7 +1708,9 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc::new(float!(250)), Usdc::new(float!(750)));
+        *guard = taken
+            .with_usdc(Usdc::new(float!(250)), Usdc::new(float!(750)))
+            .with_withdrawable_cash_cents(75_000);
     }
 
     // Cycle 3: excess = 250, capped to 100
@@ -1662,7 +1733,9 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
     {
         let mut guard = inventory.write().await;
         let taken = std::mem::take(&mut *guard);
-        *guard = taken.with_usdc(Usdc::new(float!(350)), Usdc::new(float!(650)));
+        *guard = taken
+            .with_usdc(Usdc::new(float!(350)), Usdc::new(float!(650)))
+            .with_withdrawable_cash_cents(65_000);
     }
 
     trigger.check_and_trigger_usdc().await;
@@ -1686,7 +1759,9 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     // Large imbalance: 100 onchain, 900 offchain
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
-        InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900))),
+        InventoryView::default()
+            .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(900)))
+            .with_withdrawable_cash_cents(90_000),
         event_sender,
     ));
 

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 
 use st0x_dto::{InFlightCash, InFlightEquity, SymbolInventory, UsdcInventory};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
-use st0x_finance::Usdc;
+use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 
 use super::snapshot::InventorySnapshotEvent;
@@ -275,75 +275,6 @@ where
         + std::fmt::Display
         + std::fmt::Debug,
 {
-    /// Returns the ratio of onchain to total inventory.
-    /// Returns `Ok(None)` if either venue is uninitialized or total is zero.
-    fn ratio(&self) -> Result<Option<Float>, FloatError> {
-        let Some(onchain_ref) = self.onchain.as_ref() else {
-            return Ok(None);
-        };
-        let Some(offchain_ref) = self.offchain.as_ref() else {
-            return Ok(None);
-        };
-
-        let onchain: Float = onchain_ref.total()?.into();
-        let offchain: Float = offchain_ref.total()?.into();
-        let total = (onchain + offchain)?;
-
-        if total.is_zero()? {
-            return Ok(None);
-        }
-
-        Ok(Some((onchain / total)?))
-    }
-
-    /// Detects imbalance based on threshold configuration.
-    /// Returns `Ok(None)` if either venue is uninitialized, balanced, has inflight
-    /// operations, or total is zero.
-    fn detect_imbalance(
-        &self,
-        threshold: &ImbalanceThreshold,
-    ) -> Result<Option<Imbalance<T>>, FloatError> {
-        // Require both venues to be initialized before detecting imbalance.
-        // This prevents triggering rebalancing when only one venue has been polled.
-        let Some(onchain_venue) = self.onchain.as_ref() else {
-            return Ok(None);
-        };
-        let Some(offchain_venue) = self.offchain.as_ref() else {
-            return Ok(None);
-        };
-
-        if onchain_venue.has_inflight()? || offchain_venue.has_inflight()? {
-            return Ok(None);
-        }
-
-        let Some(ratio) = self.ratio()? else {
-            return Ok(None);
-        };
-
-        let lower = (threshold.target - threshold.deviation)?;
-        let upper = (threshold.target + threshold.deviation)?;
-
-        if ratio.lt(lower)? {
-            let onchain = onchain_venue.total()?;
-            let offchain = offchain_venue.total()?;
-            let total = (onchain + offchain)?;
-            let target_onchain = (total * threshold.target)?;
-            let excess = (target_onchain - onchain)?;
-
-            Ok(Some(Imbalance::TooMuchOffchain { excess }))
-        } else if ratio.gt(upper)? {
-            let onchain = onchain_venue.total()?;
-            let offchain = offchain_venue.total()?;
-            let total = (onchain + offchain)?;
-            let target_onchain = (total * threshold.target)?;
-            let excess = (onchain - target_onchain)?;
-
-            Ok(Some(Imbalance::TooMuchOnchain { excess }))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// Detects imbalance using a normalized onchain value.
     ///
     /// This is used when onchain balance is in wrapped tokens and needs to be
@@ -638,10 +569,10 @@ where
 ///
 /// These slots track wallet balances observed by polling rather than
 /// venue inventory. The underlying imbalance math
-/// ([`InventoryView::check_usdc_imbalance`]) operates strictly on venue
-/// totals so wallet readings can never compensate a real venue
-/// imbalance. Wallet-residue-driven suppression is deferred to a broader
-/// orphan-state detection mechanism.
+/// ([`InventoryView::check_usdc_imbalance_with_gross_offchain`]) operates
+/// strictly on venue totals so wallet readings can never compensate a real
+/// venue imbalance. Wallet-residue-driven suppression is deferred to a
+/// broader orphan-state detection mechanism.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) enum InFlightCashLocation {
     /// USDC parked on the Ethereum wallet between Alpaca withdrawal and
@@ -788,19 +719,101 @@ impl InventoryView {
         Ok(inventory.detect_imbalance_normalized(threshold, onchain_equivalent)?)
     }
 
-    /// Checks USDC inventory for imbalance against the threshold.
-    /// Returns the imbalance if one exists.
+    /// Checks USDC imbalance using gross offchain cash when available.
     ///
-    /// Wallet readings (`inflight_cash`) never enter the imbalance math:
-    /// the design explicitly keeps `check_usdc_imbalance` venue-only so
-    /// wallet observations cannot mask or compensate a real venue
-    /// imbalance. Suppression-based on wallet residue is tracked
-    /// separately by a broader orphan-state detection mechanism.
-    pub(crate) fn check_usdc_imbalance(
+    /// `reserved` cash is subtracted before `OffchainUsd` is stored for
+    /// dashboard and spending-cap purposes. Rebalancing allocation should
+    /// still use gross venue balances so the reserve does not make the system
+    /// look artificially onchain-heavy. When a reserve is configured but the
+    /// gross offchain snapshot is missing, this returns `None` rather than
+    /// falling back to the reserve-adjusted venue balance — using the net
+    /// value would be the exact regression this PR exists to prevent.
+    ///
+    /// Wallet readings (`inflight_cash`) never enter the imbalance math: the
+    /// design keeps this check venue-only so wallet observations cannot mask
+    /// or compensate a real venue imbalance. Suppression based on wallet
+    /// residue is tracked separately by a broader orphan-state detection
+    /// mechanism.
+    pub(crate) fn check_usdc_imbalance_with_gross_offchain(
         &self,
         threshold: &ImbalanceThreshold,
-    ) -> Result<Option<Imbalance<Usdc>>, FloatError> {
-        self.usdc.detect_imbalance(threshold)
+        reserved: Option<Usd>,
+    ) -> Result<Option<Imbalance<Usdc>>, InventoryViewError> {
+        let Some(onchain_venue) = self.usdc.onchain.as_ref() else {
+            return Ok(None);
+        };
+        let Some(offchain_venue) = self.usdc.offchain.as_ref() else {
+            return Ok(None);
+        };
+
+        if onchain_venue.has_inflight()? || offchain_venue.has_inflight()? {
+            return Ok(None);
+        }
+
+        let onchain = onchain_venue.total()?;
+        let offchain = match (self.offchain_gross_usd_cents, reserved) {
+            (Some(cents), _) => {
+                Usdc::from_cents(cents).ok_or(InventoryViewError::UsdBalanceConversion(cents))?
+            }
+            (None, None) => offchain_venue.total()?,
+            (None, Some(_)) => {
+                tracing::warn!(
+                    target: "rebalance",
+                    "USDC imbalance check skipped: gross offchain cash snapshot is missing while a reserve is configured; refusing to compute ratio against reserve-adjusted net offchain"
+                );
+                return Ok(None);
+            }
+        };
+        let total = (onchain + offchain)?;
+        let total_float: Float = total.into();
+
+        if total_float.is_zero()? {
+            return Ok(None);
+        }
+
+        let onchain_float: Float = onchain.into();
+        let ratio = (onchain_float / total_float)?;
+        let lower = (threshold.target - threshold.deviation)?;
+        let upper = (threshold.target + threshold.deviation)?;
+
+        if ratio.lt(lower)? {
+            let target_onchain = (total * threshold.target)?;
+            let excess = (target_onchain - onchain)?;
+
+            Ok(Some(Imbalance::TooMuchOffchain { excess }))
+        } else if ratio.gt(upper)? {
+            let target_onchain = (total * threshold.target)?;
+            let excess = (onchain - target_onchain)?;
+
+            Ok(Some(Imbalance::TooMuchOnchain { excess }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Maximum USDC that may leave Alpaca while preserving the configured
+    /// offchain reserve. Returns `None` when the broker did not report
+    /// withdrawable cash, because settled cash is the outbound capacity source
+    /// of truth. Returns `Some(Usdc::ZERO)` when withdrawable cash is at or
+    /// below the reserve — the caller is expected to surface this as a
+    /// distinct skip reason rather than treating it as "below minimum
+    /// withdrawal."
+    pub(crate) fn alpaca_to_base_usdc_capacity(
+        &self,
+        reserved: Option<Usd>,
+    ) -> Result<Option<Usdc>, InventoryViewError> {
+        let Some(withdrawable_cents) = self.withdrawable_cash_cents else {
+            return Ok(None);
+        };
+        let withdrawable = Usdc::from_cents(withdrawable_cents)
+            .ok_or(InventoryViewError::UsdBalanceConversion(withdrawable_cents))?;
+        let reserved = reserved.map_or(Usdc::ZERO, |amount| Usdc::new(amount.inner()));
+
+        if reserved.gt(&withdrawable)? {
+            return Ok(Some(Usdc::ZERO));
+        }
+
+        Ok(Some((withdrawable - reserved)?))
     }
 
     /// Converts the in-memory inventory view to a DTO for dashboard serialization.
@@ -985,6 +998,24 @@ impl InventoryView {
                 offchain: Some(VenueBalance::new(offchain_available, Usdc::ZERO)),
                 last_rebalancing: None,
             },
+            ..self
+        }
+    }
+
+    /// Sets the gross offchain cash balance recorded by the inventory poller.
+    #[cfg(test)]
+    pub(crate) fn with_offchain_gross_usd_cents(self, cents: i64) -> Self {
+        Self {
+            offchain_gross_usd_cents: Some(cents),
+            ..self
+        }
+    }
+
+    /// Sets the offchain withdrawable cash balance reported by the broker.
+    #[cfg(test)]
+    pub(crate) fn with_withdrawable_cash_cents(self, cents: i64) -> Self {
+        Self {
+            withdrawable_cash_cents: Some(cents),
             ..self
         }
     }
@@ -1873,63 +1904,6 @@ mod tests {
     }
 
     #[test]
-    fn ratio_returns_none_when_total_is_zero() {
-        let inventory = make_inventory(0, 0, 0, 0);
-        assert!(inventory.ratio().unwrap().is_none());
-    }
-
-    #[test]
-    fn ratio_returns_half_for_equal_split() {
-        let inventory = make_inventory(50, 0, 50, 0);
-        assert!(inventory.ratio().unwrap().unwrap().eq(float!(0.5)).unwrap());
-    }
-
-    #[test]
-    fn ratio_returns_one_when_all_onchain() {
-        let inventory = make_inventory(100, 0, 0, 0);
-        assert!(inventory.ratio().unwrap().unwrap().eq(float!(1)).unwrap());
-    }
-
-    #[test]
-    fn ratio_returns_zero_when_all_offchain() {
-        let inventory = make_inventory(0, 0, 100, 0);
-        assert!(
-            inventory
-                .ratio()
-                .unwrap()
-                .unwrap()
-                .eq(Float::zero().unwrap())
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn ratio_includes_inflight_in_total() {
-        let inventory = make_inventory(25, 25, 25, 25);
-        assert!(inventory.ratio().unwrap().unwrap().eq(float!(0.5)).unwrap());
-    }
-
-    #[test]
-    fn ratio_returns_none_when_onchain_uninitialized() {
-        let inventory = Inventory {
-            onchain: None,
-            offchain: Some(venue(100, 0)),
-            last_rebalancing: None,
-        };
-        assert!(inventory.ratio().unwrap().is_none());
-    }
-
-    #[test]
-    fn ratio_returns_none_when_offchain_uninitialized() {
-        let inventory = Inventory {
-            onchain: Some(venue(100, 0)),
-            offchain: None,
-            last_rebalancing: None,
-        };
-        assert!(inventory.ratio().unwrap().is_none());
-    }
-
-    #[test]
     fn has_inflight_false_when_no_inflight() {
         let inventory = make_inventory(50, 0, 50, 0);
         assert!(!inventory.has_inflight().unwrap());
@@ -1951,108 +1925,6 @@ mod tests {
     fn has_inflight_true_when_both_inflight() {
         let inventory = make_inventory(50, 10, 50, 10);
         assert!(inventory.has_inflight().unwrap());
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_balanced() {
-        let inventory = make_inventory(50, 0, 50, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_has_inflight() {
-        let inventory = make_inventory(80, 10, 20, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_total_is_zero() {
-        let inventory = make_inventory(0, 0, 0, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_too_much_onchain() {
-        // 80 onchain, 20 offchain = 80% ratio, threshold is 50% +- 20%
-        let inventory = make_inventory(80, 0, 20, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        let imbalance = inventory.detect_imbalance(&thresh).unwrap().unwrap();
-
-        // Target is 50 onchain, current is 80, excess = 30
-        assert_eq!(imbalance, Imbalance::TooMuchOnchain { excess: shares(30) });
-    }
-
-    #[test]
-    fn detect_imbalance_returns_too_much_offchain() {
-        // 20 onchain, 80 offchain = 20% ratio, threshold is 50% +- 20%
-        let inventory = make_inventory(20, 0, 80, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        let imbalance = inventory.detect_imbalance(&thresh).unwrap().unwrap();
-
-        // Target is 50 onchain, current is 20, excess = 30
-        assert_eq!(imbalance, Imbalance::TooMuchOffchain { excess: shares(30) });
-    }
-
-    #[test]
-    fn detect_imbalance_at_upper_boundary_is_balanced() {
-        // 70% ratio exactly at upper threshold (50% +- 20%)
-        let inventory = make_inventory(70, 0, 30, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_at_lower_boundary_is_balanced() {
-        // 30% ratio exactly at lower threshold (50% +- 20%)
-        let inventory = make_inventory(30, 0, 70, 0);
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_onchain_not_initialized() {
-        let inventory = Inventory::<FractionalShares> {
-            onchain: None,
-            offchain: Some(venue(50, 0)),
-            last_rebalancing: None,
-        };
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_offchain_not_initialized() {
-        let inventory = Inventory::<FractionalShares> {
-            onchain: Some(venue(50, 0)),
-            offchain: None,
-            last_rebalancing: None,
-        };
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
-    }
-
-    #[test]
-    fn detect_imbalance_returns_none_when_neither_venue_initialized() {
-        let inventory = Inventory::<FractionalShares> {
-            onchain: None,
-            offchain: None,
-            last_rebalancing: None,
-        };
-        let thresh = threshold("0.5", "0.2");
-
-        assert_eq!(inventory.detect_imbalance(&thresh).unwrap(), None);
     }
 
     fn usdc_venue(available: i64, inflight: i64) -> VenueBalance<Usdc> {
@@ -2123,19 +1995,6 @@ mod tests {
             onchain_equity_snapshot_watermarks: HashMap::new(),
             offchain_equity_snapshot_watermarks: HashMap::new(),
         }
-    }
-
-    #[test]
-    fn usdc_inflight_blocks_imbalance_detection() {
-        let inventory = usdc_make_inventory(800, 0, 200, 0);
-        let thresh = threshold("0.5", "0.2");
-        assert!(inventory.detect_imbalance(&thresh).unwrap().is_some());
-
-        let inventory_with_inflight = usdc_make_inventory(700, 100, 200, 0);
-        assert_eq!(
-            inventory_with_inflight.detect_imbalance(&thresh).unwrap(),
-            None
-        );
     }
 
     #[test]
@@ -2321,50 +2180,6 @@ mod tests {
         assert!(result.unwrap().is_none());
     }
 
-    #[test]
-    fn check_usdc_imbalance_returns_none_when_balanced() {
-        let view = make_usdc_view(500, 0, 500, 0);
-
-        assert_eq!(
-            view.check_usdc_imbalance(&threshold("0.5", "0.3")).unwrap(),
-            None
-        );
-    }
-
-    #[test]
-    fn check_usdc_imbalance_returns_too_much_onchain() {
-        let view = make_usdc_view(900, 0, 100, 0);
-
-        let imbalance = view
-            .check_usdc_imbalance(&threshold("0.5", "0.3"))
-            .unwrap()
-            .unwrap();
-
-        assert!(matches!(imbalance, Imbalance::TooMuchOnchain { .. }));
-    }
-
-    #[test]
-    fn check_usdc_imbalance_returns_too_much_offchain() {
-        let view = make_usdc_view(100, 0, 900, 0);
-
-        let imbalance = view
-            .check_usdc_imbalance(&threshold("0.5", "0.3"))
-            .unwrap()
-            .unwrap();
-
-        assert!(matches!(imbalance, Imbalance::TooMuchOffchain { .. }));
-    }
-
-    #[test]
-    fn check_usdc_imbalance_returns_none_when_inflight() {
-        let view = make_usdc_view(700, 200, 100, 0);
-
-        assert_eq!(
-            view.check_usdc_imbalance(&threshold("0.5", "0.3")).unwrap(),
-            None
-        );
-    }
-
     /// Wallet-read events must populate `inflight_cash` rather than the
     /// venue inventory slots. The venue snapshot semantics ("wallet
     /// balances are a transfer-in-progress signal, not part of the
@@ -2462,16 +2277,17 @@ mod tests {
     }
 
     /// Wallet balances must NOT enter the imbalance math. The design
-    /// explicitly keeps `check_usdc_imbalance` operating on venue totals
-    /// only, so wallet readings can never mask or compensate a real venue
-    /// imbalance. Wallet-residue-driven suppression is deferred to a
-    /// broader orphan-state detection mechanism, where distinguishing
-    /// "in-flight" from "settled-with-baseline" requires transfer history.
+    /// explicitly keeps `check_usdc_imbalance_with_gross_offchain`
+    /// operating on venue totals only, so wallet readings can never mask
+    /// or compensate a real venue imbalance. Wallet-residue-driven
+    /// suppression is deferred to a broader orphan-state detection
+    /// mechanism, where distinguishing "in-flight" from
+    /// "settled-with-baseline" requires transfer history.
     #[test]
     fn wallet_balances_do_not_enter_imbalance_math() {
         let now = Utc::now();
         let imbalance_without_wallet = make_usdc_view(900, 0, 100, 0)
-            .check_usdc_imbalance(&threshold("0.5", "0.3"))
+            .check_usdc_imbalance_with_gross_offchain(&threshold("0.5", "0.3"), None)
             .unwrap();
         assert!(
             matches!(
@@ -2491,7 +2307,7 @@ mod tests {
             )
             .unwrap();
         let imbalance_with_wallet = with_huge_wallet
-            .check_usdc_imbalance(&threshold("0.5", "0.3"))
+            .check_usdc_imbalance_with_gross_offchain(&threshold("0.5", "0.3"), None)
             .unwrap();
         assert_eq!(
             imbalance_without_wallet, imbalance_with_wallet,
@@ -3154,14 +2970,6 @@ mod tests {
         assert!(
             inventory.onchain.is_none(),
             "Empty inflight snapshot should not initialize a missing venue to Some(0, 0)"
-        );
-
-        // Imbalance detection should still return None since one venue is uninitialized
-        let thresh = threshold("0.5", "0.2");
-        assert_eq!(
-            inventory.detect_imbalance(&thresh).unwrap(),
-            None,
-            "Imbalance detection should return None when a venue is uninitialized"
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -42,7 +42,7 @@ use st0x_event_sorcery::{
     AggregateError, EntityList, LifecycleError, Projection, ProjectionError, Reactor, Store, deps,
 };
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
-use st0x_finance::{HasZero, Usdc};
+use st0x_finance::{HasZero, Usd, Usdc};
 
 use crate::config::AssetsConfig;
 use crate::equity_redemption::{
@@ -1384,7 +1384,15 @@ impl RebalancingService {
                 }
             }
             // Global USDC snapshots: one USDC check.
-            OnchainUsdc { .. } | OffchainUsd { .. } => {
+            //
+            // OffchainCashWithdrawable feeds the Alpaca-to-Base capacity
+            // gate (`withdrawable_cash_cents - reserved`). After the
+            // trigger skips with `MissingWithdrawableCash` because the
+            // broker omitted the field, the recovery snapshot is what
+            // brings rebalancing back online — without scheduling on it,
+            // the imbalance would remain unresolved until some unrelated
+            // USDC balance event happened to arrive.
+            OnchainUsdc { .. } | OffchainUsd { .. } | OffchainCashWithdrawable { .. } => {
                 self.usdc_scheduler.enqueue_check().await;
             }
             // Wallet-read USDC events update `inflight_cash` for
@@ -1395,10 +1403,9 @@ impl RebalancingService {
             | BaseWalletUsdc { .. }
             | BaseWalletUnwrappedEquity { .. }
             | BaseWalletWrappedEquity { .. }
-            // Buying power and withdrawable cash are display-only and
-            // don't feed venue balances, so they never drive a rebalance.
+            // Buying power is display-only and doesn't feed any rebalance
+            // decision.
             | OffchainCashBuyingPower { .. }
-            | OffchainCashWithdrawable { .. }
             // Inflight snapshots don't trigger rebalancing -- they
             // indicate transfers already in progress, not new balances
             // to rebalance.
@@ -1992,25 +1999,23 @@ impl RebalancingService {
     }
 
     /// Returns USDC rebalancing parameters if rebalancing is enabled in config.
-    fn usdc_rebalancing_params(&self) -> Option<(ImbalanceThreshold, Option<Usdc>)> {
+    fn usdc_rebalancing_params(&self) -> Option<(ImbalanceThreshold, Option<Usdc>, Option<Usd>)> {
         let threshold = self.config.usdc.as_ref()?;
 
-        let usdc_limit = self
-            .config
-            .assets
-            .cash
-            .as_ref()
+        let cash = self.config.assets.cash.as_ref();
+        let usdc_limit = cash
             .and_then(|cash| cash.operational_limit)
             .map(Positive::inner);
+        let reserved = cash.and_then(|cash| cash.reserved).map(Positive::inner);
 
-        Some((*threshold, usdc_limit))
+        Some((*threshold, usdc_limit, reserved))
     }
 
     /// Checks inventory for USDC imbalance and triggers operation if needed.
     pub(crate) async fn check_and_trigger_usdc(&self) {
         self.expire_stuck_operations_with_logging().await;
 
-        let Some((threshold, usdc_limit)) = self.usdc_rebalancing_params() else {
+        let Some((threshold, usdc_limit, reserved)) = self.usdc_rebalancing_params() else {
             return;
         };
 
@@ -2019,11 +2024,14 @@ impl RebalancingService {
             return;
         };
 
-        let Ok(operation) =
-            usdc::check_imbalance_and_build_operation(&threshold, &self.inventory, usdc_limit)
-                .await
-                .inspect_err(|skip| debug!(target: "rebalance", ?skip, "Skipped USDC trigger"))
-        else {
+        let Ok(operation) = usdc::check_imbalance_and_build_operation(
+            &threshold,
+            &self.inventory,
+            usdc_limit,
+            reserved,
+        )
+        .await
+        .inspect_err(|skip| debug!(target: "rebalance", ?skip, "Skipped USDC trigger")) else {
             return;
         };
 
@@ -6396,7 +6404,9 @@ mod tests {
         // Start with USDC imbalance: 200 onchain, 800 offchain = 20% ratio
         // With target 50%, deviation 30%, lower bound = 20%: at boundary, no trigger
         // Use 100 onchain, 900 offchain = 10% ratio -> triggers TooMuchOffchain
-        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000);
 
         let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
         let trigger = reactor.clone();
@@ -7099,6 +7109,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_offchain_cash_withdrawable_via_reactor_enqueues_usdc_check() {
+        // Withdrawable cash now gates the Alpaca-to-Base capacity check, so a
+        // recovery from MissingWithdrawableCash must arrive as a snapshot
+        // event that re-enqueues a USDC check. If withdrawable updates did
+        // not enqueue, a transient broker omission would permanently suppress
+        // rebalancing until some unrelated USDC balance event fired.
+        let inventory = InventoryView::default().with_usdc(usdc(500), usdc(500));
+        let symbol = Symbol::new("AAPL").unwrap();
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+        let id = InventorySnapshotId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_ORDER_OWNER,
+        };
+        let pool = trigger.usdc_scheduler.queue().pool().clone();
+
+        let pending_before: i64 =
+            sqlx::query_scalar(
+                "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
+            )
+                .fetch_one(&pool)
+                .await
+                .expect("count pending usdc-check jobs before snapshot");
+
+        apply_and_dispatch_snapshot(
+            reactor.clone(),
+            id,
+            InventorySnapshotEvent::OffchainCashWithdrawable {
+                cash_withdrawable_cents: Some(50_000),
+                fetched_at: Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let pending_after: i64 =
+            sqlx::query_scalar(
+                "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
+            )
+                .fetch_one(&pool)
+                .await
+                .expect("count pending usdc-check jobs after snapshot");
+
+        assert!(
+            pending_after > pending_before,
+            "OffchainCashWithdrawable snapshot must enqueue a USDC check so the trigger \
+             recovers after a MissingWithdrawableCash skip (before: {pending_before}, \
+             after: {pending_after})"
+        );
+    }
+
+    #[tokio::test]
     async fn snapshot_offchain_usd_via_reactor_updates_usdc_balance() {
         // Start with 900 onchain, 100 offchain = 90% ratio -> TooMuchOnchain
         let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
@@ -7631,6 +7694,7 @@ mod tests {
     async fn timed_out_usdc_rebalance_clears_guards_and_ignores_late_events() {
         let inventory = InventoryView::default()
             .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
             .update_usdc(
                 Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
                 Utc::now(),
@@ -9057,7 +9121,8 @@ mod tests {
         // 20% < 30% -> should trigger USDC rebalancing (AlpacaToBase).
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(0), shares(0))
-            .with_usdc(usdc(2000), usdc(2000));
+            .with_usdc(usdc(2000), usdc(2000))
+            .with_withdrawable_cash_cents(200_000);
 
         let (trigger, mut receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
@@ -11226,7 +11291,9 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_check_dispatches_transfer_on_imbalance() {
-        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000);
         let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
         let trigger = reactor.clone();
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use st0x_float_macro::float;
 use tracing::{debug, trace, warn};
 
-use st0x_finance::Usdc;
+use st0x_finance::{Usd, Usdc};
 
 use super::{RebalancingService, RebalancingServiceError, TriggeredOperation};
 #[cfg(any(test, feature = "test-support"))]
@@ -187,6 +187,13 @@ const USDC_TRANSFER_MAX_DECIMAL_PLACES: u8 = 6;
 pub(crate) enum UsdcTriggerSkip {
     /// No USDC imbalance detected.
     NoImbalance,
+    /// Alpaca did not report settled withdrawable cash, so outbound
+    /// Alpaca-to-Base capacity cannot be proven reserve-safe.
+    MissingWithdrawableCash,
+    /// Withdrawable cash is at or below the configured reserve, so no
+    /// Alpaca-to-Base capacity is available. Operators should investigate;
+    /// the reserve may need to be lowered or the broker rebalanced.
+    ReserveCapacityExhausted,
     /// Imbalance exists but amount is below Alpaca's minimum withdrawal ($51).
     BelowMinimumWithdrawal { excess: Usdc },
     /// Arithmetic error during imbalance calculation.
@@ -242,18 +249,46 @@ pub(super) async fn check_imbalance_and_build_operation(
     threshold: &ImbalanceThreshold,
     inventory: &Arc<BroadcastingInventory>,
     usdc_limit: Option<Usdc>,
+    reserved: Option<Usd>,
 ) -> Result<TriggeredOperation, UsdcTriggerSkip> {
-    let imbalance = {
+    let imbalance_check = {
         let inventory = inventory.read().await;
-        inventory.check_usdc_imbalance(threshold).map_err(|error| {
-            warn!(
-                target: "rebalance",
-                ?error,
-                "USDC imbalance check failed due to arithmetic error"
-            );
-            UsdcTriggerSkip::ArithmeticError
-        })?
+        let imbalance = inventory
+            .check_usdc_imbalance_with_gross_offchain(threshold, reserved)
+            .map_err(|error| {
+                warn!(
+                    target: "rebalance",
+                    ?error,
+                    "USDC imbalance check failed due to inventory error"
+                );
+                UsdcTriggerSkip::ArithmeticError
+            })?;
+        // Only compute the Alpaca-to-Base capacity when we will actually use
+        // it: the imbalance is offchain-heavy AND a reserve is configured.
+        // Capacity reads parse `withdrawable_cash_cents`, so binding it to
+        // unrelated branches would let a malformed withdrawable value block
+        // Base-to-Alpaca rebalancing, which is supposed to be independent of
+        // withdrawable cash. Holding the same read guard while computing both
+        // values preserves TOCTOU safety against polling-driven updates.
+        let capacity = match (&imbalance, reserved) {
+            (Some(Imbalance::TooMuchOffchain { .. }), Some(_)) => Some(
+                inventory
+                    .alpaca_to_base_usdc_capacity(reserved)
+                    .map_err(|error| {
+                        warn!(
+                            target: "rebalance",
+                            ?error,
+                            "USDC Alpaca-to-Base capacity check failed due to inventory error"
+                        );
+                        UsdcTriggerSkip::ArithmeticError
+                    })?,
+            ),
+            _ => None,
+        };
+        drop(inventory);
+        (imbalance, capacity)
     };
+    let (imbalance, alpaca_to_base_capacity) = imbalance_check;
 
     let Some(imbalance) = imbalance else {
         trace!(target: "rebalance", "No USDC imbalance detected (balanced, partial data, or inflight)");
@@ -262,7 +297,61 @@ pub(super) async fn check_imbalance_and_build_operation(
 
     match imbalance {
         Imbalance::TooMuchOffchain { excess } => {
-            let capped = truncate_for_transfer(cap_usdc(excess, usdc_limit)).map_err(|error| {
+            // `alpaca_to_base_capacity` is `Some(capacity)` only when a
+            // reserve is configured (see the capacity computation above);
+            // when reserved is `None`, there is no reserve to protect and
+            // the transfer is constrained only by `usdc_limit` and the
+            // Alpaca minimum withdrawal.
+            let capped_by_capacity = match alpaca_to_base_capacity {
+                Some(capacity_opt) => {
+                    let Some(capacity) = capacity_opt else {
+                        warn!(
+                            target: "rebalance",
+                            excess = ?excess,
+                            "Skipping Alpaca-to-Base USDC rebalance: broker did not report withdrawable cash; reserve-safety cannot be proven"
+                        );
+                        return Err(UsdcTriggerSkip::MissingWithdrawableCash);
+                    };
+
+                    // A reserve that leaves capacity below the Alpaca minimum
+                    // withdrawal is operationally equivalent to capacity == 0
+                    // — the bot cannot make ANY reserve-safe transfer. Report
+                    // it with the precise reason rather than letting the
+                    // result fall through to BelowMinimumWithdrawal, which
+                    // would be misleading.
+                    if capacity.lt(&ALPACA_MINIMUM_WITHDRAWAL).map_err(|error| {
+                        warn!(
+                            target: "rebalance",
+                            ?error,
+                            "USDC capacity minimum-comparison failed"
+                        );
+                        UsdcTriggerSkip::ArithmeticError
+                    })? {
+                        warn!(
+                            target: "rebalance",
+                            excess = ?excess,
+                            ?reserved,
+                            ?capacity,
+                            minimum = ?*ALPACA_MINIMUM_WITHDRAWAL,
+                            "Skipping Alpaca-to-Base USDC rebalance: reserve leaves withdrawable capacity below Alpaca minimum withdrawal"
+                        );
+                        return Err(UsdcTriggerSkip::ReserveCapacityExhausted);
+                    }
+
+                    let capped = cap_usdc(excess, usdc_limit);
+                    cap_usdc_by_alpaca_capacity(capped, capacity).map_err(|error| {
+                        warn!(
+                            target: "rebalance",
+                            ?error,
+                            "USDC Alpaca capacity comparison failed"
+                        );
+                        UsdcTriggerSkip::ArithmeticError
+                    })?
+                }
+                None => cap_usdc(excess, usdc_limit),
+            };
+
+            let capped = truncate_for_transfer(capped_by_capacity).map_err(|error| {
                 warn!(
                     target: "rebalance",
                     ?error,
@@ -271,10 +360,14 @@ pub(super) async fn check_imbalance_and_build_operation(
                 UsdcTriggerSkip::ArithmeticError
             })?;
 
-            if capped
-                .lt(&ALPACA_MINIMUM_WITHDRAWAL)
-                .map_err(|_| UsdcTriggerSkip::NoImbalance)?
-            {
+            if capped.lt(&ALPACA_MINIMUM_WITHDRAWAL).map_err(|error| {
+                warn!(
+                    target: "rebalance",
+                    ?error,
+                    "USDC minimum-withdrawal comparison failed"
+                );
+                UsdcTriggerSkip::ArithmeticError
+            })? {
                 debug!(
                     target: "rebalance",
                     excess = ?capped,
@@ -296,11 +389,14 @@ pub(super) async fn check_imbalance_and_build_operation(
                 UsdcTriggerSkip::ArithmeticError
             })?;
 
-            if amount
-                .inner()
-                .is_zero()
-                .map_err(|_| UsdcTriggerSkip::NoImbalance)?
-            {
+            if amount.inner().is_zero().map_err(|error| {
+                warn!(
+                    target: "rebalance",
+                    ?error,
+                    "USDC truncated-amount zero-check failed"
+                );
+                UsdcTriggerSkip::ArithmeticError
+            })? {
                 debug!(
                     target: "rebalance",
                     excess = ?excess,
@@ -329,6 +425,20 @@ fn cap_usdc(amount: Usdc, usdc_limit: Option<Usdc>) -> Usdc {
         cap
     } else {
         amount
+    }
+}
+
+fn cap_usdc_by_alpaca_capacity(amount: Usdc, capacity: Usdc) -> Result<Usdc, FloatError> {
+    if amount.gt(&capacity)? {
+        warn!(
+            target: "rebalance",
+            computed = %amount,
+            capacity = %capacity,
+            "USDC rebalancing amount capped by Alpaca withdrawable cash after reserve"
+        );
+        Ok(capacity)
+    } else {
+        Ok(amount)
     }
 }
 
@@ -910,7 +1020,7 @@ mod tests {
             deviation: float!(0.2),
         };
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, None).await;
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
         assert_eq!(result, Err(UsdcTriggerSkip::NoImbalance));
     }
@@ -928,8 +1038,9 @@ mod tests {
     async fn test_excess_below_minimum_returns_below_minimum_withdrawal() {
         // 90 offchain, 10 onchain = 90% offchain
         // Excess to reach 50% target = 90 - 50 = 40 USDC (below $51 minimum)
-        let inventory =
-            InventoryView::default().with_usdc(Usdc::new(float!(10)), Usdc::new(float!(90)));
+        let inventory = InventoryView::default()
+            .with_usdc(Usdc::new(float!(10)), Usdc::new(float!(90)))
+            .with_withdrawable_cash_cents(9000);
 
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
@@ -938,7 +1049,7 @@ mod tests {
             deviation: float!(0.2),
         };
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, None).await;
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
         assert!(
             matches!(result, Err(UsdcTriggerSkip::BelowMinimumWithdrawal { excess }) if excess.inner().lt(float!(51)).unwrap_or(false)),
@@ -950,8 +1061,9 @@ mod tests {
     async fn test_excess_above_minimum_triggers_alpaca_to_base() {
         // 500 offchain, 100 onchain = 83% offchain
         // To reach 50% target: need 300 each, so excess = 500 - 300 = 200 USDC
-        let inventory =
-            InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)));
+        let inventory = InventoryView::default()
+            .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+            .with_withdrawable_cash_cents(50_000);
 
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
@@ -960,7 +1072,7 @@ mod tests {
             deviation: float!(0.2),
         };
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, None).await;
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
         assert!(
             matches!(result, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if !amount.inner().lt(float!(51)).unwrap_or(true)),
@@ -973,8 +1085,9 @@ mod tests {
         // Edge case: excess is exactly $51
         // Total = 102, target = 51 each
         // If offchain = 102, onchain = 0, excess = 102 - 51 = 51
-        let inventory =
-            InventoryView::default().with_usdc(Usdc::new(float!(0)), Usdc::new(float!(102)));
+        let inventory = InventoryView::default()
+            .with_usdc(Usdc::new(float!(0)), Usdc::new(float!(102)))
+            .with_withdrawable_cash_cents(10_200);
 
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
@@ -983,7 +1096,7 @@ mod tests {
             deviation: float!(0.2),
         };
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, None).await;
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
         assert!(
             matches!(result, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(51))),
@@ -1007,7 +1120,7 @@ mod tests {
             deviation: float!(0.2),
         };
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, None).await;
+        let result = check_imbalance_and_build_operation(&threshold, &inventory, None, None).await;
 
         assert!(
             matches!(result, Ok(TriggeredOperation::UsdcBaseToAlpaca { amount }) if amount == Usdc::new(float!(40))),
@@ -1017,8 +1130,9 @@ mod tests {
 
     #[tokio::test]
     async fn operational_limits_cap_usdc_amount() {
-        let inventory =
-            InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)));
+        let inventory = InventoryView::default()
+            .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+            .with_withdrawable_cash_cents(50_000);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
         let threshold = ImbalanceThreshold {
@@ -1027,7 +1141,8 @@ mod tests {
         };
         let usdc_limit = Some(Usdc::new(float!(100)));
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit).await;
+        let result =
+            check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
 
         assert!(
             matches!(result, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
@@ -1046,11 +1161,14 @@ mod tests {
         // 100 onchain / 500 offchain -> 83% offchain, excess = 200
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500))),
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_withdrawable_cash_cents(50_000),
             event_sender,
         ));
 
-        let first = check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit).await;
+        let first =
+            check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
         assert!(
             matches!(first, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
             "First transfer capped to 100, got {first:?}"
@@ -1060,12 +1178,14 @@ mod tests {
         // Still above 70% threshold? No - 400/600 = 66.7%, within 30%-70%. No trigger.
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let after_first = Arc::new(BroadcastingInventory::new(
-            InventoryView::default().with_usdc(Usdc::new(float!(200)), Usdc::new(float!(400))),
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(200)), Usdc::new(float!(400)))
+                .with_withdrawable_cash_cents(40_000),
             event_sender,
         ));
 
         let second =
-            check_imbalance_and_build_operation(&threshold, &after_first, usdc_limit).await;
+            check_imbalance_and_build_operation(&threshold, &after_first, usdc_limit, None).await;
         assert_eq!(
             second,
             Err(UsdcTriggerSkip::NoImbalance),
@@ -1076,12 +1196,15 @@ mod tests {
         // Still above 70%, so triggers again
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let partially_resolved = Arc::new(BroadcastingInventory::new(
-            InventoryView::default().with_usdc(Usdc::new(float!(150)), Usdc::new(float!(450))),
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(150)), Usdc::new(float!(450)))
+                .with_withdrawable_cash_cents(45_000),
             event_sender,
         ));
 
         let third =
-            check_imbalance_and_build_operation(&threshold, &partially_resolved, usdc_limit).await;
+            check_imbalance_and_build_operation(&threshold, &partially_resolved, usdc_limit, None)
+                .await;
         assert!(
             matches!(third, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
             "Remaining imbalance triggers another capped transfer, got {third:?}"
@@ -1093,7 +1216,9 @@ mod tests {
         // excess = $200 (above $51 minimum), but limit = $30 caps it below minimum
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default().with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500))),
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_withdrawable_cash_cents(50_000),
             event_sender,
         ));
         let threshold = ImbalanceThreshold {
@@ -1102,7 +1227,8 @@ mod tests {
         };
         let usdc_limit = Some(Usdc::new(float!(30)));
 
-        let result = check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit).await;
+        let result =
+            check_imbalance_and_build_operation(&threshold, &inventory, usdc_limit, None).await;
 
         assert!(
             matches!(
@@ -1111,6 +1237,262 @@ mod tests {
                     if excess == Usdc::new(float!(30))
             ),
             "Cap of $30 should produce BelowMinimumWithdrawal, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gross_offchain_cash_is_used_for_usdc_ratio_even_with_reserve() {
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(12600)), Usdc::new(float!(800)))
+                .with_offchain_gross_usd_cents(2_580_000)
+                .with_withdrawable_cash_cents(2_580_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(25000))),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::NoImbalance),
+            "Gross offchain cash should keep 12.6k/25.8k within the 30%-70% band"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_when_withdrawable_cash_is_missing() {
+        // Reserve configured + gross set (production invariant after first poll)
+        // but withdrawable is missing -> capacity unknown -> skip.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(250))),
+        )
+        .await;
+
+        assert_eq!(result, Err(UsdcTriggerSkip::MissingWithdrawableCash));
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_is_capped_by_withdrawable_cash_after_reserve() {
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(35_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(250))),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+            "Expected reserve-adjusted withdrawable capacity to cap transfer to 100, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_when_reserve_exhausts_capacity() {
+        // withdrawable == reserved -> capacity = 0 -> ReserveCapacityExhausted
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(2_500_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(25000))),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::ReserveCapacityExhausted),
+            "withdrawable ({}) <= reserved ({}) should produce ReserveCapacityExhausted, got {result:?}",
+            "25000",
+            "25000"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_skips_when_reserve_exceeds_withdrawable() {
+        // withdrawable < reserved -> capacity = 0 -> ReserveCapacityExhausted
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(2_000_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(25000))),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::ReserveCapacityExhausted),
+            "reserved exceeding withdrawable should produce ReserveCapacityExhausted, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_recovers_after_withdrawable_cash_returns() {
+        // End-to-end recovery: a transient broker omission causes
+        // MissingWithdrawableCash; once withdrawable cash returns, the next
+        // trigger must succeed. Pins the conjunction of the
+        // (TooMuchOffchain + reserve + missing-withdrawable) skip and the
+        // post-recovery dispatch.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+        let reserved = Some(Usd::new(float!(250)));
+
+        let before =
+            check_imbalance_and_build_operation(&threshold, &inventory, None, reserved).await;
+        assert_eq!(
+            before,
+            Err(UsdcTriggerSkip::MissingWithdrawableCash),
+            "Missing withdrawable cash must skip with the precise reason"
+        );
+
+        // Polling-side recovery: withdrawable cash arrives with enough
+        // headroom over the reserve to fund the transfer.
+        {
+            let mut guard = inventory.write().await;
+            let taken = std::mem::take(&mut *guard);
+            *guard = taken
+                .with_usdc(Usdc::new(float!(100)), Usdc::new(float!(500)))
+                .with_offchain_gross_usd_cents(50_000)
+                .with_withdrawable_cash_cents(35_000);
+        }
+
+        let after =
+            check_imbalance_and_build_operation(&threshold, &inventory, None, reserved).await;
+        assert!(
+            matches!(after, Ok(TriggeredOperation::UsdcAlpacaToBase { amount }) if amount == Usdc::new(float!(100))),
+            "Post-recovery trigger must dispatch the reserve-aware capped transfer, got {after:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn imbalance_check_skips_when_gross_missing_with_reserve_configured() {
+        // No offchain_gross_usd_cents, reserve configured -> skip (NoImbalance) rather
+        // than fall back to net offchain in the ratio.
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(12600)), Usdc::new(float!(800)))
+                .with_withdrawable_cash_cents(2_580_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(25000))),
+        )
+        .await;
+
+        assert_eq!(
+            result,
+            Err(UsdcTriggerSkip::NoImbalance),
+            "Reserve configured but gross offchain missing should skip rather than use net offchain, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_to_alpaca_is_not_capped_by_reserve_or_withdrawable_cash() {
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default()
+                .with_usdc(Usdc::new(float!(900)), Usdc::new(float!(100)))
+                .with_offchain_gross_usd_cents(10_000),
+            event_sender,
+        ));
+        let threshold = ImbalanceThreshold {
+            target: float!(0.5),
+            deviation: float!(0.2),
+        };
+
+        let result = check_imbalance_and_build_operation(
+            &threshold,
+            &inventory,
+            None,
+            Some(Usd::new(float!(100000))),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Ok(TriggeredOperation::UsdcBaseToAlpaca { amount }) if amount == Usdc::new(float!(400))),
+            "Expected Base-to-Alpaca transfer to ignore reserve and withdrawable cash, got {result:?}"
         );
     }
 


### PR DESCRIPTION
## What

Related: [RAI-685](https://linear.app/makeitrain/issue/RAI-685/decide-production-usdc-rebalancing-policy)
Follow-up: [RAI-687](https://linear.app/makeitrain/issue/RAI-687/use-alpaca-portfolio-value-for-usdc-reserve-calculation)

Enables production USDC rebalancing and updates the reserve semantics so `reserved` cash no longer affects the onchain/offchain ratio calculation. The prod config now rebalances USDC through vault `0xfab4` with a 50% target, 20% deviation, 1,000 USDC per-operation limit, and 25,000 USD offchain reserve.

## Why

The previous implementation subtracted `reserved` cash before calculating the USDC inventory ratio. That made the system treat reserved Alpaca cash as if it did not exist, which could make inventory look artificially onchain-heavy and even flip rebalance direction in some snapshots.

The intended behavior is:

- ratio calculation uses gross venue inventory
- `reserved` protects offchain cash only when moving funds Alpaca -> Base
- Base -> Alpaca transfers are not constrained by Alpaca withdrawable cash or reserve

## How

- Updates `config/prod/st0x-hedge.toml`:
  - enables `[rebalancing.usdc]`
  - sets `target = 0.5` and `deviation = 0.2`
  - switches `[assets.cash].vault_id` to `0xfab4`
  - sets `operational_limit = 1000`
  - sets `reserved = 25000`

- Adds `InventoryView::check_usdc_imbalance_with_gross_offchain`, which uses `offchain_gross_usd_cents` when available instead of the reserve-adjusted offchain venue balance.

- Adds `InventoryView::alpaca_to_base_usdc_capacity`, which computes Alpaca outbound capacity from `withdrawable_cash_cents - reserved`.

- Updates the USDC trigger path so:
  - `TooMuchOffchain` / Alpaca -> Base is capped by operational limit and reserve-adjusted withdrawable capacity
  - missing withdrawable cash skips Alpaca -> Base because capacity cannot be proven reserve-safe
  - `TooMuchOnchain` / Base -> Alpaca ignores reserved and withdrawable cash

- Updates USDC trigger and integration test fixtures to model withdrawable cash explicitly.

## Testing

Added and updated coverage for:

- gross offchain cash being used in the ratio even when `reserved` is configured
- Alpaca -> Base skipping when withdrawable cash is missing
- Alpaca -> Base capping by `withdrawable_cash - reserved`
- Base -> Alpaca not being capped by reserve or withdrawable cash
- existing USDC trigger and integration flows with explicit withdrawable cash fixtures

Verified locally:

- `nix develop -c cargo check -p st0x-hedge`
- `nix develop -c cargo nextest run -p st0x-hedge usdc --no-fail-fast`
  - 293/293 passed, including the USDC e2e rebalance tests
- `nix develop -c cargo nextest run -p st0x-hedge gross_offchain_cash_is_used_for_usdc_ratio_even_with_reserve alpaca_to_base_skips_when_withdrawable_cash_is_missing alpaca_to_base_is_capped_by_withdrawable_cash_after_reserve base_to_alpaca_is_not_capped_by_reserve_or_withdrawable_cash`
- `nix develop -c cargo clippy -p st0x-hedge --all-targets --all-features`
- `nix develop -c cargo fmt`

## Screenshots

N/A.

## Anything else

Operationally, this PR configures USDC rebalancing to one vault: `0xfab4`. Orders using other USDC vaults will not receive direct per-vault rebalancing from this implementation.

The configured no-action band is 30%-70% onchain USDC. With the current 1,000 USDC operational limit, large imbalances resolve over multiple trigger cycles rather than in one transfer.

The configured 25k reserve is a temporary static cash guard. The actual operational constraint is based on total Alpaca-held value across USDC/cash and stock positions, so [RAI-687](https://linear.app/makeitrain/issue/RAI-687/use-alpaca-portfolio-value-for-usdc-reserve-calculation) tracks replacing the hardcoded USD reserve with a portfolio-value-based reserve calculation.

I did not run the full workspace nextest suite; I ran the USDC-filtered suite, which includes the relevant slow e2e USDC rebalancing coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USDC rebalancing now enabled with configurable target allocation and deviation tolerance
  * Cash rebalancing functionality enabled with operational limits and reserve parameters
  * Rebalancing system now considers available withdrawable cash capacity when executing transfers

* **Configuration**
  * Updated cash vault identifier and introduced new operational and reserve limits for cash management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->