### PR TITLE
chore: extract bootstrap shell body to scripts/bootstrap.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cache/
 .tmp/
 .bacon-locations
 claude-local-ctx/
+result

--- a/flake.nix
+++ b/flake.nix
@@ -396,7 +396,10 @@
 
             bootstrap = rainix.mkTask.${system} {
               name = "bootstrap-nixos";
-              additionalBuildInputs = infraPkgs.buildInputs ++ [ nixos-anywhere.packages.${system}.default ];
+              additionalBuildInputs = infraPkgs.buildInputs ++ [
+                nixos-anywhere.packages.${system}.default
+                pkgs.gnused
+              ];
               body = ''
                 env="''${1:?usage: bootstrap <prod|staging>}"
                 shift
@@ -415,54 +418,9 @@
 
                 ${infraPkgs.parseIdentity}
 
-                # Resolve IP from terraform state
-                trap "rm -f infra/terraform.tfstate" EXIT
-                if [ -f "infra/terraform.tfstate.age" ]; then
-                  rage -d -i "$identity" infra/terraform.tfstate.age > infra/terraform.tfstate
-                fi
-                host_ip=$(jq -r ".outputs.''${env}_droplet_ipv4.value" infra/terraform.tfstate)
-                rm -f infra/terraform.tfstate
-                if [ -z "$host_ip" ] || [ "$host_ip" = "null" ]; then
-                  echo "ERROR: could not resolve IP from terraform output '''''${env}_droplet_ipv4'" >&2
-                  exit 1
-                fi
+                export env flake_config host_key_field identity
 
-                ssh_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=5 -i $identity"
-
-                nixos-anywhere --flake ".#$flake_config" \
-                  --option pure-eval false \
-                  --ssh-option "IdentityFile=$identity" \
-                  --target-host "root@$host_ip" "$@"
-
-                echo "Waiting for host to come back up..."
-                retries=0
-                until ssh $ssh_opts "root@$host_ip" true 2>/dev/null; do
-                  retries=$((retries + 1))
-                  if [ "$retries" -ge 60 ]; then
-                    echo "Host did not come back up after 5 minutes" >&2
-                    exit 1
-                  fi
-                  sleep 5
-                done
-
-                new_key=$(
-                  ssh $ssh_opts "root@$host_ip" \
-                    cat /etc/ssh/ssh_host_ed25519_key.pub \
-                    | awk '{print $1 " " $2}'
-                )
-
-                valid_key='^ssh-ed25519 [A-Za-z0-9+/=]+$'
-                if [ -z "$new_key" ] || ! echo "$new_key" | grep -qE "$valid_key"; then
-                  echo "ERROR: SSH host key is empty or malformed: '$new_key'" >&2
-                  exit 1
-                fi
-
-                ${pkgs.gnused}/bin/sed -i \
-                  "/$host_key_field =/{n;s|\"ssh-ed25519 [A-Za-z0-9+/=_]*\"|\"$new_key\"|;}" \
-                  keys.nix
-
-                echo "Updated $host_key_field in keys.nix, rekeying secrets..."
-                ${rekeySecrets}
+                exec ${./scripts/bootstrap.sh} "$@"
               '';
             };
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Bootstrap a NixOS host on a freshly-provisioned droplet.
+#
+# Expected environment (set by the nix wrapper before invoking this script):
+#   env              -- prod | staging
+#   flake_config     -- "${nodeName}-bootstrap"
+#   host_key_field   -- "host-prod" | "host-staging"
+#   identity         -- SSH identity (private key) to use
+#
+# All extra positional arguments are forwarded verbatim to nixos-anywhere.
+
+set -euo pipefail
+
+: "${env:?env not set by wrapper}"
+: "${flake_config:?flake_config not set by wrapper}"
+: "${host_key_field:?host_key_field not set by wrapper}"
+: "${identity:?identity not set by wrapper}"
+
+# Resolve IP from terraform state.
+trap "rm -f infra/terraform.tfstate" EXIT
+
+if [ -f "infra/terraform.tfstate.age" ]; then
+  rage -d -i "$identity" infra/terraform.tfstate.age > infra/terraform.tfstate
+elif [ ! -f "infra/terraform.tfstate" ]; then
+  echo "ERROR: neither infra/terraform.tfstate.age nor infra/terraform.tfstate found" >&2
+  exit 1
+fi
+
+host_ip=$(jq -r ".outputs.${env}_droplet_ipv4.value" infra/terraform.tfstate)
+rm -f infra/terraform.tfstate
+
+if [ -z "$host_ip" ] || [ "$host_ip" = "null" ]; then
+  echo "ERROR: could not resolve IP from terraform output '${env}_droplet_ipv4'" >&2
+  exit 1
+fi
+
+ssh_opts=(
+  -o StrictHostKeyChecking=no
+  -o ConnectTimeout=5
+  -i "$identity"
+)
+
+nixos-anywhere --flake ".#$flake_config" \
+  --option pure-eval false \
+  --ssh-option "IdentityFile=$identity" \
+  --target-host "root@$host_ip" "$@"
+
+echo "Waiting for host to come back up..."
+retries=0
+until ssh "${ssh_opts[@]}" "root@$host_ip" true 2>/dev/null; do
+  retries=$((retries + 1))
+  if [ "$retries" -ge 60 ]; then
+    echo "Host did not come back up after 5 minutes" >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+new_key=$(
+  ssh "${ssh_opts[@]}" "root@$host_ip" \
+    cat /etc/ssh/ssh_host_ed25519_key.pub \
+    | awk '{print $1 " " $2}'
+)
+
+valid_key='^ssh-ed25519 [A-Za-z0-9+/=_]+$'
+if [ -z "$new_key" ] || ! echo "$new_key" | grep -qE "$valid_key"; then
+  echo "ERROR: SSH host key is empty or malformed: '$new_key'" >&2
+  exit 1
+fi
+
+sed -i \
+  "/$host_key_field =/{n;s|\"ssh-ed25519 [A-Za-z0-9+/=_]*\"|\"$new_key\"|;}" \
+  keys.nix
+
+if ! grep -qF "$new_key" keys.nix; then
+  echo "ERROR: failed to update $host_key_field in keys.nix" >&2
+  exit 1
+fi
+
+echo "Updated $host_key_field in keys.nix, rekeying secrets..."
+ragenix --rules ./secret/secrets.nix -i "$identity" -r


