### PR TITLE
fix: carry full 32-byte CCTP nonce as B256 end-to-end

### DIFF
--- a/crates/bridge/src/cctp/mock_attestation.rs
+++ b/crates/bridge/src/cctp/mock_attestation.rs
@@ -301,11 +301,10 @@ async fn sign_cctp_message(
 ) -> Option<(Vec<u8>, Vec<u8>)> {
     let mut modified = message.to_vec();
 
-    // Generate a random nonce that fits in u64 (upper 24 bytes must be zero
-    // for AttestationResponse::new() validation). Only the low 8 bytes are
-    // randomized; the high 24 remain zero.
+    // Generate a full random 32-byte nonce, mirroring CCTP V2 where the nonce
+    // is a hash-like value with non-zero upper bytes (not a small u64).
     let mut nonce = [0u8; 32];
-    rand::thread_rng().fill(&mut nonce[24..]);
+    rand::thread_rng().fill(&mut nonce);
     // Ensure nonce is not zero (reserved)
     nonce[31] |= 1;
 

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -71,7 +71,7 @@ pub use test_contracts::{
 use std::mem::size_of;
 use std::time::Duration;
 
-use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, U256, address};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, TxHash, U256, address};
 use alloy::sol;
 use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
@@ -179,35 +179,13 @@ pub struct AttestationResponse {
     /// Circle's attestation signature for the message.
     /// Required to prove the burn happened and authorize minting.
     attestation: Bytes,
-    /// The real CCTP nonce pre-validated as u64 at construction time.
-    validated_nonce: u64,
-}
-
-impl AttestationResponse {
-    /// Constructs an `AttestationResponse`, validating that the 32-byte
-    /// nonce fits in a u64 at construction time rather than deferring to
-    /// runtime.
-    fn new(message: Bytes, attestation: Bytes, nonce: FixedBytes<32>) -> Result<Self, CctpError> {
-        let bytes: &[u8; 32] = nonce.as_ref();
-        let (padding, value) = bytes.split_at(bytes.len() - size_of::<u64>());
-
-        if padding.iter().any(|&b| b != 0) {
-            return Err(CctpError::NonceOverflow { nonce });
-        }
-
-        let validated_nonce = u64::from_be_bytes(value.try_into()?);
-
-        Ok(Self {
-            message,
-            attestation,
-            validated_nonce,
-        })
-    }
+    /// The real 32-byte CCTP V2 nonce extracted from the attested message.
+    nonce: B256,
 }
 
 impl crate::Attestation for AttestationResponse {
-    fn nonce(&self) -> u64 {
-        self.validated_nonce
+    fn nonce(&self) -> B256 {
+        self.nonce
     }
 
     fn as_bytes(&self) -> &[u8] {
@@ -319,6 +297,8 @@ pub enum CctpError {
     MintAndWithdrawEventNotFound,
     #[error("Message too short for nonce extraction: got {length} bytes, need at least 44")]
     MessageTooShort { length: usize },
+    #[error("Attested message carried an all-zero nonce: Circle returned a placeholder bytes32(0)")]
+    ZeroNonce,
     #[error("Fee calculation overflow")]
     FeeCalculationOverflow,
     #[error("Float operation error: {0}")]
@@ -331,10 +311,6 @@ pub enum CctpError {
     HexDecode(#[from] alloy::hex::FromHexError),
     #[error("Fee value parse error: {0}")]
     FeeValueParse(#[from] std::num::ParseIntError),
-    #[error("Nonce exceeds u64: upper 24 bytes are non-zero")]
-    NonceOverflow { nonce: FixedBytes<32> },
-    #[error("Slice conversion error: {0}")]
-    SliceConversion(#[from] std::array::TryFromSliceError),
 }
 
 /// Errors specific to attestation polling from Circle's API.
@@ -571,7 +547,18 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
 
         let nonce = extract_nonce_from_message(&message)?;
 
-        AttestationResponse::new(message, attestation, nonce)
+        // A "complete" attestation must carry the real nonce Circle filled in. An all-zero
+        // value means the placeholder bytes32(0) from the MessageSent event leaked through, so
+        // fail fast rather than threading an invalid nonce through the bridge as if it were real.
+        if nonce.is_zero() {
+            return Err(CctpError::ZeroNonce);
+        }
+
+        Ok(AttestationResponse {
+            message,
+            attestation,
+            nonce,
+        })
     }
 
     /// Burns USDC on the source chain for the given bridge direction.
@@ -916,6 +903,97 @@ mod tests {
             mock.calls() == 4,
             "Expected exactly 4 attempts (1 initial + 3 retries)"
         );
+    }
+
+    #[tokio::test]
+    async fn poll_attestation_rejects_all_zero_nonce() {
+        let server = MockServer::start();
+
+        // Complete attestation whose message carries the placeholder bytes32(0) nonce that
+        // CCTP V2 emits in the MessageSent event. Circle should never return this on a complete
+        // attestation; the bridge must fail fast rather than thread it through as a real nonce.
+        let zero_nonce_message = build_nonce_message(&[0u8; NONCE_INDEX], [0u8; 32], &[0u8; 56]);
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/v2/messages/{ETHEREUM_DOMAIN}"));
+            then.status(200).json_body(serde_json::json!({
+                "messages": [{
+                    "attestation": "0x1234567890abcdef",
+                    "message": alloy::hex::encode_prefixed(&zero_nonce_message),
+                    "status": "complete"
+                }]
+            }));
+        });
+
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _base_key) = setup_anvil();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            USDC_ETHEREUM,
+        )
+        .await
+        .unwrap()
+        .with_circle_api_base(server.base_url());
+
+        let burn_tx = b256!("1234567890123456789012345678901234567890123456789012345678901234");
+
+        let error = bridge
+            .poll_attestation_internal(BridgeDirection::EthereumToBase, burn_tx)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CctpError::ZeroNonce),
+            "Expected CctpError::ZeroNonce, got: {error:?}"
+        );
+        assert_eq!(mock.calls(), 1, "Expected exactly 1 API call");
+    }
+
+    #[tokio::test]
+    async fn poll_attestation_returns_real_nonce_from_attested_message() {
+        let server = MockServer::start();
+
+        let expected_nonce = [0xABu8; 32];
+        let message = build_nonce_message(&[0u8; NONCE_INDEX], expected_nonce, &[0u8; 56]);
+
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/v2/messages/{ETHEREUM_DOMAIN}"));
+            then.status(200).json_body(serde_json::json!({
+                "messages": [{
+                    "attestation": "0x1234567890abcdef",
+                    "message": alloy::hex::encode_prefixed(&message),
+                    "status": "complete"
+                }]
+            }));
+        });
+
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _base_key) = setup_anvil();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            USDC_ETHEREUM,
+        )
+        .await
+        .unwrap()
+        .with_circle_api_base(server.base_url());
+
+        let burn_tx = b256!("1234567890123456789012345678901234567890123456789012345678901234");
+
+        let response = bridge
+            .poll_attestation_internal(BridgeDirection::EthereumToBase, burn_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(response.nonce, FixedBytes::from(expected_nonce));
+        assert_eq!(mock.calls(), 1, "Expected exactly 1 API call");
     }
 
     // Committed ABI: CCTP contracts use solc 0.7.6 which solc.nix doesn't have for aarch64-darwin

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -4,7 +4,7 @@
 //! The default (no features) build ships only the trait and shared domain types.
 //! Enable the `cctp` feature for the Circle CCTP V2 implementation.
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::primitives::{Address, B256, TxHash, U256};
 use async_trait::async_trait;
 
 #[cfg(feature = "cctp")]
