### PR TITLE
fix: prevent USDC re-burns after any post-burn failure or restart

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2290,8 +2290,16 @@ know about cross-venue inventory.
   moves from inflight to destination available
 - `UsdcRebalanceEvent::ConversionConfirmed` - Terminal success for BaseToAlpaca;
   moves from inflight to destination available
-- `UsdcRebalanceEvent::WithdrawalFailed`, `BridgingFailed`, `DepositFailed`,
-  `ConversionFailed` - Reconciles inflight back to source available
+- `UsdcRebalanceEvent::WithdrawalFailed`, pre-burn `BridgingFailed`, and
+  AlpacaToBase `ConversionFailed` (the pre-withdrawal USD->USDC leg) -
+  Reconciles inflight back to source available, because the failure happened
+  before the CCTP burn so the funds are still on the source venue
+- Post-burn `UsdcRebalanceEvent::BridgingFailed`, `DepositFailed`, and
+  BaseToAlpaca `ConversionFailed` (the post-deposit USDC->USD leg) - Keeps
+  source inflight and the USDC rebalancing guard active because the funds were
+  burned (and, for the deposit/conversion failures, already minted) by CCTP and
+  are not available on the source venue. The same applies to any transfer that
+  times out at or after the burn
 - `InventorySnapshotEvent::OnchainEquity` - Onchain equity balances fetched from
   vaults
 - `InventorySnapshotEvent::OnchainCash` - Onchain USDC balance fetched from
@@ -2386,10 +2394,20 @@ when no inflight operations exist for the asset. Trigger events are emitted to
 
 #### Failure Handling and Reconciliation
 
-**Automatic Reconciliation**: When rebalancing operations fail, the projection
-logic automatically reconciles inflight balances back to source venue's
-available balance. This ensures InventoryView remains accurate even when
-operations fail.
+**Automatic Reconciliation**: When rebalancing operations fail before assets
+leave the recoverable source side, the projection logic reconciles inflight
+balances back to the source venue's available balance. Failures after an
+irreversible handoff (for example, a CCTP burn) stay inflight until settlement
+or manual operator recovery.
+
+**Durable rebalancing guard**: The single-rebalance guard that blocks a new USDC
+rebalance while one is unsettled is reconstructed from persisted `UsdcRebalance`
+event state on startup, so a restart between a post-burn failure and settlement
+cannot re-open the re-burn window. Any aggregate not in a clearable-terminal
+state (success, or a pre-burn failure that reconciles to source) re-asserts the
+guard at boot and blocks new USDC rebalancing until it settles or an operator
+recovers it. USDC bridges are not auto-resumed on restart, so the guard is held
+until manual recovery.
 
 ##### Manual Reconciliation Required
 

--- a/adrs/0003-durable-usdc-rebalance-guard-on-restart.md
+++ b/adrs/0003-durable-usdc-rebalance-guard-on-restart.md
@@ -1,0 +1,114 @@
+# ADR 0003: Reconstruct the USDC rebalancing guard from persisted state on startup
+
+## Status
+
+Accepted
+
+## Context
+
+The USDC rebalancing reactor allows exactly one rebalance at a time, gated by an
+in-memory `usdc_in_progress: Arc<AtomicBool>` on `RebalancingService`. It is
+claimed when a rebalance is dispatched and released on a _clearable-terminal_
+event (success, or a failure that reconciles inflight back to source).
+
+The parent change in this PR ("keep guard on post-USDC-burn failure") makes a
+post-burn `BridgingFailed` _keep_ the guard set instead of clearing it, so the
+next `UsdcRebalancingCheck` cannot dispatch a fresh burn against funds that CCTP
+has already burned. This closes the live and timeout-cleanup paths.
+
+But the guard is in-memory only:
+
+- `usdc_in_progress` is `AtomicBool::new(false)` at construction
+  (`RebalancingService::new`) and is never rebuilt from persisted events.
+- `usdc_tracking` is an empty `HashMap` at construction; there is no
+  `rebuild_usdc_tracking_for_recovery` (unlike mint/redemption).
+- USDC inflight bookkeeping and `active_usdc_rebalance` are set by the live
+  reactor only and are **not** persisted in `InventorySnapshot`.
+
+So after a process restart that lands between a post-burn `BridgingFailed` and
+settlement, the guard is `false`, tracking is empty, and the inventory shows no
+inflight. The next imbalance check sees the same imbalance (the burned USDC is
+gone from source) and dispatches a **new burn** -- exactly the amplification the
+PR exists to prevent. A redeploy mid-incident is precisely when this happens.
+
+The same restart hole exists for any _in-flight_ (not-yet-failed) USDC
+rebalance, because USDC bridges have no resume path: `recheck_transfer`'s
+`TransferKind::UsdcBridge` arm ("recheck is not supported for USDC bridges") and
+`UsdcRebalance::Materialized = Nil` mean no poller or reactor catch-up drives an
+interrupted bridge forward after restart.
+
+## Decision
+
+On startup, reconstruct **only the guard** from persisted `UsdcRebalance`
+aggregate state. Set `usdc_in_progress = true` if any aggregate is in a
+non-clearable-terminal state -- i.e. in progress, or a post-burn
+`BridgingFailed` (`burn_tx_hash: Some`). Do **not** reconstruct `usdc_tracking`
+or inventory inflight.
+
+Mechanically, mirroring mint/redemption recovery:
+
+- `interrupted_usdc_rebalance_ids(pool)` selects aggregates whose latest event
+  is a guard-holding candidate.
+- The conductor loads each via the existing `Store<UsdcRebalance>` and asks the
+  aggregate state itself, via a new `UsdcRebalance::holds_rebalance_guard()`,
+  whether the guard should be held (this resolves the two state-dependent cases:
+  `ConversionComplete` is terminal for BaseToAlpaca but in-flight for
+  AlpacaToBase; `BridgingFailed` holds the guard only when post-burn).
+- If any held, `RebalancingService::recover_usdc_guard()` sets the guard and
+  logs at error level (one line at boot, listing the stuck aggregate ids).
+
+## Rationale for guard-only
+
+- **The guard is the primary dispatch gate.** `check_and_trigger_usdc` claims it
+  before anything else; re-asserting it durably is sufficient to block re-burns.
+- **No settlement events arrive post-restart.** With no USDC bridge
+  resume/poller and a `Nil` reactor, an interrupted aggregate emits no further
+  events, so the inventory-inflight bookkeeping the live terminal paths would
+  consume is never needed. Reconstructing it would be dead state.
+- **Avoids financial-misaccounting risk.** Re-deriving inventory inflight on
+  restart (when available balances are independently re-hydrated from polled
+  on-chain/broker readings) risks double-counting -- the exact class of bug the
+  mint recovery path guards against with extensive care. Guard-only touches no
+  financial values.
+- **Faithful to the in-memory invariant.** The guard means "a USDC rebalance is
+  unsettled." We re-derive that boolean from the durable event log instead of
+  losing it across a restart.
+
+## Consequences
+
+- A stuck or in-flight USDC aggregate at boot holds the guard until manual
+  operator recovery, consistent with the PR's stated "minimum safe behavior"
+  (stuck post-burn funds already require manual recovery) and with the fact that
+  USDC bridges are not auto-resumed.
+- All new USDC rebalancing is blocked while one aggregate is unsettled. This is
+  correct: the system only runs one USDC rebalance at a time, and blocking is
+  the safe failure mode (the incident was double-burning, not under-burning).
+- Terminally-failed post-burn aggregates have no automatic guard clear -- the
+  same as the live in-memory behavior today; an operator clears it as part of
+  recovery. The boot-time error log surfaces it on every restart until resolved.
+
+**Operator recovery path.** There is no dedicated "clear the USDC guard" CLI
+command. The guard is derived state (see below), so the only way to clear it is
+to drive the stuck aggregate to a terminal state for which
+`UsdcRebalance::holds_rebalance_guard` returns `false` (i.e. confirm the
+post-burn funds settled, or otherwise reconcile them), then restart -- recovery
+re-derives the guard from the event log and leaves it clear. A purpose-built
+"CCTP stuck" aggregate state with an explicit operator recovery/resume command
+is the tracked follow-up (RAI-715, see Out of scope). Until it exists, recovery
+is the manual reconcile-then-restart procedure above.
+
+## Alternatives considered
+
+- **Full tracking + inventory recovery (mirror mint/redemption fully).**
+  Rejected: it reconstructs inventory inflight, carrying double-count risk, for
+  no benefit absent a resume path. Larger and riskier than the problem warrants.
+- **Persist the guard as its own flag/column.** Rejected: the guard is derived
+  state; the `UsdcRebalance` event log is the source of truth. A separate flag
+  could drift from the aggregate.
+
+## Out of scope
+
+- Resuming/retrying interrupted USDC bridges after restart (no recheck path
+  exists; tracked separately).
+- An explicit "CCTP stuck" aggregate state with retry/resume (floated in
+  RAI-715, left as follow-up).

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -118,7 +118,8 @@ decision.
 
 ## Index
 
-| #                                   | Title                                                                            | Status   |
-| ----------------------------------- | -------------------------------------------------------------------------------- | -------- |
-| [1](1-cash-bp-for-equity-hedges.md) | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
-| [0002](0002-axum-and-tower.md)      | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |
+| #                                                       | Title                                                                            | Status   |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
+| [1](1-cash-bp-for-equity-hedges.md)                     | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
+| [0002](0002-axum-and-tower.md)                          | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |
+| [0003](0003-durable-usdc-rebalance-guard-on-restart.md) | Reconstruct the USDC rebalancing guard from persisted state on startup           | Accepted |

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -895,6 +895,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         )
         .await?;
 
+        rebalancing_service
+            .recover_usdc_guard(&deps.pool, &built.usdc)
+            .await?;
+
         let frameworks = RebalancingCqrsFrameworks {
             mint: built.mint,
             redemption: built.redemption,

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -43,7 +43,8 @@ use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
 };
 use crate::usdc_rebalance::{
-    RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
+    InterruptedUsdcRebalances, RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent,
+    UsdcRebalanceId, interrupted_usdc_rebalance_ids,
 };
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
@@ -114,6 +115,8 @@ pub(crate) enum RebalancingServiceError {
         tracked_quantity: FractionalShares,
         actual_quantity: FractionalShares,
     },
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
 }
 
 /// Why loading a token address from the vault registry failed.
