### PR TITLE
feat: add repair set-position command for manual position adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ configured Base liquidity wallet):
 cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml unwrap-equity --symbol AAPL --quantity 10.5
 ```
 
+Manual repair of local position tracking after an operator trade or rebalance:
+
+```bash
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --zero --reason "manual rebalance completed"
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --long 100 --price 200 --reason "manual buy not observed by bot"
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --short 12.5 --price 200 --reason "manual sell not observed by bot"
+```
+
+`--price` (USDC per share) is required for a nonzero target when the symbol uses
+a dollar-value execution threshold and no price is already known; without it the
+repaired exposure could never be valued and would never hedge.
+
+`set-position` is rejected while the symbol still has a pending offchain hedge
+order; resolve it first with `repair fail-pending-offchain-order`, then retry.
+
 ### Brokerage Setup
 
 **Alpaca Broker API** (managed accounts, supports auto-rebalancing):

--- a/SPEC.md
+++ b/SPEC.md
@@ -941,6 +941,9 @@ struct Position {
     accumulated_short: FractionalShares,
     pending_execution_id: Option<ExecutionId>,
     threshold: ExecutionThreshold,
+    last_price_usdc: Option<Float>,  // Last known USDC price per share; drives
+                                     // dollar-threshold hedging. None until a
+                                     // priced fill or manual adjustment sets it.
     last_updated: Option<DateTime<Utc>>,
 }
 
@@ -986,6 +989,14 @@ enum PositionCommand {
         execution_id: ExecutionId,
         error: String,
     },
+    ManuallyAdjustPosition {
+        symbol: Symbol,
+        target_net: FractionalShares,
+        reason: String,
+        threshold: ExecutionThreshold,
+        expected_net: Option<FractionalShares>,
+        price_usdc: Option<Decimal>,
+    },
 }
 ```
 
@@ -1022,6 +1033,13 @@ enum PositionEvent {
         broker_code: Option<BrokerErrorCode>,
         failed_at: DateTime<Utc>,
     },
+    ManualPositionAdjusted {
+        previous_net: FractionalShares,
+        target_net: FractionalShares,
+        reason: String,
+        price_usdc: Option<Decimal>,
+        adjusted_at: DateTime<Utc>,
+    },
 }
 
 enum TriggerReason {
@@ -1042,6 +1060,25 @@ enum TriggerReason {
 
 - `AcknowledgeOnChainFill` serves as the genesis event (initializes the
   aggregate on first fill)
+- `ManuallyAdjustPosition` is an audited operator repair command that sets the
+  absolute net exposure after manual trading or rebalancing outside the bot. It
+  may initialize a missing position, including a zero target, using the
+  configured execution threshold.
+- Manual position adjustment is rejected while an offchain hedge order is
+  pending; operators must fail or resolve the pending order first.
+- Manual position adjustment changes only `net`, not accumulated long/short
+  trading volume, because it corrects exposure rather than rewriting fill
+  history.
+- Manual position adjustment is optimistically concurrency-checked: when
+  `expected_net` is supplied (the CLI always supplies the net it read), the
+  command is rejected with `ManualAdjustmentStateChanged` if the live aggregate
+  net no longer matches, so a concurrent onchain fill cannot be silently erased.
+- A nonzero target under a dollar-value threshold requires a price: the operator
+  must supply `price_usdc` (CLI `--price`) unless the position already has a
+  known `last_price_usdc`. Otherwise the command is rejected with
+  `ManualAdjustmentRequiresPrice`, preventing a repaired exposure that can never
+  be valued and would therefore never hedge. The supplied price is persisted as
+  `last_price_usdc`. A zero target needs no price.
 - Can only place offchain order when threshold is met:
   - **Shares threshold**: `|net_position| >= threshold` (e.g., whole-share
     threshold)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,7 @@ mod wrapper;
 
 use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::{ProviderBuilder, WsConnect};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
@@ -96,10 +96,49 @@ pub enum RepairCommand {
         )]
         reason: String,
     },
