### PR TITLE
fix: restore offchain inventory polling

### DIFF
--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -749,9 +749,9 @@ fn register_positions_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>
         when.method(GET)
             .path(format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/positions"));
         then.respond_with(move |_request: &HttpMockRequest| {
-            let result: Result<Vec<Value>, rain_math_float::FloatError> = {
+            let result = (|| -> Result<Vec<Value>, rain_math_float::FloatError> {
                 let state = lock(&state);
-                state
+                let mut positions = state
                     .account
                     .positions
                     .values()
@@ -761,7 +761,7 @@ fn register_positions_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>
                             .lt(Float::from_raw(alloy::primitives::B256::ZERO))?;
                         let side = if is_neg { "short" } else { "long" };
                         let abs_qty = pos.quantity.abs()?;
-                        Ok(json!({
+                        Ok::<Value, rain_math_float::FloatError>(json!({
                             "symbol": pos.symbol,
                             "qty_available": format_float_with_fallback(&abs_qty),
                             "market_value": format_float_with_fallback(&pos.market_value),
@@ -769,8 +769,30 @@ fn register_positions_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>
                             "avg_entry_price": "0",
                         }))
                     })
-                    .collect()
-            };
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let usdc_balance = state
+                    .wallet_balances
+                    .get("USDC")
+                    .copied()
+                    .unwrap_or_else(|| float!(0));
+                drop(state);
+
+                if !usdc_balance.is_zero()? {
+                    positions.push(json!({
+                        "symbol": "USDCUSD",
+                        "qty_available": format_float_with_fallback(&usdc_balance),
+                        "qty": format_float_with_fallback(&usdc_balance),
+                        "market_value": format_float_with_fallback(&usdc_balance),
+                        "side": "long",
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
+                        "avg_entry_price": "1",
+                    }));
+                }
+
+                Ok(positions)
+            })();
 
             match result {
                 Ok(positions) => json_response(200, &Value::Array(positions)),
@@ -1369,25 +1391,13 @@ fn register_wallet_get_endpoint(server: &MockServer, state: &Arc<Mutex<MockState
                     );
                 }
 
-                let (deposit_addr, balance) = {
-                    let state = lock(&state);
-                    (
-                        state.alpaca_deposit_address.clone(),
-                        state
-                            .wallet_balances
-                            .get(asset)
-                            .copied()
-                            .unwrap_or_else(|| float!(0)),
-                    )
-                };
+                let deposit_addr = lock(&state).alpaca_deposit_address.clone();
 
                 return json_response(
                     200,
                     &json!({
                         "asset_id": "00000000-0000-0000-0000-000000000000",
-                        "asset": asset,
                         "address": deposit_addr,
-                        "balance": format_float_with_fallback(&balance),
                         "created_at": "2025-01-01T00:00:00Z"
                     }),
                 );

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -169,6 +169,9 @@ pub enum AlpacaBrokerApiError {
     #[error("Invalid symbol in position: {0}")]
     InvalidSymbol(#[from] crate::EmptySymbolError),
 
+    #[error("Alpaca USDCUSD position is missing the required total quantity (qty) field")]
+    MissingPositionQuantity,
+
     #[error(
         "Order quantity {shares} is below Alpaca's \
          {max_decimals}-decimal-place precision"

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -2,6 +2,7 @@
 
 use rain_math_float::Float;
 use serde::Deserialize;
+use st0x_finance::{HasZero, Usdc};
 use st0x_float_macro::float;
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 use tracing::{debug, error, trace};
@@ -25,11 +26,23 @@ pub(super) struct AccountFunds {
 #[derive(Deserialize)]
 struct PositionResponse {
     symbol: String,
+    asset_class: Option<String>,
+    exchange: Option<String>,
     #[serde(
         rename = "qty_available",
         deserialize_with = "deserialize_float_from_number_or_string"
     )]
     quantity: Float,
+    /// Total position size including quantity locked by open orders or pending
+    /// transfers. Only read for Alpaca-held USDC, which stays at Alpaca until a
+    /// withdrawal to Ethereum settles even while the withdrawal locks it; equity
+    /// positions use `quantity` (the tradeable amount) instead.
+    #[serde(
+        default,
+        rename = "qty",
+        deserialize_with = "deserialize_option_float_from_number_or_string"
+    )]
+    total_quantity: Option<Float>,
     #[serde(
         default,
         deserialize_with = "deserialize_option_float_from_number_or_string"
@@ -41,9 +54,32 @@ impl std::fmt::Debug for PositionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PositionResponse")
             .field("symbol", &self.symbol)
+            .field("asset_class", &self.asset_class)
+            .field("exchange", &self.exchange)
             .field("quantity", &DebugFloat(&self.quantity))
+            .field("total_quantity", &DebugOptionFloat(&self.total_quantity))
             .field("market_value", &DebugOptionFloat(&self.market_value))
             .finish()
+    }
+}
+
+impl PositionResponse {
+    fn is_non_equity(&self) -> bool {
+        // USDCUSD is Alpaca's USDC/USD crypto pair, captured separately as
+        // Alpaca-held USDC by symbol. Exclude it from equity by symbol too, so
+        // it never reaches equity/vault reconciliation (TokenNotInRegistry) even
+        // if Alpaca omits the asset_class/exchange metadata on the position.
+        if self.symbol == "USDCUSD" {
+            return true;
+        }
+
+        if let Some(asset_class) = &self.asset_class {
+            return !asset_class.eq_ignore_ascii_case("us_equity");
+        }
+
+        self.exchange
+            .as_deref()
+            .is_some_and(|exchange| exchange.eq_ignore_ascii_case("CRYPTO"))
     }
 }
 
@@ -78,19 +114,19 @@ pub(super) async fn fetch_inventory(
 ) -> Result<Inventory, AlpacaBrokerApiError> {
     let positions = list_positions(client).await?;
     let account_funds = get_account_funds(client).await?;
+    let alpaca_usdc = alpaca_usdc_balance(&positions)?;
 
     let broker_positions = positions
         .into_iter()
         .filter(|position| {
-            // USDCUSD is Alpaca's crypto pair for USDC/USD conversion during
-            // rebalancing. It's not an equity position and has no vault in the
-            // registry -- filtering it here prevents downstream
-            // TokenNotInRegistry errors.
-            if position.symbol == "USDCUSD" {
+            if position.is_non_equity() {
                 trace!(
                     target: "broker",
+                    symbol = %position.symbol,
+                    asset_class = ?position.asset_class,
+                    exchange = ?position.exchange,
                     quantity = ?position.quantity,
-                    "Skipping USDCUSD crypto position from inventory"
+                    "Skipping non-equity Alpaca position from equity inventory"
                 );
                 return false;
             }
@@ -121,10 +157,31 @@ pub(super) async fn fetch_inventory(
 
     Ok(Inventory {
         positions: broker_positions,
+        alpaca_usdc: Some(alpaca_usdc),
         usd_balance_cents: account_funds.balance,
         cash_buying_power_cents: Some(account_funds.buying_power),
         cash_withdrawable_cents: account_funds.withdrawable,
     })
+}
+
+fn alpaca_usdc_balance(positions: &[PositionResponse]) -> Result<Usdc, AlpacaBrokerApiError> {
+    let Some(position) = positions
+        .iter()
+        .find(|position| position.symbol == "USDCUSD")
+    else {
+        return Ok(Usdc::ZERO);
+    };
+
+    // Track total USDC held at Alpaca, including any amount locked by an
+    // in-flight withdrawal -- it has not left Alpaca until the withdrawal
+    // settles. `qty_available` would under-report it mid-withdrawal. Alpaca
+    // always returns `qty` for a real position, so a missing value is a
+    // malformed response we must surface rather than silently treat as zero.
+    let total_quantity = position
+        .total_quantity
+        .ok_or(AlpacaBrokerApiError::MissingPositionQuantity)?;
+
+    Ok(Usdc::new(total_quantity))
 }
 
 pub(super) async fn get_account_funds(
@@ -278,6 +335,7 @@ mod tests {
         account_mock.assert();
 
         assert_eq!(state.positions.len(), 2);
+        assert_eq!(state.alpaca_usdc, Some(Usdc::ZERO));
         assert_eq!(state.usd_balance_cents, 5_000_000);
         assert_eq!(state.cash_buying_power_cents, Some(5_000_000));
 
@@ -684,7 +742,10 @@ mod tests {
                         "market_value": "1500.00"
                     },
                     {
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
                         "symbol": "USDCUSD",
+                        "qty": "5000.0",
                         "qty_available": "5000.0",
                         "market_value": "5000.00"
                     },
@@ -717,5 +778,309 @@ mod tests {
 
         assert_eq!(symbols, vec!["AAPL", "RKLB"]);
         assert_eq!(inventory.positions.len(), 2);
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::new(float!(5000.0))));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_reads_real_alpaca_usdcusd_position_shape() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "crypto",
+                        "avg_entry_price": "0.999912891",
+                        "cost_basis": "0.788445",
+                        "current_price": "0.9995",
+                        "exchange": "CRYPTO",
+                        "market_value": "0.78812",
+                        "qty": "0.788514",
+                        "qty_available": "0.788514",
+                        "side": "long",
+                        "symbol": "USDCUSD"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        assert!(inventory.positions.is_empty());
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::new(float!(0.788514))));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_uses_total_qty_not_available_for_usdc() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // Mid-withdrawal Alpaca locks part of the USDC, so qty_available drops
+        // below the total qty still held at Alpaca. We must report the total.
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
+                        "symbol": "USDCUSD",
+                        "qty": "5000.0",
+                        "qty_available": "1500.0",
+                        "market_value": "5000.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::new(float!(5000.0))));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_errors_when_usdc_position_missing_total_qty() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
+                        "symbol": "USDCUSD",
+                        "qty_available": "5000.0",
+                        "market_value": "5000.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let error = fetch_inventory(&client).await.unwrap_err();
+
+        assert!(
+            matches!(error, AlpacaBrokerApiError::MissingPositionQuantity),
+            "Expected MissingPositionQuantity, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_excludes_usdcusd_from_equity_without_metadata() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // USDCUSD with qty present but no asset_class/exchange must still be
+        // captured as Alpaca USDC and kept out of equity positions, so it never
+        // reaches vault reconciliation as a phantom equity holding.
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "symbol": "USDCUSD",
+                        "qty": "5000.0",
+                        "qty_available": "5000.0",
+                        "market_value": "5000.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        assert!(
+            inventory.positions.is_empty(),
+            "USDCUSD must never appear as an equity position"
+        );
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::new(float!(5000.0))));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_reports_zero_for_fully_locked_usdc_position() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
+                        "symbol": "USDCUSD",
+                        "qty": "0.0",
+                        "qty_available": "0.0",
+                        "market_value": "0.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::ZERO));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_ignores_other_crypto_positions() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "crypto",
+                        "exchange": "CRYPTO",
+                        "market_value": "1.00",
+                        "qty_available": "0.00001",
+                        "symbol": "BTC/USD"
+                    },
+                    {
+                        "symbol": "AAPL",
+                        "qty_available": "10.0",
+                        "market_value": "1500.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        let symbols: Vec<String> = inventory
+            .positions
+            .iter()
+            .map(|position| position.symbol.to_string())
+            .collect();
+
+        assert_eq!(symbols, vec!["AAPL"]);
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::ZERO));
+    }
+
+    #[tokio::test]
+    async fn fetch_inventory_ignores_non_equity_asset_classes() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/positions");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([
+                    {
+                        "asset_class": "option",
+                        "exchange": "OPRA",
+                        "market_value": "1.00",
+                        "qty_available": "1",
+                        "symbol": "AAPL250117C00150000"
+                    },
+                    {
+                        "asset_class": "us_equity",
+                        "symbol": "AAPL",
+                        "qty_available": "10.0",
+                        "market_value": "1500.00"
+                    }
+                ]));
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/account");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "cash": "10000.00"
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let inventory = fetch_inventory(&client).await.unwrap();
+
+        let symbols: Vec<String> = inventory
+            .positions
+            .iter()
+            .map(|position| position.symbol.to_string())
+            .collect();
+
+        assert_eq!(symbols, vec!["AAPL"]);
+        assert_eq!(inventory.alpaca_usdc, Some(Usdc::ZERO));
     }
 }

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -32,7 +32,7 @@ pub use order::{MarketOrder, OrderPlacement, OrderState, OrderStatus, OrderUpdat
 
 pub use st0x_finance::{
     EmptySymbolError, FractionalShares, HasZero, NotPositive, Positive, Symbol, ToWholeSharesError,
-    Usd,
+    Usd, Usdc,
 };
 
 /// Extension trait for U256 conversions on `FractionalShares`.
@@ -299,6 +299,11 @@ pub struct EquityPosition {
 #[derive(Debug, Clone)]
 pub struct Inventory {
     pub positions: Vec<EquityPosition>,
+    /// USDC held at Alpaca after USD/USDC conversion and before withdrawal.
+    /// `None` when the executor does not model an Alpaca USDC venue (e.g.
+    /// `MockExecutor`); a reporting executor uses `Some(Usdc::ZERO)` for a zero
+    /// balance so the snapshot is still emitted.
+    pub alpaca_usdc: Option<Usdc>,
     pub usd_balance_cents: i64,
     /// Cash buying power available for equity hedges -- Alpaca's `cash`
     /// field, which includes unsettled T+1 equity-sale proceeds and excludes

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -366,6 +366,7 @@ mod tests {
             }],
             usd_balance_cents: 5_000_000,
             cash_buying_power_cents: Some(5_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
 
@@ -403,6 +404,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000,
             cash_buying_power_cents: Some(10_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
 
@@ -418,6 +420,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -449,6 +452,7 @@ mod tests {
             }],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -485,6 +489,7 @@ mod tests {
             }],
             usd_balance_cents: 50_000,
             cash_buying_power_cents: Some(50_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -513,6 +518,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 10_000,
                 cash_buying_power_cents: Some(10_000),
+                alpaca_usdc: None,
                 cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));

--- a/src/alpaca_wallet/asset.rs
+++ b/src/alpaca_wallet/asset.rs
@@ -4,10 +4,7 @@
 //! whitelist behavior.
 
 use alloy::primitives::Address;
-use rain_math_float::Float;
 use serde::Deserialize;
-
-use st0x_finance::Usdc;
 
 use super::client::{AlpacaWalletClient, AlpacaWalletError};
 use super::transfer::{Network, TokenSymbol};
@@ -42,40 +39,6 @@ impl AlpacaWalletClient {
 
         Ok(serde_json::from_str::<WalletAddressResponse>(&body)?.address)
     }
-
-    /// Gets the Alpaca account asset balance for a token and network.
-    pub(super) async fn get_asset_balance(
-        &self,
-        asset: &TokenSymbol,
-        network: &Network,
-    ) -> Result<Usdc, AlpacaWalletError> {
-        #[derive(Deserialize)]
-        struct AssetBalanceResponse {
-            #[serde(deserialize_with = "deserialize_float")]
-            balance: Float,
-        }
-
-        fn deserialize_float<'de, D>(deserializer: D) -> Result<Float, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            let raw = String::deserialize(deserializer)?;
-            Float::parse(raw).map_err(serde::de::Error::custom)
-        }
-
-        let path = format!(
-            "/v1/accounts/{}/wallets?asset={}&network={}",
-            self.account_id(),
-            asset.as_ref(),
-            network.as_ref()
-        );
-
-        let body = self.get(&path).await?;
-
-        Ok(Usdc::new(
-            serde_json::from_str::<AssetBalanceResponse>(&body)?.balance,
-        ))
-    }
 }
 
 #[cfg(test)]