@@ -461,6 +464,12 @@ pub(crate) struct RebalancingService {
     timed_out_mints: Arc<RwLock<HashMap<IssuerRequestId, DateTime<Utc>>>>,
     timed_out_redemptions: Arc<RwLock<HashMap<RedemptionAggregateId, DateTime<Utc>>>>,
     timed_out_usdc_rebalances: Arc<RwLock<HashMap<UsdcRebalanceId, DateTime<Utc>>>>,
+    /// Ids of post-burn-stuck USDC rebalances already logged by the timeout
+    /// sweep. A preserved post-burn entry is intentionally never removed from
+    /// `usdc_tracking` (so a late success can still settle) and its
+    /// `last_progress_at` never advances, so every sweep re-selects it. This
+    /// set deduplicates the error log to once per stuck transfer.
+    post_burn_timeout_logged: Arc<RwLock<HashSet<UsdcRebalanceId>>>,
     mint_event_sync: Arc<Mutex<()>>,
     redemption_event_sync: Arc<Mutex<()>>,
     usdc_event_sync: Arc<Mutex<()>>,
@@ -482,6 +491,18 @@ type EquityInventoryUpdate = Box<
 >;
 
 const TIMEOUT_TOMBSTONE_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug)]
+enum UsdcTimeoutCleanup {
+    Cleared {
+        tracking: usdc::UsdcRebalanceTracking,
+        elapsed: Duration,
+    },
+    PreservedPostBurn {
+        tracking: usdc::UsdcRebalanceTracking,
+        elapsed: Duration,
+    },
+}
 
 impl RebalancingService {
     pub(crate) fn new(
@@ -524,6 +545,7 @@ impl RebalancingService {
             timed_out_mints: Arc::new(RwLock::new(HashMap::new())),
             timed_out_redemptions: Arc::new(RwLock::new(HashMap::new())),
             timed_out_usdc_rebalances: Arc::new(RwLock::new(HashMap::new())),
+            post_burn_timeout_logged: Arc::new(RwLock::new(HashSet::new())),
             mint_event_sync: Arc::new(Mutex::new(())),
             redemption_event_sync: Arc::new(Mutex::new(())),
             usdc_event_sync: Arc::new(Mutex::new(())),
@@ -794,21 +816,49 @@ impl RebalancingService {
                 continue;
             }
 
-            let Some((tracking, elapsed)) = self.cleanup_timed_out_usdc_rebalance(&id, now).await?
-            else {
+            let Some(cleanup) = self.cleanup_timed_out_usdc_rebalance(&id, now).await? else {
                 continue;
             };
 
-            error!(
-                target: "rebalance",
-                aggregate_id = %id,
-                direction = ?tracking.direction,
-                stage = %tracking.stage,
-                ?elapsed,
-                "USDC transfer timed out; clearing trigger guard and inventory inflight"
-            );
+            match cleanup {
+                UsdcTimeoutCleanup::Cleared { tracking, elapsed } => {
+                    error!(
+                        target: "rebalance",
+                        aggregate_id = %id,
+                        direction = ?tracking.direction,
+                        stage = %tracking.stage,
+                        ?elapsed,
+                        "USDC transfer timed out; clearing trigger guard and inventory inflight"
+                    );
 
-            self.clear_usdc_in_progress();
+                    self.clear_usdc_in_progress();
+                }
+                UsdcTimeoutCleanup::PreservedPostBurn { tracking, elapsed } => {
+                    self.usdc_in_progress.store(true, Ordering::SeqCst);
+
+                    // The preserved entry keeps its original `last_progress_at`,
+                    // so every subsequent sweep re-selects it. Log once per stuck
+                    // transfer to avoid flooding the error stream until manual
+                    // recovery. UsdcRebalanceId is never reused, so a logged id
+                    // never needs clearing.
+                    let first_log = self
+                        .post_burn_timeout_logged
+                        .write()
+                        .await
+                        .insert(id.clone());
+
+                    if first_log {
+                        error!(
+                            target: "rebalance",
+                            aggregate_id = %id,
+                            direction = ?tracking.direction,
+                            stage = %tracking.stage,
+                            ?elapsed,
+                            "USDC transfer timed out after CCTP burn; preserving trigger guard and inventory inflight"
+                        );
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -1012,7 +1062,7 @@ impl RebalancingService {
         &self,
         id: &UsdcRebalanceId,
         now: DateTime<Utc>,
-    ) -> Result<Option<(usdc::UsdcRebalanceTracking, Duration)>, RebalancingServiceError> {
+    ) -> Result<Option<UsdcTimeoutCleanup>, RebalancingServiceError> {
         let _event_sync_guard = self.usdc_event_sync.lock().await;
         let mut tracking_guard = self.usdc_tracking.write().await;
         let Some(tracking) = tracking_guard.get(id).cloned() else {
@@ -1026,6 +1076,13 @@ impl RebalancingService {
 
         if elapsed < self.config.transfer_timeout {
             return Ok(None);
+        }
+
+        if tracking.is_post_burn() {
+            return Ok(Some(UsdcTimeoutCleanup::PreservedPostBurn {
+                tracking,
+                elapsed,
+            }));
         }
 
         let mut inventory = self.inventory.write().await;
@@ -1042,7 +1099,7 @@ impl RebalancingService {
         tracking_guard.remove(id);
         drop(tracking_guard);
 
-        Ok(Some((tracking, elapsed)))
+        Ok(Some(UsdcTimeoutCleanup::Cleared { tracking, elapsed }))
     }
 
     async fn mint_timed_out(&self, id: &IssuerRequestId) -> bool {
@@ -1182,6 +1239,7 @@ impl RebalancingService {
         use RebalancingServiceError::{
             EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext, Projection,
             RedemptionUnwrappedExceedsTracked, SettledUsdcExceedsInitiatedAmount, SharesConversion,
+            Sqlx,
         };
 
         self.expire_stuck_operations_with_logging().await;
@@ -1195,7 +1253,8 @@ impl RebalancingService {
             | MissingUsdcTrackingContext { .. }
             | MissingUsdcBridgedAmount { .. }
             | SettledUsdcExceedsInitiatedAmount { .. }
-            | RedemptionUnwrappedExceedsTracked { .. }) => {
+            | RedemptionUnwrappedExceedsTracked { .. }
+            | Sqlx(_)) => {
                 return Err(other);
             }
         };
@@ -2284,6 +2343,86 @@ impl RebalancingService {
     /// Clears the in-progress flag for USDC rebalancing.
     pub(crate) fn clear_usdc_in_progress(&self) {
         self.usdc_in_progress.store(false, Ordering::SeqCst);
+    }
+
+    /// Reconstructs the single-rebalance guard (`usdc_in_progress`) from durable
+    /// `UsdcRebalance` event state on startup.
+    ///
+    /// The guard is in-memory and resets to `false` on restart. Without this, a
+    /// restart between a post-burn `BridgingFailed` (or any unsettled in-flight
+    /// rebalance) and settlement would let the next imbalance check dispatch a
+    /// fresh CCTP burn against funds CCTP has already burned. Re-asserting the
+    /// guard when any aggregate is in a guard-holding state blocks new USDC
+    /// rebalancing until the stuck transfer settles or an operator recovers it.
+    ///
+    /// Guard-only by design: USDC bridges have no resume/recheck path, so no
+    /// settlement events arrive post-restart, and reconstructing inventory
+    /// inflight (which risks double-counting against re-hydrated available
+    /// balances) would be dead state. See ADR 2.
+    pub(crate) async fn recover_usdc_guard(
+        &self,
+        pool: &SqlitePool,
+        usdc_store: &Store<UsdcRebalance>,
+    ) -> Result<(), RebalancingServiceError> {
+        let InterruptedUsdcRebalances {
+            ids: candidate_ids,
+            unparseable,
+        } = interrupted_usdc_rebalance_ids(pool).await?;
+
+        let mut held_ids = Vec::new();
+        let mut unresolved_ids = Vec::new();
+        for id in candidate_ids {
+            match usdc_store.load(&id).await {
+                Ok(Some(entity)) => {
+                    if entity.holds_rebalance_guard() {
+                        held_ids.push(id);
+                    }
+                }
+                // The id came from the event log, so a missing or unreplayable
+                // aggregate is an inconsistency we cannot classify. Fail safe:
+                // hold the guard so a possibly-post-burn rebalance can never be
+                // re-burned, and surface it for operators. Blocking is the safe
+                // direction; the alternative is the re-burn this guards against.
+                // A single bad aggregate must not abort recovery for the rest,
+                // so we do not propagate -- only the query's I/O error does.
+                Ok(None) => {
+                    error!(
+                        target: "rebalance",
+                        %id,
+                        "USDC rebalance candidate missing from store on startup; holding guard defensively"
+                    );
+                    unresolved_ids.push(id);
+                }
+                Err(error) => {
+                    error!(
+                        target: "rebalance",
+                        %id, ?error,
+                        "Failed to load USDC rebalance candidate on startup; holding guard defensively"
+                    );
+                    unresolved_ids.push(id);
+                }
+            }
+        }
+
+        // An unparseable candidate aggregate_id cannot be loaded or classified,
+        // so it joins the unresolved set: hold the guard rather than risk leaving
+        // a possibly-post-burn rebalance unguarded. Same fail-closed direction as
+        // a missing or unloadable aggregate above.
+        if held_ids.is_empty() && unresolved_ids.is_empty() && unparseable.is_empty() {
+            return Ok(());
+        }
+
+        self.usdc_in_progress.store(true, Ordering::SeqCst);
+        error!(
+            target: "rebalance",
+            held = ?held_ids,
+            unresolved = ?unresolved_ids,
+            unparseable = ?unparseable,
+            "Reconstructed USDC in-progress guard for unsettled rebalances on startup; \
+             new USDC rebalancing is blocked until they settle or are recovered"
+        );
+
+        Ok(())
     }
 
     pub(crate) async fn recover_mint_state(
@@ -7194,30 +7333,18 @@ mod tests {
                 ],
             },
             Scenario {
-                name: "bridging_failed_after_initiated",
+                name: "bridging_failed_before_burn",
                 events: vec![
                     make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
                     make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
                     make_usdc_withdrawal_confirmed(),
-                    make_usdc_bridging_initiated(),
-                    make_usdc_bridging_failed(),
+                    make_usdc_pre_burn_bridging_failed(),
                 ],
             },
-            Scenario {
-                name: "deposit_failed_after_initiated",
-                events: vec![
-                    make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
-                    make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
-                    make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
-                    make_usdc_withdrawal_confirmed(),
-                    make_usdc_bridging_initiated(),
-                    make_usdc_bridge_attestation_received(),
-                    make_usdc_bridged_with_amounts(usdc(398), usdc(1)),
-                    make_usdc_deposit_initiated(),
-                    make_usdc_deposit_failed(),
-                ],
-            },
+            // NOTE: a post-burn `deposit_failed` no longer cancels -- it is
+            // post-mint and preserves inflight + the guard. That behavior is
+            // covered by `post_burn_deposit_failure_preserves_inflight_and_guard`.
         ];
 
         for scenario in scenarios {
@@ -7262,40 +7389,18 @@ mod tests {
                 ],
             },
             Scenario {
-                name: "bridging_failed_after_initiated",
+                name: "bridging_failed_before_burn",
                 events: vec![
                     make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
                     make_usdc_withdrawal_confirmed(),
-                    make_usdc_bridging_initiated(),
-                    make_usdc_bridging_failed(),
+                    make_usdc_pre_burn_bridging_failed(),
                 ],
             },
-            Scenario {
-                name: "deposit_failed_after_initiated",
-                events: vec![
-                    make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
-                    make_usdc_withdrawal_confirmed(),
-                    make_usdc_bridging_initiated(),
-                    make_usdc_bridge_attestation_received(),
-                    make_usdc_bridged_with_amounts(usdc(399), usdc(1)),
-                    make_usdc_deposit_initiated(),
-                    make_usdc_deposit_failed(),
-                ],
-            },
-            Scenario {
-                name: "conversion_failed_after_deposit",
-                events: vec![
-                    make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
-                    make_usdc_withdrawal_confirmed(),
-                    make_usdc_bridging_initiated(),
-                    make_usdc_bridge_attestation_received(),
-                    make_usdc_bridged_with_amounts(usdc(399), usdc(1)),
-                    make_usdc_deposit_initiated(),
-                    make_usdc_deposit_confirmed(RebalanceDirection::BaseToAlpaca),
-                    make_usdc_conversion_initiated(RebalanceDirection::BaseToAlpaca, usdc(399)),
-                    make_usdc_conversion_failed(),
-                ],
-            },
+            // NOTE: post-burn failures no longer cancel -- they are post-mint and
+            // preserve inflight + the guard. `deposit_failed` is covered by
+            // `post_burn_deposit_failure_preserves_inflight_and_guard`, and the
+            // BaseToAlpaca post-deposit `conversion_failed` by
+            // `post_deposit_conversion_failure_preserves_inflight_and_guard`.
         ];
 
         for scenario in scenarios {
@@ -7322,6 +7427,426 @@ mod tests {
             assert_usdc_inventory_balances(&trigger, usdc(900), Usdc::ZERO, usdc(100), Usdc::ZERO)
                 .await;
         }
+    }
+
+    #[tokio::test]
+    async fn alpaca_to_base_post_burn_bridging_failure_preserves_inflight_and_guard() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000);
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_initiated(RebalanceDirection::AlpacaToBase, usdc(400)),
+            )
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_conversion_confirmed(RebalanceDirection::AlpacaToBase, usdc(399)),
+            )
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::AlpacaToBase, usdc(399)),
+            )
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_confirmed())
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_initiated())
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_failed())
+            .await
+            .unwrap();
+
+        // A post-burn failure must preserve the last successful stage
+        // (BridgingInitiated), not advance to a failure stage:
+        // `UsdcRebalanceStage::from_event` returns None for BridgingFailed.
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::AlpacaToBase,
+            usdc(399),
+            None,
+            usdc::UsdcRebalanceStage::BridgingInitiated,
+        )
+        .await;
+        assert_usdc_inventory_balances(&trigger, usdc(100), Usdc::ZERO, usdc(501), usdc(399)).await;
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-burn bridge failure must keep the USDC guard set"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "post-burn bridge failure must keep the active rebalance ID"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-burn bridge failure must block immediate re-burns"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_to_alpaca_post_burn_bridging_failure_preserves_inflight_and_guard() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
+            )
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_confirmed())
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_initiated())
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_failed())
+            .await
+            .unwrap();
+
+        // A post-burn failure must preserve the last successful stage
+        // (BridgingInitiated), not advance to a failure stage:
+        // `UsdcRebalanceStage::from_event` returns None for BridgingFailed.
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::BaseToAlpaca,
+            usdc(400),
+            None,
+            usdc::UsdcRebalanceStage::BridgingInitiated,
+        )
+        .await;
+        assert_usdc_inventory_balances(&trigger, usdc(500), usdc(400), usdc(100), Usdc::ZERO).await;
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-burn bridge failure must keep the USDC guard set"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "post-burn bridge failure must keep the active rebalance ID"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-burn bridge failure must block immediate re-burns"
+        );
+    }
+
+    /// Exercises the defensive fallback branch of `post_burn_failure`: the
+    /// `BridgingFailed` event carries no `burn_tx_hash`, but the tracked stage
+    /// is `BridgingInitiated`, so `is_post_burn()` must still classify it as
+    /// post-burn and preserve the guard.
+    ///
+    /// This (hashless event + post-burn stage) combination is NOT reachable via
+    /// the real command path -- `FailBridging` from `Bridging`/`Attested` always
+    /// emits `burn_tx_hash: Some`. The fallback is defense-in-depth for the live
+    /// event stream. The startup recovery path (`holds_rebalance_guard`)
+    /// deliberately keys only on `burn_tx_hash.is_some()` because the persisted
+    /// aggregate state always carries the hash for a post-burn failure, so the
+    /// two paths agree on every command-reachable state.
+    #[tokio::test]
+    async fn bridging_failure_without_burn_hash_preserved_via_tracking_stage() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
+            )
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_withdrawal_confirmed())
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_initiated())
+            .await
+            .unwrap();
+        // burn_tx_hash: None -- only the tracked BridgingInitiated stage marks
+        // this as post-burn.
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_pre_burn_bridging_failed())
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "stage-fallback must classify a hashless post-burn failure as post-burn and keep the guard"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "stage-fallback post-burn failure must keep the active rebalance ID"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "stage-fallback post-burn failure must block immediate re-burns"
+        );
+    }
+
+    /// A `BridgingFailed` carrying a `cctp_nonce` but no `burn_tx_hash` is
+    /// post-burn evidence on its own: the nonce only exists once the burn reached
+    /// CCTP. When in-memory tracking is absent -- e.g. the failure arrives after a
+    /// restart where the reactor never rebuilt tracking -- the nonce alone must
+    /// keep the guard set, otherwise the caller would clear it and re-open the
+    /// re-burn window for funds already irreversibly committed.
+    #[tokio::test]
+    async fn nonce_only_bridging_failure_preserves_guard_without_tracking() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        // No prior Initiated/BridgingInitiated events: in-memory tracking is empty,
+        // mirroring a restart where only the nonce proves the burn happened.
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_nonce_only_bridging_failed())
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.usdc_tracking.read().await.get(&id).is_none(),
+            "test setup invariant: tracking must be absent so only the nonce can classify post-burn"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a nonce-only bridging failure is post-burn evidence and must keep the guard set even \
+             without tracking"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "a nonce-only post-burn failure must keep the active rebalance ID"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "a nonce-only post-burn failure must block immediate re-burns"
+        );
+    }
+
+    /// A deposit failure happens after the CCTP mint, so the funds are post-burn
+    /// and unreconcilable. It must preserve inflight and the guard (not Clear),
+    /// the same as a post-burn bridge failure.
+    #[tokio::test]
+    async fn post_burn_deposit_failure_preserves_inflight_and_guard() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        for event in [
+            make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
+            make_usdc_withdrawal_confirmed(),
+            make_usdc_bridging_initiated(),
+            make_usdc_bridge_attestation_received(),
+            make_usdc_bridged(),
+            make_usdc_deposit_initiated(),
+            make_usdc_deposit_failed(),
+        ] {
+            harness
+                .receive::<UsdcRebalance>(id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "post-burn deposit failure must preserve in-flight tracking"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-burn deposit failure must keep the USDC guard set"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "post-burn deposit failure must keep the active rebalance ID"
+        );
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_inflight(Venue::MarketMaking),
+            Some(usdc(400)),
+            "post-burn deposit failure must preserve source inflight"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-burn deposit failure must block immediate re-burns"
+        );
+    }
+
+    /// For BaseToAlpaca the conversion is the post-deposit USDC->USD leg, so a
+    /// `ConversionFailed` there is post-mint: it must preserve inflight + the
+    /// guard, even though `ConversionInitiated` resets the tracked stage to a
+    /// pre-burn-looking value.
+    #[tokio::test]
+    async fn post_deposit_conversion_failure_preserves_inflight_and_guard() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        for event in [
+            make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
+            make_usdc_withdrawal_confirmed(),
+            make_usdc_bridging_initiated(),
+            make_usdc_bridge_attestation_received(),
+            make_usdc_bridged(),
+            make_usdc_deposit_initiated(),
+            make_usdc_deposit_confirmed(RebalanceDirection::BaseToAlpaca),
+            make_usdc_conversion_initiated(RebalanceDirection::BaseToAlpaca, usdc(399)),
+            make_usdc_conversion_failed(),
+        ] {
+            harness
+                .receive::<UsdcRebalance>(id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "post-deposit conversion failure must preserve in-flight tracking"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-deposit conversion failure must keep the USDC guard set"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id),
+            "post-deposit conversion failure must keep the active rebalance ID"
+        );
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_inflight(Venue::MarketMaking),
+            Some(usdc(400)),
+            "post-deposit conversion failure must preserve source inflight"
+        );
+
+        UsdcRebalancingCheck.perform(&trigger).await.unwrap();
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-deposit conversion failure must block immediate re-burns"
+        );
+    }
+
+    /// A transfer that times out while stalled at a post-mint stage (here
+    /// `DepositInitiated`) is also post-burn: the timeout sweep must preserve it,
+    /// not reconcile to source and clear the guard (which would re-open a re-burn
+    /// of already-burned funds).
+    #[tokio::test]
+    async fn timed_out_post_mint_usdc_rebalance_preserves_guard_and_inflight() {
+        let now = Utc::now();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(900), usdc(100))
+            .update_usdc(
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(400)),
+                now,
+            )
+            .unwrap();
+        let (reactor, mut receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: Some(usdc(399)),
+                stage: usdc::UsdcRebalanceStage::DepositInitiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "post-mint USDC timeout must preserve in-flight tracking"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-mint USDC timeout must keep the guard set"
+        );
+        assert_eq!(
+            trigger
+                .inventory
+                .read()
+                .await
+                .usdc_inflight(Venue::MarketMaking),
+            Some(usdc(400)),
+            "post-mint USDC timeout must preserve source inflight"
+        );
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-mint USDC timeout must not allow another rebalance dispatch"
+        );
     }
 
     #[tokio::test]
