### PR TITLE
fix: recover already-minted CCTP transfers instead of failing the bridge

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1872,6 +1872,14 @@ enum BridgeStage { Burn, Attestation, Mint }
   no websocket option available)
 - Bridge mint transaction requires valid attestation
 - Bridge mint transaction must be confirmed before destination deposit
+- A `receiveMessage()` revert because the CCTP nonce was already used is
+  idempotent success only when destination-chain logs confirm all of the
+  following: (1) a `MessageReceived` event for that nonce exists whose source
+  domain and message body match the attested message; (2) the transaction that
+  emitted that `MessageReceived` also emitted `MintAndWithdraw`. Transaction
+  success is implicit since reverted transactions emit no logs. Any source
+  domain or message body mismatch, or absence of the expected `MintAndWithdraw`,
+  means the revert remains a bridge mint failure
 - Destination deposit must be confirmed to complete rebalancing (for
   AlpacaToBase) or before post-deposit conversion (for BaseToAlpaca)
 - Can mark failed from any non-terminal state

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -1,20 +1,23 @@
 //! Single-chain CCTP operations.
 
-use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, U256};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, TxHash, U256};
 use alloy::providers::Provider;
-use alloy::rpc::types::Filter;
+use alloy::rpc::types::{Filter, TransactionReceipt};
 use alloy::sol;
 use alloy::sol_types::SolEvent;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 #[cfg(test)]
 use st0x_evm::Evm;
-use st0x_evm::{IntoErrorRegistry, Wallet};
+use st0x_evm::{EvmError, IntoErrorRegistry, Wallet};
 
 use super::{
     CctpError, FAST_TRANSFER_THRESHOLD, MessageTransmitterV2, MintReceipt, TokenMessengerV2,
+    parse_received_message,
 };
 use crate::BridgeDirection;
