### PR TITLE
chore: restructure os.nix into focused modules

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   deploy-rs,
   self,
   environments,
@@ -14,23 +15,23 @@ let
   rage = "/run/current-system/sw/bin/rage";
   hostKey = "/etc/ssh/ssh_host_ed25519_key";
 
-  services = import ./services.nix;
-  enabledServices = builtins.attrNames (
-    builtins.removeAttrs services (
-      builtins.filter (n: !services.${n}.enabled) (builtins.attrNames services)
-    )
-  );
-  # Explicit ordering: sort enabledServices by each service's declared `order`
+  inherit (import ./services.nix { inherit lib; }) enabled;
+
+  enabledNames = builtins.attrNames enabled;
+
+  # Explicit ordering: sort enabled services by each service's declared `order`
   # field so adding a new entry forces choosing its slot rather than inheriting
   # the alphabetical attribute order. Duplicate orders would produce a
   # non-deterministic activation sequence, so assert uniqueness here.
-  enabledOrders = map (n: services.${n}.order) enabledServices;
+  enabledOrders = map (name: enabled.${name}.order) enabledNames;
+
   uniqueOrders = builtins.foldl' (
     acc: o: if builtins.elem o acc then acc else acc ++ [ o ]
   ) [ ] enabledOrders;
+
   orderedServices =
     if (builtins.length enabledOrders) == (builtins.length uniqueOrders) then
-      builtins.sort (a: b: services.${a}.order < services.${b}.order) enabledServices
+      builtins.sort (a: b: enabled.${a}.order < enabled.${b}.order) enabledNames
     else
       throw "services.nix: duplicate `order` values among enabled services: ${builtins.toJSON enabledOrders}";
 
@@ -40,7 +41,7 @@ let
   mkServiceProfile =
     env: name:
     let
-      cfg = services.${name};
+      cfg = enabled.${name};
       pkg = self.packages.${system}.${cfg.package};
     in
     if cfg.kind == "st0x" then

--- a/flake.nix
+++ b/flake.nix
@@ -66,16 +66,19 @@
     }:
     let
       inherit (import ./keys.nix) keys;
+      inherit (rainix.inputs.nixpkgs) lib;
       environments = {
         prod = {
           nodeName = "st0x-liquidity";
           volumeName = "st0x-liquidity-data";
           hostKey = keys.host-prod;
+          tailscaleMagicDnsName = "st0x-liquidity-nixos.taile5cf8a.ts.net";
         };
         staging = {
           nodeName = "st0x-liquidity-staging";
           volumeName = "st0x-liquidity-staging-data";
           hostKey = keys.host-staging;
+          tailscaleMagicDnsName = "st0x-liquidity-staging.taile5cf8a.ts.net";
         };
       };
       envNames = builtins.attrNames environments;
@@ -85,11 +88,11 @@
         let
           mkNixos =
             { environment, modules }:
-            rainix.inputs.nixpkgs.lib.nixosSystem {
+            lib.nixosSystem {
               system = "x86_64-linux";
               specialArgs = {
                 inherit environment;
-                inherit (environments.${environment}) volumeName;
+                inherit (environments.${environment}) volumeName tailscaleMagicDnsName;
                 inherit (self.packages.x86_64-linux) st0x-cli;
               };
               modules = [ disko.nixosModules.disko ] ++ modules;
@@ -126,7 +129,15 @@
           ]) envNames
         );
 
-      deploy = (import ./deploy.nix { inherit deploy-rs self environments; }).config;
+      deploy =
+        (import ./deploy.nix {
+          inherit
+            lib
+            deploy-rs
+            self
+            environments
+            ;
+        }).config;
     }
     // flake-utils.lib.eachDefaultSystem (
       system:
@@ -159,7 +170,12 @@
 
         deployScripts =
           (import ./deploy.nix {
-            inherit deploy-rs self environments;
+            inherit
+              lib
+              deploy-rs
+              self
+              environments
+              ;
           }).mkDeployScripts
             {
               inherit pkgs infraPkgs;

--- a/os.nix
+++ b/os.nix
@@ -5,6 +5,7 @@
   st0x-cli,
   environment,
   volumeName,
+  tailscaleMagicDnsName,
   ...
 }:
 
