### PR TITLE
ci: support dbus-broker boot migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: Cache cargo artifacts
         uses: actions/cache@v4
@@ -142,6 +143,9 @@ jobs:
             accept-flake-config = true
             fallback = true
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: deploy migration invariants
+        run: ./scripts/validate-deploy-migration.sh
 
       - name: pre-commit hooks
         run: nix develop .#ci-hooks -c pre-commit run --all-files

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -7,6 +7,14 @@ on:
         description: "Git tag to deploy (must be on master)"
         required: true
         type: string
+      mode:
+        description: "Deployment mode"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - broker-migration
 
 permissions:
   contents: read
@@ -48,6 +56,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
@@ -66,11 +75,72 @@ jobs:
           chmod 700 ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
+          ssh-keygen -R "$DEPLOY_HOST" >/dev/null 2>&1 || true
+          echo "$DEPLOY_HOST $(nix eval --raw --file keys.nix keys.host-prod)" >> ~/.ssh/known_hosts
 
       - name: Warm up Tailscale tunnel
-        run: tailscale ping --c 1 "$DEPLOY_HOST"
+        run: |
+          for attempt in {1..6}; do
+            if tailscale ping --c 1 "$DEPLOY_HOST"; then
+              exit 0
+            fi
+            echo "Tailscale ping failed on attempt $attempt; retrying..."
+            sleep 5
+          done
+          tailscale status
+          exit 1
 
       - name: Deploy
+        if: ${{ inputs.mode == 'all' }}
+        run: nix run .#prodDeployAll
+
+      - name: Deploy NixOS system for next boot
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: nix run .#prodDeployNixosBoot
+
+      - name: Record current boot ID
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          pre_reboot_boot_id=$(ssh -o BatchMode=yes root@"$DEPLOY_HOST" 'cat /proc/sys/kernel/random/boot_id')
+          if [ -z "$pre_reboot_boot_id" ]; then
+            echo "Failed to read pre-reboot boot ID" >&2
+            exit 1
+          fi
+          printf 'PRE_REBOOT_BOOT_ID=%s\n' "$pre_reboot_boot_id" >> "$GITHUB_ENV"
+
+      - name: Reboot production host
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: ssh -o BatchMode=yes -o ConnectTimeout=10 root@"$DEPLOY_HOST" 'systemctl reboot' || true
+
+      - name: Wait for production host
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          for attempt in {1..60}; do
+            current_boot_id=$(ssh -o BatchMode=yes -o ConnectTimeout=5 root@"$DEPLOY_HOST" 'cat /proc/sys/kernel/random/boot_id' 2>/dev/null || true)
+            if [ -n "$current_boot_id" ] && [ "$current_boot_id" != "$PRE_REBOOT_BOOT_ID" ]; then
+              exit 0
+            fi
+            echo "Host has not returned on a new boot after attempt $attempt; retrying..."
+            sleep 10
+          done
+          tailscale status
+          exit 1
+
+      - name: Verify dbus-broker migration
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          ssh -o BatchMode=yes root@"$DEPLOY_HOST" '
+            set -eu
+            systemctl is-active --quiet dbus-broker.service
+            failed_units=$(systemctl --failed --no-legend --plain)
+            if [ -n "$failed_units" ]; then
+              echo "$failed_units" >&2
+              exit 1
+            fi
+          '
+
+      - name: Deploy all profiles after reboot
+        if: ${{ inputs.mode == 'broker-migration' }}
         run: nix run .#prodDeployAll
 
       - name: Cleanup SSH

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -8,6 +8,14 @@ on:
         required: true
         default: "master"
         type: string
+      mode:
+        description: "Deployment mode"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - broker-migration
 
 permissions:
   contents: read
@@ -35,6 +43,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
@@ -53,11 +62,72 @@ jobs:
           chmod 700 ~/.ssh
           echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
+          ssh-keygen -R "$DEPLOY_HOST" >/dev/null 2>&1 || true
+          echo "$DEPLOY_HOST $(nix eval --raw --file keys.nix keys.host-staging)" >> ~/.ssh/known_hosts
 
       - name: Warm up Tailscale tunnel
-        run: tailscale ping --c 1 "$DEPLOY_HOST"
+        run: |
+          for attempt in {1..6}; do
+            if tailscale ping --c 1 "$DEPLOY_HOST"; then
+              exit 0
+            fi
+            echo "Tailscale ping failed on attempt $attempt; retrying..."
+            sleep 5
+          done
+          tailscale status
+          exit 1
 
       - name: Deploy