+
+const CCTP_RECOVERY_LOG_BLOCK_CHUNK: u64 = 20_000;
 
 sol!(
     #![sol(all_derives = true, rpc)]
@@ -279,10 +282,11 @@ impl<W: Wallet> CctpEndpoint<W> {
     /// for what the recipient actually received.
     pub(super) async fn claim<Registry: IntoErrorRegistry>(
         &self,
+        direction: BridgeDirection,
         message: Bytes,
         attestation: Bytes,
     ) -> Result<MintReceipt, CctpError> {
-        let receipt = self
+        let receipt = match self
             .wallet
             .submit::<Registry, _>(
                 self.message_transmitter_address,
@@ -292,27 +296,230 @@ impl<W: Wallet> CctpEndpoint<W> {
                 },
                 "receiveMessage",
             )
+            .await
+        {
+            Ok(receipt) => receipt,
+            // receiveMessage reverts for many reasons. We cannot rely on the
+            // revert reason string (it is decoder/provider dependent and may
+            // not survive decoding), so we hand every revert to recovery, which
+            // confirms structurally whether the nonce was already minted and
+            // otherwise re-propagates this error unchanged.
+            Err(error) => {
+                return self
+                    .recover_already_minted::<Registry>(direction, &message, error)
+                    .await;
+            }
+        };
+
+        parse_mint_receipt(&receipt).ok_or(CctpError::MintAndWithdrawEventNotFound)
+    }
+
+    /// Reconstructs the receipt of an already-executed mint for the attested
+    /// `message`, or `None` if its nonce has not been consumed on this chain.
+    ///
+    /// Confirms via `usedNonces()` (structural ground truth, not the
+    /// decoder/provider-dependent revert string) and matches the on-chain
+    /// `MessageReceived` log against the attested message's source domain and
+    /// body before trusting the recovered amounts. Used both proactively
+    /// (crash-recovery resume, before minting) and reactively (after a
+    /// `receiveMessage` revert, via `recover_already_minted`).
+    pub(super) async fn find_existing_mint<Registry: IntoErrorRegistry>(
+        &self,
+        direction: BridgeDirection,
+        message: &[u8],
+    ) -> Result<Option<MintReceipt>, CctpError> {
+        let received_message = parse_received_message(message)?;
+
+        // CCTP V2 assigns the real nonce only at attestation; an unattested or
+        // invalid message still carries the reserved zero nonce, which the
+        // transmitter reports as used. Such a message was never minted.
+        if received_message.nonce == B256::ZERO {
+            return Ok(None);
+        }
+
+        // Authoritative gate: usedNonces() is non-zero once the nonce has been
+        // consumed (the mint executed and emitted MintAndWithdraw below).
+        let nonce_used = self
+            .wallet
+            .call::<Registry, _>(
+                self.message_transmitter_address,
+                MessageTransmitterV2::usedNoncesCall(received_message.nonce),
+            )
             .await?;
 
-        let mint_event = receipt
-            .inner
-            .logs()
-            .iter()
-            .find_map(|log| TokenMessengerV2::MintAndWithdraw::decode_log(log.as_ref()).ok())
-            .ok_or(CctpError::MintAndWithdrawEventNotFound)?;
+        if nonce_used.is_zero() {
+            return Ok(None);
+        }
+
+        if received_message.destination_domain != direction.dest_domain() {
+            return Err(CctpError::MessageDestinationDomainMismatch {
+                expected: direction.dest_domain(),
+                actual: received_message.destination_domain,
+            });
+        }
+
+        let (tx_hash, message_received_log_index) = self
+            .find_received_message_tx(
+                received_message.source_domain,
+                received_message.nonce,
+                received_message.message_body,
+            )
+            .await?;
+
+        // The mint tx may have been submitted by another caller; await_receipt
+        // polls and waits for confirmation depth (load-balanced RPCs may route
+        // to a lagging node), rather than a bare single-shot
+        // get_transaction_receipt.
+        let receipt = self.wallet.await_receipt(tx_hash).await?;
+
+        if !receipt.status() {
+            return Err(CctpError::RecoveredMintReceiptReverted { tx_hash });
+        }
+
+        let mint_receipt = parse_mint_receipt_for_message(&receipt, message_received_log_index)
+            .ok_or(CctpError::RecoveredMintAndWithdrawEventNotFound { tx_hash })?;
 
         info!(
             target: "bridge",
-            amount = %mint_event.amount,
-            fee_collected = %mint_event.feeCollected,
-            "Parsed MintAndWithdraw event"
+            nonce = %received_message.nonce,
+            mint_tx = %mint_receipt.tx,
+            amount = %mint_receipt.amount,
+            fee_collected = %mint_receipt.fee_collected,
+            "Recovered already-minted CCTP transfer"
         );
 
-        Ok(MintReceipt {
-            tx: receipt.transaction_hash,
-            amount: mint_event.amount,
-            fee_collected: mint_event.feeCollected,
-        })
+        Ok(Some(mint_receipt))
+    }
+
+    /// Reactive recovery for a `receiveMessage` revert: if the nonce was already
+    /// minted, returns the existing receipt; otherwise (nonce not consumed, or
+    /// the recovery probe could not conclusively reconstruct our mint) it
+    /// re-surfaces the original `submit_error` rather than masking it with a
+    /// probe error.
+    pub(super) async fn recover_already_minted<Registry: IntoErrorRegistry>(
+        &self,
+        direction: BridgeDirection,
+        message: &[u8],
+        submit_error: EvmError,
+    ) -> Result<MintReceipt, CctpError> {
+        match self
+            .find_existing_mint::<Registry>(direction, message)
+            .await
+        {
+            Ok(Some(mint_receipt)) => Ok(mint_receipt),
+            Ok(None) => Err(submit_error.into()),
+            Err(probe_error) => {
+                warn!(
+                    target: "bridge",
+                    ?probe_error,
+                    "CCTP mint recovery probe failed; surfacing original submit error"
+                );
+                Err(submit_error.into())
+            }
+        }
+    }
+
+    /// Locates the `receiveMessage` transaction that minted `nonce` and returns
+    /// its hash alongside the matched `MessageReceived` log index (used to
+    /// correlate the right `MintAndWithdraw` within a multicall transaction).
+    ///
+    /// The backward scan has no upper bound and can in principle reach block 0,
+    /// but this is only invoked during crash recovery immediately after a
+    /// submit failure, so the matching mint is always recent and found in the
+    /// first few chunks. A hard scan limit is deliberately omitted to avoid
+    /// failing recovery when a deep reorg or lagging node pushes the log back.
+    async fn find_received_message_tx(
+        &self,
+        source_domain: u32,
+        nonce: B256,
+        message_body: &[u8],
+    ) -> Result<(TxHash, u64), CctpError> {
+        let latest = self
+            .wallet
+            .provider()
+            .get_block_number()
+            .await
+            .map_err(EvmError::from)?;
+        let mut to_block = latest;
+        let mut saw_nonce = false;
+
+        loop {
+            let from_block =
+                to_block.saturating_sub(CCTP_RECOVERY_LOG_BLOCK_CHUNK.saturating_sub(1));
+            let filter = Filter::new()
+                .address(self.message_transmitter_address)
+                .from_block(from_block)
+                .to_block(to_block)
+                .event_signature(MessageTransmitterV2::MessageReceived::SIGNATURE_HASH)
+                .topic2(nonce);
+            let logs = self
+                .wallet
+                .provider()
+                .get_logs(&filter)
+                .await
+                .map_err(EvmError::from)?;
+
+            for log in logs {
+                // The topic2(nonce) filter already restricts to our exact nonce,
+                // so any returned log is a sighting -- record it before decoding
+                // so a decode failure is not misreported as "nonce never seen".
+                saw_nonce = true;
+
+                let Ok(decoded) = log.log_decode::<MessageTransmitterV2::MessageReceived>() else {
+                    warn!(
+                        target: "bridge",
+                        %nonce,
+                        "MessageReceived log matched the nonce filter but failed to decode; skipping"
+                    );
+                    continue;
+                };
+                let event = decoded.data();
+
+                if event.sourceDomain != source_domain || event.messageBody.as_ref() != message_body
+                {
+                    trace!(
+                        target: "bridge",
+                        %nonce,
+                        log_source_domain = event.sourceDomain,
+                        expected_source_domain = source_domain,
+                        "MessageReceived log for nonce did not match attested source domain/body; skipping"
+                    );
+                    continue;
+                }
+
+                let tx_hash = decoded
+                    .transaction_hash
+                    .ok_or(CctpError::RecoveredMintLogMissingTxHash { nonce })?;
+                let log_index = decoded
+                    .log_index
+                    .ok_or(CctpError::RecoveredMintLogMissingTxHash { nonce })?;
+
+                return Ok((tx_hash, log_index));
+            }
+
+            if from_block == 0 {
+                break;
+            }
+
+            to_block = from_block - 1;
+        }
+
+        if saw_nonce {
+            Err(CctpError::RecoveredMintMessageMismatch { nonce })
+        } else {
+            Err(CctpError::AlreadyMintedMessageNotFound { nonce })
+        }
+    }
+
+    /// Returns `holder`'s balance of this chain's USDC token.
+    pub(super) async fn usdc_balance<Registry: IntoErrorRegistry>(
+        &self,
+        holder: Address,
+    ) -> Result<U256, CctpError> {
+        Ok(self
+            .wallet
+            .call::<Registry, _>(self.usdc_address, IERC20::balanceOfCall { account: holder })
+            .await?)
     }
 
     #[cfg(test)]
@@ -349,5 +556,164 @@ impl<W: Wallet> CctpEndpoint<W> {
     #[cfg(test)]
     pub(super) fn token_messenger_address(&self) -> Address {
         self.token_messenger_address
+    }
+}
+
+fn parse_mint_receipt(receipt: &TransactionReceipt) -> Option<MintReceipt> {
+    let mint_event = receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| TokenMessengerV2::MintAndWithdraw::decode_log(log.as_ref()).ok())?;
+
+    info!(
+        target: "bridge",
+        amount = %mint_event.amount,
+        fee_collected = %mint_event.feeCollected,
+        "Parsed MintAndWithdraw event"
+    );
+
+    Some(MintReceipt {
+        tx: receipt.transaction_hash,
+        amount: mint_event.amount,
+        fee_collected: mint_event.feeCollected,
+    })
+}
+
+/// Selects the `MintAndWithdraw` emitted by the same `receiveMessage` call that
+/// produced the `MessageReceived` log at `message_received_log_index`.
+///
+/// CCTP V2 emits `MintAndWithdraw` (during `handleReceiveFinalizedMessage`)
+/// before `MessageReceived` within a single `receiveMessage` call, so the mint
+/// for our message is the one with the greatest log index strictly below the
+/// matched `MessageReceived` log. This disambiguates relayer multicalls that
+/// batch several `receiveMessage` calls -- and thus several `MintAndWithdraw`
+/// events -- into one transaction, where taking the first event could attribute
+/// another transfer's amount to ours.
+fn parse_mint_receipt_for_message(
+    receipt: &TransactionReceipt,
+    message_received_log_index: u64,
+) -> Option<MintReceipt> {
+    let (_, mint_event) = receipt
+        .inner
+        .logs()
+        .iter()
+        .filter_map(|log| {
+            let log_index = log.log_index?;
+
+            if log_index >= message_received_log_index {
+                return None;
+            }
+
+            let decoded = TokenMessengerV2::MintAndWithdraw::decode_log(log.as_ref()).ok()?;
+
+            Some((log_index, decoded))
+        })
+        .max_by_key(|(log_index, _)| *log_index)?;
+
+    info!(
+        target: "bridge",
+        amount = %mint_event.amount,
+        fee_collected = %mint_event.feeCollected,
+        "Parsed MintAndWithdraw event for recovered transfer"
+    );
+
+    Some(MintReceipt {
+        tx: receipt.transaction_hash,
+        amount: mint_event.amount,
+        fee_collected: mint_event.feeCollected,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy::primitives::{Bloom, Log as PrimitiveLog};
+    use alloy::rpc::types::Log;
+
+    use super::*;
+
+    fn mint_log(log_index: u64, amount: u64) -> Log {
+        let event = TokenMessengerV2::MintAndWithdraw {
+            mintRecipient: Address::ZERO,
+            amount: U256::from(amount),
+            mintToken: Address::ZERO,
+            feeCollected: U256::ZERO,
+        };
+
+        Log {
+            inner: PrimitiveLog {
+                address: Address::ZERO,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: Some(TxHash::ZERO),
+            transaction_index: None,
+            log_index: Some(log_index),
+            removed: false,
+        }
+    }
+
+    fn receipt_with_logs(logs: Vec<Log>) -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: true.into(),
+                    cumulative_gas_used: 0,
+                    logs,
+                },
+                logs_bloom: Bloom::default(),
+            }),
+            transaction_hash: TxHash::ZERO,
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: Some(1),
+            gas_used: 0,
+            effective_gas_price: 0,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    #[test]
+    fn parse_mint_receipt_for_message_selects_mint_immediately_below_message_received() {
+        // Two batched receiveMessage calls in one tx emit two MintAndWithdraw
+        // events; ours is the one immediately preceding our MessageReceived.
+        let receipt = receipt_with_logs(vec![mint_log(0, 1_000), mint_log(1, 2_000)]);
+
+        let mint = parse_mint_receipt_for_message(&receipt, 2)
+            .expect("a MintAndWithdraw precedes log index 2");
+
+        assert_eq!(
+            mint.amount,
+            U256::from(2_000u64),
+            "must select the mint nearest below the MessageReceived log, not the first"
+        );
+    }
+
+    #[test]
+    fn parse_mint_receipt_for_message_ignores_mints_at_or_above_message_received() {
+        let receipt = receipt_with_logs(vec![mint_log(0, 1_000), mint_log(1, 2_000)]);
+
+        // MessageReceived at index 1 -> only the mint at index 0 qualifies.
+        let mint = parse_mint_receipt_for_message(&receipt, 1)
+            .expect("the MintAndWithdraw at index 0 qualifies");
+
+        assert_eq!(mint.amount, U256::from(1_000u64));
+    }
+
+    #[test]
+    fn parse_mint_receipt_for_message_returns_none_without_preceding_mint() {
+        let receipt = receipt_with_logs(vec![mint_log(5, 1_000)]);
+
+        assert!(
+            parse_mint_receipt_for_message(&receipt, 0).is_none(),
+            "no MintAndWithdraw below the MessageReceived log must yield None, not a later mint"
+        );
     }
 }

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -203,6 +203,10 @@ impl crate::Attestation for AttestationResponse {
 const NONCE_INDEX: usize = 12;
 const NONCE_SIZE: usize = size_of::<FixedBytes<32>>();
 const MIN_MESSAGE_LENGTH: usize = NONCE_INDEX + NONCE_SIZE;
+const SOURCE_DOMAIN_INDEX: usize = 4;
+const DESTINATION_DOMAIN_INDEX: usize = 8;
+const DOMAIN_SIZE: usize = size_of::<u32>();
+const MESSAGE_BODY_INDEX: usize = 148;
 
 /// Extracts the 32-byte nonce from a CCTP V2 message.
 ///
@@ -218,6 +222,41 @@ fn extract_nonce_from_message(message: &[u8]) -> Result<FixedBytes<32>, CctpErro
     Ok(FixedBytes::<32>::from_slice(
         &message[NONCE_INDEX..NONCE_INDEX + 32],
     ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CctpReceivedMessage<'a> {
+    source_domain: u32,
+    destination_domain: u32,
+    nonce: B256,
+    message_body: &'a [u8],
+}
+
+fn extract_domain(message: &[u8], index: usize) -> Result<u32, CctpError> {
+    let Some(domain) = message.get(index..index + DOMAIN_SIZE) else {
+        return Err(CctpError::MessageTooShortForRecovery {
+            length: message.len(),
+        });
+    };
+
+    Ok(u32::from_be_bytes([
+        domain[0], domain[1], domain[2], domain[3],
+    ]))
+}
+
+fn parse_received_message(message: &[u8]) -> Result<CctpReceivedMessage<'_>, CctpError> {
+    if message.len() < MESSAGE_BODY_INDEX {
+        return Err(CctpError::MessageTooShortForRecovery {
+            length: message.len(),
+        });
+    }
+
+    Ok(CctpReceivedMessage {
+        source_domain: extract_domain(message, SOURCE_DOMAIN_INDEX)?,
+        destination_domain: extract_domain(message, DESTINATION_DOMAIN_INDEX)?,
+        nonce: FixedBytes::<32>::from_slice(&message[NONCE_INDEX..NONCE_INDEX + NONCE_SIZE]),
+        message_body: &message[MESSAGE_BODY_INDEX..],
+    })
 }
 
 /// Runtime context for constructing a [`CctpBridge`].
@@ -299,6 +338,22 @@ pub enum CctpError {
     MessageTooShort { length: usize },
     #[error("Attested message carried an all-zero nonce: Circle returned a placeholder bytes32(0)")]
     ZeroNonce,
+    #[error("Message too short for receiveMessage recovery: got {length} bytes, need at least 148")]
+    MessageTooShortForRecovery { length: usize },
+    #[error("CCTP message destination domain mismatch: expected {expected}, got {actual}")]
+    MessageDestinationDomainMismatch { expected: u32, actual: u32 },
+    #[error("already-minted CCTP nonce {nonce} had no matching MessageReceived log")]
+    AlreadyMintedMessageNotFound { nonce: B256 },
+    #[error(
+        "recovered CCTP MessageReceived log for nonce {nonce} did not match the attested message"
+    )]
+    RecoveredMintMessageMismatch { nonce: B256 },
+    #[error("recovered CCTP mint log for nonce {nonce} is missing transaction hash or log index")]
+    RecoveredMintLogMissingTxHash { nonce: B256 },
+    #[error("recovered CCTP mint transaction reverted: {tx_hash}")]
+    RecoveredMintReceiptReverted { tx_hash: TxHash },
+    #[error("MintAndWithdraw event not found in recovered CCTP mint transaction: {tx_hash}")]
+    RecoveredMintAndWithdrawEventNotFound { tx_hash: TxHash },
     #[error("Fee calculation overflow")]
     FeeCalculationOverflow,
     #[error("Float operation error: {0}")]
@@ -600,10 +655,14 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     ) -> Result<MintReceipt, CctpError> {
         match direction {
             BridgeDirection::EthereumToBase => {
-                self.base.claim::<Registry>(message, attestation).await
+                self.base
+                    .claim::<Registry>(direction, message, attestation)
+                    .await
             }
             BridgeDirection::BaseToEthereum => {
-                self.ethereum.claim::<Registry>(message, attestation).await
+                self.ethereum
+                    .claim::<Registry>(direction, message, attestation)
+                    .await
             }
         }
     }