+    /// Set a position's net exposure after an operator manual correction.
+    #[command(group(
+        ArgGroup::new("target")
+            .required(true)
+            .multiple(false)
+            .args(["zero", "long", "short"])
+    ))]
+    SetPosition {
+        /// Position symbol (e.g., SPYM)
+        #[arg(short = 's', long = "symbol")]
+        symbol: Symbol,
+        /// Set the position to exactly zero shares
+        #[arg(long = "zero")]
+        zero: bool,
+        /// Set the position to a positive long net exposure
+        #[arg(long = "long", value_parser = parse_positive_shares)]
+        long: Option<Positive<FractionalShares>>,
+        /// Set the position to a negative short net exposure
+        #[arg(long = "short", value_parser = parse_positive_shares)]
+        short: Option<Positive<FractionalShares>>,
+        /// USDC price per share, required for nonzero targets under a dollar-value threshold
+        #[arg(long = "price", value_parser = parse_positive_price)]
+        price: Option<Float>,
+        /// Operator reason to persist on the Position::ManualPositionAdjusted event
+        #[arg(short = 'r', long = "reason")]
+        reason: String,
+    },
 }
 
 fn parse_float(input: &str) -> Result<Float, String> {
     Float::parse(input.to_string()).map_err(|err| format!("{err}"))
+}
+
+/// Parses a strictly-positive price. A zero or negative `--price` would poison
+/// `last_price_usdc` and make a dollar-value threshold never trigger a hedge --
+/// the exact never-hedges state the price requirement exists to prevent.
+fn parse_positive_price(input: &str) -> Result<Float, String> {
+    let value = Float::parse(input.to_string()).map_err(|err| format!("{err}"))?;
+    let zero = Float::parse("0".to_string()).map_err(|err| format!("{err}"))?;
+    if !value.gt(zero).map_err(|err| format!("{err}"))? {
+        return Err(format!("--price must be strictly positive, got {value:?}"));
+    }
+    Ok(value)
 }
 
 fn parse_positive_shares(input: &str) -> Result<Positive<FractionalShares>, String> {
@@ -1129,7 +1168,9 @@ async fn run_simple_command<W: Write>(
         SimpleCommand::RebuildView { aggregate, id, all } => {
             rebuild_view(stdout, pool, aggregate, id, all).await
         }
-        SimpleCommand::Repair { command } => run_repair_command(stdout, pool, command).await,
+        SimpleCommand::Repair { command } => {
+            run_repair_command(stdout, pool, command, ctx.execution_threshold).await
+        }
         SimpleCommand::FailTransfer {
             transfer_type,
             id,
@@ -1194,6 +1235,7 @@ async fn run_repair_command<W: Write>(
     stdout: &mut W,
     pool: &SqlitePool,
     command: RepairCommand,
+    execution_threshold: st0x_config::ExecutionThreshold,
 ) -> anyhow::Result<()> {
     match command {
         RepairCommand::FailPendingOffchainOrder {
@@ -1203,6 +1245,58 @@ async fn run_repair_command<W: Write>(
         } => {
             repair::fail_pending_offchain_order_command(stdout, pool, &symbol, order_id, reason)
                 .await
+        }
+        RepairCommand::SetPosition {
+            symbol,
+            zero,
+            long,
+            short,
+            price,
+            reason,
+        } => {
+            let target_net = ManualPositionTarget::from_flags(zero, long, short)?.net()?;
+            repair::set_position_command(
+                stdout,
+                pool,
+                &symbol,
+                target_net,
+                reason,
+                execution_threshold,
+                price,
+            )
+            .await
+        }
+    }
+}
+
+/// Operator-chosen target for `repair set-position`, converted from the mutually
+/// exclusive `--zero`/`--long`/`--short` clap flags at the parser boundary so
+/// internal code carries one valid state instead of three flags.
+enum ManualPositionTarget {
+    Zero,
+    Long(Positive<FractionalShares>),
+    Short(Positive<FractionalShares>),
+}
+
+impl ManualPositionTarget {
+    fn from_flags(
+        zero: bool,
+        long: Option<Positive<FractionalShares>>,
+        short: Option<Positive<FractionalShares>>,
+    ) -> anyhow::Result<Self> {
+        match (zero, long, short) {
+            (true, None, None) => Ok(Self::Zero),
+            (false, Some(shares), None) => Ok(Self::Long(shares)),
+            (false, None, Some(shares)) => Ok(Self::Short(shares)),
+            _ => anyhow::bail!("exactly one of --zero, --long, or --short is required"),
+        }
+    }
+
+    fn net(self) -> anyhow::Result<FractionalShares> {
+        match self {
+            Self::Zero => Ok(FractionalShares::ZERO),
+            Self::Long(shares) => Ok(shares.inner()),
+            Self::Short(shares) => Ok((FractionalShares::ZERO - shares.inner())?),
         }
     }
 }
@@ -1543,6 +1637,159 @@ mod tests {
     }
 
     #[test]
+    fn repair_set_position_zero_parses() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--zero",
+            "--reason",
+            "manual rebalance completed",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Repair {
+                command:
+                    RepairCommand::SetPosition {
+                        symbol,
+                        zero,
+                        long,
+                        short,
+                        price,
+                        reason,
+                    },
+            } => {
+                assert_eq!(symbol, Symbol::new("SPYM").unwrap());
+                assert!(zero);
+                assert_eq!(long, None);
+                assert_eq!(short, None);
+                assert!(price.is_none());
+                assert_eq!(reason, "manual rebalance completed");
+            }
+            other => panic!("expected repair set-position command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn repair_set_position_long_and_short_parse_positive_amounts() {
+        let long = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--long",
+            "100",
+            "--reason",
+            "manual buy",
+        ])
+        .unwrap();
+
+        match long.command {
+            Commands::Repair {
+                command:
+                    RepairCommand::SetPosition {
+                        long: Some(quantity),
+                        ..
+                    },
+            } => assert_eq!(quantity, positive_shares("100")),
+            other => panic!("expected repair set-position --long, got: {other:?}"),
+        }
+
+        let short = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--short",
+            "12.5",
+            "--reason",
+            "manual sell",
+        ])
+        .unwrap();
+
+        match short.command {
+            Commands::Repair {
+                command:
+                    RepairCommand::SetPosition {
+                        short: Some(quantity),
+                        ..
+                    },
+            } => assert_eq!(quantity, positive_shares("12.5")),
+            other => panic!("expected repair set-position --short, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn repair_set_position_rejects_missing_reason() {
+        let error = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--zero",
+        ])
+        .unwrap_err();
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("reason"),
+            "unexpected clap error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn repair_set_position_rejects_multiple_targets() {
+        let error = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--zero",
+            "--long",
+            "1",
+            "--reason",
+            "operator repair",
+        ])
+        .unwrap_err();
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("cannot be used with")
+                && rendered.contains("--zero")
+                && rendered.contains("--long"),
+            "unexpected clap error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn repair_set_position_rejects_zero_long_amount() {
+        let error = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--long",
+            "0",
+            "--reason",
+            "operator repair",
+        ])
+        .unwrap_err();
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("invalid value '0'")
+                && rendered.contains("--long")
+                && rendered.contains("value must be positive"),
+            "unexpected clap error: {rendered}"
+        );
+    }
+
+    #[test]
     fn classify_repair_command_as_simple() {
         let order_id = OffchainOrderId::new();
         let command = Commands::Repair {
@@ -1578,6 +1825,49 @@ mod tests {
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification"),
         }
+    }
+
+    #[tokio::test]
+    async fn run_command_with_writers_executes_repair_set_position() {
+        let ctx = create_test_ctx();
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let command = Commands::Repair {
+            command: RepairCommand::SetPosition {
+                symbol: symbol.clone(),
+                zero: false,
+                long: Some(positive_shares("100")),
+                short: None,
+                price: None,
+                reason: "manual buy not observed by bot".to_string(),
+            },
+        };
+
+        let mut stdout_buffer = Vec::new();
+        run_command_with_writers(ctx, command, &pool, &mut stdout_buffer)
+            .await
+            .unwrap();
+
+        let projection = Projection::<Position>::sqlite(pool.clone());
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.net, positive_shares("100").inner());
+
+        let output = String::from_utf8(stdout_buffer).unwrap();
+        assert!(
+            output.contains("Set SPYM position from 0 to 100"),
+            "unexpected output: {output}"
+        );
+    }
+
+    #[test]
+    fn manual_position_target_converts_short_to_negative_net() {
+        let target = ManualPositionTarget::from_flags(false, None, Some(positive_shares("12.5")))
+            .unwrap()
+            .net()
+            .unwrap();
+        let expected = (FractionalShares::ZERO - positive_shares("12.5").inner()).unwrap();
+
+        assert_eq!(target, expected);
     }
 
     #[tokio::test]

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -1,11 +1,13 @@
 //! Repair CLI commands for manually recovering stuck local CQRS state.
 
 use anyhow::{Context, bail};