@@ -7695,6 +8220,24 @@ mod tests {
         UsdcRebalanceEvent::BridgingFailed {
             burn_tx_hash: Some(TxHash::random()),
             cctp_nonce: Some(B256::left_padding_from(&12345u64.to_be_bytes())),
+            reason: "Attestation timeout".to_string(),
+            failed_at: Utc::now(),
+        }
+    }
+
+    fn make_usdc_pre_burn_bridging_failed() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgingFailed {
+            burn_tx_hash: None,
+            cctp_nonce: None,
+            reason: "Burn failed".to_string(),
+            failed_at: Utc::now(),
+        }
+    }
+
+    fn make_usdc_nonce_only_bridging_failed() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgingFailed {
+            burn_tx_hash: None,
+            cctp_nonce: Some(B256::left_padding_from(&54321u64.to_be_bytes())),
             reason: "Attestation timeout".to_string(),
             failed_at: Utc::now(),
         }
@@ -8287,6 +8830,407 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timeout_does_not_clear_guard_while_market_making_transfer_job_in_flight() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(900), usdc(100))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(400)),
+                Utc::now(),
+            )
+            .unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // An Alpaca->Base transfer whose apalis row is still in flight. The gate
+        // must cover this direction too: it is driven by TransferUsdcToMarketMaking,
+        // not TransferUsdcToHedging, and a resuming job may have an irreversible
+        // withdraw/burn pending.
+        let mut queue = trigger.transfer_usdc_to_market_making_queue.clone();
+        queue
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount: usdc(400),
+            })
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "timeout must NOT clear the in-progress guard while the Alpaca->Base \
+             apalis transfer job is in flight -- an irreversible withdraw/burn may \
+             be pending and clearing would let a second transfer touch the same funds",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "timeout must not drop tracking for an in-flight Alpaca->Base transfer",
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "timeout must not mark an in-flight Alpaca->Base transfer timed-out (the \
+             reactor would then ignore its terminal event and latch the guard forever)",
+        );
+    }
+
+    #[tokio::test]
+    async fn timed_out_post_burn_usdc_rebalance_preserves_guard_and_inflight() {
+        let now = Utc::now();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                now,
+            )
+            .unwrap();
+        let (reactor, mut receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "post-burn USDC timeout must preserve in-flight tracking"
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "post-burn USDC timeout must not tombstone late events"
+        );
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "post-burn USDC timeout must keep the guard set"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_inflight(Venue::Hedging),
+            Some(usdc(400)),
+            "post-burn USDC timeout must preserve source inflight"
+        );
+        drop(inventory);
+
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "post-burn USDC timeout must not allow another rebalance dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_burn_usdc_timeout_logs_once_across_sweeps() {
+        let now = Utc::now();
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                now,
+            )
+            .unwrap();
+        let (reactor, _receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let trigger = reactor.clone();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::AlpacaToBase,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: now - ChronoDuration::minutes(31),
+            },
+        );
+
+        // The preserved entry is re-selected on every sweep. We assert on the
+        // dedup set (`post_burn_timeout_logged`) rather than captured logs: the
+        // `error!` is gated directly on this set's `insert` returning true, so a
+        // single retained entry across sweeps is a faithful proxy for "logged
+        // exactly once".
+        trigger.check_and_trigger_usdc().await;
+        assert!(
+            trigger.post_burn_timeout_logged.read().await.contains(&id),
+            "first sweep must record the stuck id for log deduplication"
+        );
+
+        trigger.check_and_trigger_usdc().await;
+        trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            trigger.post_burn_timeout_logged.read().await.len(),
+            1,
+            "subsequent sweeps must not re-log: the dedup set stays at one entry"
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "the entry must remain preserved across sweeps"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_guard_reasserts_guard_for_post_burn_bridging_failure() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000aa");
+
+        // Persist a history that ends in a post-burn bridge failure.
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: usdc(400),
+                    withdrawal: TransferRef::OnchainTx(burn_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailBridging {
+                    reason: "mint reverted".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // A fresh service has the guard cleared, as a restarted process would.
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        assert!(
+            !service.usdc_in_progress.load(Ordering::SeqCst),
+            "guard must start clear, simulating a fresh process"
+        );
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "post-burn bridge failure must re-assert the USDC guard on startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_guard_reasserts_guard_for_bridging_submitting() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000bb");
+
+        // Crash at BridgingSubmitting -- the intent marker written immediately
+        // before the irreversible CCTP burn, where the burn may already have
+        // been broadcast but not yet recorded. holds_rebalance_guard treats this
+        // as guard-holding, and the recovery candidate query must select it.
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: usdc(400),
+                    withdrawal: TransferRef::OnchainTx(burn_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::BeginBridging { from_block: 99 })
+            .await
+            .unwrap();
+
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "a crash at BridgingSubmitting (burn possibly already broadcast) must \
+             re-assert the USDC guard on startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_guard_leaves_guard_clear_for_pre_burn_failure() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let withdrawal =
+            fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000cc");
+
+        // A pre-burn bridge failure (FailBridging from WithdrawalComplete) carries
+        // no burn hash and reconciles to source, so it must not hold the guard.
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: usdc(400),
+                    withdrawal: TransferRef::OnchainTx(withdrawal),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailBridging {
+                    reason: "usdc-to-u256 conversion error".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            !service.usdc_in_progress.load(Ordering::SeqCst),
+            "pre-burn bridge failure must not hold the USDC guard on startup"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_guard_holds_defensively_when_candidate_cannot_load() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // Persist a guard-relevant event that cannot originate an aggregate (the
+        // first event must be ConversionInitiated/Initiated). The candidate
+        // query returns this id, but Store::load replays to None -- exactly the
+        // store/event inconsistency the recovery must fail safe on.
+        let event = UsdcRebalanceEvent::BridgingInitiated {
+            burn_tx_hash: fixed_bytes!(
+                "0x00000000000000000000000000000000000000000000000000000000000000aa"
+            ),
+            burned_at: Utc::now(),
+        };
+        let payload = serde_json::to_string(&event).unwrap();
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES ('UsdcRebalance', ?, 0, 'UsdcRebalanceEvent::BridgingInitiated', '1.0', ?, '{}')",
+        )
+        .bind(id.to_string())
+        .bind(payload)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            store.load(&id).await.unwrap().is_none(),
+            "an unoriginated first event must not load into an aggregate"
+        );
+
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "an unloadable guard-relevant candidate must hold the guard defensively"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_guard_holds_defensively_when_candidate_id_is_unparseable() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+
+        // Persist a guard-relevant event whose aggregate_id is not a valid UUID --
+        // a corrupt/partially-written durable row. The candidate query surfaces it
+        // as unparseable; recovery must fail closed and hold the guard rather than
+        // silently dropping it and re-opening the re-burn window.
+        let event = UsdcRebalanceEvent::BridgingInitiated {
+            burn_tx_hash: fixed_bytes!(
+                "0x00000000000000000000000000000000000000000000000000000000000000ab"
+            ),
+            burned_at: Utc::now(),
+        };
+        let payload = serde_json::to_string(&event).unwrap();
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES ('UsdcRebalance', 'not-a-uuid', 0, 'UsdcRebalanceEvent::BridgingInitiated', '1.0', ?, '{}')",
+        )
+        .bind(payload)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            service.usdc_in_progress.load(Ordering::SeqCst),
+            "an unparseable guard-relevant candidate aggregate_id must hold the guard defensively"
+        );
+    }
+
+    #[tokio::test]
     async fn usdc_post_deposit_conversion_refreshes_timeout_tracking() {
         let inventory = InventoryView::default()
             .with_usdc(usdc(900), usdc(100))
@@ -8428,7 +9372,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn conversion_failed_without_started_transfer_still_clears_in_progress() {
+    async fn conversion_failed_without_tracking_preserves_guard_conservatively() {
         let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
         let harness = ReactorHarness::new(Arc::clone(&trigger));
@@ -8442,30 +9386,31 @@ mod tests {
             .unwrap();
 
         assert!(
-            !trigger.usdc_in_progress.load(Ordering::SeqCst),
-            "pre-withdrawal conversion failure should still clear usdc_in_progress"
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "without tracking we cannot prove the conversion failure was pre-burn, so the guard \
+             is preserved conservatively rather than risk dispatching a fresh burn"
         );
         assert!(
             !trigger.usdc_tracking.read().await.contains_key(&id),
-            "pre-withdrawal conversion failure should not leave tracking context behind"
+            "a conversion failure with no prior tracking should not fabricate a context"
         );
 
         let inventory = trigger.inventory.read().await;
         assert_eq!(
             inventory.usdc_available(Venue::MarketMaking),
             Some(usdc(5000)),
-            "conversion failure before withdrawal should not change onchain USDC inventory"
+            "preserving the guard must not change onchain USDC inventory"
         );
         assert_eq!(
             inventory.usdc_available(Venue::Hedging),
             Some(usdc(5000)),
-            "conversion failure before withdrawal should not change offchain USDC inventory"
+            "preserving the guard must not change offchain USDC inventory"
         );
         drop(inventory);
     }
 
     #[tokio::test]
-    async fn conversion_confirmed_without_tracking_returns_error_and_preserves_in_progress() {
+    async fn conversion_confirmed_without_tracking_clears_guard_without_reconciliation() {
         let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
         let harness = ReactorHarness::new(Arc::clone(&trigger));
@@ -8473,25 +9418,36 @@ mod tests {
 
         trigger.usdc_in_progress.store(true, Ordering::SeqCst);
 
-        let error = harness
+        harness
             .receive::<UsdcRebalance>(
                 id.clone(),
                 make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
             )
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(
-            error,
-            RebalancingServiceError::MissingUsdcTrackingContext {
-                id: error_id,
-                event: usdc::UsdcTrackingEvent::ConversionConfirmed,
-            } if error_id == id
-        ));
         assert!(
-            trigger.usdc_in_progress.load(Ordering::SeqCst),
-            "usdc_in_progress should stay set when conversion settlement context is missing"
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a terminal-success conversion with no tracking (resumed after restart) clears the \
+             guard rather than wedging it forever on a missing-context error"
         );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "completing without tracking should not fabricate a context"
+        );
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(5000)),
+            "clearing the guard with no tracking must not reconcile onchain USDC inventory"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(5000)),
+            "clearing the guard with no tracking must not reconcile offchain USDC inventory"
+        );
+        drop(inventory);
     }
 
     #[tokio::test]