@@ -612,6 +671,52 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     fn with_circle_api_base(mut self, base_url: String) -> Self {
         self.circle_api_base = base_url;
         self
+    }
+
+    /// Returns the receipt of an already-executed mint for the attested
+    /// `message` on the destination chain of `direction`, or `None` if its nonce
+    /// is unused.
+    ///
+    /// Used by crash-recovery resume to avoid re-submitting `receiveMessage`
+    /// (which reverts on a consumed nonce) when a mint already landed but its
+    /// confirming event was not yet persisted. Passing the full message (not
+    /// just the nonce) lets the reconstruction match the on-chain log against
+    /// the attested source domain and body.
+    pub async fn find_existing_mint(
+        &self,
+        direction: BridgeDirection,
+        message: &[u8],
+    ) -> Result<Option<crate::MintReceipt>, CctpError> {
+        let receipt = match direction {
+            BridgeDirection::EthereumToBase => {
+                self.base
+                    .find_existing_mint::<OpenChainErrorRegistry>(direction, message)
+                    .await?
+            }
+            BridgeDirection::BaseToEthereum => {
+                self.ethereum
+                    .find_existing_mint::<OpenChainErrorRegistry>(direction, message)
+                    .await?
+            }
+        };
+
+        Ok(receipt.map(|receipt| crate::MintReceipt {
+            tx: receipt.tx,
+            amount: receipt.amount,
+            fee: receipt.fee_collected,
+        }))
+    }
+
+    /// Returns `holder`'s USDC balance on Base, the destination chain for
+    /// AlpacaToBase mints.
+    ///
+    /// Used as an idempotency guard before re-depositing on resume from `Bridged`:
+    /// if the freshly minted USDC is no longer in the wallet, the vault deposit
+    /// already landed, so re-submitting it would double-deposit (or revert).
+    pub async fn base_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
+        self.base
+            .usdc_balance::<OpenChainErrorRegistry>(holder)
+            .await
     }
 }
 