@@ -90,42 +53,6 @@ mod tests {
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
         AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
-
-    #[tokio::test]
-    async fn get_asset_balance_reads_account_token_balance() {
-        let server = MockServer::start();
-
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets"))
-                .query_param("asset", "USDC")
-                .query_param("network", "ethereum");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "asset_id": "5d0de74f-827b-41a7-9f74-9c07c08fe55f",
-                    "asset": "USDC",
-                    "address": "0x42a76C83014e886e639768D84EAF3573b1876844",
-                    "balance": "125.75",
-                    "created_at": "2025-08-07T08:52:40.656166Z"
-                }));
-        });
-
-        let client = AlpacaWalletClient::new(
-            server.base_url(),
-            TEST_ACCOUNT_ID,
-            "test_key_id".to_string(),
-            "test_secret_key".to_string(),
-        );
-
-        let balance = client
-            .get_asset_balance(&TokenSymbol::new("USDC"), &Network::new("ethereum"))
-            .await
-            .unwrap();
-
-        assert_eq!(balance, Usdc::new(st0x_float_macro::float!(125.75)));
-        mock.assert();
-    }
 
     #[tokio::test]
     async fn test_get_wallet_address_success() {

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -1,7 +1,7 @@
 //! Alpaca Broker API crypto wallet client for USDC deposits and withdrawals.
 //!
 //! This module integrates with the wallet endpoints of the Alpaca Broker API,
-//! supporting USDC balance checks, deposits, and withdrawals.
+//! supporting USDC deposit address lookup, deposits, and withdrawals.
 //!
 //! # Authentication
 //!
@@ -41,8 +41,8 @@ pub(crate) use whitelist::{TravelRuleInfo, WhitelistEntry, WhitelistStatus};
 
 /// Service facade for Alpaca crypto wallet operations.
 ///
-/// Provides a high-level API for balance checks, deposits, withdrawals, and
-/// transfer polling.
+/// Provides a high-level API for deposit address lookup, deposits, withdrawals,
+/// and transfer polling.
 pub(crate) struct AlpacaWalletService {
     client: Arc<AlpacaWalletClient>,
     polling_config: PollingConfig,
@@ -146,15 +146,6 @@ impl AlpacaWalletService {
         network: &Network,
     ) -> Result<Address, AlpacaWalletError> {
         self.client.get_wallet_address(asset, network).await
-    }
-
-    /// Gets the Alpaca account balance for the given token.
-    pub(crate) async fn get_asset_balance(
-        &self,
-        asset: &TokenSymbol,
-        network: &Network,
-    ) -> Result<Usdc, AlpacaWalletError> {
-        self.client.get_asset_balance(asset, network).await
     }
 
     pub(crate) async fn create_whitelist_entry(

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -185,7 +185,6 @@ impl Conductor {
             rebalancer,
             rebalancer_shutdown_token,
             wallet_polling,
-            alpaca_wallet,
             tokenizer,
             service: rebalancing_service,
             recovery_transfer,
@@ -255,7 +254,6 @@ impl Conductor {
             frameworks,
             pool,
             wallet_polling,
-            alpaca_wallet,
             tokenizer,
             shutdown_token: shutdown_token.clone(),
             #[cfg(any(test, feature = "test-support"))]
@@ -562,7 +560,6 @@ struct RebalancingInfrastructure {
     snapshot: Arc<Store<InventorySnapshot>>,
     rebalancer: JoinHandle<()>,
     rebalancer_shutdown_token: CancellationToken,
-    alpaca_wallet: Arc<AlpacaWalletService>,
     tokenizer: Arc<dyn Tokenizer>,
     service: Arc<RebalancingService>,
     recovery_transfer: Arc<CrossVenueEquityTransfer>,
@@ -591,7 +588,6 @@ struct PositionAndRebalancing {
     rebalancer: Option<JoinHandle<()>>,
     rebalancer_shutdown_token: CancellationToken,
     wallet_polling: Option<crate::inventory::WalletPollingCtx>,
-    alpaca_wallet: Option<Arc<AlpacaWalletService>>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     service: Option<Arc<RebalancingService>>,
     recovery_transfer: Option<Arc<CrossVenueEquityTransfer>>,
@@ -644,7 +640,6 @@ impl PositionAndRebalancing {
                 rebalancer: Some(infra.rebalancer),
                 rebalancer_shutdown_token: infra.rebalancer_shutdown_token,
                 wallet_polling: Some(wallet_polling),
-                alpaca_wallet: Some(infra.alpaca_wallet),
                 tokenizer: Some(infra.tokenizer),
                 service: Some(infra.service),
                 recovery_transfer: Some(infra.recovery_transfer),
@@ -668,7 +663,6 @@ impl PositionAndRebalancing {
                 rebalancer: None,
                 rebalancer_shutdown_token: CancellationToken::new(),
                 wallet_polling: None,
-                alpaca_wallet: None,
                 tokenizer: None,
                 service: None,
                 recovery_transfer: None,
@@ -904,7 +898,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             snapshot: built.snapshot,
             rebalancer: handle,
             rebalancer_shutdown_token,
-            alpaca_wallet,
             tokenizer,
             service: rebalancing_service,
             recovery_transfer,
@@ -2796,6 +2789,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -2854,6 +2848,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -2917,6 +2912,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -3154,6 +3150,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 10_000,
                 cash_buying_power_cents: Some(1_000_000),
+                alpaca_usdc: None,
                 cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
@@ -3218,6 +3215,7 @@ mod tests {
                 }],
                 usd_balance_cents: 15_000,
                 cash_buying_power_cents: Some(15_000),
+                alpaca_usdc: None,
                 cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));
@@ -3282,6 +3280,7 @@ mod tests {
             }],
             usd_balance_cents: 100_000,
             cash_buying_power_cents: Some(100_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         });
 
@@ -3377,6 +3376,7 @@ mod tests {
                 positions: vec![],
                 usd_balance_cents: 15_000,
                 cash_buying_power_cents: Some(15_000),
+                alpaca_usdc: None,
                 cash_withdrawable_cents: None,
             })
             .with_preflight_price(float!(100));

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -74,7 +74,6 @@ pub(crate) struct ConductorCtx<Prov, Exec> {
     pub(crate) frameworks: CqrsFrameworks,
     pub(crate) pool: SqlitePool,
     pub(crate) wallet_polling: Option<WalletPollingCtx>,
-    pub(crate) alpaca_wallet: Option<Arc<crate::alpaca_wallet::AlpacaWalletService>>,
     pub(crate) tokenizer: Option<Arc<dyn Tokenizer>>,
     pub(crate) shutdown_token: CancellationToken,
     #[cfg(any(test, feature = "test-support"))]
@@ -145,7 +144,6 @@ where
         .collect();
 
     let wallet_polling = context.wallet_polling;
-    let alpaca_wallet = context.alpaca_wallet;
     let tokenizer = context.tokenizer;
 
     let mut polling_service = InventoryPollingService::new(
@@ -159,10 +157,6 @@ where
         reserved_cash,
     )
     .with_configured_equity_symbols(configured_equity_symbols);
-
-    if let Some(alpaca_wallet) = alpaca_wallet {
-        polling_service = polling_service.with_alpaca_wallet(alpaca_wallet);
-    }
 
     if let Some(rebalancing_service) = &rebalancing_service {
         polling_service =

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -1228,6 +1228,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
         positions: vec![],
         usd_balance_cents: 50_000,
         cash_buying_power_cents: Some(50_000),
+        alpaca_usdc: None,
         cash_withdrawable_cents: None,
     });
 

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -23,7 +23,6 @@ use st0x_execution::{
 };
 use st0x_finance::{HasZero, Usd, UsdToCentsError};
 
-use crate::alpaca_wallet::{AlpacaWalletError, AlpacaWalletService, Network, TokenSymbol};
 use crate::bindings::IERC20;
 use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
@@ -71,8 +70,6 @@ pub(crate) enum InventoryPollingError<ExecutorError> {
     #[error(transparent)]
     UsdcConversion(#[from] UsdcTransferError),
     #[error(transparent)]
-    AlpacaWallet(#[from] AlpacaWalletError),
-    #[error(transparent)]
     Tokenizer(#[from] TokenizerError),
     #[error(transparent)]
     Float(#[from] FloatError),
@@ -119,7 +116,6 @@ where
     snapshot_id: InventorySnapshotId,
     snapshot: Arc<Store<InventorySnapshot>>,
     wallet_polling: Option<WalletPollingCtx>,
-    alpaca_wallet: Option<Arc<AlpacaWalletService>>,
     tokenizer: Option<Arc<dyn Tokenizer>>,
     pending_request_ownership: Option<Arc<dyn PendingRequestOwnership>>,
     external_pending_warnings: Mutex<HashSet<TokenizationRequestId>>,
@@ -151,7 +147,6 @@ where
             snapshot_id,
             snapshot,
             wallet_polling,
-            alpaca_wallet: None,
             tokenizer,
             pending_request_ownership: None,
             external_pending_warnings: Mutex::new(HashSet::new()),
@@ -177,32 +172,45 @@ where
         self
     }
 
-    pub(crate) fn with_alpaca_wallet(mut self, alpaca_wallet: Arc<AlpacaWalletService>) -> Self {
-        self.alpaca_wallet = Some(alpaca_wallet);
-        self
-    }
-
     /// Polls actual inventory from all venues and emits snapshot commands.
     ///
     /// 1. Queries inflight equity from tokenization provider (must be first)
     /// 2. Queries onchain equity and USDC balances from Base vaults
     /// 3. Queries Ethereum wallet USDC balance (if configured)
-    /// 4. Queries Alpaca account USDC balance (if configured)
-    /// 5. Queries offchain positions and cash from executor
+    /// 4. Queries offchain positions, cash, and Alpaca USDC from executor
     ///
-    /// Inflight must be polled first. Balance snapshots trigger
-    /// check_and_trigger_equity, which skips when has_inflight() is true.
-    /// On startup the first poll tick runs immediately -- if balance
-    /// snapshots land before inflight, the system can trigger a duplicate
-    /// operation for a request Alpaca already has pending.
+    /// Inflight is a hard precondition, not an independent poll group. Balance
+    /// snapshots trigger check_and_trigger_equity, whose dedup guard is
+    /// has_inflight(). On startup the first poll tick runs immediately -- if
+    /// balance snapshots land before a fresh inflight snapshot, the system can
+    /// trigger a duplicate operation for a request Alpaca already has pending.
+    /// So an inflight poll failure aborts the whole tick before any balance
+    /// snapshot is emitted. The remaining three groups (onchain, wallet,
+    /// offchain) are independent: each logs and continues on failure so a
+    /// single venue outage does not stall the others.
     pub(crate) async fn poll_and_record(&self) -> Result<(), InventoryPollingError<Exe::Error>> {
         let snapshot_id = &self.snapshot_id;
 
-        self.poll_inflight_equity(snapshot_id).await?;
-        self.poll_onchain(snapshot_id).await?;
-        self.poll_wallets(snapshot_id).await?;
-        self.poll_alpaca_usdc(snapshot_id).await?;
-        self.poll_offchain(snapshot_id).await?;
+        if let Err(error) = self.poll_inflight_equity(snapshot_id).await {
+            warn!(
+                target: "inventory",
+                ?error,
+                "Inventory inflight equity polling failed; aborting tick before balance snapshots to avoid duplicate operations"
+            );
+            return Ok(());
+        }
+
+        if let Err(error) = self.poll_onchain(snapshot_id).await {
+            warn!(target: "inventory", ?error, "Inventory onchain polling failed");
+        }
+
+        if let Err(error) = self.poll_wallets(snapshot_id).await {
+            warn!(target: "inventory", ?error, "Inventory wallet polling failed");
+        }
+
+        if let Err(error) = self.poll_offchain(snapshot_id).await {
+            warn!(target: "inventory", ?error, "Inventory offchain polling failed");
+        }
 
         Ok(())
     }
@@ -461,29 +469,6 @@ where
         Ok(results.into_iter().collect())
     }
 
-    async fn poll_alpaca_usdc(
-        &self,
-        snapshot_id: &InventorySnapshotId,
-    ) -> Result<(), InventoryPollingError<Exe::Error>> {
-        let Some(alpaca_wallet) = &self.alpaca_wallet else {
-            debug!(target: "inventory", "No Alpaca asset balance polling configured, skipping Alpaca USDC polling");
-            return Ok(());
-        };
-
-        let usdc_balance = alpaca_wallet
-            .get_asset_balance(&TokenSymbol::new("USDC"), &Network::new("ethereum"))
-            .await?;
-
-        self.snapshot
-            .send(
-                snapshot_id,
-                InventorySnapshotCommand::AlpacaUsdc { usdc_balance },
-            )
-            .await?;
-
-        Ok(())
-    }
-
     async fn poll_offchain(
         &self,
         snapshot_id: &InventorySnapshotId,
@@ -538,6 +523,15 @@ where
                 },
             )
             .await?;
+
+        if let Some(usdc_balance) = inventory.alpaca_usdc {
+            self.snapshot
+                .send(
+                    snapshot_id,
+                    InventorySnapshotCommand::AlpacaUsdc { usdc_balance },
+                )
+                .await?;
+        }
 
         Ok(())
     }
@@ -861,16 +855,12 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
     use httpmock::prelude::*;
-    use serde_json::json;
     use sqlx::{Row, SqlitePool};
     use st0x_event_sorcery::{StoreBuilder, test_store};
     use st0x_evm::ReadOnlyEvm;
-    use st0x_execution::{
-        AlpacaAccountId, EquityPosition, FractionalShares, Inventory, MockExecutor, Symbol,
-    };
+    use st0x_execution::{EquityPosition, FractionalShares, Inventory, MockExecutor, Symbol};
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
-    use uuid::uuid;
 
     use super::*;
     use crate::inventory::snapshot::InventorySnapshotEvent;
@@ -1110,6 +1100,7 @@ mod tests {
             ],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory.clone());
@@ -1167,6 +1158,7 @@ mod tests {
             }],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1231,6 +1223,7 @@ mod tests {
             ],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1288,6 +1281,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 25_000_000, // $250,000.00
             cash_buying_power_cents: Some(25_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1337,6 +1331,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000_000, // $100,000
             cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1396,6 +1391,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 3_000_000, // $30,000
             cash_buying_power_cents: Some(3_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1455,6 +1451,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000_000,
             cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1511,6 +1508,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 5_000_000,
             cash_buying_power_cents: Some(5_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1612,6 +1610,7 @@ mod tests {
             }],
             usd_balance_cents: -5_000_000, // -$50,000 (margin debt)
             cash_buying_power_cents: Some(0),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1630,7 +1629,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_offchain(&snapshot_id).await.unwrap_err();
 
         assert!(
             matches!(error, InventoryPollingError::Reserve(_)),
@@ -1654,6 +1657,7 @@ mod tests {
             }],
             usd_balance_cents: 1_000_000,
             cash_buying_power_cents: Some(1_000_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1702,6 +1706,7 @@ mod tests {
             positions: vec![],
             usd_balance_cents: 10_000,
             cash_buying_power_cents: Some(10_000),
+            alpaca_usdc: None,
             cash_withdrawable_cents: None,
         };
         let executor = MockExecutor::new().with_inventory(inventory);
@@ -1942,7 +1947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_fails_on_rpc_failure_for_equity_vault() {
+    async fn poll_onchain_fails_on_rpc_failure_for_equity_vault() {
         let pool = setup_test_db().await;
         let (orderbook, order_owner) = test_addresses();
 
@@ -1977,7 +1982,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_onchain(&snapshot_id).await.unwrap_err();
 
         assert!(
             matches!(error, InventoryPollingError::Raindex(_)),
@@ -1986,7 +1995,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_fails_on_rpc_failure_for_usdc_vault() {
+    async fn poll_onchain_fails_on_rpc_failure_for_usdc_vault() {
         let pool = setup_test_db().await;
         let (orderbook, order_owner) = test_addresses();
 
@@ -2013,7 +2022,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_onchain(&snapshot_id).await.unwrap_err();
 
         assert!(
             matches!(error, InventoryPollingError::Raindex(_)),
@@ -2021,42 +2034,58 @@ mod tests {
         );
     }
 
-    /// Loads all InventorySnapshotEvents for the given orderbook/owner from the event store.
-    const TEST_ALPACA_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+    #[tokio::test]
+    async fn poll_and_record_continues_to_offchain_after_onchain_failure() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
 
-    fn alpaca_wallet_balance_mock<'server>(
-        server: &'server MockServer,
-        balance: &str,
-    ) -> httpmock::Mock<'server> {
-        server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ALPACA_ACCOUNT_ID}/wallets"))
-                .query_param("asset", "USDC")
-                .query_param("network", "ethereum");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "asset_id": "5d0de74f-827b-41a7-9f74-9c07c08fe55f",
-                    "asset": "USDC",
-                    "address": "0x42a76C83014e886e639768D84EAF3573b1876844",
-                    "balance": balance,
-                    "created_at": "2025-08-07T08:52:40.656166Z"
-                }));
-        })
-    }
+        discover_usdc_vault(&pool, orderbook, order_owner, TEST_VAULT_ID).await;
 
-    fn alpaca_wallet_service(server: &MockServer) -> Arc<AlpacaWalletService> {
-        Arc::new(AlpacaWalletService::new(
-            server.base_url(),
-            TEST_ALPACA_ACCOUNT_ID,
-            "test_key_id".to_string(),
-            "test_secret_key".to_string(),
-        ))
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("RPC failure");
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(&pool, provider).await;
+        let inventory = Inventory {
+            positions: vec![],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: Some(Usdc::new(float!(0.788514))),
+            cash_withdrawable_cents: None,
+        };
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            MockExecutor::new().with_inventory(inventory),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. })),
+            "Offchain inventory must still emit when onchain polling fails"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, InventorySnapshotEvent::AlpacaUsdc { .. })),
+            "Alpaca USDC must still emit when onchain polling fails"
+        );
     }
 
     #[tokio::test]