@@ -43,8 +43,8 @@ pub struct MintReceipt {
 
 /// Attestation data required to mint on the destination chain.
 pub trait Attestation: Send + Sync {
-    /// Returns the nonce for this attestation.
-    fn nonce(&self) -> u64;
+    /// Returns the 32-byte CCTP V2 nonce for this attestation.
+    fn nonce(&self) -> B256;
 
     /// Returns the raw attestation bytes.
     fn as_bytes(&self) -> &[u8];

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -3122,7 +3122,7 @@ pub(crate) async fn drain_pending_jobs(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, TxHash, U256, address, fixed_bytes};
+    use alloy::primitives::{Address, B256, TxHash, U256, address, fixed_bytes};
     use async_trait::async_trait;
     use chrono::{Duration as ChronoDuration, Utc};
     use rain_math_float::Float;
@@ -7669,7 +7669,7 @@ mod tests {
     fn make_usdc_bridge_attestation_received() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![1, 2, 3, 4],
-            cctp_nonce: 42,
+            cctp_nonce: B256::left_padding_from(&42u64.to_be_bytes()),
             mint_scan_from_block: Some(100),
             attested_at: Utc::now(),
         }
@@ -7694,7 +7694,7 @@ mod tests {
     fn make_usdc_bridging_failed() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgingFailed {
             burn_tx_hash: Some(TxHash::random()),
-            cctp_nonce: Some(12345),
+            cctp_nonce: Some(B256::left_padding_from(&12345u64.to_be_bytes())),
             reason: "Attestation timeout".to_string(),
             failed_at: Utc::now(),
         }
@@ -8746,7 +8746,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
-                    cctp_nonce: 12345,
+                    cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
                     mint_scan_from_block: 100,
                 },
             )
@@ -8833,7 +8833,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
-                    cctp_nonce: 67890,
+                    cctp_nonce: B256::left_padding_from(&67890u64.to_be_bytes()),
                     mint_scan_from_block: 100,
                 },
             )
