### PR TITLE
chore: restructure os.nix into focused modules

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   deploy-rs,
   self,
   environments,
@@ -14,23 +15,23 @@ let
   rage = "/run/current-system/sw/bin/rage";
   hostKey = "/etc/ssh/ssh_host_ed25519_key";
 
-  services = import ./services.nix;
-  enabledServices = builtins.attrNames (
-    builtins.removeAttrs services (
-      builtins.filter (n: !services.${n}.enabled) (builtins.attrNames services)
-    )
-  );
-  # Explicit ordering: sort enabledServices by each service's declared `order`
+  inherit (import ./services.nix { inherit lib; }) enabled;
+
+  enabledNames = builtins.attrNames enabled;
+
+  # Explicit ordering: sort enabled services by each service's declared `order`
   # field so adding a new entry forces choosing its slot rather than inheriting
   # the alphabetical attribute order. Duplicate orders would produce a
   # non-deterministic activation sequence, so assert uniqueness here.
-  enabledOrders = map (n: services.${n}.order) enabledServices;
+  enabledOrders = map (name: enabled.${name}.order) enabledNames;
+
   uniqueOrders = builtins.foldl' (
     acc: o: if builtins.elem o acc then acc else acc ++ [ o ]
   ) [ ] enabledOrders;
+
   orderedServices =
     if (builtins.length enabledOrders) == (builtins.length uniqueOrders) then
-      builtins.sort (a: b: services.${a}.order < services.${b}.order) enabledServices
+      builtins.sort (a: b: enabled.${a}.order < enabled.${b}.order) enabledNames
     else
       throw "services.nix: duplicate `order` values among enabled services: ${builtins.toJSON enabledOrders}";
 
@@ -40,7 +41,7 @@ let
   mkServiceProfile =
     env: name:
     let
-      cfg = services.${name};
+      cfg = enabled.${name};
       pkg = self.packages.${system}.${cfg.package};
     in
     if cfg.kind == "st0x" then

--- a/flake.nix
+++ b/flake.nix
@@ -79,16 +79,19 @@
     }:
     let
       inherit (import ./keys.nix) keys;
+      inherit (rainix.inputs.nixpkgs) lib;
       environments = {
         prod = {
           nodeName = "st0x-liquidity";
           volumeName = "st0x-liquidity-data";
           hostKey = keys.host-prod;
+          tailscaleMagicDnsName = "st0x-liquidity-nixos.taile5cf8a.ts.net";
         };
         staging = {
           nodeName = "st0x-liquidity-staging";
           volumeName = "st0x-liquidity-staging-data";
           hostKey = keys.host-staging;
+          tailscaleMagicDnsName = "st0x-liquidity-staging.taile5cf8a.ts.net";
         };
       };
       envNames = builtins.attrNames environments;
@@ -98,11 +101,11 @@
         let
           mkNixos =
             { environment, modules }:
-            rainix.inputs.nixpkgs.lib.nixosSystem {
+            lib.nixosSystem {
               system = "x86_64-linux";
               specialArgs = {
                 inherit environment;
-                inherit (environments.${environment}) volumeName;
+                inherit (environments.${environment}) volumeName tailscaleMagicDnsName;
                 inherit (self.packages.x86_64-linux) st0x-cli;
               };
               modules = [ disko.nixosModules.disko ] ++ modules;
@@ -139,7 +142,15 @@
           ]) envNames
         );
 
-      deploy = (import ./deploy.nix { inherit deploy-rs self environments; }).config;
+      deploy =
+        (import ./deploy.nix {
+          inherit
+            lib
+            deploy-rs
+            self
+            environments
+            ;
+        }).config;
     }
     // flake-utils.lib.eachDefaultSystem (
       system:
@@ -172,7 +183,12 @@
 
         deployScripts =
           (import ./deploy.nix {
-            inherit deploy-rs self environments;
+            inherit
+              lib
+              deploy-rs
+              self
+              environments
+              ;
           }).mkDeployScripts
             {
               inherit pkgs infraPkgs;

--- a/nix/tailscale.nix
+++ b/nix/tailscale.nix
@@ -1,0 +1,111 @@
+# Tailscale stack for the deployed hosts: enrolls the node onto our
+# tailnet via a per-environment agenix-encrypted auth key, opens the
+# WireGuard port + marks `tailscale0` as a trusted firewall interface,
+# and provisions a Tailscale-issued HTTPS certificate that nginx
+# serves the dashboard from.
+#
+# The `tailscale-cert` oneshot waits for tailscaled to be Running,
+# then writes the cert/key into `/var/lib/tailscale-cert` and reloads
+# nginx so it picks up the new files. A daily timer re-runs the same
+# oneshot to renew before expiry. `tailscaled.ExecStartPre` deletes
+# the stale `tailscale0` TUN device so the unit doesn't crash-loop
+# when a previous tailscaled hasn't released it yet.
+{
+  pkgs,
+  environment,
+  tailscaleMagicDnsName,
+  ...
+}:
+
+let
+  certDir = "/var/lib/tailscale-cert";
+in
+{
+  # Per-environment reusable, tagged auth key. Used only on first
+  # enrollment — after that Tailscale re-authenticates via the stored
+  # node key in /var/lib/tailscale. To rotate the node identity
+  # (e.g. re-tag), run `tailscale up --force-reauth --auth-key ...`
+  # manually on the droplet.
+  services.tailscale = {
+    enable = true;
+    authKeyFile = "/run/agenix/tailscale-authkey-${environment}";
+    permitCertUid = "nginx";
+  };
+
+  networking.firewall = {
+    allowedUDPPorts = [
+      41641 # Tailscale WireGuard
+    ];
+    trustedInterfaces = [ "tailscale0" ];
+  };
+
+  age.secrets."tailscale-authkey-${environment}" = {
+    file = ./secret/tailscale-authkey-${environment}.age;
+    mode = "0400";
+  };
+
+  systemd = {
+    tmpfiles.rules = [
+      "d ${certDir} 0750 nginx nginx -"
+    ];
+
+    services = {
+      # Clean up stale TUN device before tailscaled starts. During NixOS
+      # activation the old tailscaled may still hold /dev/net/tun when the
+      # new unit starts, causing a crash-loop.
+      tailscaled.serviceConfig.ExecStartPre = [ "-${pkgs.iproute2}/bin/ip link delete tailscale0" ];
+
+      # Provision a Tailscale-issued TLS certificate so the dashboard is
+      # served over HTTPS. Runs before nginx to guarantee cert files exist.
+      tailscale-cert = {
+        description = "Provision Tailscale HTTPS certificate for ${tailscaleMagicDnsName}";
+        after = [ "tailscaled.service" ];
+        wants = [ "tailscaled.service" ];
+        before = [ "nginx.service" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [
+          pkgs.tailscale
+          pkgs.jq
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "nginx";
+          Group = "nginx";
+          # Reload nginx so it picks up renewed certs on subsequent runs
+          # triggered by the timer. || true keeps the unit green on first
+          # boot when nginx hasn't started yet.
+          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
+        };
+        script = ''
+          set -euo pipefail
+          retries=0
+          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
+            retries=$((retries + 1))
+            if [ "$retries" -ge 30 ]; then
+              echo "Tailscale BackendState != Running after 60s" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          tailscale cert \
+            --cert-file ${certDir}/${tailscaleMagicDnsName}.crt \
+            --key-file ${certDir}/${tailscaleMagicDnsName}.key \
+            ${tailscaleMagicDnsName}
+        '';
+      };
+
+      nginx.after = [ "tailscale-cert.service" ];
+      nginx.requires = [ "tailscale-cert.service" ];
+    };
+
+    timers.tailscale-cert = {
+      description = "Renew Tailscale HTTPS certificate daily";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "daily";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/nix/upgradeable-services.nix
+++ b/nix/upgradeable-services.nix
@@ -1,0 +1,97 @@
+# Systemd units for the binaries we deploy (st0x-server, st0x-cli
+# crons, datasette) -- distinct from nixos built-ins like sshd or
+# tailscale. These are "upgradeable" in that deploy-rs swaps a new
+# binary into each unit's per-service nix profile and restarts the
+# unit without requiring a full nixos rebuild + switch.
+#
+# Units defined here are gated against auto-start: empty `wantedBy`,
+# `X-OnlyManualStart`, and `ConditionPathExists` on a marker file
+# that only the per-service profile activation in deploy.nix
+# creates. The activation script below resets any unit left in a
+# failed state by a previous deploy so the next
+# switch-to-configuration can complete and let deploy.nix install
+# the fix.
+{
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  inherit (import ../services.nix { inherit lib; }) enabled;
+
+  # Services with a systemd unit (everything except kind = "static").
+  unitServices = lib.filterAttrs (_: v: v.kind != "static") enabled;
+
+  mkService =
+    name: cfg:
+    let
+      execStartArgs =
+        if cfg.kind == "st0x" then
+          [
+            "--config"
+            cfg.configPath
+            "--secrets"
+            cfg.decryptedSecretPath
+          ]
+        else if cfg.kind == "plain" then
+          cfg.args
+        else
+          throw "services.${name}: kind '${cfg.kind}' has no systemd unit";
+    in
+    {
+      description = if cfg.kind == "st0x" then "st0x ${cfg.bin} (${name})" else cfg.description;
+
+      # Service is started by deploy.nix profile, not by systemd on boot.
+      # This avoids coordination issues during deployments.
+      wantedBy = [ ];
+
+      restartIfChanged = false;
+      stopIfChanged = false;
+
+      unitConfig = {
+        "X-OnlyManualStart" = true;
+        StartLimitBurst = 10;
+        StartLimitIntervalSec = 300;
+
+        # Marker file created ONLY by service profile activation.
+        # Guarantees service is SKIPPED (not failed) during system activation.
+        ConditionPathExists = cfg.markerFile;
+      };
+
+      serviceConfig = {
+        User = "st0x";
+        Group = "st0x";
+        ExecStart = utils.escapeSystemdExecArgs ([ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs);
+        Restart = "always";
+        RestartSec = 30;
+      };
+    };
+in
+{
+  systemd.services = lib.mapAttrs mkService unitServices;
+
+  system.activationScripts.reset-upgradeable-services.text = ''
+    mkdir -p /nix/var/nix/profiles/per-service
+
+    # Managed services use restartIfChanged = false + ConditionPathExists so
+    # that deploy.nix's per-service profile owns stop/install/restart. But if
+    # a previous deploy left one crash-looping (Restart = always), its failed
+    # state persists into the next activation and switch-to-configuration's
+    # final "units failed" check exits 4, which makes deploy-rs roll back
+    # before it ever reaches the per-service profile that would install the
+    # fix. Stop + reset-failed any managed service that is currently broken
+    # so activation can complete; the service profile restarts it afterwards.
+    systemctl=${pkgs.systemd}/bin/systemctl
+    for svc in ${builtins.concatStringsSep " " (builtins.attrNames unitServices)}; do
+      state=$($systemctl show -p ActiveState --value "$svc.service" \
+        2>/dev/null || echo "")
+
+      if [ "$state" = "failed" ] || [ "$state" = "activating" ]; then
+        $systemctl stop "$svc.service" 2>/dev/null || true
+        $systemctl reset-failed "$svc.service" 2>/dev/null || true
+      fi
+    done
+  '';
+}

--- a/os.nix
+++ b/os.nix
@@ -5,6 +5,7 @@
   st0x-cli,
   environment,
   volumeName,
+  tailscaleMagicDnsName,
   ...
 }:
 
@@ -12,18 +13,7 @@ let
   inherit (import ./keys.nix) roles;
   envRoles = roles.${environment};
 
-  tailscaleFqdn =
-    {
-      prod = "st0x-liquidity-nixos.taile5cf8a.ts.net";
-      staging = "st0x-liquidity-staging.taile5cf8a.ts.net";
-    }
-    .${environment};
   certDir = "/var/lib/tailscale-cert";
-
-  services = import ./services.nix;
-  enabledServices = lib.filterAttrs (_: v: v.enabled) services;
-  # Services with a systemd unit (everything except kind = "static").
-  unitServices = lib.filterAttrs (_: v: v.kind != "static") enabledServices;
 
   cli = pkgs.writeShellApplication {
     name = "stox";
@@ -36,59 +26,14 @@ let
     '';
   };
 
-  mkService =
-    name: cfg:
-    let
-      execStartArgs =
-        if cfg.kind == "st0x" then
-          [
-            "--config"
-            cfg.configPath
-            "--secrets"
-            cfg.decryptedSecretPath
-          ]
-        else if cfg.kind == "plain" then
-          cfg.args
-        else
-          throw "services.${name}: kind '${cfg.kind}' has no systemd unit";
-    in
-    {
-      description = if cfg.kind == "st0x" then "st0x ${cfg.bin} (${name})" else cfg.description;
-
-      # Service is started by deploy.nix profile, not by systemd on boot.
-      # This avoids coordination issues during deployments.
-      wantedBy = [ ];
-
-      restartIfChanged = false;
-      stopIfChanged = false;
-
-      unitConfig = {
-        "X-OnlyManualStart" = true;
-        StartLimitBurst = 10;
-        StartLimitIntervalSec = 300;
-
-        # Marker file created ONLY by service profile activation.
-        # Guarantees service is SKIPPED (not failed) during system activation.
-        ConditionPathExists = cfg.markerFile;
-      };
-
-      serviceConfig = {
-        User = "st0x";
-        Group = "st0x";
-        ExecStart = builtins.concatStringsSep " " (
-          [ "${cfg.profilePath}/bin/${cfg.bin}" ] ++ execStartArgs
-        );
-        Restart = "always";
-        RestartSec = 30;
-      };
-    };
-
 in
 {
   imports = [
     (modulesPath + "/virtualisation/digital-ocean-config.nix")
     (modulesPath + "/profiles/qemu-guest.nix")
     ./disko.nix
+    ./nix/tailscale.nix
+    ./nix/upgradeable-services.nix
   ];
 
   boot.loader.grub = {
@@ -154,17 +99,6 @@ in
       };
     };
 
-    # Per-environment reusable, tagged auth key. Used only on first
-    # enrollment — after that Tailscale re-authenticates via the stored
-    # node key in /var/lib/tailscale. To rotate the node identity
-    # (e.g. re-tag), run `tailscale up --force-reauth --auth-key ...`
-    # manually on the droplet.
-    tailscale = {
-      enable = true;
-      authKeyFile = "/run/agenix/tailscale-authkey-${environment}";
-      permitCertUid = "nginx";
-    };
-
     fail2ban = {
       enable = true;
       bantime = "1h";
@@ -173,11 +107,11 @@ in
 
     nginx = {
       enable = true;
-      virtualHosts.${tailscaleFqdn} = {
+      virtualHosts.${tailscaleMagicDnsName} = {
         default = true;
         forceSSL = true;
-        sslCertificate = "${certDir}/${tailscaleFqdn}.crt";
-        sslCertificateKey = "${certDir}/${tailscaleFqdn}.key";
+        sslCertificate = "${certDir}/${tailscaleMagicDnsName}.crt";
+        sslCertificateKey = "${certDir}/${tailscaleMagicDnsName}.key";
         root = "/nix/var/nix/profiles/per-service/dashboard";
 
         locations =
@@ -233,13 +167,9 @@ in
     enable = true;
     # All inbound access is gated by the DO Cloud Firewall (infra/modules/stack)
     # which only permits Tailscale WireGuard. SSH and the dashboard are reached
-    # exclusively over tailscale0, which is trusted below and bypasses the
-    # NixOS firewall entirely.
+    # exclusively over tailscale0, which is configured as a trusted interface
+    # in tailscale.nix and bypasses the NixOS firewall entirely.
     allowedTCPPorts = [ ];
-    allowedUDPPorts = [
-      41641 # Tailscale WireGuard
-    ];
-    trustedInterfaces = [ "tailscale0" ];
   };
 
   fileSystems."/mnt/data" = {
@@ -266,79 +196,11 @@ in
 
   programs.bash.interactiveShellInit = "set -o vi";
 
-  age.secrets = {
-    "tailscale-authkey-${environment}" = {
-      file = ./secret/tailscale-authkey-${environment}.age;
-      mode = "0400";
-    };
-  };
-  systemd = {
-    tmpfiles.rules = [
-      "d /mnt/data 0755 st0x st0x -"
-      "d /mnt/data/logs 0755 st0x st0x -"
-      "d /mnt/data/grafana 0750 grafana grafana -"
-      "d ${certDir} 0750 nginx nginx -"
-    ];
-
-    services = lib.recursiveUpdate (lib.mapAttrs mkService unitServices) {
-      # Clean up stale TUN device before tailscaled starts. During NixOS
-      # activation the old tailscaled may still hold /dev/net/tun when the
-      # new unit starts, causing a crash-loop.
-      tailscaled.serviceConfig.ExecStartPre = [ "-${pkgs.iproute2}/bin/ip link delete tailscale0" ];
-
-      # Provision a Tailscale-issued TLS certificate so the dashboard is
-      # served over HTTPS. Runs before nginx to guarantee cert files exist.
-      tailscale-cert = {
-        description = "Provision Tailscale HTTPS certificate for ${tailscaleFqdn}";
-        after = [ "tailscaled.service" ];
-        wants = [ "tailscaled.service" ];
-        before = [ "nginx.service" ];
-        wantedBy = [ "multi-user.target" ];
-        path = [
-          pkgs.tailscale
-          pkgs.jq
-        ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          User = "nginx";
-          Group = "nginx";
-          # Reload nginx so it picks up renewed certs on subsequent runs
-          # triggered by the timer. || true keeps the unit green on first
-          # boot when nginx hasn't started yet.
-          ExecStartPost = "+${pkgs.bash}/bin/bash -c 'systemctl is-active --quiet nginx.service && systemctl reload nginx.service || true'";
-        };
-        script = ''
-          set -euo pipefail
-          retries=0
-          until [ "$(tailscale status --json 2>/dev/null | jq -r '.BackendState' 2>/dev/null)" = "Running" ]; do
-            retries=$((retries + 1))
-            if [ "$retries" -ge 30 ]; then
-              echo "Tailscale BackendState != Running after 60s" >&2
-              exit 1
-            fi
-            sleep 2
-          done
-          tailscale cert \
-            --cert-file ${certDir}/${tailscaleFqdn}.crt \
-            --key-file ${certDir}/${tailscaleFqdn}.key \
-            ${tailscaleFqdn}
-        '';
-      };
-
-      nginx.after = [ "tailscale-cert.service" ];
-      nginx.requires = [ "tailscale-cert.service" ];
-    };
-
-    timers.tailscale-cert = {
-      description = "Renew Tailscale HTTPS certificate daily";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = "daily";
-        Persistent = true;
-      };
-    };
-  };
+  systemd.tmpfiles.rules = [
+    "d /mnt/data 0755 st0x st0x -"
+    "d /mnt/data/logs 0755 st0x st0x -"
+    "d /mnt/data/grafana 0750 grafana grafana -"
+  ];
 
   # The system bus implementation cannot be live-switched safely. Deploy this
   # change with deploy-rs --boot and a reboot, not a normal switch.
@@ -355,26 +217,6 @@ in
     zellij
     cli
   ];
-
-  system.activationScripts.per-service-profiles.text = ''
-    mkdir -p /nix/var/nix/profiles/per-service
-
-    # Managed services use restartIfChanged = false + ConditionPathExists so
-    # that deploy.nix's per-service profile owns stop/install/restart. But if
-    # a previous deploy left one crash-looping (Restart = always), its failed
-    # state persists into the next activation and switch-to-configuration's
-    # final "units failed" check exits 4, which makes deploy-rs roll back
-    # before it ever reaches the per-service profile that would install the
-    # fix. Stop + reset-failed any managed service that is currently broken
-    # so activation can complete; the service profile restarts it afterwards.
-    for svc in ${builtins.concatStringsSep " " (builtins.attrNames unitServices)}; do
-      state=$(${pkgs.systemd}/bin/systemctl show -p ActiveState --value "$svc.service" 2>/dev/null || echo "")
-      if [ "$state" = "failed" ] || [ "$state" = "activating" ]; then
-        ${pkgs.systemd}/bin/systemctl stop "$svc.service" 2>/dev/null || true
-        ${pkgs.systemd}/bin/systemctl reset-failed "$svc.service" 2>/dev/null || true
-      fi
-    done
-  '';
 
   system.stateVersion = "24.11";
 

--- a/services.nix
+++ b/services.nix
@@ -1,3 +1,12 @@
+{ lib }:
+
+# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
+#                    chown data dirs, write git-rev, marker file, restart unit.
+# kind = "plain"   -- has a systemd unit, no secrets/config. Marker file gates
+#                    ConditionPathExists; deploy step just touches it and restarts.
+# kind = "static"  -- no systemd unit (e.g. nginx-served static assets). Deploy step
+#                    runs a custom activation command.
+
 let
   profileBase = "/nix/var/nix/profiles/per-service";
 
@@ -16,54 +25,54 @@ let
 
   withPaths =
     name: attrs: attrs // baseFields name // (if attrs.kind == "st0x" then st0xFields name else { });
+
+  byName = builtins.mapAttrs withPaths {
+    # `order` controls deploy-rs activation sequence within `profilesOrder`. The
+    # system profile always runs first; remaining profiles activate in ascending
+    # `order`. Lower numbers go first.
+    st0x-hedge = {
+      enabled = true;
+      order = 30;
+      kind = "st0x";
+      package = "st0x-liquidity";
+      bin = "server";
+    };
+
+    dashboard = {
+      enabled = true;
+      order = 10;
+      kind = "static";
+      package = "st0x-dashboard";
+      activation = "systemctl reload nginx";
+    };
+
+    datasette = {
+      enabled = true;
+      # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
+      # before datasette opens it. (--immutable would close the WAL out and serve
+      # stale reads, so we open the DB normally and rely on the host firewall +
+      # Tailscale for access control.)
+      order = 40;
+      kind = "plain";
+      package = "datasette";
+      bin = "datasette";
+      description = "Datasette SQLite explorer";
+      # Bind to all interfaces so the service is reachable over the tailnet
+      # (e.g. http://<host>.taile5cf8a.ts.net:8081). Public access is blocked
+      # by the host firewall.
+      args = [
+        "serve"
+        "/mnt/data/st0x-hedge.db"
+        "-p"
+        "8081"
+        "-h"
+        "0.0.0.0"
+      ];
+    };
+  };
+
+  enabled = lib.filterAttrs (_: v: v.enabled) byName;
 in
-# kind = "st0x"    -- full pipeline: agenix decrypt, install config, validate-config,
-#                    chown data dirs, write git-rev, marker file, restart unit.
-# kind = "plain"   -- has a systemd unit, no secrets/config. Marker file gates
-#                    ConditionPathExists; deploy step just touches it and restarts.
-# kind = "static"  -- no systemd unit (e.g. nginx-served static assets). Deploy step
-#                    runs a custom activation command.
-builtins.mapAttrs withPaths {
-  # `order` controls deploy-rs activation sequence within `profilesOrder`. The
-  # system profile always runs first; remaining profiles activate in ascending
-  # `order`. Lower numbers go first.
-  st0x-hedge = {
-    enabled = true;
-    order = 30;
-    kind = "st0x";
-    package = "st0x-liquidity";
-    bin = "server";
-  };
-
-  dashboard = {
-    enabled = true;
-    order = 10;
-    kind = "static";
-    package = "st0x-dashboard";
-    activation = "systemctl reload nginx";
-  };
-
-  datasette = {
-    enabled = true;
-    # Deploy after st0x-hedge so the DB file exists and is chowned to st0x:st0x
-    # before datasette opens it. (--immutable would close the WAL out and serve
-    # stale reads, so we open the DB normally and rely on the host firewall +
-    # Tailscale for access control.)
-    order = 40;
-    kind = "plain";
-    package = "datasette";
-    bin = "datasette";
-    description = "Datasette SQLite explorer";
-    # Bind to all interfaces so the service is reachable over the tailnet
-    # (e.g. http://<host>.taile5cf8a.ts.net:8081). Public access is blocked
-    # by the host firewall.
-    args = [
-      "serve"
-      "/mnt/data/st0x-hedge.db"
-      "-p"
-      "8081"
-      "-h"
-      "0.0.0.0"
-    ];
-  };
+{
+  inherit byName enabled;
 }


### PR DESCRIPTION
## What

Closes [RAI-696](https://linear.app/makeitrain/issue/RAI-696).

Split `os.nix` into focused modules. Three concerns that had grown
together into one ~370-line file now live where they can be scanned,
replaced, or reused independently.

## Why

`os.nix` had accreted three independently-coherent concerns:

1. Base NixOS host config (DigitalOcean / qemu imports, grub,
   cloud-init, sshd, fail2ban, nginx vhost, grafana stub,
   `/mnt/data` mount, nix settings + gc, users, system state).
2. Tailscale stack (`services.tailscale`, the `tailscale-cert`
   systemd unit that provisions the HTTPS cert, the daily renewal
   timer, the `tailscaled.ExecStartPre` cleanup of `tailscale0`,
   the per-env authkey agenix secret, and the trusted-interface
   firewall entries).
3. Per-service profile lifecycle (the `mkService` builder that
   produces `systemd.services.<name>` from `services.nix` data,
   and the `system.activationScripts.per-service-profiles` that
   resets any service left in a failed state so the next
   activation can proceed).

The `enabled` filter for services was also duplicated between
`os.nix` and `deploy.nix` because `services.nix` was a data-only
file rather than a function taking `lib`.

## How

- Extract the Tailscale stack into `tailscale.nix` — both the
  authkey secret declaration and the cert provisioning / firewall
  config. `os.nix` imports it.
- Extract the per-service profile machinery into
  `service-profiles.nix` — the `mkService` builder and the
  `per-service-profiles` activation script. `os.nix` imports it.
- Convert `services.nix` from a data-only attrset into a function
  taking `lib`. Returns `{ byName, enabled }` so the
  `lib.filterAttrs (_: v: v.enabled) byName` step happens once
  and is shared by `deploy.nix` and the new
  `service-profiles.nix` instead of being duplicated.
- Thread `lib` from `rainix.inputs.nixpkgs` through the call sites
  that consume `services.nix`.
- Centralize the per-env `tailscaleMagicDnsName` in `flake.nix`'s
  `environments` attrset (was previously a per-env lookup hardcoded
  inside `os.nix`).

## Testing

`nix --accept-flake-config flake metadata` evaluates cleanly across
all systems. `nix build .#nixosConfigurations.st0x-liquidity.config.system.build.toplevel`
and `nix build .#nixosConfigurations.st0x-liquidity-staging.config.system.build.toplevel`
both build with the extracted modules.

## Anything else

Part of the [Fast and reliable CI](https://linear.app/makeitrain/project/re-usable-infra-and-secret-management-ac645cca3477)
milestone.

Stacked on [#693](https://github.com/ST0x-Technology/st0x.liquidity/pull/693)
([RAI-667](https://linear.app/makeitrain/issue/RAI-667));
followed by [#696](https://github.com/ST0x-Technology/st0x.liquidity/pull/696).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Tailscale networking with automatic HTTPS certificate provisioning and renewal.
  * Per-service upgradeable units enabling safer, restartable service updates.

* **Refactor**
  * Reworked service selection and activation ordering for clearer, ordered deployments.
  * Simplified system wiring to centralize Tailscale and reduce local provisioning.

* **Bug Fixes**
  * Improved recovery for services stuck during activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->