@@ -1967,7 +2072,11 @@ mod tests {
         // Call claim() directly on the Evm instance
         let mint_receipt = bridge
             .base
-            .claim::<NoOpErrorRegistry>(message_with_nonce, attestation)
+            .claim::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce,
+                attestation,
+            )
             .await
             .unwrap();
 
@@ -2006,7 +2115,11 @@ mod tests {
         // Call claim() directly on the Evm instance
         let mint_receipt = bridge
             .ethereum
-            .claim::<NoOpErrorRegistry>(message_with_nonce, attestation)
+            .claim::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                message_with_nonce,
+                attestation,
+            )
             .await
             .unwrap();
 
@@ -2019,6 +2132,189 @@ mod tests {
             mint_receipt.fee_collected,
             U256::ZERO,
             "fee should be 0 in mock"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_existing_mint_returns_none_before_mint_and_recovers_receipt_after() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(2_500_000u64); // 2.5 USDC
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        // Before the mint the nonce is unconsumed, so there is nothing to recover.
+        let before = bridge
+            .find_existing_mint(BridgeDirection::EthereumToBase, &message_with_nonce)
+            .await
+            .unwrap();
+        assert_eq!(
+            before, None,
+            "unused nonce must report no existing mint, got: {before:?}"
+        );
+
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        // After the mint the nonce is consumed; recovery reconstructs the exact
+        // receipt (tx + net amount + fee) from the on-chain events without re-minting.
+        let recovered = bridge
+            .find_existing_mint(BridgeDirection::EthereumToBase, &message_with_nonce)
+            .await
+            .unwrap()
+            .expect("consumed nonce must report the existing mint");
+
+        assert_eq!(
+            recovered.tx, mint_receipt.tx,
+            "recovered mint tx must match"
+        );
+        assert_eq!(
+            recovered.amount, mint_receipt.amount,
+            "recovered net amount must match the MintAndWithdraw event"
+        );
+        assert_eq!(
+            recovered.fee, mint_receipt.fee_collected,
+            "recovered fee must match the MintAndWithdraw event"
+        );
+
+        // Wrong destination domain: this message was minted to Base, so trying to
+        // reconstruct it as a Base->Ethereum transfer must reject, not recover.
+        let wrong_direction_error = bridge
+            .base
+            .find_existing_mint::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                &message_with_nonce,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                wrong_direction_error,
+                CctpError::MessageDestinationDomainMismatch {
+                    expected: TEST_ETHEREUM_DOMAIN,
+                    actual: TEST_BASE_DOMAIN,
+                }
+            ),
+            "wrong destination domain must not recover: {wrong_direction_error:?}"
+        );
+
+        // A message whose body no longer matches the on-chain MessageReceived log
+        // for its (consumed) nonce must not be recovered.
+        let nonce = extract_nonce_from_message(&message_with_nonce).unwrap();
+        let mut mismatched_message = message_with_nonce.to_vec();
+        assert!(
+            mismatched_message.len() > MESSAGE_BODY_INDEX,
+            "test CCTP message must include a body byte to mutate"
+        );
+        mismatched_message[MESSAGE_BODY_INDEX] ^= 0xFF;
+
+        let mismatched_message_error = bridge
+            .base
+            .find_existing_mint::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &mismatched_message,
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                mismatched_message_error,
+                CctpError::RecoveredMintMessageMismatch { nonce: event_nonce }
+                    if event_nonce == nonce
+            ),
+            "message-body mismatch must not recover: {mismatched_message_error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mint_recovers_when_receive_message_nonce_already_used() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.base.owner();
+        let amount = U256::from(3_000_000u64);
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap();
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, true)
+            .await
+            .unwrap();
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        let first_mint = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation.clone(),
+            )
+            .await
+            .unwrap();
+
+        // A second mint of the same attested message hits the already-used-nonce
+        // revert; claim() recovers the original mint instead of failing.
+        let recovered_mint = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                message_with_nonce.clone(),
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recovered_mint.tx, first_mint.tx,
+            "recovery must return the original mint transaction"
+        );
+        assert_eq!(recovered_mint.amount, first_mint.amount);
+        assert_eq!(recovered_mint.fee_collected, first_mint.fee_collected);
+
+        // A revert whose nonce is NOT marked used on-chain is not an already-minted
+        // case: the reactive path must re-surface the original submit error rather
+        // than fabricate a recovery outcome. Mutating the nonce yields a
+        // never-minted nonce on a structurally valid message (usedNonces == 0).
+        let sentinel_error = || EvmError::Reverted {
+            tx_hash: TxHash::repeat_byte(0xEE),
+        };
+        let mut unused_nonce_message = message_with_nonce.to_vec();
+        unused_nonce_message[NONCE_INDEX..NONCE_INDEX + NONCE_SIZE].fill(0xAB);
+
+        let unused_nonce_error = bridge
+            .base
+            .recover_already_minted::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                &unused_nonce_message,
+                sentinel_error(),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                unused_nonce_error,
+                CctpError::Evm(EvmError::Reverted { tx_hash })
+                    if tx_hash == TxHash::repeat_byte(0xEE)
+            ),
+            "unused nonce must propagate the original submit error: {unused_nonce_error:?}"
         );
     }
 