@@ -9131,7 +9131,7 @@ mod tests {
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
-                    cctp_nonce: 99999,
+                    cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
                     mint_scan_from_block: 100,
                 },
             )

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -970,7 +970,7 @@ pub(crate) async fn drain_pending_usdc_jobs(service: &Arc<RebalancingService>) -
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::TxHash;
+    use alloy::primitives::{B256, TxHash};
     use chrono::TimeZone;
     use tokio::sync::broadcast;
     use uuid::Uuid;
@@ -1560,7 +1560,7 @@ mod tests {
     fn bridge_attestation_received_event() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![],
-            cctp_nonce: 0,
+            cctp_nonce: B256::ZERO,
             mint_scan_from_block: Some(100),
             attested_at: ts(105),
         }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1955,7 +1955,7 @@ mod tests {
             id,
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 99999,
+                cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
                 mint_scan_from_block: 100,
             },
         )
@@ -2044,7 +2044,7 @@ mod tests {
             id,
             ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 12345,
+                cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
                 mint_scan_from_block: 100,
             },
         )
@@ -2132,7 +2132,7 @@ mod tests {
             id,
             ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 12345,
+                cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
                 // Scan from genesis: the fresh test chain sits below 100, so a 0
                 // bound makes the find_recent_mint scan a valid range that
                 // genuinely finds no mint, letting resume proceed to the mint.
@@ -2959,7 +2959,7 @@ mod tests {
             &id,
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 12345,
+                cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
                 mint_scan_from_block: 100,
             },
         )
@@ -3634,7 +3634,7 @@ mod tests {
             id,
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 99_999,
+                cctp_nonce: B256::left_padding_from(&99_999u64.to_be_bytes()),
                 // Scan from genesis, not the sibling helpers' `100`: the resume test
                 // built on this helper actually scans from this block for an
                 // already-submitted mint, and the fresh test chain (advanced only via
@@ -3682,7 +3682,7 @@ mod tests {
             id,
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 99_999,
+                cctp_nonce: B256::left_padding_from(&99_999u64.to_be_bytes()),
                 mint_scan_from_block: 100,
             },
         )
