### PR TITLE
fix: clear offchain hedge gate even when inventory update fails

### DIFF
--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1457,13 +1457,15 @@ impl Reactor for RebalancingService {
                         price,
                         ..
                     } => {
-                        // Defer clearing the suppression until the fill has been
-                        // applied to inventory below. If that update fails, the
-                        // gate deliberately stays closed: we never resume equity
-                        // rebalancing on inventory we failed to record the fill
-                        // into. It self-heals when the next terminal offchain
-                        // order event for this symbol applies cleanly, or on
-                        // restart via recover_pending_offchain_order_symbols.
+                        // Always clear the gate on a Filled event, even if the
+                        // inventory update below fails. A fail-closed gate would
+                        // deadlock equity rebalancing for the symbol until the
+                        // next bot restart, because the only event that could
+                        // re-clear it (a later terminal offchain event) is
+                        // itself gated. The polling cycle is the source of
+                        // truth for the broker balance, so any local
+                        // bookkeeping miss self-heals within ~60s and is bounded
+                        // to wasted rebalances, not lost capital.
                         clear_pending_offchain_order = true;
                         let equity_op: Operator = (*direction).into();
                         let quantity: Float = shares_filled.inner().into();
@@ -1496,21 +1498,48 @@ impl Reactor for RebalancingService {
                     Initialized { .. } | ThresholdUpdated { .. } => return Ok(()),
                 };
 
-                let mut inventory = self.inventory.write().await;
-                let updated = inventory
-                    .clone()
-                    .update_equity(&symbol, equity_update, timestamp)?
-                    .update_usdc(usdc_update, timestamp)?;
-                *inventory = updated;
-                drop(inventory);
+                let inventory_result = {
+                    let mut inventory = self.inventory.write().await;
+                    let result = inventory
+                        .clone()
+                        .update_equity(&symbol, equity_update, timestamp)
+                        .and_then(|inv| inv.update_usdc(usdc_update, timestamp));
+                    if let Ok(updated) = &result {
+                        *inventory = updated.clone();
+                    }
+                    result
+                };
 
                 if clear_pending_offchain_order {
+                    // Clear the gate regardless of inventory outcome. See the
+                    // OffChainOrderFilled arm above for the rationale.
+                    if let Err(error) = &inventory_result {
+                        warn!(
+                            target: "rebalance",
+                            %symbol,
+                            ?error,
+                            "Inventory update failed for offchain fill; clearing gate anyway and relying on next polling snapshot"
+                        );
+                    }
                     self.pending_offchain_order_symbols
                         .write()
                         .await
                         .remove(&symbol);
+                    self.equity_scheduler.enqueue_check(symbol).await;
+                    // Only re-check USDC if the cash leg actually applied.
+                    // With and_then chaining, inventory_result == Err means
+                    // neither leg was persisted, so the USDC mirror is
+                    // unchanged from before this event -- the check would
+                    // re-evaluate identical inputs and produce no new
+                    // decision. The periodic USDC scheduler tick covers
+                    // any drift the polling snapshot picks up.
+                    if inventory_result.is_ok() {
+                        self.usdc_scheduler.enqueue_check().await;
+                    }
+                    return Ok(());
                 }
 
+                inventory_result?;
                 self.equity_scheduler.enqueue_check(symbol).await;
                 self.usdc_scheduler.enqueue_check().await;
                 Ok::<(), RebalancingServiceError>(())
@@ -11359,6 +11388,51 @@ mod tests {
         assert!(
             !trigger.has_pending_offchain_order(&symbol).await,
             "A filled offchain order should release the rebalancing block"
+        );
+    }
+
+    /// A Filled event whose inventory update would underflow (because the
+    /// polling snapshot already absorbed the fill before the reactor saw it)
+    /// must still clear the gate. Holding the gate closed deadlocks equity
+    /// rebalancing for the symbol until the next bot restart, because the
+    /// only path that could re-issue a terminal offchain event for the
+    /// symbol is itself gated. Inventory drift is bounded by the next
+    /// polling snapshot (~60s) and is preferable to indefinite deadlock.
+    #[tokio::test]
+    async fn offchain_order_filled_releases_gate_even_when_inventory_update_fails() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let offchain_order_id = OffchainOrderId::new();
+        // Offchain shows only 4 shares (e.g., the polling snapshot already
+        // reflects a 10-share sell that the broker filled before the reactor
+        // got a chance to record it). The fill below subtracts 10, which
+        // would underflow the in-memory mirror.
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(4))
+            .with_usdc(usdc(5000), usdc(5000));
+
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        harness
+            .receive::<Position>(symbol.clone(), make_offchain_placed(offchain_order_id))
+            .await
+            .unwrap();
+        assert!(
+            trigger.has_pending_offchain_order(&symbol).await,
+            "OffChainOrderPlaced should set the gate"
+        );
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                make_offchain_fill(shares(10), Direction::Sell),
+            )
+            .await
+            .expect("reactor must not propagate inventory underflow for offchain fills");
+
+        assert!(
+            !trigger.has_pending_offchain_order(&symbol).await,
+            "Inventory update failure on a Filled event must not leave the gate stuck"
         );
     }
 