### PR DESCRIPTION
## What

Closes [RAI-694](https://linear.app/makeitrain/issue/RAI-694).

Moves the bulk of the `bootstrap` task body from `flake.nix` into
`scripts/bootstrap.sh`. The nix wrapper retains the env-case for
per-environment dispatch, the `parseIdentity` shell, and an `exec` of
the script with the resolved values exported as env vars.

## Why

The 50-line shell body inlined in `flake.nix` was dominating that
file's lower half and could not be tested, shellchecked, or read in
isolation from nix evaluation. Pulling it to a standalone `.sh` lets
the script stand on its own.

The full `.nu` rewrite of this and other shell-heavy embedded scripts
is tracked separately under [RAI-695](https://linear.app/makeitrain/issue/RAI-695).

## How

- `scripts/bootstrap.sh` carries the terraform-state-decrypt → IP
  resolve → `nixos-anywhere` → SSH wait → host-key extract → `sed`
  mutate `keys.nix` → `ragenix` rekey flow.
- The nix wrapper sets `env`, `flake_config`, `host_key_field`,
  `identity` and execs the script. `pkgs.gnused` is added to
  `runtimeInputs` so the script can call plain `sed`.
- The script asserts each expected env var is set, uses an array for
  `ssh_opts` (avoids SC2086), pre-checks for the terraform state
  file existing in either encrypted or plaintext form, and verifies
  the `sed` substitution actually wrote `keys.nix` before invoking
  the rekey.

## Testing

`nix build .#bootstrap` builds cleanly (validates `shellcheck` via
`writeShellApplication` plus shellcheck on the extracted `.sh`).

## Anything else

Part of the [Fast and reliable CI](https://linear.app/makeitrain/project/re-usable-infra-and-secret-management-ac645cca3477)
milestone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Infrastructure deployment process restructured to improve modularity and maintainability by separating initialization logic into a dedicated external script while preserving all existing functionality.

* **Chores**
  * Updated exclusion patterns for build artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->