+use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::io::Write;
 
+use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::StoreBuilder;
-use st0x_execution::Symbol;
+use st0x_execution::{FractionalShares, Symbol};
 
 use crate::offchain::order::OffchainOrderId;
 use crate::position::{Position, PositionCommand};
@@ -52,6 +54,67 @@ pub(super) async fn fail_pending_offchain_order_command<W: Write>(
     writeln!(
         stdout,
         "Failed pending offchain order {offchain_order_id} for {symbol}"
+    )?;
+
+    Ok(())
+}
+
+pub(super) async fn set_position_command<W: Write>(
+    stdout: &mut W,
+    pool: &SqlitePool,
+    symbol: &Symbol,
+    target_net: FractionalShares,
+    reason: String,
+    threshold: ExecutionThreshold,
+    price_usdc: Option<Float>,
+) -> anyhow::Result<()> {
+    if reason.trim().is_empty() {
+        bail!(
+            "--reason must not be empty; it is persisted as the audit record for this adjustment"
+        );
+    }
+
+    let (position, projection) = StoreBuilder::<Position>::new(pool.clone())
+        .build(())
+        .await
+        .context("failed to build position store")?;
+
+    let current = projection
+        .load(symbol)
+        .await
+        .context("failed to load position view")?;
+
+    if let Some(view) = &current
+        && let Some(pending) = view.pending_offchain_order_id.as_ref()
+    {
+        bail!(
+            "position {symbol} has pending offchain order {pending}; \
+             run repair fail-pending-offchain-order before setting position"
+        );
+    }
+
+    let previous_net = current
+        .as_ref()
+        .map_or(FractionalShares::ZERO, |view| view.net);
+
+    position
+        .send(
+            symbol,
+            PositionCommand::ManuallyAdjustPosition {
+                symbol: symbol.clone(),
+                target_net,
+                reason: reason.clone(),
+                threshold,
+                expected_net: Some(previous_net),
+                price_usdc,
+            },
+        )
+        .await
+        .context("failed to set position")?;
+
+    writeln!(
+        stdout,
+        "Set {symbol} position from {previous_net} to {target_net} because \"{reason}\""
     )?;
 
     Ok(())
@@ -220,5 +283,230 @@ mod tests {
             error.to_string().contains("no pending offchain order"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn set_position_initializes_missing_position() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let target_net = FractionalShares::new(float!(100));
+
+        let mut stdout_buffer = Vec::new();
+        set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            target_net,
+            "manual long correction".to_string(),
+            ExecutionThreshold::whole_share(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.net, target_net);
+        assert_eq!(view.threshold, ExecutionThreshold::whole_share());
+
+        let output = String::from_utf8(stdout_buffer).unwrap();
+        assert!(
+            output.contains("because \"manual long correction\""),
+            "unexpected output: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_position_updates_existing_position() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        position
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 0,
+                    },
+                    amount: FractionalShares::new(float!(5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(420),
+                    block_timestamp: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let target_net = FractionalShares::new(float!(-3.25));
+        let mut stdout_buffer = Vec::new();
+        set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            target_net,
+            "manual short correction".to_string(),
+            ExecutionThreshold::whole_share(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.net, target_net);
+        assert_eq!(view.accumulated_long, FractionalShares::new(float!(5)));
+
+        let output = String::from_utf8(stdout_buffer).unwrap();
+        assert!(
+            output.contains("from 5 to -3.25"),
+            "unexpected output: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_position_rejects_nonzero_dollar_target_without_price() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold =
+            ExecutionThreshold::dollar_value(st0x_finance::Usdc::new(float!(1000))).unwrap();
+
+        let mut stdout_buffer = Vec::new();
+        let error = set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            FractionalShares::new(float!(100)),
+            "manual long correction".to_string(),
+            threshold,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("without a price"),
+            "unexpected error: {error:#}"
+        );
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&symbol).await.unwrap().is_none(),
+            "rejected adjustment must not persist a position"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_position_rejects_whitespace_only_reason() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+
+        let mut stdout_buffer = Vec::new();
+        let error = set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            FractionalShares::ZERO,
+            "   ".to_string(),
+            ExecutionThreshold::whole_share(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("--reason must not be empty"),
+            "unexpected error: {error:#}"
+        );
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        assert!(
+            projection.load(&symbol).await.unwrap().is_none(),
+            "rejected adjustment must not persist a position"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_position_initializes_dollar_position_with_price() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold =
+            ExecutionThreshold::dollar_value(st0x_finance::Usdc::new(float!(1000))).unwrap();
+        let target_net = FractionalShares::new(float!(100));
+
+        let mut stdout_buffer = Vec::new();
+        set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            target_net,
+            "manual long correction".to_string(),
+            threshold,
+            Some(float!(200)),
+        )
+        .await
+        .unwrap();
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.net, target_net);
+        let (direction, shares) = view.is_ready_for_execution(None).unwrap().unwrap();
+        assert_eq!(direction, Direction::Sell);
+        assert_eq!(shares, target_net);
+    }
+
+    #[tokio::test]
+    async fn set_position_rejects_position_with_pending_order() {
+        let pool = setup_test_db().await;
+        let symbol = Symbol::new("SPYM").unwrap();
+        let pending_order_id = OffchainOrderId::new();
+        seed_pending_position(&pool, &symbol, pending_order_id).await;
+
+        let mut stdout_buffer = Vec::new();
+        let error = set_position_command(
+            &mut stdout_buffer,
+            &pool,
+            &symbol,
+            FractionalShares::ZERO,
+            "manual rebalance completed".to_string(),
+            ExecutionThreshold::whole_share(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("pending offchain order"),
+            "unexpected error: {error}"
+        );
+
+        let (_position, projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let view = projection.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(view.pending_offchain_order_id, Some(pending_order_id));
+        assert_eq!(view.net, FractionalShares::new(float!(1)));
     }
 }

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -93,6 +93,7 @@ impl Reactor for Broadcaster {
                     event,
                     PositionEvent::OnChainOrderFilled { .. }
                         | PositionEvent::OffChainOrderFilled { .. }
+                        | PositionEvent::ManualPositionAdjusted { .. }
                 ) {
                     return;
                 }
@@ -362,6 +363,100 @@ mod tests {
         match msg {
             Statement::PositionUpdate(position) => {
                 assert_eq!(position.symbol, symbol);
+                assert!(
+                    position.net.eq(st0x_float_macro::float!(1)).unwrap(),
+                    "expected net 1, got {:?}",
+                    position.net
+                );
+            }
+            other => panic!("expected PositionUpdate message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_position_adjustment_broadcasts_adjusted_net() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let harness = ReactorHarness::new(broadcaster);
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = chrono::Utc::now();
+        let threshold = crate::ExecutionThreshold::Shares(
+            st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                st0x_float_macro::float!(1),
+            ))
+            .unwrap(),
+        );
+
+        store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: TradeId {
+                        tx_hash: alloy::primitives::TxHash::ZERO,
+                        log_index: 0,
+                    },
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(1)),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &symbol,
+                PositionCommand::ManuallyAdjustPosition {
+                    symbol: symbol.clone(),
+                    target_net: st0x_execution::FractionalShares::new(st0x_float_macro::float!(-3)),
+                    reason: "operator repair".to_string(),
+                    threshold,
+                    expected_net: Some(st0x_execution::FractionalShares::new(
+                        st0x_float_macro::float!(1),
+                    )),
+                    price_usdc: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                PositionEvent::ManualPositionAdjusted {
+                    previous_net: st0x_execution::FractionalShares::new(st0x_float_macro::float!(
+                        1
+                    )),
+                    target_net: st0x_execution::FractionalShares::new(st0x_float_macro::float!(-3)),
+                    reason: "operator repair".to_string(),
+                    price_usdc: None,
+                    adjusted_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let msg = receiver
+            .recv()
+            .await
+            .expect("should receive position update");
+
+        match msg {
+            Statement::PositionUpdate(position) => {
+                assert_eq!(position.symbol, symbol);
+                assert!(
+                    position.net.eq(st0x_float_macro::float!(-3)).unwrap(),
+                    "expected adjusted net -3, got {:?}",
+                    position.net
+                );
             }
             other => panic!("expected PositionUpdate message, got {other:?}"),
         }

--- a/src/position.rs
+++ b/src/position.rs
@@ -18,6 +18,7 @@ use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, HasZero, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::{Usd, Usdc};
+use st0x_float_macro::float;
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 
 use crate::offchain::order::OffchainOrderId;
@@ -79,7 +80,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -218,6 +219,23 @@ impl EventSourced for Position {
                 ..entity.clone()
             })),
 
+            ManualPositionAdjusted {
+                target_net,
+                price_usdc,
+                adjusted_at,
+                ..
+            } => Ok(Some(Self {
+                net: *target_net,
+                last_price_usdc: (*price_usdc).or(entity.last_price_usdc),
+                last_updated: Some(*adjusted_at),
+                // A manual reconciliation supersedes any prior failed hedge, so
+                // clear the broker-idempotency anchor. Otherwise the next hedge
+                // could reuse the failed order's client_order_id and be deduped
+                // by the broker against a stale order.
+                last_failed_offchain_order_id: None,
+                ..entity.clone()
+            })),
+
             Initialized { .. } => Ok(None),
         }
     }
@@ -251,6 +269,47 @@ impl EventSourced for Position {
                         price_usdc,
                         block_timestamp,
                         seen_at: now,
+                    },
+                ])
+            }
+
+            ManuallyAdjustPosition {
+                symbol,
+                target_net,
+                reason,
+                threshold,
+                expected_net,
+                price_usdc,
+            } => {
+                Self::validate_manual_adjustment(
+                    expected_net,
+                    FractionalShares::ZERO,
+                    target_net,
+                    &threshold,
+                    None,
+                    price_usdc,
+                )?;
+
+                let now = Utc::now();
+
+                warn!(
+                    target: "hedge",
+                    %symbol, target_net = %target_net, %reason,
+                    "Manually adjusted uninitialized position"
+                );
+
+                Ok(vec![
+                    PositionEvent::Initialized {
+                        symbol,
+                        threshold,
+                        initialized_at: now,
+                    },
+                    PositionEvent::ManualPositionAdjusted {
+                        previous_net: FractionalShares::ZERO,
+                        target_net,
+                        reason,
+                        price_usdc,
+                        adjusted_at: now,
                     },
                 ])
             }