@@ -3797,9 +3797,8 @@ mod tests {
 
         // Return a `complete` attestation for any /v2/messages request so
         // poll_circle_attestation resolves immediately (no 5-minute real-API
-        // retry). The message must be >= 44 bytes with the upper 24 bytes of the
-        // 32-byte nonce (offset 12..36) zero so AttestationResponse::new's u64
-        // nonce check passes -- a mostly-zero 100-byte message with one low byte.
+        // retry). The message just needs to be >= MIN_MESSAGE_LENGTH (44 bytes)
+        // for nonce extraction to succeed -- a mostly-zero 100-byte message.
         let mut message = vec![0u8; 100];
         message[43] = 1;
         let message_hex = format!("0x{}", alloy::hex::encode(&message));

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -65,7 +65,7 @@
 //!
 //! [`AlpacaWalletService`]: crate::alpaca_wallet::AlpacaWalletService
 
-use alloy::primitives::TxHash;
+use alloy::primitives::{B256, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -234,7 +234,7 @@ pub(crate) enum UsdcRebalanceCommand {
     /// bounding the crash-safe resume scan that adopts an already-submitted mint.
     ReceiveAttestation {
         attestation: Vec<u8>,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         mint_scan_from_block: u64,
     },
     /// Confirm the CCTP mint transaction. Valid only from `Attested` state.
@@ -330,7 +330,7 @@ pub(crate) enum UsdcRebalanceEvent {
     /// which could adopt an unrelated mint to the same wallet.
     BridgeAttestationReceived {
         attestation: Vec<u8>,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         #[serde(default)]
         mint_scan_from_block: Option<u64>,
         attested_at: DateTime<Utc>,
@@ -348,7 +348,7 @@ pub(crate) enum UsdcRebalanceEvent {
     /// Bridging failed. Preserves burn data when available for debugging.
     BridgingFailed {
         burn_tx_hash: Option<TxHash>,
-        cctp_nonce: Option<u64>,
+        cctp_nonce: Option<B256>,
         reason: String,
         failed_at: DateTime<Utc>,
     },
@@ -487,7 +487,7 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         attestation: Vec<u8>,
         /// Destination chain head captured before the mint, bounding the
         /// crash-safe resume scan that adopts an already-submitted mint. `None`
@@ -515,7 +515,7 @@ pub(crate) enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: Option<TxHash>,
-        cctp_nonce: Option<u64>,
+        cctp_nonce: Option<B256>,
         reason: String,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
@@ -783,7 +783,12 @@ impl EventSourced for UsdcRebalance {
 
     const AGGREGATE_TYPE: &'static str = "UsdcRebalance";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    // v2: cctp_nonce widened from u64 to B256 (full CCTP V2 nonce) in the
+    // Attested/BridgingFailed state variants. Bumped to clear stale snapshots
+    // so they rebuild from events. No event upcaster needed: persisted events
+    // only ever stored cctp_nonce=null (the nonce bug prevented any successful
+    // attestation), which deserializes unchanged into Option<B256>.
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1578,7 +1583,7 @@ impl UsdcRebalance {
     fn transition_receive_attestation(
         &self,
         attestation: Vec<u8>,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         mint_scan_from_block: u64,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
@@ -1790,6 +1795,14 @@ mod tests {
     use super::*;
     use st0x_float_macro::float;
 
+    /// Realistic CCTP V2 nonce with non-zero upper bytes -- the actual nonce
+    /// from a prod burn that the old u64 validation rejected. Regression guard
+    /// against forcing a 32-byte nonce into a u64.
+    const TEST_CCTP_NONCE: B256 =
+        fixed_bytes!("0xa01ca42d9082e926a81dc287d973a8f072dfa1b20a4fbf7b20f3abda1b376278");
+    const OTHER_CCTP_NONCE: B256 =
+        fixed_bytes!("0x524cd90eb8dffcb29fcc163aa8258d84e6cc25abc0b4700d704936812ee39824");
+
     // An event persisted before `mint_scan_from_block` existed must still
     // deserialize on replay -- to `None`, not a hard error -- so older aggregates
     // can be rebuilt after this field was added (the `#[serde(default)]`).
@@ -1798,7 +1811,7 @@ mod tests {
         let old_event = json!({
             "BridgeAttestationReceived": {
                 "attestation": [1, 2, 3],
-                "cctp_nonce": 42,
+                "cctp_nonce": "0xa01ca42d9082e926a81dc287d973a8f072dfa1b20a4fbf7b20f3abda1b376278",
                 "attested_at": "2026-01-01T00:00:00Z"
             }
         });
@@ -2459,7 +2472,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: attestation.clone(),
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 8_675_309,
             })
             .await
@@ -2468,6 +2481,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         let UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: event_attestation,
+            cctp_nonce: event_nonce,
             mint_scan_from_block,
             ..
         } = &events[0]
@@ -2481,6 +2495,9 @@ mod tests {
             Some(8_675_309),
             "ReceiveAttestation must persist the destination-chain scan bound into the event",
         );
+        // Regression guard for RAI-714: the full 32-byte nonce must survive
+        // unchanged through ReceiveAttestation, not be truncated/zeroed.
+        assert_eq!(*event_nonce, TEST_CCTP_NONCE);
     }
 
     #[test]
@@ -2500,7 +2517,7 @@ mod tests {
             &bridging,
             &UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01],
-                cctp_nonce: 42,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: Some(8_675_309),
                 attested_at: Utc::now(),
             },
@@ -2529,7 +2546,7 @@ mod tests {
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -2554,7 +2571,7 @@ mod tests {
             }])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -2584,7 +2601,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -2615,7 +2632,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -2650,14 +2667,14 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x03, 0x04],
-                cctp_nonce: 99999,
+                cctp_nonce: OTHER_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -2694,7 +2711,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02, 0x03, 0x04],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -2844,7 +2861,7 @@ mod tests {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
-        let cctp_nonce = 12345u64;
+        let cctp_nonce = TEST_CCTP_NONCE;
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -2963,7 +2980,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3015,7 +3032,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3106,7 +3123,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3164,7 +3181,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3217,7 +3234,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3262,7 +3279,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3314,7 +3331,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3363,7 +3380,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3427,7 +3444,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3487,7 +3504,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0xAB, 0xCD, 0xEF],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3540,7 +3557,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x11, 0x22, 0x33, 0x44],
-                    cctp_nonce: 67890,
+                    cctp_nonce: OTHER_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3648,7 +3665,7 @@ mod tests {
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: 100,
             })
             .await
@@ -3727,7 +3744,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3781,7 +3798,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3838,7 +3855,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4156,7 +4173,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4223,7 +4240,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4296,7 +4313,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4358,7 +4375,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
-                    cctp_nonce: 12345,
+                    cctp_nonce: TEST_CCTP_NONCE,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4426,7 +4443,7 @@ mod tests {
             },
             UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01],