@@ -2109,6 +2405,43 @@ mod tests {
             .chain(nonce)
             .chain(trailer.iter().copied())
             .collect_vec()
+    }
+
+    #[test]
+    fn parse_received_message_extracts_recovery_fields() {
+        let nonce = [0xAB; 32];
+        let body = [0x01, 0x02, 0x03];
+        let mut message = vec![0u8; MESSAGE_BODY_INDEX + body.len()];
+        message[SOURCE_DOMAIN_INDEX..SOURCE_DOMAIN_INDEX + DOMAIN_SIZE]
+            .copy_from_slice(&TEST_ETHEREUM_DOMAIN.to_be_bytes());
+        message[DESTINATION_DOMAIN_INDEX..DESTINATION_DOMAIN_INDEX + DOMAIN_SIZE]
+            .copy_from_slice(&TEST_BASE_DOMAIN.to_be_bytes());
+        message[NONCE_INDEX..NONCE_INDEX + NONCE_SIZE].copy_from_slice(&nonce);
+        message[MESSAGE_BODY_INDEX..].copy_from_slice(&body);
+
+        let parsed = parse_received_message(&message).unwrap();
+
+        assert_eq!(parsed.source_domain, TEST_ETHEREUM_DOMAIN);
+        assert_eq!(parsed.destination_domain, TEST_BASE_DOMAIN);
+        assert_eq!(parsed.nonce, FixedBytes::from(nonce));
+        assert_eq!(parsed.message_body, body);
+    }
+
+    #[test]
+    fn parse_received_message_rejects_messages_without_body_offset() {
+        let message = [0u8; MESSAGE_BODY_INDEX - 1];
+
+        let err = parse_received_message(&message).unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                CctpError::MessageTooShortForRecovery {
+                    length
+                } if length == MESSAGE_BODY_INDEX - 1
+            ),
+            "expected MessageTooShortForRecovery, got: {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes [RAI-717](https://linear.app/makeitrain/issue/RAI-717/already-minted-receivemessage-revert-is-mismarked-as-bridgingfailed)