+        if: ${{ inputs.mode == 'all' }}
+        run: nix run .#stagingDeployAll
+
+      - name: Deploy NixOS system for next boot
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: nix run .#stagingDeployNixosBoot
+
+      - name: Record current boot ID
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          pre_reboot_boot_id=$(ssh -o BatchMode=yes root@"$DEPLOY_HOST" 'cat /proc/sys/kernel/random/boot_id')
+          if [ -z "$pre_reboot_boot_id" ]; then
+            echo "Failed to read pre-reboot boot ID" >&2
+            exit 1
+          fi
+          printf 'PRE_REBOOT_BOOT_ID=%s\n' "$pre_reboot_boot_id" >> "$GITHUB_ENV"
+
+      - name: Reboot staging host
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: ssh -o BatchMode=yes -o ConnectTimeout=10 root@"$DEPLOY_HOST" 'systemctl reboot' || true
+
+      - name: Wait for staging host
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          for attempt in {1..60}; do
+            current_boot_id=$(ssh -o BatchMode=yes -o ConnectTimeout=5 root@"$DEPLOY_HOST" 'cat /proc/sys/kernel/random/boot_id' 2>/dev/null || true)
+            if [ -n "$current_boot_id" ] && [ "$current_boot_id" != "$PRE_REBOOT_BOOT_ID" ]; then
+              exit 0
+            fi
+            echo "Host has not returned on a new boot after attempt $attempt; retrying..."
+            sleep 10
+          done
+          tailscale status
+          exit 1
+
+      - name: Verify dbus-broker migration
+        if: ${{ inputs.mode == 'broker-migration' }}
+        run: |
+          ssh -o BatchMode=yes root@"$DEPLOY_HOST" '
+            set -eu
+            systemctl is-active --quiet dbus-broker.service
+            failed_units=$(systemctl --failed --no-legend --plain)
+            if [ -n "$failed_units" ]; then
+              echo "$failed_units" >&2
+              exit 1
+            fi
+          '
+
+      - name: Deploy all profiles after reboot
+        if: ${{ inputs.mode == 'broker-migration' }}
         run: nix run .#stagingDeployAll
 
       - name: Cleanup SSH

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -27,6 +27,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: Setup SSH key
         run: |

--- a/README.md
+++ b/README.md
@@ -364,14 +364,36 @@ Pass `-i <path>` to use a different key.
 **Deployment** (requires SSH key for host access and terraform state
 decryption):
 
-| Command         | Usage                               | Notes                                               |
-| --------------- | ----------------------------------- | --------------------------------------------------- |
-| `deployAll`     | `nix run .#deployAll`               | Deploy system config + all services                 |
-| `deployNixos`   | `nix run .#deployNixos`             | Deploy NixOS system config only                     |
-| `deployService` | `nix run .#deployService <profile>` | Deploy a single service (`st0x-hedge`, `datasette`) |
-| `remote`        | `nix run .#remote [-- <cmd>]`       | SSH into production host                            |
-| `secret`        | `nix run .#secret <file.age>`       | Edit an encrypted config, then re-encrypt all       |
-| `bootstrap`     | `nix run .#bootstrap`               | One-time NixOS install on a new host                |
+| Command                  | Usage                                   | Notes                                         |
+| ------------------------ | --------------------------------------- | --------------------------------------------- |
+| `prodDeployAll`          | `nix run .#prodDeployAll`               | Deploy prod system config + all services      |
+| `prodDeployNixos`        | `nix run .#prodDeployNixos`             | Deploy prod NixOS system config only          |
+| `prodDeployNixosBoot`    | `nix run .#prodDeployNixosBoot`         | Register prod NixOS config for next boot      |
+| `prodDeployService`      | `nix run .#prodDeployService <profile>` | Deploy a single prod service                  |
+| `stagingDeployAll`       | `nix run .#stagingDeployAll`            | Deploy staging system config + all services   |
+| `stagingDeployNixosBoot` | `nix run .#stagingDeployNixosBoot`      | Register staging NixOS config for next boot   |
+| `remote`                 | `nix run .#remote [-- <cmd>]`           | SSH into production host                      |
+| `secret`                 | `nix run .#secret <file.age>`           | Edit an encrypted config, then re-encrypt all |
+| `bootstrap`              | `nix run .#bootstrap`                   | One-time NixOS install on a new host          |
+
+The deploy workflows also expose a `broker-migration` mode for the one-time
+`dbus` to `dbus-broker` migration. Use that mode when a NixOS change must be
+registered for next boot instead of live-switched: it boot-deploys the system
+profile, reboots the host, waits for SSH over Tailscale, verifies `dbus-broker`,
+then runs the normal full deploy to reactivate service profiles. This keeps the
+host on the current NixOS default instead of carrying a permanent override back
+to classic `dbus`.
+
+To run the production migration:
+
+1. Draft the release tag from `master`.
+2. Open the **Deploy to Production** GitHub Actions workflow.
+3. Click **Run workflow**.
+4. Enter the release tag.
+5. Set `mode` to `broker-migration`.
+6. Start the workflow and wait for the final `Deploy all profiles after reboot`
+   step to pass.
+7. Use the default `all` mode for future production deploys.
 
 **Infrastructure** (requires SSH key for terraform state decryption):
 