@@ -363,6 +422,46 @@ impl EventSourced for Position {
                 new_threshold: threshold,
                 updated_at: Utc::now(),
             }]),
+
+            ManuallyAdjustPosition {
+                target_net,
+                reason,
+                expected_net,
+                price_usdc,
+                ..
+            } => {
+                if let Some(pending) = self.pending_offchain_order_id {
+                    return Err(PositionError::ManualAdjustmentBlockedByPendingExecution {
+                        offchain_order_id: pending,
+                    });
+                }
+
+                Self::validate_manual_adjustment(
+                    expected_net,
+                    self.net,
+                    target_net,
+                    &self.threshold,
+                    self.last_price_usdc,
+                    price_usdc,
+                )?;
+
+                warn!(
+                    target: "hedge",
+                    symbol = %self.symbol,
+                    previous_net = %self.net,
+                    target_net = %target_net,
+                    %reason,
+                    "Manually adjusted position"
+                );
+
+                Ok(vec![PositionEvent::ManualPositionAdjusted {
+                    previous_net: self.net,
+                    target_net,
+                    reason,
+                    price_usdc,
+                    adjusted_at: Utc::now(),
+                }])
+            }
         }
     }
 }
@@ -423,6 +522,56 @@ impl Position {
                 expected: pending_id,
                 actual: offchain_order_id,
             });
+        }
+
+        Ok(())
+    }
+
+    /// Validates a manual position adjustment before emitting events.
+    ///
+    /// Enforces optimistic concurrency (the live net must still match what the
+    /// operator observed) and ensures a nonzero target under a dollar-value
+    /// threshold has a usable price, so the adjusted exposure can actually be
+    /// hedged instead of stalling on a missing `last_price_usdc`.
+    fn validate_manual_adjustment(
+        expected_net: Option<FractionalShares>,
+        current_net: FractionalShares,
+        target_net: FractionalShares,
+        threshold: &ExecutionThreshold,
+        existing_price: Option<Float>,
+        provided_price: Option<Float>,
+    ) -> Result<(), PositionError> {
+        if let Some(expected) = expected_net
+            && expected != current_net
+        {
+            return Err(PositionError::ManualAdjustmentStateChanged {
+                expected,
+                actual: current_net,
+            });
+        }
+
+        // The aggregate is the real domain boundary: a non-positive price
+        // would value the repaired exposure at zero or a negative dollar
+        // amount, stalling or corrupting dollar-threshold hedging. Reject the
+        // price that will actually drive valuation (the provided override, or
+        // the persisted price it falls back to).
+        if let Some(price) = provided_price.or(existing_price)
+            && !price.gt(float!(0))?
+        {
+            return Err(PositionError::ManualAdjustmentInvalidPrice {
+                price: Usdc::new(price),
+            });
+        }
+
+        let needs_price = match threshold {
+            ExecutionThreshold::DollarValue(_) => {
+                !target_net.is_zero()? && existing_price.is_none() && provided_price.is_none()
+            }
+            ExecutionThreshold::Shares(_) => false,
+        };
+
+        if needs_price {
+            return Err(PositionError::ManualAdjustmentRequiresPrice { target_net });
         }
 
         Ok(())
@@ -505,6 +654,32 @@ pub enum PositionError {
          pending execution {offchain_order_id:?}"
     )]
     PendingExecution { offchain_order_id: OffchainOrderId },