-                cctp_nonce: 12345,
+                cctp_nonce: TEST_CCTP_NONCE,
                 mint_scan_from_block: Some(100),
                 attested_at: withdrawal_confirmed_at + chrono::Duration::seconds(15),
             },
@@ -4805,7 +4822,7 @@ mod tests {
             direction: RebalanceDirection::BaseToAlpaca,
             amount: Usdc::new(float!(1500)),
             burn_tx_hash: burn_tx,
-            cctp_nonce: 42,
+            cctp_nonce: TEST_CCTP_NONCE,
             attestation: vec![0xAA, 0xBB],
             mint_scan_from_block: Some(100),
             initiated_at,


### PR DESCRIPTION
## What

Closes [RAI-714](https://linear.app/makeitrain/issue/RAI-714/usdc-rebalancing-broken-cctp-nonce-parser-rejects-all-v2-attestations).

Carry the full 32-byte CCTP V2 nonce as `B256` end-to-end instead of forcing it into a `u64`. This fixes USDC rebalancing (Base→Alpaca), which was completely broken because every real Circle attestation was being rejected.

## Why

CCTP V2 nonces are 32-byte values, but `AttestationResponse` forced them into a `u64`, rejecting any nonce whose upper 24 bytes were non-zero via `CctpError::NonceOverflow`. Every real Circle attestation has a 32-byte nonce, so this rejected **all** attestations — breaking USDC rebalancing entirely and stranding ~25k USDC burned-but-not-minted in CCTP.

## How

Widen the nonce type from `u64` to `B256` (alloy's 32-byte fixed bytes) across the whole bridge/rebalancing path:

- **`crates/bridge/src/lib.rs`** — `Attestation::nonce()` now returns `B256` instead of `u64`.
- **`crates/bridge/src/cctp/mod.rs`** — `AttestationResponse` stores the full 32-byte `nonce: B256`. Removed `AttestationResponse::new()` and its u64 validation (inlined the now-trivial struct construction in `fetch_attestation`), and dropped the now-dead `NonceOverflow` and `SliceConversion` `CctpError` variants.
- **`src/usdc_rebalance.rs`** — `cctp_nonce` is `B256` / `Option<B256>` across the `ReceiveAttestation` command, the `BridgeAttestationReceived` / `BridgingFailed` events, the `Attested` / `BridgingFailed` aggregate states, and `transition_receive_attestation`. Bumped `UsdcRebalance::SCHEMA_VERSION` 1→2 (state shape changed) so stale snapshots rebuild from events.
- **`crates/bridge/src/cctp/mock_attestation.rs`** — the mock attester now randomizes all 32 bytes of the nonce (instead of zeroing the upper 24), so every mock-attestation test now exercises the previously-failing case.

## Testing

- Added `TEST_CCTP_NONCE` / `OTHER_CCTP_NONCE` constants in `src/usdc_rebalance.rs` — `TEST_CCTP_NONCE` is the real prod nonce that tripped the bug — and threaded them through all `ReceiveAttestation` / `BridgeAttestationReceived` test fixtures (previously small `u64` literals).
- `test_receive_attestation_after_bridging_initiated` now asserts the full 32-byte nonce survives `ReceiveAttestation` unchanged (explicit RAI-714 regression guard).
- Updated the remaining `cctp_nonce` fixtures in `src/rebalancing/trigger/` and `src/rebalancing/usdc/manager.rs` to `B256` (via `B256::left_padding_from` / `B256::ZERO`).
- Verified locally:
  - `cargo clippy -p st0x-bridge -p st0x-hedge --all-features --all-targets` — clean
  - `cargo nextest run -p st0x-bridge --all-features` — 37 passed

## Anything else

**Event-schema compatibility — no upcaster needed.** Verified against the prod event store: persisted `UsdcRebalance` events only ever stored `cctp_nonce: null` (the bug prevented any successful attestation, and no `BridgeAttestationReceived` events exist), which deserializes unchanged into `Option<B256>`. A numeric-nonce payload cannot exist in any real environment because real CCTP V2 nonces never fit a `u64`. The `SCHEMA_VERSION` bump only invalidates rebuildable snapshots.