### PR DESCRIPTION
## What

Fixes a deadlock in the equity rebalancing gate introduced by #685.

When an `OffChainOrderFilled` event arrives, the rebalancer updates an in-memory `InventoryView` mirror and removes the symbol from `pending_offchain_order_symbols` (the gate that suppresses duplicate equity rebalance triggers while a hedge order is in flight). Previously, the gate-clearing was deferred until *after* the inventory update succeeded — fail-closed. If the inventory update errored, the gate stayed set on the assumption that "the next terminal event for this symbol, or a restart, will clear it."

That assumption is wrong. The only path that can produce another `OffChainOrderFilled`/`OffChainOrderFailed` for the symbol is itself gated by `pending_offchain_order_symbols`, so once the flag sticks it stays stuck until the bot is restarted.

## Why

Hit in prod today (2026-05-26) on **MSTR**, and earlier the same day on **SPYM**. The pattern:

1. The inventory poller calls Alpaca's `/positions` endpoint at `T+0`. The broker had just filled a 5.143-share sell, so the response shows `MSTR = 4.698` (post-fill).
2. The mirror is overwritten with `4.698`.
3. ~0.1s later the bot's order-status poll receives the fill notification.
4. The `OffChainOrderFilled` reactor fires, tries to subtract `5.143` from the mirror, gets `InsufficientAvailable { requested: 5.143, available: 4.698 }`.
5. The fail-closed branch leaves MSTR in `pending_offchain_order_symbols`.
6. Every subsequent `EquityRebalancingCheck(MSTR)` job logs `Skipped equity trigger: offchain hedge order pending symbol=MSTR` and does nothing.

MSTR equity rebalancing was silently suppressed for ~15 minutes until the operator restarted the bot. The onchain vault held 14.76 MSTR while the broker held 4.70 — drift would have kept growing.

## How

Always clear the gate on a `Filled` event, even if the inventory update fails. If it fails, log a warning at `target: "rebalance"` and rely on the next polling snapshot (~60s) to reconcile the mirror.

Trade-off: at most one stale rebalance trigger window (~60s) before polling overwrites the in-memory value, versus an indefinite deadlock requiring manual restart. The drift is bounded to wasted rebalances, not lost capital — the polling snapshot is the source of truth.

Implementation detail: restructured the inventory-apply block in `src/rebalancing/trigger/mod.rs` to capture the result without `?`, so the gate-clear branch can run regardless of inventory outcome and early-return. The `OnChainOrderFilled` path keeps the original `?` propagation since it has no gate to deadlock.

## Testing

New unit test `offchain_order_filled_releases_gate_even_when_inventory_update_fails` (`src/rebalancing/trigger/mod.rs`) sets up an inventory where offchain shares are smaller than the incoming fill, fires `OffChainOrderPlaced` then `OffChainOrderFilled`, and asserts:

- the reactor does not propagate the inventory underflow (returns `Ok`)
- the symbol is no longer in `pending_offchain_order_symbols`

The test fails against the previous code with `Inventory(Equity(InsufficientAvailable { requested: FractionalShares(10), available: FractionalShares(4) }))` (confirmed locally before the fix).

Existing tests around the gate lifecycle (`offchain_order_filled_releases_equity_rebalancing_block`, `offchain_order_failed_enqueues_equity_recheck`, `offchain_order_filled_enqueues_equity_recheck`, `position_offchain_order_lifecycle_blocks_then_releases_equity_check`, `recover_pending_offchain_order_symbols_restores_block_from_projection`) still pass — the only behavior change is on the inventory-error path.

`cargo check -p st0x-hedge --tests` passes locally. Full test suite left to CI (workspace nextest build is slow on this machine).

## Screenshots

N/A.

## Anything else

This patches the deadlock symptom, not the underlying race. The root cause is that the in-memory `InventoryView` has two independent writers — the polling loop (overwrites from broker truth every ~60s) and the fill reactor (subtracts on order events) — with no coordination, so the same fill can be applied twice. The `InsufficientAvailable` error is the second writer noticing the first writer already absorbed the fill.

Follow-up tracked in [RAI-682](https://linear.app/makeitrain/issue/RAI-682/design-proper-reconciliation-between-inventory-poller-and-offchain-order) — designing a proper fix (track inflight orders so the snapshot can be adjusted, use broker timestamps to detect "snapshot already includes this fill," or eliminate one of the writers entirely). The deadlock fix here is independently shippable and not blocked on that design.

Related PRs:
- Introduced by #685 (`fix: normalize absent Alpaca positions to zero`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented off-chain filled orders from becoming stuck when inventory updates fail: pending state is now cleared, a warning is logged when clearing on failure, an equity recheck is always queued, and a cash/USDC recheck is queued only if the inventory update succeeded.

* **Tests**
  * Added a regression test to ensure an off-chain filled-event underflow does not leave orders stuck.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->