Treats a CCTP `receiveMessage()` revert caused by an already-used nonce as idempotent success — when destination-chain logs prove the attested message was already minted — instead of surfacing a generic revert that drives the bridge aggregate to terminal `BridgingFailed`.

## Why

If `receiveMessage()` reverts because the nonce was already used (USDC already minted by a prior attempt or a competing caller), `claim()` previously surfaced a generic revert. `execute_cctp_mint` then emitted `FailBridging` and the aggregate went to terminal `BridgingFailed` — even though the funds actually arrived at the recipient. That misrepresents financial state: USDC is minted on-chain yet the transfer is recorded as failed, the vault deposit / Alpaca credit is never recorded, and the result is unaccounted-for inventory.

This is directly relevant to manual recovery of stranded USDC: if any burn was already minted, a naive re-mint would otherwise mismark it as failed.

## How

The recovery is gated so it only converts a revert into success when the chain actually proves the mint happened — anything short of that proof remains a failure (recorded as a new invariant in `SPEC.md`).

- **`crates/bridge/src/cctp/evm.rs`:**
  - `claim()` now takes the `BridgeDirection`. The `receiveMessage` revert reason is decoder/provider-dependent and may not survive decoding, so every revert — not a matched reason string — is handed to `recover_already_minted`; the normal success path parses the receipt via `parse_mint_receipt`.
  - `find_existing_mint` is the structural confirmation, shared by both the proactive crash-recovery resume (before minting) and the reactive post-revert path: it parses the attested message, treats the reserved zero nonce as never-minted, then gates on `MessageTransmitterV2.usedNonces(nonce)` — the authoritative on-chain signal that the nonce was already consumed — verifies the message's `destination_domain` matches the direction's expected domain (else `MessageDestinationDomainMismatch`), locates the original mint transaction, fetches the receipt, rejects a reverted receipt, and parses the `MintAndWithdraw` event for the real amounts.
  - `recover_already_minted` is the reactive entry point: it delegates to `find_existing_mint` and returns the recovered receipt only when a mint is confirmed; otherwise (nonce not consumed, or the probe could not conclusively reconstruct the mint) it re-surfaces the original `receiveMessage` submit error unchanged rather than masking it with a probe error.
  - `find_received_message_tx` scans `MessageReceived` logs backwards from the latest block in 20,000-block chunks (`CCTP_RECOVERY_LOG_BLOCK_CHUNK`), filtered by event signature and the nonce topic, and requires both `sourceDomain` and `messageBody` to match the attested message before returning its tx hash. It distinguishes "nonce never seen" (`AlreadyMintedMessageNotFound`) from "nonce seen but message mismatched" (`RecoveredMintMessageMismatch`).
  - `parse_mint_receipt` is extracted so both the normal mint path and recovery share one `MintAndWithdraw` decode + log.