@@ -11079,7 +12035,10 @@ mod tests {
                 direction: RebalanceDirection::BaseToAlpaca,
                 initiated_amount: usdc(700),
                 bridged_amount_received: None,
-                stage: usdc::UsdcRebalanceStage::DepositConfirmed,
+                // Pre-burn stage: a stalled withdrawal still reconciles to source
+                // and tombstones on timeout (post-burn stages preserve instead,
+                // covered by timed_out_post_mint_usdc_rebalance_*).
+                stage: usdc::UsdcRebalanceStage::WithdrawalConfirmed,
                 last_progress_at: now - ChronoDuration::minutes(40),
             },
         );
@@ -11154,7 +12113,10 @@ mod tests {
                 direction: RebalanceDirection::BaseToAlpaca,
                 initiated_amount: usdc(700),
                 bridged_amount_received: None,
-                stage: usdc::UsdcRebalanceStage::DepositConfirmed,
+                // Pre-burn stage: a stalled withdrawal still reconciles to source
+                // and tombstones on timeout (post-burn stages preserve instead,
+                // covered by timed_out_post_mint_usdc_rebalance_*).
+                stage: usdc::UsdcRebalanceStage::WithdrawalConfirmed,
                 last_progress_at: now - ChronoDuration::minutes(40),
             },
         );