+    #[error(
+        "Cannot manually adjust position: already have \
+         pending execution {offchain_order_id:?}"
+    )]
+    ManualAdjustmentBlockedByPendingExecution { offchain_order_id: OffchainOrderId },
+    #[error(
+        "Cannot manually adjust position: expected net \
+         {expected:?} but live net is {actual:?}; reload \
+         and retry"
+    )]
+    ManualAdjustmentStateChanged {
+        expected: FractionalShares,
+        actual: FractionalShares,
+    },
+    #[error(
+        "Cannot manually adjust nonzero position \
+         {target_net:?} under a dollar-value threshold \
+         without a price; provide --price"
+    )]
+    ManualAdjustmentRequiresPrice { target_net: FractionalShares },
+    #[error(
+        "Cannot manually adjust position with non-positive price \
+         {price:?}; the price must be strictly positive to value the \
+         repaired exposure"
+    )]
+    ManualAdjustmentInvalidPrice { price: Usdc },
     #[error("Cannot complete offchain order: no pending execution")]
     NoPendingExecution,
     #[error(
@@ -564,6 +739,18 @@ pub enum PositionCommand {
     UpdateThreshold {
         threshold: ExecutionThreshold,
     },
+    ManuallyAdjustPosition {
+        symbol: Symbol,
+        target_net: FractionalShares,
+        reason: String,
+        threshold: ExecutionThreshold,
+        /// Net exposure the operator observed; rejects the command if the live
+        /// aggregate has since changed. `None` skips the concurrency check.
+        expected_net: Option<FractionalShares>,
+        /// USDC price per share to record, required for nonzero adjustments
+        /// under a dollar-value threshold when no price is already known.
+        price_usdc: Option<Float>,
+    },
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -611,6 +798,18 @@ pub enum PositionEvent {
         new_threshold: ExecutionThreshold,
         updated_at: DateTime<Utc>,
     },
+    ManualPositionAdjusted {
+        previous_net: FractionalShares,
+        target_net: FractionalShares,
+        reason: String,
+        #[serde(
+            default,
+            serialize_with = "st0x_float_serde::serialize_option_float",
+            deserialize_with = "st0x_float_serde::deserialize_option_float_from_number_or_string"
+        )]
+        price_usdc: Option<Float>,
+        adjusted_at: DateTime<Utc>,
+    },
 }
 
 impl PositionEvent {
@@ -625,6 +824,7 @@ impl PositionEvent {
             } => *broker_timestamp,
             OffChainOrderFailed { failed_at, .. } => *failed_at,
             ThresholdUpdated { updated_at, .. } => *updated_at,
+            ManualPositionAdjusted { adjusted_at, .. } => *adjusted_at,
         }
     }
 }
@@ -639,11 +839,22 @@ impl DomainEvent for PositionEvent {
             OffChainOrderFilled { .. } => "PositionEvent::OffChainOrderFilled".to_string(),
             OffChainOrderFailed { .. } => "PositionEvent::OffChainOrderFailed".to_string(),
             ThresholdUpdated { .. } => "PositionEvent::ThresholdUpdated".to_string(),
+            ManualPositionAdjusted { .. } => "PositionEvent::ManualPositionAdjusted".to_string(),
         }
     }
 
     fn event_version(&self) -> String {
         "1.0".to_string()
+    }
+}
+
+/// Compares two optional `Float` prices, treating both-absent as equal.
+/// `Float` has no `PartialEq`, so this routes through its fallible `eq`.
+fn option_float_eq(left: Option<Float>, right: Option<Float>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => left.eq(right).unwrap_or(false),
+        _ => false,
     }
 }
 
@@ -748,6 +959,22 @@ impl PartialEq for PositionEvent {
                     updated_at: u2,
                 },
             ) => ot1 == ot2 && nt1 == nt2 && u1 == u2,
+            (
+                Self::ManualPositionAdjusted {
+                    previous_net: pn1,
+                    target_net: tn1,
+                    reason: r1,
+                    price_usdc: pr1,
+                    adjusted_at: a1,
+                },
+                Self::ManualPositionAdjusted {
+                    previous_net: pn2,
+                    target_net: tn2,
+                    reason: r2,
+                    price_usdc: pr2,
+                    adjusted_at: a2,
+                },
+            ) => pn1 == pn2 && tn1 == tn2 && r1 == r2 && option_float_eq(*pr1, *pr2) && a1 == a2,
             _ => false,
         }
     }
@@ -908,6 +1135,22 @@ impl std::fmt::Debug for PositionCommand {
                 .debug_struct("UpdateThreshold")
                 .field("threshold", threshold)
                 .finish(),
+            Self::ManuallyAdjustPosition {
+                symbol,
+                target_net,
+                reason,
+                threshold,
+                expected_net,
+                price_usdc,
+            } => f
+                .debug_struct("ManuallyAdjustPosition")
+                .field("symbol", symbol)
+                .field("target_net", target_net)
+                .field("reason", reason)
+                .field("threshold", threshold)
+                .field("expected_net", expected_net)
+                .field("price_usdc", &DebugOptionFloat(price_usdc))
+                .finish(),
         }
     }
 }
@@ -994,6 +1237,20 @@ impl std::fmt::Debug for PositionEvent {
                 .field("old_threshold", old_threshold)
                 .field("new_threshold", new_threshold)
                 .field("updated_at", updated_at)
+                .finish(),
+            Self::ManualPositionAdjusted {
+                previous_net,
+                target_net,
+                reason,
+                price_usdc,
+                adjusted_at,
+            } => f
+                .debug_struct("ManualPositionAdjusted")
+                .field("previous_net", previous_net)
+                .field("target_net", target_net)
+                .field("reason", reason)
+                .field("price_usdc", &DebugOptionFloat(price_usdc))
+                .field("adjusted_at", adjusted_at)
                 .finish(),
         }
     }