-    async fn poll_alpaca_usdc_emits_command_with_polled_balance() {
+    async fn poll_offchain_emits_alpaca_usdc_from_executor_inventory() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2066,24 +2095,26 @@ mod tests {
             owner: order_owner,
         };
 
-        let server = MockServer::start();
-        let mock = alpaca_wallet_balance_mock(&server, "125.75");
+        let inventory = Inventory {
+            positions: vec![],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: Some(Usdc::new(float!(125.75))),
+            cash_withdrawable_cents: None,
+        };
 
         let service = InventoryPollingService::new(
             raindex_service,
-            MockExecutor::new(),
+            MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             snapshot_id.clone(),
             Arc::new(test_store(pool.clone(), ())),
             None,
             None,
             Usd::ZERO,
-        )
-        .with_alpaca_wallet(alpaca_wallet_service(&server));
+        );
 
-        service.poll_alpaca_usdc(&snapshot_id).await.unwrap();
-
-        mock.assert();
+        service.poll_offchain(&snapshot_id).await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
         let alpaca_event = events
@@ -2098,7 +2129,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_alpaca_usdc_is_noop_when_wallet_unconfigured() {
+    async fn poll_offchain_skips_alpaca_usdc_when_executor_omits_it() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2107,10 +2138,17 @@ mod tests {
             orderbook,
             owner: order_owner,
         };
+        let inventory = Inventory {
+            positions: vec![],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: None,
+            cash_withdrawable_cents: None,
+        };
 
         let service = InventoryPollingService::new(
             raindex_service,
-            MockExecutor::new(),
+            MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             snapshot_id.clone(),
             Arc::new(test_store(pool.clone(), ())),
@@ -2119,57 +2157,59 @@ mod tests {
             Usd::ZERO,
         );
 
-        service.poll_alpaca_usdc(&snapshot_id).await.unwrap();
+        service.poll_offchain(&snapshot_id).await.unwrap();
 
         let events = load_snapshot_events(&pool, orderbook, order_owner).await;
         assert!(
             !events
                 .iter()
                 .any(|event| matches!(event, InventorySnapshotEvent::AlpacaUsdc { .. })),
-            "Must not emit AlpacaUsdc when no Alpaca wallet is configured",
+            "Must not emit AlpacaUsdc when executor omits Alpaca USDC",
         );
     }
 
     #[tokio::test]
-    async fn poll_alpaca_usdc_propagates_balance_query_error() {
+    async fn poll_and_record_aborts_tick_when_inflight_poll_fails() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
         let (orderbook, order_owner) = test_addresses();
-        let snapshot_id = InventorySnapshotId {
-            orderbook,
-            owner: order_owner,
+
+        // Inventory is present, so the offchain group would emit balance
+        // snapshots if the tick were allowed to continue past the failed
+        // inflight poll.
+        let inventory = Inventory {
+            positions: vec![],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: Some(Usdc::new(float!(125.75))),
+            cash_withdrawable_cents: None,
         };
 
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path(format!("/v1/accounts/{TEST_ALPACA_ACCOUNT_ID}/wallets"))
-                .query_param("asset", "USDC")
-                .query_param("network", "ethereum");
-            then.status(500)
-                .header("content-type", "application/json")
-                .json_body(json!({ "message": "internal error" }));
-        });
+        let tokenizer =
+            Arc::new(crate::tokenization::mock::MockTokenizer::new().with_list_pending_failure());
 
         let service = InventoryPollingService::new(
             raindex_service,
-            MockExecutor::new(),
+            MockExecutor::new().with_inventory(inventory),
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
-            snapshot_id.clone(),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
             Arc::new(test_store(pool.clone(), ())),
             None,
-            None,
+            Some(tokenizer),
             Usd::ZERO,
-        )
-        .with_alpaca_wallet(alpaca_wallet_service(&server));
+        );
 
