### PR TITLE
fix: drop --impure from deploy by using deploy-rs --hostname override

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -92,10 +92,18 @@ let
     profilePath = "${profileBase}/${name}";
   };
 
+  # `hostname` here is an eval-time placeholder that keeps the flake pure.
+  # The real SSH target is the public IPv4 resolved from terraform state
+  # at deploy time and injected via deploy-rs's runtime `--hostname`
+  # override (see `deployPreamble`).
   mkNode =
-    { env, nixosConfig }:
     {
-      hostname = builtins.getEnv "DEPLOY_HOST";
+      env,
+      nixosConfig,
+      tailscaleMagicDnsName,
+    }:
+    {
+      hostname = tailscaleMagicDnsName;
       sshUser = "root";
       user = "root";
 
@@ -125,6 +133,8 @@ in
           name = cfg.nodeName;
           value = mkNode {
             inherit env;
+            inherit (cfg) tailscaleMagicDnsName;
+
             nixosConfig = self.nixosConfigurations.${cfg.nodeName};
           };
         }
@@ -150,7 +160,7 @@ in
         else
           "--debug-logs --skip-checks --remote-build";
 
-      nixFlags = "--impure --accept-flake-config --extra-experimental-features 'nix-command flakes'";
+      nixFlags = "--accept-flake-config --extra-experimental-features 'nix-command flakes'";
 
       mkEnvDeployScripts =
         env:
@@ -165,7 +175,6 @@ in
               echo "Using pre-set DEPLOY_HOST=$host_ip"
             else
               ${envInfraPkgs.resolveIp}
-              export DEPLOY_HOST="$host_ip"
             fi
 
             # Pin the host key from keys.nix so SSH verifies it during
@@ -196,8 +205,9 @@ in
               text = ''
                 ${deployPreamble}
                 ${prelude}
-                deploy ${deployFlags} ${extraDeployFlags} ''${ssh_flag:+"$ssh_flag"} ${target} \
-                  -- ${nixFlags} "$@"
+                deploy ${deployFlags} ${extraDeployFlags} --hostname "$host_ip" \
+                  ''${ssh_flag:+"$ssh_flag"} "$@" ${target} \
+                  -- ${nixFlags}
               '';
             };
 


### PR DESCRIPTION
## What

Drop `--impure` from the deploy pipeline by replacing the eval-time
`builtins.getEnv "DEPLOY_HOST"` with a pure placeholder and injecting
the real SSH target via deploy-rs's runtime `--hostname` override.

## Why

`builtins.getEnv` makes flake evaluation depend on the ambient
environment, which forces every deploy invocation through
`--impure`. Two consequences:

- The flake outputs aren't reproducible -- two evals of the same
  `self.rev` produce different deploy specs if `DEPLOY_HOST` differs
  (or is missing). Cache hits become invalid across runs and CI.
- Anything downstream that wants to reuse our flake outputs
  (`nix flake check`, evaluator-as-a-library tools, deploy-rs
  rollback) inherits the impurity.

deploy-rs supports a runtime `--hostname` override that bypasses the
eval-time `hostname` attribute on a node, so the placeholder can be
anything pure and the real target gets injected by the wrapper
script after it resolves the IP from terraform state.

## How

- `mkNode` now takes a `tailscaleMagicDnsName` parameter and uses it
  as `hostname` -- a pure, stable placeholder. The tailscale FQDN
  is already exposed per-environment from `flake.nix`'s
  `environments` attrset, so no new data is needed.
- `nixFlags` drops `--impure`.
- `deployPreamble` no longer exports `DEPLOY_HOST` (deploy-rs no
  longer reads it via the impure getEnv).
- The `deploy` invocation passes `--hostname "$host_ip"` at runtime,
  using the IP resolved by `${envInfraPkgs.resolveIp}` (or the
  pre-set `DEPLOY_HOST` env var, for one-off overrides).
- The wrapper-script `"$@"` position moves from after `--` to
  before the target, so callers can pass deploy-rs flags (in
  particular `--dry-activate`) through the wrapper. Extra nix
  build args were never actually used; deploy-rs needs flags is
  the common case.

## Testing

`nix --accept-flake-config flake check --impure` evaluates the four
`nixosConfigurations` cleanly with the placeholder hostname.

For end-to-end validation, dry-activate against the staging host:

```
nix --accept-flake-config run .#staging-deploy-nixos -- --dry-activate
```

deploy-rs builds the new system, copies it to the host over SSH,
runs `switch-to-configuration dry-activate`, and prints the planned
unit/service changes without taking any action. A clean dry-run
means the pure-eval path produces the same system the previous
impure-eval path did.

## Anything else

Part of the [Fast and reliable CI](https://linear.app/makeitrain/project/re-usable-infra-and-secret-management-ac645cca3477)
milestone.

Stacked on [#697](https://github.com/ST0x-Technology/st0x.liquidity/pull/697)
([RAI-696](https://linear.app/makeitrain/issue/RAI-696));
followed by [#667](https://github.com/ST0x-Technology/st0x.liquidity/pull/667).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated deployment target host resolution to use per-environment configuration instead of environment variable lookup
  * Removed `--impure` flag from deployment invocations and adjusted deployment command structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->