--- a/deploy.nix
+++ b/deploy.nix
@@ -185,6 +185,7 @@ in
           mkDeployScript =
             name:
             {
+              extraDeployFlags ? "",
               prelude ? "",
               target,
             }:
@@ -194,7 +195,7 @@ in
               text = ''
                 ${deployPreamble}
                 ${prelude}
-                deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} ${target} \
+                deploy ${deployFlags} ${extraDeployFlags} ''${ssh_flag:+"$ssh_flag"} ${target} \
                   -- ${nixFlags} "$@"
               '';
             };
@@ -202,6 +203,11 @@ in
         in
         {
           "${env}DeployNixos" = mkDeployScript "${env}-deploy-nixos" {
+            target = ".#${nodeName}.system";
+          };
+
+          "${env}DeployNixosBoot" = mkDeployScript "${env}-deploy-nixos-boot" {
+            extraDeployFlags = "--boot";
             target = ".#${nodeName}.system";
           };
 

--- a/os.nix
+++ b/os.nix
@@ -340,6 +340,10 @@ in
     };
   };
 
+  # The system bus implementation cannot be live-switched safely. Deploy this
+  # change with deploy-rs --boot and a reboot, not a normal switch.
+  services.dbus.implementation = "broker";
+
   environment.systemPackages = with pkgs; [
     bat
     curl

--- a/scripts/validate-deploy-migration.sh
+++ b/scripts/validate-deploy-migration.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+line_number_after() {
+  local file="$1"
+  local pattern="$2"
+  local previous="$3"
+
+  local line
+  line=$(grep -nF "$pattern" "$file" | cut -d: -f1 | awk -v previous="$previous" '$1 > previous { print; exit }')
+  if [ -z "$line" ]; then
+    echo "Missing '$pattern' after line $previous in $file" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$line"
+}
+
+assert_order() {
+  local file="$1"
+  shift
+
+  local previous=0
+  local pattern
+  for pattern in "$@"; do
+    local current
+    current=$(line_number_after "$file" "$pattern" "$previous")
+    previous="$current"
+  done
+}
+
+assert_workflow() {
+  local file="$1"
+  local boot_app="$2"
+  local final_app="$3"
+
+  grep -qF "mode:" "$file"
+  grep -qF "broker-migration" "$file"
+
+  assert_order "$file" \
+    "run: nix run .#$boot_app" \
+    "PRE_REBOOT_BOOT_ID=" \
+    "systemctl reboot" \
+    "current_boot_id=" \
+    "systemctl is-active --quiet dbus-broker.service" \
+    "failed_units=\$(systemctl --failed --no-legend --plain)" \
+    "run: nix run .#$final_app"
+}
+
+assert_boot_app() {
+  local attr="$1"
+  local app="$2"
+  local target="$3"
+
+  local out
+  out=$(nix build ".#$attr" --no-link --print-out-paths)
+
+  local script="$out/bin/$app"
+  grep -q -- "--boot" "$script"
+  grep -qF "$target" "$script"
+}
+
+assert_dbus_broker() {
+  local attr="$1"
+  local value
+  value=$(nix eval --raw ".#nixosConfigurations.$attr.config.services.dbus.implementation")
+  if [ "$value" != "broker" ]; then
+    echo "$attr expected services.dbus.implementation=broker, got $value" >&2
+    exit 1
+  fi
+}
+
+assert_workflow ".github/workflows/deploy-prod.yaml" "prodDeployNixosBoot" "prodDeployAll"
+assert_workflow ".github/workflows/deploy-staging.yaml" "stagingDeployNixosBoot" "stagingDeployAll"
+
+assert_boot_app "prodDeployNixosBoot" "prod-deploy-nixos-boot" ".#st0x-liquidity.system"
+assert_boot_app "stagingDeployNixosBoot" "staging-deploy-nixos-boot" ".#st0x-liquidity-staging.system"
+
+assert_dbus_broker "st0x-liquidity"
+assert_dbus_broker "st0x-liquidity-staging"


### PR DESCRIPTION
Resolved by this PR: [RAI-706](https://linear.app/makeitrain/issue/RAI-706)

## What

Adds an explicit GitHub Actions path for the one-time NixOS `dbus` -> `dbus-broker` migration, and keeps deploy workflows resilient to cache and Tailscale flakes.

- `.github/workflows/deploy-prod.yaml` and `.github/workflows/deploy-staging.yaml` now expose a `mode` input:
  - `all` keeps the existing normal deploy behavior.
  - `broker-migration` boot-deploys the NixOS system profile, reboots the host, waits for a new boot ID, verifies `dbus-broker.service`, then runs the normal full deploy to reactivate service profiles.
- `deploy.nix` adds `prodDeployNixosBoot` and `stagingDeployNixosBoot`, passing deploy-rs `--boot` before the target so it reaches deploy-rs rather than Nix.
- `os.nix` explicitly sets `services.dbus.implementation = "broker"`.
- CI/deploy/rekey workflows treat Magic Nix Cache failures as non-blocking.
- Deploy workflows retry Tailscale tunnel warmup instead of failing on a single missed ping.
- `README.md` documents the new deploy commands, migration mode, production operator steps, and why the broker migration should be done via boot/reboot.

## Why

The production deploy reached NixOS activation and failed because NixOS refused to live-switch a critical system component:

```text
dbus-implementation : dbus -> broker
Switching into this system is not recommended.
You probably want to run 'nixos-rebuild boot' and reboot your system instead.
```

`dbus-broker` is the current default in our pinned nixpkgs. Pinning back to classic `dbus` would only defer the same reboot-required migration. Since prod is already in a maintenance window, this PR moves to the intended broker state and follows NixOS' safe migration path instead of bypassing switch inhibitors.

The workflow hardening addresses the other deploy flakes seen while unblocking this path: Magic Nix Cache S3 timeouts and transient Tailscale ping failures.

## How

- `mkDeployScript` accepts `extraDeployFlags`, letting boot-mode wrappers inject `--boot` before the flake target:
  - normal deploy: `deploy <flags> .#node`
  - boot deploy: `deploy <flags> --boot .#node.system`
- `broker-migration` mode uses the existing deploy workflow credentials, Tailscale setup, SSH key, release-tag checkout, and concurrency guard.
- The workflow records `/proc/sys/kernel/random/boot_id` before reboot, then waits until SSH returns with a different boot ID. This avoids racing ahead while the old boot is still answering SSH.
- After reboot, the workflow verifies:
  - `dbus-broker.service` is active
  - `systemctl --failed` is empty
- The final `prodDeployAll` / `stagingDeployAll` run is still required because app services are activated by deploy-rs custom service profiles, not by systemd boot alone.

## Testing

- `nix eval --raw .#nixosConfigurations.st0x-liquidity.config.services.dbus.implementation` -> `broker`
- `nix eval --raw .#nixosConfigurations.st0x-liquidity-staging.config.services.dbus.implementation` -> `broker`
- `nix build .#prodDeployNixosBoot .#stagingDeployNixosBoot --no-link`
- Ruby YAML parse/assertion for prod and staging deploy workflows
- `nix develop --command pre-commit run --files deploy.nix os.nix .github/workflows/deploy-prod.yaml .github/workflows/deploy-staging.yaml README.md`

## Screenshots

N/A.

## Anything else

Production migration steps after merge:

1. Draft/create the release tag from `master`.
2. Open **Actions -> Deploy to Production**.
3. Click **Run workflow**.
4. Enter the release tag.
5. Set `mode` to `broker-migration`.
6. Start the workflow.
7. Wait for `Deploy all profiles after reboot` to pass.
8. Use normal `mode = all` for future production deploys.

This does not require any database reset or data migration. The change is OS-level: boot the host into the NixOS generation that uses `dbus-broker`, then reactivate the service profiles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "broker-migration" deployment mode and a boot-mode deploy for targeted system updates.

* **Improvements**
  * More resilient deploys: cache steps tolerate failures, Tailscale warm-up retries, and stronger SSH host-key handling.
  * Deploy flow verifies reboot completion and service health when performing broker migrations.
  * D-Bus broker option set in system configuration (requires boot-mode deploy + reboot).

* **Chores**
  * Added a validation script to assert deployment/migration workflow ordering and boot-mode usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->