-        let error = service.poll_alpaca_usdc(&snapshot_id).await.unwrap_err();
+        service.poll_and_record().await.unwrap();
 
-        mock.assert();
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
         assert!(
-            matches!(error, InventoryPollingError::AlpacaWallet(_)),
-            "Balance query failure must surface as AlpacaWallet error, got {error:?}",
+            events.is_empty(),
+            "Inflight poll failure must abort the tick before any balance \
+             snapshot is emitted, but got: {events:?}"
         );
     }
 
@@ -2392,7 +2432,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_propagates_ethereum_rpc_failure() {
+    async fn poll_wallets_propagates_ethereum_rpc_failure() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2422,12 +2462,16 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
         assert!(matches!(error, InventoryPollingError::Evm(_)));
     }
 
     #[tokio::test]
-    async fn poll_and_record_propagates_base_wallet_rpc_failure() {
+    async fn poll_wallets_propagates_base_wallet_rpc_failure() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2457,8 +2501,66 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
         assert!(matches!(error, InventoryPollingError::Evm(_)));
+    }
+
+    #[tokio::test]
+    async fn poll_and_record_continues_to_offchain_after_wallet_failure() {
+        let pool = setup_test_db().await;
+        let provider = mock_provider();
+        let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
+        let (orderbook, order_owner) = test_addresses();
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("Ethereum RPC failure");
+        let ethereum_wallet = MockEthereumWallet::with_asserter(&asserter);
+
+        let server = MockServer::start();
+        let inventory = Inventory {
+            positions: vec![],
+            usd_balance_cents: 10_000_000,
+            cash_buying_power_cents: Some(10_000_000),
+            alpaca_usdc: Some(Usdc::new(float!(0.788514))),
+            cash_withdrawable_cents: None,
+        };
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            MockExecutor::new().with_inventory(inventory),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            Some(WalletPollingCtx {
+                ethereum: ethereum_wallet,
+                ..mock_wallet_polling_ctx(&server)
+            }),
+            None,
+            Usd::ZERO,
+        );
+
+        service.poll_and_record().await.unwrap();
+
+        let events = load_snapshot_events(&pool, orderbook, order_owner).await;
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, InventorySnapshotEvent::OffchainUsd { .. })),
+            "Offchain inventory must still emit when wallet polling fails"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, InventorySnapshotEvent::AlpacaUsdc { .. })),
+            "Alpaca USDC must still emit when wallet polling fails"
+        );
     }
 
     #[tokio::test]
