### PR TITLE
fix: use one nixpkgs pin for deploy tooling

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -45,6 +45,7 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -32,6 +32,7 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -24,6 +24,7 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/flake.lock
+++ b/flake.lock
@@ -51,26 +51,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1769737823,
-        "narHash": "sha256-DrBaNpZ+sJ4stXm+0nBX7zqZT9t9P22zbk6m5YhQxS4=",
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b2f45c3830aa96b7456a4c4bc327d04d7a43e1ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_2": {
-      "locked": {
-        "lastModified": 1760924934,
-        "narHash": "sha256-tuuqY5aU7cUkR71sO2TraVKK2boYrdW3gCSXUkF4i44=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "c6b4d5308293d0d04fcfeee92705017537cad02f",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
         "type": "github"
       },
       "original": {
@@ -105,7 +90,9 @@
     "deploy-rs": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "utils": "utils"
       },
       "locked": {
@@ -342,7 +329,9 @@
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1773213477,
@@ -362,7 +351,9 @@
       "inputs": {
         "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1774104215,
@@ -465,7 +456,9 @@
         "flake-parts": "flake-parts_2",
         "nix-vm-test": "nix-vm-test",
         "nixos-images": "nixos-images",
-        "nixos-stable": "nixos-stable",
+        "nixos-stable": [
+          "nixpkgs"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -510,34 +503,18 @@
         "type": "github"
       }
     },
-    "nixos-stable": {
-      "locked": {
-        "lastModified": 1769318308,
-        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743014863,
-        "narHash": "sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg=",
+        "lastModified": 1779963766,
+        "narHash": "sha256-Y6Tuk9aewk+HpKGoB+YfbpxCmKoq/g5sWkpYC5OT7ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f",
+        "rev": "d556754720159ad11fea22549c0e990bd2df8b5a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -557,106 +534,16 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1774106199,
-        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1761672384,
-        "narHash": "sha256-o9KF3DJL7g7iYMZq9SWgfS1BFlNbsm6xplRjVlOCkXI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "08dacfca559e1d7da38f3cf05f1f45ee9bfd213c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1666753130,
-        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "ragenix": {
       "inputs": {
         "agenix": "agenix",
-        "crane": "crane_2",
+        "crane": [
+          "crane"
+        ],
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       },
       "locked": {
@@ -749,7 +636,7 @@
         "flake-utils": "flake-utils",
         "forge-std": "forge-std",
         "nixos-anywhere": "nixos-anywhere",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "ragenix": "ragenix",
         "rain-math-float": "rain-math-float",
         "rain-orderbook": "rain-orderbook",
@@ -779,7 +666,9 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1773216618,
@@ -798,7 +687,9 @@
     "solc": {
       "inputs": {
         "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,16 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    rainix.url = "github:rainprotocol/rainix?rev=36342d3f1a104adf987793df7f101cf804e62a34";
-    rainix.inputs.nixpkgs.follows = "nixpkgs";
+    rainix = {
+      url = "github:rainprotocol/rainix?rev=36342d3f1a104adf987793df7f101cf804e62a34";
+      inputs = {
+        foundry.inputs.nixpkgs.follows = "nixpkgs";
+        git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
+        nixpkgs.follows = "nixpkgs";
+        rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+        solc.inputs.nixpkgs.follows = "nixpkgs";
+      };
+    };
 
     rain-math-float = {
       type = "git";
@@ -34,8 +42,13 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
-    ragenix.url = "github:yaxitech/ragenix";
+    ragenix = {
+      url = "github:yaxitech/ragenix";
+      inputs.crane.follows = "crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     deploy-rs.url = "github:serokell/deploy-rs";
+    deploy-rs.inputs.nixpkgs.follows = "nixpkgs";
 
     bun2nix.url = "github:nix-community/bun2nix/2.0.8";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
@@ -45,8 +58,11 @@
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
 
-    nixos-anywhere.url = "github:nix-community/nixos-anywhere";
-    nixos-anywhere.inputs.nixpkgs.follows = "nixpkgs";
+    nixos-anywhere = {
+      url = "github:nix-community/nixos-anywhere";
+      inputs.nixos-stable.follows = "nixpkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =


### PR DESCRIPTION
Resolved by this PR: [RAI-705](https://linear.app/makeitrain/issue/RAI-705)

## What

Fixes the Nix deploy failure caused by crates.io rejecting legacy crate download URLs.

This PR:
- Makes deploy/tooling flakes use one root `nixpkgs` pin.
- Makes `deploy-rs` follow the project `nixpkgs`.
- Makes `ragenix` follow the project `nixpkgs` and root `crane`.
- Makes Rainix's nested `foundry`, `git-hooks-nix`, `rust-overlay`, and `solc` inputs follow the root `nixpkgs`.
- Makes `nixos-anywhere`'s `nixos-stable` input follow the root `nixpkgs`.
- Updates the root `nixpkgs` lock to `d556754720159ad11fea22549c0e990bd2df8b5a`, which includes the Nixpkgs fixes for static crates.io downloads.
- Updates the root `crane` lock to `edb38893982a3338972bb4a2ec7ce7c29ba10fd9`.
- Adds authenticated GitHub fetches to deploy/rekey workflows via `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}`.

## Why

The production deploy failed while building `deploy-rs` from source:

`crate-rnix-0.8.1.tar.gz` tried to download from `https://crates.io/api/v1/crates/rnix/0.8.1/download` and received HTTP 403.

This lines up with the upstream Nixpkgs fix in [NixOS/nixpkgs#524985](https://github.com/NixOS/nixpkgs/pull/524985), `rustPlatform.importCargoLock: download crates from static.crates.io`, merged on 2026-05-27 at `c0a89c379b4ac67c7b13b051ddbd4e0dbc9b0eaf`. That change moved `importCargoLock` crate downloads away from the crates.io API endpoint and onto `static.crates.io`.

The first-order issue was stale Nix/Rust vendoring inputs in the deploy closure using the legacy crates.io API path. Keeping multiple nested `nixpkgs` pins made that easy to miss: even after `deploy-rs` followed the root `nixpkgs`, other tooling inputs could still carry older Rust crate fetchers.

## How

The flake now has a single locked `nixpkgs` node for deploy/tooling inputs. `flake.lock` no longer contains duplicate `nixpkgs_2`, `nixpkgs_3`, etc. nodes, or the separate `nixos-stable` node from `nixos-anywhere`.

The root `nixpkgs` is pinned to a commit containing both static crates.io fixes:

- `importCargoLock` via [NixOS/nixpkgs#524985](https://github.com/NixOS/nixpkgs/pull/524985)
- `fetchCrate`

The root `crane` is also updated so `ragenix` uses the current cargo vendoring path.

The workflow token changes are separate hardening for GitHub flake-input fetches, matching the CI workflow behavior.

## Testing

- `nix fmt -- flake.nix`
- `gt modify` hooks passed:
  - `deadnix`
  - `nil`
  - `nixfmt`
  - `statix`
- Confirmed `flake.lock` has exactly one locked `nixpkgs` node:
  - `nixpkgs -> d556754720159ad11fea22549c0e990bd2df8b5a`
- Evaluated Linux deploy package:
  - `nix eval --raw .#packages.x86_64-linux.prodDeployAll.drvPath`
- Inspected the Linux `prodDeployAll` derivation closure:
  - no active old `crates.io/api/v1/crates` URLs in URL/env fields
  - old helper is not used for network `create-vendor-staging`
- Built locally:
  - `nix build .#prodDeployAll --no-link --print-out-paths`
  - output: `/nix/store/8r3jpzg8lk3mia9nbggdhmkd7k2n12pb-prod-deploy-all`
- Build logs confirmed crate fetches use `https://static.crates.io/crates/...`.

## Screenshots

N/A

## Anything else

Final end-to-end confirmation is to rerun the failed production deploy after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub authentication configuration in deployment workflows to improve build reliability across environments.
  * Optimized dependency pinning setup for more consistent and predictable builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->