@@ -12,18 +13,7 @@ let
   inherit (import ./keys.nix) roles;
   envRoles = roles.${environment};
 
-  tailscaleFqdn =
-    {
-      prod = "st0x-liquidity-nixos.taile5cf8a.ts.net";
-      staging = "st0x-liquidity-staging.taile5cf8a.ts.net";
-    }
-    .${environment};
   certDir = "/var/lib/tailscale-cert";
-
-  services = import ./services.nix;
-  enabledServices = lib.filterAttrs (_: v: v.enabled) services;
-  # Services with a systemd unit (everything except kind = "static").
-  unitServices = lib.filterAttrs (_: v: v.kind != "static") enabledServices;
 
   cli = pkgs.writeShellApplication {
     name = "stox";
@@ -36,59 +26,14 @@ let
     '';
   };
 
-  mkService =
-    name: cfg:
-    let
-      execStartArgs =
-        if cfg.kind == "st0x" then
-          [
-            "--config"
-            cfg.configPath
-            "--secrets"
-            cfg.decryptedSecretPath
-          ]
-        else if cfg.kind == "plain" then
-          cfg.args
-        else
-          throw "services.${name}: kind '${cfg.kind}' has no systemd unit";
-    in
-    {
-      description = if cfg.kind == "st0x" then "st0x ${cfg.bin} (${name})" else cfg.description;
-
-      # Service is started by deploy.nix profile, not by systemd on boot.
-      # This avoids coordination issues during deployments.
-      wantedBy = [ ];
-
-      restartIfChanged = false;
-      stopIfChanged = false;
-
-      unitConfig = {
-        "X-OnlyManualStart" = true;
-        StartLimitBurst = 10;
-        StartLimitIntervalSec = 300;
-
-        # Marker file created ONLY by service profile activation.
-        # Guarantees service is SKIPPED (not failed) during system activation.
-        ConditionPathExists = cfg.markerFile;
-      };
-
-      serviceConfig = {
-        User = "st0x";
-        Group = "st0x";
-        ExecStart = builtins.concatStringsSep " " (
-          [ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs
-        );
-        Restart = "always";
-        RestartSec = 30;
-      };
-    };
-
 in
 {
   imports = [
     (modulesPath + "/virtualisation/digital-ocean-config.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
     ./disko.nix
+    ./tailscale.nix
+    ./service-profiles.nix
   ];
 
   boot.loader.grub = {
@@ -154,17 +99,6 @@ in
       };
     };
 
-    # Per-environment reusable, tagged auth key. Used only on first
-    # enrollment — after that Tailscale re-authenticates via the stored
-    # node key in /var/lib/tailscale. To rotate the node identity
-    # (e.g. re-tag), run `tailscale up --force-reauth --auth-key ...`
-    # manually on the droplet.
-    tailscale = {
-      enable = true;
-      authKeyFile = "/run/agenix/tailscale-authkey-${environment}";
-      permitCertUid = "nginx";
-    };
-
     fail2ban = {
       enable = true;
       bantime = "1h";
@@ -173,11 +107,11 @@ in
 
     nginx = {
       enable = true;
-      virtualHosts.${tailscaleFqdn} = {
+      virtualHosts.${tailscaleMagicDnsName} = {
         default = true;
         forceSSL = true;
-        sslCertificate = "${certDir}/${tailscaleFqdn}.crt";
-        sslCertificateKey = "${certDir}/${tailscaleFqdn}.key";
+        sslCertificate = "${certDir}/${tailscaleMagicDnsName}.crt";
+        sslCertificateKey = "${certDir}/${tailscaleMagicDnsName}.key";
         root = "/nix/var/nix/profiles/per-service/dashboard";
 
         locations =
@@ -233,13 +167,9 @@ in
     enable = true;
     # All inbound access is gated by the DO Cloud Firewall (infra/modules/stack)
     # which only permits Tailscale WireGuard. SSH and the dashboard are reached
-    # exclusively over tailscale0, which is trusted below and bypasses the
-    # NixOS firewall entirely.
+    # exclusively over tailscale0, which is configured as a trusted interface
+    # in tailscale.nix and bypasses the NixOS firewall entirely.
     allowedTCPPorts = [ ];
-    allowedUDPPorts = [
-      41641 # Tailscale WireGuard
-    ];
-    trustedInterfaces = [ "tailscale0" ];
   };
 
   fileSystems."/mnt/data" = {
@@ -266,79 +196,11 @@ in
 
   programs.bash.interactiveShellInit = "set -o vi";
 
-  age.secrets = {
-    "tailscale-authkey-${environment}" = {
-      file = ./secret/tailscale-authkey-${environment}.age;
-      mode = "0400";
-    };
-  };
-  systemd = {
-    tmpfiles.rules = [
-      "d /mnt/data 0755 st0x st0x -"
-      "d /mnt/data/logs 0755 st0x st0x -"
-      "d /mnt/data/grafana 0750 grafana grafana -"
-      "d ${certDir} 0750 nginx nginx -"
-    ];
-
-    services = lib.recursiveUpdate (lib.mapAttrs mkService unitServices) {
-      # Clean up stale TUN device before tailscaled starts. During NixOS
-      # activation the old tailscaled may still hold /dev/net/tun when the
-      # new unit starts, causing a crash-loop.
-      tailscaled.serviceConfig.ExecStartPre = [ "-${pkgs.iproute2}/bin/ip link delete tailscale0" ];
-
-      # Provision a Tailscale-issued TLS certificate so the dashboard is
-      # served over HTTPS. Runs before nginx to guarantee cert files exist.
-      tailscale-cert = {
-        description = "Provision Tailscale HTTPS certificate for ${tailscaleFqdn}";
-        after = [ "tailscaled.service" ];
-        wants = [ "tailscaled.service" ];
-        before = [ "nginx.service" ];
-        wantedBy = [ "multi-user.target" ];
-        path = [
-          pkgs.tailscale
-          pkgs.jq
-        ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          User = "nginx";
-          Group = "nginx";
-          # Reload nginx so it picks up renewed certs on subsequent runs
-          # triggered by the timer. || true keeps the unit green on first
-          # boot when nginx hasn't started yet.
-          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
-        };
-        script = ''
-          set -euo pipefail
-          retries=0
-          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
-            retries=$((retries + 1))
-            if [ "$retries" -ge 30 ]; then
-              echo "Tailscale BackendState != Running after 60s" >&2
-              exit 1
-            fi
-            sleep 2
-          done
-          tailscale cert \
-            --cert-file ${certDir}/${tailscaleFqdn}.crt \
-            --key-file ${certDir}/${tailscaleFqdn}.key \
-            ${tailscaleFqdn}
-        '';
-      };
-
-      nginx.after = [ "tailscale-cert.service" ];
-      nginx.requires = [ "tailscale-cert.service" ];
-    };
-
-    timers.tailscale-cert = {
-      description = "Renew Tailscale HTTPS certificate daily";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = "daily";
-        Persistent = true;
-      };
-    };
-  };
+  systemd.tmpfiles.rules = [
+    "d /mnt/data 0755 st0x st0x -"
+    "d /mnt/data/logs 0755 st0x st0x -"
+    "d /mnt/data/grafana 0750 grafana grafana -"
+  ];
 
   environment.systemPackages = with pkgs; [
     bat
@@ -351,26 +213,6 @@ in
     zellij
     cli
   ];
-
-  system.activationScripts.per-service-profiles.text = ''
-    mkdir -p /nix/var/nix/profiles/per-service
-
-    # Managed services use restartIfChanged = false + ConditionPathExists so
-    # that deploy.nix's per-service profile owns stop/install/restart. But if
-    # a previous deploy left one crash-looping (Restart = always), its failed
-    # state persists into the next activation and switch-to-configuration's
-    # final "units failed" check exits 4, which makes deploy-rs roll back
-    # before it ever reaches the per-service profile that would install the
-    # fix. Stop + reset-failed any managed service that is currently broken
-    # so activation can complete; the service profile restarts it afterwards.
-    for svc in ${builtins.concatStringsSep " " (builtins.attrNames unitServices)}; do
-      state=$(${pkgs.systemd}/bin/systemctl show -p ActiveState --value "$svc.service" 2>/dev/null || echo "")
-      if [ "$state" = "failed" ] || [ "$state" = "activating" ]; then
-        ${pkgs.systemd}/bin/systemctl stop "$svc.service" 2>/dev/null || true
-        ${pkgs.systemd}/bin/systemctl reset-failed "$svc.service" 2>/dev/null || true
-      fi
-    done
-  '';
 
   system.stateVersion = "24.11";
 

--- a/service-profiles.nix
+++ b/service-profiles.nix
@@ -1,0 +1,82 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  inherit (import ./services.nix { inherit lib; }) enabled;
+
+  # Services with a systemd unit (everything except kind = "static").
+  unitServices = lib.filterAttrs (_: v: v.kind != "static") enabled;
+
+  mkService =
+    name: cfg:
+    let
+      execStartArgs =
+        if cfg.kind == "st0x" then
+          [
+            "--config"
+            cfg.configPath
+            "--secrets"
+            cfg.decryptedSecretPath
+          ]
+        else if cfg.kind == "plain" then
+          cfg.args
+        else
+          throw "services.${name}: kind '${cfg.kind}' has no systemd unit";
+    in
+    {
+      description = if cfg.kind == "st0x" then "st0x ${cfg.bin} (${name})" else cfg.description;
+
+      # Service is started by deploy.nix profile, not by systemd on boot.
+      # This avoids coordination issues during deployments.
+      wantedBy = [ ];
+
+      restartIfChanged = false;
+      stopIfChanged = false;
+
+      unitConfig = {
+        "X-OnlyManualStart" = true;
+        StartLimitBurst = 10;
+        StartLimitIntervalSec = 300;
+
+        # Marker file created ONLY by service profile activation.
+        # Guarantees service is SKIPPED (not failed) during system activation.
+        ConditionPathExists = cfg.markerFile;
+      };
+
+      serviceConfig = {
+        User = "st0x";
+        Group = "st0x";
+        ExecStart = builtins.concatStringsSep " " (
+          [ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs
+        );
+        Restart = "always";
+        RestartSec = 30;
+      };
+    };
+in
+{
+  systemd.services = lib.mapAttrs mkService unitServices;
+
+  system.activationScripts.per-service-profiles.text = ''
+    mkdir -p /nix/var/nix/profiles/per-service
+
+    # Managed services use restartIfChanged = false + ConditionPathExists so
+    # that deploy.nix's per-service profile owns stop/install/restart. But if
+    # a previous deploy left one crash-looping (Restart = always), its failed
+    # state persists into the next activation and switch-to-configuration's
+    # final "units failed" check exits 4, which makes deploy-rs roll back
+    # before it ever reaches the per-service profile that would install the
+    # fix. Stop + reset-failed any managed service that is currently broken
+    # so activation can complete; the service profile restarts it afterwards.
+    for svc in ${builtins.concatStringsSep " " (builtins.attrNames unitServices)}; do
+      state=$(${pkgs.systemd}/bin/systemctl show -p ActiveState --value "$svc.service" 2>/dev/null || echo "")
+      if [ "$state" = "failed" ] || [ "$state" = "activating" ]; then
+        ${pkgs.systemd}/bin/systemctl stop "$svc.service" 2>/dev/null || true
+        ${pkgs.systemd}/bin/systemctl reset-failed "$svc.service" 2>/dev/null || true
+      fi
+    done
+  '';
+}

--- a/services.nix
+++ b/services.nix
@@ -1,3 +1,12 @@
+{ lib }:
+
+# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
+#                    chown data dirs, write git-rev, marker file, restart unit.
+# kind = "plain"   -- has a systemd unit, no secrets/config. Marker file gates
+#                    ConditionPathExists; deploy step just touches it and restarts.
+# kind = "static"  -- no systemd unit (e.g. nginx-served static assets). Deploy step
+#                    runs a custom activation command.
+
 let
   profileBase = "/nix/var/nix/profiles/per-service";
 
@@ -16,54 +25,54 @@ let
 
   withPaths =
     name: attrs: attrs // baseFields name // (if attrs.kind == "st0x" then st0xFields name else { });
+
+  byName = builtins.mapAttrs withPaths {
+    # `order` controls deploy-rs activation sequence within `profilesOrder`. The
+    # system profile always runs first; remaining profiles activate in ascending
+    # `order`. Lower numbers go first.
+    st0x-hedge = {
+      enabled = true;
+      order = 30;
+      kind = "st0x";
+      package = "st0x-liquidity";
+      bin = "server";
+    };
+
+    dashboard = {
+      enabled = true;
+      order = 10;
+      kind = "static";
+      package = "st0x-dashboard";
+      activation = "systemctl reload nginx";
+    };
+
+    datasette = {
+      enabled = true;
+      # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
+      # before datasette opens it. (--immutable would close the WAL out and serve
+      # stale reads, so we open the DB normally and rely on the host firewall +
+      # Tailscale for access control.)
+      order = 40;
+      kind = "plain";
+      package = "datasette";
+      bin = "datasette";
+      description = "Datasette SQLite explorer";
+      # Bind to all interfaces so the service is reachable over the tailnet
+      # (e.g. http://<host>.taile5cf8a.ts.net:8081). Public access is blocked
+      # by the host firewall.
+      args = [
+        "serve"
+        "/mnt/data/st0x-hedge.db"
+        "-p"
+        "8081"
+        "-h"
+        "0.0.0.0"
+      ];
+    };
+  };
+
+  enabled = lib.filterAttrs (_: v: v.enabled) byName;
 in
-# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
-#                    chown data dirs, write git-rev, marker file, restart unit.
-# kind = "plain"   -- has a systemd unit, no secrets/config. Marker file gates
-#                    ConditionPathExists; deploy step just touches it and restarts.
-# kind = "static"  -- no systemd unit (e.g. nginx-served static assets). Deploy step
-#                    runs a custom activation command.
-builtins.mapAttrs withPaths {
-  # `order` controls deploy-rs activation sequence within `profilesOrder`. The
-  # system profile always runs first; remaining profiles activate in ascending
-  # `order`. Lower numbers go first.
-  st0x-hedge = {
-    enabled = true;
-    order = 30;
-    kind = "st0x";
-    package = "st0x-liquidity";
-    bin = "server";
-  };
-
-  dashboard = {
-    enabled = true;
-    order = 10;
-    kind = "static";
-    package = "st0x-dashboard";
-    activation = "systemctl reload nginx";
-  };
-
-  datasette = {
-    enabled = true;
-    # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
-    # before datasette opens it. (--immutable would close the WAL out and serve
-    # stale reads, so we open the DB normally and rely on the host firewall +
-    # Tailscale for access control.)
-    order = 40;
-    kind = "plain";
-    package = "datasette";
-    bin = "datasette";
-    description = "Datasette SQLite explorer";
-    # Bind to all interfaces so the service is reachable over the tailnet
-    # (e.g. http://<host>.taile5cf8a.ts.net:8081). Public access is blocked
-    # by the host firewall.
-    args = [
-      "serve"
-      "/mnt/data/st0x-hedge.db"
-      "-p"
-      "8081"
-      "-h"
-      "0.0.0.0"
-    ];
-  };
+{
+  inherit byName enabled;
 }

--- a/tailscale.nix
+++ b/tailscale.nix
@@ -1,0 +1,99 @@
+{
+  pkgs,
+  environment,
+  tailscaleMagicDnsName,
+  ...
+}:
+
+let
+  certDir = "/var/lib/tailscale-cert";
+in
+{
+  # Per-environment reusable, tagged auth key. Used only on first
+  # enrollment — after that Tailscale re-authenticates via the stored
+  # node key in /var/lib/tailscale. To rotate the node identity
+  # (e.g. re-tag), run `tailscale up --force-reauth --auth-key ...`
+  # manually on the droplet.
+  services.tailscale = {
+    enable = true;
+    authKeyFile = "/run/agenix/tailscale-authkey-${environment}";
+    permitCertUid = "nginx";
+  };
+
+  networking.firewall = {
+    allowedUDPPorts = [
+      41641 # Tailscale WireGuard
+    ];
+    trustedInterfaces = [ "tailscale0" ];
+  };
+
+  age.secrets."tailscale-authkey-${environment}" = {
+    file = ./secret/tailscale-authkey-${environment}.age;
+    mode = "0400";
+  };
+
+  systemd = {
+    tmpfiles.rules = [
+      "d ${certDir} 0750 nginx nginx -"
+    ];
+
+    services = {
+      # Clean up stale TUN device before tailscaled starts. During NixOS
+      # activation the old tailscaled may still hold /dev/net/tun when the
+      # new unit starts, causing a crash-loop.
+      tailscaled.serviceConfig.ExecStartPre = [ "-${pkgs.iproute2}/bin/ip link delete tailscale0" ];
+
+      # Provision a Tailscale-issued TLS certificate so the dashboard is
+      # served over HTTPS. Runs before nginx to guarantee cert files exist.
+      tailscale-cert = {
+        description = "Provision Tailscale HTTPS certificate for ${tailscaleMagicDnsName}";
+        after = [ "tailscaled.service" ];
+        wants = [ "tailscaled.service" ];
+        before = [ "nginx.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [
+          pkgs.tailscale
+          pkgs.jq
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "nginx";
+          Group = "nginx";
+          # Reload nginx so it picks up renewed certs on subsequent runs
+          # triggered by the timer. || true keeps the unit green on first
+          # boot when nginx hasn't started yet.
+          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
+        };
+        script = ''
+          set -euo pipefail
+          retries=0
+          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
+            retries=$((retries + 1))
+            if [ "$retries" -ge 30 ]; then
+              echo "Tailscale BackendState != Running after 60s" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          tailscale cert \
+            --cert-file ${certDir}/${tailscaleMagicDnsName}.crt \
+            --key-file ${certDir}/${tailscaleMagicDnsName}.key \
+            ${tailscaleMagicDnsName}
+        '';
+      };
+
+      nginx.after = [ "tailscale-cert.service" ];
+      nginx.requires = [ "tailscale-cert.service" ];
+    };
+
+    timers.tailscale-cert = {
+      description = "Renew Tailscale HTTPS certificate daily";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
## What

Closes [RAI-696](https://linear.app/makeitrain/issue/RAI-696).

Splits `os.nix` into focused modules so each concern can be read,
reviewed, and reused independently.

## Why

`os.nix` had three independently-coherent concerns interleaved:
the base NixOS host config, the tailscale stack (services +
cert provisioning + firewall + agenix authkey), and the per-service
profile lifecycle management (`mkService` + activation cleanup). The
shared `enabled`-services filter was also duplicated between
`os.nix` and `deploy.nix` because `services.nix` was a data-only
file rather than a function that could expose a pre-filtered shape.

## How

- New `./tailscale.nix` module: `services.tailscale`, the
  `tailscale-cert` systemd unit + daily renewal timer, the
  `tailscaled.ExecStartPre` workaround that cleans up `tailscale0`
  before tailscaled restarts, the per-env agenix authkey, and the
  `tailscale0` trusted-interface + WireGuard firewall entries.
- New `./service-profiles.nix` module: the `mkService` builder that
  produces `systemd.services.<name>` from `services.nix` data, plus
  the `system.activationScripts.per-service-profiles` shell that
  resets any service left in a failed state from a previous deploy.
- `services.nix` becomes a function taking `lib`, exposes
  `{ byName, enabled }`. `os.nix` and `deploy.nix` consume the
  shared `enabled` filter.
- Per-env `tailscaleMagicDnsName` centralized in `flake.nix`
  `environments`; threaded through `specialArgs` to `os.nix`. `lib`
  pulled from `rainix.inputs.nixpkgs` once at the top of outputs
  and passed to `deploy.nix`.

## Testing

`nix flake show --impure --allow-import-from-derivation`, `statix
check .`, and `deadnix .` all clean.

## Anything else

Part of the [Fast and reliable CI](https://linear.app/makeitrain/project/re-usable-infra-and-secret-management-ac645cca3477)
milestone.

Stacked on [#693](https://github.com/ST0x-Technology/st0x.liquidity/pull/693)
([RAI-667](https://linear.app/makeitrain/issue/RAI-667)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tailscale MagicDNS-based HTTPS certificate provisioning with automatic daily renewal
  * Implemented improved systemd service management with per-service activation control

* **Improvements**
  * Enhanced HTTPS dashboard configuration and certificate handling
  * Refined service activation and ordering for better reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->