### PR TITLE
fix: persist attested CCTP message bytes for crash-recoverable bridging

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1660,7 +1660,8 @@ enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
+        message: Vec<u8>,
         attestation: Vec<u8>,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
@@ -1677,7 +1678,7 @@ enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: Option<TxHash>,
-        cctp_nonce: Option<u64>,
+        cctp_nonce: Option<B256>,
         reason: String,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
@@ -1740,7 +1741,7 @@ enum UsdcRebalanceCommand {
 
     // Bridging commands
     InitiateBridging { burn_tx: TxHash },
-    ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: u64 },
+    ReceiveAttestation { message: Vec<u8>, attestation: Vec<u8>, cctp_nonce: B256 },
     ConfirmBridging { mint_tx: TxHash },
     FailBridging { reason: String },
 
@@ -1780,8 +1781,9 @@ enum UsdcRebalanceEvent {
     // Bridging events (cctp_nonce comes from attestation, not burn tx)
     BridgingInitiated { burn_tx_hash: TxHash, burned_at: DateTime<Utc> },
     BridgeAttestationReceived {
+        message: Vec<u8>,
         attestation: Vec<u8>,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         attested_at: DateTime<Utc>,
     },
     Bridged {
@@ -1844,7 +1846,9 @@ enum BridgeStage { Burn, Attestation, Mint }
   logs
 - Attestation must be retrieved by polling Circle's REST API (~13 sec finality,
   no websocket option available)
-- Bridge mint transaction requires valid attestation
+- Bridge mint transaction requires both the attested CCTP message bytes and the
+  Circle attestation signature; both must be persisted before minting so the
+  transfer can resume after restart
 - Bridge mint transaction must be confirmed before destination deposit
 - Destination deposit must be confirmed to complete rebalancing (for
   AlpacaToBase) or before post-deposit conversion (for BaseToAlpaca)

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -1,6 +1,8 @@
 //! Single-chain CCTP operations.
 
-use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
+use alloy::providers::Provider;
+use alloy::rpc::types::Filter;
 use alloy::sol;
 use alloy::sol_types::SolEvent;
 use tracing::{info, trace};
@@ -175,6 +177,91 @@ impl<W: Wallet> CctpEndpoint<W> {
             amount: mint_event.amount,
             fee_collected: mint_event.feeCollected,
         })
+    }
+
+    /// Returns the receipt of an already-executed mint for `nonce`, or `None` if
+    /// the nonce has not been consumed on this chain yet.
+    ///
+    /// Crash recovery uses this before re-minting: `receiveMessage` reverts on an
+    /// already-used nonce, so when the mint already landed (process died after the
+    /// mint confirmed but before the `Bridged` event committed) we reconstruct the
+    /// receipt from the on-chain `MessageReceived`/`MintAndWithdraw` events instead
+    /// of re-submitting. The `MessageReceived` event carries the nonce as its second
+    /// indexed topic, so a topic filter pinpoints the originating transaction. The
+    /// log query is unbounded because this is a rare recovery path with no cheap
+    /// block bound; if a provider range-limits it, the error propagates and the
+    /// resume is retried on the next restart with the aggregate left resumable.
+    pub(super) async fn find_existing_mint<Registry: IntoErrorRegistry>(
+        &self,
+        nonce: B256,
+    ) -> Result<Option<MintReceipt>, CctpError> {
+        let used = self
+            .wallet
+            .call::<Registry, _>(
+                self.message_transmitter_address,
+                MessageTransmitterV2::usedNoncesCall(nonce),
+            )
+            .await?;
+
+        if used.is_zero() {
+            return Ok(None);
+        }
+
+        let filter = Filter::new()
+            .address(self.message_transmitter_address)
+            .event_signature(MessageTransmitterV2::MessageReceived::SIGNATURE_HASH)
+            .topic2(nonce);
+
+        let tx_hash = self
+            .wallet
+            .provider()
+            .get_logs(&filter)
+            .await?
+            .iter()
+            .find_map(|log| log.transaction_hash)
+            .ok_or(CctpError::MintReceiveLogNotFound { nonce })?;
+
+        let receipt = self
+            .wallet
+            .provider()
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(CctpError::MintAndWithdrawEventNotFound)?;
+
+        // `receiveMessage` processes a single CCTP message, so its receipt carries
+        // exactly one MintAndWithdraw -- the one for this nonce. Taking the first is
+        // correct for the bot's single-message receives.
+        let mint_event = receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| TokenMessengerV2::MintAndWithdraw::decode_log(log.as_ref()).ok())
+            .ok_or(CctpError::MintAndWithdrawEventNotFound)?;
+
+        info!(
+            target: "bridge",
+            %tx_hash,
+            amount = %mint_event.amount,
+            fee_collected = %mint_event.feeCollected,
+            "Recovered existing CCTP mint for already-consumed nonce"
+        );
+
+        Ok(Some(MintReceipt {
+            tx: tx_hash,
+            amount: mint_event.amount,
+            fee_collected: mint_event.feeCollected,
+        }))
+    }
+
+    /// Returns `holder`'s balance of this chain's USDC token.
+    pub(super) async fn usdc_balance<Registry: IntoErrorRegistry>(
+        &self,
+        holder: Address,
+    ) -> Result<U256, CctpError> {
+        Ok(self
+            .wallet
+            .call::<Registry, _>(self.usdc_address, IERC20::balanceOfCall { account: holder })
+            .await?)
     }
 
     #[cfg(test)]

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -162,6 +162,18 @@ struct MintReceipt {
     fee_collected: U256,
 }
 
+/// CCTP message bytes attested by Circle (the payload passed to `receiveMessage`).
+///
+/// A distinct newtype from [`CctpAttestation`] so the two byte blobs cannot be
+/// swapped at the positional [`AttestationResponse::from_message_and_attestation`]
+/// call site -- a swap would corrupt the mint and is a compile error here.
+#[derive(Debug, Clone)]
+pub struct CctpMessage(pub Bytes);
+
+/// Circle's attestation signature authorizing the mint of a [`CctpMessage`].
+#[derive(Debug, Clone)]
+pub struct CctpAttestation(pub Bytes);
+
 /// Response from Circle's attestation API for CCTP V2.
 ///
 /// Contains both the CCTP message bytes and the Circle attestation signature,
@@ -182,9 +194,35 @@ pub struct AttestationResponse {
     nonce: B256,
 }
 
+impl AttestationResponse {
+    /// Reconstructs an attestation response from persisted CCTP message and
+    /// attestation bytes.
+    ///
+    /// Takes distinct [`CctpMessage`]/[`CctpAttestation`] newtypes so the two
+    /// byte blobs cannot be transposed at the call site.
+    pub fn from_message_and_attestation(
+        message: CctpMessage,
+        attestation: CctpAttestation,
+    ) -> Result<Self, CctpError> {
+        let CctpMessage(message) = message;
+        let CctpAttestation(attestation) = attestation;
+        let nonce = extract_nonce_from_message(&message)?;
+
+        Ok(Self {
+            message,
+            attestation,
+            nonce,
+        })
+    }
+}
+
 impl crate::Attestation for AttestationResponse {
     fn nonce(&self) -> B256 {
         self.nonce
+    }
+
+    fn message_bytes(&self) -> &[u8] {
+        &self.message
     }
 
     fn as_bytes(&self) -> &[u8] {
@@ -274,6 +312,11 @@ pub enum CctpError {
     Evm(#[from] EvmError),
     #[error("Contract view error: {0}")]
     Contract(#[from] alloy::contract::Error),
+    /// Transport error from a direct `provider()` query (e.g. `get_logs`,
+    /// `get_transaction_receipt`). Wallet-mediated transport errors arrive via
+    /// [`CctpError::Evm`] instead.
+    #[error("RPC transport error: {0}")]
+    Transport(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("Attestation timeout after {attempts} attempts: {source}")]
@@ -285,6 +328,10 @@ pub enum CctpError {
     MessageSentEventNotFound,
     #[error("MintAndWithdraw event not found in transaction receipt")]
     MintAndWithdrawEventNotFound,
+    #[error(
+        "nonce {nonce} reports as used but no MessageReceived log was found to locate the mint"
+    )]
+    MintReceiveLogNotFound { nonce: B256 },
     #[error("Message too short for nonce extraction: got {length} bytes, need at least 44")]
     MessageTooShort { length: usize },
     #[error("Fee calculation overflow")]
@@ -533,13 +580,10 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
                 source: err,
             })?;
 
-        let nonce = extract_nonce_from_message(&message)?;
-
-        Ok(AttestationResponse {
-            message,
-            attestation,
-            nonce,
-        })
+        AttestationResponse::from_message_and_attestation(
+            CctpMessage(message),
+            CctpAttestation(attestation),
+        )
     }
 
     /// Burns USDC on the source chain for the given bridge direction.
@@ -593,6 +637,49 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     fn with_circle_api_base(mut self, base_url: String) -> Self {
         self.circle_api_base = base_url;
         self
+    }
+
+    /// Returns the receipt of an already-executed mint for `nonce` on the
+    /// destination chain of `direction`, or `None` if the nonce is unused.
+    ///
+    /// Used by crash-recovery resume to avoid re-submitting `receiveMessage`
+    /// (which reverts on a consumed nonce) when a mint already landed but its
+    /// confirming event was not yet persisted.
+    pub async fn find_existing_mint(
+        &self,
+        direction: BridgeDirection,
+        nonce: B256,
+    ) -> Result<Option<crate::MintReceipt>, CctpError> {
+        let receipt = match direction {
+            BridgeDirection::EthereumToBase => {
+                self.base
+                    .find_existing_mint::<OpenChainErrorRegistry>(nonce)
+                    .await?
+            }
+            BridgeDirection::BaseToEthereum => {
+                self.ethereum
+                    .find_existing_mint::<OpenChainErrorRegistry>(nonce)
+                    .await?
+            }
+        };
+
+        Ok(receipt.map(|receipt| crate::MintReceipt {
+            tx: receipt.tx,
+            amount: receipt.amount,
+            fee: receipt.fee_collected,
+        }))
+    }
+
+    /// Returns `holder`'s USDC balance on Base, the destination chain for
+    /// AlpacaToBase mints.
+    ///
+    /// Used as an idempotency guard before re-depositing on resume from `Bridged`:
+    /// if the freshly minted USDC is no longer in the wallet, the vault deposit
+    /// already landed, so re-submitting it would double-deposit (or revert).
+    pub async fn base_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
+        self.base
+            .usdc_balance::<OpenChainErrorRegistry>(holder)
+            .await
     }
 }
 
