### PR TITLE
ci: cache nix source closure before matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,78 @@ permissions:
   contents: read
 
 jobs:
+  nix-source-cache:
+    name: nix source cache
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Git fetch fail-fast
+        run: |
+          git config --global http.lowSpeedLimit 524288
+          git config --global http.lowSpeedTime 60
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Nix source cache
+        id: nix-source-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .tmp/nix-ci-cache
+            .tmp/nix-ci-cache-paths.txt
+          key: nix-source-abi-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/*.nix') }}
+
+      - name: Populate Nix source cache
+        if: steps.nix-source-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+
+          cache_dir="$GITHUB_WORKSPACE/.tmp/nix-ci-cache"
+          archive_json="$GITHUB_WORKSPACE/.tmp/nix-ci-cache-flake-archive.json"
+          abi_outputs="$GITHUB_WORKSPACE/.tmp/nix-ci-cache-abi-outputs.txt"
+          paths_file="$GITHUB_WORKSPACE/.tmp/nix-ci-cache-paths.txt"
+
+          mkdir -p "$cache_dir"
+
+          retry() {
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+
+              if [ "$attempt" = 3 ]; then
+                return 1
+              fi
+
+              sleep "$((attempt * 15))"
+            done
+          }
+
+          retry bash -c 'nix flake archive --json --to "$1" . > "$2"' \
+            _ "file://$cache_dir" "$archive_json"
+
+          jq -r '[.. | objects | select(has("path")) | .path] | unique | .[]' \
+            "$archive_json" > "$paths_file"
+
+          retry bash -c 'nix build --no-link --print-out-paths .#forgeStd .#rainOrderbook .#pyth > "$1"' \
+            _ "$abi_outputs"
+
+          retry bash -c 'xargs nix copy --to "$1" < "$2"' \
+            _ "file://$cache_dir" "$abi_outputs"
+
+          xargs nix path-info -r < "$abi_outputs" >> "$paths_file"
+          sort -u "$paths_file" -o "$paths_file"
+
   backend-validation:
     name: backend ${{ matrix.name }}
+    needs: nix-source-cache
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
     strategy:
@@ -64,6 +134,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure Git fetch fail-fast
+        run: |
+          git config --global http.lowSpeedLimit 524288
+          git config --global http.lowSpeedTime 60
+
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
@@ -73,6 +148,23 @@ jobs:
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
         continue-on-error: true
+
+      - name: Restore Nix source cache
+        id: nix-source-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .tmp/nix-ci-cache
+            .tmp/nix-ci-cache-paths.txt
+          key: nix-source-abi-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/*.nix') }}
+          fail-on-cache-miss: true
+
+      - name: Import Nix source cache
+        run: |
+          nix copy \
+            --from "file://$GITHUB_WORKSPACE/.tmp/nix-ci-cache" \
+            --no-check-sigs \
+            --stdin < "$GITHUB_WORKSPACE/.tmp/nix-ci-cache-paths.txt"
 
       - name: Cache cargo artifacts
         uses: actions/cache@v4
@@ -107,6 +199,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure Git fetch fail-fast
+        run: |
+          git config --global http.lowSpeedLimit 524288
+          git config --global http.lowSpeedTime 60
+
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
@@ -136,6 +233,11 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
+
+      - name: Configure Git fetch fail-fast
+        run: |
+          git config --global http.lowSpeedLimit 524288
+          git config --global http.lowSpeedTime 60
 
       - uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -196,11 +196,13 @@
             };
           })
           abis
+          abiEnvs
           abiEnv
           ;
 
         rust = pkgs.callPackage ./rust.nix {
           inherit craneLib abiEnv;
+          rainMathFloatAbiEnv = abiEnvs.rainMathFloat;
           rainMathFloat = rain-math-float;
         };
       in
@@ -492,17 +494,14 @@
             # CI hooks: pre-commit invokes hook tools by absolute /nix/store
             # path, so they must be realized. rainix's rust-shell includes
             # pre-commit + all linter packages (deadnix/nil/nixfmt/statix/
-            # taplo/yamlfmt/shellcheck/deno) without the heavy default closure.
-            ci-hooks = pkgs.mkShell (
-              {
-                shellHook = ''
-                  ${rustShell.shellHook}
-                  ${rainMathFloatLink}
-                '';
-                inherit (rustShell) buildInputs;
-              }
-              // abiEnv
-            );
+            # taplo/yamlfmt/shellcheck/deno) without the backend ABI closure.
+            ci-hooks = pkgs.mkShell {
+              shellHook = ''
+                ${rustShell.shellHook}
+                ${rainMathFloatLink}
+              '';
+              inherit (rustShell) buildInputs;
+            };
           };
       }
     );

--- a/nix/abis.nix
+++ b/nix/abis.nix
@@ -60,5 +60,6 @@ let
 in
 {
   abis = builtins.mapAttrs (_: feature: feature.abi) features;
+  abiEnvs = envs;
   abiEnv = mergedEnv;
 }

--- a/rust.nix
+++ b/rust.nix
@@ -2,6 +2,7 @@
   pkgs,
   craneLib,
   abiEnv,
+  rainMathFloatAbiEnv,
   rainMathFloat,
 }:
 
@@ -38,6 +39,7 @@ let
   };
 
   fullSrc = withRainMathFloat "st0x-src" cleanedSrc;
+  eventSorceryHash = "sha256-bpj3QE2z2F8RLH4O++5gor1SrDFGf23CnzGgATUE5OQ=";
 
   # Vendor cargo deps with git dependency hashes
   baseVendorDir = craneLib.vendorCargoDeps {
@@ -47,7 +49,7 @@ let
       "git+https://github.com/rainlanguage/rain.error#3d2ed70fb2f7c6156706846e10f163d1e493a8d3" =
         "sha256-dDsvRkrGXhfoFunvk6fwP+12fSsjiWYoxz/CzVVGpHA=";
       "git+https://github.com/ST0x-Technology/event-sorcery.git?branch=docs/examples#262d12b3f797a0b7445ee62d846119d3d7110dc7" =
-        "sha256-bpj3QE2z2F8RLH4O++5gor1SrDFGf23CnzGgATUE5OQ=";
+        eventSorceryHash;
       "git+https://github.com/rainlanguage/rain.wasm?rev=06990d85a0b7c55378a1c8cca4dd9e2bc34a596a#06990d85a0b7c55378a1c8cca4dd9e2bc34a596a" =
         "sha256-MkuPc9mWAmry5Yzjph4/IbaIvjevFUerji1lipLUK4g=";
     };
@@ -63,9 +65,11 @@ let
   sqliteEsRev = builtins.head (builtins.match ".*#([a-f0-9]+)" sqliteEsPackage.source);
 
   sqliteEsMigrations =
-    builtins.fetchGit {
-      url = "https://github.com/ST0x-Technology/event-sorcery";
+    pkgs.fetchFromGitHub {
+      owner = "ST0x-Technology";
+      repo = "event-sorcery";
       rev = sqliteEsRev;
+      hash = eventSorceryHash;
     }
     + "/migrations";
 
@@ -118,6 +122,10 @@ let
   # exercising any tests the matrix doesn't already cover.
   commonArgs = depsArgs // abiEnv // { doCheck = false; };
 
+  # DTO only needs rain-math-float's ABI env through its Float dependency; keep
+  # dashboard builds from realizing backend contract ABIs.
+  dtoArgs = depsArgs // rainMathFloatAbiEnv // { doCheck = false; };
+
   # Build only dependencies (cached separately from source changes).
   # Crane's mkDummySrc internally strips to manifests + dummy crate roots,
   # so we feed it fullSrc rather than pre-stripping ourselves -- our prior
@@ -131,7 +139,8 @@ in
   # source at crates/dto/default.nix; rust.nix only supplies shared crane
   # infra.
   st0x-dto = import ./crates/dto {
-    inherit craneLib commonArgs cargoArtifacts;
+    inherit craneLib cargoArtifacts;
+    commonArgs = dtoArgs;
   };
 
   # Server binary for deployment


### PR DESCRIPTION
Closes [RAI-707](https://linear.app/makeitrain/issue/RAI-707)

## What

Adds a `nix source cache` warmup job to CI and makes backend, dashboard, and hooks jobs depend on it before running their Nix-based validation steps.

## Why

CI has been repeatedly hanging during Nix/Git source downloads for Solidity/Nix inputs. The failures are stochastic: rerunning only the failed job usually passes, but rerunning the whole workflow often causes a different matrix leg to stall while fetching another source repository.

## How

The new warmup job fetches and realizes the shared Nix source/ABI closure once, then stores it in an Actions-backed local Nix binary cache under `.tmp/nix-ci-cache`.

Downstream jobs restore that cache and import the paths before entering `nix develop`, so the matrix no longer fans out simultaneous live Git fetches for the same flake inputs and ABI derivations.

This keeps generated ABI JSON dynamic and uncommitted. It also configures Git low-speed limits so genuinely stalled downloads fail fast instead of hanging indefinitely.

## Testing

- CI passed on this PR:
  - `nix source cache`
  - backend check
  - backend test 1-4
  - backend clippy
  - dashboard
  - hooks
  - Graphite mergeability check

## Screenshots

Not applicable.

## Anything else

The cache key is tied to runner OS/arch plus `flake.lock`, `flake.nix`, and `nix/*.nix`, so cache invalidation follows the Nix source/ABI configuration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782599932&installation_id=125569124&pr_number=704&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F704&signature=54eae475a2cfedd6fca04388f6415ec30c13119e63cea2f5ddf51be2e7355d79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI caching to speed and stabilize validation builds and restore prebuilt inputs for faster pipeline runs.
  * Added a faster Git fetch fail-fast to reduce waiting on slow clones.
  * Updated developer shells and build wiring to streamline ABI-specific environments and more reliable dependency fetching for reproducible local builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->