@@ -1343,6 +1600,404 @@ mod tests {
         assert_eq!(events.len(), 1);
     }
 
+    #[tokio::test]
+    async fn manual_position_adjustment_initializes_position() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = one_share_threshold();
+        let target_net = FractionalShares::new(float!(100));
+
+        let events = TestHarness::<Position>::with(())
+            .given_no_previous_events()
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol: symbol.clone(),
+                target_net,
+                reason: "manual long correction".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::ZERO),
+                price_usdc: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            2,
+            "Expected Initialized + ManualPositionAdjusted"
+        );
+        assert!(matches!(
+            events.first(),
+            Some(PositionEvent::Initialized {
+                symbol: initialized_symbol,
+                threshold: initialized_threshold,
+                ..
+            }) if *initialized_symbol == symbol && *initialized_threshold == threshold
+        ));
+
+        match events.get(1) {
+            Some(PositionEvent::ManualPositionAdjusted {
+                previous_net,
+                target_net: adjusted_target,
+                reason,
+                ..
+            }) => {
+                assert_eq!(*previous_net, FractionalShares::ZERO);
+                assert_eq!(*adjusted_target, target_net);
+                assert_eq!(reason, "manual long correction");
+            }
+            other => panic!("expected ManualPositionAdjusted event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_position_adjustment_sets_existing_position_to_zero() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = one_share_threshold();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(2.5)),
+                    direction: Direction::Sell,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::ZERO,
+                reason: "manual rebalance completed".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::new(float!(-2.5))),
+                price_usdc: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+
+        match events.first() {
+            Some(PositionEvent::ManualPositionAdjusted {
+                previous_net,
+                target_net,
+                reason,
+                ..
+            }) => {
+                assert_eq!(*previous_net, FractionalShares::new(float!(-2.5)));
+                assert_eq!(*target_net, FractionalShares::ZERO);
+                assert_eq!(reason, "manual rebalance completed");
+            }
+            other => panic!("expected ManualPositionAdjusted event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_position_adjustment_rejects_pending_offchain_order() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = one_share_threshold();
+        let offchain_order_id = OffchainOrderId::new();
+
+        let error = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(2)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+                PositionEvent::OffChainOrderPlaced {
+                    offchain_order_id,
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    trigger_reason: TriggerReason::SharesThreshold {
+                        net_position_shares: float!(2),
+                        threshold_shares: float!(1),
+                    },
+                    placed_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::ZERO,
+                reason: "operator repair".to_string(),
+                threshold,
+                expected_net: None,
+                price_usdc: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(PositionError::ManualAdjustmentBlockedByPendingExecution {
+                offchain_order_id: blocked_order_id
+            }) if blocked_order_id == offchain_order_id
+        ));
+    }
+
+    #[test]
+    fn manual_position_adjustment_replay_sets_net_without_rewriting_volume() {
+        let adjusted_at = Utc::now();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("SPYM").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at: Utc::now(),
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: FractionalShares::new(float!(5)),
+                target_net: FractionalShares::new(float!(-2.5)),
+                reason: "manual short correction".to_string(),
+                price_usdc: None,
+                adjusted_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(position.net, FractionalShares::new(float!(-2.5)));
+        assert_eq!(position.accumulated_long, FractionalShares::new(float!(5)));
+        assert_eq!(position.accumulated_short, FractionalShares::ZERO);
+        assert_eq!(position.last_updated, Some(adjusted_at));
+    }
+
+    #[tokio::test]
+    async fn manual_adjustment_rejects_nonzero_dollar_target_without_price() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
+
+        let error = TestHarness::<Position>::with(())
+            .given_no_previous_events()
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::new(float!(100)),
+                reason: "manual long correction".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::ZERO),
+                price_usdc: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(PositionError::ManualAdjustmentRequiresPrice { target_net })
+                if target_net == FractionalShares::new(float!(100))
+        ));
+    }
+
+    #[tokio::test]
+    async fn manual_adjustment_rejects_non_positive_price() {
+        for price in [float!(0), float!(-5)] {
+            let symbol = Symbol::new("SPYM").unwrap();
+            let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
+
+            let error = TestHarness::<Position>::with(())
+                .given_no_previous_events()
+                .when(PositionCommand::ManuallyAdjustPosition {
+                    symbol,
+                    target_net: FractionalShares::new(float!(100)),
+                    reason: "manual long correction".to_string(),
+                    threshold,
+                    expected_net: Some(FractionalShares::ZERO),
+                    price_usdc: Some(price),
+                })
+                .await
+                .then_expect_error();
+
+            assert!(
+                matches!(
+                    error,
+                    LifecycleError::Apply(PositionError::ManualAdjustmentInvalidPrice {
+                        price: rejected,
+                    }) if rejected == Usdc::new(price)
+                ),
+                "expected ManualAdjustmentInvalidPrice for price {price:?}, got {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_adjustment_allows_zero_dollar_target_without_price() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
+
+        let events = TestHarness::<Position>::with(())
+            .given_no_previous_events()
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::ZERO,
+                reason: "manual rebalance completed".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::ZERO),
+                price_usdc: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            2,
+            "Expected Initialized + ManualPositionAdjusted"
+        );
+    }
+
+    #[test]
+    fn manual_adjustment_with_price_is_hedge_ready_under_dollar_threshold() {
+        let now = Utc::now();
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("SPYM").unwrap(),
+                threshold: ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap(),
+                initialized_at: now,
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: FractionalShares::ZERO,
+                target_net: FractionalShares::new(float!(100)),
+                reason: "manual long correction".to_string(),
+                price_usdc: Some(float!(200)),
+                adjusted_at: now,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            option_float_eq(position.last_price_usdc, Some(float!(200))),
+            "manual adjustment should persist the supplied price"
+        );
+
+        let (direction, shares) = position.is_ready_for_execution(None).unwrap().unwrap();
+        assert_eq!(direction, Direction::Sell);
+        assert_eq!(shares, FractionalShares::new(float!(100)));
+    }
+
+    #[tokio::test]
+    async fn manual_adjustment_allows_nonzero_dollar_target_when_price_known() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(1000))).unwrap();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(2)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::new(float!(50)),
+                reason: "manual correction".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::new(float!(2))),
+                price_usdc: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+
+        match events.first() {
+            Some(PositionEvent::ManualPositionAdjusted {
+                target_net,
+                price_usdc,
+                ..
+            }) => {
+                assert_eq!(*target_net, FractionalShares::new(float!(50)));
+                assert!(price_usdc.is_none());
+            }
+            other => panic!("expected ManualPositionAdjusted event, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_adjustment_rejects_stale_expected_net() {
+        let symbol = Symbol::new("SPYM").unwrap();
+        let threshold = one_share_threshold();
+
+        let error = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(2)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::ManuallyAdjustPosition {
+                symbol,
+                target_net: FractionalShares::ZERO,
+                reason: "operator repair".to_string(),
+                threshold,
+                expected_net: Some(FractionalShares::new(float!(5))),
+                price_usdc: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(PositionError::ManualAdjustmentStateChanged { expected, actual })
+                if expected == FractionalShares::new(float!(5))
+                    && actual == FractionalShares::new(float!(2))
+        ));
+    }
+
     #[test]
     fn offchain_sell_reduces_net_position() {
         let offchain_order_id = OffchainOrderId::new();
@@ -1645,6 +2300,65 @@ mod tests {
     }
 
     #[test]
+    fn manual_adjustment_clears_failed_offchain_order_anchor() {
+        let offchain_order_id = OffchainOrderId::new();
+
+        // Drive the position to a failed offchain order (which records the
+        // broker-idempotency anchor), then manually reconcile. The manual
+        // adjustment must clear the anchor so the next hedge does not reuse the
+        // failed order's client_order_id and get deduped by the broker.
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at: Utc::now(),
+            },
+            PositionEvent::OffChainOrderPlaced {
+                offchain_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            PositionEvent::OffChainOrderFailed {
+                offchain_order_id,
+                error: "Market closed".to_string(),
+                failed_at: Utc::now(),
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: FractionalShares::new(float!(1.5)),
+                target_net: FractionalShares::ZERO,
+                reason: "operator reconciliation".to_string(),
+                price_usdc: None,
+                adjusted_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(position.net, FractionalShares::ZERO);
+        assert_eq!(
+            position.last_failed_offchain_order_id, None,
+            "manual adjustment must clear the stale broker-idempotency anchor"
+        );
+    }
+
+    #[test]
     fn threshold_updated_changes_threshold() {
         let new_threshold = ExecutionThreshold::dollar_value(Usdc::new(float!(10000))).unwrap();
 
@@ -1769,6 +2483,20 @@ mod tests {
                 Positive::new(FractionalShares::new(float!(5))).unwrap(),
             ),
             updated_at: timestamp,
+        };
+
+        assert_eq!(event.timestamp(), timestamp);
+    }
+
+    #[test]
+    fn timestamp_returns_adjusted_at_for_manual_position_adjusted_event() {
+        let timestamp = Utc::now();
+        let event = PositionEvent::ManualPositionAdjusted {
+            previous_net: FractionalShares::new(float!(2)),
+            target_net: FractionalShares::ZERO,
+            reason: "operator repair".to_string(),
+            price_usdc: None,
+            adjusted_at: timestamp,
         };
 
         assert_eq!(event.timestamp(), timestamp);

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1548,7 +1548,17 @@ impl Reactor for RebalancingService {
                         self.equity_scheduler.enqueue_check(symbol).await;
                         return Ok(());
                     }
-                    Initialized { .. } | ThresholdUpdated { .. } => return Ok(()),
+                    Initialized { .. } | ThresholdUpdated { .. } => {
+                        return Ok(());
+                    }
+                    ManualPositionAdjusted { .. } => {
+                        // A manual adjustment can create a hedgeable imbalance.
+                        // Nudge an immediate equity check (mirroring the
+                        // OffChainOrderFailed arm) rather than waiting up to a
+                        // full poll cycle for the periodic scan to notice.
+                        self.equity_scheduler.enqueue_check(symbol).await;
+                        return Ok(());
+                    }
                 };
 
                 let inventory_result = {
@@ -6416,36 +6426,92 @@ mod tests {
     #[tokio::test]
     async fn position_noop_events_via_reactor_do_not_error() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let inventory = InventoryView::default().with_equity(symbol.clone(), shares(0), shares(0));
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(5), shares(5))
+            .with_usdc(usdc(10000), usdc(10000));
 
         let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
         let harness = ReactorHarness::new(Arc::clone(&trigger));
 
-        // Initialized, OffChainOrderPlaced, OffChainOrderFailed, ThresholdUpdated
-        // all return Ok(()) without modifying inventory
-        harness
-            .receive::<Position>(
-                symbol.clone(),
-                PositionEvent::Initialized {
-                    symbol: symbol.clone(),
-                    threshold: ExecutionThreshold::whole_share(),
-                    initialized_at: Utc::now(),
-                },
-            )
+        // Seed the pending-hedge gate so we can prove no-op events leave it intact
+        // (OffChainOrderFailed clears it; manual adjustments must not).
+        trigger
+            .pending_offchain_order_symbols
+            .write()
             .await
-            .unwrap();
+            .insert(symbol.clone());
 
-        harness
-            .receive::<Position>(
-                symbol.clone(),
-                PositionEvent::ThresholdUpdated {
-                    old_threshold: ExecutionThreshold::whole_share(),
-                    new_threshold: ExecutionThreshold::whole_share(),
-                    updated_at: Utc::now(),
-                },
-            )
-            .await
-            .unwrap();
+        // Initialized, ThresholdUpdated, and ManualPositionAdjusted all return
+        // Ok(()) without touching inventory or the pending-hedge gate.
+        for event in [
+            PositionEvent::Initialized {
+                symbol: symbol.clone(),
+                threshold: ExecutionThreshold::whole_share(),
+                initialized_at: Utc::now(),
+            },
+            PositionEvent::ThresholdUpdated {
+                old_threshold: ExecutionThreshold::whole_share(),
+                new_threshold: ExecutionThreshold::whole_share(),
+                updated_at: Utc::now(),
+            },
+            PositionEvent::ManualPositionAdjusted {
+                previous_net: shares(5),
+                target_net: shares(0),
+                reason: "operator repair".to_string(),
+                price_usdc: Some(float!(150)),
+                adjusted_at: Utc::now(),
+            },
+        ] {
+            harness
+                .receive::<Position>(symbol.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::Hedging),
+            Some(shares(5)),
+            "manual adjustment must not change hedging equity"
+        );
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(5)),
+            "manual adjustment must not change market-making equity"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(10000)),
+            "manual adjustment must not change hedging USDC"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(10000)),
+            "manual adjustment must not change market-making USDC"
+        );
+        drop(inventory);
+
+        assert!(
+            trigger
+                .pending_offchain_order_symbols
+                .read()
+                .await
+                .contains(&symbol),
+            "manual adjustment must not clear the pending-hedge gate"
+        );
+
+        let pending_equity_checks = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<EquityRebalancingCheck>())
+        .fetch_one(trigger.equity_scheduler.queue().pool())
+        .await
+        .expect("count pending equity-check jobs after ManualPositionAdjusted");
+
+        assert_eq!(
+            pending_equity_checks, 1,
+            "ManualPositionAdjusted must enqueue exactly one immediate equity recheck"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Closes [RAI-719](https://linear.app/makeitrain/issue/RAI-719/operator-command-to-manually-adjust-a-positions-net-exposure)

Adds an audited operator repair command, `cli repair set-position`, that sets a position's absolute net exposure after manual trading or rebalancing done outside the bot. It is backed by a new `Position::ManuallyAdjustPosition` command and `PositionEvent::ManualPositionAdjusted` event.

## Why

When an operator buys/sells or rebalances a symbol outside the bot, the local `Position` aggregate drifts from the true exposure. Editing event-sourced state by hand is forbidden, so there was no supported way to reconcile. This adds a first-class, audited correction path that emits a proper domain event through the CQRS framework.

## How

- **CLI (`src/cli/mod.rs`, `src/cli/repair.rs`):** new `repair set-position` subcommand takes `--symbol`, a mutually-exclusive required target (`--zero` | `--long <shares>` | `--short <shares>`), a `--reason`, and a `--price` (USDC price per share, required for nonzero targets under a dollar-value threshold). A clap `ArgGroup` enforces exactly one target; `--long`/`--short` use `parse_positive_shares` so amounts must be strictly positive, and `--price` uses `parse_positive_price` (a zero/negative price would poison `last_price_usdc`). `ManualPositionTarget::from_flags(...).net()` maps the flags to a signed `FractionalShares` net (short -> negative). `set_position_command` loads the current view, bails if a pending offchain order exists, captures `previous_net`, sends the command, and prints a `from <previous> to <target> because "<reason>"` summary.
- **Aggregate (`src/position.rs`):** `ManuallyAdjustPosition` handles two cases — an uninitialized position emits `Initialized` + `ManualPositionAdjusted` (using the configured `ExecutionThreshold`); an initialized position emits `ManualPositionAdjusted`, but is rejected with the new `PositionError::ManualAdjustmentBlockedByPendingExecution` when a hedge order is pending. Applying the event sets `net` and `last_updated` only — it does **not** touch `accumulated_long`/`accumulated_short`, because it corrects exposure rather than rewriting fill history. Both adjustment paths log a `warn!` for the audit trail. Includes `Debug`, `PartialEq`, `timestamp()`, and `event_type` wiring for the new event.
- **Dashboard (`src/dashboard/event.rs`):** `ManualPositionAdjusted` is added to the broadcaster's allowlist so the dashboard pushes the corrected net to connected clients, same as fills.
- **Rebalancing (`src/rebalancing/trigger/mod.rs`):** the reactor reacts to `ManualPositionAdjusted` by calling `enqueue_check` for the symbol (mirroring `OffChainOrderFailed`), so a hedgeable imbalance from the adjustment is acted on immediately rather than on the next poll cycle; `Initialized`/`ThresholdUpdated` remain no-ops.
- **Spec/docs:** `SPEC.md` documents the command/event and its semantics; `README.md` adds usage examples.

## Testing

New tests, no manual verification:
- CLI parsing (`src/cli/mod.rs`): `--zero`/`--long`/`--short` parse, missing reason rejected, multiple targets rejected, zero long amount rejected, classification as a simple command, and `manual_position_target` short -> negative net.
- Command behavior (`src/cli/repair.rs`): initializes a missing position, updates an existing position (preserving accumulated volume), and rejects a position with a pending offchain order.
- Aggregate (`src/position.rs`): initializes via adjustment, sets an existing position to zero, rejects when a hedge order is pending, replay sets `net` without rewriting volume, and `timestamp()` returns `adjusted_at`.

## Anything else

No schema/migration changes — the new event flows through the existing CQRS event store. No breaking changes.



## Self-review fixes & follow-ups

A 5-reviewer self-review (after the rebase onto `feat/drop-usdc-from-rebalancer`) confirmed position accounting and the `expected_net` optimistic-concurrency guard are sound. Fixed in this revision:

- **Production compile bug:** `run_repair_command` used `crate::ExecutionThreshold`, which is only re-exported under `#[cfg(test/test-support)]` — the production binary failed to build. Switched to `st0x_config::ExecutionThreshold`.
- **Stale broker-idempotency anchor (correctness):** `ManualPositionAdjusted` preserved `last_failed_offchain_order_id` (a field foreign added) via `..entity.clone()`, so the next hedge could reuse a failed order's `client_order_id` and be deduped by the broker. Now cleared on adjustment, with a regression test.
- **`--price` zero/negative:** parsed with a strict `parse_positive_price` (a zero/negative price poisons `last_price_usdc` and makes a dollar-value threshold never hedge).
- **Re-hedge latency:** the rebalancing reactor now `enqueue_check`s on `ManualPositionAdjusted` (mirroring `OffChainOrderFailed`) so a hedgeable imbalance is acted on immediately, not on the next poll cycle.
- **Empty `--reason`** is now rejected (it is the audit record).

Deferred (non-blocking, practical path already guarded by the above):
- Aggregate-level price-positivity check in `validate_manual_adjustment` (the CLI guard covers the only non-test caller; the clean fix is a `Positive<Usdc>` price type).
- Block manual adjustment when a non-terminal `OffchainOrder` aggregate exists for the symbol even without a live position pointer.
- Make `expected_net` required (not `Option`) to remove the concurrency-bypass footgun.
- Minor test-style nits (`assert!(x.is_none())` -> `assert_eq!(x, None)`; `||` in an assertion).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added operator CLI command `repair set-position` to manually correct equity position tracking
- Supports zeroing, setting long, or setting short targets with required explanation
- Optional price parameter for specific position scenarios
- Safeguards prevent adjustments during pending executions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->