@@ -662,6 +749,7 @@ mod tests {
     use st0x_evm::local::RawPrivateKeyWallet;
 
     use super::*;
+    use crate::Attestation;
 
     const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
@@ -1837,6 +1925,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_existing_mint_returns_none_before_mint_and_recovers_receipt_after() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(2_500_000u64); // 2.5 USDC
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+        let nonce = extract_nonce_from_message(&message_with_nonce).unwrap();
+
+        // Before the mint the nonce is unconsumed, so there is nothing to recover.
+        let before = bridge
+            .find_existing_mint(BridgeDirection::EthereumToBase, nonce)
+            .await
+            .unwrap();
+        assert_eq!(
+            before, None,
+            "unused nonce must report no existing mint, got: {before:?}"
+        );
+
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce,
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        // After the mint the nonce is consumed; recovery reconstructs the exact
+        // receipt (tx + net amount + fee) from the on-chain events without re-minting.
+        let recovered = bridge
+            .find_existing_mint(BridgeDirection::EthereumToBase, nonce)
+            .await
+            .unwrap()
+            .expect("consumed nonce must report the existing mint");
+
+        assert_eq!(
+            recovered.tx, mint_receipt.tx,
+            "recovered mint tx must match"
+        );
+        assert_eq!(
+            recovered.amount, mint_receipt.amount,
+            "recovered net amount must match the MintAndWithdraw event"
+        );
+        assert_eq!(
+            recovered.fee, mint_receipt.fee_collected,
+            "recovered fee must match the MintAndWithdraw event"
+        );
+    }
+
+    #[tokio::test]
     async fn test_mint_on_ethereum_with_invalid_attestation() {
         let cctp = LocalCctp::new().await.unwrap();
         let bridge = cctp.create_bridge().await.unwrap();
@@ -1957,6 +2107,41 @@ mod tests {
         let nonce = extract_nonce_from_message(&message).unwrap();
 
         assert_eq!(nonce, FixedBytes::from(expected_nonce));
+    }
+
+    #[test]
+    fn attestation_response_reconstructs_nonce_from_persisted_message() {
+        let expected_nonce = [0x42; 32];
+        let message = Bytes::from(build_nonce_message(
+            &[0u8; NONCE_INDEX],
+            expected_nonce,
+            &[0xAA; 8],
+        ));
+        let attestation = Bytes::from(vec![0x11, 0x22, 0x33]);
+
+        let response = AttestationResponse::from_message_and_attestation(
+            CctpMessage(message.clone()),
+            CctpAttestation(attestation.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(response.nonce(), FixedBytes::from(expected_nonce));
+        assert_eq!(response.message_bytes(), message.as_ref());
+        assert_eq!(response.as_bytes(), attestation.as_ref());
+    }
+
+    #[test]
+    fn attestation_response_rejects_too_short_persisted_message() {
+        let error = AttestationResponse::from_message_and_attestation(
+            CctpMessage(Bytes::from(vec![0; 43])),
+            CctpAttestation(Bytes::new()),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, CctpError::MessageTooShort { length: 43 }),
+            "Expected MessageTooShort with length 43, got: {error:?}"
+        );
     }
 
     #[test]

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -31,7 +31,7 @@ pub struct BurnReceipt {
 }
 
 /// Receipt from minting USDC on the destination chain.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MintReceipt {
     /// Transaction hash of the mint transaction
     pub tx: TxHash,
@@ -45,6 +45,9 @@ pub struct MintReceipt {
 pub trait Attestation: Send + Sync {
     /// Returns the 32-byte CCTP V2 nonce for this attestation.
     fn nonce(&self) -> B256;
+
+    /// Returns the raw CCTP message bytes attested by Circle.
+    fn message_bytes(&self) -> &[u8];
 
     /// Returns the raw attestation bytes.
     fn as_bytes(&self) -> &[u8];

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -60,6 +60,7 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+use crate::rebalancing::usdc::CrossVenueCashTransfer;
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
     RebalancingServiceConfig,
@@ -70,6 +71,7 @@ use crate::tokenization::alpaca::AlpacaTokenizationService;
 use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{DexTradeAccountingJobQueue, TradeAccountingError};
+use crate::usdc_rebalance::{UsdcRebalance, UsdcRebalanceId, resumable_usdc_rebalance_ids};
 use crate::vault_registry::{
     SeedVaultRegistry, SeedVaultRegistryCtx, SeedVaultRegistryJobQueue, VaultRegistry,
     VaultRegistryCommand, VaultRegistryId,
@@ -857,12 +859,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .recover_usdc_guard(&deps.pool, &built.usdc)
             .await?;
 
-        let frameworks = RebalancingCqrsFrameworks {
-            mint: built.mint,
-            redemption: built.redemption,
-            usdc: built.usdc,
-        };
-
         let alpaca_wallet = Arc::new(AlpacaWalletService::new(
             alpaca_auth.base_url().to_string(),
             alpaca_auth.account_id,
@@ -889,6 +885,26 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .as_ref()
             .and_then(|cash| cash.vault_ids.first().copied())
             .ok_or(CtxError::MissingCashVaultId)?;
+
+        let recovery_cash_transfer = Arc::new(services.usdc_transfer(
+            market_maker_wallet,
+            RaindexVaultId(usdc_vault_id),
+            built.usdc.clone(),
+        ));
+
+        recover_interrupted_usdc_rebalance_aggregates(
+            &deps.pool,
+            &rebalancing_service,
+            &recovery_cash_transfer,
+            built.usdc.clone(),
+        )
+        .await?;
+
+        let frameworks = RebalancingCqrsFrameworks {
+            mint: built.mint,
+            redemption: built.redemption,
+            usdc: built.usdc,
+        };
 
         let mint_store = frameworks.mint.clone();
         let redemption_store = frameworks.redemption.clone();
@@ -991,6 +1007,62 @@ async fn recover_interrupted_tokenization_aggregates(
     resume_interrupted_transfers(transfer, &interrupted_mints, &interrupted_redemptions).await;
 
     Ok(())
+}
+
+async fn recover_interrupted_usdc_rebalance_aggregates<Chain: Wallet>(
+    pool: &SqlitePool,
+    rebalancing_service: &RebalancingService,
+    transfer: &CrossVenueCashTransfer<Chain>,
+    usdc_store: Arc<Store<UsdcRebalance>>,
+) -> anyhow::Result<()> {
+    let interrupted_rebalances = resumable_usdc_rebalance_ids(pool).await?;
+
+    for id in &interrupted_rebalances {
+        let Some(rebalance) = usdc_store.load(id).await? else {
+            // Skip rather than abort startup: the resume pass below is non-fatal
+            // per id, so a single missing aggregate should not block the whole
+            // server from coming up. resume_usdc_rebalance also surfaces this as
+            // AggregateNotFound and skips it.
+            warn!(
+                target: "rebalance",
+                %id,
+                "Interrupted USDC rebalance aggregate missing from store; skipping recovery"
+            );
+            continue;
+        };
+
+        rebalancing_service
+            .recover_usdc_rebalance_state(id, &rebalance)
+            .await?;
+    }
+
+    resume_interrupted_usdc_rebalances(transfer, &interrupted_rebalances).await;
+
+    Ok(())
+}
+
+async fn resume_interrupted_usdc_rebalances<Chain: Wallet>(
+    transfer: &CrossVenueCashTransfer<Chain>,
+    interrupted_rebalances: &[UsdcRebalanceId],
+) {
+    let mut failed_rebalances = 0usize;
+
+    for id in interrupted_rebalances {
+        failed_rebalances += usize::from(
+            transfer
+                .resume_usdc_rebalance(id)
+                .await
+                .inspect_err(|error| {
+                    error!(%id, ?error, "Failed to resume USDC rebalance -- skipping");
+                })
+                .is_err(),
+        );
+    }
+
+    info!(
+        count = interrupted_rebalances.len(),
+        failed_rebalances, "Interrupted USDC rebalance resume completed"
+    );
 }
 
 async fn resume_interrupted_transfers(

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -111,6 +111,23 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         })
     }
 
+    pub(crate) fn usdc_transfer(
+        &self,
+        market_maker_wallet: Address,
+        usdc_vault_id: RaindexVaultId,
+        usdc_store: Arc<Store<UsdcRebalance>>,
+    ) -> CrossVenueCashTransfer<Chain> {
+        CrossVenueCashTransfer::new(
+            self.broker.clone(),
+            self.wallet.clone(),
+            self.cctp.clone(),
+            self.raindex.clone(),
+            usdc_store,
+            market_maker_wallet,
+            usdc_vault_id,
+        )
+    }
+
     /// Spawns the rebalancer as a background task.
     ///
     /// All CQRS frameworks are created in the conductor and passed here to
@@ -125,6 +142,9 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
         usdc_in_progress: Arc<AtomicBool>,
     ) -> (JoinHandle<()>, CancellationToken) {
+        let usdc =
+            Arc::new(self.usdc_transfer(market_maker_wallet, usdc_vault_id, frameworks.usdc));
+
         let equity = Arc::new(CrossVenueEquityTransfer::new(
             self.raindex.clone(),
             self.tokenizer,
@@ -132,16 +152,6 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             market_maker_wallet,
             frameworks.mint,
             frameworks.redemption,
-        ));
-
-        let usdc = Arc::new(CrossVenueCashTransfer::new(
-            self.broker,
-            self.wallet,
-            self.cctp,
-            self.raindex,
-            frameworks.usdc,
-            market_maker_wallet,
-            usdc_vault_id,
         ));
 
         let shutdown_token = CancellationToken::new();

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -6619,6 +6619,282 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recover_usdc_rebalance_state_restores_deposit_initiated_tracking() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::DepositInitiated {
+            direction: RebalanceDirection::AlpacaToBase,
+            initiated_amount: usdc(500),
+            amount: usdc(499),
+            burn_tx_hash: TxHash::random(),
+            mint_tx_hash: TxHash::random(),
+            deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+            initiated_at,
+            deposit_initiated_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::AlpacaToBase,
+            usdc(500),
+            Some(usdc(499)),
+            usdc::UsdcRebalanceStage::DepositInitiated,
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), Some(&id));
+        assert_eq!(inventory.usdc_available(Venue::Hedging), Some(usdc(400)));
+        assert_eq!(inventory.usdc_inflight(Venue::Hedging), Some(usdc(500)));
+        drop(inventory);
+        assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_restores_bridging_tracking() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::Bridging {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: usdc(500),
+            burn_tx_hash: TxHash::random(),
+            initiated_at,
+            burned_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::AlpacaToBase,
+            usdc(500),
+            None,
+            usdc::UsdcRebalanceStage::BridgingInitiated,
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), Some(&id));
+        assert_eq!(inventory.usdc_available(Venue::Hedging), Some(usdc(400)));
+        assert_eq!(inventory.usdc_inflight(Venue::Hedging), Some(usdc(500)));
+        drop(inventory);
+        assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_restores_attested_tracking() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::Attested {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: usdc(500),
+            burn_tx_hash: TxHash::random(),
+            cctp_nonce: B256::random(),
+            message: vec![0u8; 44],
+            attestation: vec![0x01],
+            initiated_at,
+            attested_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::AlpacaToBase,
+            usdc(500),
+            None,
+            usdc::UsdcRebalanceStage::BridgeAttestationReceived,
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), Some(&id));
+        assert_eq!(inventory.usdc_available(Venue::Hedging), Some(usdc(400)));
+        assert_eq!(inventory.usdc_inflight(Venue::Hedging), Some(usdc(500)));
+        drop(inventory);
+        assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_restores_bridged_tracking_base_to_alpaca() {
+        // BaseToAlpaca sources from the market-making venue, so seed it with the
+        // balance and assert the Start lands on MarketMaking, not Hedging.
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::Bridged {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: usdc(500),
+            amount_received: usdc(499),
+            fee_collected: usdc(1),
+            burn_tx_hash: TxHash::random(),
+            mint_tx_hash: TxHash::random(),
+            initiated_at,
+            minted_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::BaseToAlpaca,
+            usdc(500),
+            Some(usdc(499)),
+            usdc::UsdcRebalanceStage::Bridged,
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), Some(&id));
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(400))
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(usdc(500))
+        );
+        drop(inventory);
+        assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_restores_base_to_alpaca_deposit_confirmed() {
+        // BaseToAlpaca DepositConfirmed is non-terminal: the post-deposit conversion
+        // still runs, so recovery must re-track it (guard + inflight) from MarketMaking.
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::DepositConfirmed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: usdc(499),
+            burn_tx_hash: TxHash::random(),
+            mint_tx_hash: TxHash::random(),
+            initiated_at,
+            deposit_confirmed_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert_usdc_tracking_state(
+            &trigger,
+            &id,
+            RebalanceDirection::BaseToAlpaca,
+            usdc(499),
+            Some(usdc(499)),
+            usdc::UsdcRebalanceStage::DepositConfirmed,
+        )
+        .await;
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(inventory.active_usdc_rebalance(), Some(&id));
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(401))
+        );
+        assert_eq!(
+            inventory.usdc_inflight(Venue::MarketMaking),
+            Some(usdc(499))
+        );
+        drop(inventory);
+        assert!(trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_skips_alpaca_to_base_deposit_confirmed() {
+        // AlpacaToBase DepositConfirmed is terminal -> recovery must NOT re-track it.
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::DepositConfirmed {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: usdc(499),
+            burn_tx_hash: TxHash::random(),
+            mint_tx_hash: TxHash::random(),
+            initiated_at,
+            deposit_confirmed_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        assert!(!trigger.usdc_tracking.read().await.contains_key(&id));
+        assert!(!trigger.usdc_in_progress.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn recover_usdc_rebalance_state_skips_duplicate_recovery() {
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+
+        let state = UsdcRebalance::Bridging {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: usdc(500),
+            burn_tx_hash: TxHash::random(),
+            initiated_at,
+            burned_at: initiated_at + ChronoDuration::seconds(30),
+        };
+
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+        // A second recovery for the same id must not re-apply the inflight Start.
+        trigger
+            .recover_usdc_rebalance_state(&id, &state)
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        let available = inventory.usdc_available(Venue::Hedging);
+        let inflight = inventory.usdc_inflight(Venue::Hedging);
+        drop(inventory);
+
+        assert_eq!(available, Some(usdc(400)));
+        assert_eq!(inflight, Some(usdc(500)));
+    }
+
+    #[tokio::test]
     async fn alpaca_to_base_usdc_lifecycle_tracks_started_and_cleared_inflight() {
         let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
@@ -7777,6 +8053,7 @@ mod tests {
 
     fn make_usdc_bridge_attestation_received() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgeAttestationReceived {
+            message: vec![0; 44],
             attestation: vec![1, 2, 3, 4],
             cctp_nonce: B256::left_padding_from(&42u64.to_be_bytes()),
             attested_at: Utc::now(),
@@ -8878,6 +9155,7 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
+                    message: vec![0; 44],
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
                 },
@@ -8964,6 +9242,7 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
+                    message: vec![0; 44],
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&67890u64.to_be_bytes()),
                 },
@@ -9261,6 +9540,7 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::ReceiveAttestation {
+                    message: vec![0; 44],
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
                 },

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -15,7 +15,9 @@ use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
 };
-use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent, UsdcRebalanceId};
+use crate::usdc_rebalance::{
+    RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum UsdcTrackingEvent {
@@ -46,6 +48,94 @@ pub(super) struct UsdcRebalanceTracking {
 }
 
 impl UsdcRebalanceTracking {
+    fn from_recovered_state(entity: &UsdcRebalance) -> Option<Self> {
+        match entity {
+            UsdcRebalance::Bridging {
+                direction,
+                amount,
+                burned_at,
+                ..
+            } => Some(Self {
+                direction: direction.clone(),
+                initiated_amount: *amount,
+                bridged_amount_received: None,
+                stage: UsdcRebalanceStage::BridgingInitiated,
+                last_progress_at: *burned_at,
+            }),
+            UsdcRebalance::Attested {
+                direction,
+                amount,
+                attested_at,
+                ..
+            } => Some(Self {
+                direction: direction.clone(),
+                initiated_amount: *amount,
+                bridged_amount_received: None,
+                stage: UsdcRebalanceStage::BridgeAttestationReceived,
+                last_progress_at: *attested_at,
+            }),
+            UsdcRebalance::Bridged {
+                direction,
+                amount,
+                amount_received,
+                minted_at,
+                ..
+            } => Some(Self {
+                direction: direction.clone(),
+                initiated_amount: *amount,
+                bridged_amount_received: Some(*amount_received),
+                stage: UsdcRebalanceStage::Bridged,
+                last_progress_at: *minted_at,
+            }),
+            UsdcRebalance::DepositInitiated {
+                direction,
+                initiated_amount,
+                amount,
+                deposit_initiated_at,
+                ..
+            } => Some(Self {
+                direction: direction.clone(),
+                initiated_amount: *initiated_amount,
+                bridged_amount_received: Some(*amount),
+                stage: UsdcRebalanceStage::DepositInitiated,
+                last_progress_at: *deposit_initiated_at,
+            }),
+            // BaseToAlpaca: DepositConfirmed is non-terminal (post-deposit USDC->USD
+            // conversion still pending), so it must stay tracked through the resumed
+            // conversion. The aggregate dropped the pre-bridge `initiated_amount` at
+            // this stage, so we track the post-bridge `amount` (USDC received) -- the
+            // figure the resumed conversion and its terminal settle both reference.
+            UsdcRebalance::DepositConfirmed {
+                direction: direction @ RebalanceDirection::BaseToAlpaca,
+                amount,
+                deposit_confirmed_at,
+                ..
+            } => Some(Self {
+                direction: direction.clone(),
+                initiated_amount: *amount,
+                bridged_amount_received: Some(*amount),
+                stage: UsdcRebalanceStage::DepositConfirmed,
+                last_progress_at: *deposit_confirmed_at,
+            }),
+            // Non-resumable states carry no in-flight bridge to re-track. Listed
+            // explicitly (rather than a wildcard) so a new mid-flight variant forces
+            // a compile-time decision about whether recovery must track it.
+            // AlpacaToBase DepositConfirmed is terminal, hence non-recoverable here.
+            UsdcRebalance::Converting { .. }
+            | UsdcRebalance::ConversionComplete { .. }
+            | UsdcRebalance::ConversionFailed { .. }
+            | UsdcRebalance::Withdrawing { .. }
+            | UsdcRebalance::WithdrawalComplete { .. }
+            | UsdcRebalance::WithdrawalFailed { .. }
+            | UsdcRebalance::BridgingFailed { .. }
+            | UsdcRebalance::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            }
+            | UsdcRebalance::DepositFailed { .. } => None,
+        }
+    }
+
     pub(super) fn source_venue(&self) -> Venue {
         match self.direction {
             RebalanceDirection::AlpacaToBase => Venue::Hedging,
@@ -487,6 +577,56 @@ fn truncate_for_transfer(amount: Usdc) -> Result<Usdc, FloatError> {
 }
 
 impl RebalancingService {
+    pub(crate) async fn recover_usdc_rebalance_state(
+        &self,
+        id: &UsdcRebalanceId,
+        entity: &UsdcRebalance,
+    ) -> Result<(), RebalancingServiceError> {
+        let Some(tracking) = UsdcRebalanceTracking::from_recovered_state(entity) else {
+            debug!(
+                target: "rebalance",
+                %id,
+                state = ?entity,
+                "Skipping recovery for non-resumable USDC rebalance state"
+            );
+            return Ok(());
+        };
+
+        // Idempotent recovery: if this rebalance is already tracked, the inflight
+        // Start was already applied for it this run. Re-applying it (e.g. if the
+        // same id were recovered twice) would double-count in-flight USDC, so skip.
+        if self.usdc_tracking.read().await.contains_key(id) {
+            warn!(
+                target: "rebalance",
+                %id,
+                "USDC rebalance already tracked; skipping duplicate state recovery"
+            );
+            return Ok(());
+        }
+
+        let now = Utc::now();
+        let update = Inventory::transfer(
+            tracking.source_venue(),
+            TransferOp::Start,
+            tracking.initiated_amount,
+        );
+
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory
+            .clone()
+            .update_usdc(update, now)?
+            .set_active_usdc_rebalance(id.clone());
+        drop(inventory);
+
+        self.usdc_tracking
+            .write()
+            .await
+            .insert(id.clone(), tracking);
+        self.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        Ok(())
+    }
+
     pub(super) async fn on_usdc_rebalance(
         &self,
         id: UsdcRebalanceId,
@@ -1658,6 +1798,7 @@ mod tests {
 
     fn bridge_attestation_received_event() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgeAttestationReceived {
+            message: vec![0; 44],
             attestation: vec![],
             cctp_nonce: B256::ZERO,
             attested_at: ts(105),

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -4,14 +4,14 @@
 //! `CctpBridge`, `RaindexService`, and the `UsdcRebalance` aggregate to
 //! execute USDC transfers between Alpaca and Base.
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::primitives::{Address, Bytes, TxHash, U256};
 use async_trait::async_trait;
 use std::sync::Arc;
 use tracing::{info, instrument, warn};
 use uuid::Uuid;
 
 use rain_math_float::Float;
-use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
+use st0x_bridge::cctp::{AttestationResponse, CctpAttestation, CctpBridge, CctpMessage};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
@@ -283,12 +283,15 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let attestation_response = self.poll_attestation(id, &burn_receipt).await?;
 
-        // Use the actual minted amount (net of CCTP fee) for vault deposit
         let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
 
-        self.deposit_to_vault(id, mint_receipt.amount).await?;
-
-        self.confirm_deposit(id).await?;
+        self.continue_after_confirmed_mint(
+            id,
+            RebalanceDirection::AlpacaToBase,
+            mint_receipt.tx,
+            mint_receipt.amount,
+        )
+        .await?;
 
         info!(target: "rebalance", "Alpaca to Base rebalance completed successfully");
         Ok(())
@@ -426,9 +429,19 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         burn_receipt: &BurnReceipt,
     ) -> Result<AttestationResponse, UsdcTransferError> {
+        self.poll_attestation_for_direction(id, &RebalanceDirection::AlpacaToBase, burn_receipt.tx)
+            .await
+    }
+
+    async fn poll_attestation_for_direction(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: &RebalanceDirection,
+        burn_tx: TxHash,
+    ) -> Result<AttestationResponse, UsdcTransferError> {
         let response = match self
             .cctp_bridge
-            .poll_attestation(BridgeDirection::EthereumToBase, burn_receipt.tx)
+            .poll_attestation(bridge_direction(direction), burn_tx)
             .await
         {
             Ok(response) => response,
@@ -450,6 +463,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .send(
                 id,
                 UsdcRebalanceCommand::ReceiveAttestation {
+                    message: response.message_bytes().to_vec(),
                     attestation: response.as_bytes().to_vec(),
                     cctp_nonce: response.nonce(),
                 },
@@ -466,24 +480,64 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
     ) -> Result<MintReceipt, UsdcTransferError> {
+        self.execute_cctp_mint_for_direction(
+            id,
+            &RebalanceDirection::AlpacaToBase,
+            attestation_response,
+        )
+        .await
+    }
+
+    async fn execute_cctp_mint_for_direction(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: &RebalanceDirection,
+        attestation_response: AttestationResponse,
+    ) -> Result<MintReceipt, UsdcTransferError> {
+        let bridge_direction = bridge_direction(direction);
+
+        // Idempotency for crash recovery: a CCTP nonce can only be minted once, and
+        // `receiveMessage` reverts on an already-consumed nonce. If the process died
+        // after the mint confirmed on-chain but before `ConfirmBridging` was
+        // persisted, the aggregate is still `Bridging`/`Attested` and a naive resume
+        // would re-submit the mint, hit the revert, and incorrectly fail the bridge --
+        // stranding the already-minted USDC. So before minting we check whether the
+        // nonce was already consumed and, if so, recover the prior mint receipt and
+        // continue from there instead of re-submitting.
         let mint_receipt = match self
             .cctp_bridge
-            .mint(BridgeDirection::EthereumToBase, &attestation_response)
+            .find_existing_mint(bridge_direction, attestation_response.nonce())
             .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
         {
-            Ok(receipt) => receipt,
-            Err(error) => {
-                warn!(target: "rebalance", "CCTP mint failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Mint failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
+            Some(existing) => {
+                info!(
+                    target: "rebalance",
+                    %id,
+                    mint_tx = %existing.tx,
+                    "CCTP nonce already minted; recovering existing mint receipt instead of re-minting"
+                );
+                existing
             }
+            None => match self
+                .cctp_bridge
+                .mint(bridge_direction, &attestation_response)
+                .await
+            {
+                Ok(receipt) => receipt,
+                Err(error) => {
+                    warn!(target: "rebalance", "CCTP mint failed: {error}");
+                    self.cqrs
+                        .send(
+                            id,
+                            UsdcRebalanceCommand::FailBridging {
+                                reason: format!("Mint failed: {error}"),
+                            },
+                        )
+                        .await?;
+                    return Err(UsdcTransferError::Cctp(Box::new(error)));
+                }
+            },
         };
 
         self.cqrs
@@ -506,12 +560,85 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         Ok(mint_receipt)
     }
 
+    async fn continue_after_confirmed_mint(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: RebalanceDirection,
+        mint_tx: TxHash,
+        amount_received: U256,
+    ) -> Result<(), UsdcTransferError> {
+        let amount_received = u256_to_usdc(amount_received)?;
+
+        self.continue_after_bridged_state(id, direction, mint_tx, amount_received)
+            .await
+    }
+
+    async fn continue_after_bridged_state(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: RebalanceDirection,
+        mint_tx: TxHash,
+        amount_received: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        match direction {
+            RebalanceDirection::AlpacaToBase => {
+                self.deposit_to_vault(id, usdc_to_u256(amount_received)?)
+                    .await?;
+                self.confirm_deposit(id).await
+            }
+            RebalanceDirection::BaseToAlpaca => {
+                self.poll_and_confirm_alpaca_deposit(id, mint_tx).await?;
+                self.execute_usdc_to_usd_conversion(id, amount_received)
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
     async fn deposit_to_vault(
         &self,
         id: &UsdcRebalanceId,
         amount: U256,
     ) -> Result<(), UsdcTransferError> {
+        // Idempotency guard for crash recovery. Unlike the CCTP mint (protected by
+        // usedNonces), a vault deposit has no on-chain idempotency primitive, so a
+        // resume from `Bridged` could re-submit a deposit that already landed in the
+        // crash window between the deposit confirming and `InitiateDeposit` being
+        // persisted. The bridged USDC is minted to (and deposited from) the
+        // market-maker wallet, so if that wallet no longer holds the amount we are
+        // about to deposit, the deposit already happened: refuse to re-submit (which
+        // would double-deposit or revert) and surface for operator review. On the
+        // live path the wallet still holds the freshly minted USDC, so this is a
+        // no-op. NOTE: this prevents the double-spend but does not auto-complete the
+        // already-deposited aggregate; an operator must reconcile it. It is also a
+        // balance heuristic, not an authoritative idempotency check: the market-maker
+        // wallet is the shared trading wallet, so if it independently holds >= `amount`
+        // of operational float the guard can false-negative and still re-deposit. An
+        // authoritative deposit-already-landed check (e.g. matching the vault deposit
+        // event) is tracked as a follow-up.
+        let available = self
+            .cctp_bridge
+            .base_usdc_balance(self.market_maker_wallet)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
+        if available < amount {
+            let available = u256_to_usdc(available)?;
+            let required = u256_to_usdc(amount)?;
+            warn!(
+                target: "rebalance",
+                %id,
+                %available,
+                %required,
+                "Skipping vault deposit: minted USDC already left the wallet (deposit already landed)"
+            );
+            return Err(UsdcTransferError::DepositFundsAlreadyMoved {
+                available,
+                required,
+            });
+        }
+
         let deposit_tx = match self.raindex.deposit_usdc(self.vault_id, amount).await {
             Ok(tx) => tx,
             Err(error) => {
@@ -584,21 +711,131 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .poll_attestation_for_base_burn(id, &burn_receipt)
             .await?;
 
-        // Use the actual minted amount (net of CCTP fee) for downstream operations
         let mint_receipt = self
             .execute_cctp_mint_on_ethereum(id, attestation_response)
             .await?;
 
-        self.poll_and_confirm_alpaca_deposit(id, mint_receipt.tx)
-            .await?;
-
-        // Convert deposited USDC to USD buying power using actual received amount
-        let amount_received = u256_to_usdc(mint_receipt.amount)?;
-        self.execute_usdc_to_usd_conversion(id, amount_received)
-            .await?;
+        self.continue_after_confirmed_mint(
+            id,
+            RebalanceDirection::BaseToAlpaca,
+            mint_receipt.tx,
+            mint_receipt.amount,
+        )
+        .await?;
 
         info!(target: "rebalance", "Base to Alpaca rebalance completed successfully");
         Ok(())
+    }
+
+    #[instrument(target = "rebalance", skip(self), fields(%id), level = tracing::Level::DEBUG)]
+    pub(crate) async fn resume_usdc_rebalance(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<(), UsdcTransferError> {
+        let Some(state) = self.cqrs.load(id).await? else {
+            return Err(UsdcTransferError::AggregateNotFound { id: id.clone() });
+        };
+
+        match state {
+            UsdcRebalance::Bridging {
+                direction,
+                burn_tx_hash,
+                ..
+            } => {
+                let response = self
+                    .poll_attestation_for_direction(id, &direction, burn_tx_hash)
+                    .await?;
+                let mint_receipt = self
+                    .execute_cctp_mint_for_direction(id, &direction, response)
+                    .await?;
+                self.continue_after_confirmed_mint(
+                    id,
+                    direction,
+                    mint_receipt.tx,
+                    mint_receipt.amount,
+                )
+                .await
+            }
+            UsdcRebalance::Attested {
+                direction,
+                message,
+                attestation,
+                ..
+            } => {
+                let response = AttestationResponse::from_message_and_attestation(
+                    CctpMessage(Bytes::from(message)),
+                    CctpAttestation(Bytes::from(attestation)),
+                )
+                .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+                let mint_receipt = self
+                    .execute_cctp_mint_for_direction(id, &direction, response)
+                    .await?;
+                self.continue_after_confirmed_mint(
+                    id,
+                    direction,
+                    mint_receipt.tx,
+                    mint_receipt.amount,
+                )
+                .await
+            }
+            UsdcRebalance::Bridged {
+                direction,
+                mint_tx_hash,
+                amount_received,
+                ..
+            } => {
+                self.continue_after_bridged_state(id, direction, mint_tx_hash, amount_received)
+                    .await
+            }
+            UsdcRebalance::DepositInitiated {
+                direction,
+                mint_tx_hash,
+                amount,
+                ..
+            } => {
+                self.resume_after_deposit_initiated(id, direction, mint_tx_hash, amount)
+                    .await
+            }
+            // For BaseToAlpaca, DepositConfirmed is NOT terminal -- the bridged USDC
+            // still needs the post-deposit USDC->USD conversion. A crash here would
+            // otherwise leave the USDC unconverted on Alpaca. AlpacaToBase
+            // DepositConfirmed is terminal and is excluded by the interrupted query,
+            // so it only reaches here in tests; treat it as the no-op it is.
+            UsdcRebalance::DepositConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                ..
+            } => {
+                info!(
+                    target: "rebalance",
+                    %id,
+                    %amount,
+                    "Resuming BaseToAlpaca post-deposit USDC->USD conversion after restart"
+                );
+                self.execute_usdc_to_usd_conversion(id, amount).await?;
+                Ok(())
+            }
+            state @ (UsdcRebalance::Converting { .. }
+            | UsdcRebalance::ConversionComplete { .. }
+            | UsdcRebalance::ConversionFailed { .. }
+            | UsdcRebalance::Withdrawing { .. }
+            | UsdcRebalance::WithdrawalComplete { .. }
+            | UsdcRebalance::WithdrawalFailed { .. }
+            | UsdcRebalance::BridgingFailed { .. }
+            | UsdcRebalance::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            }
+            | UsdcRebalance::DepositFailed { .. }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    ?state,
+                    "Skipping USDC resume for non-resumable state"
+                );
+                Ok(())
+            }
+        }
     }
 
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
@@ -685,38 +922,8 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         burn_receipt: &BurnReceipt,
     ) -> Result<AttestationResponse, UsdcTransferError> {
-        let response = match self
-            .cctp_bridge
-            .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
+        self.poll_attestation_for_direction(id, &RebalanceDirection::BaseToAlpaca, burn_receipt.tx)
             .await
-        {
-            Ok(response) => response,
-            Err(error) => {
-                warn!(target: "rebalance", "Attestation polling failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Attestation polling failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
-            }
-        };
-
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ReceiveAttestation {
-                    attestation: response.as_bytes().to_vec(),
-                    cctp_nonce: response.nonce(),
-                },
-            )
-            .await?;
-
-        info!(target: "rebalance", "Circle attestation received for Base burn");
-        Ok(response)
     }
 
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
@@ -725,44 +932,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         attestation_response: AttestationResponse,
     ) -> Result<MintReceipt, UsdcTransferError> {
-        let mint_receipt = match self
-            .cctp_bridge
-            .mint(BridgeDirection::BaseToEthereum, &attestation_response)
-            .await
-        {
-            Ok(receipt) => receipt,
-            Err(error) => {
-                warn!(target: "rebalance", "CCTP mint on Ethereum failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Mint on Ethereum failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
-            }
-        };
-
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ConfirmBridging {
-                    mint_tx: mint_receipt.tx,
-                    amount_received: u256_to_usdc(mint_receipt.amount)?,
-                    fee_collected: u256_to_usdc(mint_receipt.fee)?,
-                },
-            )
-            .await?;
-
-        info!(target: "rebalance",
-            mint_tx = %mint_receipt.tx,
-            amount = %mint_receipt.amount,
-            fee = %mint_receipt.fee,
-            "CCTP mint on Ethereum executed"
-        );
-        Ok(mint_receipt)
+        self.execute_cctp_mint_for_direction(
+            id,
+            &RebalanceDirection::BaseToAlpaca,
+            attestation_response,
+        )
+        .await
     }
 
     #[instrument(target = "rebalance", skip(self), fields(%id, %mint_tx), level = tracing::Level::DEBUG)]
@@ -783,6 +958,33 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         info!(target: "rebalance", %mint_tx, "Polling Alpaca for deposit detection");
 
+        self.confirm_alpaca_deposit_from_mint_tx(id, mint_tx).await
+    }
+
+    async fn resume_after_deposit_initiated(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: RebalanceDirection,
+        mint_tx: TxHash,
+        amount_received: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        match direction {
+            RebalanceDirection::AlpacaToBase => self.confirm_deposit(id).await,
+            RebalanceDirection::BaseToAlpaca => {
+                self.confirm_alpaca_deposit_from_mint_tx(id, mint_tx)
+                    .await?;
+                self.execute_usdc_to_usd_conversion(id, amount_received)
+                    .await?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn confirm_alpaca_deposit_from_mint_tx(
+        &self,
+        id: &UsdcRebalanceId,
+        mint_tx: TxHash,
+    ) -> Result<(), UsdcTransferError> {
         let transfer = match self.alpaca_wallet.poll_deposit_by_tx_hash(&mint_tx).await {
             Ok(transfer) => transfer,
             Err(error) => {
@@ -833,6 +1035,13 @@ pub(crate) fn u256_to_usdc(amount: U256) -> Result<Usdc, UsdcTransferError> {
     Ok(Usdc::new(Float::from_fixed_decimal(amount, 6)?))
 }
 
+fn bridge_direction(direction: &RebalanceDirection) -> BridgeDirection {
+    match direction {
+        RebalanceDirection::AlpacaToBase => BridgeDirection::EthereumToBase,
+        RebalanceDirection::BaseToAlpaca => BridgeDirection::BaseToEthereum,
+    }
+}
+
 /// Alpaca -> Base (hedging -> market-making): convert USD to USDC,
 /// withdraw, bridge via CCTP, deposit to vault.
 #[async_trait]
@@ -876,24 +1085,28 @@ mod tests {
     use std::sync::Arc;
     use uuid::{Uuid, uuid};
 
+    use st0x_bridge::cctp::{
+        CctpAttestationMock, CctpBridge, CctpCtx, CctpError, DeployedCctpChain,
+        deploy_cctp_on_chain, link_chains, mint_usdc,
+    };
+    use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder, test_store};
+    use st0x_evm::Wallet;
+    use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_execution::alpaca_broker_api::CryptoOrderFailureReason;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiError, AlpacaBrokerApiMode, Executor,
         TimeInForce,
     };
-
-    use st0x_bridge::cctp::{CctpBridge, CctpCtx};
-    use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder, test_store};
-    use st0x_evm::Wallet;
-    use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_finance::UsdcConversionError;
 
     use super::*;
     use crate::alpaca_wallet::{AlpacaTransferId, AlpacaWalletClient, AlpacaWalletError};
     use crate::onchain::raindex::RaindexService;
     use crate::rebalancing::usdc::mock::MockUsdcRebalance;
-    use crate::usdc_rebalance::{RebalanceDirection, TransferRef, UsdcRebalanceError};
+    use crate::usdc_rebalance::{
+        RebalanceDirection, TransferRef, UsdcRebalanceError, cctp_message_with_nonce_for_test,
+    };
     use crate::vault_registry::VaultRegistry;
-    use st0x_finance::UsdcConversionError;
 
     fn usdc(value: &str) -> Usdc {
         Usdc::from_str(value).unwrap()
@@ -947,6 +1160,7 @@ mod tests {
         cqrs.send(
             id,
             UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
             },
@@ -975,6 +1189,65 @@ mod tests {
         .unwrap();
 
         cqrs.send(id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+    }
+
+    async fn advance_to_deposit_initiated(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        direction: RebalanceDirection,
+        amount: Usdc,
+        amount_received: Usdc,
+        mint_tx: TxHash,
+        deposit: TransferRef,
+    ) {
+        let burn_tx =
+            fixed_bytes!("0xdddd000000000000000000000000000000000000000000000000000000000001");
+        let cctp_nonce = B256::left_padding_from(&99999u64.to_be_bytes());
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message: cctp_message_with_nonce_for_test(cctp_nonce),
+                attestation: vec![0x01],
+                cctp_nonce,
+            },
+        )
+        .await
+        .unwrap();
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received,
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
+
+        cqrs.send(id, UsdcRebalanceCommand::InitiateDeposit { deposit })
             .await
             .unwrap();
     }
@@ -1134,6 +1407,30 @@ mod tests {
                     "filled_qty": if status == "filled" { Some(amount) } else { None },
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
+        })
+    }
+
+    fn create_completed_deposit_mock(server: &MockServer, mint_tx: TxHash) -> httpmock::Mock<'_> {
+        server.mock(move |when, then| {
+            when.method(GET)
+                .path(format!("/v1/accounts/{TEST_ACCOUNT_ID}/wallets/transfers"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": Uuid::new_v4(),
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x9999999999999999999999999999999999999999",
+                    "to_address": "0x1234567890abcdef1234567890abcdef12345678",
+                    "status": "COMPLETE",
+                    "tx_hash": mint_tx,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }]));
         })
     }
 
@@ -1689,6 +1986,722 @@ mod tests {
         );
     }
 
+    /// Locally deployed two-chain CCTP plus an auto-signing attestation mock, so
+    /// manager resume paths can exercise real `receiveMessage` mints / `usedNonces`
+    /// reconstruction. Mirrors the bridge crate's `LocalCctp`, reusing the exported
+    /// deploy helpers. Contract addresses are deterministic (same deployer key +
+    /// deploy order on both anvils), so a single set of addresses wires both chains.
+    #[cfg(feature = "test-support")]
+    struct DeployedCctp {
+        _eth_anvil: alloy::node_bindings::AnvilInstance,
+        _base_anvil: alloy::node_bindings::AnvilInstance,
+        _watcher: tokio::task::JoinHandle<()>,
+        _attestation_mock: CctpAttestationMock,
+        eth_endpoint: String,
+        base_endpoint: String,
+        deployer_key: B256,
+        bot: Address,
+        usdc: Address,
+        token_messenger: Address,
+        message_transmitter: Address,
+        circle_api_base: String,
+    }
+
+    #[cfg(feature = "test-support")]
+    async fn deploy_local_cctp() -> DeployedCctp {
+        use alloy::signers::local::PrivateKeySigner;
+
+        const ETHEREUM_DOMAIN: u32 = 0;
+        const BASE_DOMAIN: u32 = 6;
+
+        let eth_anvil = Anvil::new().spawn();
+        let base_anvil = Anvil::new().spawn();
+        let eth_endpoint = eth_anvil.endpoint();
+        let base_endpoint = base_anvil.endpoint();
+
+        let deployer_key = B256::from_slice(&eth_anvil.keys()[0].to_bytes());
+        let attester_key = B256::from_slice(&eth_anvil.keys()[1].to_bytes());
+        let attester = PrivateKeySigner::from_bytes(&attester_key)
+            .unwrap()
+            .address();
+        let bot = PrivateKeySigner::from_bytes(&deployer_key)
+            .unwrap()
+            .address();
+
+        let eth: DeployedCctpChain =
+            deploy_cctp_on_chain(&eth_endpoint, &deployer_key, ETHEREUM_DOMAIN, attester)
+                .await
+                .unwrap();
+        let base: DeployedCctpChain =
+            deploy_cctp_on_chain(&base_endpoint, &deployer_key, BASE_DOMAIN, attester)
+                .await
+                .unwrap();
+        link_chains(&eth_endpoint, &base_endpoint, &deployer_key, &eth, &base)
+            .await
+            .unwrap();
+
+        // Fund the bot wallet on Base so it can burn (BaseToEthereum direction).
+        mint_usdc(
+            &base_endpoint,
+            &deployer_key,
+            base.usdc,
+            bot,
+            U256::from(1_000_000_000u64),
+        )
+        .await
+        .unwrap();
+
+        let attestation_mock = CctpAttestationMock::start().await;
+        let eth_provider = ProviderBuilder::new().connect_http(eth_endpoint.parse().unwrap());
+        let base_provider = ProviderBuilder::new().connect_http(base_endpoint.parse().unwrap());
+        let watcher = attestation_mock
+            .start_watcher(eth_provider, base_provider, attester_key)
+            .await
+            .unwrap();
+        let circle_api_base = attestation_mock.base_url();
+
+        DeployedCctp {
+            _eth_anvil: eth_anvil,
+            _base_anvil: base_anvil,
+            _watcher: watcher,
+            _attestation_mock: attestation_mock,
+            eth_endpoint,
+            base_endpoint,
+            deployer_key,
+            bot,
+            usdc: eth.usdc,
+            token_messenger: eth.token_messenger,
+            message_transmitter: eth.message_transmitter,
+            circle_api_base,
+        }
+    }
+
+    /// The crash-recovery payload of this PR: when the process died after the CCTP
+    /// mint confirmed on-chain but before `ConfirmBridging` persisted, resuming from
+    /// `Attested` must recover the existing mint via `usedNonces`/`find_existing_mint`
+    /// and continue, NOT re-submit `receiveMessage` (which reverts on the used nonce
+    /// and would strand the minted USDC). Reaching `ConversionComplete` proves no
+    /// re-mint occurred -- a re-mint would revert and surface as an error.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_attested_recovers_existing_mint_without_reminting() {
+        let dep = deploy_local_cctp().await;
+        let server = MockServer::start();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let (_throwaway, vault_service) =
+            create_test_onchain_services(create_test_wallet(&dep.base_endpoint, &dep.deployer_key))
+                .await;
+        // Build the bridge from `create_test_wallet` results so its `Chain` unifies
+        // with the vault service's (both are the same opaque wallet type).
+        let cctp_bridge = Arc::new(
+            CctpBridge::try_from_ctx(CctpCtx {
+                usdc_ethereum: dep.usdc,
+                usdc_base: dep.usdc,
+                ethereum_wallet: create_test_wallet(&dep.eth_endpoint, &dep.deployer_key),
+                base_wallet: create_test_wallet(&dep.base_endpoint, &dep.deployer_key),
+                circle_api_base: dep.circle_api_base.clone(),
+                token_messenger: dep.token_messenger,
+                message_transmitter: dep.message_transmitter,
+            })
+            .unwrap(),
+        );
+        let cqrs = create_test_store_instance().await;
+
+        // Setup: real burn on Base -> mock-signed attestation -> mint on Ethereum,
+        // consuming the nonce, exactly as a pre-crash run would have.
+        let amount = U256::from(100_000_000u64); // 100 USDC
+        let burn = cctp_bridge
+            .burn(BridgeDirection::BaseToEthereum, amount, dep.bot)
+            .await
+            .unwrap();
+        let response = cctp_bridge
+            .poll_attestation(BridgeDirection::BaseToEthereum, burn.tx)
+            .await
+            .unwrap();
+        let nonce = response.nonce();
+        let message = response.message_bytes().to_vec();
+        let attestation = response.as_bytes().to_vec();
+        let mint = cctp_bridge
+            .mint(BridgeDirection::BaseToEthereum, &response)
+            .await
+            .unwrap();
+
+        // Drive an aggregate to Attested carrying the real persisted bytes, as if the
+        // crash happened right after BridgeAttestationReceived committed.
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: usdc("100"),
+                withdrawal: TransferRef::OnchainTx(burn.tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateBridging { burn_tx: burn.tx },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message,
+                attestation,
+                cctp_nonce: nonce,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Alpaca continuation mocks: incoming deposit keyed by the recovered mint tx,
+        // then the USDC->USD conversion order.
+        let deposit_mock = create_completed_deposit_mock(&server, mint.tx);
+        let order_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::clone(&cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            dep.bot,
+            TEST_VAULT_ID,
+        );
+
+        manager.resume_usdc_rebalance(&id).await.unwrap();
+
+        deposit_mock.assert();
+        order_mock.assert();
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                entity,
+                UsdcRebalance::ConversionComplete {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    ..
+                }
+            ),
+            "resume must recover the existing mint and complete, got: {entity:?}"
+        );
+    }
+
+    /// Deposit idempotency guard: resuming an AlpacaToBase rebalance from `Bridged`
+    /// must NOT re-submit the vault deposit when the minted USDC has already left the
+    /// wallet (i.e. the deposit already landed in the crash window). The wallet is
+    /// funded with less USDC than the rebalance's amount, emulating "already
+    /// deposited", and resume must fail fast with `DepositFundsAlreadyMoved` instead
+    /// of re-depositing.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_bridged_alpaca_to_base_guards_against_redepositing() {
+        let dep = deploy_local_cctp().await;
+        let server = MockServer::start();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let (_throwaway, vault_service) =
+            create_test_onchain_services(create_test_wallet(&dep.base_endpoint, &dep.deployer_key))
+                .await;
+        let cctp_bridge = Arc::new(
+            CctpBridge::try_from_ctx(CctpCtx {
+                usdc_ethereum: dep.usdc,
+                usdc_base: dep.usdc,
+                ethereum_wallet: create_test_wallet(&dep.eth_endpoint, &dep.deployer_key),
+                base_wallet: create_test_wallet(&dep.base_endpoint, &dep.deployer_key),
+                circle_api_base: dep.circle_api_base.clone(),
+                token_messenger: dep.token_messenger,
+                message_transmitter: dep.message_transmitter,
+            })
+            .unwrap(),
+        );
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xf00d000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0xf00d111111111111111111111111111111111111111111111111111111111111");
+
+        // Drive to Bridged with amount_received (2000 USDC) far above the wallet's
+        // funded balance (1000 USDC) -- the "minted USDC already left" condition.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: usdc("2000"),
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message: cctp_message_with_nonce_for_test(B256::repeat_byte(0x7)),
+                attestation: vec![0x01],
+                cctp_nonce: B256::repeat_byte(0x7),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received: usdc("2000"),
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::clone(&cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            dep.bot,
+            TEST_VAULT_ID,
+        );
+
+        let error = manager.resume_usdc_rebalance(&id).await.unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::DepositFundsAlreadyMoved { .. }),
+            "expected DepositFundsAlreadyMoved guard, got: {error:?}"
+        );
+        // The aggregate stays at Bridged (resumable / operator-reconcilable), NOT
+        // double-deposited or failed.
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, UsdcRebalance::Bridged { .. }),
+            "aggregate must remain Bridged after the guard, got: {entity:?}"
+        );
+    }
+
+    /// The deposit guard must NOT block a legitimate deposit: when the wallet holds
+    /// at least the deposit amount (the normal post-mint case), resume proceeds past
+    /// the guard into the deposit. Guards against a regression that inverts the
+    /// comparison and rejects every deposit.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_bridged_alpaca_to_base_deposits_when_funds_present() {
+        let dep = deploy_local_cctp().await;
+        let server = MockServer::start();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let (_throwaway, vault_service) =
+            create_test_onchain_services(create_test_wallet(&dep.base_endpoint, &dep.deployer_key))
+                .await;
+        let cctp_bridge = Arc::new(
+            CctpBridge::try_from_ctx(CctpCtx {
+                usdc_ethereum: dep.usdc,
+                usdc_base: dep.usdc,
+                ethereum_wallet: create_test_wallet(&dep.eth_endpoint, &dep.deployer_key),
+                base_wallet: create_test_wallet(&dep.base_endpoint, &dep.deployer_key),
+                circle_api_base: dep.circle_api_base.clone(),
+                token_messenger: dep.token_messenger,
+                message_transmitter: dep.message_transmitter,
+            })
+            .unwrap(),
+        );
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xbeef000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0xbeef111111111111111111111111111111111111111111111111111111111111");
+
+        // amount_received (500 USDC) is well below the wallet's funded balance
+        // (1000 USDC), so the guard is a no-op and the deposit proceeds.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: usdc("500"),
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message: cctp_message_with_nonce_for_test(B256::repeat_byte(0x9)),
+                attestation: vec![0x01],
+                cctp_nonce: B256::repeat_byte(0x9),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received: usdc("500"),
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::clone(&cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            dep.bot,
+            TEST_VAULT_ID,
+        );
+
+        // With sufficient balance the guard is a no-op: resume proceeds INTO the
+        // vault deposit (which then fails against the undeployed vault address on
+        // this anvil -- the vault contract is not part of this CCTP-only harness).
+        // The point is that the failure is NOT the guard: a DepositFundsAlreadyMoved
+        // here would mean the guard wrongly blocked a fully-funded deposit.
+        let error = manager.resume_usdc_rebalance(&id).await.unwrap_err();
+
+        assert!(
+            !matches!(error, UsdcTransferError::DepositFundsAlreadyMoved { .. }),
+            "guard must not block a deposit when the wallet holds sufficient USDC; \
+             got a guard rejection: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_deposit_initiated_confirms_deposit() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let mint_tx =
+            fixed_bytes!("0xaaaa111111111111111111111111111111111111111111111111111111111111");
+
+        advance_to_deposit_initiated(
+            &cqrs,
+            &id,
+            RebalanceDirection::AlpacaToBase,
+            usdc("100"),
+            usdc("99.99"),
+            mint_tx,
+            TransferRef::OnchainTx(fixed_bytes!(
+                "0xaaaa222222222222222222222222222222222222222222222222222222222222"
+            )),
+        )
+        .await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x1111111111111111111111111111111111111111"),
+            TEST_VAULT_ID,
+        );
+
+        manager.resume_usdc_rebalance(&id).await.unwrap();
+
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(matches!(entity, UsdcRebalance::DepositConfirmed { .. }));
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_deposit_initiated_polls_deposit_and_converts() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let mint_tx =
+            fixed_bytes!("0xbbbb111111111111111111111111111111111111111111111111111111111111");
+
+        advance_to_deposit_initiated(
+            &cqrs,
+            &id,
+            RebalanceDirection::BaseToAlpaca,
+            usdc("100"),
+            usdc("99.99"),
+            mint_tx,
+            TransferRef::OnchainTx(mint_tx),
+        )
+        .await;
+
+        let deposit_mock = create_completed_deposit_mock(&server, mint_tx);
+        let order_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x1111111111111111111111111111111111111111"),
+            TEST_VAULT_ID,
+        );
+
+        manager.resume_usdc_rebalance(&id).await.unwrap();
+
+        deposit_mock.assert();
+        order_mock.assert();
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            entity,
+            UsdcRebalance::ConversionComplete {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_polls_deposit_and_converts() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xeeee000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0xeeee111111111111111111111111111111111111111111111111111111111111");
+        let cctp_nonce = B256::left_padding_from(&424_242u64.to_be_bytes());
+
+        // Drive the aggregate to `Bridged` (mint confirmed, deposit not yet started).
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: usdc("100"),
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message: cctp_message_with_nonce_for_test(cctp_nonce),
+                attestation: vec![0x01],
+                cctp_nonce,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received: usdc("99.99"),
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
+
+        let deposit_mock = create_completed_deposit_mock(&server, mint_tx);
+        let order_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x1111111111111111111111111111111111111111"),
+            TEST_VAULT_ID,
+        );
+
+        manager.resume_usdc_rebalance(&id).await.unwrap();
+
+        deposit_mock.assert();
+        order_mock.assert();
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            entity,
+            UsdcRebalance::ConversionComplete {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_deposit_confirmed_runs_post_deposit_conversion() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // DepositConfirmed is terminal for AlpacaToBase but NOT for BaseToAlpaca,
+        // which still owes the USDC->USD conversion. A crash here must resume it.
+        advance_to_deposit_confirmed_base_to_alpaca(&cqrs, &id, usdc("100")).await;
+
+        let order_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            address!("0x1111111111111111111111111111111111111111"),
+            TEST_VAULT_ID,
+        );
+
+        manager.resume_usdc_rebalance(&id).await.unwrap();
+
+        order_mock.assert();
+        let entity = cqrs.load(&id).await.unwrap().unwrap();
+        assert!(matches!(
+            entity,
+            UsdcRebalance::ConversionComplete {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn resume_attested_requires_persisted_message_bytes() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0xcccc111111111111111111111111111111111111111111111111111111111111");
+
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: usdc("100"),
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 43],
+                attestation: vec![0x01],
+                cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs,
+            address!("0x1111111111111111111111111111111111111111"),
+            TEST_VAULT_ID,
+        );
+
+        let error = manager.resume_usdc_rebalance(&id).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::Cctp(ref error)
+                    if matches!(error.as_ref(), CctpError::MessageTooShort { length: 43 })
+            ),
+            "Expected MessageTooShort from persisted message bytes, got: {error:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_conversion_polls_until_filled() {
         let server = MockServer::start();
@@ -1830,6 +2843,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
             },

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -34,6 +34,10 @@ pub(crate) enum UsdcTransferError {
     Vault(#[from] RaindexError),
     #[error("Aggregate error: {0}")]
     Aggregate(Box<SendError<crate::usdc_rebalance::UsdcRebalance>>),
+    #[error("USDC rebalance aggregate {id} not found")]
+    AggregateNotFound {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+    },
     #[error("Withdrawal failed with terminal status: {status}")]
     WithdrawalFailed { status: String },
     #[error("Deposit failed with terminal status: {status}")]
@@ -51,6 +55,12 @@ pub(crate) enum UsdcTransferError {
          filled_quantity is missing"
     )]
     MissingFilledQuantity { order_id: uuid::Uuid },
+    #[error(
+        "vault deposit skipped: wallet holds {available} USDC but {required} is required -- the \
+         minted USDC already left the wallet (deposit already landed pre-crash); leaving the \
+         rebalance resumable for operator review rather than double-depositing"
+    )]
+    DepositFundsAlreadyMoved { available: Usdc, required: Usdc },
 }
 
 impl From<SendError<crate::usdc_rebalance::UsdcRebalance>> for UsdcTransferError {

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -215,6 +215,7 @@ pub(crate) enum UsdcRebalanceCommand {
     /// Record the Circle attestation. Valid only from `Bridging` state.
     /// The cctp_nonce is extracted from the attested message (not the burn tx, which has placeholder).
     ReceiveAttestation {
+        message: Vec<u8>,
         attestation: Vec<u8>,
         cctp_nonce: B256,
     },
@@ -291,6 +292,8 @@ pub(crate) enum UsdcRebalanceEvent {
     /// Circle attestation received. Enables minting on destination chain.
     /// The cctp_nonce is extracted from the attested message (the real nonce, not the placeholder).
     BridgeAttestationReceived {
+        #[serde(default)]
+        message: Vec<u8>,
         attestation: Vec<u8>,
         cctp_nonce: B256,
         attested_at: DateTime<Utc>,
@@ -428,6 +431,8 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         burn_tx_hash: TxHash,
         cctp_nonce: B256,
+        #[serde(default)]
+        message: Vec<u8>,
         attestation: Vec<u8>,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
@@ -459,6 +464,9 @@ pub(crate) enum UsdcRebalance {
     /// Deposit to destination has been initiated
     DepositInitiated {
         direction: RebalanceDirection,
+        /// Original source amount moved into the cross-venue transfer.
+        initiated_amount: Usdc,
+        /// Actual amount minted on the destination chain after CCTP fees.
         amount: Usdc,
         burn_tx_hash: TxHash,
         mint_tx_hash: TxHash,
@@ -798,6 +806,60 @@ pub(crate) async fn interrupted_usdc_rebalance_ids(
         .collect())
 }
 
+/// Returns USDC rebalance aggregate IDs whose latest event is resumable after a
+/// restart -- the ones [`recover_interrupted_usdc_rebalance_aggregates`] drives to
+/// completion. This is narrower than [`interrupted_usdc_rebalance_ids`], which
+/// returns the broader candidate set for in-progress *guard* reassertion.
+pub(crate) async fn resumable_usdc_rebalance_ids(
+    pool: &SqlitePool,
+) -> Result<Vec<UsdcRebalanceId>, sqlx::Error> {
+    let rows: Vec<String> = sqlx::query_scalar(
+        "WITH latest AS ( \
+             SELECT aggregate_id, MAX(sequence) AS max_seq \
+             FROM events \
+             WHERE aggregate_type = 'UsdcRebalance' \
+             GROUP BY aggregate_id \
+         ) \
+         SELECT latest.aggregate_id \
+         FROM events last_ev \
+         INNER JOIN latest \
+             ON last_ev.aggregate_id = latest.aggregate_id \
+            AND last_ev.sequence = latest.max_seq \
+         WHERE last_ev.aggregate_type = 'UsdcRebalance' \
+           AND ( \
+               last_ev.event_type IN ( \
+                   'UsdcRebalanceEvent::BridgingInitiated', \
+                   'UsdcRebalanceEvent::BridgeAttestationReceived', \
+                   'UsdcRebalanceEvent::Bridged', \
+                   'UsdcRebalanceEvent::DepositInitiated' \
+               ) \
+               OR ( \
+                   last_ev.event_type = 'UsdcRebalanceEvent::DepositConfirmed' \
+                   AND json_extract(last_ev.payload, '$.DepositConfirmed.direction') = 'BaseToAlpaca' \
+               ) \
+           ) \
+         ORDER BY latest.aggregate_id",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            UsdcRebalanceId::from_str(&row).map_err(|error| sqlx::Error::Decode(Box::new(error)))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) fn cctp_message_with_nonce_for_test(nonce: B256) -> Vec<u8> {
+    const NONCE_INDEX: usize = 12;
+    const MESSAGE_LENGTH: usize = 44;
+
+    let mut message = vec![0; MESSAGE_LENGTH];
+    message[NONCE_INDEX..MESSAGE_LENGTH].copy_from_slice(nonce.as_slice());
+    message
+}
+
 #[async_trait]
 impl EventSourced for UsdcRebalance {
     type Id = UsdcRebalanceId;
@@ -814,7 +876,9 @@ impl EventSourced for UsdcRebalance {
     // so they rebuild from events. No event upcaster needed: persisted events
     // only ever stored cctp_nonce=null (the nonce bug prevented any successful
     // attestation), which deserializes unchanged into Option<B256>.
-    const SCHEMA_VERSION: u64 = 2;
+    // v3: Attested now persists full attested message bytes, and
+    // DepositInitiated retains the original initiated amount for recovery.
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -975,6 +1039,7 @@ impl EventSourced for UsdcRebalance {
 
             (
                 BridgeAttestationReceived {
+                    message,
                     attestation,
                     cctp_nonce,
                     attested_at,
@@ -991,6 +1056,7 @@ impl EventSourced for UsdcRebalance {
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
+                message: message.clone(),
                 attestation: attestation.clone(),
                 initiated_at: *initiated_at,
                 attested_at: *attested_at,
@@ -1063,6 +1129,7 @@ impl EventSourced for UsdcRebalance {
                 },
                 Self::Bridged {
                     direction,
+                    amount,
                     amount_received,
                     burn_tx_hash,
                     mint_tx_hash,
@@ -1071,6 +1138,7 @@ impl EventSourced for UsdcRebalance {
                 },
             ) => Self::DepositInitiated {
                 direction: direction.clone(),
+                initiated_amount: *amount,
                 amount: *amount_received,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
@@ -1086,6 +1154,7 @@ impl EventSourced for UsdcRebalance {
                 },
                 Self::DepositInitiated {
                     direction,
+                    initiated_amount: _,
                     amount,
                     burn_tx_hash,
                     mint_tx_hash,
@@ -1210,9 +1279,10 @@ impl EventSourced for UsdcRebalance {
             FailWithdrawal { reason } => self.transition_fail_withdrawal(reason),
             InitiateBridging { burn_tx } => self.transition_initiate_bridging(burn_tx),
             ReceiveAttestation {
+                message,
                 attestation,
                 cctp_nonce,
-            } => self.transition_receive_attestation(attestation, cctp_nonce),
+            } => self.transition_receive_attestation(message, attestation, cctp_nonce),
             ConfirmBridging {
                 mint_tx,
                 amount_received,
@@ -1409,6 +1479,7 @@ impl UsdcRebalance {
 
     fn transition_receive_attestation(
         &self,
+        message: Vec<u8>,
         attestation: Vec<u8>,
         cctp_nonce: B256,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
@@ -1421,6 +1492,7 @@ impl UsdcRebalance {
             | Self::WithdrawalComplete { .. }
             | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
             Self::Bridging { .. } => Ok(vec![BridgeAttestationReceived {
+                message,
                 attestation,
                 cctp_nonce,
                 attested_at: Utc::now(),
@@ -1612,6 +1684,117 @@ mod tests {
         fixed_bytes!("0xa01ca42d9082e926a81dc287d973a8f072dfa1b20a4fbf7b20f3abda1b376278");
     const OTHER_CCTP_NONCE: B256 =
         fixed_bytes!("0x524cd90eb8dffcb29fcc163aa8258d84e6cc25abc0b4700d704936812ee39824");
+
+    async fn insert_usdc_event(
+        pool: &SqlitePool,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES ('UsdcRebalance', ?, ?, ?, '1.0', '{}', '{}')",
+        )
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resumable_usdc_rebalance_ids_returns_resumable_bridge_states() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        for (id, event_type) in [
+            (
+                "00000000-0000-0000-0000-000000000001",
+                "UsdcRebalanceEvent::BridgingInitiated",
+            ),
+            (
+                "00000000-0000-0000-0000-000000000002",
+                "UsdcRebalanceEvent::BridgeAttestationReceived",
+            ),
+            (
+                "00000000-0000-0000-0000-000000000003",
+                "UsdcRebalanceEvent::Bridged",
+            ),
+            (
+                "00000000-0000-0000-0000-000000000004",
+                "UsdcRebalanceEvent::DepositInitiated",
+            ),
+        ] {
+            insert_usdc_event(&pool, id, 0, "UsdcRebalanceEvent::Initiated").await;
+            insert_usdc_event(&pool, id, 1, event_type).await;
+        }
+
+        insert_usdc_event(
+            &pool,
+            "00000000-0000-0000-0000-000000000005",
+            0,
+            "UsdcRebalanceEvent::Initiated",
+        )
+        .await;
+        insert_usdc_event(
+            &pool,
+            "00000000-0000-0000-0000-000000000005",
+            1,
+            "UsdcRebalanceEvent::DepositConfirmed",
+        )
+        .await;
+
+        let result = resumable_usdc_rebalance_ids(&pool).await.unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                UsdcRebalanceId::from_str("00000000-0000-0000-0000-000000000001").unwrap(),
+                UsdcRebalanceId::from_str("00000000-0000-0000-0000-000000000002").unwrap(),
+                UsdcRebalanceId::from_str("00000000-0000-0000-0000-000000000003").unwrap(),
+                UsdcRebalanceId::from_str("00000000-0000-0000-0000-000000000004").unwrap(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resumable_usdc_rebalance_ids_includes_base_to_alpaca_deposit_confirmed_only() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        let insert_deposit_confirmed = |id: &'static str, direction: &'static str| {
+            let pool = pool.clone();
+            async move {
+                insert_usdc_event(&pool, id, 0, "UsdcRebalanceEvent::Initiated").await;
+                let payload = format!(
+                    "{{\"DepositConfirmed\":{{\"direction\":\"{direction}\",\
+                     \"deposit_confirmed_at\":\"2026-05-29T00:00:00Z\"}}}}"
+                );
+                sqlx::query(
+                    "INSERT INTO events \
+                     (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+                     VALUES ('UsdcRebalance', ?, 1, 'UsdcRebalanceEvent::DepositConfirmed', '1.0', ?, '{}')",
+                )
+                .bind(id)
+                .bind(payload)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+        };
+
+        // BaseToAlpaca DepositConfirmed is non-terminal (conversion pending) -> resumable.
+        insert_deposit_confirmed("00000000-0000-0000-0000-0000000000b2", "BaseToAlpaca").await;
+        // AlpacaToBase DepositConfirmed is terminal -> excluded.
+        insert_deposit_confirmed("00000000-0000-0000-0000-0000000000a2", "AlpacaToBase").await;
+
+        let result = resumable_usdc_rebalance_ids(&pool).await.unwrap();
+
+        assert_eq!(
+            result,
+            vec![UsdcRebalanceId::from_str("00000000-0000-0000-0000-0000000000b2").unwrap()]
+        );
+    }
 
     #[tokio::test]
     async fn test_initiate_alpaca_to_base() {
@@ -2043,6 +2226,7 @@ mod tests {
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let message = cctp_message_with_nonce_for_test(TEST_CCTP_NONCE);
         let attestation = vec![0x01, 0x02, 0x03, 0x04];
 
         let events = TestHarness::<UsdcRebalance>::with(())
@@ -2062,6 +2246,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: message.clone(),
                 attestation: attestation.clone(),
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -2070,6 +2255,7 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         let UsdcRebalanceEvent::BridgeAttestationReceived {
+            message: event_message,
             attestation: event_attestation,
             ..
         } = &events[0]
@@ -2077,7 +2263,54 @@ mod tests {
             panic!("Expected BridgeAttestationReceived event");
         };
 
+        assert_eq!(*event_message, message);
         assert_eq!(*event_attestation, attestation);
+    }
+
+    #[test]
+    fn replay_attestation_received_restores_message_bytes() {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx_hash =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let message = cctp_message_with_nonce_for_test(TEST_CCTP_NONCE);
+        let attestation = vec![0x01, 0x02, 0x03, 0x04];
+
+        let entity = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                message: message.clone(),
+                attestation: attestation.clone(),
+                cctp_nonce: TEST_CCTP_NONCE,
+                attested_at: Utc::now(),
+            },
+        ])
+        .unwrap();
+
+        let Some(UsdcRebalance::Attested {
+            message: replayed_message,
+            attestation: replayed_attestation,
+            cctp_nonce,
+            ..
+        }) = entity
+        else {
+            panic!("Expected Attested state");
+        };
+
+        assert_eq!(replayed_message, message);
+        assert_eq!(replayed_attestation, attestation);
+        assert_eq!(cctp_nonce, TEST_CCTP_NONCE);
     }
 
     #[tokio::test]
@@ -2085,6 +2318,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -2109,6 +2343,7 @@ mod tests {
                 initiated_at: Utc::now(),
             }])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -2138,6 +2373,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -2168,6 +2404,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -2202,12 +2439,14 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x03, 0x04],
                 cctp_nonce: OTHER_CCTP_NONCE,
             })
@@ -2244,6 +2483,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02, 0x03, 0x04],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2412,6 +2652,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce,
                     attested_at: Utc::now(),
@@ -2511,6 +2752,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2562,6 +2804,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2652,6 +2895,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2709,6 +2953,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2761,6 +3006,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2805,6 +3051,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2856,6 +3103,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2904,6 +3152,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -2967,6 +3216,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3026,6 +3276,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0xAB, 0xCD, 0xEF],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3078,6 +3329,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x11, 0x22, 0x33, 0x44],
                     cctp_nonce: OTHER_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3185,6 +3437,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
+                message: vec![0; 44],
                 attestation: vec![0x01],
                 cctp_nonce: TEST_CCTP_NONCE,
             })
@@ -3263,6 +3516,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3316,6 +3570,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3372,6 +3627,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3689,6 +3945,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3755,6 +4012,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3827,6 +4085,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3888,6 +4147,7 @@ mod tests {
                     burned_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::BridgeAttestationReceived {
+                    message: vec![0; 44],
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
                     attested_at: Utc::now(),
@@ -3955,6 +4215,7 @@ mod tests {
                 burned_at: withdrawal_confirmed_at,
             },
             UsdcRebalanceEvent::BridgeAttestationReceived {
+                message: vec![0; 44],
                 attestation: vec![0x01],
                 cctp_nonce: TEST_CCTP_NONCE,
                 attested_at: withdrawal_confirmed_at + chrono::Duration::seconds(15),
@@ -4335,6 +4596,7 @@ mod tests {
             amount: Usdc::new(float!(1500)),
             burn_tx_hash: burn_tx,
             cctp_nonce: TEST_CCTP_NONCE,
+            message: cctp_message_with_nonce_for_test(TEST_CCTP_NONCE),
             attestation: vec![0xAA, 0xBB],
             initiated_at,
             attested_at,
@@ -4401,6 +4663,7 @@ mod tests {
             fixed_bytes!("0x000000000000000000000000000000000000000000000000000000000000000b");
         let state = UsdcRebalance::DepositInitiated {
             direction: RebalanceDirection::BaseToAlpaca,
+            initiated_amount: Usdc::new(float!(3001)),
             amount: Usdc::new(float!(3000)),
             burn_tx_hash: burn_tx,
             mint_tx_hash: mint_tx,
@@ -4483,6 +4746,7 @@ mod tests {
                 amount,
                 burn_tx_hash: BURN_TX,
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 attestation: vec![],
                 initiated_at: now,
                 attested_at: now,
@@ -4505,6 +4769,7 @@ mod tests {
         assert!(
             DepositInitiated {
                 direction: AlpacaToBase,
+                initiated_amount: amount,
                 amount,
                 burn_tx_hash: BURN_TX,
                 mint_tx_hash: MINT_TX,


### PR DESCRIPTION
## What

Persists the full attested CCTP **message** bytes (not just Circle's
attestation signature) alongside the `UsdcRebalance` aggregate, and adds a
startup recovery path that resumes interrupted USDC rebalances from any
mid-bridge state (`Bridging`, `Attested`, `Bridged`, `DepositInitiated`)
after a process restart.

Closes [RAI-716](https://linear.app/makeitrain/issue/RAI-716/attested-cctp-state-is-not-crash-recoverable-attested-message-bytes).

## Why

`ReceiveAttestation` / `BridgeAttestationReceived` previously persisted only
the Circle attestation signature (`response.as_bytes()`) and the nonce — not
the attested CCTP message bytes. The `receiveMessage` mint needs *both* the
message and the signature. The mint only ever ran against the in-memory
`AttestationResponse`, so if the process restarted after
`BridgeAttestationReceived` was committed but before the mint confirmed, the
persisted `Attested` state could not reconstruct a valid mint call — the
burned USDC was stranded with no way to resume.

On top of that, nothing re-drove an interrupted USDC rebalance on startup, so
even the recoverable stages (post-burn, post-mint, post-deposit-initiation)
would silently stall.

## How

**Persist the message bytes (`src/usdc_rebalance.rs`, `SPEC.md`)**
- `ReceiveAttestation` command, `BridgeAttestationReceived` event, and the
  `Attested` state now carry `message: Vec<u8>`. New `message` fields are
  `#[serde(default)]` so previously persisted events still deserialize.
- `DepositInitiated` now retains `initiated_amount` (original source amount)
  in addition to `amount` (minted amount net of CCTP fees), so recovery can
  restore the correct inflight inventory figure.
- `SCHEMA_VERSION` bumped 2 → 3. No upcaster needed — old events default the
  new fields.
- New `interrupted_usdc_rebalance_ids(pool)` query returns aggregates whose
  latest event is one of the resumable bridge stages.
- SPEC.md updated to document that the mint requires both the message bytes
  and the signature, both persisted before minting; the enum/command/event
  shapes are synced (including `cctp_nonce: B256`).

**Reconstruct the attestation from persistence (`crates/bridge`)**
- `Attestation` trait gains `message_bytes() -> &[u8]`.
- New `AttestationResponse::from_message_and_attestation(message, attestation)`
  re-derives the nonce from the persisted message via
  `extract_nonce_from_message`; the live `poll_attestation` path now routes
  through the same constructor.

**Startup recovery (`src/conductor.rs`, `src/rebalancing/`)**
- `recover_interrupted_usdc_rebalance_aggregates` loads each interrupted
  aggregate, restores in-memory inventory/tracking via
  `RebalancingService::recover_usdc_rebalance_state` (rebuilt from
  `UsdcRebalanceTracking::from_recovered_state`), then calls
  `resume_interrupted_usdc_rebalances`, which drives each one to completion
  and logs per-rebalance failures without aborting the others. Framework
  construction moved after recovery.
- `CrossVenueCashTransfer::resume_usdc_rebalance(id)` is the resume entrypoint
  — it matches the persisted state and continues from the right point:
  `Bridging` → poll attestation → mint → continue; `Attested` → rebuild
  `AttestationResponse` from persisted bytes → mint → continue; `Bridged` →
  finish deposit/conversion; `DepositInitiated` → confirm deposit (and convert
  for BaseToAlpaca). Non-resumable states warn and no-op.
- Direction handling was generalized: `poll_attestation_for_direction`,
  `execute_cctp_mint_for_direction`, `continue_after_confirmed_mint` /
  `continue_after_bridged_state`, and a `bridge_direction` helper now back
  both the live AlpacaToBase / BaseToAlpaca flows and the resume flow, removing
  the previously duplicated per-direction code.
- `CrossVenueCashTransfer` construction extracted into
  `RebalancerServices::usdc_transfer` so the conductor's recovery path and the
  spawned rebalancer build it the same way.
- New `UsdcTransferError::AggregateNotFound { id }` for a missing aggregate on
  resume.

## Testing

All new logic is unit/integration tested:
- `crates/bridge`: `from_message_and_attestation` reconstructs the nonce; a
  too-short persisted message yields `CctpError::MessageTooShort`.
- `src/usdc_rebalance.rs`: `interrupted_usdc_rebalance_ids` returns only
  resumable stages (and excludes `DepositConfirmed`);
  `replay_attestation_received_restores_message_bytes` proves the message
  survives event replay; existing command/replay tests updated for the new
  field.
- `src/rebalancing/usdc/manager.rs`: resume-from-`DepositInitiated` for both
  directions (deposit-confirm vs. Alpaca-deposit-poll + USD conversion, with
  anvil + httpmock); `resume_attested_requires_persisted_message_bytes`
  asserts a corrupt/short persisted message surfaces `MessageTooShort`.
- `src/rebalancing/trigger/`: `recover_usdc_rebalance_state` restores
  inventory inflight, active-rebalance, and `usdc_in_progress` tracking.

## Anything else

- **Schema migration:** `SCHEMA_VERSION` 2 → 3. Backward-compatible — the new
  `message` / `initiated_amount` fields are `#[serde(default)]`, so events
  written before this change still replay. No DB migration file required.
- **Behavioral note:** old `Attested` events persisted before this change have
  no message bytes; resuming such an aggregate will fail fast with
  `MessageTooShort` rather than minting against incomplete data. Per RAI-716
  the nonce bug meant no such attested events were ever successfully written,
  so this is not expected in practice.
- Stacked on `05-29-keep-guard-on-post-usdc-burn-failure`.


---

## Hardening from self-review (added after initial spec)

A multi-pass review of this branch surfaced correctness gaps that are now fixed
and tested:

- **CCTP mint idempotency on resume (the core bug).** Resuming from
  `Bridging`/`Attested` previously re-submitted `receiveMessage`, which reverts
  on an already-used nonce if the process crashed after the mint confirmed but
  before `ConfirmBridging` persisted — stranding the minted USDC. New
  `CctpBridge::find_existing_mint` checks `usedNonces` and reconstructs the prior
  mint from the on-chain `MessageReceived`/`MintAndWithdraw` events, driving
  `ConfirmBridging` instead of re-minting. Verified against real anvil-deployed
  CCTP (bridge primitive + a manager-level resume test that mints once then
  resumes from `Attested`, asserting it completes without re-minting).
- **Vault-deposit idempotency guard.** Resuming from `Bridged` (AlpacaToBase)
  now checks the market-maker wallet's Base-USDC balance before re-depositing; if
  the minted USDC already left the wallet (deposit already landed pre-crash) it
  refuses to re-submit and surfaces `DepositFundsAlreadyMoved` for operator
  review instead of double-depositing.
- **BaseToAlpaca post-deposit resume.** A crash after `ConfirmDeposit` (state
  `DepositConfirmed`, conversion still pending) now resumes the USDC->USD
  conversion (direction-aware `interrupted_usdc_rebalance_ids` + resume arm +
  recovery tracking) instead of stalling.
- **Exhaustive matches**, `CctpMessage`/`CctpAttestation` newtypes (swap-proof),
  log+skip on a missing aggregate at startup, idempotent recovery, and a
  distinct `MintReceiveLogNotFound` error.

### Known residuals (tracked as follow-ups)

These are inherent to non-idempotent external effects (no on-chain dedup key) and
are documented in code; each is fail-safe:

- The deposit guard is a balance heuristic: it cannot auto-complete an
  already-deposited aggregate (operator reconciles), and can false-negative if
  the shared wallet independently holds operational float >= the amount. An
  authoritative deposit-already-landed check is a follow-up.
- A crash mid post-deposit conversion (`Converting`, order already placed) is not
  auto-resumed (the Alpaca order isn't keyed by a recoverable id); funds are safe
  on Alpaca but need operator action.
- Manager-level full-continuation tests for the `Bridging` / `Attested`-fresh-mint
  resume arms are constrained by the Alpaca deposit mock needing the fresh mint tx
  (unknown until resume runs); that mint path is covered by the bridge crate's
  full-flow tests plus the idempotency test's real burn->poll->mint setup.
