### PR TITLE
Feat/pnl dashboard prototype

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,2 +1,12 @@
 # WebSocket URL for the dashboard backend
 PUBLIC_ALPACA_WS_URL=ws://localhost:8001/ws
+
+# Optional backend origin for the local dev proxy.
+PUBLIC_BACKEND_API_URL=
+
+# Set to 1/true to use mock API responses and synthetic PnL data.
+PUBLIC_DASHBOARD_MOCK_MODE=
+
+# Optional direct SQL JSON endpoint for the PnL prototype.
+# Example: http://st0x-liquidity-nixos.taile5cf8a.ts.net:8081/st0x-hedge.json
+PUBLIC_PNL_SQL_API_URL=

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -2,6 +2,14 @@
 
 Real-time monitoring dashboard for the st0x liquidity system.
 
+## Panels
+
+- Dashboard: inventory, recent trades, and transfers.
+- Orders: active Raindex order view.
+- PnL: persisted fill replay for counter-trade PnL, directional exposure PnL,
+  total PnL, and current replay exposure.
+- Logs: structured production log browser.
+
 ## Development
 
 Install dependencies:
@@ -17,6 +25,40 @@ bun run dev
 
 # or start the server and open the app in a new browser tab
 bun run dev --open
+```
+
+Run the dashboard with mock API responses and synthetic PnL data:
+
+```sh
+PUBLIC_DASHBOARD_MOCK_MODE=1 bun run dev
+```
+
+Run the PnL tab against a Datasette-style SQL JSON endpoint:
+
+```sh
+PUBLIC_PNL_SQL_API_URL=http://st0x-liquidity-nixos.taile5cf8a.ts.net:8081/st0x-hedge.json \
+bun run dev
+```
+
+Run the full dashboard locally against production backend data and production
+PnL SQL data:
+
+```sh
+PUBLIC_BACKEND_API_URL=https://st0x-liquidity-nixos.taile5cf8a.ts.net \
+PUBLIC_PNL_SQL_API_URL=http://st0x-liquidity-nixos.taile5cf8a.ts.net:8081/st0x-hedge.json \
+bun run dev
+```
+
+In local dev, absolute SQL URLs are proxied through `/__pnl_sql` so the browser
+does not depend on CORS headers from the SQL endpoint. `PUBLIC_BACKEND_API_URL`
+points the existing dashboard API proxy at a backend origin. In production, set
+`PUBLIC_PNL_SQL_API_URL` to a same-origin path or to an endpoint that allows the
+dashboard origin.
+
+The adapter expects URLs with this shape:
+
+```text
+http://<host>:8081/st0x-hedge.json?sql=SELECT+symbol,net_position+FROM+position_view&_shape=array
 ```
 
 ## Building

--- a/dashboard/src/lib/components/header-bar.svelte
+++ b/dashboard/src/lib/components/header-bar.svelte
@@ -7,6 +7,7 @@
     getSimulateRev,
     getSimulateBackendPort,
     getSimulateSourceId,
+    isDashboardMockMode,
   } from '$lib/env'
   import { formatUtcClock, FETCH_TIMEOUT_MS } from '$lib/time'
   import { reactive } from '$lib/frp.svelte'
@@ -57,6 +58,12 @@
   const now = reactive(new Date())
 
   const fetchHealth = async () => {
+    if (isDashboardMockMode()) {
+      health.update(() => ({ gitCommit: 'mock', uptimeSeconds: 0 }))
+      botReachable.update(() => true)
+      return
+    }
+
     try {
       const baseUrl = getApiBaseUrl()
       const response = await fetch(`${baseUrl}/health`, {

--- a/dashboard/src/lib/components/pnl-panel.svelte
+++ b/dashboard/src/lib/components/pnl-panel.svelte
@@ -1,0 +1,1846 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import * as Card from '$lib/components/ui/card'
+  import * as Table from '$lib/components/ui/table'
+  import MultiSelect from '$lib/components/multi-select.svelte'
+  import { decimalCompare, formatDecimal } from '$lib/decimal'
+  import { getPnlSqlApiUrl, isDashboardMockMode } from '$lib/env'
+  import { reactive } from '$lib/frp.svelte'
+  import { formatUtc } from '$lib/time'
+  import { fetchPnlReport } from '$lib/pnl/api'
+  import { STREAM_KEYS } from '$lib/pnl/report'
+  import { syntheticPnlDashboard } from '$lib/pnl/synthetic'
+  import type {
+    PnlEntry,
+    PnlResponse,
+    PnlStreamKey,
+    PnlSummary,
+    PnlSymbolSummary,
+    PnlWindow,
+    PnlWindowSymbol
+  } from '$lib/pnl/report'
+
+  type RangePreset = '1w' | '1m' | 'ytd' | '1y' | 'all' | 'custom'
+
+  const PNL_ENTRY_LIMIT = Number.MAX_SAFE_INTEGER
+  const POLL_INTERVAL_MS = 10_000
+  const MS_PER_DAY = 24 * 60 * 60 * 1_000
+  const mockMode = isDashboardMockMode()
+  const hasSqlPnlSource = getPnlSqlApiUrl() !== null
+
+  const dateFromIso = (value: string): Date => new Date(`${value}T00:00:00.000Z`)
+
+  const isoDate = (date: Date): string => date.toISOString().slice(0, 10)
+
+  const shiftDate = (value: string, days: number): string => {
+    const date = dateFromIso(value)
+    date.setUTCDate(date.getUTCDate() + days)
+    return isoDate(date)
+  }
+
+  const syntheticAvailableStartDate = syntheticPnlDashboard.windows[0]?.startAt.slice(0, 10) ?? ''
+  const syntheticAvailableEndDate = syntheticPnlDashboard.windows.at(-1)?.startAt.slice(0, 10) ?? ''
+  const initialAvailableEndDate =
+    !mockMode && hasSqlPnlSource ? new Date().toISOString().slice(0, 10) : syntheticAvailableEndDate
+  const initialAvailableStartDate =
+    !mockMode && hasSqlPnlSource
+      ? shiftDate(initialAvailableEndDate, -6)
+      : syntheticAvailableStartDate
+  const defaultChartSymbols = syntheticPnlDashboard.report.symbols.map((row) => row.symbol).sort()
+
+  const clampDateForRange = (value: string, start: string, end: string): string => {
+    if (!start || !end) return value
+    if (value < start) return start
+    if (value > end) return end
+    return value
+  }
+
+  const startOfYear = (value: string): string => `${value.slice(0, 4)}-01-01`
+  const presetStartForRange = (preset: RangePreset, start: string, end: string): string => {
+    switch (preset) {
+      case '1w':
+        return clampDateForRange(shiftDate(end, -6), start, end)
+      case '1m':
+        return clampDateForRange(shiftDate(end, -29), start, end)
+      case 'ytd':
+        return clampDateForRange(startOfYear(end), start, end)
+      case '1y':
+        return clampDateForRange(shiftDate(end, -364), start, end)
+      case 'all':
+        return start
+      case 'custom':
+        return clampDateForRange(shiftDate(end, -6), start, end)
+    }
+  }
+
+  const report = reactive<PnlResponse | null>(null)
+  const entries = reactive<PnlEntry[]>([])
+  const loading = reactive(false)
+  const error = reactive<string | null>(null)
+  const total = reactive(0)
+  const selectedSymbols = reactive<Set<string>>(new Set())
+  const selectedAssetChartSymbols = reactive<Set<string>>(new Set(defaultChartSymbols))
+  const selectedAssetChartStreams = reactive<Set<PnlStreamKey>>(new Set(STREAM_KEYS))
+  const selectedMethodChartSymbols = reactive<Set<string>>(new Set(defaultChartSymbols))
+  const selectedMethodChartStreams = reactive<Set<PnlStreamKey>>(new Set(STREAM_KEYS))
+  const dayFilter = reactive<'all' | 'weekday' | 'weekend'>('all')
+  const dataMode = reactive<'synthetic' | 'backend'>(
+    !mockMode && hasSqlPnlSource ? 'backend' : 'synthetic'
+  )
+  const availableStartDate = $derived.by(() => {
+    if (dataMode.current === 'synthetic') return syntheticAvailableStartDate
+    return (
+      report.current?.sampleStats?.firstAt?.slice(0, 10) ??
+      report.current?.windows?.[0]?.startAt.slice(0, 10) ??
+      initialAvailableStartDate
+    )
+  })
+  const availableEndDate = $derived.by(() => {
+    if (dataMode.current === 'synthetic') return syntheticAvailableEndDate
+    return (
+      report.current?.sampleStats?.lastAt?.slice(0, 10) ??
+      report.current?.windows?.at(-1)?.startAt.slice(0, 10) ??
+      initialAvailableEndDate
+    )
+  })
+  const clampDate = (value: string): string =>
+    clampDateForRange(value, availableStartDate, availableEndDate)
+  const presetStart = (preset: RangePreset): string =>
+    presetStartForRange(preset, availableStartDate, availableEndDate)
+  const allSymbols = reactive<string[]>([])
+  const selectedPreset = reactive<RangePreset>('1w')
+  const fromDate = reactive(
+    presetStartForRange('1w', initialAvailableStartDate, initialAvailableEndDate)
+  )
+  const toDate = reactive(initialAvailableEndDate)
+  const dateRangeKey = (from: string, to: string): string => `${from}:${to}`
+  let lastRequestedDateRangeKey: string | null = null
+  let fetchSeq = 0
+
+  const streamLabels: Record<PnlStreamKey, string> = {
+    counterTradePnlUsd: 'Counter-trade',
+    onchainNettingPnlUsd: 'On-chain netting',
+    directionalInventoryBaselinePnlUsd: 'Baseline drift',
+    directionalImbalanceExcessPnlUsd: 'Directional realized'
+  }
+  const streamColors: Record<PnlStreamKey, string> = {
+    counterTradePnlUsd: '#38bdf8',
+    onchainNettingPnlUsd: '#22c55e',
+    directionalInventoryBaselinePnlUsd: '#f59e0b',
+    directionalImbalanceExcessPnlUsd: '#f43f5e'
+  }
+  const assetColors = ['#38bdf8', '#f59e0b', '#22c55e', '#f43f5e', '#a78bfa']
+  const formulaRows = [
+    {
+      label: 'Counter-trade PnL',
+      formula: 'sum((broker_price - onchain_price) * matched_qty * side_sign)',
+      note: 'Only broker fills inside the counter-trade threshold are attributed here. side_sign is +1 for long inventory opened by the on-chain fill and -1 for short inventory.'
+    },
+    {
+      label: 'On-chain netting PnL',
+      formula: 'sum((closing_onchain_price - opening_onchain_price) * matched_qty * side_sign)',
+      note: 'Used when a later opposite on-chain fill closes inventory before or instead of a broker counter-trade.'
+    },
+    {
+      label: 'Baseline drift PnL',
+      formula: 'sum(frozen_start_qty * (bucket_end_mark - bucket_start_mark))',
+      note: 'Requires historical portfolio and mark snapshots; currently reported as zero.'
+    },
+    {
+      label: 'Directional realized PnL',
+      formula: 'sum((close_price - open_price) * matched_qty * side_sign)',
+      note: 'Realized closed-lot PnL for delayed or offchain-origin exposure.'
+    },
+    {
+      label: 'Directional realized total',
+      formula: 'baseline_drift_pnl + directional_excess_pnl',
+      note: 'Baseline drift is zero until historical snapshots are persisted.'
+    },
+    {
+      label: 'Realized gross PnL',
+      formula:
+        'counter_trade_pnl + onchain_netting_pnl + baseline_drift_pnl + directional_excess_pnl',
+      note: 'Gross realized replay by close date; costs, financing, and unrealized NAV drift are not included.'
+    }
+  ]
+
+  const streamOptions = STREAM_KEYS.map((stream) => ({
+    value: stream,
+    label: streamLabels[stream]
+  }))
+
+  const symbolOptions = $derived(
+    allSymbols.current.map((symbol) => ({
+      value: symbol,
+      label: symbol
+    }))
+  )
+
+  const isPnlStreamKey = (value: string): value is PnlStreamKey =>
+    (STREAM_KEYS as readonly string[]).includes(value)
+
+  const isWeekendTimestamp = (timestamp: string): boolean =>
+    [0, 6].includes(new Date(timestamp).getUTCDay())
+
+  const matchesDayFilter = (isWeekend: boolean): boolean => {
+    if (dayFilter.current === 'weekday') return !isWeekend
+    if (dayFilter.current === 'weekend') return isWeekend
+    return true
+  }
+
+  const dateKey = (timestamp: string): string => timestamp.slice(0, 10)
+
+  const matchesDateRange = (date: string): boolean => {
+    const start = fromDate.current <= toDate.current ? fromDate.current : toDate.current
+    const end = fromDate.current <= toDate.current ? toDate.current : fromDate.current
+
+    return (!start || date >= start) && (!end || date <= end)
+  }
+
+  const emptySymbolSummary = (symbol: string): PnlSymbolSummary => ({
+    symbol,
+    counterTradePnlUsd: '0',
+    onchainNettingPnlUsd: '0',
+    directionalInventoryBaselinePnlUsd: '0',
+    directionalImbalanceExcessPnlUsd: '0',
+    directionalExposurePnlUsd: '0',
+    totalPnlUsd: '0',
+    realizedPnlUsd: '0',
+    matchedShares: '0',
+    inventoryDriftShares: '0',
+    inventoryDriftUsd: '0',
+    openLongShares: '0',
+    openShortShares: '0',
+    unmatchedOffchainShares: '0',
+    matchedLotCount: 0,
+    onchainFillCount: 0,
+    offchainFillCount: 0,
+    unmatchedOffchainFillCount: 0
+  })
+
+  const addWindowSymbol = (target: PnlSymbolSummary, row: PnlWindowSymbol): void => {
+    const counter = Number(target.counterTradePnlUsd) + Number(row.counterTradePnlUsd)
+    const onchain = Number(target.onchainNettingPnlUsd) + Number(row.onchainNettingPnlUsd)
+    const baseline =
+      Number(target.directionalInventoryBaselinePnlUsd) +
+      Number(row.directionalInventoryBaselinePnlUsd)
+    const excess =
+      Number(target.directionalImbalanceExcessPnlUsd) + Number(row.directionalImbalanceExcessPnlUsd)
+    const directional = baseline + excess
+    const realized = counter + onchain
+
+    target.counterTradePnlUsd = moneyText(counter)
+    target.onchainNettingPnlUsd = moneyText(onchain)
+    target.directionalInventoryBaselinePnlUsd = moneyText(baseline)
+    target.directionalImbalanceExcessPnlUsd = moneyText(excess)
+    target.directionalExposurePnlUsd = moneyText(directional)
+    target.realizedPnlUsd = moneyText(realized + excess)
+    target.totalPnlUsd = moneyText(realized + directional)
+    target.inventoryDriftUsd = target.directionalInventoryBaselinePnlUsd
+  }
+
+  const syntheticWindowsForCurrentFilter = (): PnlWindow[] =>
+    syntheticPnlDashboard.windows.filter(
+      (window) => matchesDayFilter(window.isWeekend) && matchesDateRange(dateKey(window.startAt))
+    )
+
+  const syntheticEntriesForCurrentFilter = (): PnlEntry[] => {
+    const selected = selectedSymbols.current
+
+    return syntheticPnlDashboard.report.entries.filter((entry) => {
+      if (selected.size > 0 && !selected.has(entry.symbol)) return false
+      if (!matchesDateRange(dateKey(entry.closedAt))) return false
+      return matchesDayFilter(isWeekendTimestamp(entry.closedAt))
+    })
+  }
+
+  const syntheticSymbolRowsForCurrentFilter = (
+    syntheticEntries: PnlEntry[]
+  ): PnlSymbolSummary[] => {
+    const selected = selectedSymbols.current
+    const windows = syntheticWindowsForCurrentFilter()
+    const symbols = new Map<string, PnlSymbolSummary>()
+
+    for (const row of syntheticPnlDashboard.report.symbols) {
+      if (selected.size > 0 && !selected.has(row.symbol)) continue
+      symbols.set(row.symbol, emptySymbolSummary(row.symbol))
+    }
+
+    for (const window of windows) {
+      for (const row of window.symbols) {
+        if (selected.size > 0 && !selected.has(row.symbol)) continue
+        const target = symbols.get(row.symbol)
+        if (target) addWindowSymbol(target, row)
+      }
+    }
+
+    for (const row of symbols.values()) {
+      const symbolEntries = syntheticEntries.filter((entry) => entry.symbol === row.symbol)
+      row.matchedLotCount = symbolEntries.length
+      row.onchainFillCount = windows.length * 28
+      row.offchainFillCount = windows.length * 20
+      row.unmatchedOffchainFillCount = symbolEntries.filter(
+        (entry) => entry.delayedCounterTrade
+      ).length
+      row.matchedShares = moneyText(
+        symbolEntries.reduce((totalValue, entry) => totalValue + Number(entry.shares), 0)
+      )
+      row.unmatchedOffchainShares = moneyText(
+        symbolEntries
+          .filter((entry) => entry.delayedCounterTrade)
+          .reduce((totalValue, entry) => totalValue + Number(entry.shares) * 0.08, 0)
+      )
+    }
+
+    return [...symbols.values()].sort((left, right) => left.symbol.localeCompare(right.symbol))
+  }
+
+  const isCompleteSelection = (selected: Set<string>, symbols: string[]): boolean =>
+    symbols.length > 0 && symbols.every((symbol) => selected.has(symbol))
+
+  const reconcileSymbolSelection = (
+    selected: Set<string>,
+    previousSymbols: string[],
+    nextSymbols: string[],
+    replace = false
+  ): Set<string> => {
+    if (nextSymbols.length === 0) return new Set()
+
+    const shouldSelectAll =
+      replace ||
+      previousSymbols.length === 0 ||
+      selected.size === 0 ||
+      isCompleteSelection(selected, previousSymbols)
+
+    if (shouldSelectAll) return new Set(nextSymbols)
+
+    const nextSymbolSet = new Set(nextSymbols)
+    const filtered = [...selected].filter((symbol) => nextSymbolSet.has(symbol))
+    return new Set(filtered.length > 0 ? filtered : nextSymbols)
+  }
+
+  const syncAvailableSymbols = (symbols: string[], replace = false) => {
+    const previousSymbols = allSymbols.current
+    const source = replace ? symbols : [...allSymbols.current, ...symbols]
+    const sorted = [...new Set(source)].sort()
+    allSymbols.update(() => sorted)
+
+    selectedSymbols.update((selected) =>
+      reconcileSymbolSelection(selected, previousSymbols, sorted, replace)
+    )
+    selectedAssetChartSymbols.update((selected) =>
+      reconcileSymbolSelection(selected, previousSymbols, sorted, replace)
+    )
+    selectedMethodChartSymbols.update((selected) =>
+      reconcileSymbolSelection(selected, previousSymbols, sorted, replace)
+    )
+  }
+
+  const aggregateSummary = (symbols: PnlSymbolSummary[]): PnlSummary => {
+    const sums = symbols.reduce(
+      (acc, row) => ({
+        counterTradePnlUsd: acc.counterTradePnlUsd + Number(row.counterTradePnlUsd),
+        onchainNettingPnlUsd: acc.onchainNettingPnlUsd + Number(row.onchainNettingPnlUsd),
+        directionalInventoryBaselinePnlUsd:
+          acc.directionalInventoryBaselinePnlUsd + Number(row.directionalInventoryBaselinePnlUsd),
+        directionalImbalanceExcessPnlUsd:
+          acc.directionalImbalanceExcessPnlUsd + Number(row.directionalImbalanceExcessPnlUsd),
+        matchedLotCount: acc.matchedLotCount + row.matchedLotCount,
+        onchainFillCount: acc.onchainFillCount + row.onchainFillCount,
+        offchainFillCount: acc.offchainFillCount + row.offchainFillCount,
+        unmatchedOffchainFillCount: acc.unmatchedOffchainFillCount + row.unmatchedOffchainFillCount,
+        matchedShares: acc.matchedShares + Number(row.matchedShares),
+        unmatchedOffchainShares: acc.unmatchedOffchainShares + Number(row.unmatchedOffchainShares)
+      }),
+      {
+        counterTradePnlUsd: 0,
+        onchainNettingPnlUsd: 0,
+        directionalInventoryBaselinePnlUsd: 0,
+        directionalImbalanceExcessPnlUsd: 0,
+        matchedLotCount: 0,
+        onchainFillCount: 0,
+        offchainFillCount: 0,
+        unmatchedOffchainFillCount: 0,
+        matchedShares: 0,
+        unmatchedOffchainShares: 0
+      }
+    )
+    const directional =
+      sums.directionalInventoryBaselinePnlUsd + sums.directionalImbalanceExcessPnlUsd
+    const realized =
+      sums.counterTradePnlUsd + sums.onchainNettingPnlUsd + sums.directionalImbalanceExcessPnlUsd
+
+    return {
+      counterTradePnlUsd: moneyText(sums.counterTradePnlUsd),
+      onchainNettingPnlUsd: moneyText(sums.onchainNettingPnlUsd),
+      directionalInventoryBaselinePnlUsd: moneyText(sums.directionalInventoryBaselinePnlUsd),
+      directionalImbalanceExcessPnlUsd: moneyText(sums.directionalImbalanceExcessPnlUsd),
+      directionalExposurePnlUsd: moneyText(directional),
+      realizedPnlUsd: moneyText(realized),
+      totalPnlUsd: moneyText(realized + sums.directionalInventoryBaselinePnlUsd),
+      inventoryDriftShares: '0',
+      inventoryDriftUsd: moneyText(sums.directionalInventoryBaselinePnlUsd),
+      openLongShares: '0',
+      openShortShares: '0',
+      matchedLotCount: sums.matchedLotCount,
+      onchainFillCount: sums.onchainFillCount,
+      offchainFillCount: sums.offchainFillCount,
+      openLotCount: 0,
+      unmatchedOffchainFillCount: sums.unmatchedOffchainFillCount,
+      matchedShares: moneyText(sums.matchedShares),
+      onchainNotionalUsd: moneyText(sums.matchedShares * 42),
+      offchainNotionalUsd: moneyText(sums.matchedShares * 41.9),
+      unmatchedOffchainShares: moneyText(sums.unmatchedOffchainShares),
+      unmatchedOffchainNotionalUsd: moneyText(sums.unmatchedOffchainShares * 55)
+    }
+  }
+
+  const loadSyntheticPnl = () => {
+    const selectedEntries = syntheticEntriesForCurrentFilter()
+    const selectedSymbolRows = syntheticSymbolRowsForCurrentFilter(selectedEntries)
+
+    report.update(() => ({
+      ...syntheticPnlDashboard.report,
+      summary: aggregateSummary(selectedSymbolRows),
+      symbols: selectedSymbolRows,
+      entries: selectedEntries,
+      total: selectedEntries.length,
+      hasMore: false
+    }))
+    total.update(() => selectedEntries.length)
+    entries.update(() => selectedEntries)
+    syncAvailableSymbols(
+      syntheticPnlDashboard.report.symbols.map((row) => row.symbol),
+      true
+    )
+    error.update(() => null)
+  }
+
+  const fetchPnl = async () => {
+    const seq = ++fetchSeq
+
+    if (dataMode.current === 'synthetic') {
+      loadSyntheticPnl()
+      return
+    }
+
+    loading.update(() => true)
+    error.update(() => null)
+    const requestFromDate = fromDate.current
+    const requestToDate = toDate.current
+    lastRequestedDateRangeKey = dateRangeKey(requestFromDate, requestToDate)
+
+    try {
+      const data = await fetchPnlReport({
+        limit: PNL_ENTRY_LIMIT,
+        offset: 0,
+        symbols: selectedSymbols.current,
+        fromDate: requestFromDate,
+        toDate: requestToDate,
+        dayFilter: dayFilter.current
+      })
+
+      if (seq !== fetchSeq) return
+
+      report.update(() => data)
+      total.update(() => data.total)
+      entries.update(() => data.entries)
+
+      syncAvailableSymbols(data.symbolUniverse ?? data.symbols.map((summary) => summary.symbol))
+    } catch (fetchError) {
+      if (seq !== fetchSeq) return
+
+      error.update(() => (fetchError instanceof Error ? fetchError.message : 'Unknown error'))
+    } finally {
+      if (seq === fetchSeq) loading.update(() => false)
+    }
+  }
+
+  const refresh = () => {
+    void fetchPnl()
+  }
+
+  const handleSymbolChange = (selected: Set<string>) => {
+    selectedSymbols.update(() => (selected.size === 0 ? new Set(allSymbols.current) : selected))
+    void fetchPnl()
+  }
+
+  const clearFilters = () => {
+    selectedSymbols.update(() => new Set(allSymbols.current))
+    void fetchPnl()
+  }
+
+  const handleAssetChartSymbolChange = (selected: Set<string>) => {
+    selectedAssetChartSymbols.update(() => selected)
+  }
+
+  const handleAssetChartStreamChange = (selected: Set<string>) => {
+    selectedAssetChartStreams.update(() => new Set([...selected].filter(isPnlStreamKey)))
+  }
+
+  const handleMethodChartSymbolChange = (selected: Set<string>) => {
+    selectedMethodChartSymbols.update(() => selected)
+  }
+
+  const handleMethodChartStreamChange = (selected: Set<string>) => {
+    selectedMethodChartStreams.update(() => new Set([...selected].filter(isPnlStreamKey)))
+  }
+
+  const setDayFilter = (filter: 'all' | 'weekday' | 'weekend') => {
+    dayFilter.update(() => filter)
+    refresh()
+  }
+
+  const setDateRange = (side: 'from' | 'to', value: string) => {
+    const nextDate = clampDate(value)
+
+    selectedPreset.update(() => 'custom')
+    if (side === 'from') {
+      fromDate.update(() => nextDate)
+      if (nextDate > toDate.current) {
+        toDate.update(() => nextDate)
+      }
+    } else {
+      toDate.update(() => nextDate)
+      if (nextDate < fromDate.current) {
+        fromDate.update(() => nextDate)
+      }
+    }
+    refresh()
+  }
+
+  const openDatePicker = (input: HTMLInputElement) => {
+    try {
+      input.showPicker()
+    } catch {
+      // Some browsers only allow showPicker from direct pointer activation.
+    }
+  }
+
+  const applyRangePreset = (preset: RangePreset) => {
+    selectedPreset.update(() => preset)
+    fromDate.update(() => presetStart(preset))
+    toDate.update(() => availableEndDate)
+    refresh()
+  }
+
+  const presetButtons: { value: Exclude<RangePreset, 'custom'>; label: string }[] = [
+    { value: '1w', label: '1W' },
+    { value: '1m', label: '1M' },
+    { value: 'ytd', label: 'YTD' },
+    { value: '1y', label: '1Y' },
+    { value: 'all', label: 'All' }
+  ]
+
+  const hasFilters = $derived(
+    allSymbols.current.length > 0 &&
+      !isCompleteSelection(selectedSymbols.current, allSymbols.current)
+  )
+
+  $effect(() => {
+    if (!availableStartDate || !availableEndDate) return
+
+    const nextFrom =
+      selectedPreset.current === 'custom'
+        ? clampDate(fromDate.current)
+        : presetStart(selectedPreset.current)
+    const nextTo =
+      selectedPreset.current === 'custom' ? clampDate(toDate.current) : availableEndDate
+
+    const nextRangeKey = dateRangeKey(nextFrom, nextTo)
+    if (nextRangeKey === dateRangeKey(fromDate.current, toDate.current)) return
+
+    fromDate.update(() => nextFrom)
+    toDate.update(() => nextTo)
+    if (nextRangeKey !== lastRequestedDateRangeKey) void fetchPnl()
+  })
+
+  onMount(() => {
+    void fetchPnl()
+    const interval = setInterval(() => {
+      void fetchPnl()
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      clearInterval(interval)
+    }
+  })
+
+  const pnlColor = (value: string): string => {
+    const comparison = decimalCompare(value, '0')
+
+    if (comparison > 0) {
+      return 'text-green-500'
+    }
+
+    if (comparison < 0) {
+      return 'text-red-500'
+    }
+
+    return 'text-muted-foreground'
+  }
+
+  const directionColor = (direction: string): string =>
+    direction.toLowerCase() === 'buy' ? 'text-green-500' : 'text-red-500'
+
+  const fmtUsd = (value: string): string => `$${formatDecimal(value, 2)}`
+  const fmtSignedUsd = (value: string): string => {
+    const prefix = decimalCompare(value, '0') > 0 ? '+' : ''
+    return `${prefix}${fmtUsd(value)}`
+  }
+  const fmtShares = (value: string): string => formatDecimal(value, 4)
+  const moneyText = (value: number): string => value.toFixed(2).replace(/\.?0+$/u, '')
+  const fmtDuration = (seconds: number): string => {
+    if (seconds < 60) return `${String(seconds)}s`
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    return remainingSeconds === 0
+      ? `${String(minutes)}m`
+      : `${String(minutes)}m ${String(remainingSeconds)}s`
+  }
+  const fmtCount = (value: number): string => new Intl.NumberFormat('en-US').format(value)
+  const fmtMaybeUtc = (value: string | null): string => (value === null ? 'n/a' : formatUtc(value))
+
+  const shortId = (id: string): string => {
+    if (id.length <= 18) return id
+    return `${id.slice(0, 8)}...${id.slice(-6)}`
+  }
+
+  const chartSymbolUniverse = $derived(
+    allSymbols.current.length > 0 ? allSymbols.current : defaultChartSymbols
+  )
+  const chartSymbolOptions = $derived(
+    chartSymbolUniverse.map((symbol) => ({
+      value: symbol,
+      label: symbol
+    }))
+  )
+  const selectedAssetChartSymbolValues = $derived(
+    new Set(chartSymbolUniverse.filter((symbol) => selectedAssetChartSymbols.current.has(symbol)))
+  )
+  const assetChartSymbols = $derived(
+    chartSymbolUniverse.filter((symbol) => selectedAssetChartSymbols.current.has(symbol))
+  )
+  const selectedAssetChartStreamValues = $derived(
+    new Set<string>(STREAM_KEYS.filter((stream) => selectedAssetChartStreams.current.has(stream)))
+  )
+  const assetChartStreams = $derived(
+    STREAM_KEYS.filter((stream) => selectedAssetChartStreams.current.has(stream))
+  )
+  const selectedMethodChartSymbolValues = $derived(
+    new Set(chartSymbolUniverse.filter((symbol) => selectedMethodChartSymbols.current.has(symbol)))
+  )
+  const methodChartSymbols = $derived(
+    chartSymbolUniverse.filter((symbol) => selectedMethodChartSymbols.current.has(symbol))
+  )
+  const selectedMethodChartStreamValues = $derived(
+    new Set<string>(STREAM_KEYS.filter((stream) => selectedMethodChartStreams.current.has(stream)))
+  )
+  const methodChartStreams = $derived(
+    STREAM_KEYS.filter((stream) => selectedMethodChartStreams.current.has(stream))
+  )
+
+  const chartWindowSource = $derived(report.current?.windows ?? syntheticPnlDashboard.windows)
+  const chartWindows = $derived(
+    chartWindowSource.filter(
+      (window) => matchesDayFilter(window.isWeekend) && matchesDateRange(dateKey(window.startAt))
+    )
+  )
+
+  type BucketCadence = 'day' | 'week' | 'month'
+
+  type BucketWindow = {
+    key: string
+    label: string
+    windows: PnlWindow[]
+  }
+
+  type RawBarSegment = {
+    key: string
+    label: string
+    value: number
+    color: string
+  }
+
+  type BarSegment = RawBarSegment & {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+
+  type BarRow = {
+    key: string
+    label: string
+    labelX: number
+    total: number
+    segments: BarSegment[]
+  }
+
+  type AreaPoint = {
+    x: number
+    y0: number
+    y1: number
+  }
+
+  type AreaLayer = {
+    key: string
+    label: string
+    color: string
+    path: string
+    points: AreaPoint[]
+  }
+
+  type AreaLabel = {
+    key: string
+    label: string
+    x: number
+  }
+
+  type AreaLayout = {
+    layers: AreaLayer[]
+    labels: AreaLabel[]
+    zeroY: number
+    min: number
+    max: number
+  }
+
+  const barChartWidth = 860
+  const barChartHeight = 330
+  const barChartViewBox = ['0', '0', String(barChartWidth), String(barChartHeight)].join(' ')
+  const barPadX = 92
+  const barPadTop = 24
+  const barPadBottom = 50
+  const labelY = barChartHeight - 18
+  const rotateLabel = (x: number): string => `rotate(-45 ${String(x)} ${String(labelY)})`
+
+  const assetColor = (index: number): string => assetColors[index % assetColors.length] ?? '#94a3b8'
+  const assetColorForSymbol = (symbol: string): string =>
+    assetColor(Math.max(0, chartSymbolUniverse.indexOf(symbol)))
+
+  const selectedRangeDays = $derived(
+    Math.floor(
+      Math.abs(dateFromIso(toDate.current).getTime() - dateFromIso(fromDate.current).getTime()) /
+        MS_PER_DAY
+    ) + 1
+  )
+
+  const bucketCadence = $derived<BucketCadence>(
+    selectedRangeDays > 183 ? 'month' : selectedRangeDays > 31 ? 'week' : 'day'
+  )
+
+  const startOfWeek = (value: string): string => {
+    const date = dateFromIso(value)
+    const dayOffset = (date.getUTCDay() + 6) % 7
+    date.setUTCDate(date.getUTCDate() - dayOffset)
+    return isoDate(date)
+  }
+
+  const bucketKeyFor = (window: PnlWindow, cadence: BucketCadence): string => {
+    const key = dateKey(window.startAt)
+    if (cadence === 'month') return key.slice(0, 7)
+    if (cadence === 'week') return startOfWeek(key)
+    return key
+  }
+
+  const monthLabelFor = (key: string): string => {
+    const date = new Date(`${key}-01T00:00:00.000Z`)
+    return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit', timeZone: 'UTC' })
+  }
+
+  const weekLabelFor = (key: string): string => {
+    const weekStart = dateFromIso(key)
+    const weekEnd = dateFromIso(key)
+    weekEnd.setUTCDate(weekStart.getUTCDate() + 6)
+
+    return `${key.slice(5)}-${isoDate(weekEnd).slice(5)}`
+  }
+
+  const bucketLabelFor = (key: string, cadence: BucketCadence): string => {
+    if (cadence === 'month') return monthLabelFor(key)
+    if (cadence === 'week') return weekLabelFor(key)
+    return key.slice(5)
+  }
+
+  const bucketWindows = (windows: PnlWindow[], cadence: BucketCadence): BucketWindow[] => {
+    const buckets = new Map<string, BucketWindow>()
+
+    for (const window of windows) {
+      const key = bucketKeyFor(window, cadence)
+      const bucket = buckets.get(key)
+
+      if (bucket) {
+        bucket.windows.push(window)
+      } else {
+        buckets.set(key, {
+          key,
+          label: bucketLabelFor(key, cadence),
+          windows: [window]
+        })
+      }
+    }
+
+    return [...buckets.values()]
+  }
+
+  const windowValueForSymbol = (
+    window: PnlWindow,
+    symbol: string,
+    streams: PnlStreamKey[]
+  ): number => {
+    const row = window.symbols.find((candidate) => candidate.symbol === symbol)
+    if (!row) return 0
+
+    return streams.reduce((totalValue, stream) => totalValue + Number(row[stream]), 0)
+  }
+
+  const layoutVerticalStackBars = (
+    rows: { key: string; label: string; segments: RawBarSegment[] }[]
+  ): BarRow[] => {
+    const maxAbs = Math.max(
+      1,
+      ...rows.flatMap((row) => {
+        const positive = row.segments
+          .filter((segment) => segment.value > 0)
+          .reduce((totalValue, segment) => totalValue + segment.value, 0)
+        const negative = Math.abs(
+          row.segments
+            .filter((segment) => segment.value < 0)
+            .reduce((totalValue, segment) => totalValue + segment.value, 0)
+        )
+
+        return [positive, negative]
+      })
+    )
+    const plotWidth = barChartWidth - barPadX * 2
+    const plotHeight = barChartHeight - barPadTop - barPadBottom
+    const slotWidth = rows.length > 0 ? plotWidth / rows.length : plotWidth
+    const barWidth = Math.min(34, Math.max(1, slotWidth * 0.68))
+    const zeroY = barPadTop + plotHeight / 2
+
+    return rows.map((row, rowIndex) => {
+      let positiveCursor = 0
+      let negativeCursor = 0
+      const x = barPadX + rowIndex * slotWidth + (slotWidth - barWidth) / 2
+      const segments = row.segments.map((segment) => {
+        const height = (Math.abs(segment.value) / maxAbs) * (plotHeight / 2)
+
+        if (segment.value >= 0) {
+          const y = zeroY - positiveCursor - height
+          positiveCursor += height
+          return { ...segment, x, y, width: barWidth, height }
+        }
+
+        const y = zeroY + negativeCursor
+        negativeCursor += height
+        return { ...segment, x, y, width: barWidth, height }
+      })
+
+      return {
+        key: row.key,
+        label: row.label,
+        labelX: x + barWidth / 2,
+        total: row.segments.reduce((totalValue, segment) => totalValue + segment.value, 0),
+        segments
+      }
+    })
+  }
+
+  const layoutCumulativeArea = (
+    rows: { key: string; label: string; segments: RawBarSegment[] }[]
+  ): AreaLayout => {
+    const cumulativeByKey = new Map<string, number>()
+    const cumulativeRows = rows.map((row) => ({
+      key: row.key,
+      label: row.label,
+      segments: row.segments.map((segment) => {
+        const cumulative = (cumulativeByKey.get(segment.key) ?? 0) + segment.value
+        cumulativeByKey.set(segment.key, cumulative)
+        return { ...segment, cumulative }
+      })
+    }))
+    const allValues = cumulativeRows.flatMap((row) =>
+      row.segments.map((segment) => segment.cumulative)
+    )
+    const min = Math.min(0, ...allValues)
+    const max = Math.max(0, ...allValues)
+    const range = max - min || 1
+    const plotWidth = barChartWidth - barPadX * 2
+    const plotHeight = barChartHeight - barPadTop - barPadBottom
+    const xDenominator = Math.max(1, rows.length - 1)
+    const yFor = (value: number): number => barPadTop + ((max - value) / range) * plotHeight
+    const xFor = (index: number): number =>
+      rows.length <= 1 ? barPadX + plotWidth / 2 : barPadX + (index / xDenominator) * plotWidth
+    const keys = [...new Set(rows.flatMap((row) => row.segments.map((segment) => segment.key)))]
+    const layers = keys.map((key) => {
+      const points = cumulativeRows.map((row, rowIndex) => {
+        const segment = row.segments.find((candidate) => candidate.key === key)
+        const cumulative = segment?.cumulative ?? 0
+        return {
+          x: xFor(rowIndex),
+          y0: yFor(0),
+          y1: yFor(cumulative)
+        }
+      })
+      const top = points.map((point) => `${point.x.toFixed(1)},${point.y1.toFixed(1)}`)
+      const bottom = [...points]
+        .reverse()
+        .map((point) => `${point.x.toFixed(1)},${point.y0.toFixed(1)}`)
+      const firstSegment = rows
+        .flatMap((row) => row.segments)
+        .find((segment) => segment.key === key)
+
+      return {
+        key,
+        label: firstSegment?.label ?? key,
+        color: firstSegment?.color ?? '#94a3b8',
+        path: [...top, ...bottom].join(' '),
+        points
+      }
+    })
+
+    return {
+      min,
+      max,
+      zeroY: yFor(0),
+      labels: rows.map((row, rowIndex) => ({
+        key: row.key,
+        label: row.label,
+        x: xFor(rowIndex)
+      })),
+      layers
+    }
+  }
+
+  const stackAxisLimit = (rows: BarRow[]): number =>
+    Math.max(
+      1,
+      ...rows.map((row) => {
+        const positive = row.segments
+          .filter((segment) => segment.value > 0)
+          .reduce((totalValue, segment) => totalValue + segment.value, 0)
+        const negative = Math.abs(
+          row.segments
+            .filter((segment) => segment.value < 0)
+            .reduce((totalValue, segment) => totalValue + segment.value, 0)
+        )
+
+        return Math.max(positive, negative)
+      })
+    )
+
+  const timeBuckets = $derived.by(() => bucketWindows(chartWindows, bucketCadence))
+  const barZeroY = $derived(barPadTop + (barChartHeight - barPadTop - barPadBottom) / 2)
+  const cadenceLabel = $derived(
+    bucketCadence === 'month' ? 'monthly' : bucketCadence === 'week' ? 'weekly' : 'daily'
+  )
+  const bucketSemantics = $derived(
+    bucketCadence === 'day'
+      ? 'Each bar is one calendar day of non-cumulative PnL.'
+      : `Each bar sums non-cumulative daily PnL into one ${bucketCadence}.`
+  )
+
+  const byAssetBarRows = $derived.by(() =>
+    layoutVerticalStackBars(
+      timeBuckets.map((bucket) => ({
+        key: bucket.key,
+        label: bucket.label,
+        segments: assetChartSymbols.map((symbol) => ({
+          key: symbol,
+          label: symbol,
+          value: bucket.windows.reduce(
+            (totalValue, window) =>
+              totalValue + windowValueForSymbol(window, symbol, assetChartStreams),
+            0
+          ),
+          color: assetColorForSymbol(symbol)
+        }))
+      }))
+    )
+  )
+  const byAssetBarAxisLimit = $derived(stackAxisLimit(byAssetBarRows))
+
+  const byMethodBarRows = $derived.by(() =>
+    layoutVerticalStackBars(
+      timeBuckets.map((bucket) => ({
+        key: bucket.key,
+        label: bucket.label,
+        segments: methodChartStreams.map((stream) => ({
+          key: stream,
+          label: streamLabels[stream],
+          value: bucket.windows.reduce(
+            (bucketTotal, window) =>
+              bucketTotal +
+              methodChartSymbols.reduce(
+                (symbolTotal, symbol) =>
+                  symbolTotal + windowValueForSymbol(window, symbol, [stream]),
+                0
+              ),
+            0
+          ),
+          color: streamColors[stream]
+        }))
+      }))
+    )
+  )
+  const byMethodBarAxisLimit = $derived(stackAxisLimit(byMethodBarRows))
+  const byAssetArea = $derived.by(() =>
+    layoutCumulativeArea(
+      timeBuckets.map((bucket) => ({
+        key: bucket.key,
+        label: bucket.label,
+        segments: assetChartSymbols.map((symbol) => ({
+          key: symbol,
+          label: symbol,
+          value: bucket.windows.reduce(
+            (totalValue, window) =>
+              totalValue + windowValueForSymbol(window, symbol, assetChartStreams),
+            0
+          ),
+          color: assetColorForSymbol(symbol)
+        }))
+      }))
+    )
+  )
+
+  const byMethodArea = $derived.by(() =>
+    layoutCumulativeArea(
+      timeBuckets.map((bucket) => ({
+        key: bucket.key,
+        label: bucket.label,
+        segments: methodChartStreams.map((stream) => ({
+          key: stream,
+          label: streamLabels[stream],
+          value: bucket.windows.reduce(
+            (bucketTotal, window) =>
+              bucketTotal +
+              methodChartSymbols.reduce(
+                (symbolTotal, symbol) =>
+                  symbolTotal + windowValueForSymbol(window, symbol, [stream]),
+                0
+              ),
+            0
+          ),
+          color: streamColors[stream]
+        }))
+      }))
+    )
+  )
+
+  const axisUsd = (value: number): string => {
+    const prefix = value > 0 ? '+' : ''
+    return `${prefix}$${value.toFixed(0)}`
+  }
+</script>
+
+<Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-amber-500/60">
+  <Card.Header class="shrink-0 space-y-3 pb-0">
+    <Card.Title class="flex flex-wrap items-center justify-between gap-2">
+      <span>PnL</span>
+
+      <div class="flex items-center gap-2">
+        {#if !mockMode && hasFilters}
+          <button
+            class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+            onclick={clearFilters}>All assets</button
+          >
+        {/if}
+        <button
+          class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+          onclick={refresh}
+          disabled={loading.current}
+        >
+          {loading.current ? 'Loading...' : 'Refresh'}
+        </button>
+      </div>
+    </Card.Title>
+
+    <div class="flex flex-wrap items-center gap-2 rounded-md bg-muted/30 px-2 py-1.5 text-xs">
+      {#if !mockMode && symbolOptions.length > 0}
+        <MultiSelect
+          label="Assets"
+          options={symbolOptions}
+          selected={selectedSymbols.current}
+          onchange={handleSymbolChange}
+        />
+      {/if}
+      <div class="inline-flex overflow-hidden rounded border text-xs">
+        {#each presetButtons as preset (preset.value)}
+          <button
+            class="px-2 py-1 hover:bg-accent {selectedPreset.current === preset.value
+              ? 'bg-amber-500/20 text-amber-200'
+              : 'bg-background'}"
+            onclick={() => {
+              applyRangePreset(preset.value)
+            }}
+          >
+            {preset.label}
+          </button>
+        {/each}
+      </div>
+      <label class="inline-flex items-center gap-2 rounded border bg-background px-2 py-1">
+        <span class="text-muted-foreground">From</span>
+        <input
+          class="w-32 cursor-pointer rounded bg-muted/40 px-1 py-0.5 font-mono text-xs text-foreground outline-none hover:bg-muted"
+          type="date"
+          min={availableStartDate}
+          max={toDate.current || availableEndDate}
+          value={fromDate.current}
+          onchange={(event) => {
+            setDateRange('from', event.currentTarget.value)
+          }}
+          onfocus={(event) => {
+            openDatePicker(event.currentTarget)
+          }}
+          onclick={(event) => {
+            openDatePicker(event.currentTarget)
+          }}
+        />
+      </label>
+      <label class="inline-flex items-center gap-2 rounded border bg-background px-2 py-1">
+        <span class="text-muted-foreground">To</span>
+        <input
+          class="w-32 cursor-pointer rounded bg-muted/40 px-1 py-0.5 font-mono text-xs text-foreground outline-none hover:bg-muted"
+          type="date"
+          min={fromDate.current || availableStartDate}
+          max={availableEndDate}
+          value={toDate.current}
+          onchange={(event) => {
+            setDateRange('to', event.currentTarget.value)
+          }}
+          onfocus={(event) => {
+            openDatePicker(event.currentTarget)
+          }}
+          onclick={(event) => {
+            openDatePicker(event.currentTarget)
+          }}
+        />
+      </label>
+      <div class="inline-flex overflow-hidden rounded border text-xs">
+        <button
+          class="px-2 py-1 hover:bg-accent {dayFilter.current === 'all'
+            ? 'bg-amber-500/20 text-amber-200'
+            : 'bg-background'}"
+          onclick={() => {
+            setDayFilter('all')
+          }}>All days</button
+        >
+        <button
+          class="border-l px-2 py-1 hover:bg-accent {dayFilter.current === 'weekday'
+            ? 'bg-amber-500/20 text-amber-200'
+            : 'bg-background'}"
+          onclick={() => {
+            setDayFilter('weekday')
+          }}>Weekdays</button
+        >
+        <button
+          class="border-l px-2 py-1 hover:bg-accent {dayFilter.current === 'weekend'
+            ? 'bg-amber-500/20 text-amber-200'
+            : 'bg-background'}"
+          onclick={() => {
+            setDayFilter('weekend')
+          }}>Weekends</button
+        >
+      </div>
+      <span class="text-muted-foreground">
+        Showing realized close dates {fromDate.current} to {toDate.current} as {timeBuckets.length}
+        {cadenceLabel} non-cumulative buckets. Cash values treat USD and USDC 1:1; portfolio percentage
+        return is not shown because historical NAV is not persisted.
+      </span>
+    </div>
+  </Card.Header>
+
+  <Card.Content class="relative min-h-0 flex-1 overflow-auto px-6 pt-3">
+    {#if error.current}
+      <div class="flex h-full items-center justify-center text-destructive">
+        Failed to load PnL: {error.current}
+      </div>
+    {:else if !report.current && loading.current}
+      <div class="flex h-full items-center justify-center text-muted-foreground">
+        Loading PnL...
+      </div>
+    {:else if report.current}
+      {@const summary = report.current.summary}
+
+      {#if report.current.sampleStats}
+        {@const sample = report.current.sampleStats}
+        <section class="mb-3 rounded-xl border bg-card/50 p-3">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div class="text-sm font-semibold">Database Trade Sample</div>
+              <div class="mt-1 text-xs text-muted-foreground">
+                Full unfiltered Position fill history available through the SQL JSON endpoint. Use
+                this range when choosing dashboard dates.
+              </div>
+            </div>
+            <div class="grid gap-2 text-xs sm:grid-cols-2 lg:grid-cols-5">
+              <div class="rounded border bg-background/50 px-3 py-2">
+                <div class="text-muted-foreground">First fill</div>
+                <div class="mt-1 font-mono">{fmtMaybeUtc(sample.firstAt)}</div>
+              </div>
+              <div class="rounded border bg-background/50 px-3 py-2">
+                <div class="text-muted-foreground">Last fill</div>
+                <div class="mt-1 font-mono">{fmtMaybeUtc(sample.lastAt)}</div>
+              </div>
+              <div class="rounded border bg-background/50 px-3 py-2">
+                <div class="text-muted-foreground">Total fills</div>
+                <div class="mt-1 font-mono">{fmtCount(sample.totalFillCount)}</div>
+              </div>
+              <div class="rounded border bg-background/50 px-3 py-2">
+                <div class="text-muted-foreground">On / off-chain</div>
+                <div class="mt-1 font-mono">
+                  {fmtCount(sample.onchainFillCount)} / {fmtCount(sample.offchainFillCount)}
+                </div>
+              </div>
+              <div class="rounded border bg-background/50 px-3 py-2">
+                <div class="text-muted-foreground">Assets</div>
+                <div class="mt-1 font-mono">{fmtCount(sample.symbolCount)}</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-3 flex gap-2 overflow-x-auto pb-1 text-xs">
+            {#each sample.symbols as row (row.symbol)}
+              <div class="min-w-44 rounded border bg-background/40 px-3 py-2">
+                <div class="flex items-center justify-between gap-2">
+                  <span class="font-mono font-semibold">{row.symbol}</span>
+                  <span class="font-mono text-muted-foreground"
+                    >{fmtCount(row.totalFillCount)} fills</span
+                  >
+                </div>
+                <div class="mt-1 font-mono text-[11px] text-muted-foreground">
+                  {fmtCount(row.onchainFillCount)} on / {fmtCount(row.offchainFillCount)} off
+                </div>
+                <div class="mt-1 text-[11px] text-muted-foreground">
+                  {row.firstAt?.slice(0, 10) ?? 'n/a'} to {row.lastAt?.slice(0, 10) ?? 'n/a'}
+                </div>
+              </div>
+            {/each}
+          </div>
+        </section>
+      {/if}
+
+      <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Realized Gross PnL</div>
+          <div class="mt-1 font-mono text-xl font-semibold {pnlColor(summary.totalPnlUsd)}">
+            {fmtSignedUsd(summary.totalPnlUsd)}
+          </div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Counter-Trade PnL</div>
+          <div class="mt-1 font-mono text-xl font-semibold {pnlColor(summary.counterTradePnlUsd)}">
+            {fmtSignedUsd(summary.counterTradePnlUsd)}
+          </div>
+          <div class="mt-1 text-xs text-muted-foreground">Broker hedge stream</div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">On-Chain Netting PnL</div>
+          <div
+            class="mt-1 font-mono text-xl font-semibold {pnlColor(summary.onchainNettingPnlUsd)}"
+          >
+            {fmtSignedUsd(summary.onchainNettingPnlUsd)}
+          </div>
+          <div class="mt-1 text-xs text-muted-foreground">
+            Users passively crossed open inventory
+          </div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Directional Realized PnL</div>
+          <div
+            class="mt-1 font-mono text-xl font-semibold {pnlColor(
+              summary.directionalImbalanceExcessPnlUsd
+            )}"
+          >
+            {fmtSignedUsd(summary.directionalImbalanceExcessPnlUsd)}
+          </div>
+          <div class="mt-1 text-xs text-muted-foreground">
+            Closed delayed or offchain-origin exposure
+          </div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Baseline Drift PnL</div>
+          <div
+            class="mt-1 font-mono text-xl font-semibold {pnlColor(
+              summary.directionalInventoryBaselinePnlUsd
+            )}"
+          >
+            {fmtSignedUsd(summary.directionalInventoryBaselinePnlUsd)}
+          </div>
+          <div class="mt-1 text-xs text-muted-foreground">Requires historical snapshots</div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Directional Realized Total</div>
+          <div
+            class="mt-1 font-mono text-xl font-semibold {pnlColor(
+              summary.directionalExposurePnlUsd
+            )}"
+          >
+            {fmtSignedUsd(summary.directionalExposurePnlUsd)}
+          </div>
+          <div class="mt-1 text-xs text-muted-foreground">
+            Open long {fmtShares(summary.openLongShares)} / short {fmtShares(
+              summary.openShortShares
+            )}
+          </div>
+        </div>
+
+        <div class="rounded-lg border bg-card/60 p-3">
+          <div class="text-xs text-muted-foreground">Open Replay Inventory</div>
+          <div class="mt-1 font-mono text-xl font-semibold text-muted-foreground">
+            {fmtShares(summary.inventoryDriftShares)}
+          </div>
+          <div class="mt-1 font-mono text-xs text-muted-foreground">
+            cost basis {fmtUsd(summary.inventoryDriftUsd)}
+          </div>
+        </div>
+      </div>
+
+      {#if report.current.warnings.length > 0}
+        <details
+          class="mt-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100"
+        >
+          <summary class="cursor-pointer select-none font-semibold">
+            Debug ({report.current.warnings.length})
+          </summary>
+          <div class="mt-3 space-y-1 font-mono text-xs leading-5">
+            {#each report.current.warnings as warning (warning)}
+              <div class="break-words">{warning}</div>
+            {/each}
+          </div>
+        </details>
+      {/if}
+
+      <details class="mt-3 rounded-xl border bg-card/40 p-3 text-sm">
+        <summary class="cursor-pointer select-none font-semibold">
+          Math / formula reference
+        </summary>
+        <div class="mt-3 grid gap-3 lg:grid-cols-2">
+          {#each formulaRows as formula (formula.label)}
+            <div class="rounded-lg border bg-background/50 p-3">
+              <div class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {formula.label}
+              </div>
+              <code class="mt-2 block rounded bg-muted/50 px-2 py-1 font-mono text-xs">
+                {formula.formula}
+              </code>
+              <p class="mt-2 text-xs leading-5 text-muted-foreground">
+                {formula.note}
+              </p>
+            </div>
+          {/each}
+        </div>
+      </details>
+
+      <div class="mt-4 grid gap-4 xl:grid-cols-2">
+        <section class="overflow-hidden rounded-xl border bg-card/40">
+          <div class="flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+            <div>
+              <div class="text-sm font-semibold">PnL by Asset per Time Unit</div>
+              <div class="text-xs text-muted-foreground">
+                {bucketSemantics} Assets are stacked using selected streams.
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+              <MultiSelect
+                label="Assets"
+                options={chartSymbolOptions}
+                selected={selectedAssetChartSymbolValues}
+                onchange={handleAssetChartSymbolChange}
+              />
+              <MultiSelect
+                label="Streams"
+                options={streamOptions}
+                selected={selectedAssetChartStreamValues}
+                onchange={handleAssetChartStreamChange}
+              />
+              {#each assetChartSymbols as symbol (symbol)}
+                <span class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5">
+                  <span class="h-2 w-2 rounded-full" style:background={assetColorForSymbol(symbol)}
+                  ></span>
+                  {symbol}
+                </span>
+              {/each}
+            </div>
+          </div>
+
+          <div class="overflow-x-auto p-3">
+            <svg viewBox={barChartViewBox} class="h-80 min-w-[860px] w-full">
+              <rect
+                x="0"
+                y="0"
+                width={barChartWidth}
+                height={barChartHeight}
+                rx="14"
+                class="fill-background/30"
+              />
+              <line
+                x1={barPadX}
+                x2={barChartWidth - barPadX}
+                y1={barZeroY}
+                y2={barZeroY}
+                class="stroke-border"
+              />
+              <line
+                x1={barPadX}
+                x2={barPadX}
+                y1={barPadTop}
+                y2={barChartHeight - barPadBottom}
+                class="stroke-border"
+              />
+              <text x="8" y={barPadTop + 4} class="fill-muted-foreground text-[11px]"
+                >{axisUsd(byAssetBarAxisLimit)}</text
+              >
+              <text x="8" y={barZeroY + 4} class="fill-muted-foreground text-[11px]">$0</text>
+              <text
+                x="8"
+                y={barChartHeight - barPadBottom}
+                class="fill-muted-foreground text-[11px]">{axisUsd(-byAssetBarAxisLimit)}</text
+              >
+
+              {#each byAssetBarRows as row (row.key)}
+                {#each row.segments as segment (segment.key)}
+                  {#if segment.height > 0.1}
+                    <rect
+                      x={segment.x}
+                      y={segment.y}
+                      width={segment.width}
+                      height={segment.height}
+                      rx="3"
+                      fill={segment.color}
+                      opacity="0.82"
+                    />
+                  {/if}
+                {/each}
+                <text
+                  x={row.labelX}
+                  y={labelY}
+                  text-anchor="middle"
+                  transform={rotateLabel(row.labelX)}
+                  class="fill-muted-foreground text-[10px]"
+                >
+                  {row.label}
+                </text>
+              {/each}
+            </svg>
+          </div>
+        </section>
+
+        <section class="overflow-hidden rounded-xl border bg-card/40">
+          <div class="flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+            <div>
+              <div class="text-sm font-semibold">PnL by PnL-Stream per Time Unit</div>
+              <div class="text-xs text-muted-foreground">
+                {bucketSemantics} PnL methods are stacked for selected assets.
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+              <MultiSelect
+                label="Assets"
+                options={chartSymbolOptions}
+                selected={selectedMethodChartSymbolValues}
+                onchange={handleMethodChartSymbolChange}
+              />
+              <MultiSelect
+                label="Streams"
+                options={streamOptions}
+                selected={selectedMethodChartStreamValues}
+                onchange={handleMethodChartStreamChange}
+              />
+              {#each methodChartStreams as stream (stream)}
+                <span class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5">
+                  <span class="h-2 w-2 rounded-full" style:background={streamColors[stream]}></span>
+                  {streamLabels[stream]}
+                </span>
+              {/each}
+            </div>
+          </div>
+
+          <div class="overflow-x-auto p-3">
+            <svg viewBox={barChartViewBox} class="h-80 min-w-[860px] w-full">
+              <rect
+                x="0"
+                y="0"
+                width={barChartWidth}
+                height={barChartHeight}
+                rx="14"
+                class="fill-background/30"
+              />
+              <line
+                x1={barPadX}
+                x2={barChartWidth - barPadX}
+                y1={barZeroY}
+                y2={barZeroY}
+                class="stroke-border"
+              />
+              <line
+                x1={barPadX}
+                x2={barPadX}
+                y1={barPadTop}
+                y2={barChartHeight - barPadBottom}
+                class="stroke-border"
+              />
+              <text x="8" y={barPadTop + 4} class="fill-muted-foreground text-[11px]"
+                >{axisUsd(byMethodBarAxisLimit)}</text
+              >
+              <text x="8" y={barZeroY + 4} class="fill-muted-foreground text-[11px]">$0</text>
+              <text
+                x="8"
+                y={barChartHeight - barPadBottom}
+                class="fill-muted-foreground text-[11px]">{axisUsd(-byMethodBarAxisLimit)}</text
+              >
+
+              {#each byMethodBarRows as row (row.key)}
+                {#each row.segments as segment (segment.key)}
+                  {#if segment.height > 0.1}
+                    <rect
+                      x={segment.x}
+                      y={segment.y}
+                      width={segment.width}
+                      height={segment.height}
+                      rx="3"
+                      fill={segment.color}
+                      opacity="0.82"
+                    />
+                  {/if}
+                {/each}
+                <text
+                  x={row.labelX}
+                  y={labelY}
+                  text-anchor="middle"
+                  transform={rotateLabel(row.labelX)}
+                  class="fill-muted-foreground text-[10px]"
+                >
+                  {row.label}
+                </text>
+              {/each}
+            </svg>
+          </div>
+        </section>
+      </div>
+
+      <div class="mt-4 grid gap-4 xl:grid-cols-2">
+        <section class="overflow-hidden rounded-xl border bg-card/40">
+          <div class="flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+            <div>
+              <div class="text-sm font-semibold">Cumulative PnL by Asset</div>
+              <div class="text-xs text-muted-foreground">
+                Cumulative PnL on the y-axis using the same assets and streams as the asset bar
+                chart.
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+              <MultiSelect
+                label="Assets"
+                options={chartSymbolOptions}
+                selected={selectedAssetChartSymbolValues}
+                onchange={handleAssetChartSymbolChange}
+              />
+              <MultiSelect
+                label="Streams"
+                options={streamOptions}
+                selected={selectedAssetChartStreamValues}
+                onchange={handleAssetChartStreamChange}
+              />
+            </div>
+          </div>
+
+          <div class="overflow-x-auto p-3">
+            <svg viewBox={barChartViewBox} class="h-80 min-w-[860px] w-full">
+              <rect
+                x="0"
+                y="0"
+                width={barChartWidth}
+                height={barChartHeight}
+                rx="14"
+                class="fill-background/30"
+              />
+              <line
+                x1={barPadX}
+                x2={barChartWidth - barPadX}
+                y1={byAssetArea.zeroY}
+                y2={byAssetArea.zeroY}
+                class="stroke-border"
+              />
+              <line
+                x1={barPadX}
+                x2={barPadX}
+                y1={barPadTop}
+                y2={barChartHeight - barPadBottom}
+                class="stroke-border"
+              />
+              <text x="8" y={barPadTop + 4} class="fill-muted-foreground text-[11px]"
+                >{axisUsd(byAssetArea.max)}</text
+              >
+              <text x="8" y={byAssetArea.zeroY + 4} class="fill-muted-foreground text-[11px]"
+                >$0</text
+              >
+              <text
+                x="8"
+                y={barChartHeight - barPadBottom}
+                class="fill-muted-foreground text-[11px]">{axisUsd(byAssetArea.min)}</text
+              >
+
+              {#each byAssetArea.layers as layer (layer.key)}
+                <polygon points={layer.path} fill={layer.color} opacity="0.3" />
+                <polyline
+                  points={layer.points
+                    .map((point) => `${point.x.toFixed(1)},${point.y1.toFixed(1)}`)
+                    .join(' ')}
+                  fill="none"
+                  stroke={layer.color}
+                  stroke-width="1.6"
+                  opacity="0.9"
+                />
+              {/each}
+              {#each byAssetArea.labels as label (label.key)}
+                <text
+                  x={label.x}
+                  y={labelY}
+                  text-anchor="middle"
+                  transform={rotateLabel(label.x)}
+                  class="fill-muted-foreground text-[10px]"
+                >
+                  {label.label}
+                </text>
+              {/each}
+            </svg>
+          </div>
+        </section>
+
+        <section class="overflow-hidden rounded-xl border bg-card/40">
+          <div class="flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2">
+            <div>
+              <div class="text-sm font-semibold">Cumulative PnL by PnL-Stream</div>
+              <div class="text-xs text-muted-foreground">
+                Cumulative PnL on the y-axis using the same assets and streams as the stream bar
+                chart.
+              </div>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs">
+              <MultiSelect
+                label="Assets"
+                options={chartSymbolOptions}
+                selected={selectedMethodChartSymbolValues}
+                onchange={handleMethodChartSymbolChange}
+              />
+              <MultiSelect
+                label="Streams"
+                options={streamOptions}
+                selected={selectedMethodChartStreamValues}
+                onchange={handleMethodChartStreamChange}
+              />
+            </div>
+          </div>
+
+          <div class="overflow-x-auto p-3">
+            <svg viewBox={barChartViewBox} class="h-80 min-w-[860px] w-full">
+              <rect
+                x="0"
+                y="0"
+                width={barChartWidth}
+                height={barChartHeight}
+                rx="14"
+                class="fill-background/30"
+              />
+              <line
+                x1={barPadX}
+                x2={barChartWidth - barPadX}
+                y1={byMethodArea.zeroY}
+                y2={byMethodArea.zeroY}
+                class="stroke-border"
+              />
+              <line
+                x1={barPadX}
+                x2={barPadX}
+                y1={barPadTop}
+                y2={barChartHeight - barPadBottom}
+                class="stroke-border"
+              />
+              <text x="8" y={barPadTop + 4} class="fill-muted-foreground text-[11px]"
+                >{axisUsd(byMethodArea.max)}</text
+              >
+              <text x="8" y={byMethodArea.zeroY + 4} class="fill-muted-foreground text-[11px]"
+                >$0</text
+              >
+              <text
+                x="8"
+                y={barChartHeight - barPadBottom}
+                class="fill-muted-foreground text-[11px]">{axisUsd(byMethodArea.min)}</text
+              >
+
+              {#each byMethodArea.layers as layer (layer.key)}
+                <polygon points={layer.path} fill={layer.color} opacity="0.3" />
+                <polyline
+                  points={layer.points
+                    .map((point) => `${point.x.toFixed(1)},${point.y1.toFixed(1)}`)
+                    .join(' ')}
+                  fill="none"
+                  stroke={layer.color}
+                  stroke-width="1.6"
+                  opacity="0.9"
+                />
+              {/each}
+              {#each byMethodArea.labels as label (label.key)}
+                <text
+                  x={label.x}
+                  y={labelY}
+                  text-anchor="middle"
+                  transform={rotateLabel(label.x)}
+                  class="fill-muted-foreground text-[10px]"
+                >
+                  {label.label}
+                </text>
+              {/each}
+            </svg>
+          </div>
+        </section>
+      </div>
+
+      {#if timeBuckets.length === 0}
+        <div class="mt-4 rounded-xl border bg-card/40 p-4 text-sm text-muted-foreground">
+          No PnL chart buckets for the selected asset/date filters.
+        </div>
+      {/if}
+
+      <div class="mt-4 grid gap-4 lg:grid-cols-[0.9fr_1.4fr]">
+        <section class="min-h-0 overflow-hidden rounded-lg border">
+          <div class="border-b px-3 py-2 text-sm font-semibold">By Asset</div>
+          <div class="max-h-80 overflow-auto">
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.Head>Asset</Table.Head>
+                  <Table.Head class="text-right">Realized</Table.Head>
+                  <Table.Head class="text-right">Counter</Table.Head>
+                  <Table.Head class="text-right">On-chain</Table.Head>
+                  <Table.Head class="text-right">Directional</Table.Head>
+                  <Table.Head class="text-right">Baseline Drift</Table.Head>
+                  <Table.Head class="text-right">Lots</Table.Head>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {#each report.current.symbols as row (row.symbol)}
+                  <Table.Row>
+                    <Table.Cell class="font-mono text-xs font-medium">{row.symbol}</Table.Cell>
+                    <Table.Cell class="text-right font-mono text-xs {pnlColor(row.totalPnlUsd)}">
+                      {fmtSignedUsd(row.totalPnlUsd)}
+                    </Table.Cell>
+                    <Table.Cell
+                      class="text-right font-mono text-xs {pnlColor(row.counterTradePnlUsd)}"
+                    >
+                      {fmtSignedUsd(row.counterTradePnlUsd)}
+                    </Table.Cell>
+                    <Table.Cell
+                      class="text-right font-mono text-xs {pnlColor(row.onchainNettingPnlUsd)}"
+                    >
+                      {fmtSignedUsd(row.onchainNettingPnlUsd)}
+                    </Table.Cell>
+                    <Table.Cell
+                      class="text-right font-mono text-xs {pnlColor(
+                        row.directionalImbalanceExcessPnlUsd
+                      )}"
+                    >
+                      {fmtSignedUsd(row.directionalImbalanceExcessPnlUsd)}
+                    </Table.Cell>
+                    <Table.Cell
+                      class="text-right font-mono text-xs {pnlColor(
+                        row.directionalInventoryBaselinePnlUsd
+                      )}"
+                    >
+                      {fmtSignedUsd(row.directionalInventoryBaselinePnlUsd)}
+                    </Table.Cell>
+                    <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
+                      {row.matchedLotCount}
+                    </Table.Cell>
+                  </Table.Row>
+                {/each}
+              </Table.Body>
+            </Table.Root>
+          </div>
+        </section>
+
+        <section class="min-h-0 overflow-hidden rounded-lg border">
+          <div class="flex items-center justify-between gap-2 border-b px-3 py-2">
+            <span class="text-sm font-semibold">Linked Lots</span>
+            <span class="font-mono text-xs text-muted-foreground">
+              {fmtCount(total.current)} matched lots
+            </span>
+          </div>
+          <div class="max-h-80 overflow-auto">
+            {#if entries.current.length === 0 && !loading.current}
+              <div class="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                No matched PnL lots yet
+              </div>
+            {:else}
+              <Table.Root>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.Head class="text-right">Closed</Table.Head>
+                    <Table.Head>Asset</Table.Head>
+                    <Table.Head class="text-right">Bucket</Table.Head>
+                    <Table.Head class="text-right">Flow</Table.Head>
+                    <Table.Head class="text-right">Lag</Table.Head>
+                    <Table.Head class="text-right">Shares</Table.Head>
+                    <Table.Head class="text-right">Spread</Table.Head>
+                    <Table.Head class="text-right">PnL</Table.Head>
+                    <Table.Head class="text-right">IDs</Table.Head>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {#each entries.current as entry, idx (`${entry.openingFillId}-${entry.closingFillId}-${String(idx)}`)}
+                    <Table.Row class={idx % 2 === 0 ? 'bg-muted/40' : ''}>
+                      <Table.Cell class="text-right font-mono text-xs text-muted-foreground">
+                        {formatUtc(entry.closedAt)}
+                      </Table.Cell>
+                      <Table.Cell class="font-mono text-xs font-medium">{entry.symbol}</Table.Cell>
+                      <Table.Cell class="text-right font-mono text-[11px] text-muted-foreground">
+                        {entry.pnlBucket}
+                      </Table.Cell>
+                      <Table.Cell class="text-right text-xs">
+                        <span class={directionColor(entry.openingDirection)}
+                          >{entry.openingDirection}</span
+                        >
+                        <span class="text-muted-foreground"> / </span>
+                        <span class={directionColor(entry.closingDirection)}
+                          >{entry.closingDirection}</span
+                        >
+                      </Table.Cell>
+                      <Table.Cell
+                        class="text-right font-mono text-[11px] {entry.delayedCounterTrade
+                          ? 'text-amber-300'
+                          : 'text-muted-foreground'}"
+                      >
+                        {fmtDuration(entry.elapsedSeconds)}
+                      </Table.Cell>
+                      <Table.Cell class="text-right font-mono text-xs"
+                        >{fmtShares(entry.shares)}</Table.Cell
+                      >
+                      <Table.Cell class="text-right font-mono text-xs {pnlColor(entry.spreadUsd)}">
+                        {fmtSignedUsd(entry.spreadUsd)}
+                      </Table.Cell>
+                      <Table.Cell
+                        class="text-right font-mono text-xs {pnlColor(entry.realizedPnlUsd)}"
+                      >
+                        {fmtSignedUsd(entry.realizedPnlUsd)}
+                      </Table.Cell>
+                      <Table.Cell class="text-right font-mono text-[11px] text-muted-foreground">
+                        <div>{entry.openingVenue}: {shortId(entry.openingFillId)}</div>
+                        <div>{entry.closingVenue}: {shortId(entry.closingFillId)}</div>
+                      </Table.Cell>
+                    </Table.Row>
+                  {/each}
+                </Table.Body>
+              </Table.Root>
+            {/if}
+          </div>
+        </section>
+      </div>
+    {/if}
+  </Card.Content>
+</Card.Root>

--- a/dashboard/src/lib/env.test.ts
+++ b/dashboard/src/lib/env.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getWebSocketUrl, getExplorerTxUrl } from './env'
+import { getWebSocketUrl, getExplorerTxUrl, getPnlSqlApiUrl } from './env'
 
 const mockEnv = { current: {} as Record<string, string | undefined> }
 
@@ -89,6 +89,24 @@ describe('getWebSocketUrl', () => {
 
     expect(getWebSocketUrl()).toBe('ws://localhost:8002/api/ws')
   })
+
+  it('uses the dev proxy websocket path when a backend API URL is configured', () => {
+    mockEnv.current = { PUBLIC_BACKEND_API_URL: 'https://backend.example.com' }
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '5173',
+          host: 'localhost:5173',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    expect(getWebSocketUrl()).toBe('ws://localhost:5173/api/ws')
+  })
 })
 
 describe('getExplorerTxUrl', () => {
@@ -110,5 +128,75 @@ describe('getExplorerTxUrl', () => {
     mockEnv.current = { PUBLIC_EXPLORER_URL: '  https://arbiscan.io  ' }
 
     expect(getExplorerTxUrl('0xabc123')).toBe('https://arbiscan.io/tx/0xabc123')
+  })
+})
+
+describe('getPnlSqlApiUrl', () => {
+  beforeEach(() => {
+    mockEnv.current = {}
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'example.com',
+          port: '80',
+          host: 'example.com',
+          protocol: 'https:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+  })
+
+  it('returns null when no SQL source is configured', () => {
+    expect(getPnlSqlApiUrl()).toBeNull()
+  })
+
+  it('returns trimmed SQL source URL when configured', () => {
+    mockEnv.current = {
+      PUBLIC_PNL_SQL_API_URL: '  http://example.com:8081/st0x-hedge.json  '
+    }
+
+    expect(getPnlSqlApiUrl()).toBe('http://example.com:8081/st0x-hedge.json')
+  })
+
+  it('uses the dev proxy for absolute SQL URLs during local development', () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: 'localhost',
+          port: '5173',
+          host: 'localhost:5173',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+    mockEnv.current = {
+      PUBLIC_PNL_SQL_API_URL: 'http://example.com:8081/st0x-hedge.json'
+    }
+
+    expect(getPnlSqlApiUrl()).toBe('/__pnl_sql')
+  })
+
+  it('uses the dev proxy for 127.0.0.1 local development URLs', () => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        location: {
+          hostname: '127.0.0.1',
+          port: '5174',
+          host: '127.0.0.1:5174',
+          protocol: 'http:'
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+    mockEnv.current = {
+      PUBLIC_PNL_SQL_API_URL: 'http://example.com:8081/st0x-hedge.json'
+    }
+
+    expect(getPnlSqlApiUrl()).toBe('/__pnl_sql')
   })
 })

--- a/dashboard/src/lib/env.ts
+++ b/dashboard/src/lib/env.ts
@@ -2,6 +2,8 @@ import { browser } from '$app/environment'
 import { env } from '$env/dynamic/public'
 
 const DEFAULT_LOCAL_DEV_PORT = '8001'
+const PNL_SQL_DEV_PROXY_PATH = '/__pnl_sql'
+const BACKEND_API_URL_ENV = 'PUBLIC_BACKEND_API_URL'
 
 const localDevPort = (): string => {
   const configured = env['PUBLIC_BACKEND_PORT']?.trim()
@@ -11,16 +13,33 @@ const localDevPort = (): string => {
 const isLocalDev = (): boolean => {
   if (!browser) return true
   const { hostname, port } = window.location
-  return hostname === 'localhost' && port !== '80' && port !== ''
+  return ['localhost', '127.0.0.1', '::1'].includes(hostname) && port !== '80' && port !== ''
+}
+
+const isAbsoluteHttpUrl = (value: string): boolean =>
+  value.startsWith('http://') || value.startsWith('https://')
+
+const getConfiguredBackendApiUrl = (): string | null => {
+  const val = env[BACKEND_API_URL_ENV]?.trim()
+  return val !== undefined && val !== '' ? val : null
+}
+
+const getSameOriginWsUrl = (): string => {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}/api/ws`
 }
 
 const getDefaultWsUrl = (): string => {
   if (isLocalDev()) {
+    const backendApiUrl = getConfiguredBackendApiUrl()
+    if (browser && backendApiUrl !== null && isAbsoluteHttpUrl(backendApiUrl)) {
+      return getSameOriginWsUrl()
+    }
+
     return `ws://localhost:${localDevPort()}/api/ws`
   }
 
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${protocol}//${window.location.host}/api/ws`
+  return getSameOriginWsUrl()
 }
 
 export const getWebSocketUrl = (): string => {
@@ -44,6 +63,19 @@ export const getSimulateBackendPort = (): string | null => {
 export const getSimulateSourceId = (): string | null => {
   const val = env['PUBLIC_SIMULATE_SOURCE_ID']?.trim()
   return val !== undefined && val !== '' ? val : null
+}
+
+export const getPnlSqlApiUrl = (): string | null => {
+  const envKey = 'PUBLIC_PNL_SQL_API_URL'
+  const val = env[envKey]?.trim()
+  if (val === undefined || val === '') return null
+  if (isLocalDev() && isAbsoluteHttpUrl(val)) return PNL_SQL_DEV_PROXY_PATH
+  return val
+}
+
+export const isDashboardMockMode = (): boolean => {
+  const val = env['PUBLIC_DASHBOARD_MOCK_MODE']?.trim().toLowerCase()
+  return val === '1' || val === 'true'
 }
 
 export const getExplorerTxUrl = (txHash: string): string => {

--- a/dashboard/src/lib/pnl/api.test.ts
+++ b/dashboard/src/lib/pnl/api.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildPnlParams } from './api'
+
+describe('buildPnlParams', () => {
+  it('serializes filters for the backend PnL endpoint', () => {
+    const params = buildPnlParams({
+      limit: 500,
+      offset: 25,
+      symbols: new Set(['SPYM', 'MSTR']),
+      fromDate: '2026-05-19',
+      toDate: '2026-05-24',
+      dayFilter: 'weekday'
+    })
+
+    expect(params.toString()).toBe(
+      'limit=500&offset=25&symbol=MSTR%2CSPYM&fromDate=2026-05-19&toDate=2026-05-24&dayFilter=weekday'
+    )
+  })
+
+  it('omits optional filters when all symbols and all days are selected', () => {
+    const params = buildPnlParams({
+      limit: 100,
+      offset: 0,
+      symbols: new Set(),
+      dayFilter: 'all'
+    })
+
+    expect(params.toString()).toBe('limit=100&offset=0')
+  })
+})

--- a/dashboard/src/lib/pnl/api.ts
+++ b/dashboard/src/lib/pnl/api.ts
@@ -1,0 +1,55 @@
+import { getApiBaseUrl, getPnlSqlApiUrl } from '$lib/env'
+import { FETCH_TIMEOUT_MS } from '$lib/time'
+import { fetchPnlReportFromSql } from '$lib/pnl/sql-source'
+import type { PnlResponse } from '$lib/pnl/report'
+
+export type PnlQuery = {
+  limit: number
+  offset: number
+  symbols: Set<string>
+  fromDate?: string
+  toDate?: string
+  dayFilter?: 'all' | 'weekday' | 'weekend'
+}
+
+export const buildPnlParams = (query: PnlQuery): URLSearchParams => {
+  const params = new URLSearchParams({
+    limit: String(query.limit),
+    offset: String(query.offset)
+  })
+
+  if (query.symbols.size > 0) {
+    params.set('symbol', [...query.symbols].sort().join(','))
+  }
+
+  if (query.fromDate !== undefined && query.fromDate !== '') {
+    params.set('fromDate', query.fromDate)
+  }
+
+  if (query.toDate !== undefined && query.toDate !== '') {
+    params.set('toDate', query.toDate)
+  }
+
+  if (query.dayFilter !== undefined && query.dayFilter !== 'all') {
+    params.set('dayFilter', query.dayFilter)
+  }
+
+  return params
+}
+
+export const fetchPnlReport = async (query: PnlQuery): Promise<PnlResponse> => {
+  const sqlApiUrl = getPnlSqlApiUrl()
+  if (sqlApiUrl !== null) {
+    return await fetchPnlReportFromSql(sqlApiUrl, query)
+  }
+
+  const response = await fetch(`${getApiBaseUrl()}/pnl?${buildPnlParams(query).toString()}`, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS)
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${String(response.status)}`)
+  }
+
+  return (await response.json()) as PnlResponse
+}

--- a/dashboard/src/lib/pnl/report.ts
+++ b/dashboard/src/lib/pnl/report.ts
@@ -1,0 +1,140 @@
+export type PnlSummary = {
+  counterTradePnlUsd: string
+  onchainNettingPnlUsd: string
+  directionalInventoryBaselinePnlUsd: string
+  directionalImbalanceExcessPnlUsd: string
+  directionalExposurePnlUsd: string
+  totalPnlUsd: string
+  realizedPnlUsd: string
+  matchedShares: string
+  onchainNotionalUsd: string
+  offchainNotionalUsd: string
+  inventoryDriftShares: string
+  inventoryDriftUsd: string
+  openLongShares: string
+  openShortShares: string
+  unmatchedOffchainShares: string
+  unmatchedOffchainNotionalUsd: string
+  onchainFillCount: number
+  offchainFillCount: number
+  matchedLotCount: number
+  openLotCount: number
+  unmatchedOffchainFillCount: number
+}
+
+export type PnlSymbolSummary = {
+  symbol: string
+  counterTradePnlUsd: string
+  onchainNettingPnlUsd: string
+  directionalInventoryBaselinePnlUsd: string
+  directionalImbalanceExcessPnlUsd: string
+  directionalExposurePnlUsd: string
+  totalPnlUsd: string
+  realizedPnlUsd: string
+  matchedShares: string
+  inventoryDriftShares: string
+  inventoryDriftUsd: string
+  openLongShares: string
+  openShortShares: string
+  unmatchedOffchainShares: string
+  matchedLotCount: number
+  onchainFillCount: number
+  offchainFillCount: number
+  unmatchedOffchainFillCount: number
+}
+
+export type PnlEntry = {
+  symbol: string
+  pnlBucket: string
+  matchedAt: string
+  openedAt: string
+  closedAt: string
+  openingFillId: string
+  closingFillId: string
+  openingRowid: number
+  closingRowid: number
+  openingVenue: string
+  closingVenue: string
+  openingDirection: string
+  closingDirection: string
+  openingPriceUsd: string
+  closingPriceUsd: string
+  onchainTradeId: string
+  offchainOrderId: string
+  onchainDirection: string
+  offchainDirection: string
+  shares: string
+  onchainPriceUsdc: string
+  offchainPriceUsd: string
+  spreadUsd: string
+  realizedPnlUsd: string
+  elapsedSeconds: number
+  counterTradeThresholdSeconds: number
+  delayedCounterTrade: boolean
+  attributionMethod: string
+}
+
+export type PnlSampleSymbolStats = {
+  symbol: string
+  firstAt: string | null
+  lastAt: string | null
+  onchainFillCount: number
+  offchainFillCount: number
+  totalFillCount: number
+}
+
+export type PnlSampleStats = {
+  firstAt: string | null
+  lastAt: string | null
+  symbolCount: number
+  onchainFillCount: number
+  offchainFillCount: number
+  totalFillCount: number
+  symbols: PnlSampleSymbolStats[]
+}
+
+export type PnlStreamKey =
+  | 'counterTradePnlUsd'
+  | 'onchainNettingPnlUsd'
+  | 'directionalInventoryBaselinePnlUsd'
+  | 'directionalImbalanceExcessPnlUsd'
+
+export const STREAM_KEYS: PnlStreamKey[] = [
+  'counterTradePnlUsd',
+  'onchainNettingPnlUsd',
+  'directionalInventoryBaselinePnlUsd',
+  'directionalImbalanceExcessPnlUsd'
+]
+
+export type PnlWindowSymbol = {
+  symbol: string
+  counterTradePnlUsd: string
+  onchainNettingPnlUsd: string
+  directionalInventoryBaselinePnlUsd: string
+  directionalImbalanceExcessPnlUsd: string
+  directionalExposurePnlUsd: string
+  totalPnlUsd: string
+}
+
+export type PnlWindow = {
+  windowId: string
+  startAt: string
+  endAt: string
+  label: string
+  isWeekend: boolean
+  granularity: 'day'
+  symbols: PnlWindowSymbol[]
+}
+
+export type PnlResponse = {
+  attributionMethod: string
+  warnings: string[]
+  sampleStats?: PnlSampleStats
+  summary: PnlSummary
+  symbols: PnlSymbolSummary[]
+  symbolUniverse?: string[]
+  entries: PnlEntry[]
+  total: number
+  hasMore: boolean
+  windows?: PnlWindow[]
+}

--- a/dashboard/src/lib/pnl/sql-source.test.ts
+++ b/dashboard/src/lib/pnl/sql-source.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPnlResponseFromSqlRows,
+  buildSqlApiUrl,
+  type SqlPositionEventRow,
+  type SqlPositionViewRow,
+  type SqlSampleStatsRow
+} from './sql-source'
+
+const baseQuery = {
+  limit: 100,
+  offset: 0,
+  symbols: new Set<string>(),
+  fromDate: '2026-05-15',
+  toDate: '2026-05-15',
+  dayFilter: 'all' as const
+}
+
+const positionRows: SqlPositionViewRow[] = [
+  {
+    symbol: 'RKLB',
+    net_position: '0',
+    last_updated: '2026-05-15T10:01:00Z',
+    last_price_usdc: '8'
+  },
+  {
+    symbol: 'SPYM',
+    net_position: '0',
+    last_updated: '2026-05-15T10:01:00Z',
+    last_price_usdc: '86'
+  }
+]
+
+const sampleRows: SqlSampleStatsRow[] = [
+  {
+    symbol: 'RKLB',
+    onchain_fill_count: 1,
+    offchain_fill_count: 1,
+    first_at: '2026-05-15T10:00:00Z',
+    last_at: '2026-05-15T10:01:00Z'
+  },
+  {
+    symbol: 'SPYM',
+    onchain_fill_count: 4,
+    offchain_fill_count: 3,
+    first_at: '2026-05-15T11:00:00Z',
+    last_at: '2026-05-15T11:05:00Z'
+  }
+]
+
+const onchainSell = (
+  rowid: number,
+  price = '10',
+  timestamp = '2026-05-15T10:00:00Z'
+): SqlPositionEventRow => ({
+  rowid,
+  symbol: 'RKLB',
+  event_type: 'PositionEvent::OnChainOrderFilled',
+  payload: JSON.stringify({
+    OnChainOrderFilled: {
+      amount: '1',
+      direction: 'Sell',
+      price_usdc: price,
+      block_timestamp: timestamp,
+      trade_id: {
+        tx_hash: `0x${String(rowid)}`,
+        log_index: 0
+      }
+    }
+  })
+})
+
+const offchainBuy = (
+  rowid: number,
+  timestamp: string,
+  price = '8',
+  shares = '1'
+): SqlPositionEventRow => ({
+  rowid,
+  symbol: 'RKLB',
+  event_type: 'PositionEvent::OffChainOrderFilled',
+  payload: {
+    OffChainOrderFilled: {
+      offchain_order_id: `alpaca-${String(rowid)}`,
+      shares_filled: shares,
+      direction: 'Buy',
+      price,
+      broker_timestamp: timestamp
+    }
+  }
+})
+
+describe('buildSqlApiUrl', () => {
+  it('uses the Datasette SQL JSON shape expected by the prod read endpoint', () => {
+    const url = buildSqlApiUrl(
+      'http://host:8081/st0x-hedge.json',
+      'SELECT symbol, net_position FROM position_view'
+    )
+
+    expect(url).toBe(
+      'http://host:8081/st0x-hedge.json?sql=SELECT+symbol%2C+net_position+FROM+position_view&_shape=objects&_size=max'
+    )
+  })
+
+  it('supports the local same-origin SQL proxy path', () => {
+    const previousLocation = (globalThis as { location?: Location }).location
+    try {
+      Object.defineProperty(globalThis, 'location', {
+        value: { origin: 'http://localhost:5174' },
+        writable: true,
+        configurable: true
+      })
+
+      expect(buildSqlApiUrl('/__pnl_sql', 'SELECT 1')).toBe(
+        'http://localhost:5174/__pnl_sql?sql=SELECT+1&_shape=objects&_size=max'
+      )
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        value: previousLocation,
+        writable: true,
+        configurable: true
+      })
+    }
+  })
+})
+
+describe('buildPnlResponseFromSqlRows', () => {
+  it('maps prompt counter-trades into counter-trade PnL', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [onchainSell(1, '10'), offchainBuy(2, '2026-05-15T10:01:00Z', '8')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.summary.counterTradePnlUsd).toBe('2')
+    expect(report.summary.directionalImbalanceExcessPnlUsd).toBe('0')
+    expect(report.summary.totalPnlUsd).toBe('2')
+    expect(report.entries[0]?.pnlBucket).toBe('counter_trade')
+    expect(report.entries[0]?.delayedCounterTrade).toBe(false)
+  })
+
+  it('replays fills by execution timestamp rather than event rowid', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [offchainBuy(1, '2026-05-15T10:01:00Z', '8'), onchainSell(2, '10')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.summary.counterTradePnlUsd).toBe('2')
+    expect(report.summary.directionalImbalanceExcessPnlUsd).toBe('0')
+    expect(report.entries[0]).toEqual(
+      expect.objectContaining({
+        openingRowid: 2,
+        closingRowid: 1,
+        pnlBucket: 'counter_trade',
+        realizedPnlUsd: '2'
+      })
+    )
+  })
+
+  it('classifies late broker fills as directional exposure', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [onchainSell(1, '10'), offchainBuy(2, '2026-05-15T10:06:01Z', '8')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.summary.counterTradePnlUsd).toBe('0')
+    expect(report.summary.directionalImbalanceExcessPnlUsd).toBe('2')
+    expect(report.summary.directionalExposurePnlUsd).toBe('2')
+    expect(report.summary.totalPnlUsd).toBe('2')
+    expect(report.summary.realizedPnlUsd).toBe('2')
+    expect(report.entries[0]?.pnlBucket).toBe('directional_exposure')
+    expect(report.entries[0]?.delayedCounterTrade).toBe(true)
+  })
+
+  it('keeps the full symbol universe separate from filtered PnL rows', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [onchainSell(1, '10'), offchainBuy(2, '2026-05-15T10:01:00Z', '8')],
+      positionRows,
+      sampleRows,
+      {
+        ...baseQuery,
+        symbols: new Set(['RKLB'])
+      }
+    )
+
+    expect(report.symbols.map((row) => row.symbol)).toEqual(['RKLB'])
+    expect(report.symbolUniverse).toEqual(['RKLB', 'SPYM'])
+  })
+
+  it('reports unfiltered database sample statistics for date-range selection', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [onchainSell(1, '10'), offchainBuy(2, '2026-05-15T10:01:00Z', '8')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.sampleStats).toEqual({
+      firstAt: '2026-05-15T10:00:00Z',
+      lastAt: '2026-05-15T11:05:00Z',
+      symbolCount: 2,
+      onchainFillCount: 5,
+      offchainFillCount: 4,
+      totalFillCount: 9,
+      symbols: [
+        {
+          symbol: 'RKLB',
+          firstAt: '2026-05-15T10:00:00Z',
+          lastAt: '2026-05-15T10:01:00Z',
+          onchainFillCount: 1,
+          offchainFillCount: 1,
+          totalFillCount: 2
+        },
+        {
+          symbol: 'SPYM',
+          firstAt: '2026-05-15T11:00:00Z',
+          lastAt: '2026-05-15T11:05:00Z',
+          onchainFillCount: 4,
+          offchainFillCount: 3,
+          totalFillCount: 7
+        }
+      ]
+    })
+  })
+
+  it('drops unsafe symbols from SQL replay rows and warnings', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [
+        {
+          ...onchainSell(1, '10'),
+          symbol: "RKLB'); DROP TABLE events; --"
+        },
+        onchainSell(2, '10'),
+        offchainBuy(3, '2026-05-15T10:01:00Z', '8')
+      ],
+      [
+        ...positionRows,
+        {
+          symbol: "BAD';--",
+          net_position: '0',
+          last_updated: '2026-05-15T10:01:00Z',
+          last_price_usdc: '1'
+        }
+      ],
+      [
+        ...sampleRows,
+        {
+          symbol: "BAD';--",
+          onchain_fill_count: 1,
+          offchain_fill_count: 1,
+          first_at: '2026-05-15T10:00:00Z',
+          last_at: '2026-05-15T10:01:00Z'
+        }
+      ],
+      {
+        ...baseQuery,
+        symbols: new Set(["RKLB'); DROP TABLE events; --"])
+      }
+    )
+
+    expect(report.summary.counterTradePnlUsd).toBe('2')
+    expect(report.symbolUniverse).toEqual(['RKLB', 'SPYM'])
+    expect(report.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Skipped 1 invalid symbol filters'),
+        expect.stringContaining('Skipped unsafe position_view symbol'),
+        expect.stringContaining('Skipped unsafe sample stats symbol'),
+        expect.stringContaining('Skipped unsafe position event symbol')
+      ])
+    )
+  })
+
+  it('summarizes replay diagnostics without raw per-fill allocation warnings', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [offchainBuy(1, '2026-05-15T10:01:00Z', '8')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Allocation note: 1 offchain fills opened offchain-origin inventory'
+        ),
+        expect.stringContaining('Reconciliation note: replayed open lots differ from position_view')
+      ])
+    )
+    expect(report.warnings.some((warning) => warning.includes('no open opposite-side'))).toBe(false)
+    expect(report.warnings.some((warning) => warning.includes('PnL audit warning'))).toBe(false)
+    expect(report.summary.unmatchedOffchainFillCount).toBe(0)
+    expect(report.summary.unmatchedOffchainShares).toBe('0')
+    expect(report.summary.openLongShares).toBe('1')
+    expect(report.symbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: 'RKLB',
+          unmatchedOffchainFillCount: 0,
+          unmatchedOffchainShares: '0',
+          openLongShares: '1'
+        })
+      ])
+    )
+  })
+
+  it('carries offchain-origin inventory until later fills close it', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [
+        offchainBuy(1, '2026-05-15T10:01:00Z', '8'),
+        onchainSell(2, '10', '2026-05-15T10:02:00Z')
+      ],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.summary.totalPnlUsd).toBe('2')
+    expect(report.summary.directionalImbalanceExcessPnlUsd).toBe('2')
+    expect(report.summary.realizedPnlUsd).toBe('2')
+    expect(report.summary.onchainNotionalUsd).toBe('10')
+    expect(report.summary.offchainNotionalUsd).toBe('8')
+    expect(report.summary.unmatchedOffchainShares).toBe('0')
+    expect(report.summary.openLongShares).toBe('0')
+    expect(report.entries[0]).toEqual(
+      expect.objectContaining({
+        openingVenue: 'offchain',
+        closingVenue: 'onchain',
+        onchainDirection: 'sell',
+        offchainDirection: 'buy',
+        onchainPriceUsdc: '10',
+        offchainPriceUsd: '8',
+        pnlBucket: 'directional_exposure',
+        realizedPnlUsd: '2'
+      })
+    )
+    expect(report.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('offchain fills opened offchain-origin inventory')
+      ])
+    )
+  })
+
+  it('splits offchain overshoots between counter-trade close and carried inventory', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [
+        onchainSell(1, '10', '2026-05-15T10:00:00Z'),
+        offchainBuy(2, '2026-05-15T10:01:00Z', '8', '2'),
+        onchainSell(3, '11', '2026-05-15T10:02:00Z')
+      ],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.summary.totalPnlUsd).toBe('5')
+    expect(report.summary.counterTradePnlUsd).toBe('2')
+    expect(report.summary.directionalImbalanceExcessPnlUsd).toBe('3')
+    expect(report.summary.realizedPnlUsd).toBe('5')
+    expect(report.summary.openLongShares).toBe('0')
+    expect(report.summary.openShortShares).toBe('0')
+    expect(report.summary.unmatchedOffchainShares).toBe('0')
+    expect(report.entries).toHaveLength(2)
+    expect(report.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          openingVenue: 'onchain',
+          closingVenue: 'offchain',
+          shares: '1',
+          pnlBucket: 'counter_trade',
+          realizedPnlUsd: '2'
+        }),
+        expect.objectContaining({
+          openingVenue: 'offchain',
+          closingVenue: 'onchain',
+          shares: '1',
+          pnlBucket: 'directional_exposure',
+          realizedPnlUsd: '3'
+        })
+      ])
+    )
+  })
+
+  it('keeps current replay exposure even when there are no closed PnL lots', () => {
+    const report = buildPnlResponseFromSqlRows(
+      [onchainSell(1, '10')],
+      positionRows,
+      sampleRows,
+      baseQuery
+    )
+
+    expect(report.entries).toEqual([])
+    expect(report.summary.totalPnlUsd).toBe('0')
+    expect(report.summary.openShortShares).toBe('1')
+    expect(report.summary.inventoryDriftShares).toBe('-1')
+    expect(report.symbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          symbol: 'RKLB',
+          totalPnlUsd: '0',
+          openShortShares: '1',
+          inventoryDriftShares: '-1'
+        })
+      ])
+    )
+  })
+})

--- a/dashboard/src/lib/pnl/sql-source.ts
+++ b/dashboard/src/lib/pnl/sql-source.ts
@@ -1,0 +1,1321 @@
+import Decimal from 'decimal.js'
+import type {
+  PnlEntry,
+  PnlResponse,
+  PnlSampleStats,
+  PnlSampleSymbolStats,
+  PnlStreamKey,
+  PnlSummary,
+  PnlSymbolSummary,
+  PnlWindow,
+  PnlWindowSymbol
+} from './report'
+
+export type SqlPnlQuery = {
+  limit: number
+  offset: number
+  symbols: Set<string>
+  fromDate?: string
+  toDate?: string
+  dayFilter?: 'all' | 'weekday' | 'weekend'
+}
+
+export type SqlPositionEventRow = {
+  rowid: number
+  symbol: string
+  event_type: string
+  payload: unknown
+}
+
+export type SqlPositionViewRow = {
+  symbol: string
+  net_position: string | null
+  last_updated: string | null
+  last_price_usdc: string | null
+}
+
+export type SqlSampleStatsRow = {
+  symbol: string
+  onchain_fill_count: number
+  offchain_fill_count: number
+  first_at: string | null
+  last_at: string | null
+}
+
+type Direction = 'Buy' | 'Sell'
+type LotSide = 'long' | 'short'
+type PnlBucket = 'counter_trade' | 'onchain_netting' | 'directional_exposure'
+type SqlSymbolColumn = 'aggregate_id' | 'symbol'
+type Venue = 'onchain' | 'offchain'
+
+type Fill = {
+  rowid: number
+  id: string
+  symbol: string
+  shares: Decimal
+  direction: Direction
+  price: Decimal
+  executedAt: string
+  venue: Venue
+}
+
+type Lot = {
+  tradeId: string
+  side: LotSide
+  remainingShares: Decimal
+  price: Decimal
+  openedAt: string
+  openedRowid: number
+  openedVenue: Venue
+}
+
+type SummaryAcc = {
+  counterTradePnlUsd: Decimal
+  onchainNettingPnlUsd: Decimal
+  directionalInventoryBaselinePnlUsd: Decimal
+  directionalImbalanceExcessPnlUsd: Decimal
+  directionalExposurePnlUsd: Decimal
+  realizedPnlUsd: Decimal
+  matchedShares: Decimal
+  onchainNotionalUsd: Decimal
+  offchainNotionalUsd: Decimal
+  openLongShares: Decimal
+  openShortShares: Decimal
+  openLongNotionalUsd: Decimal
+  openShortNotionalUsd: Decimal
+  unmatchedOffchainBuyShares: Decimal
+  unmatchedOffchainSellShares: Decimal
+  unmatchedOffchainBuyNotionalUsd: Decimal
+  unmatchedOffchainSellNotionalUsd: Decimal
+  onchainFillCount: number
+  offchainFillCount: number
+  matchedLotCount: number
+  openLotCount: number
+  unmatchedOffchainFillCount: number
+}
+
+type SymbolBook = {
+  longLots: Lot[]
+  shortLots: Lot[]
+  seenOnchainFillIds: Set<string>
+  seenOffchainPlacementIds: Set<string>
+  seenOffchainFillIds: Set<string>
+  originalOnchainShares: Map<string, Decimal>
+  matchedOnchainShares: Map<string, Decimal>
+  summary: SummaryAcc
+}
+
+type UnmatchedOffchainAllocation = {
+  symbol: string
+  fillId: string
+  shares: Decimal
+}
+
+type PositionReplayDelta = {
+  symbol: string
+  replayNet: Decimal
+  positionNet: Decimal
+}
+
+const ATTRIBUTION_METHOD = 'direct_sql_position_fill_replay_fifo'
+const COUNTER_TRADE_THRESHOLD_SECONDS = 300
+const DATASSETTE_DEFAULT_MAX_RETURNED_ROWS = 1000
+const SQL_FETCH_TIMEOUT_MS = 30000
+const SAFE_SQL_SYMBOL = /^[A-Za-z0-9._-]+$/u
+const ZERO = new Decimal(0)
+
+const ATTRIBUTION_WARNING =
+  'PnL source: realized gross replay from the deployed SQL JSON endpoint. Fills are ordered by execution timestamp and replayed through per-symbol FIFO inventory lots for accounting and attribution; explicit offchain_order_id -> onchain_trade_ids parentage is not currently persisted.'
+const BASELINE_WARNING =
+  'Displayed PnL is realized gross PnL by lot close date from persisted fills only. Baseline drift, percentage return, true period/NAV PnL, and cost-inclusive PnL require a persisted portfolio state vector plus price vector over time, cash-flow events, fees, and financing data; those are not currently persisted, so baseline drift is zero.'
+
+const emptySummary = (): SummaryAcc => ({
+  counterTradePnlUsd: new Decimal(0),
+  onchainNettingPnlUsd: new Decimal(0),
+  directionalInventoryBaselinePnlUsd: new Decimal(0),
+  directionalImbalanceExcessPnlUsd: new Decimal(0),
+  directionalExposurePnlUsd: new Decimal(0),
+  realizedPnlUsd: new Decimal(0),
+  matchedShares: new Decimal(0),
+  onchainNotionalUsd: new Decimal(0),
+  offchainNotionalUsd: new Decimal(0),
+  openLongShares: new Decimal(0),
+  openShortShares: new Decimal(0),
+  openLongNotionalUsd: new Decimal(0),
+  openShortNotionalUsd: new Decimal(0),
+  unmatchedOffchainBuyShares: new Decimal(0),
+  unmatchedOffchainSellShares: new Decimal(0),
+  unmatchedOffchainBuyNotionalUsd: new Decimal(0),
+  unmatchedOffchainSellNotionalUsd: new Decimal(0),
+  onchainFillCount: 0,
+  offchainFillCount: 0,
+  matchedLotCount: 0,
+  openLotCount: 0,
+  unmatchedOffchainFillCount: 0
+})
+
+const emptyBook = (): SymbolBook => ({
+  longLots: [],
+  shortLots: [],
+  seenOnchainFillIds: new Set(),
+  seenOffchainPlacementIds: new Set(),
+  seenOffchainFillIds: new Set(),
+  originalOnchainShares: new Map(),
+  matchedOnchainShares: new Map(),
+  summary: emptySummary()
+})
+
+const isSafeSqlSymbol = (symbol: string): boolean => SAFE_SQL_SYMBOL.test(symbol)
+
+const sqlString = (value: string): string => `'${value.replaceAll("'", "''")}'`
+
+const symbolPredicate = (symbols: Set<string>, column: SqlSymbolColumn): string => {
+  if (symbols.size === 0) return ''
+
+  const safeSymbols = [...symbols].filter(isSafeSqlSymbol)
+  if (safeSymbols.length === 0) return ' AND 1 = 0'
+
+  return ` AND ${column} IN (${safeSymbols.map(sqlString).join(',')})`
+}
+
+const globalOrigin = (): string => {
+  const maybeLocation = (globalThis as Record<string, unknown>)['location']
+  if (
+    typeof maybeLocation === 'object' &&
+    maybeLocation !== null &&
+    'origin' in maybeLocation &&
+    typeof maybeLocation.origin === 'string'
+  ) {
+    return maybeLocation.origin
+  }
+
+  return 'http://localhost'
+}
+
+export const buildSqlApiUrl = (baseUrl: string, sql: string): string => {
+  const url = new URL(baseUrl, globalOrigin())
+  url.searchParams.set('sql', sql)
+  url.searchParams.set('_shape', 'objects')
+  url.searchParams.set('_size', 'max')
+  return url.toString()
+}
+
+type DatasetteRowsResponse = {
+  rows?: unknown
+  truncated?: boolean
+}
+
+const fetchSqlRows = async <Row>(baseUrl: string, sql: string): Promise<Row[]> => {
+  const response = await fetch(buildSqlApiUrl(baseUrl, sql), {
+    signal: AbortSignal.timeout(SQL_FETCH_TIMEOUT_MS)
+  })
+
+  if (!response.ok) {
+    throw new Error(`SQL endpoint HTTP ${String(response.status)}`)
+  }
+
+  const body = (await response.json()) as DatasetteRowsResponse
+  if (!Array.isArray(body.rows)) {
+    throw new Error('SQL endpoint returned a response without rows')
+  }
+
+  if (body.truncated === true) {
+    throw new Error('SQL endpoint truncated the result set; refusing to render partial PnL')
+  }
+
+  if (body.truncated === undefined && body.rows.length >= DATASSETTE_DEFAULT_MAX_RETURNED_ROWS) {
+    throw new Error('SQL endpoint may have truncated the result set; refusing to render partial PnL')
+  }
+
+  return body.rows as Row[]
+}
+
+const positionEventsSql = (symbols: Set<string>): string => `
+SELECT rowid, aggregate_id AS symbol, event_type, payload
+FROM events
+WHERE aggregate_type = 'Position'
+  AND event_type IN (
+    'PositionEvent::OnChainOrderFilled',
+    'PositionEvent::OffChainOrderPlaced',
+    'PositionEvent::OffChainOrderFilled'
+  )
+  ${symbolPredicate(symbols, 'aggregate_id')}
+ORDER BY rowid ASC
+`
+
+const positionViewSql = (symbols: Set<string>): string => `
+SELECT
+  symbol,
+  net_position,
+  last_updated
+FROM position_view
+WHERE symbol IS NOT NULL
+  ${symbolPredicate(symbols, 'symbol')}
+ORDER BY symbol ASC
+`
+
+const sampleStatsSql = (): string => `
+SELECT
+  aggregate_id AS symbol,
+  SUM(CASE WHEN event_type = 'PositionEvent::OnChainOrderFilled' THEN 1 ELSE 0 END) AS onchain_fill_count,
+  SUM(CASE WHEN event_type = 'PositionEvent::OffChainOrderFilled' THEN 1 ELSE 0 END) AS offchain_fill_count,
+  MIN(COALESCE(
+    json_extract(payload, '$.OnChainOrderFilled.block_timestamp'),
+    json_extract(payload, '$.OffChainOrderFilled.broker_timestamp')
+  )) AS first_at,
+  MAX(COALESCE(
+    json_extract(payload, '$.OnChainOrderFilled.block_timestamp'),
+    json_extract(payload, '$.OffChainOrderFilled.broker_timestamp')
+  )) AS last_at
+FROM events
+WHERE aggregate_type = 'Position'
+  AND event_type IN (
+    'PositionEvent::OnChainOrderFilled',
+    'PositionEvent::OffChainOrderFilled'
+  )
+GROUP BY aggregate_id
+ORDER BY aggregate_id ASC
+`
+
+const parsePayload = (payload: unknown): Record<string, unknown> | null => {
+  if (payload !== null && typeof payload === 'object' && !Array.isArray(payload)) {
+    return payload as Record<string, unknown>
+  }
+
+  if (typeof payload !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(payload) as unknown
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+const nestedRecord = (
+  payload: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | null => {
+  const value = payload[key]
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+const textField = (payload: Record<string, unknown>, key: string): string | null => {
+  const value = payload[key]
+  return typeof value === 'string' ? value : null
+}
+
+const numberTextField = (payload: Record<string, unknown>, key: string): string | null => {
+  const value = payload[key]
+  if (typeof value === 'string' || typeof value === 'number') return String(value)
+  return null
+}
+
+const decimalField = (payload: Record<string, unknown>, key: string): Decimal | null => {
+  const value = numberTextField(payload, key)
+  if (value === null) return null
+
+  try {
+    return new Decimal(value)
+  } catch {
+    return null
+  }
+}
+
+const directionField = (payload: Record<string, unknown>, key: string): Direction | null => {
+  const value = textField(payload, key)
+  if (value === 'Buy' || value === 'Sell') return value
+  if (value === 'buy') return 'Buy'
+  if (value === 'sell') return 'Sell'
+  return null
+}
+
+const positionEventReplayTimestamp = (row: SqlPositionEventRow): string | null => {
+  const payload = parsePayload(row.payload)
+  if (payload === null) return null
+
+  if (row.event_type === 'PositionEvent::OnChainOrderFilled') {
+    const filled = nestedRecord(payload, 'OnChainOrderFilled')
+    return filled === null ? null : textField(filled, 'block_timestamp')
+  }
+
+  if (row.event_type === 'PositionEvent::OffChainOrderFilled') {
+    const filled = nestedRecord(payload, 'OffChainOrderFilled')
+    return filled === null ? null : textField(filled, 'broker_timestamp')
+  }
+
+  if (row.event_type === 'PositionEvent::OffChainOrderPlaced') {
+    const placed = nestedRecord(payload, 'OffChainOrderPlaced')
+    return placed === null ? null : textField(placed, 'placed_at')
+  }
+
+  return null
+}
+
+const orderedPositionEvents = (
+  rows: SqlPositionEventRow[],
+  warnings: string[]
+): SqlPositionEventRow[] =>
+  [...rows]
+    .map((row) => {
+      const timestamp = positionEventReplayTimestamp(row)
+      const parsed = timestamp === null ? Number.NaN : Date.parse(timestamp)
+      const hasTimestamp = Number.isFinite(parsed)
+      if (timestamp !== null && !hasTimestamp) {
+        warnings.push(
+          `PnL audit note: invalid replay timestamp for ${row.symbol} row ${String(row.rowid)}; using event row order`
+        )
+      }
+
+      return {
+        row,
+        timestampMs: hasTimestamp ? parsed : Number.POSITIVE_INFINITY
+      }
+    })
+    .sort((left, right) => {
+      if (left.timestampMs !== right.timestampMs) return left.timestampMs - right.timestampMs
+      return left.row.rowid - right.row.rowid
+    })
+    .map(({ row }) => row)
+
+const dateKey = (iso: string): string => iso.slice(0, 10)
+
+const isWeekendIso = (iso: string): boolean => {
+  const day = new Date(iso).getUTCDay()
+  return day === 0 || day === 6
+}
+
+const matchesDateFilter = (entry: PnlEntry, query: SqlPnlQuery): boolean => {
+  const day = dateKey(entry.closedAt)
+  if (query.fromDate !== undefined && day < query.fromDate) return false
+  if (query.toDate !== undefined && day > query.toDate) return false
+  if (query.dayFilter === 'weekday' && isWeekendIso(entry.closedAt)) return false
+  if (query.dayFilter === 'weekend' && !isWeekendIso(entry.closedAt)) return false
+  return true
+}
+
+const secondsBetween = (startIso: string, endIso: string): number =>
+  Math.max(0, Math.floor((new Date(endIso).getTime() - new Date(startIso).getTime()) / 1000))
+
+const fmtDecimal = (value: Decimal): string => {
+  const fixed = value.toFixed(9)
+  const trimmed = fixed.replace(/\.?0+$/u, '')
+  return trimmed === '-0' || trimmed === '' ? '0' : trimmed
+}
+
+const allocationSummaryText = (allocations: UnmatchedOffchainAllocation[]): string | null => {
+  if (allocations.length === 0) return null
+
+  const bySymbol = new Map<string, { fillIds: Set<string>; shares: Decimal }>()
+  for (const allocation of allocations) {
+    const current = bySymbol.get(allocation.symbol) ?? { fillIds: new Set<string>(), shares: ZERO }
+    current.fillIds.add(allocation.fillId)
+    current.shares = current.shares.plus(allocation.shares)
+    bySymbol.set(allocation.symbol, current)
+  }
+
+  const symbolDetails = [...bySymbol.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([symbol, value]) =>
+        `${symbol}: ${fmtDecimal(value.shares)} shares across ${String(value.fillIds.size)} fills`
+    )
+    .join('; ')
+
+  return `Allocation note: ${String(allocations.length)} offchain fills opened offchain-origin inventory outside the intended onchain-to-offchain hedge flow (${symbolDetails}). Those shares are carried in the FIFO ledger so later fills can close them.`
+}
+
+const positionReplayDeltaText = (deltas: PositionReplayDelta[]): string | null => {
+  if (deltas.length === 0) return null
+
+  const details = [...deltas]
+    .sort((left, right) => left.symbol.localeCompare(right.symbol))
+    .map(
+      (delta) =>
+        `${delta.symbol}: replay ${fmtDecimal(delta.replayNet)}, position_view ${fmtDecimal(delta.positionNet)}`
+    )
+    .join('; ')
+
+  return `Reconciliation note: replayed open lots differ from position_view for ${String(deltas.length)} symbols (${details}). This means the persisted Position fill events available to the dashboard do not fully reconstruct the current projected position for those symbols.`
+}
+
+const appendInvalidQuerySymbols = (warnings: string[], symbols: Set<string>): void => {
+  const invalidSymbols = [...symbols].filter((symbol) => !isSafeSqlSymbol(symbol))
+  if (invalidSymbols.length === 0) return
+
+  warnings.push(
+    `Skipped ${String(invalidSymbols.length)} invalid symbol filters in SQL PnL query: ${invalidSymbols.join(', ')}`
+  )
+}
+
+const appendReplayDiagnostics = (
+  warnings: string[],
+  unmatchedOffchainAllocations: UnmatchedOffchainAllocation[],
+  positionReplayDeltas: PositionReplayDelta[]
+): void => {
+  const allocationText = allocationSummaryText(unmatchedOffchainAllocations)
+  if (allocationText !== null) warnings.push(allocationText)
+
+  const deltaText = positionReplayDeltaText(positionReplayDeltas)
+  if (deltaText !== null) warnings.push(deltaText)
+}
+
+const directionLabel = (direction: Direction): string => (direction === 'Buy' ? 'buy' : 'sell')
+const lotSideToOnchainDirection = (side: LotSide): string => (side === 'long' ? 'buy' : 'sell')
+
+const addVenueNotional = (summary: SummaryAcc, venue: Venue, notional: Decimal): void => {
+  if (venue === 'onchain') {
+    summary.onchainNotionalUsd = summary.onchainNotionalUsd.plus(notional)
+  } else {
+    summary.offchainNotionalUsd = summary.offchainNotionalUsd.plus(notional)
+  }
+}
+
+const addRealizedPnl = (summary: SummaryAcc, bucket: PnlBucket, value: Decimal): void => {
+  if (bucket === 'counter_trade') {
+    summary.counterTradePnlUsd = summary.counterTradePnlUsd.plus(value)
+    summary.realizedPnlUsd = summary.realizedPnlUsd.plus(value)
+    return
+  }
+
+  if (bucket === 'onchain_netting') {
+    summary.onchainNettingPnlUsd = summary.onchainNettingPnlUsd.plus(value)
+    summary.realizedPnlUsd = summary.realizedPnlUsd.plus(value)
+    return
+  }
+
+  summary.directionalImbalanceExcessPnlUsd = summary.directionalImbalanceExcessPnlUsd.plus(value)
+  summary.directionalExposurePnlUsd = summary.directionalExposurePnlUsd.plus(value)
+  summary.realizedPnlUsd = summary.realizedPnlUsd.plus(value)
+}
+
+const parseOnchainFill = (row: SqlPositionEventRow, warnings: string[]): Fill | null => {
+  const payload = parsePayload(row.payload)
+  const filled = payload === null ? null : nestedRecord(payload, 'OnChainOrderFilled')
+  if (filled === null) {
+    warnings.push(
+      `Skipped malformed position onchain fill ${row.symbol}: missing OnChainOrderFilled`
+    )
+    return null
+  }
+
+  const amount = decimalField(filled, 'amount')
+  const direction = directionField(filled, 'direction')
+  const price = decimalField(filled, 'price_usdc')
+  const executedAt = textField(filled, 'block_timestamp')
+  const tradeId = nestedRecord(filled, 'trade_id')
+  const txHash = tradeId === null ? null : textField(tradeId, 'tx_hash')
+  const logIndex = tradeId === null ? null : numberTextField(tradeId, 'log_index')
+
+  if (
+    amount === null ||
+    direction === null ||
+    price === null ||
+    executedAt === null ||
+    txHash === null ||
+    logIndex === null
+  ) {
+    warnings.push(`Skipped malformed position onchain fill ${row.symbol}: incomplete payload`)
+    return null
+  }
+
+  return {
+    rowid: row.rowid,
+    id: `${txHash}:${logIndex}`,
+    symbol: row.symbol,
+    shares: amount,
+    direction,
+    price,
+    executedAt,
+    venue: 'onchain'
+  }
+}
+
+const parseOffchainFill = (row: SqlPositionEventRow, warnings: string[]): Fill | null => {
+  const payload = parsePayload(row.payload)
+  const filled = payload === null ? null : nestedRecord(payload, 'OffChainOrderFilled')
+  if (filled === null) {
+    warnings.push(
+      `Skipped malformed position offchain fill ${row.symbol}: missing OffChainOrderFilled`
+    )
+    return null
+  }
+
+  const orderId = textField(filled, 'offchain_order_id')
+  const shares = decimalField(filled, 'shares_filled')
+  const direction = directionField(filled, 'direction')
+  const price = decimalField(filled, 'price')
+  const executedAt = textField(filled, 'broker_timestamp')
+
+  if (
+    orderId === null ||
+    shares === null ||
+    direction === null ||
+    price === null ||
+    executedAt === null
+  ) {
+    warnings.push(`Skipped malformed position offchain fill ${row.symbol}: incomplete payload`)
+    return null
+  }
+
+  return {
+    rowid: row.rowid,
+    id: orderId,
+    symbol: row.symbol,
+    shares,
+    direction,
+    price,
+    executedAt,
+    venue: 'offchain'
+  }
+}
+
+const parseOffchainPlacementId = (row: SqlPositionEventRow, warnings: string[]): string | null => {
+  const payload = parsePayload(row.payload)
+  const placed = payload === null ? null : nestedRecord(payload, 'OffChainOrderPlaced')
+  const orderId = placed === null ? null : textField(placed, 'offchain_order_id')
+
+  if (orderId === null) {
+    warnings.push(`Skipped malformed position offchain placement ${row.symbol}: incomplete payload`)
+  }
+
+  return orderId
+}
+
+const getBook = (books: Map<string, SymbolBook>, symbol: string): SymbolBook => {
+  const existing = books.get(symbol)
+  if (existing !== undefined) return existing
+  const book = emptyBook()
+  books.set(symbol, book)
+  return book
+}
+
+const openResidualLot = (book: SymbolBook, fill: Fill, remaining: Decimal): void => {
+  const side: LotSide = fill.direction === 'Buy' ? 'long' : 'short'
+  const lot: Lot = {
+    tradeId: fill.id,
+    side,
+    remainingShares: remaining,
+    price: fill.price,
+    openedAt: fill.executedAt,
+    openedRowid: fill.rowid,
+    openedVenue: fill.venue
+  }
+
+  if (side === 'long') {
+    book.longLots.push(lot)
+  } else {
+    book.shortLots.push(lot)
+  }
+}
+
+const applyOnchainFill = (
+  book: SymbolBook,
+  fill: Fill,
+  entries: PnlEntry[],
+  warnings: string[]
+): void => {
+  if (book.seenOnchainFillIds.has(fill.id)) {
+    warnings.push(
+      `PnL audit error: duplicate onchain trade_id ${fill.id} for ${fill.symbol} was skipped`
+    )
+    return
+  }
+
+  book.seenOnchainFillIds.add(fill.id)
+  book.summary.onchainFillCount += 1
+
+  const sourceLots = fill.direction === 'Buy' ? book.shortLots : book.longLots
+  const remaining = matchFillAgainstLots(
+    fill,
+    sourceLots,
+    book.summary,
+    book.matchedOnchainShares,
+    entries,
+    'onchain_netting'
+  )
+  if (remaining.isZero()) return
+
+  const original = book.originalOnchainShares.get(fill.id) ?? ZERO
+  book.originalOnchainShares.set(fill.id, original.plus(remaining))
+
+  openResidualLot(book, fill, remaining)
+}
+
+const applyOffchainPlacement = (
+  book: SymbolBook,
+  row: SqlPositionEventRow,
+  warnings: string[]
+): void => {
+  const orderId = parseOffchainPlacementId(row, warnings)
+  if (orderId === null) return
+
+  if (book.seenOffchainPlacementIds.has(orderId)) {
+    warnings.push(
+      `PnL audit error: duplicate offchain placement ${orderId} for ${row.symbol} was skipped`
+    )
+    return
+  }
+
+  book.seenOffchainPlacementIds.add(orderId)
+}
+
+const applyOffchainFill = (
+  book: SymbolBook,
+  fill: Fill,
+  entries: PnlEntry[],
+  warnings: string[],
+  unmatchedOffchainAllocations: UnmatchedOffchainAllocation[]
+): void => {
+  if (book.seenOffchainFillIds.has(fill.id)) {
+    warnings.push(
+      `PnL audit error: duplicate offchain fill ${fill.id} for ${fill.symbol} was skipped`
+    )
+    return
+  }
+
+  book.seenOffchainFillIds.add(fill.id)
+  book.summary.offchainFillCount += 1
+  const sourceLots = fill.direction === 'Buy' ? book.shortLots : book.longLots
+  const remaining = matchFillAgainstLots(
+    fill,
+    sourceLots,
+    book.summary,
+    book.matchedOnchainShares,
+    entries,
+    'counter_trade'
+  )
+
+  if (!remaining.isZero()) {
+    unmatchedOffchainAllocations.push({
+      symbol: fill.symbol,
+      fillId: fill.id,
+      shares: remaining
+    })
+    openResidualLot(book, fill, remaining)
+  }
+}
+
+const matchFillAgainstLots = (
+  fill: Fill,
+  sourceLots: Lot[],
+  summary: SummaryAcc,
+  matchedOnchainShares: Map<string, Decimal>,
+  entries: PnlEntry[],
+  bucket: PnlBucket
+): Decimal => {
+  let remaining = fill.shares
+
+  while (!remaining.isZero() && sourceLots.length > 0) {
+    const frontLot = sourceLots[0]
+    if (frontLot === undefined) break
+
+    const matchedShares = Decimal.min(remaining, frontLot.remainingShares)
+    if (matchedShares.isZero()) {
+      sourceLots.shift()
+      continue
+    }
+
+    const elapsedSeconds = secondsBetween(frontLot.openedAt, fill.executedAt)
+    const effectiveBucket: PnlBucket =
+      frontLot.openedVenue === 'offchain'
+        ? 'directional_exposure'
+        : bucket === 'counter_trade' && elapsedSeconds > COUNTER_TRADE_THRESHOLD_SECONDS
+          ? 'directional_exposure'
+          : bucket
+    const spread =
+      frontLot.side === 'long' ? fill.price.minus(frontLot.price) : frontLot.price.minus(fill.price)
+    const realizedPnl = matchedShares.mul(spread)
+    const openingNotional = matchedShares.mul(frontLot.price)
+    const closingNotional = matchedShares.mul(fill.price)
+
+    frontLot.remainingShares = frontLot.remainingShares.minus(matchedShares)
+    if (frontLot.remainingShares.isZero()) {
+      sourceLots.shift()
+    }
+
+    addRealizedPnl(summary, effectiveBucket, realizedPnl)
+    summary.matchedShares = summary.matchedShares.plus(matchedShares)
+    addVenueNotional(summary, frontLot.openedVenue, openingNotional)
+    addVenueNotional(summary, fill.venue, closingNotional)
+    summary.matchedLotCount += 1
+
+    if (frontLot.openedVenue === 'onchain') {
+      const matched = matchedOnchainShares.get(frontLot.tradeId) ?? ZERO
+      matchedOnchainShares.set(frontLot.tradeId, matched.plus(matchedShares))
+    }
+
+    const openingDirection = lotSideToOnchainDirection(frontLot.side)
+    const closingDirection = directionLabel(fill.direction)
+    const openingPriceText = fmtDecimal(frontLot.price)
+    const closingPriceText = fmtDecimal(fill.price)
+    const onchainDirection =
+      frontLot.openedVenue === 'onchain'
+        ? openingDirection
+        : fill.venue === 'onchain'
+          ? closingDirection
+          : ''
+    const offchainDirection =
+      frontLot.openedVenue === 'offchain'
+        ? openingDirection
+        : fill.venue === 'offchain'
+          ? closingDirection
+          : ''
+    const onchainTradeId =
+      frontLot.openedVenue === 'onchain'
+        ? frontLot.tradeId
+        : fill.venue === 'onchain'
+          ? fill.id
+          : ''
+    const offchainOrderId =
+      frontLot.openedVenue === 'offchain'
+        ? frontLot.tradeId
+        : fill.venue === 'offchain'
+          ? fill.id
+          : ''
+    const onchainPriceText =
+      frontLot.openedVenue === 'onchain'
+        ? openingPriceText
+        : fill.venue === 'onchain'
+          ? closingPriceText
+          : ''
+    const offchainPriceText =
+      frontLot.openedVenue === 'offchain'
+        ? openingPriceText
+        : fill.venue === 'offchain'
+          ? closingPriceText
+          : ''
+
+    entries.push({
+      symbol: fill.symbol,
+      pnlBucket: effectiveBucket,
+      matchedAt: fill.executedAt,
+      openedAt: frontLot.openedAt,
+      closedAt: fill.executedAt,
+      openingFillId: frontLot.tradeId,
+      closingFillId: fill.id,
+      openingRowid: frontLot.openedRowid,
+      closingRowid: fill.rowid,
+      openingVenue: frontLot.openedVenue,
+      closingVenue: fill.venue,
+      openingDirection,
+      closingDirection,
+      openingPriceUsd: openingPriceText,
+      closingPriceUsd: closingPriceText,
+      onchainTradeId,
+      offchainOrderId,
+      onchainDirection,
+      offchainDirection,
+      shares: fmtDecimal(matchedShares),
+      onchainPriceUsdc: onchainPriceText,
+      offchainPriceUsd: offchainPriceText,
+      spreadUsd: fmtDecimal(spread),
+      realizedPnlUsd: fmtDecimal(realizedPnl),
+      elapsedSeconds,
+      counterTradeThresholdSeconds: COUNTER_TRADE_THRESHOLD_SECONDS,
+      delayedCounterTrade: effectiveBucket === 'directional_exposure',
+      attributionMethod: ATTRIBUTION_METHOD
+    })
+
+    remaining = remaining.minus(matchedShares)
+  }
+
+  return remaining
+}
+
+const finalizeLots = (summary: SummaryAcc, lots: Lot[]): void => {
+  for (const lot of lots) {
+    const notional = lot.remainingShares.mul(lot.price)
+
+    if (lot.side === 'long') {
+      summary.openLongShares = summary.openLongShares.plus(lot.remainingShares)
+      summary.openLongNotionalUsd = summary.openLongNotionalUsd.plus(notional)
+    } else {
+      summary.openShortShares = summary.openShortShares.plus(lot.remainingShares)
+      summary.openShortNotionalUsd = summary.openShortNotionalUsd.plus(notional)
+    }
+
+    summary.openLotCount += 1
+  }
+}
+
+const finalizeBook = (
+  symbol: string,
+  book: SymbolBook,
+  positionNets: Map<string, Decimal>,
+  warnings: string[],
+  positionReplayDeltas: PositionReplayDelta[]
+): void => {
+  finalizeLots(book.summary, book.longLots)
+  finalizeLots(book.summary, book.shortLots)
+
+  for (const [tradeId, matchedShares] of book.matchedOnchainShares) {
+    const originalShares = book.originalOnchainShares.get(tradeId)
+    if (originalShares !== undefined && matchedShares.gt(originalShares.plus('0.000001'))) {
+      warnings.push(
+        `PnL audit error: onchain lot ${tradeId} for ${symbol} matched ${fmtDecimal(matchedShares)} shares above original ${fmtDecimal(originalShares)}`
+      )
+    }
+  }
+
+  const positionNet = positionNets.get(symbol)
+  if (positionNet !== undefined) {
+    const replayNet = book.summary.openLongShares.minus(book.summary.openShortShares)
+    if (replayNet.minus(positionNet).abs().gt('0.000001')) {
+      positionReplayDeltas.push({
+        symbol,
+        replayNet,
+        positionNet
+      })
+    }
+  }
+}
+
+const addSummary = (target: SummaryAcc, source: SummaryAcc): void => {
+  target.counterTradePnlUsd = target.counterTradePnlUsd.plus(source.counterTradePnlUsd)
+  target.onchainNettingPnlUsd = target.onchainNettingPnlUsd.plus(source.onchainNettingPnlUsd)
+  target.directionalInventoryBaselinePnlUsd = target.directionalInventoryBaselinePnlUsd.plus(
+    source.directionalInventoryBaselinePnlUsd
+  )
+  target.directionalImbalanceExcessPnlUsd = target.directionalImbalanceExcessPnlUsd.plus(
+    source.directionalImbalanceExcessPnlUsd
+  )
+  target.directionalExposurePnlUsd = target.directionalExposurePnlUsd.plus(
+    source.directionalExposurePnlUsd
+  )
+  target.realizedPnlUsd = target.realizedPnlUsd.plus(source.realizedPnlUsd)
+  target.matchedShares = target.matchedShares.plus(source.matchedShares)
+  target.onchainNotionalUsd = target.onchainNotionalUsd.plus(source.onchainNotionalUsd)
+  target.offchainNotionalUsd = target.offchainNotionalUsd.plus(source.offchainNotionalUsd)
+  target.openLongShares = target.openLongShares.plus(source.openLongShares)
+  target.openShortShares = target.openShortShares.plus(source.openShortShares)
+  target.openLongNotionalUsd = target.openLongNotionalUsd.plus(source.openLongNotionalUsd)
+  target.openShortNotionalUsd = target.openShortNotionalUsd.plus(source.openShortNotionalUsd)
+  target.unmatchedOffchainBuyShares = target.unmatchedOffchainBuyShares.plus(
+    source.unmatchedOffchainBuyShares
+  )
+  target.unmatchedOffchainSellShares = target.unmatchedOffchainSellShares.plus(
+    source.unmatchedOffchainSellShares
+  )
+  target.unmatchedOffchainBuyNotionalUsd = target.unmatchedOffchainBuyNotionalUsd.plus(
+    source.unmatchedOffchainBuyNotionalUsd
+  )
+  target.unmatchedOffchainSellNotionalUsd = target.unmatchedOffchainSellNotionalUsd.plus(
+    source.unmatchedOffchainSellNotionalUsd
+  )
+  target.onchainFillCount += source.onchainFillCount
+  target.offchainFillCount += source.offchainFillCount
+  target.matchedLotCount += source.matchedLotCount
+  target.openLotCount += source.openLotCount
+  target.unmatchedOffchainFillCount += source.unmatchedOffchainFillCount
+}
+
+const summaryToDto = (summary: SummaryAcc): PnlSummary => {
+  const directionalExposurePnl = summary.directionalInventoryBaselinePnlUsd.plus(
+    summary.directionalImbalanceExcessPnlUsd
+  )
+  const totalPnl = summary.counterTradePnlUsd
+    .plus(summary.onchainNettingPnlUsd)
+    .plus(summary.directionalInventoryBaselinePnlUsd)
+    .plus(summary.directionalImbalanceExcessPnlUsd)
+
+  return {
+    counterTradePnlUsd: fmtDecimal(summary.counterTradePnlUsd),
+    onchainNettingPnlUsd: fmtDecimal(summary.onchainNettingPnlUsd),
+    directionalInventoryBaselinePnlUsd: fmtDecimal(summary.directionalInventoryBaselinePnlUsd),
+    directionalImbalanceExcessPnlUsd: fmtDecimal(summary.directionalImbalanceExcessPnlUsd),
+    directionalExposurePnlUsd: fmtDecimal(directionalExposurePnl),
+    totalPnlUsd: fmtDecimal(totalPnl),
+    realizedPnlUsd: fmtDecimal(summary.realizedPnlUsd),
+    matchedShares: fmtDecimal(summary.matchedShares),
+    onchainNotionalUsd: fmtDecimal(summary.onchainNotionalUsd),
+    offchainNotionalUsd: fmtDecimal(summary.offchainNotionalUsd),
+    inventoryDriftShares: fmtDecimal(summary.openLongShares.minus(summary.openShortShares)),
+    inventoryDriftUsd: fmtDecimal(summary.openLongNotionalUsd.minus(summary.openShortNotionalUsd)),
+    openLongShares: fmtDecimal(summary.openLongShares),
+    openShortShares: fmtDecimal(summary.openShortShares),
+    unmatchedOffchainShares: fmtDecimal(
+      summary.unmatchedOffchainBuyShares.plus(summary.unmatchedOffchainSellShares)
+    ),
+    unmatchedOffchainNotionalUsd: fmtDecimal(
+      summary.unmatchedOffchainBuyNotionalUsd.plus(summary.unmatchedOffchainSellNotionalUsd)
+    ),
+    onchainFillCount: summary.onchainFillCount,
+    offchainFillCount: summary.offchainFillCount,
+    matchedLotCount: summary.matchedLotCount,
+    openLotCount: summary.openLotCount,
+    unmatchedOffchainFillCount: summary.unmatchedOffchainFillCount
+  }
+}
+
+const symbolSummaryToDto = (symbol: string, summary: SummaryAcc): PnlSymbolSummary => {
+  const dto = summaryToDto(summary)
+  return {
+    symbol,
+    counterTradePnlUsd: dto.counterTradePnlUsd,
+    onchainNettingPnlUsd: dto.onchainNettingPnlUsd,
+    directionalInventoryBaselinePnlUsd: dto.directionalInventoryBaselinePnlUsd,
+    directionalImbalanceExcessPnlUsd: dto.directionalImbalanceExcessPnlUsd,
+    directionalExposurePnlUsd: dto.directionalExposurePnlUsd,
+    totalPnlUsd: dto.totalPnlUsd,
+    realizedPnlUsd: dto.realizedPnlUsd,
+    matchedShares: dto.matchedShares,
+    inventoryDriftShares: dto.inventoryDriftShares,
+    inventoryDriftUsd: dto.inventoryDriftUsd,
+    openLongShares: dto.openLongShares,
+    openShortShares: dto.openShortShares,
+    unmatchedOffchainShares: dto.unmatchedOffchainShares,
+    matchedLotCount: dto.matchedLotCount,
+    onchainFillCount: dto.onchainFillCount,
+    offchainFillCount: dto.offchainFillCount,
+    unmatchedOffchainFillCount: dto.unmatchedOffchainFillCount
+  }
+}
+
+const withReplayExposure = (filtered: PnlSummary, replay: PnlSummary): PnlSummary => ({
+  ...filtered,
+  inventoryDriftShares: replay.inventoryDriftShares,
+  inventoryDriftUsd: replay.inventoryDriftUsd,
+  openLongShares: replay.openLongShares,
+  openShortShares: replay.openShortShares,
+  unmatchedOffchainShares: replay.unmatchedOffchainShares,
+  unmatchedOffchainNotionalUsd: replay.unmatchedOffchainNotionalUsd,
+  openLotCount: replay.openLotCount,
+  unmatchedOffchainFillCount: replay.unmatchedOffchainFillCount
+})
+
+const withSymbolReplayExposure = (
+  filtered: PnlSymbolSummary,
+  replay: PnlSymbolSummary
+): PnlSymbolSummary => ({
+  ...filtered,
+  inventoryDriftShares: replay.inventoryDriftShares,
+  inventoryDriftUsd: replay.inventoryDriftUsd,
+  openLongShares: replay.openLongShares,
+  openShortShares: replay.openShortShares,
+  unmatchedOffchainShares: replay.unmatchedOffchainShares,
+  unmatchedOffchainFillCount: replay.unmatchedOffchainFillCount
+})
+
+const emptySymbolSummary = (symbol: string): PnlSymbolSummary =>
+  symbolSummaryToDto(symbol, emptySummary())
+
+const isNonZeroText = (value: string): boolean => {
+  try {
+    return !new Decimal(value).isZero()
+  } catch {
+    return false
+  }
+}
+
+const hasReplayExposure = (summary: PnlSymbolSummary): boolean =>
+  isNonZeroText(summary.inventoryDriftShares) ||
+  isNonZeroText(summary.inventoryDriftUsd) ||
+  isNonZeroText(summary.openLongShares) ||
+  isNonZeroText(summary.openShortShares) ||
+  isNonZeroText(summary.unmatchedOffchainShares) ||
+  summary.unmatchedOffchainFillCount > 0
+
+const mergeSymbolReplayExposure = (
+  filteredSymbols: PnlSymbolSummary[],
+  replaySymbols: PnlSymbolSummary[]
+): PnlSymbolSummary[] => {
+  const bySymbol = new Map(filteredSymbols.map((row) => [row.symbol, row]))
+
+  for (const replay of replaySymbols) {
+    const existing = bySymbol.get(replay.symbol) ?? emptySymbolSummary(replay.symbol)
+    if (bySymbol.has(replay.symbol) || hasReplayExposure(replay)) {
+      bySymbol.set(replay.symbol, withSymbolReplayExposure(existing, replay))
+    }
+  }
+
+  return [...bySymbol.values()].sort((left, right) => left.symbol.localeCompare(right.symbol))
+}
+
+const entryBucketToStream = (bucket: string): PnlStreamKey | null => {
+  if (bucket === 'counter_trade') return 'counterTradePnlUsd'
+  if (bucket === 'onchain_netting') return 'onchainNettingPnlUsd'
+  if (bucket === 'directional_exposure') return 'directionalImbalanceExcessPnlUsd'
+  return null
+}
+
+const entryVenue = (value: string): Venue | null => {
+  if (value === 'onchain' || value === 'offchain') return value
+  return null
+}
+
+const summaryFromEntries = (
+  entries: PnlEntry[]
+): { summary: PnlSummary; symbols: PnlSymbolSummary[] } => {
+  const total = emptySummary()
+  const perSymbol = new Map<string, SummaryAcc>()
+
+  for (const entry of entries) {
+    const summary = perSymbol.get(entry.symbol) ?? emptySummary()
+    perSymbol.set(entry.symbol, summary)
+    const shares = new Decimal(entry.shares)
+    const openingNotional = shares.mul(new Decimal(entry.openingPriceUsd))
+    const closingNotional = shares.mul(new Decimal(entry.closingPriceUsd))
+    const pnl = new Decimal(entry.realizedPnlUsd)
+
+    summary.matchedShares = summary.matchedShares.plus(shares)
+    const openingVenue = entryVenue(entry.openingVenue)
+    const closingVenue = entryVenue(entry.closingVenue)
+    if (openingVenue !== null) addVenueNotional(summary, openingVenue, openingNotional)
+    if (closingVenue !== null) addVenueNotional(summary, closingVenue, closingNotional)
+    summary.matchedLotCount += 1
+
+    if (entry.pnlBucket === 'counter_trade') {
+      summary.counterTradePnlUsd = summary.counterTradePnlUsd.plus(pnl)
+      summary.realizedPnlUsd = summary.realizedPnlUsd.plus(pnl)
+    } else if (entry.pnlBucket === 'onchain_netting') {
+      summary.onchainNettingPnlUsd = summary.onchainNettingPnlUsd.plus(pnl)
+      summary.realizedPnlUsd = summary.realizedPnlUsd.plus(pnl)
+    } else if (entry.pnlBucket === 'directional_exposure') {
+      summary.directionalImbalanceExcessPnlUsd = summary.directionalImbalanceExcessPnlUsd.plus(pnl)
+      summary.directionalExposurePnlUsd = summary.directionalExposurePnlUsd.plus(pnl)
+      summary.realizedPnlUsd = summary.realizedPnlUsd.plus(pnl)
+    }
+  }
+
+  const symbols = [...perSymbol.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([symbol, summary]) => {
+      addSummary(total, summary)
+      return symbolSummaryToDto(symbol, summary)
+    })
+
+  return { summary: summaryToDto(total), symbols }
+}
+
+const buildWindows = (entries: PnlEntry[], symbols: string[]): PnlWindow[] => {
+  const byDate = new Map<string, PnlEntry[]>()
+
+  for (const entry of entries) {
+    const key = dateKey(entry.closedAt)
+    const dayEntries = byDate.get(key)
+    if (dayEntries === undefined) {
+      byDate.set(key, [entry])
+    } else {
+      dayEntries.push(entry)
+    }
+  }
+
+  return [...byDate.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([date, dayEntries]) => {
+      const rows: PnlWindowSymbol[] = symbols.map((symbol) => {
+        const values: Record<PnlStreamKey, Decimal> = {
+          counterTradePnlUsd: new Decimal(0),
+          onchainNettingPnlUsd: new Decimal(0),
+          directionalInventoryBaselinePnlUsd: new Decimal(0),
+          directionalImbalanceExcessPnlUsd: new Decimal(0)
+        }
+
+        for (const entry of dayEntries) {
+          if (entry.symbol !== symbol) continue
+          const stream = entryBucketToStream(entry.pnlBucket)
+          if (stream === null) continue
+          values[stream] = values[stream].plus(new Decimal(entry.realizedPnlUsd))
+        }
+
+        const directionalExposure = values.directionalInventoryBaselinePnlUsd.plus(
+          values.directionalImbalanceExcessPnlUsd
+        )
+        const totalPnl = values.counterTradePnlUsd
+          .plus(values.onchainNettingPnlUsd)
+          .plus(values.directionalInventoryBaselinePnlUsd)
+          .plus(values.directionalImbalanceExcessPnlUsd)
+
+        return {
+          symbol,
+          counterTradePnlUsd: fmtDecimal(values.counterTradePnlUsd),
+          onchainNettingPnlUsd: fmtDecimal(values.onchainNettingPnlUsd),
+          directionalInventoryBaselinePnlUsd: fmtDecimal(values.directionalInventoryBaselinePnlUsd),
+          directionalImbalanceExcessPnlUsd: fmtDecimal(values.directionalImbalanceExcessPnlUsd),
+          directionalExposurePnlUsd: fmtDecimal(directionalExposure),
+          totalPnlUsd: fmtDecimal(totalPnl)
+        }
+      })
+
+      return {
+        windowId: date,
+        startAt: `${date}T00:00:00.000Z`,
+        endAt: `${date}T23:59:59.999Z`,
+        label: date,
+        isWeekend: isWeekendIso(`${date}T00:00:00.000Z`),
+        granularity: 'day',
+        symbols: rows
+      }
+    })
+}
+
+const parsePositionView = (
+  rows: SqlPositionViewRow[],
+  warnings: string[]
+): { positionNets: Map<string, Decimal>; symbols: string[] } => {
+  const positionNets = new Map<string, Decimal>()
+  const symbols = new Set<string>()
+
+  for (const row of rows) {
+    if (!isSafeSqlSymbol(row.symbol)) {
+      warnings.push(`Skipped unsafe position_view symbol in SQL PnL response: ${row.symbol}`)
+      continue
+    }
+
+    symbols.add(row.symbol)
+
+    if (row.net_position !== null) {
+      try {
+        positionNets.set(row.symbol, new Decimal(row.net_position))
+      } catch {
+        warnings.push(`Skipped malformed position net for ${row.symbol}: ${row.net_position}`)
+      }
+    }
+  }
+
+  return { positionNets, symbols: [...symbols].sort() }
+}
+
+const parseCount = (value: number | string | null | undefined): number => {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+const buildSampleStats = (rows: SqlSampleStatsRow[], warnings: string[]): PnlSampleStats => {
+  const symbols: PnlSampleSymbolStats[] = []
+  for (const row of rows) {
+    if (!isSafeSqlSymbol(row.symbol)) {
+      warnings.push(`Skipped unsafe sample stats symbol in SQL PnL response: ${row.symbol}`)
+      continue
+    }
+
+    const onchainFillCount = parseCount(row.onchain_fill_count)
+    const offchainFillCount = parseCount(row.offchain_fill_count)
+
+    symbols.push({
+      symbol: row.symbol,
+      firstAt: row.first_at,
+      lastAt: row.last_at,
+      onchainFillCount,
+      offchainFillCount,
+      totalFillCount: onchainFillCount + offchainFillCount
+    })
+  }
+
+  const firstAt =
+    symbols
+      .map((row) => row.firstAt)
+      .filter((value): value is string => value !== null)
+      .sort((left, right) => left.localeCompare(right))[0] ?? null
+  const lastAt =
+    symbols
+      .map((row) => row.lastAt)
+      .filter((value): value is string => value !== null)
+      .sort((left, right) => right.localeCompare(left))[0] ?? null
+
+  return {
+    firstAt,
+    lastAt,
+    symbolCount: symbols.length,
+    onchainFillCount: symbols.reduce((total, row) => total + row.onchainFillCount, 0),
+    offchainFillCount: symbols.reduce((total, row) => total + row.offchainFillCount, 0),
+    totalFillCount: symbols.reduce((total, row) => total + row.totalFillCount, 0),
+    symbols
+  }
+}
+
+export const buildPnlResponseFromSqlRows = (
+  eventRows: SqlPositionEventRow[],
+  positionRows: SqlPositionViewRow[],
+  sampleRows: SqlSampleStatsRow[],
+  query: SqlPnlQuery
+): PnlResponse => {
+  const warnings = [ATTRIBUTION_WARNING, BASELINE_WARNING]
+  appendInvalidQuerySymbols(warnings, query.symbols)
+  const {
+    positionNets,
+    symbols: positionSymbols
+  } = parsePositionView(positionRows, warnings)
+  const sampleStats = buildSampleStats(sampleRows, warnings)
+  const books = new Map<string, SymbolBook>()
+  const entries: PnlEntry[] = []
+  const unmatchedOffchainAllocations: UnmatchedOffchainAllocation[] = []
+  const positionReplayDeltas: PositionReplayDelta[] = []
+
+  for (const row of orderedPositionEvents(eventRows, warnings)) {
+    if (!isSafeSqlSymbol(row.symbol)) {
+      warnings.push(`Skipped unsafe position event symbol in SQL PnL response: ${row.symbol}`)
+      continue
+    }
+
+    const book = getBook(books, row.symbol)
+
+    if (row.event_type === 'PositionEvent::OnChainOrderFilled') {
+      const fill = parseOnchainFill(row, warnings)
+      if (fill !== null) applyOnchainFill(book, fill, entries, warnings)
+    } else if (row.event_type === 'PositionEvent::OffChainOrderPlaced') {
+      applyOffchainPlacement(book, row, warnings)
+    } else if (row.event_type === 'PositionEvent::OffChainOrderFilled') {
+      const fill = parseOffchainFill(row, warnings)
+      if (fill !== null)
+        applyOffchainFill(book, fill, entries, warnings, unmatchedOffchainAllocations)
+    }
+  }
+
+  const fullTotal = emptySummary()
+  const replaySymbols: PnlSymbolSummary[] = []
+  for (const [symbol, book] of books) {
+    finalizeBook(symbol, book, positionNets, warnings, positionReplayDeltas)
+    addSummary(fullTotal, book.summary)
+    replaySymbols.push(symbolSummaryToDto(symbol, book.summary))
+  }
+  appendReplayDiagnostics(warnings, unmatchedOffchainAllocations, positionReplayDeltas)
+
+  const filteredEntries = entries
+    .filter((entry) => matchesDateFilter(entry, query))
+    .sort((left, right) => right.matchedAt.localeCompare(left.matchedAt))
+  const total = filteredEntries.length
+  const start = Math.min(query.offset, total)
+  const end = Math.min(start + query.limit, total)
+  const pageEntries = filteredEntries.slice(start, end)
+  const filtered = summaryFromEntries(filteredEntries)
+  const replaySummary = summaryToDto(fullTotal)
+  const summary = withReplayExposure(filtered.summary, replaySummary)
+  const symbols = mergeSymbolReplayExposure(filtered.symbols, replaySymbols)
+  const symbolUniverse = [
+    ...new Set([...positionSymbols, ...books.keys(), ...symbols.map((row) => row.symbol)])
+  ].sort()
+
+  return {
+    attributionMethod: ATTRIBUTION_METHOD,
+    warnings,
+    sampleStats,
+    summary,
+    symbols,
+    symbolUniverse,
+    entries: pageEntries,
+    total,
+    hasMore: end < total,
+    windows: buildWindows(filteredEntries, symbolUniverse)
+  }
+}
+
+export const fetchPnlReportFromSql = async (
+  baseUrl: string,
+  query: SqlPnlQuery
+): Promise<PnlResponse> => {
+  const [eventRows, positionRows, sampleRows] = await Promise.all([
+    fetchSqlRows<SqlPositionEventRow>(baseUrl, positionEventsSql(query.symbols)),
+    fetchSqlRows<SqlPositionViewRow>(baseUrl, positionViewSql(new Set())),
+    fetchSqlRows<SqlSampleStatsRow>(baseUrl, sampleStatsSql())
+  ])
+
+  return buildPnlResponseFromSqlRows(eventRows, positionRows, sampleRows, query)
+}

--- a/dashboard/src/lib/pnl/synthetic.test.ts
+++ b/dashboard/src/lib/pnl/synthetic.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { STREAM_KEYS } from './report'
+import {
+  generateSyntheticPnlDashboard,
+  generateSyntheticPnlDataset,
+} from './synthetic'
+
+describe('generateSyntheticPnlDataset', () => {
+  it('generates deterministic multi-day multi-asset PnL fixtures', () => {
+    const dataset = generateSyntheticPnlDataset()
+
+    expect(dataset.symbols).toEqual(['RKLB', 'SGOV', 'CRCL', 'BMNR'])
+    expect(dataset.startAt).toBe('2026-05-04T13:30:00.000Z')
+    expect(dataset.endAt).toBe('2026-05-14T13:30:00.000Z')
+    expect(dataset.fills.length).toBeGreaterThan(1_800)
+    expect(dataset.marks.length).toBe(360)
+    expect(dataset.fills[0]?.rowid).toBe(1)
+    expect(dataset.fills.at(-1)?.rowid).toBe(dataset.fills.length)
+    expect(dataset.fills.some((fill) => fill.venue === 'onchain')).toBe(true)
+    expect(dataset.fills.some((fill) => fill.venue === 'offchain')).toBe(true)
+    expect(dataset.fills.some((fill) => fill.fillId.includes('passive-net'))).toBe(true)
+  })
+
+  it('generates dashboard-ready mock PnL windows and linked lots', () => {
+    const dashboard = generateSyntheticPnlDashboard()
+
+    expect(STREAM_KEYS).toEqual([
+      'counterTradePnlUsd',
+      'onchainNettingPnlUsd',
+      'directionalInventoryBaselinePnlUsd',
+      'directionalImbalanceExcessPnlUsd',
+    ])
+    expect(dashboard.windows).toHaveLength(500)
+    expect(dashboard.windows[0]?.startAt).toBe('2025-01-01T13:30:00.000Z')
+    expect(dashboard.windows.at(-1)?.startAt).toBe('2026-05-15T13:30:00.000Z')
+    expect(dashboard.windows.filter((window) => window.isWeekend).length).toBeGreaterThan(140)
+    expect(dashboard.report.symbols.map((row) => row.symbol)).toEqual([
+      'BMNR',
+      'CRCL',
+      'RKLB',
+      'SGOV',
+    ])
+    expect(dashboard.report.entries.some((entry) => entry.pnlBucket === 'counter_trade')).toBe(true)
+    expect(dashboard.report.entries.some((entry) => entry.pnlBucket === 'onchain_netting')).toBe(true)
+    expect(dashboard.report.entries.some((entry) => entry.pnlBucket === 'directional_exposure')).toBe(true)
+    expect(dashboard.report.entries.some((entry) => entry.delayedCounterTrade)).toBe(true)
+    expect(Number(dashboard.report.summary.totalPnlUsd)).not.toBe(0)
+  })
+
+  it('keeps baseline drift fields internally consistent', () => {
+    const dashboard = generateSyntheticPnlDashboard()
+    const symbolBaseline = dashboard.report.symbols.reduce(
+      (total, row) => total + Number(row.directionalInventoryBaselinePnlUsd),
+      0,
+    )
+
+    expect(Number(dashboard.report.summary.directionalInventoryBaselinePnlUsd)).toBeCloseTo(symbolBaseline, 2)
+    expect(Number(dashboard.report.summary.inventoryDriftUsd)).toBe(
+      Number(dashboard.report.summary.directionalInventoryBaselinePnlUsd),
+    )
+
+    for (const row of dashboard.report.symbols) {
+      expect(Number(row.inventoryDriftUsd)).toBe(Number(row.directionalInventoryBaselinePnlUsd))
+    }
+  })
+
+  it('keeps aggregate PnL identities and linked entries reconciled', () => {
+    const dashboard = generateSyntheticPnlDashboard()
+    const summary = dashboard.report.summary
+    const entrySum = (bucket: string) => dashboard.report.entries
+      .filter((entry) => entry.pnlBucket === bucket)
+      .reduce((total, entry) => total + Number(entry.realizedPnlUsd), 0)
+
+    expect(Number(summary.directionalExposurePnlUsd)).toBeCloseTo(
+      Number(summary.directionalInventoryBaselinePnlUsd) + Number(summary.directionalImbalanceExcessPnlUsd),
+      1,
+    )
+    expect(Number(summary.totalPnlUsd)).toBeCloseTo(
+      Number(summary.counterTradePnlUsd)
+        + Number(summary.onchainNettingPnlUsd)
+        + Number(summary.directionalInventoryBaselinePnlUsd)
+        + Number(summary.directionalImbalanceExcessPnlUsd),
+      1,
+    )
+    expect(Number(summary.realizedPnlUsd)).toBeCloseTo(
+      Number(summary.counterTradePnlUsd)
+        + Number(summary.onchainNettingPnlUsd)
+        + Number(summary.directionalImbalanceExcessPnlUsd),
+      1,
+    )
+    expect(entrySum('counter_trade')).toBeCloseTo(Number(summary.counterTradePnlUsd), 1)
+    expect(entrySum('onchain_netting')).toBeCloseTo(Number(summary.onchainNettingPnlUsd), 1)
+    expect(entrySum('directional_exposure')).toBeCloseTo(Number(summary.directionalImbalanceExcessPnlUsd), 1)
+  })
+})

--- a/dashboard/src/lib/pnl/synthetic.ts
+++ b/dashboard/src/lib/pnl/synthetic.ts
@@ -1,0 +1,513 @@
+import {
+  type PnlEntry,
+  type PnlResponse,
+  type PnlSummary,
+  type PnlSymbolSummary,
+  type PnlWindow,
+  type PnlWindowSymbol,
+} from './report'
+
+type AssetScenario = {
+  symbol: string
+  basePrice: string
+  dailyDriftBps: number
+  volatilityBps: number
+}
+
+type SyntheticOptions = {
+  startAt?: string
+  days?: number
+  assets?: AssetScenario[]
+  onchainFillsPerAssetDay?: number
+}
+
+export type SyntheticPnlDashboard = {
+  report: PnlResponse
+  windows: PnlWindow[]
+}
+
+export type SyntheticPnlFill = {
+  rowid: number
+  fillId: string
+  symbol: string
+  venue: 'onchain' | 'offchain'
+  direction: 'Buy' | 'Sell'
+  shares: string
+  priceUsd: string
+  executedAt: string
+}
+
+export type SyntheticPnlMark = {
+  symbol: string
+  timestamp: string
+  priceUsd: string
+}
+
+export type SyntheticPnlDataset = {
+  generatedAt: string
+  startAt: string
+  endAt: string
+  symbols: string[]
+  fills: SyntheticPnlFill[]
+  marks: SyntheticPnlMark[]
+}
+
+const DEFAULT_ASSETS: AssetScenario[] = [
+  { symbol: 'RKLB', basePrice: '22.40', dailyDriftBps: 18, volatilityBps: 95 },
+  { symbol: 'SGOV', basePrice: '100.72', dailyDriftBps: 1, volatilityBps: 6 },
+  { symbol: 'CRCL', basePrice: '87.50', dailyDriftBps: -11, volatilityBps: 160 },
+  { symbol: 'BMNR', basePrice: '41.80', dailyDriftBps: 24, volatilityBps: 130 },
+]
+
+const DEFAULT_START_AT = '2026-05-04T13:30:00.000Z'
+const DEFAULT_DASHBOARD_START_AT = '2025-01-01T13:30:00.000Z'
+const DEFAULT_DASHBOARD_DAYS = 500
+const MS_PER_MINUTE = 60_000
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE
+const priceText = (value: number): string => value.toFixed(4).replace(/\.?0+$/u, '')
+const shareText = (value: number): string => value.toFixed(9).replace(/\.?0+$/u, '')
+const moneyText = (value: number): string => value.toFixed(2).replace(/\.?0+$/u, '')
+
+const pseudoNoise = (seed: number): number => {
+  const raw = Math.sin(seed * 12.9898 + 78.233) * 43758.5453
+  return raw - Math.floor(raw)
+}
+
+const signedNoise = (seed: number): number => pseudoNoise(seed) * 2 - 1
+
+const marketPrice = (asset: AssetScenario, day: number, minute: number): number => {
+  const drift = (asset.dailyDriftBps * day) / 10_000
+  const wave = (Math.sin((day + 1) * 0.7 + minute / 83) * asset.volatilityBps) / 10_000
+  const micro = (signedNoise((day + 1) * 997 + minute) * asset.volatilityBps) / 30_000
+
+  return Number(asset.basePrice) * (1 + drift + wave + micro)
+}
+
+const fillPrice = (
+  asset: AssetScenario,
+  day: number,
+  minute: number,
+  venue: 'onchain' | 'offchain',
+  direction: 'Buy' | 'Sell',
+): number => {
+  const mid = marketPrice(asset, day, minute)
+  const venueEdgeBps = venue === 'onchain' ? 8 : 5
+  const directionSign = direction === 'Buy' ? 1 : -1
+  const noiseBps = signedNoise((day + 11) * 1231 + minute * 13 + asset.symbol.length) * 2
+  return mid * (1 + (directionSign * venueEdgeBps + noiseBps) / 10_000)
+}
+
+const directionFor = (assetIndex: number, day: number, tradeIndex: number): 'Buy' | 'Sell' => {
+  const pulse = (tradeIndex + day + assetIndex) % 9
+  if (pulse === 0 || pulse === 1) return 'Buy'
+  if (pulse === 5 || pulse === 6) return 'Sell'
+  return (tradeIndex + assetIndex) % 2 === 0 ? 'Buy' : 'Sell'
+}
+
+const opposite = (direction: 'Buy' | 'Sell'): 'Buy' | 'Sell' =>
+  direction === 'Buy' ? 'Sell' : 'Buy'
+
+const shareSize = (asset: AssetScenario, day: number, tradeIndex: number): number => {
+  const base = asset.symbol === 'SGOV' ? 0.035 : 0.18
+  const scale = 1 + ((day + tradeIndex) % 7) / 10
+  const jitter = (pseudoNoise(day * 101 + tradeIndex * 17) * base) / 2
+  return base * scale + jitter
+}
+
+const pushFill = (
+  fills: SyntheticPnlFill[],
+  fill: Omit<SyntheticPnlFill, 'rowid'>,
+): void => {
+  fills.push({
+    rowid: fills.length + 1,
+    ...fill,
+  })
+}
+
+export const generateSyntheticPnlDataset = (
+  options: SyntheticOptions = {},
+): SyntheticPnlDataset => {
+  const startAt = new Date(options.startAt ?? DEFAULT_START_AT)
+  const days = options.days ?? 10
+  const assets = options.assets ?? DEFAULT_ASSETS
+  const onchainFillsPerAssetDay = options.onchainFillsPerAssetDay ?? 28
+  const fills: SyntheticPnlFill[] = []
+  const marks: SyntheticPnlMark[] = []
+
+  assets.forEach((asset, assetIndex) => {
+    for (let day = 0; day < days; day += 1) {
+      for (let markIndex = 0; markIndex <= 8; markIndex += 1) {
+        const minute = markIndex * 60
+        const timestamp = new Date(startAt.getTime() + day * MS_PER_DAY + minute * MS_PER_MINUTE)
+        marks.push({
+          symbol: asset.symbol,
+          timestamp: timestamp.toISOString(),
+          priceUsd: priceText(marketPrice(asset, day, minute)),
+        })
+      }
+
+      for (let tradeIndex = 0; tradeIndex < onchainFillsPerAssetDay; tradeIndex += 1) {
+        const minute = 7 + tradeIndex * 13 + ((day + assetIndex) % 5)
+        const direction = directionFor(assetIndex, day, tradeIndex)
+        const onchainShares = shareSize(asset, day, tradeIndex)
+        const onchainAt = new Date(startAt.getTime() + day * MS_PER_DAY + minute * MS_PER_MINUTE)
+        const onchainId = `synthetic-on-${asset.symbol}-${String(day + 1).padStart(2, '0')}-${String(tradeIndex + 1).padStart(3, '0')}`
+
+        pushFill(fills, {
+          fillId: onchainId,
+          symbol: asset.symbol,
+          venue: 'onchain',
+          direction,
+          shares: shareText(onchainShares),
+          priceUsd: priceText(fillPrice(asset, day, minute, 'onchain', direction)),
+          executedAt: onchainAt.toISOString(),
+        })
+
+        const passiveNetting = tradeIndex % 11 === 4
+        if (passiveNetting) {
+          const nettingDirection = opposite(direction)
+          const nettingShares = onchainShares * (0.45 + ((day + assetIndex) % 3) / 10)
+          const nettingMinute = minute + 3
+          const nettingAt = new Date(startAt.getTime() + day * MS_PER_DAY + nettingMinute * MS_PER_MINUTE)
+          pushFill(fills, {
+            fillId: `${onchainId}-passive-net`,
+            symbol: asset.symbol,
+            venue: 'onchain',
+            direction: nettingDirection,
+            shares: shareText(nettingShares),
+            priceUsd: priceText(fillPrice(asset, day, nettingMinute, 'onchain', nettingDirection)),
+            executedAt: nettingAt.toISOString(),
+          })
+        }
+
+        const counterTrade = tradeIndex % 4 !== 2
+        if (counterTrade) {
+          const hedgeDirection = opposite(direction)
+          const hedgeRatio = tradeIndex % 10 === 7 ? 0.62 : 0.96
+          const hedgeShares = onchainShares * hedgeRatio
+          const lagMinutes = 2 + ((tradeIndex + day + assetIndex) % 9)
+          const hedgeMinute = minute + lagMinutes
+          const hedgeAt = new Date(startAt.getTime() + day * MS_PER_DAY + hedgeMinute * MS_PER_MINUTE)
+
+          pushFill(fills, {
+            fillId: `synthetic-off-${asset.symbol}-${String(day + 1).padStart(2, '0')}-${String(tradeIndex + 1).padStart(3, '0')}`,
+            symbol: asset.symbol,
+            venue: 'offchain',
+            direction: hedgeDirection,
+            shares: shareText(hedgeShares),
+            priceUsd: priceText(fillPrice(asset, day, hedgeMinute, 'offchain', hedgeDirection)),
+            executedAt: hedgeAt.toISOString(),
+          })
+        }
+      }
+    }
+  })
+
+  fills.sort((left, right) => left.executedAt.localeCompare(right.executedAt))
+  fills.forEach((fill, index) => {
+    fill.rowid = index + 1
+  })
+
+  const endAt = new Date(startAt.getTime() + days * MS_PER_DAY).toISOString()
+
+  return {
+    generatedAt: new Date('2026-05-12T00:00:00.000Z').toISOString(),
+    startAt: startAt.toISOString(),
+    endAt,
+    symbols: assets.map((asset) => asset.symbol),
+    fills,
+    marks: marks.sort((left, right) => left.timestamp.localeCompare(right.timestamp)),
+  }
+}
+
+export const syntheticPnlDataset = generateSyntheticPnlDataset()
+
+const dailyPnl = (
+  asset: AssetScenario,
+  assetIndex: number,
+  day: number,
+  isWeekend: boolean,
+): PnlWindowSymbol => {
+  const capitalScale = Number(asset.basePrice) * (asset.symbol === 'SGOV' ? 0.25 : 1)
+  const quality = 1 + signedNoise((assetIndex + 1) * 17 + day * 31) * 0.35
+  const counterTrade = isWeekend
+    ? 0
+    : capitalScale * (0.52 + assetIndex * 0.08) * quality
+  const onchainNetting = capitalScale * signedNoise(200 + assetIndex * 19 + day * 7) * 0.16
+  const frozenNotional = capitalScale * (asset.symbol === 'SGOV' ? 7 : 9 + assetIndex * 2)
+  const bucketReturn =
+    asset.dailyDriftBps / 10_000
+    + Math.sin((day + 1) * 0.41 + assetIndex) * asset.volatilityBps / 18_000
+    + signedNoise(700 + assetIndex * 29 + day * 17) * asset.volatilityBps / 35_000
+  const baseline = frozenNotional * bucketReturn
+  const delayedSpike = day % 5 === 3 ? capitalScale * 0.38 : 0
+  const weekendExposure = isWeekend
+    ? capitalScale * (0.9 + assetIndex * 0.2) * signedNoise(900 + day * 11 + assetIndex)
+    : 0
+  const danglingExposure = capitalScale * signedNoise(500 + assetIndex * 23 + day * 13) * 0.12
+  const excess = weekendExposure + delayedSpike + danglingExposure
+  const directional = baseline + excess
+  const total = counterTrade + onchainNetting + directional
+
+  return {
+    symbol: asset.symbol,
+    counterTradePnlUsd: moneyText(counterTrade),
+    onchainNettingPnlUsd: moneyText(onchainNetting),
+    directionalInventoryBaselinePnlUsd: moneyText(baseline),
+    directionalImbalanceExcessPnlUsd: moneyText(excess),
+    directionalExposurePnlUsd: moneyText(directional),
+    totalPnlUsd: moneyText(total),
+  }
+}
+
+const emptySummary = (): PnlSummary => ({
+  counterTradePnlUsd: '0',
+  onchainNettingPnlUsd: '0',
+  directionalInventoryBaselinePnlUsd: '0',
+  directionalImbalanceExcessPnlUsd: '0',
+  directionalExposurePnlUsd: '0',
+  totalPnlUsd: '0',
+  realizedPnlUsd: '0',
+  matchedShares: '0',
+  onchainNotionalUsd: '0',
+  offchainNotionalUsd: '0',
+  inventoryDriftShares: '0',
+  inventoryDriftUsd: '0',
+  openLongShares: '0',
+  openShortShares: '0',
+  unmatchedOffchainShares: '0',
+  unmatchedOffchainNotionalUsd: '0',
+  onchainFillCount: 0,
+  offchainFillCount: 0,
+  matchedLotCount: 0,
+  openLotCount: 0,
+  unmatchedOffchainFillCount: 0,
+})
+
+const addSummaryStreams = (
+  target: PnlSummary,
+  row: PnlWindowSymbol,
+): void => {
+  const counter = Number(target.counterTradePnlUsd) + Number(row.counterTradePnlUsd)
+  const onchain = Number(target.onchainNettingPnlUsd) + Number(row.onchainNettingPnlUsd)
+  const baseline = Number(target.directionalInventoryBaselinePnlUsd) + Number(row.directionalInventoryBaselinePnlUsd)
+  const excess = Number(target.directionalImbalanceExcessPnlUsd) + Number(row.directionalImbalanceExcessPnlUsd)
+  const directional = baseline + excess
+  const realized = counter + onchain + excess
+
+  target.counterTradePnlUsd = moneyText(counter)
+  target.onchainNettingPnlUsd = moneyText(onchain)
+  target.directionalInventoryBaselinePnlUsd = moneyText(baseline)
+  target.directionalImbalanceExcessPnlUsd = moneyText(excess)
+  target.directionalExposurePnlUsd = moneyText(directional)
+  target.realizedPnlUsd = moneyText(realized)
+  target.totalPnlUsd = moneyText(realized + baseline)
+}
+
+const addSymbolStreams = (
+  target: PnlSymbolSummary,
+  row: PnlWindowSymbol,
+): void => {
+  const counter = Number(target.counterTradePnlUsd) + Number(row.counterTradePnlUsd)
+  const onchain = Number(target.onchainNettingPnlUsd) + Number(row.onchainNettingPnlUsd)
+  const baseline = Number(target.directionalInventoryBaselinePnlUsd) + Number(row.directionalInventoryBaselinePnlUsd)
+  const excess = Number(target.directionalImbalanceExcessPnlUsd) + Number(row.directionalImbalanceExcessPnlUsd)
+  const directional = baseline + excess
+  const realized = counter + onchain + excess
+
+  target.counterTradePnlUsd = moneyText(counter)
+  target.onchainNettingPnlUsd = moneyText(onchain)
+  target.directionalInventoryBaselinePnlUsd = moneyText(baseline)
+  target.directionalImbalanceExcessPnlUsd = moneyText(excess)
+  target.directionalExposurePnlUsd = moneyText(directional)
+  target.realizedPnlUsd = moneyText(realized)
+  target.totalPnlUsd = moneyText(realized + baseline)
+}
+
+const symbolSummary = (symbol: string): PnlSymbolSummary => ({
+  symbol,
+  counterTradePnlUsd: '0',
+  onchainNettingPnlUsd: '0',
+  directionalInventoryBaselinePnlUsd: '0',
+  directionalImbalanceExcessPnlUsd: '0',
+  directionalExposurePnlUsd: '0',
+  totalPnlUsd: '0',
+  realizedPnlUsd: '0',
+  matchedShares: '0',
+  inventoryDriftShares: '0',
+  inventoryDriftUsd: '0',
+  openLongShares: '0',
+  openShortShares: '0',
+  unmatchedOffchainShares: '0',
+  matchedLotCount: 0,
+  onchainFillCount: 0,
+  offchainFillCount: 0,
+  unmatchedOffchainFillCount: 0,
+})
+
+const syntheticEntry = (
+  rowid: number,
+  symbol: string,
+  bucket: 'counter_trade' | 'onchain_netting' | 'directional_exposure',
+  dayStart: Date,
+  amount: number,
+  delayed: boolean,
+): PnlEntry => {
+  const openedAt = new Date(dayStart.getTime() + (60 + (rowid % 48) * 9) * MS_PER_MINUTE)
+  const elapsedSeconds = delayed ? 540 + (rowid % 5) * 90 : 70 + (rowid % 4) * 45
+  const closedAt = new Date(openedAt.getTime() + elapsedSeconds * 1_000)
+  const openingDirection = rowid % 2 === 0 ? 'buy' : 'sell'
+  const closingDirection = openingDirection === 'buy' ? 'sell' : 'buy'
+  const openingPrice = 20 + rowid * 0.07
+  const spread = amount >= 0 ? 0.18 + (rowid % 4) * 0.03 : -0.16 - (rowid % 3) * 0.02
+  const shares = Math.abs(amount / spread)
+  const closingPrice = openingDirection === 'buy'
+    ? openingPrice + spread
+    : openingPrice - spread
+
+  return {
+    symbol,
+    pnlBucket: bucket,
+    matchedAt: closedAt.toISOString(),
+    openedAt: openedAt.toISOString(),
+    closedAt: closedAt.toISOString(),
+    openingFillId: `mock-on-${symbol}-${String(rowid).padStart(4, '0')}`,
+    closingFillId: `mock-close-${symbol}-${String(rowid).padStart(4, '0')}`,
+    openingRowid: rowid * 2 - 1,
+    closingRowid: rowid * 2,
+    openingVenue: 'onchain',
+    closingVenue: bucket === 'onchain_netting' ? 'onchain' : 'offchain',
+    openingDirection,
+    closingDirection,
+    openingPriceUsd: priceText(openingPrice),
+    closingPriceUsd: priceText(closingPrice),
+    onchainTradeId: `mock-on-${symbol}-${String(rowid).padStart(4, '0')}`,
+    offchainOrderId: `mock-off-${symbol}-${String(rowid).padStart(4, '0')}`,
+    onchainDirection: openingDirection,
+    offchainDirection: closingDirection,
+    shares: shareText(shares),
+    onchainPriceUsdc: priceText(openingPrice),
+    offchainPriceUsd: priceText(closingPrice),
+    spreadUsd: moneyText(spread),
+    realizedPnlUsd: moneyText(amount),
+    elapsedSeconds,
+    counterTradeThresholdSeconds: 300,
+    delayedCounterTrade: delayed,
+    attributionMethod: 'synthetic_window_replay',
+  }
+}
+
+export const generateSyntheticPnlDashboard = (
+  options: SyntheticOptions = {},
+): SyntheticPnlDashboard => {
+  const startAt = new Date(options.startAt ?? DEFAULT_DASHBOARD_START_AT)
+  const days = options.days ?? DEFAULT_DASHBOARD_DAYS
+  const assets = options.assets ?? DEFAULT_ASSETS
+  const windows: PnlWindow[] = []
+  const summary = emptySummary()
+  const symbols = new Map<string, PnlSymbolSummary>()
+  const entries: PnlEntry[] = []
+  let entryRowid = 1
+
+  const pushEntry = (
+    symbol: string,
+    bucket: 'counter_trade' | 'onchain_netting' | 'directional_exposure',
+    dayStart: Date,
+    amount: number,
+    delayed: boolean,
+  ) => {
+    if (Math.abs(amount) < 0.005) return
+
+    entries.push(syntheticEntry(entryRowid, symbol, bucket, dayStart, amount, delayed))
+    entryRowid += 1
+  }
+
+  assets.forEach((asset) => {
+    symbols.set(asset.symbol, symbolSummary(asset.symbol))
+  })
+
+  for (let day = 0; day < days; day += 1) {
+    const start = new Date(startAt.getTime() + day * MS_PER_DAY)
+    const end = new Date(start.getTime() + MS_PER_DAY)
+    const isWeekend = [0, 6].includes(start.getUTCDay())
+    const windowSymbols = assets.map((asset, assetIndex) => {
+      const row = dailyPnl(asset, assetIndex, day, isWeekend)
+      addSummaryStreams(summary, row)
+      addSymbolStreams(symbols.get(asset.symbol) ?? symbolSummary(asset.symbol), row)
+      return row
+    })
+
+    windows.push({
+      windowId: `day-${String(day + 1).padStart(2, '0')}`,
+      startAt: start.toISOString(),
+      endAt: end.toISOString(),
+      label: start.toISOString().slice(5, 10),
+      isWeekend,
+      granularity: 'day',
+      symbols: windowSymbols,
+    })
+
+    windowSymbols.forEach((row) => {
+      if (Number(row.counterTradePnlUsd) !== 0) {
+        pushEntry(row.symbol, 'counter_trade', start, Number(row.counterTradePnlUsd), false)
+      }
+      if (Number(row.onchainNettingPnlUsd) !== 0) {
+        pushEntry(row.symbol, 'onchain_netting', start, Number(row.onchainNettingPnlUsd), false)
+      }
+      if (Number(row.directionalImbalanceExcessPnlUsd) !== 0) {
+        pushEntry(row.symbol, 'directional_exposure', start, Number(row.directionalImbalanceExcessPnlUsd), true)
+      }
+    })
+  }
+
+  const symbolRows = [...symbols.values()].sort((left, right) => left.symbol.localeCompare(right.symbol))
+  const matchedShares = entries.reduce((total, entry) => total + Number(entry.shares), 0)
+  const unmatchedOffchainShares = entries
+    .filter((entry) => entry.delayedCounterTrade)
+    .reduce((total, entry) => total + Number(entry.shares) * 0.08, 0)
+
+  summary.matchedShares = shareText(matchedShares)
+  summary.onchainNotionalUsd = moneyText(matchedShares * 42)
+  summary.offchainNotionalUsd = moneyText(matchedShares * 41.9)
+  summary.inventoryDriftShares = shareText(assets.length * 0.42)
+  summary.inventoryDriftUsd = moneyText(Number(summary.directionalInventoryBaselinePnlUsd))
+  summary.openLongShares = shareText(assets.length * 0.76)
+  summary.openShortShares = shareText(assets.length * 0.34)
+  summary.unmatchedOffchainShares = shareText(unmatchedOffchainShares)
+  summary.unmatchedOffchainNotionalUsd = moneyText(unmatchedOffchainShares * 55)
+  summary.onchainFillCount = days * assets.length * 28
+  summary.offchainFillCount = days * assets.length * 20
+  summary.matchedLotCount = entries.length
+  summary.openLotCount = days * assets.length
+  summary.unmatchedOffchainFillCount = entries.filter((entry) => entry.delayedCounterTrade).length
+
+  symbolRows.forEach((row, index) => {
+    row.matchedShares = shareText(matchedShares / symbolRows.length)
+    row.inventoryDriftShares = shareText((index + 1) * 0.14)
+    row.inventoryDriftUsd = row.directionalInventoryBaselinePnlUsd
+    row.openLongShares = shareText(0.45 + index * 0.12)
+    row.openShortShares = shareText(0.12 + index * 0.08)
+    row.unmatchedOffchainShares = shareText(unmatchedOffchainShares / symbolRows.length)
+    row.matchedLotCount = entries.filter((entry) => entry.symbol === row.symbol).length
+    row.onchainFillCount = days * 28
+    row.offchainFillCount = days * 20
+    row.unmatchedOffchainFillCount = entries.filter((entry) => entry.symbol === row.symbol && entry.delayedCounterTrade).length
+  })
+
+  const report: PnlResponse = {
+    attributionMethod: 'synthetic_window_replay',
+    warnings: [
+      'Synthetic PnL data: generated locally for dashboard validation, not loaded from production.',
+      'Delayed broker fills > 5m are displayed as directional exposure rather than counter-trade PnL.',
+    ],
+    summary,
+    symbols: symbolRows,
+    entries: entries.sort((left, right) => right.closedAt.localeCompare(left.closedAt)),
+    total: entries.length,
+    hasMore: false,
+  }
+
+  return { report, windows }
+}
+
+export const syntheticPnlDashboard = generateSyntheticPnlDashboard()

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,14 +8,18 @@
   import TransferPanel from '$lib/components/transfer-panel.svelte'
   import LogPanel from '$lib/components/log-panel.svelte'
   import OrdersPanel from '$lib/components/orders-panel.svelte'
-  import { getWebSocketUrl } from '$lib/env'
+  import PnlPanel from '$lib/components/pnl-panel.svelte'
+  import { getWebSocketUrl, isDashboardMockMode } from '$lib/env'
   import { reactive } from '$lib/frp.svelte'
   import { createWebSocket, type WebSocketConnection } from '$lib/websocket'
 
   const queryClient = useQueryClient()
   const ws = reactive<WebSocketConnection | null>(null)
+  const mockMode = isDashboardMockMode()
 
   onMount(() => {
+    if (mockMode) return
+
     ws.update(() => createWebSocket(getWebSocketUrl(), queryClient))
     ws.current?.connect()
 
@@ -24,7 +28,7 @@
     }
   })
 
-  const connectionState = $derived(ws.current?.state ?? 'disconnected')
+  const connectionState = $derived(mockMode ? 'connected' : (ws.current?.state ?? 'disconnected'))
   const errorContext = $derived(ws.current?.error ?? null)
 
   let countdown = $state(0)
@@ -40,10 +44,12 @@
       countdown = Math.max(0, countdown - 1)
     }, 1000)
 
-    return () => { clearInterval(interval); }
+    return () => {
+      clearInterval(interval)
+    }
   })
 
-  type Tab = 'dashboard' | 'orders' | 'logs'
+  type Tab = 'dashboard' | 'orders' | 'pnl' | 'logs'
   type MobilePanel = 'inventory' | 'trades' | 'transfers'
 
   const activeTab = reactive<Tab>('dashboard')
@@ -57,36 +63,69 @@
 </script>
 
 <div class="flex h-screen flex-col bg-background">
-  <HeaderBar
-    connectionStatus={connectionState === 'error' ? 'disconnected' : connectionState}
-  />
+  <HeaderBar connectionStatus={connectionState === 'error' ? 'disconnected' : connectionState} />
 
   {#if errorContext}
     <div
       class="mx-2 mt-2 rounded-md border border-destructive bg-destructive/10
         px-4 py-2 text-sm text-destructive md:mx-4"
     >
-      Connection error. Reconnecting in {countdown}s
-      (attempt {errorContext.attempts})...
+      Connection error. Reconnecting in {countdown}s (attempt {errorContext.attempts})...
     </div>
   {/if}
 
   <!-- Mobile nav: panel tabs + logs -->
   <nav class="flex shrink-0 gap-1 overflow-x-auto border-b bg-card/50 px-2 md:hidden">
     {#if activeTab.current === 'dashboard'}
-      <button class={mobilePanelClass('inventory')} onclick={() => { mobilePanel.update(() => 'inventory'); }}>Inventory</button>
-      <button class={mobilePanelClass('trades')} onclick={() => { mobilePanel.update(() => 'trades'); }}>Trades</button>
-      <button class={mobilePanelClass('transfers')} onclick={() => { mobilePanel.update(() => 'transfers'); }}>Transfers</button>
+      <button
+        class={mobilePanelClass('inventory')}
+        onclick={() => {
+          mobilePanel.update(() => 'inventory')
+        }}>Inventory</button
+      >
+      <button
+        class={mobilePanelClass('trades')}
+        onclick={() => {
+          mobilePanel.update(() => 'trades')
+        }}>Trades</button
+      >
+      <button
+        class={mobilePanelClass('transfers')}
+        onclick={() => {
+          mobilePanel.update(() => 'transfers')
+        }}>Transfers</button
+      >
     {/if}
     <button
-      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'orders' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => { activeTab.update((tab) => tab === 'orders' ? 'dashboard' : 'orders'); }}
+      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current ===
+      'orders'
+        ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => {
+        activeTab.update((tab) => (tab === 'orders' ? 'dashboard' : 'orders'))
+      }}
     >
       Orders
     </button>
     <button
-      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current === 'logs' ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary' : 'text-muted-foreground hover:text-foreground'}"
-      onclick={() => { activeTab.update((tab) => tab === 'logs' ? 'dashboard' : 'logs'); }}
+      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current ===
+      'pnl'
+        ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => {
+        activeTab.update((tab) => (tab === 'pnl' ? 'dashboard' : 'pnl'))
+      }}
+    >
+      PnL
+    </button>
+    <button
+      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current ===
+      'logs'
+        ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => {
+        activeTab.update((tab) => (tab === 'logs' ? 'dashboard' : 'logs'))
+      }}
     >
       Logs
     </button>
@@ -96,21 +135,36 @@
   <nav class="hidden shrink-0 gap-1 border-b bg-card/50 px-4 md:flex">
     <button
       class={desktopTabClass(activeTab.current === 'dashboard')}
-      onclick={() => { activeTab.update(() => 'dashboard'); }}
+      onclick={() => {
+        activeTab.update(() => 'dashboard')
+      }}
     >
       Dashboard
     </button>
 
     <button
       class={desktopTabClass(activeTab.current === 'orders')}
-      onclick={() => { activeTab.update(() => 'orders'); }}
+      onclick={() => {
+        activeTab.update(() => 'orders')
+      }}
     >
       Orders
     </button>
 
     <button
+      class={desktopTabClass(activeTab.current === 'pnl')}
+      onclick={() => {
+        activeTab.update(() => 'pnl')
+      }}
+    >
+      PnL
+    </button>
+
+    <button
       class={desktopTabClass(activeTab.current === 'logs')}
-      onclick={() => { activeTab.update(() => 'logs'); }}
+      onclick={() => {
+        activeTab.update(() => 'logs')
+      }}
     >
       Logs
     </button>
@@ -142,6 +196,10 @@
   {:else if activeTab.current === 'orders'}
     <main class="flex-1 overflow-hidden p-2 md:p-4">
       <OrdersPanel />
+    </main>
+  {:else if activeTab.current === 'pnl'}
+    <main class="flex-1 overflow-hidden p-2 md:p-4">
+      <PnlPanel />
     </main>
   {:else}
     <main class="flex-1 overflow-hidden p-2 md:p-4">

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -5,19 +5,156 @@ import { defineConfig } from 'vite'
 declare const process: {
   env: Record<string, string | undefined>
 }
+const nonEmptyEnv = (key: string): string | undefined => {
+  const value = process.env[key]?.trim()
+  return value !== undefined && value !== '' ? value : undefined
+}
 
-const backendPort = process.env['BACKEND_PORT'] ?? '8001'
-const backendUrl = `http://localhost:${backendPort}`
+const backendPort = nonEmptyEnv('PUBLIC_BACKEND_PORT') ?? nonEmptyEnv('BACKEND_PORT') ?? '8001'
+const configuredBackendUrl = process.env['PUBLIC_BACKEND_API_URL']?.trim()
+const backendUrl =
+  configuredBackendUrl !== undefined && configuredBackendUrl !== ''
+    ? configuredBackendUrl
+    : `http://localhost:${backendPort}`
+
+type MockRequest = {
+  url?: string | null
+}
+
+type MockResponse = {
+  statusCode: number
+  setHeader: (name: string, value: string) => void
+  end: (body?: string) => void
+}
+
+type MockNext = () => void
+
+const isMockMode = (): boolean => {
+  const value = process.env['PUBLIC_DASHBOARD_MOCK_MODE']?.trim().toLowerCase()
+  return value === '1' || value === 'true'
+}
+
+const pnlSqlApiUrl = (): string | null => {
+  const value = process.env['PUBLIC_PNL_SQL_API_URL']?.trim()
+  return value !== undefined && value !== '' ? value : null
+}
+
+const pnlSqlProxy = () => {
+  const value = pnlSqlApiUrl()
+  if (value === null || !(value.startsWith('http://') || value.startsWith('https://'))) {
+    return {}
+  }
+
+  const url = new URL(value)
+  return {
+    '/__pnl_sql': {
+      target: url.origin,
+      changeOrigin: true,
+      rewrite: (path: string) => {
+        const queryStart = path.indexOf('?')
+        const query = queryStart === -1 ? '' : path.slice(queryStart)
+        return `${url.pathname}${query}`
+      }
+    }
+  }
+}
+
+const backendProxy = (websocket = false) => ({
+  target: backendUrl,
+  changeOrigin: true,
+  ...(websocket ? { ws: true } : {})
+})
+
+const mockJson = (res: MockResponse, body: unknown): void => {
+  res.statusCode = 200
+  res.setHeader('content-type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+const emptyPage = {
+  entries: [],
+  total: 0,
+  hasMore: false
+}
+
+const mockApi = () => ({
+  name: 'st0x-dashboard-mock-api',
+  configureServer(server: import('vite').ViteDevServer) {
+    if (!isMockMode()) return
+
+    server.middlewares.use((req: unknown, res: unknown, next: unknown) => {
+      const request = req as MockRequest
+      const response = res as MockResponse
+      const goNext = next as MockNext
+      const path = new URL(request.url ?? '/', 'http://localhost').pathname
+
+      if (path === '/health') {
+        mockJson(response, { gitCommit: 'mock', uptimeSeconds: 0 })
+        return
+      }
+
+      if (path === '/orders/pending') {
+        mockJson(response, [])
+        return
+      }
+
+      if (path === '/orders/raindex') {
+        mockJson(response, {
+          orders: [],
+          pagination: {
+            page: 1,
+            pageSize: 100,
+            totalOrders: 0,
+            totalPages: 0,
+            hasMore: false
+          }
+        })
+        return
+      }
+
+      if (path === '/trades') {
+        mockJson(response, emptyPage)
+        return
+      }
+
+      if (path.startsWith('/trades/') && path.endsWith('/events')) {
+        mockJson(response, { events: [] })
+        return
+      }
+
+      if (path === '/transfers') {
+        mockJson(response, emptyPage)
+        return
+      }
+
+      if (path.startsWith('/transfers/') && path.endsWith('/events')) {
+        mockJson(response, { events: [] })
+        return
+      }
+
+      if (path === '/logs') {
+        mockJson(response, emptyPage)
+        return
+      }
+
+      goNext()
+    })
+  }
+})
 
 export default defineConfig({
-  plugins: [tailwindcss(), sveltekit()],
+  plugins: [mockApi(), tailwindcss(), sveltekit()],
   server: {
-    proxy: {
-      '/logs': backendUrl,
-      '/health': backendUrl,
-      '/orders': backendUrl,
-      '/trades': backendUrl,
-      '/transfers': backendUrl,
-    }
+    proxy: isMockMode()
+      ? {}
+      : {
+          '/api/ws': backendProxy(true),
+          '/logs': backendProxy(),
+          '/health': backendProxy(),
+          '/orders': backendProxy(),
+          '/trades': backendProxy(),
+          '/transfers': backendProxy(),
+          ...pnlSqlProxy()
+        }
   }
 })


### PR DESCRIPTION
## What

  Adds a PnL tab to the dashboard.

  The tab reads persisted fill data through the deployed SQL JSON endpoint and displays:

  - counter-trade PnL
  - on-chain netting PnL
  - directional exposure PnL
  - total PnL
  - current replay exposure
  - unmatched counter-trade exposure
  - per-symbol breakdowns
  - time-bucketed chart views
  - expandable debug notes for replay/reconciliation limitations

  Also adds local dev configuration for connecting the dashboard to a production backend
  and SQL JSON endpoint.

  ## Why

  We need a dashboard view over the PnL behavior of the currently deployed system using
  persisted production data.

  The deployed persistence model does not currently store explicit hedge parentage or
  historical portfolio state plus price/NAV snapshots. This PR makes the available
  realized replay view usable while surfacing those persistence limits directly in the
  dashboard.

  ## How

  The SQL PnL source builds a deterministic replay from persisted `Position` events:

  - on-chain fills open or net inventory lots
  - offchain fills are allocated against open opposite-side onchain lots by FIFO replay
  - prompt offchain matches are attributed to counter-trade PnL
  - late matched offchain fills are attributed to directional exposure
  - unmatched offchain fills are carried as current unmatched exposure
  - replayed open lots are reconciled against `position_view`
  - debug notes summarize allocation/reconciliation limitations

  Realized PnL remains date-filtered for the selected dashboard window. Current replay
  exposure is preserved separately so open and unmatched exposure does not disappear when
  there are no closed lots in the selected period.

  Percentage return display is intentionally omitted because historical portfolio state
  and price/NAV snapshots are not currently persisted. Baseline drift is reported as zero
  for the same reason.

  ## Testing

  Tested locally after rebasing onto latest `origin/master`.

  Commands run:

  ```bash
  npx eslint src/lib/components/pnl-panel.svelte src/lib/pnl/api.ts src/lib/pnl/
  api.test.ts src/lib/pnl/sql-source.ts src/lib/pnl/sql-source.test.ts src/lib/pnl/
  synthetic.ts src/lib/pnl/synthetic.test.ts src/lib/pnl/types.ts src/routes/+page.svelte
  src/lib/env.ts src/lib/env.test.ts vite.config.ts src/lib/components/header-bar.svelte

  npm run test:run -- src/lib/pnl/sql-source.test.ts src/lib/pnl/api.test.ts src/lib/pnl/
  synthetic.test.ts src/lib/env.test.ts
  ```
  Result: 29 tests passed.

  Also smoke-tested local dev against production data:

  - /health proxy to production backend
  - /__pnl_sql proxy to production SQL JSON endpoint

  ## Screenshots
  
<img width="3568" height="1730" alt="image" src="https://github.com/user-attachments/assets/d620cab7-96bc-4e40-8a48-e8ba0303aa55" />
<img width="3452" height="1552" alt="image" src="https://github.com/user-attachments/assets/1d29ab57-5dbe-4122-a2c2-8e22e7d56f85" />
<img width="3448" height="1184" alt="image" src="https://github.com/user-attachments/assets/c0792859-2289-4d9b-a84e-29e2f11abf96" />
<img width="1720" height="481" alt="Screenshot 2026-05-27 at 16 52 22" src="https://github.com/user-attachments/assets/a6603307-3aed-4569-ba99-c1f2cb130cc1" />

  ## Anything else

  Known current limitations:

  - explicit offchain_order_id -> onchain_trade_ids parentage is not persisted
  - historical portfolio state and price/NAV snapshots are not persisted
  - baseline drift is therefore reported as zero
  - replayed open lots may differ from position_view when the persisted fill history does
    not fully reconstruct projected state

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425034&installation_id=125569124&pr_number=691&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F691&signature=e165648bd7b812b6b54595f016579a6efc1856ad85d9ef105a6e033b7205f634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PnL dashboard tab with interactive charts, stacked/cumulative views, asset multiselect, date-range presets/custom dates, day-type filtering, summary cards and detailed tables.
  * Local mock mode to use synthetic PnL data and avoid backend/WebSocket setup for development.
  * Optional SQL-backed PnL source for querying real backend data.

* **Documentation**
  * Expanded dashboard README with setup/config examples for mock mode, SQL PnL endpoint, and local proxying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->