@@ -2570,7 +2672,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_propagates_base_wallet_unwrapped_equity_rpc_failure() {
+    async fn poll_wallets_propagates_base_wallet_unwrapped_equity_rpc_failure() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2609,7 +2711,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
         assert!(
             matches!(error, InventoryPollingError::Evm(_)),
             "Expected Evm error, got {error:?}"
@@ -2617,7 +2723,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_propagates_base_wallet_unwrapped_equity_shares_conversion_failure() {
+    async fn poll_wallets_propagates_base_wallet_unwrapped_equity_shares_conversion_failure() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2657,7 +2763,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
         assert!(
             matches!(
                 error,
@@ -2845,7 +2955,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_and_record_propagates_base_wallet_wrapped_equity_rpc_failure() {
+    async fn poll_wallets_propagates_base_wallet_wrapped_equity_rpc_failure() {
         let pool = setup_test_db().await;
         let provider = mock_provider();
         let raindex_service = create_test_raindex_service(&pool, provider.clone()).await;
@@ -2884,7 +2994,11 @@ mod tests {
             Usd::ZERO,
         );
 
-        let error = service.poll_and_record().await.unwrap_err();
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        let error = service.poll_wallets(&snapshot_id).await.unwrap_err();
         assert!(
             matches!(error, InventoryPollingError::Evm(_)),
             "Expected Evm error, got {error:?}"

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -76,6 +76,7 @@ pub(crate) struct MockTokenizer {
     completion_outcome: Option<MockCompletionOutcome>,
     verification_outcome: MockVerificationOutcome,
     should_fail_send: bool,
+    should_fail_list_pending: bool,
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
     pending_requests: Vec<TokenizationRequest>,
     /// Override the token_symbol in completed mint responses.
@@ -95,6 +96,7 @@ impl MockTokenizer {
             completion_outcome: None,
             verification_outcome: MockVerificationOutcome::Success,
             should_fail_send: false,
+            should_fail_list_pending: false,
             last_issuer_request_id: Mutex::new(None),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
@@ -129,6 +131,11 @@ impl MockTokenizer {
 
     pub(crate) fn with_send_failure(mut self) -> Self {
         self.should_fail_send = true;
+        self
+    }
+
+    pub(crate) fn with_list_pending_failure(mut self) -> Self {
+        self.should_fail_list_pending = true;
         self
     }
 
@@ -341,6 +348,13 @@ impl Tokenizer for MockTokenizer {
     }
 
     async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
+        if self.should_fail_list_pending {
+            return Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                message: "mock list_pending_requests failure".to_string(),
+            }));
+        }
+
         Ok(self
             .pending_requests
             .iter()


### PR DESCRIPTION
## What

Restores offchain inventory polling by tracking Alpaca-held USDC from the broker positions endpoint instead of the Alpaca wallet endpoint.

This PR:
- reads Alpaca `USDCUSD` crypto positions from the broker positions endpoint and stores them as `Inventory.alpaca_usdc`, using the position's total `qty` (not `qty_available`)
- emits `InventorySnapshotCommand::AlpacaUsdc` from `poll_offchain()`
- excludes `USDCUSD` from equity inventory by symbol, and filters other non-equity Alpaca positions out before symbol parsing
- removes wallet-balance polling from inventory; Alpaca wallet APIs remain for deposit/withdrawal flow plumbing
- makes inflight equity polling a hard precondition in `poll_and_record()`, while onchain, wallet, and offchain polling each fail independently (log and continue)

## Why

Prod offchain inventory polling was failing because the bot tried to parse Alpaca wallet endpoint responses as account balances, but that endpoint does not return the balance shape the poller expected. As a result, offchain inventory stopped updating.

The USDC value we need is the Alpaca-held `USDCUSD` position created after USD-to-USDC conversion and before withdrawal to Ethereum, not the wallet endpoint response. We read its total `qty` rather than `qty_available` so a USDC amount locked by an in-flight withdrawal is still counted as held at Alpaca until the withdrawal settles.

Inventory polling also needs partial freshness: an onchain or wallet polling failure should not prevent broker/offchain inventory from updating during the same tick. Inflight equity is the exception -- it must be polled first because balance snapshots drive `check_and_trigger_equity`, whose dedup guard is `has_inflight()`. If inflight data is stale, a balance snapshot could trigger a duplicate operation for a request the provider already has pending, so an inflight poll failure aborts the whole tick.

## How

`st0x_execution::Inventory` now includes optional `alpaca_usdc` (`None` when the executor does not model an Alpaca USDC venue; `Some(Usdc::ZERO)` for a reporting executor with no balance).

`fetch_inventory()` in the Alpaca broker implementation:
- captures the `USDCUSD` position's total `qty` as Alpaca-held USDC, and fails fast with `MissingPositionQuantity` if a `USDCUSD` position omits `qty` (rather than silently reporting zero)
- excludes `USDCUSD` from equity by symbol in `is_non_equity()`, so it never reaches equity/vault reconciliation even if Alpaca omits `asset_class`/`exchange` metadata
- ignores other non-equity Alpaca positions instead of parsing them as equity symbols
- returns zero USDC when no `USDCUSD` position is present

`InventoryPollingService::poll_offchain()` emits the Alpaca USDC snapshot event alongside offchain equity, USD, buying power, and withdrawable cash.

`poll_and_record()` polls inflight equity first; on failure it logs and aborts the tick before emitting any balance snapshot. The onchain, wallet, and offchain groups then each warn-and-continue on failure so one venue outage does not stall the others.

The Alpaca wallet `get_asset_balance()` path was removed because wallet endpoints are not the source of this inventory value.

## Testing

Added/updated tests for:
- parsing the real Alpaca `USDCUSD` position shape
- reading total `qty` (not `qty_available`) for USDC, and erroring when `qty` is absent
- reporting zero for a fully-locked `USDCUSD` position
- excluding `USDCUSD` from equity even when `asset_class`/`exchange` are absent
- ignoring other Alpaca crypto positions / non-equity asset classes without breaking equity inventory
- emitting / skipping Alpaca USDC based on executor inventory
- aborting the tick (no balance snapshots) when inflight polling fails
- continuing to emit offchain inventory after onchain or wallet polling failure
- preserving lower-level error tests by calling `poll_onchain()` / `poll_wallets()` directly

Verified locally (`nix develop`): `cargo check`, targeted `cargo nextest run` for the execution `fetch_inventory*` and hedge `poll_*` tests (19 + 35 passing), and `cargo clippy`/`cargo fmt` on the changed crates.

## Screenshots

Not applicable.

## Anything else

Stacked on #704 (`ci-cache-nix-source-closure`).

Follow-up deferred to [RAI-703](https://linear.app/makeitrain/issue/RAI-703): during a degraded tick (onchain/wallet poll fails, offchain succeeds), fresh offchain balance snapshots can still trigger rebalancing checks that read stale counterpart-venue data. Tracked separately as it concerns the deliberate partial-freshness design.