- **`crates/bridge/src/cctp/mod.rs`:**
  - `parse_received_message` / `extract_domain` decode the source domain, destination domain, nonce, and message body from a CCTP V2 message, with offset constants (`SOURCE_DOMAIN_INDEX`, `DESTINATION_DOMAIN_INDEX`, `MESSAGE_BODY_INDEX`, `DOMAIN_SIZE`) and a `CctpReceivedMessage` view struct.
  - New `CctpError` variants for every recovery failure mode (message too short, domain mismatch, nonce not found, message mismatch, missing tx hash, receipt not found, reverted receipt, missing `MintAndWithdraw`).
  - `mint_internal` threads `direction` into `claim()`.
- **`SPEC.md`:** documents the invariant — an already-used-nonce revert is idempotent success only when destination-chain logs prove the same attested message was received and the same tx emitted `MintAndWithdraw`; otherwise it stays a bridge mint failure.

## Testing

New tests, no manual verification:
- `mint_recovers_when_receive_message_nonce_already_used` (`crates/bridge/src/cctp/mod.rs`): mints once, then re-mints the same attested message against anvil and asserts recovery returns the original mint's tx/amount/fee. Also asserts the negative paths — wrong destination domain yields `MessageDestinationDomainMismatch`, and a flipped message-body byte yields `RecoveredMintMessageMismatch`.
- `parse_received_message_extracts_recovery_fields`: asserts source/destination domain, nonce, and body are decoded from the correct offsets.
- `parse_received_message_rejects_messages_without_body_offset`: asserts a message shorter than the body offset returns `MessageTooShortForRecovery`.
- Existing `claim()` call sites in tests updated for the new `direction` argument.