@@ -12179,26 +13141,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deposit_confirmed_without_any_tracking_returns_missing_context_error() {
+    async fn deposit_confirmed_without_any_tracking_clears_guard_without_reconciliation() {
         let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
-        let error = harness
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
             .receive::<UsdcRebalance>(
                 id.clone(),
                 make_usdc_deposit_confirmed(RebalanceDirection::AlpacaToBase),
             )
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(
-            error,
-            RebalancingServiceError::MissingUsdcTrackingContext {
-                id: error_id,
-                event: usdc::UsdcTrackingEvent::DepositConfirmed,
-            } if error_id == id
-        ));
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "an AlpacaToBase deposit confirmation with no tracking (resumed after restart) clears \
+             the guard rather than wedging it forever on a missing-context error"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "completing without tracking should not fabricate a context"
+        );
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -71,6 +71,32 @@ impl UsdcRebalanceTracking {
         }
     }
 
+    /// Whether the CCTP burn has irreversibly committed the funds. Past the
+    /// burn the funds are no longer on the source venue, so a failure or timeout
+    /// must NOT reconcile inflight back to source and must keep the guard.
+    ///
+    /// Defined per direction as "not a pre-burn stage", so any future stage
+    /// defaults to post-burn (the safe, re-burn-blocking direction):
+    /// - `AlpacaToBase` converts USD->USDC *before* withdrawing, so its
+    ///   conversion stages are pre-burn; the burn begins at `BridgingInitiated`.
+    /// - `BaseToAlpaca`'s only conversion is the *post-deposit* USDC->USD leg
+    ///   (post-mint), so every stage except the pre-bridge withdrawal is
+    ///   post-burn -- including the conversion stages, even though
+    ///   `ConversionInitiated` resets the tracked stage after the deposit.
+    pub(super) fn is_post_burn(&self) -> bool {
+        use UsdcRebalanceStage::*;
+
+        match self.direction {
+            RebalanceDirection::AlpacaToBase => !matches!(
+                self.stage,
+                ConversionInitiated | ConversionConfirmed | Initiated | WithdrawalConfirmed
+            ),
+            RebalanceDirection::BaseToAlpaca => {
+                !matches!(self.stage, Initiated | WithdrawalConfirmed)
+            }
+        }
+    }
+
     fn track_progress(&mut self, event: &UsdcRebalanceEvent) {
         let Some(stage) = UsdcRebalanceStage::from_event(event) else {
             return;
@@ -82,6 +108,13 @@ impl UsdcRebalanceTracking {
         self.stage = stage;
         self.last_progress_at = last_progress_at;
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UsdcTerminalAction {
+    NotTerminal,
+    Clear,
+    PreservePostBurn,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -484,21 +517,31 @@ impl RebalancingService {
             return Ok(());
         }
 
-        self.apply_usdc_rebalance_event(&id, &event).await?;
+        let terminal_action = self.usdc_terminal_action(&id, &event).await;
+        self.apply_usdc_rebalance_event(&id, &event, terminal_action)
+            .await?;
 
-        let is_terminal = Self::is_terminal_usdc_rebalance_event(&event);
+        let is_clearable_terminal = terminal_action == UsdcTerminalAction::Clear;
         {
             let mut inventory = self.inventory.write().await;
-            *inventory = if is_terminal {
+            *inventory = if is_clearable_terminal {
                 inventory.clone().clear_active_usdc_rebalance()
             } else {
                 inventory.clone().set_active_usdc_rebalance(id.clone())
             };
         }
-        if is_terminal {
+        if is_clearable_terminal {
             self.usdc_tracking.write().await.remove(&id);
             self.clear_usdc_in_progress();
             debug!(target: "rebalance", "Cleared USDC in-progress flag after rebalance terminal event");
+        } else if terminal_action == UsdcTerminalAction::PreservePostBurn {
+            self.usdc_in_progress.store(true, Ordering::SeqCst);
+            warn!(
+                target: "rebalance",
+                id = %id,
+                ?event,
+                "Preserving USDC in-progress guard after post-burn terminal failure"
+            );
         }
 
         drop(event_sync_guard);
@@ -506,7 +549,7 @@ impl RebalancingService {
         // A terminal USDC transfer cleared the in-progress claim, so we
         // cancel any pre-rebalance checks and push a fresh one against
         // the post-rebalance inventory.
-        if is_terminal {
+        if is_clearable_terminal {
             self.equity_scheduler.cancel_pending().await;
             self.usdc_scheduler.cancel_pending().await;
             self.usdc_scheduler.enqueue_check().await;
@@ -515,10 +558,85 @@ impl RebalancingService {
         Ok(())
     }
 
+    async fn usdc_terminal_action(
+        &self,
+        id: &UsdcRebalanceId,
+        event: &UsdcRebalanceEvent,
+    ) -> UsdcTerminalAction {
+        if !Self::is_terminal_usdc_rebalance_event(event) {
+            return UsdcTerminalAction::NotTerminal;
+        }
+
+        if self.post_burn_failure(id, event).await {
+            UsdcTerminalAction::PreservePostBurn
+        } else {
+            UsdcTerminalAction::Clear
+        }
+    }
+
+    /// Whether a terminal failure event happened after the CCTP burn, so its
+    /// funds cannot be reconciled to source and the guard must be kept.
+    async fn post_burn_failure(&self, id: &UsdcRebalanceId, event: &UsdcRebalanceEvent) -> bool {
+        use UsdcRebalanceEvent::*;
+
+        // A recorded burn hash OR a CCTP nonce proves post-burn even if tracking
+        // was lost: both are only ever populated after the burn reaches CCTP, so
+        // either is irreversible evidence the guard must outlive a restart.
+        if matches!(
+            event,
+            BridgingFailed {
+                burn_tx_hash: Some(_),
+                ..
+            } | BridgingFailed {
+                cctp_nonce: Some(_),
+                ..
+            }
+        ) {
+            return true;
+        }
+
+        // Every terminal failure is post-burn iff the tracked transfer is past
+        // the burn. `is_post_burn` is direction-aware, so a BaseToAlpaca
+        // post-deposit `ConversionFailed` (post-mint) is correctly preserved
+        // while an AlpacaToBase pre-withdrawal `ConversionFailed` clears.
+        // Terminal successes fall through to `false` and settle normally.
+        //
+        // When in-memory tracking is absent -- e.g. an apalis job that resumes
+        // after a restart, where `recover_usdc_guard` reasserts the guard but
+        // does not rebuild tracking -- we must NOT speculatively clear the guard
+        // on a failure that could be post-burn. So:
+        //   - `DepositFailed` is only reachable from `DepositInitiated`
+        //     (post-mint), hence unconditionally post-burn.
+        //   - `ConversionFailed` defaults to preserve when tracking is absent
+        //     (the BaseToAlpaca post-deposit leg must hold; the rare lost-track
+        //     AlpacaToBase pre-burn case holds conservatively rather than risk a
+        //     re-burn -- safe, at worst it wedges that one rebalance until an
+        //     operator clears it).
+        //   - `WithdrawalFailed` / pre-burn `BridgingFailed` are always pre-burn,
+        //     so absent tracking correctly clears.
+        match event {
+            DepositFailed { .. } => true,
+            ConversionFailed { .. } => self
+                .usdc_tracking
+                .read()
+                .await
+                .get(id)
+                .is_none_or(UsdcRebalanceTracking::is_post_burn),
+            WithdrawalFailed { .. } | BridgingFailed { .. } => self
+                .usdc_tracking
+                .read()
+                .await
+                .get(id)
+                .is_some_and(UsdcRebalanceTracking::is_post_burn),
+            _ => false,
+        }
+    }
+
     async fn apply_usdc_rebalance_event(
         &self,
         id: &UsdcRebalanceId,
         event: &UsdcRebalanceEvent,
+        terminal_action: UsdcTerminalAction,
     ) -> Result<(), RebalancingServiceError> {
         use UsdcRebalanceEvent::*;
 
@@ -578,15 +696,39 @@ impl RebalancingService {
             // BridgingInitiated; the inventory's active-rebalance claim is set by
             // the caller on this (first non-terminal) event, so nothing to do here.
             WithdrawalSubmitting { .. } | BridgingSubmitting { .. } => {}
-            WithdrawalFailed { .. }
-            | BridgingFailed { .. }
-            | DepositFailed { .. }
-            | ConversionFailed { .. } => {
+            // Withdrawal failure is always pre-burn -> reconcile to source.
+            WithdrawalFailed { .. } => {
                 self.cancel_tracked_usdc_rebalance(id).await?;
+            }
+            // These failures may be pre- or post-burn (BridgingFailed by burn
+            // stage; ConversionFailed by direction -- BaseToAlpaca's conversion
+            // is post-deposit; DepositFailed is always post-mint). The classifier
+            // decides: preserve post-burn, otherwise reconcile to source.
+            BridgingFailed { .. } | DepositFailed { .. } | ConversionFailed { .. } => {
+                if terminal_action == UsdcTerminalAction::PreservePostBurn {
+                    // Preservation is achieved by NOT cancelling: the tracking
+                    // entry, guard, and active id are all kept by the caller. This
+                    // call only surfaces a diagnostic if tracking is absent.
+                    self.warn_if_post_burn_tracking_missing(id).await;
+                } else {
+                    self.cancel_tracked_usdc_rebalance(id).await?;
+                }
             }
         }
 
         Ok(())
+    }
+
+    async fn warn_if_post_burn_tracking_missing(&self, id: &UsdcRebalanceId) {
+        if self.usdc_tracking.read().await.contains_key(id) {
+            return;
+        }
+
+        warn!(
+            target: "rebalance",
+            id = %id,
+            "Post-burn terminal failure had no USDC tracking context to preserve"
+        );
     }
 
     async fn track_initiated_usdc_rebalance(
@@ -738,11 +880,12 @@ impl RebalancingService {
         id: &UsdcRebalanceId,
     ) -> Result<(), RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
-            warn!(target: "rebalance", id = %id, "DepositConfirmed event missing USDC tracking context");
-            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
-                id: id.clone(),
-                event: UsdcTrackingEvent::DepositConfirmed,
-            });
+            // Resumed after a restart with no rebuilt tracking: the transfer
+            // already settled, so there is no inventory inflight to reconcile.
+            // Return Ok so the caller clears the guard (terminal success) rather
+            // than wedging it forever on a MissingUsdcTrackingContext error.
+            warn!(target: "rebalance", id = %id, "DepositConfirmed event missing USDC tracking context; clearing guard without reconciliation (resumed after restart)");
+            return Ok(());
         };
 
         let Some(amount_received) = tracking.bridged_amount_received else {
@@ -798,11 +941,12 @@ impl RebalancingService {
         settled_amount: Usdc,
     ) -> Result<(), RebalancingServiceError> {
         let Some(tracking) = self.usdc_tracking.read().await.get(id).cloned() else {
-            warn!(target: "rebalance", id = %id, "Terminal success event missing USDC tracking context");
-            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
-                id: id.clone(),
-                event,
-            });
+            // Resumed after a restart with no rebuilt tracking: the transfer
+            // already settled, so there is no inventory inflight to reconcile.
+            // Return Ok so the caller clears the guard (terminal success) rather
+            // than wedging it forever on a MissingUsdcTrackingContext error.
+            warn!(target: "rebalance", id = %id, ?event, "Terminal success event missing USDC tracking context; clearing guard without reconciliation (resumed after restart)");
+            return Ok(());
         };
 
         let source_venue = tracking.source_venue();
@@ -2059,5 +2203,51 @@ mod tests {
         ));
         assert_eq!(entry.stage, UsdcRebalanceStage::DepositConfirmed);
         assert_eq!(entry.last_progress_at, ts(0));
+    }
+
+    #[test]
+    fn is_post_burn_is_direction_aware() {
+        use RebalanceDirection::{AlpacaToBase, BaseToAlpaca};
+        use UsdcRebalanceStage::*;
+
+        let tracking = |direction, stage| UsdcRebalanceTracking {
+            direction,
+            initiated_amount: Usdc::new(float!(400.0)),
+            bridged_amount_received: None,
+            stage,
+            last_progress_at: ts(0),
+        };
+
+        // Stages from BridgingInitiated through DepositConfirmed are post-burn
+        // for both directions.
+        for stage in [
+            BridgingInitiated,
+            BridgeAttestationReceived,
+            Bridged,
+            DepositInitiated,
+            DepositConfirmed,
+        ] {
+            assert!(tracking(AlpacaToBase, stage).is_post_burn(), "A2B {stage}");
+            assert!(tracking(BaseToAlpaca, stage).is_post_burn(), "B2A {stage}");
+        }
+
+        // Withdrawal stages are pre-burn for both directions.
+        for stage in [Initiated, WithdrawalConfirmed] {
+            assert!(!tracking(AlpacaToBase, stage).is_post_burn(), "A2B {stage}");
+            assert!(!tracking(BaseToAlpaca, stage).is_post_burn(), "B2A {stage}");
+        }
+
+        // Conversion stages differ by direction: AlpacaToBase converts before the
+        // withdrawal (pre-burn); BaseToAlpaca converts after the deposit (post-mint).
+        for stage in [ConversionInitiated, ConversionConfirmed] {
+            assert!(
+                !tracking(AlpacaToBase, stage).is_post_burn(),
+                "A2B {stage} (pre-withdrawal conversion) must be pre-burn"
+            );
+            assert!(
+                tracking(BaseToAlpaca, stage).is_post_burn(),
+                "B2A {stage} (post-deposit conversion) must be post-burn"
+            );
+        }
     }
 }

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -69,8 +69,10 @@ use alloy::primitives::{B256, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use tracing::warn;
 use uuid::Uuid;
 
 use st0x_dto::{TransferOperation, UsdcBridgeOperation, UsdcBridgeStatus};
@@ -770,6 +772,145 @@ impl UsdcRebalance {
             updated_at,
         })
     }
+
+    /// Whether an aggregate in this state should hold the single-rebalance
+    /// guard (`usdc_in_progress`) when the guard is reconstructed on startup.
+    ///
+    /// True for any state where a rebalance is still in progress or stranded
+    /// after a CCTP burn; false only for clearable-terminal states -- success,
+    /// or a failure that reconciles inflight back to the source venue. The live
+    /// reactor holds the guard from dispatch until a clearable-terminal event;
+    /// re-deriving that boolean from durable event state keeps a restart from
+    /// re-opening the re-burn window. See ADR 2.
+    pub(crate) fn holds_rebalance_guard(&self) -> bool {
+        match self {
+            // `WithdrawalSubmitting`/`BridgingSubmitting` are transient intent
+            // markers persisted immediately before an irreversible on-chain
+            // withdraw/burn. A crash here may have already broadcast that effect,
+            // so they hold the guard defensively to keep a restart from opening a
+            // re-burn window while apalis resumes the job.
+            Self::Converting { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalComplete { .. }
+            | Self::WithdrawalSubmitting { .. }
+            | Self::BridgingSubmitting { .. }
+            | Self::Bridging { .. }
+            | Self::Attested { .. }
+            | Self::Bridged { .. }
+            | Self::DepositInitiated { .. }
+            // DepositFailed is post-burn/post-mint (the CCTP mint already
+            // happened), so the funds cannot be reconciled to source; the live
+            // reactor preserves it (PreservePostBurn), so recovery holds too.
+            | Self::DepositFailed { .. } => true,
+            // AlpacaToBase: pre-withdrawal conversion, still has withdraw/bridge/
+            // deposit ahead. BaseToAlpaca: post-deposit conversion -> terminal.
+            Self::ConversionComplete { direction, .. } => match direction {
+                RebalanceDirection::AlpacaToBase => true,
+                RebalanceDirection::BaseToAlpaca => false,
+            },
+            // Post-burn failure (burn already broadcast) keeps the guard so a
+            // re-burn cannot fire against funds CCTP already burned. The
+            // `FailBridging` command only emits `burn_tx_hash: Some` from the
+            // post-burn `Bridging`/`Attested` states; a pre-burn failure (from
+            // `WithdrawalComplete`) carries `None` and reconciles to source.
+            Self::BridgingFailed { burn_tx_hash, .. } => burn_tx_hash.is_some(),
+            // BaseToAlpaca-only post-burn legs: after DepositConfirmed the
+            // post-deposit USDC->USD conversion is still pending, and a
+            // post-deposit ConversionFailed is post-mint -- both hold. For
+            // AlpacaToBase both clear: DepositConfirmed is terminal success and
+            // ConversionFailed is the pre-withdrawal (pre-burn) leg.
+            Self::DepositConfirmed { direction, .. } | Self::ConversionFailed { direction, .. } => {
+                match direction {
+                    RebalanceDirection::BaseToAlpaca => true,
+                    RebalanceDirection::AlpacaToBase => false,
+                }
+            }
+            // Withdrawal failure is always pre-burn: reconcile to source and clear.
+            Self::WithdrawalFailed { .. } => false,
+        }
+    }
+}
+
+/// Candidate `UsdcRebalance` aggregates whose latest event leaves them
+/// potentially holding the single-rebalance guard, for startup recovery, split
+/// by whether their persisted `aggregate_id` parsed.
+///
+/// `unparseable` rows cannot be loaded or classified, so the recovery path must
+/// fail closed and hold the guard for them rather than silently dropping them --
+/// dropping would leave the guard clear for a possibly-post-burn rebalance and
+/// re-open the re-burn window. The raw ids are retained for diagnostics.
+pub(crate) struct InterruptedUsdcRebalances {
+    pub(crate) ids: Vec<UsdcRebalanceId>,
+    pub(crate) unparseable: Vec<String>,
+}
+
+/// Returns the candidate `UsdcRebalance` aggregates whose latest event leaves
+/// them potentially holding the single-rebalance guard, for startup recovery.
+///
+/// The `event_type` filter is a coarse pre-filter: it excludes only
+/// `WithdrawalFailed` (always pre-burn, reconciles to source) and keeps every
+/// other latest event -- including `ConversionFailed` (post-burn for
+/// BaseToAlpaca's post-deposit leg, pre-burn for AlpacaToBase) and the events
+/// that are terminal in one direction but intermediate in the other
+/// (`ConversionConfirmed`, `DepositConfirmed`). The caller loads each aggregate
+/// and applies [`UsdcRebalance::holds_rebalance_guard`] for the precise,
+/// direction-aware decision. USDC rebalances are infrequent, large operations,
+/// so loading the recently-terminal ones to filter them out is cheap.
+pub(crate) async fn interrupted_usdc_rebalance_ids(
+    pool: &SqlitePool,
+) -> Result<InterruptedUsdcRebalances, sqlx::Error> {
+    let rows: Vec<String> = sqlx::query_scalar(
+        "WITH latest AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'UsdcRebalance' \
+             GROUP BY aggregate_id \
+         ) \
+         SELECT latest.aggregate_id \
+         FROM events last_ev \
+         INNER JOIN latest \
+             ON last_ev.aggregate_id = latest.aggregate_id \
+            AND last_ev.sequence = latest.max_seq \
+         WHERE last_ev.aggregate_type = 'UsdcRebalance' \
+           AND last_ev.event_type IN ( \
+               'UsdcRebalanceEvent::ConversionInitiated', \
+               'UsdcRebalanceEvent::ConversionConfirmed', \
+               'UsdcRebalanceEvent::ConversionFailed', \
+               'UsdcRebalanceEvent::Initiated', \
+               'UsdcRebalanceEvent::WithdrawalSubmitting', \
+               'UsdcRebalanceEvent::WithdrawalConfirmed', \
+               'UsdcRebalanceEvent::BridgingSubmitting', \
+               'UsdcRebalanceEvent::BridgingInitiated', \
+               'UsdcRebalanceEvent::BridgeAttestationReceived', \
+               'UsdcRebalanceEvent::Bridged', \
+               'UsdcRebalanceEvent::BridgingFailed', \
+               'UsdcRebalanceEvent::DepositInitiated', \
+               'UsdcRebalanceEvent::DepositConfirmed', \
+               'UsdcRebalanceEvent::DepositFailed' \
+           ) \
+         ORDER BY latest.aggregate_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut ids = Vec::new();
+    let mut unparseable = Vec::new();
+    for raw in rows {
+        match raw.parse::<UsdcRebalanceId>() {
+            Ok(id) => ids.push(id),
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %raw, ?error,
+                    "Unparseable UsdcRebalance aggregate_id during guard recovery; \
+                     holding guard defensively"
+                );
+                unparseable.push(raw);
+            }
+        }
+    }
+
+    Ok(InterruptedUsdcRebalances { ids, unparseable })
 }
 
 #[async_trait]
@@ -1788,12 +1929,13 @@ impl UsdcRebalance {
 mod tests {
     use alloy::primitives::fixed_bytes;
     use serde_json::{from_value, json};
+    use std::collections::HashSet;
     use uuid::Uuid;
 
-    use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
+    use st0x_event_sorcery::{LifecycleError, TestHarness, replay, test_store};
+    use st0x_float_macro::float;
 
     use super::*;
-    use st0x_float_macro::float;
 
     /// Realistic CCTP V2 nonce with non-zero upper bytes -- the actual nonce
     /// from a prod burn that the old u64 validation rejected. Regression guard
@@ -4911,5 +5053,320 @@ mod tests {
         assert_eq!(bridge.amount, Usdc::new(float!(3000)));
         assert_eq!(bridge.started_at, initiated_at);
         assert_eq!(bridge.updated_at, deposit_initiated_at);
+    }
+
+    const BURN_TX: TxHash =
+        fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000aa");
+    const MINT_TX: TxHash =
+        fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000bb");
+
+    #[test]
+    fn holds_rebalance_guard_holds_for_in_progress_and_post_burn_failure() {
+        use RebalanceDirection::{AlpacaToBase, BaseToAlpaca};
+        use UsdcRebalance::*;
+
+        let now = Utc::now();
+        let amount = Usdc::new(float!(400.0));
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+        let withdrawal_ref = TransferRef::OnchainTx(BURN_TX);
+
+        // In-progress states hold the guard, pre- and post-burn, both directions.
+        assert!(
+            Converting {
+                direction: AlpacaToBase,
+                amount,
+                order_id,
+                initiated_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            Withdrawing {
+                direction: BaseToAlpaca,
+                amount,
+                withdrawal_ref: withdrawal_ref.clone(),
+                initiated_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            WithdrawalComplete {
+                direction: AlpacaToBase,
+                amount,
+                initiated_at: now,
+                confirmed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            Bridging {
+                direction: BaseToAlpaca,
+                amount,
+                burn_tx_hash: BURN_TX,
+                initiated_at: now,
+                burned_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            Attested {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash: BURN_TX,
+                cctp_nonce: TEST_CCTP_NONCE,
+                attestation: vec![],
+                mint_scan_from_block: Some(0),
+                initiated_at: now,
+                attested_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            Bridged {
+                direction: BaseToAlpaca,
+                amount,
+                amount_received: amount,
+                fee_collected: Usdc::new(float!(0.0)),
+                burn_tx_hash: BURN_TX,
+                mint_tx_hash: MINT_TX,
+                initiated_at: now,
+                minted_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            DepositInitiated {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash: BURN_TX,
+                mint_tx_hash: MINT_TX,
+                deposit_ref: withdrawal_ref.clone(),
+                initiated_at: now,
+                deposit_initiated_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        // Deposit failure is post-burn/post-mint -> holds the guard.
+        assert!(
+            DepositFailed {
+                direction: BaseToAlpaca,
+                amount,
+                burn_tx_hash: BURN_TX,
+                mint_tx_hash: MINT_TX,
+                deposit_ref: Some(withdrawal_ref),
+                reason: "deposit failed".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        // Post-burn bridge failure keeps the guard; pre-burn failure clears it.
+        assert!(
+            BridgingFailed {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash: Some(BURN_TX),
+                cctp_nonce: None,
+                reason: "post-burn".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            !BridgingFailed {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash: None,
+                cctp_nonce: None,
+                reason: "pre-burn".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+    }
+
+    #[test]
+    fn holds_rebalance_guard_is_direction_aware_for_conversion_and_deposit_terminals() {
+        use RebalanceDirection::{AlpacaToBase, BaseToAlpaca};
+        use UsdcRebalance::*;
+
+        let now = Utc::now();
+        let amount = Usdc::new(float!(400.0));
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        // ConversionComplete: AlpacaToBase is the pre-withdrawal conversion (still
+        // in progress); BaseToAlpaca is the post-deposit terminal success.
+        assert!(
+            ConversionComplete {
+                direction: AlpacaToBase,
+                amount,
+                filled_amount: amount,
+                initiated_at: now,
+                converted_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            !ConversionComplete {
+                direction: BaseToAlpaca,
+                amount,
+                filled_amount: amount,
+                initiated_at: now,
+                converted_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+
+        // DepositConfirmed: AlpacaToBase is terminal; BaseToAlpaca still has the
+        // post-deposit USDC->USD conversion ahead.
+        assert!(
+            !DepositConfirmed {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash: BURN_TX,
+                mint_tx_hash: MINT_TX,
+                initiated_at: now,
+                deposit_confirmed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            DepositConfirmed {
+                direction: BaseToAlpaca,
+                amount,
+                burn_tx_hash: BURN_TX,
+                mint_tx_hash: MINT_TX,
+                initiated_at: now,
+                deposit_confirmed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+
+        // ConversionFailed is direction-aware: AlpacaToBase's pre-withdrawal
+        // conversion reconciles to source (clear); BaseToAlpaca's post-deposit
+        // conversion is post-mint (hold).
+        assert!(
+            !ConversionFailed {
+                direction: AlpacaToBase,
+                amount,
+                order_id: order_id.clone(),
+                reason: "x".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
+            ConversionFailed {
+                direction: BaseToAlpaca,
+                amount,
+                order_id,
+                reason: "x".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+        // Withdrawal failure is always pre-burn -> clears.
+        assert!(
+            !WithdrawalFailed {
+                direction: BaseToAlpaca,
+                amount,
+                withdrawal_ref: TransferRef::OnchainTx(BURN_TX),
+                reason: "x".to_string(),
+                initiated_at: now,
+                failed_at: now,
+            }
+            .holds_rebalance_guard()
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_usdc_rebalance_ids_excludes_clearable_terminals() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let amount = Usdc::new(float!(400.0));
+
+        // Clearable terminal (withdrawal failed, pre-burn) -- must be excluded.
+        let withdrawal_failed = UsdcRebalanceId(Uuid::new_v4());
+        store
+            .send(
+                &withdrawal_failed,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(BURN_TX),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &withdrawal_failed,
+                UsdcRebalanceCommand::FailWithdrawal {
+                    reason: "x".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // Post-burn bridge failure -- must be included.
+        let bridge_failed = UsdcRebalanceId(Uuid::new_v4());
+        store
+            .send(
+                &bridge_failed,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(BURN_TX),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&bridge_failed, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(
+                &bridge_failed,
+                UsdcRebalanceCommand::InitiateBridging { burn_tx: BURN_TX },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &bridge_failed,
+                UsdcRebalanceCommand::FailBridging {
+                    reason: "x".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        // In-progress (mid-withdrawal) -- must be included.
+        let withdrawing = UsdcRebalanceId(Uuid::new_v4());
+        store
+            .send(
+                &withdrawing,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(BURN_TX),
+                },
+            )
+            .await
+            .unwrap();
+
+        let interrupted = interrupted_usdc_rebalance_ids(&pool).await.unwrap();
+        let got: HashSet<UsdcRebalanceId> = interrupted.ids.into_iter().collect();
+
+        assert_eq!(got, HashSet::from([bridge_failed, withdrawing]));
+        assert!(
+            interrupted.unparseable.is_empty(),
+            "well-formed UUID aggregate_ids must not be reported as unparseable"
+        );
     }
 }


### PR DESCRIPTION
## What

Closes [RAI-715](https://linear.app/makeitrain/issue/RAI-715).

Stops the USDC rebalancing reactor from ever dispatching a **new CCTP burn while a prior rebalance's funds are post-burn (burned and/or minted) but not yet settled**. Two dimensions:

1. **Every post-burn failure/timeout now preserves** source inflight and the rebalancing guard instead of reconciling funds back to source and clearing the guard.
2. **The guard is durable across restart** — reconstructed from persisted `UsdcRebalance` event state on startup.

## Why

This is the accounting bug behind the 2026-05-29 incident: a single nonce-parsing bug ([RAI-714](https://linear.app/makeitrain/issue/RAI-714), fixed in parent branch `05-29-fix_cctp_nonce`) was amplified into **25 consecutive burns of 1,000 USDC** (~25k stranded) because each failed attestation reconciled the burned funds as if still on source and cleared the guard, letting the next `UsdcRebalancingCheck` re-trigger immediately.

The nonce fix stops that specific trigger, but the reconciliation bug was a latent footgun for *any* post-burn failure. The original scope of this PR closed only the post-burn `BridgingFailed` path; review surfaced that the same re-burn class remained open on three other post-burn paths and across process restarts. This PR removes the amplifier on all of them.

## How

The unifying rule: **once the CCTP burn has irreversibly committed funds, no failure/timeout may reconcile them to source or clear the guard.**

**`src/rebalancing/trigger/usdc.rs` — classification**

- `UsdcRebalanceTracking::is_post_burn()` is the single source of truth, defined per direction as "not a pre-burn stage" (so any future stage defaults to the safe, re-burn-blocking side). AlpacaToBase converts USD→USDC *before* withdrawing (conversion is pre-burn); BaseToAlpaca's only conversion is the *post-deposit* USDC→USD leg (post-mint), so its conversion stages are post-burn — even though `ConversionInitiated` resets the tracked stage.
- `post_burn_failure()` routes every terminal failure (`WithdrawalFailed`, `BridgingFailed`, `DepositFailed`, `ConversionFailed`) through `is_post_burn` (plus a `burn_tx_hash: Some` shortcut for `BridgingFailed` when tracking is lost). `usdc_terminal_action()` maps the result to `NotTerminal`/`Clear`/`PreservePostBurn`.
- `apply_usdc_rebalance_event()` preserves (keeps tracking, guard, active id) for `PreservePostBurn`; only pre-burn failures `cancel_tracked_usdc_rebalance` (reconcile to source).

This closes three previously-open re-burn vectors beyond the original `BridgingFailed`: post-mint `DepositFailed`, timeouts stalled at any post-burn stage, and the BaseToAlpaca post-deposit `ConversionFailed`.

**`src/rebalancing/trigger/mod.rs` — timeout + durable guard**

- `cleanup_timed_out_usdc_rebalance()` uses `is_post_burn()` to preserve (vs. reconcile-and-tombstone) any transfer that times out post-burn; a `post_burn_timeout_logged` set de-dupes the error log to once per stuck transfer.
- `recover_usdc_guard()` reconstructs the in-memory `usdc_in_progress` guard on startup: `interrupted_usdc_rebalance_ids()` selects candidate aggregates from the event log, each is loaded and classified by `UsdcRebalance::holds_rebalance_guard()`, and the guard is re-asserted if any hold it. It **fails safe** — an unloadable candidate holds the guard rather than aborting startup or silently skipping (only the query's I/O error propagates). Wired into conductor startup recovery.

**`src/usdc_rebalance.rs`**

- `UsdcRebalance::holds_rebalance_guard()` — the restart-recovery classifier, consistent with the live and timeout surfaces for every state and direction.
- `interrupted_usdc_rebalance_ids()` — event-log query for guard-holding candidates.

**`adrs/2-durable-usdc-rebalance-guard-on-restart.md`** — records the guard-only recovery decision (no inventory reconstruction: avoids double-count risk, and USDC bridges have no resume path so no settlement events arrive post-restart).

**`SPEC.md`** — documents post-burn preservation across all failure types and the durable guard.

## Testing

All new logic is unit- and integration-tested (full backend suite green in CI: 4 test shards + check + clippy):

- `is_post_burn_is_direction_aware`, `holds_rebalance_guard_*` — exhaustive classification across every state/stage and both directions, including the direction-dependent `ConversionFailed`/`ConversionComplete`/`DepositConfirmed`.
- `post_burn_deposit_failure_preserves_inflight_and_guard`, `post_deposit_conversion_failure_preserves_inflight_and_guard`, `timed_out_post_mint_usdc_rebalance_preserves_guard_and_inflight`, `bridging_failure_without_burn_hash_preserved_via_tracking_stage`, `alpaca_to_base`/`base_to_alpaca_post_burn_bridging_failure_preserves_*` — end-to-end preserve for each post-burn failure/timeout path, asserting the guard stays set, inflight is preserved, and a subsequent check dispatches nothing.
- `recover_usdc_guard_reasserts_guard_for_post_burn_bridging_failure`, `recover_usdc_guard_leaves_guard_clear_for_pre_burn_failure`, `recover_usdc_guard_holds_defensively_when_candidate_cannot_load` — the three startup-recovery branches, including the fail-safe.
- `post_burn_usdc_timeout_logs_once_across_sweeps` — log de-dup.
- `interrupted_usdc_rebalance_ids_excludes_clearable_terminals` — the candidate query.
- The `*_usdc_failures_cancel_inflight_end_to_end` scenario tables were adapted: the now-preserved post-burn scenarios moved to the dedicated preserve tests above; the tables retain the genuinely pre-burn cancel cases.

## Anything else

- Stacked on `05-29-fix_cctp_nonce` (PR #706, RAI-714) — review/merge that first.
- Scope grew during review beyond the original post-burn `BridgingFailed` fix. The expansion (durable guard + the three additional post-burn vectors) is the logical completion of the same incident class; see `adrs/2-...` for the durable-guard decision rationale.
- This blocks re-burns and keeps accounting honest, but funds stuck post-burn still require settlement or manual operator recovery. USDC bridges are not auto-resumed on restart, so a reconstructed guard stays held until the stuck transfer settles or an operator clears it. An explicit "CCTP stuck" state with retry/resume (floated in RAI-715) remains follow-up.


## Update — rebased onto the USDC-apalis stack (`feat/drop-usdc-from-rebalancer`)

This branch now stacks on the foreign refactor that moved USDC transfers into crash-recoverable **apalis jobs**. That **invalidated ADR 2's premise** that "no settlement events arrive post-restart" — the apalis jobs *do* resume transfers after a restart. Self-review (5 reviewers) caught two resulting safety gaps in the ported guard, both now fixed:

- **Re-burn on resumed failure:** `post_burn_failure` only had a burn-hash fallback for `BridgingFailed`. A resumed `DepositFailed`/`ConversionFailed` with no in-memory tracking (recovery rebuilds the guard, not tracking) would classify as pre-burn and clear the guard. Fixed: `DepositFailed` is unconditionally post-burn (only reachable post-mint), and `ConversionFailed` defaults to *preserve* when tracking is absent — never speculatively clear on a failure that might be post-burn.
- **Wedge-forever on resumed success:** a resumed terminal success (`DepositConfirmed`/`ConversionConfirmed`) with no tracking errored with `MissingUsdcTrackingContext` *before* the guard-clear path, latching the guard forever. Fixed: the completion handlers now clear the guard on a confirmed success even when tracking is absent (nothing to reconcile after a restart).
- **Recovery candidate query:** `interrupted_usdc_rebalance_ids` omitted `WithdrawalSubmitting`/`BridgingSubmitting` — the highest-risk pre-burn- broadcast states `holds_rebalance_guard` is designed to protect. Added both, with `recover_usdc_guard_reasserts_guard_for_bridging_submitting` proving it.

The "USDC bridges are not auto-resumed on restart" caveat below is **superseded** by this rebase: they now are, and the guard recovery is hardened accordingly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672075&installation_id=125569124&pr_number=707&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F707&signature=d4fcf22e6c3421e300cc997812d0a74149dc4324d823cb9cbfb9e06d5005b9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * USDC rebalancing state now persists across system restarts, preventing loss of in-progress transfers.

* **New Features**
  * Intelligent USDC failure handling: pre-burn failures can be automatically reconciled; post-burn failures are preserved for manual operator recovery.

* **Documentation**
  * Updated USDC rebalancing failure handling specifications.
  * Added architecture decision for durable guard recovery on restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