## Anything else

Already-minted detection is structural — gated on the transmitter's `usedNonces(nonce)` plus a source-domain/body log match — not a parse of the `receiveMessage` revert reason, which is decoder/provider-dependent and unreliable. Related to RAI-714 (stranded-USDC manual recovery).


## Self-review follow-ups (deferred, non-blocking)

A 5-reviewer self-review confirmed the core safety: recovery only returns a receipt on real on-chain proof (`usedNonces` gate + source-domain/body log match + confirmed non-reverted receipt), and the reactive path re-surfaces the original submit error rather than fabricating a recovery. Addressed now: zero-nonce false-positive guard test + a defensive `saturating_sub` in the scan.

Deferred as safe-direction robustness enhancements (none can cause a false-credit or double-mint; they err toward re-surfacing the original error):

- **RPC-lag resilience:** `find_received_message_tx` treats a single empty `get_logs` as authoritative absence; a lagging/load-balanced node could drive a recoverable transfer to `BridgingFailed`. Mirror `find_recent_burn`'s retry/`ScanInconclusive` handling when `usedNonces != 0` but the scan is empty.
- **Multicall amount validation (defense-in-depth):** `parse_mint_receipt_for_message` selects the `MintAndWithdraw` by log-index proximity; additionally decode and assert `mintRecipient`/`amount` against the matched burn body.
- **Test coverage:** add a `recover_already_minted` probe-error-arm test (must re-surface the submit error) and a real-Anvil multicall disambiguation test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672078&installation_id=125569124&pr_number=709&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F709&signature=c7daec1a984e1427b368b651ed9ca2e8c531c7d79cb1a9aaa32240fc57e28f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified CCTP V2 receiveMessage() idempotency behavior for handling failed transactions

* **Bug Fixes**
  * Enhanced crash-safety with automatic recovery of already-executed mint transactions when submission fails

* **New Features**
  * Added public methods to query existing mints and check USDC balances

<!-- end of auto-generated comment: release notes by coderabbit.ai -->