### PR TITLE
feat: TransferUsdcToHedging apalis job (Base->Alpaca)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ alloy-primitives = "1.4"
 alloy-signer-turnkey = "=1.0.41"
 anyhow = "1.0.102"
 apalis-board = { version = "1.0.0-rc.8", features = ["axum", "ui"] }
-apalis-workflow = "0.1.0-rc.7"
+apalis-workflow = "0.1.0-rc.9"
 apca = "0.30.0"
 approx = "0.5.1"
 async-trait = "0.1.81"
 axum = { version = "0.8.9", features = ["ws", "json"] }
 backon = { version = "1.5.1", features = ["tokio"] }
 base64 = "0.22"
-bon = "3.9.0"
+bon = "3.9.1"
 chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = "0.10.4"
 clap = { version = "4.5.40", features = ["derive", "env"] }
@@ -165,11 +165,11 @@ mock = [
 ]
 
 [dependencies]
-apalis = "1.0.0-rc.7"
-apalis-sqlite = "1.0.0-rc.7"
-apalis-codec = "0.1.0-rc.7"
-apalis-core = "1.0.0-rc.4"
-apalis-cron = { version = "1.0.0-rc.7", default-features = false }
+apalis = "1.0.0-rc.9"
+apalis-sqlite = "1.0.0-rc.8"
+apalis-codec = "0.1.0-rc.9"
+apalis-core = "1.0.0-rc.9"
+apalis-cron = { version = "1.0.0-rc.8", default-features = false }
 task-supervisor = { version = "0.4", features = ["tracing"] }
 
 aes-gcm.workspace = true

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -49,6 +49,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 
 [rebalancing]
 transfer_timeout_secs = 1800
+transfer_attempt_timeout_secs = 3600
 
 [rebalancing.usdc]
 mode = "enabled"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -48,6 +48,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 
 [rebalancing]
 transfer_timeout_secs = 1800
+transfer_attempt_timeout_secs = 3600
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "disabled" }
 

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -1,9 +1,11 @@
 //! Single-chain CCTP operations.
 
-use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, U256};
+use alloy::providers::Provider;
+use alloy::rpc::types::Filter;
 use alloy::sol;
 use alloy::sol_types::SolEvent;
-use tracing::{info, trace};
+use tracing::{debug, info, trace};
 
 #[cfg(test)]
 use st0x_evm::Evm;
@@ -132,6 +134,45 @@ impl<W: Wallet> CctpEndpoint<W> {
             tx: receipt.transaction_hash,
             amount,
         })
+    }
+
+    /// Scans for a `DepositForBurn` event from this endpoint's wallet at or
+    /// after `from_block`, returning the transaction hash of the most recent
+    /// match.
+    ///
+    /// Used for crash-safe burn recovery: a transfer records the chain head
+    /// before submitting the burn, so on resume this detects an already-
+    /// submitted burn instead of re-burning (which would burn USDC twice with at
+    /// most one mint). Matches on `(depositor, amount)` -- CCTP burns are exact,
+    /// and the single-in-flight invariant guarantees the newest match at/after
+    /// the captured chain head is the resuming transfer's burn.
+    pub(super) async fn find_recent_burn(
+        &self,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<Option<TxHash>, CctpError> {
+        let depositor = self.wallet.address();
+        let filter = Filter::new()
+            .from_block(from_block)
+            .address(self.token_messenger_address)
+            .event_signature(TokenMessengerV2::DepositForBurn::SIGNATURE_HASH);
+
+        let logs = self.wallet.provider().get_logs(&filter).await?;
+
+        for log in logs.iter().rev() {
+            let decoded = log.log_decode::<TokenMessengerV2::DepositForBurn>()?;
+            let event = decoded.data();
+
+            if event.depositor == depositor
+                && event.amount == amount
+                && let Some(tx_hash) = log.transaction_hash
+            {
+                debug!(target: "bridge", %tx_hash, from_block, "Found existing burn during resume");
+                return Ok(Some(tx_hash));
+            }
+        }
+
+        Ok(None)
     }
 
     /// Claims USDC on this chain by submitting the attestation.

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -73,6 +73,7 @@ use std::time::Duration;
 
 use alloy::primitives::{Address, Bytes, FixedBytes, TxHash, U256, address};
 use alloy::sol;
+use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use backon::Retryable;
 use rain_math_float::Float;
@@ -296,6 +297,10 @@ pub enum CctpError {
     Evm(#[from] EvmError),
     #[error("Contract view error: {0}")]
     Contract(#[from] alloy::contract::Error),
+    #[error("RPC transport error: {0}")]
+    RpcTransport(#[from] RpcError<TransportErrorKind>),
+    #[error("ABI decode error: {0}")]
+    SolType(#[from] alloy::sol_types::Error),
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("Attestation timeout after {attempts} attempts: {source}")]
@@ -663,6 +668,23 @@ where
             amount: internal.amount,
             fee: internal.fee_collected,
         })
+    }
+
+    /// Scans the burn source chain for an already-submitted burn matching
+    /// `amount` at or after `from_block`, for crash-safe resume. Delegates to
+    /// the source endpoint for the given direction.
+    async fn find_recent_burn(
+        &self,
+        direction: BridgeDirection,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<Option<TxHash>, Self::Error> {
+        match direction {
+            BridgeDirection::EthereumToBase => {
+                self.ethereum.find_recent_burn(amount, from_block).await
+            }
+            BridgeDirection::BaseToEthereum => self.base.find_recent_burn(amount, from_block).await,
+        }
     }
 }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -82,4 +82,13 @@ pub trait Bridge: Send + Sync + 'static {
         direction: BridgeDirection,
         attestation: &Self::Attestation,
     ) -> Result<MintReceipt, Self::Error>;
+
+    /// Scans the burn source chain for an already-submitted burn matching
+    /// `amount` at or after `from_block`, for crash-safe resume.
+    async fn find_recent_burn(
+        &self,
+        direction: BridgeDirection,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<Option<TxHash>, Self::Error>;
 }

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1838,6 +1838,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [wallet]
             kind = "private-key"
@@ -1946,6 +1947,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [wallet]
             kind = "private-key"
@@ -2152,6 +2154,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [rebalancing.equity]
             target = "0.5"
@@ -2211,6 +2214,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [rebalancing.equity]
             target = "0.5"
@@ -2272,6 +2276,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [rebalancing.equity]
             target = "0.5"
@@ -2617,6 +2622,7 @@ mod tests {
 
             [rebalancing]
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [wallet]
             kind = "private-key"

--- a/crates/config/src/rebalancing.rs
+++ b/crates/config/src/rebalancing.rs
@@ -26,6 +26,8 @@ pub enum RebalancingCtxError {
     NotAlpacaBroker,
     #[error("rebalancing transfer_timeout_secs must be non-zero")]
     ZeroTransferTimeout,
+    #[error("rebalancing transfer_attempt_timeout_secs must be non-zero")]
+    ZeroTransferAttemptTimeout,
     #[error("invalid wallet config: {0}")]
     WalletConfig(#[from] toml::de::Error),
     #[error(transparent)]
@@ -51,6 +53,11 @@ pub struct RebalancingConfig {
     pub equity: ImbalanceThreshold,
     pub usdc: UsdcRebalancing,
     pub transfer_timeout_secs: u64,
+    /// Per-attempt wall-clock bound for a single Base->Alpaca transfer job
+    /// attempt. A hung RPC is aborted after this so the attempt fails and
+    /// retries rather than wedging forever. Distinct from
+    /// `transfer_timeout_secs`, which is the whole-transfer stall reaper.
+    pub transfer_attempt_timeout_secs: u64,
 }
 
 /// Runtime configuration for rebalancing operations.
@@ -63,6 +70,10 @@ pub struct RebalancingCtx {
     pub equity: ImbalanceThreshold,
     pub usdc: Option<ImbalanceThreshold>,
     pub transfer_timeout: Duration,
+    /// Per-attempt wall-clock bound for a single Base->Alpaca transfer job
+    /// attempt (hung-RPC backstop). See
+    /// [`RebalancingConfig::transfer_attempt_timeout_secs`].
+    pub transfer_attempt_timeout: Duration,
     /// Circle attestation/fee API base URL (test-only override).
     #[cfg(feature = "test-support")]
     pub circle_api_base: String,
@@ -82,6 +93,10 @@ impl RebalancingCtx {
             return Err(RebalancingCtxError::ZeroTransferTimeout);
         }
 
+        if config.transfer_attempt_timeout_secs == 0 {
+            return Err(RebalancingCtxError::ZeroTransferAttemptTimeout);
+        }
+
         let usdc = match config.usdc {
             UsdcRebalancing::Enabled { target, deviation } => {
                 Some(ImbalanceThreshold { target, deviation })
@@ -93,6 +108,7 @@ impl RebalancingCtx {
             equity: config.equity,
             usdc,
             transfer_timeout: Duration::from_secs(config.transfer_timeout_secs),
+            transfer_attempt_timeout: Duration::from_secs(config.transfer_attempt_timeout_secs),
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -115,11 +131,13 @@ impl RebalancingCtx {
         equity: ImbalanceThreshold,
         usdc: Option<ImbalanceThreshold>,
         #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
+        #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
     ) -> Self {
         Self {
             equity,
             usdc,
             transfer_timeout,
+            transfer_attempt_timeout,
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -140,6 +158,7 @@ impl RebalancingCtx {
         equity: ImbalanceThreshold,
         usdc: UsdcRebalancing,
         #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
+        #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
     ) -> Self {
         let usdc = match usdc {
             UsdcRebalancing::Enabled { target, deviation } => {
@@ -152,6 +171,7 @@ impl RebalancingCtx {
             equity,
             usdc,
             transfer_timeout,
+            transfer_attempt_timeout,
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
             message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
@@ -197,6 +217,7 @@ mod tests {
     fn valid_rebalancing_config_toml() -> &'static str {
         r#"
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [equity]
             target = "0.5"
@@ -222,6 +243,7 @@ mod tests {
         assert!(target.eq(float!(0.5)).unwrap());
         assert!(deviation.eq(float!(0.3)).unwrap());
         assert_eq!(config.transfer_timeout_secs, 1800);
+        assert_eq!(config.transfer_attempt_timeout_secs, 3600);
     }
 
     #[test]
@@ -229,6 +251,7 @@ mod tests {
         let config: RebalancingConfig = toml::from_str(
             r#"
             transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
 
             [equity]
             target = "0.6"
@@ -305,5 +328,53 @@ mod tests {
             error.message().contains("usdc"),
             "Expected missing usdc error, got: {error}"
         );
+    }
+
+    #[test]
+    fn deserialize_missing_transfer_attempt_timeout_secs_fails() {
+        let toml_str = r#"
+            transfer_timeout_secs = 1800
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("transfer_attempt_timeout_secs"),
+            "Expected missing transfer_attempt_timeout_secs error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn zero_transfer_attempt_timeout_secs_fails_validation() {
+        let config: RebalancingConfig = toml::from_str(
+            r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 0
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#,
+        )
+        .unwrap();
+
+        let error = RebalancingCtx::new(&config).unwrap_err();
+        assert!(matches!(
+            error,
+            RebalancingCtxError::ZeroTransferAttemptTimeout
+        ));
     }
 }

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -69,6 +69,19 @@ Discrete units of work that are serialized to SQLite before processing and have
 a defined point of completion. If the worker crashes or the process restarts,
 unprocessed jobs are still in the database.
 
+**Gotcha -- a job that was _in flight_ (`Running`/`Queued`) when the process
+died is not auto-re-driven on a quick restart.** apalis's `fetch_next` only
+picks `Pending`/retryable-`Failed` rows; an orphaned in-flight row is reset to
+`Pending` only by apalis's `reenqueue_orphaned` sweep, which fires once the
+owning worker's heartbeat ages past `reenqueue_orphaned_after` (5 min default).
+Worker names are deterministic across restarts (`{WORKER_NAME}-{index}`), so a
+fresh process re-registers the same worker id and keeps its heartbeat current --
+the orphan never ages out, and any per-job enqueue dedup keyed off the in-flight
+row then suppresses new work indefinitely. Jobs that must survive a crash
+mid-execution reset their own orphaned rows at startup, before the monitor
+spawns (where every `Running` row is by definition orphaned): see
+`JobQueue::requeue_orphaned`, wired for the Base->Alpaca USDC transfer.
+
 ### Job trait
 
 Defined in `src/conductor/job.rs`. Wraps apalis's function-based handler API

--- a/example.config.toml
+++ b/example.config.toml
@@ -53,6 +53,12 @@ redemption_wallet = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 # Transfer timeout in seconds before stuck inflight state is tombstoned and cleared.
 # 1800 = 30 minutes.
 transfer_timeout_secs = 1800
+# Per-attempt wall-clock bound for a single Base->Alpaca transfer job attempt.
+# A hung RPC inside the transfer is aborted after this so the attempt fails and
+# retries instead of wedging forever. Must exceed the worst-case single resume
+# (CCTP attestation + Alpaca deposit polling); only trips on a true hang.
+# 3600 = 60 minutes.
+transfer_attempt_timeout_secs = 3600
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -60,6 +60,7 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+use crate::rebalancing::usdc::TransferUsdcToHedgingCtx;
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
     RebalancingServiceConfig,
@@ -207,6 +208,7 @@ impl Conductor {
             wrapped_equity_recovery_store,
             mint_store,
             redemption_store,
+            transfer_usdc_to_hedging_ctx,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -218,6 +220,34 @@ impl Conductor {
             schedulers.clone(),
         )
         .await?;
+
+        // A previous process may have died mid-transfer, leaving an apalis
+        // `Running` row that no live worker owns. apalis cannot rescue such an
+        // orphan on a quick restart -- the deterministic worker name keeps its
+        // heartbeat fresh, so the row never ages out -- and the enqueue dedup
+        // keys off that row, wedging every future Base->Alpaca transfer. Reset
+        // orphans here, before the monitor spawns (so any `Running` row is by
+        // definition orphaned), letting the worker re-drive them through the
+        // crash-safe resume path. Only meaningful when the transfer worker is
+        // wired, i.e. rebalancing is enabled.
+        if transfer_usdc_to_hedging_ctx.is_some() {
+            // Fail startup fast if the reset fails: a stale `Running` row left
+            // wedged silently suppresses every future Base->Alpaca transfer, so
+            // the bot must not come up looking healthy with recovery disabled.
+            let count = schedulers
+                .transfer_usdc_to_hedging
+                .requeue_orphaned()
+                .await
+                .context("failed to re-queue orphaned Base->Alpaca transfer jobs at startup")?;
+
+            if count > 0 {
+                info!(
+                    target: "rebalance",
+                    count,
+                    "Re-queued orphaned Base->Alpaca transfer job(s) for crash-safe resume",
+                );
+            }
+        }
 
         // Hydrate the in-memory InventoryView from persisted snapshot
         // state so the runtime projection has the same data as the
@@ -320,6 +350,8 @@ impl Conductor {
             .maybe_wrapped_equity_recovery_ctx(wrapped_equity_recovery_ctx)
             .equity_check_scheduler(schedulers.equity)
             .usdc_check_scheduler(schedulers.usdc)
+            .transfer_usdc_to_hedging_queue(schedulers.transfer_usdc_to_hedging)
+            .maybe_transfer_usdc_to_hedging_ctx(transfer_usdc_to_hedging_ctx)
             .maybe_rebalancing_service(rebalancing_service)
             .seed_vault_registry_queue(seed_vault_registry_queue)
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
@@ -610,6 +642,7 @@ struct RebalancingInfrastructure {
     wrapped_equity_recovery_store: Arc<Store<WrappedEquityRecovery>>,
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
+    transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -641,6 +674,7 @@ struct PositionAndRebalancing {
     wrapped_equity_recovery_store: Option<Arc<Store<WrappedEquityRecovery>>>,
     mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
+    transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
 }
 
 impl PositionAndRebalancing {
@@ -696,6 +730,7 @@ impl PositionAndRebalancing {
                 wrapped_equity_recovery_store: Some(infra.wrapped_equity_recovery_store),
                 mint_store: Some(infra.mint_store),
                 redemption_store: Some(infra.redemption_store),
+                transfer_usdc_to_hedging_ctx: Some(infra.transfer_usdc_to_hedging_ctx),
             })
         } else {
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -722,6 +757,7 @@ impl PositionAndRebalancing {
                 wrapped_equity_recovery_store: None,
                 mint_store: None,
                 redemption_store: None,
+                transfer_usdc_to_hedging_ctx: None,
             })
         }
     }
@@ -889,27 +925,33 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let mint_store = frameworks.mint.clone();
         let redemption_store = frameworks.redemption.clone();
 
-        let (handle, rebalancer_shutdown_token) = services.spawn(
+        let spawned = services.spawn(
             market_maker_wallet,
             RaindexVaultId(usdc_vault_id),
             operation_receiver,
             frameworks,
             equity_in_progress,
-            usdc_in_progress,
+            Arc::clone(&usdc_in_progress),
         );
+
+        let transfer_usdc_to_hedging_ctx = Arc::new(TransferUsdcToHedgingCtx {
+            transfer: spawned.resume_base_to_alpaca,
+            timeout: rebalancing_ctx.transfer_attempt_timeout,
+        });
 
         Ok(RebalancingInfrastructure {
             position: built.position,
             position_projection: built.position_projection,
             snapshot: built.snapshot,
-            rebalancer: handle,
-            rebalancer_shutdown_token,
+            rebalancer: spawned.handle,
+            rebalancer_shutdown_token: spawned.shutdown_token,
             tokenizer,
             service: rebalancing_service,
             recovery_transfer,
             wrapped_equity_recovery_store,
             mint_store,
             redemption_store,
+            transfer_usdc_to_hedging_ctx,
         })
     })
 }

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use st0x_config::{Ctx, ExecutionThreshold};
 use st0x_event_sorcery::{Projection, Store};
@@ -41,6 +41,9 @@ use crate::onchain::raindex::RaindexService;
 use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
+use crate::rebalancing::usdc::{
+    TransferUsdcToHedging, TransferUsdcToHedgingCtx, TransferUsdcToHedgingJobQueue,
+};
 use crate::rebalancing::{
     EquityRebalancingCheck, EquityRebalancingCheckScheduler, RebalancingService,
     UsdcRebalancingCheck, UsdcRebalancingCheckScheduler,
@@ -100,6 +103,8 @@ pub(crate) fn spawn<Prov, Exec>(
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
+    transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
+    transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     rebalancing_service: Option<Arc<RebalancingService>>,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
@@ -297,6 +302,8 @@ where
         wrapped_equity_recovery_ctx,
         equity_check_scheduler,
         usdc_check_scheduler,
+        transfer_usdc_to_hedging_queue,
+        transfer_usdc_to_hedging_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
@@ -345,6 +352,8 @@ where
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
+    transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
+    transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
@@ -380,6 +389,8 @@ where
             wrapped_equity_recovery_ctx,
             equity_check_scheduler,
             usdc_check_scheduler,
+            transfer_usdc_to_hedging_queue,
+            transfer_usdc_to_hedging_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
@@ -406,6 +417,8 @@ where
         let failure_injector_for_wrapped_equity_recovery = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_check_positions = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_transfer_usdc_to_hedging = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -417,6 +430,7 @@ where
         let failure_notify_for_seed_vault_registry = failure_notify.clone();
         let failure_notify_for_wrapped_equity_recovery = failure_notify.clone();
         let failure_notify_for_check_positions = failure_notify.clone();
+        let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -432,6 +446,7 @@ where
         let fail_stop_for_seed_vault_registry = fail_stop.clone();
         let fail_stop_for_wrapped_equity_recovery = fail_stop.clone();
         let fail_stop_for_check_positions = fail_stop.clone();
+        let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -579,6 +594,16 @@ where
                 failure_injector_for_wrapped_equity_recovery,
             );
 
+            let apalis_monitor = register_transfer_usdc_to_hedging_worker(
+                apalis_monitor,
+                transfer_usdc_to_hedging_ctx,
+                transfer_usdc_to_hedging_queue,
+                fail_stop_for_transfer_usdc_to_hedging,
+                failure_notify_for_transfer_usdc_to_hedging,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_transfer_usdc_to_hedging,
+            );
+
             let is_draining = apalis_shutdown_token.clone();
 
             let shutdown_signal = async {
@@ -643,6 +668,40 @@ fn register_wrapped_equity_recovery_worker(
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),
+            fail_stop.clone(),
+            failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Conditionally registers the `TransferUsdcToHedging` worker. The ctx is
+/// `None` when rebalancing is disabled in config; in that case the queue is
+/// still constructed (so tests that build it directly compile) but no worker
+/// consumes it.
+fn register_transfer_usdc_to_hedging_worker(
+    monitor: Monitor,
+    transfer_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
+    transfer_queue: TransferUsdcToHedgingJobQueue,
+    fail_stop: CircuitBreakerConfig,
+    failure_notify: Arc<tokio::sync::Notify>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(transfer_ctx) = transfer_ctx else {
+        warn!(
+            "TransferUsdcToHedging worker not registered: rebalancing disabled \
+             (no transfer ctx). Base->Alpaca USDC transfers will not be processed."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_supervised_worker!(
+            ::<TransferUsdcToHedgingCtx, TransferUsdcToHedging>,
+            index,
+            transfer_queue.clone(),
+            transfer_ctx.clone(),
             fail_stop.clone(),
             failure_notify.clone(),
             #[cfg(any(test, feature = "test-support"))]

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -170,6 +170,36 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
             );
         }
     }
+
+    /// Resets this queue's in-flight rows (`Running`/`Queued`) back to
+    /// `Pending` so the apalis monitor re-drives them, and returns the number
+    /// of rows reset.
+    ///
+    /// Must only be called at startup, BEFORE the apalis monitor spawns: at
+    /// that point no worker is alive to legitimately own a `Running` row, so
+    /// every such row is necessarily orphaned by a previous process that died
+    /// mid-job. apalis's own orphan recovery cannot rescue these on a quick
+    /// restart -- it re-enqueues a locked row only once the owning worker's
+    /// heartbeat ages past `reenqueue_orphaned_after` (5 min default), but the
+    /// worker name is deterministic across restarts, so a fresh process
+    /// re-registers the same worker id and keeps refreshing its heartbeat,
+    /// and the orphan is never aged out. Resetting the row here closes that
+    /// gap. `Failed` rows (retries exhausted) are deliberately left untouched
+    /// so a latched job awaiting operator reconciliation is not re-driven on
+    /// every restart. `attempts` is preserved because a crash is not a failed
+    /// attempt against the retry budget.
+    pub(crate) async fn requeue_orphaned(&self) -> Result<u64, sqlx::Error> {
+        let job_type = std::any::type_name::<Task>();
+        let result = sqlx::query(
+            "UPDATE Jobs SET status = 'Pending', lock_by = NULL, lock_at = NULL \
+             WHERE job_type = ? AND status IN ('Running', 'Queued')",
+        )
+        .bind(job_type)
+        .execute(self.pool())
+        .await?;
+
+        Ok(result.rows_affected())
+    }
 }
 
 /// A persistent, retryable unit of work backed by apalis storage.
@@ -312,6 +342,7 @@ pub enum JobKind {
     SeedVaultRegistry,
     WrappedEquityRecovery,
     CheckPositions,
+    TransferUsdcToHedging,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -347,6 +378,7 @@ pub struct FailureInjector {
     seed_vault_registry: Arc<Mutex<InjectionState>>,
     wrapped_equity_recovery: Arc<Mutex<InjectionState>>,
     check_positions: Arc<Mutex<InjectionState>>,
+    transfer_usdc_to_hedging: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -380,6 +412,7 @@ impl FailureInjector {
             seed_vault_registry: Arc::new(Mutex::new(InjectionState::Idle)),
             wrapped_equity_recovery: Arc::new(Mutex::new(InjectionState::Idle)),
             check_positions: Arc::new(Mutex::new(InjectionState::Idle)),
+            transfer_usdc_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -425,6 +458,7 @@ impl FailureInjector {
             JobKind::SeedVaultRegistry => &self.seed_vault_registry,
             JobKind::WrappedEquityRecovery => &self.wrapped_equity_recovery,
             JobKind::CheckPositions => &self.check_positions,
+            JobKind::TransferUsdcToHedging => &self.transfer_usdc_to_hedging,
         };
 
         match mutex.lock() {
@@ -796,6 +830,97 @@ mod tests {
                 "pending".to_string(),
                 "running".to_string()
             ]
+        );
+    }
+
+    async fn insert_locked_job(
+        pool: &SqlitePool,
+        id: &str,
+        job_type: &str,
+        status: &str,
+        lock_by: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO Jobs \
+             (job, id, job_type, status, attempts, max_attempts, run_at, priority, lock_by, lock_at) \
+             VALUES (?, ?, ?, ?, 0, 25, 0, 0, ?, ?)",
+        )
+        .bind(vec![0_u8])
+        .bind(id)
+        .bind(job_type)
+        .bind(status)
+        .bind(lock_by)
+        .bind(lock_by.map(|_| 0_i64))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn status_of(pool: &SqlitePool, id: &str) -> String {
+        sqlx::query_scalar::<_, String>("SELECT status FROM Jobs WHERE id = ?")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    async fn lock_by_of(pool: &SqlitePool, id: &str) -> Option<String> {
+        sqlx::query_scalar::<_, Option<String>>("SELECT lock_by FROM Jobs WHERE id = ?")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    async fn insert_worker(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, 'test', 'test')",
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn requeue_orphaned_resets_only_in_flight_rows_of_this_queue() {
+        let pool = setup_test_db().await;
+        let job_type = std::any::type_name::<TestJob>();
+
+        // A previous process died holding the lock on these in-flight rows.
+        insert_worker(&pool, "dead-worker").await;
+        insert_locked_job(&pool, "running", job_type, "Running", Some("dead-worker")).await;
+        insert_locked_job(&pool, "queued", job_type, "Queued", Some("dead-worker")).await;
+        insert_locked_job(&pool, "pending", job_type, "Pending", None).await;
+        insert_locked_job(&pool, "failed", job_type, "Failed", Some("dead-worker")).await;
+        insert_locked_job(&pool, "done", job_type, "Done", Some("dead-worker")).await;
+        // A Running row of a different queue's job type must be left alone.
+        insert_locked_job(&pool, "other", "other::Job", "Running", Some("dead-worker")).await;
+
+        let queue = JobQueue::<TestJob>::new(&pool);
+        let reset = queue.requeue_orphaned().await.unwrap();
+
+        assert_eq!(reset, 2, "only this queue's Running + Queued rows reset");
+        assert_eq!(status_of(&pool, "running").await, "Pending");
+        assert_eq!(status_of(&pool, "queued").await, "Pending");
+        assert_eq!(
+            lock_by_of(&pool, "running").await,
+            None,
+            "lock cleared so the apalis monitor re-picks the row",
+        );
+        assert_eq!(lock_by_of(&pool, "queued").await, None);
+
+        assert_eq!(status_of(&pool, "pending").await, "Pending");
+        assert_eq!(
+            status_of(&pool, "failed").await,
+            "Failed",
+            "a latched failure awaiting operator reconciliation is not re-driven",
+        );
+        assert_eq!(status_of(&pool, "done").await, "Done");
+        assert_eq!(
+            status_of(&pool, "other").await,
+            "Running",
+            "another queue's in-flight row is untouched",
         );
     }
 }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -44,6 +44,7 @@ use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
+use crate::rebalancing::usdc::TransferUsdcToHedging;
 use crate::rebalancing::usdc::mock::MockUsdcRebalance;
 use crate::rebalancing::{
     Rebalancer, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
@@ -1115,21 +1116,47 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
 
     rebalancer.run().await;
 
+    // Base->Alpaca is dispatched via the TransferUsdcToHedging apalis job
+    // queue, not the Rebalancer mpsc channel. Assert exactly one pending row
+    // with the expected payload.
+    let job_type = std::any::type_name::<TransferUsdcToHedging>();
+
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM Jobs \
+         WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(job_type)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
     assert_eq!(
-        usdc.base_to_alpaca_calls(),
-        1,
-        "Expected USDC manager to be called once for base_to_alpaca"
+        pending, 1,
+        "Expected exactly one pending TransferUsdcToHedging job"
     );
 
-    let call = usdc
-        .last_base_to_alpaca_call()
-        .expect("Expected a captured call");
+    let payload: Vec<u8> = sqlx::query_scalar(
+        "SELECT job FROM Jobs \
+         WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(job_type)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let job: TransferUsdcToHedging =
+        serde_json::from_slice(&payload).expect("deserialize TransferUsdcToHedging payload");
     assert_eq!(
-        call.amount,
+        job.amount,
         Usdc::new(float!(400)),
         "Expected excess of $400 (actual $900 - target $500)"
     );
 
+    assert_eq!(
+        usdc.base_to_alpaca_calls(),
+        0,
+        "Rebalancer mpsc path should not be exercised for Base->Alpaca anymore",
+    );
     assert_eq!(
         usdc.alpaca_to_base_calls(),
         0,

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -12,7 +12,10 @@
 //! standard fixed-point amounts (U256) and the float format MUST use rain-math-float.
 
 use alloy::primitives::{Address, B256, TxHash, U256, address};
-use alloy::rpc::types::TransactionReceipt;
+use alloy::providers::Provider;
+use alloy::rpc::types::{Filter, TransactionReceipt};
+use alloy::sol_types::SolEvent;
+use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use rain_math_float::Float;
 use std::sync::Arc;
@@ -26,7 +29,7 @@ use st0x_finance::Usdc;
 use crate::bindings::{IERC20, IOrderBookV6};
 use crate::vault_registry::{VaultRegistry, VaultRegistryId, VaultRegistryProjection};
 
-const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+pub(crate) const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 const USDC_DECIMALS: u8 = 6;
 
 /// Vault identifier for Rain OrderBook vaults.
@@ -51,7 +54,29 @@ pub(crate) enum RaindexError {
     VaultNotFound(Address),
     #[error("Token not found for symbol {0}")]
     TokenNotFound(Symbol),
+    #[error("RPC transport error: {0}")]
+    RpcTransport(#[from] RpcError<TransportErrorKind>),
+    #[error("ABI decode error: {0}")]
+    SolType(#[from] alloy::sol_types::Error),
+    /// A withdrawal scan could not confirm presence or absence: the queried node
+    /// is not confirmations-deep past `from_block`, so an empty result may be RPC
+    /// lag rather than a true absence. Retryable -- the caller must NOT re-execute
+    /// the irreversible withdraw on this.
+    #[error("withdrawal scan inconclusive: node not caught up past block {from_block}")]
+    ScanInconclusive { from_block: u64 },
 }
+
+/// Number of `eth_getLogs` scans that must agree the effect is absent before a
+/// resume re-executes an irreversible withdraw. Defends against a single
+/// load-balanced RPC node lagging and returning a false-empty result.
+const SCAN_ATTEMPTS: u32 = 5;
+
+/// Backoff between scan retries; different load-balanced nodes may answer each.
+const SCAN_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Blocks the chain head must be past `from_block` before an empty scan is
+/// trusted as a true absence (the on-chain effect lands at/after `from_block`).
+const SCAN_FINALITY_MARGIN: u64 = 2;
 
 /// Service for managing Rain OrderBook vault operations.
 ///
@@ -293,6 +318,82 @@ impl<E: Evm> RaindexService<E> {
             .get_vault_balance::<Registry>(owner, USDC_BASE, vault_id)
             .await?;
         Ok(Usdc::new(exact))
+    }
+
+    /// Scans for a `WithdrawV2` event from this owner's vault at or after
+    /// `from_block`, returning the most recent match's `(tx_hash, withdrawn_amount)`.
+    ///
+    /// Crash-safe withdrawal recovery: a transfer records the chain head before
+    /// the on-chain withdraw, so on resume this detects an already-submitted
+    /// withdrawal and the caller adopts it instead of re-issuing (which would
+    /// double-spend the vault). Matches on `(sender == self.owner, token, vaultId)`
+    /// -- never on amount, so a partial fill is still detected -- and returns the
+    /// actual on-chain `withdrawAmountUint256` so the caller can reconcile a
+    /// partial withdrawal rather than laundering it into a full-amount burn.
+    ///
+    /// Returns `Ok(None)` ONLY when the queried node is confirmations-deep past
+    /// `from_block` and repeated scans agree the effect is absent. A node that may
+    /// be lagging (the dRPC load-balancing hazard AGENTS.md warns about) yields a
+    /// retryable [`RaindexError::ScanInconclusive`] instead, so the caller never
+    /// re-executes the irreversible withdraw off a single stale empty `eth_getLogs`.
+    pub(crate) async fn find_recent_withdrawal(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        from_block: u64,
+    ) -> Result<Option<(TxHash, U256)>, RaindexError> {
+        let RaindexVaultId(vault_id) = vault_id;
+        let filter = Filter::new()
+            .from_block(from_block)
+            .address(self.orderbook_address)
+            .event_signature(IOrderBookV6::WithdrawV2::SIGNATURE_HASH);
+
+        for attempt in 1..=SCAN_ATTEMPTS {
+            let logs = self.evm.provider().get_logs(&filter).await?;
+
+            // get_logs returns ascending block order; iterate newest-first so the
+            // most recent matching withdrawal wins -- under single-in-flight that
+            // is this transfer's withdrawal.
+            for log in logs.iter().rev() {
+                let decoded = log.log_decode::<IOrderBookV6::WithdrawV2>()?;
+                let event = decoded.data();
+
+                if event.sender == self.owner
+                    && event.token == token
+                    && event.vaultId == vault_id
+                    && let Some(tx_hash) = log.transaction_hash
+                {
+                    debug!(target: "orderbook", %tx_hash, from_block, "Found existing withdrawal during resume");
+                    return Ok(Some((tx_hash, event.withdrawAmountUint256)));
+                }
+            }
+
+            // No match on this query. A single empty eth_getLogs from a
+            // load-balanced node is not authoritative (the dRPC lag hazard, see
+            // src/onchain/clear.rs). Only conclude a true absence once the head is
+            // confirmations-deep past from_block AND repeated scans agree; else
+            // retry, and if still inconclusive return a retryable error so the
+            // caller never re-withdraws off a stale empty result.
+            let head = self.evm.provider().get_block_number().await?;
+            let caught_up = head >= from_block.saturating_add(SCAN_FINALITY_MARGIN);
+
+            if caught_up && attempt == SCAN_ATTEMPTS {
+                return Ok(None);
+            }
+
+            if attempt < SCAN_ATTEMPTS {
+                tokio::time::sleep(SCAN_RETRY_BACKOFF).await;
+            }
+        }
+
+        Err(RaindexError::ScanInconclusive { from_block })
+    }
+
+    /// Returns the current chain head. Captured before submitting an on-chain
+    /// action so a later [`find_recent_withdrawal`](Self::find_recent_withdrawal)
+    /// scan can bound its search to blocks at or after the action.
+    pub(crate) async fn current_block(&self) -> Result<u64, RaindexError> {
+        Ok(self.evm.provider().get_block_number().await?)
     }
 
     async fn get_vault_balance<Registry: IntoErrorRegistry>(

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -10,16 +10,15 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx, CctpError};
+use st0x_config::{EquityAssetConfig, RebalancingCtx};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, EmptySymbolError, Executor, Symbol,
 };
 
-use st0x_config::RebalancingCtx;
-
 use super::equity::CrossVenueEquityTransfer;
-use super::usdc::CrossVenueCashTransfer;
+use super::usdc::{CrossVenueCashTransfer, ResumeBaseToAlpaca};
 use super::{Rebalancer, TriggeredOperation};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::equity_redemption::EquityRedemption;
@@ -29,7 +28,18 @@ use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::wrapper::WrapperService;
-use st0x_config::EquityAssetConfig;
+
+/// Handles to the rebalancer task surfaced by [`RebalancerServices::spawn`].
+///
+/// Holds the spawned task's join handle, its shutdown token, and a
+/// trait-erased reference to the cash transfer so the conductor can build the
+/// `TransferUsdcToHedging` apalis job's ctx without leaking the wallet
+/// `Chain` generic upstream.
+pub(crate) struct SpawnedRebalancer {
+    pub(crate) handle: JoinHandle<()>,
+    pub(crate) shutdown_token: CancellationToken,
+    pub(crate) resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca>,
+}
 
 /// Errors that can occur when spawning the rebalancer.
 #[derive(Debug, thiserror::Error)]
@@ -124,7 +134,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         frameworks: RebalancingCqrsFrameworks,
         equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
         usdc_in_progress: Arc<AtomicBool>,
-    ) -> (JoinHandle<()>, CancellationToken) {
+    ) -> SpawnedRebalancer {
         let equity = Arc::new(CrossVenueEquityTransfer::new(
             self.raindex.clone(),
             self.tokenizer,
@@ -144,6 +154,8 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             usdc_vault_id,
         ));
 
+        let resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca> = usdc.clone();
+
         let shutdown_token = CancellationToken::new();
 
         let rebalancer = Rebalancer::new(
@@ -158,11 +170,16 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         );
 
         info!(target: "rebalance", "Rebalancing infrastructure initialized");
+
         let handle = tokio::spawn(async move {
             rebalancer.run().await;
         });
 
-        (handle, shutdown_token)
+        SpawnedRebalancer {
+            handle,
+            shutdown_token,
+            resume_base_to_alpaca,
+        }
     }
 }
 
@@ -424,7 +441,7 @@ mod tests {
 
         let (tx, rx) = tokio::sync::mpsc::channel(10);
 
-        let (handle, _shutdown_token) = services.spawn(
+        let spawned = services.spawn(
             Address::random(),
             RaindexVaultId(B256::ZERO),
             rx,
@@ -432,6 +449,7 @@ mod tests {
             Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
         );
+        let handle = spawned.handle;
 
         tx.send(TriggeredOperation::Mint {
             symbol: Symbol::new("AAPL").unwrap(),

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{debug, error, trace, warn};
+use uuid::Uuid;
 
 use rain_math_float::Float;
 use st0x_config::{AssetsConfig, OperationMode};
@@ -22,6 +23,7 @@ use st0x_event_sorcery::{
 use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, Usdc};
 
+use crate::conductor::job::QueuePushError;
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
 };
@@ -32,6 +34,7 @@ use crate::inventory::{
     Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
 };
 use crate::position::{Position, PositionEvent};
+use crate::rebalancing::usdc::{TransferUsdcToHedging, TransferUsdcToHedgingJobQueue};
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
 };
@@ -53,6 +56,7 @@ pub(crate) struct RebalancingSchedulers {
     pub(crate) equity: EquityRebalancingCheckScheduler,
     pub(crate) usdc: UsdcRebalancingCheckScheduler,
     pub(crate) wrapped_equity_recovery: WrappedEquityRecoveryJobQueue,
+    pub(crate) transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue,
 }
 
 impl RebalancingSchedulers {
@@ -61,6 +65,7 @@ impl RebalancingSchedulers {
             equity: EquityRebalancingCheckScheduler::new(pool),
             usdc: UsdcRebalancingCheckScheduler::new(pool),
             wrapped_equity_recovery: WrappedEquityRecoveryJobQueue::new(pool),
+            transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue::new(pool),
         }
     }
 }
@@ -434,6 +439,10 @@ pub(crate) struct RebalancingService {
     pub(super) equity_scheduler: EquityRebalancingCheckScheduler,
     pub(super) usdc_scheduler: UsdcRebalancingCheckScheduler,
     pub(super) wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
+    /// Queue for `TransferUsdcToHedging` apalis jobs that drive Base->Alpaca
+    /// USDC transfers. Enqueued by `check_and_trigger_usdc` instead of being
+    /// dispatched through the `Rebalancer` mpsc channel.
+    pub(super) transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
     /// Tracks symbol/quantity for in-flight mints. The initial `MintRequested`
     /// event carries this data; follow-up events don't.
     mint_tracking: Arc<RwLock<HashMap<IssuerRequestId, MintTracking>>>,
@@ -484,6 +493,7 @@ impl RebalancingService {
             equity: equity_scheduler,
             usdc: usdc_scheduler,
             wrapped_equity_recovery: wrapped_equity_recovery_queue,
+            transfer_usdc_to_hedging: transfer_usdc_to_hedging_queue,
         } = schedulers;
         Self {
             config,
@@ -499,6 +509,7 @@ impl RebalancingService {
             equity_scheduler,
             usdc_scheduler,
             wrapped_equity_recovery_queue,
+            transfer_usdc_to_hedging_queue,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
             usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
@@ -1942,12 +1953,125 @@ impl RebalancingService {
             return;
         };
 
-        if !self.try_send_operation(&operation, "usdc") {
+        let dispatched = match &operation {
+            TriggeredOperation::UsdcBaseToAlpaca { amount } => {
+                self.enqueue_transfer_usdc_to_hedging(*amount).await
+            }
+            TriggeredOperation::Mint { .. }
+            | TriggeredOperation::Redemption { .. }
+            | TriggeredOperation::UsdcAlpacaToBase { .. } => {
+                self.try_send_operation(&operation, "usdc")
+            }
+        };
+
+        if !dispatched {
             return;
         }
 
         debug!(target: "rebalance", ?operation, "Triggered USDC rebalancing");
         guard.defuse();
+    }
+
+    /// Enqueues a [`TransferUsdcToHedging`] apalis job for a Base->Alpaca
+    /// transfer. Generates a fresh `UsdcRebalanceId` at push time so apalis
+    /// retries (and bot restarts that re-pick the job row) hit the same
+    /// aggregate. Returns `true` on successful enqueue.
+    ///
+    /// Before enqueueing, queries the apalis Jobs table for any
+    /// non-terminal `TransferUsdcToHedging` row. The in-memory
+    /// `usdc_in_progress` guard resets on restart, so without this check a
+    /// crash between `queue.push` and the first persisted `UsdcRebalance`
+    /// event would let the next imbalance check enqueue a second job for
+    /// the same imbalance.
+    async fn enqueue_transfer_usdc_to_hedging(&self, amount: Usdc) -> bool {
+        // A non-terminal row in flight longer than this is treated as likely
+        // stuck: the suppression is logged at warn (with the row id and age) so
+        // it is actionable, rather than silently starving the hedge side with
+        // only a debug log. `run_at` is a unix-seconds column.
+        const STUCK_TRANSFER_WARN_AFTER_SECS: i64 = 15 * 60;
+
+        let queue = self.transfer_usdc_to_hedging_queue.clone();
+        let job_type = std::any::type_name::<TransferUsdcToHedging>();
+
+        let existing: Result<Option<(String, i64)>, _> = sqlx::query_as(
+            "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
+             FROM Jobs \
+             WHERE job_type = ? \
+             AND status IN ('Pending', 'Queued', 'Running') \
+             ORDER BY run_at ASC \
+             LIMIT 1",
+        )
+        .bind(job_type)
+        .fetch_optional(queue.pool())
+        .await;
+
+        match existing {
+            Ok(Some((row_id, age_secs))) if age_secs >= STUCK_TRANSFER_WARN_AFTER_SECS => {
+                warn!(
+                    target: "rebalance",
+                    %row_id,
+                    age_secs,
+                    threshold_secs = STUCK_TRANSFER_WARN_AFTER_SECS,
+                    %amount,
+                    "Skipped TransferUsdcToHedging enqueue: in-flight row looks stuck and is \
+                     suppressing new Base->Alpaca rebalances; investigate before it starves hedging",
+                );
+                return false;
+            }
+            Ok(Some((row_id, age_secs))) => {
+                debug!(
+                    target: "rebalance",
+                    %row_id,
+                    age_secs,
+                    %amount,
+                    "Skipped TransferUsdcToHedging enqueue: non-terminal row \
+                     already exists; apalis will resume it",
+                );
+                return false;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    "Failed to query for existing TransferUsdcToHedging rows; \
+                     skipping enqueue to avoid double-pushing",
+                );
+                return false;
+            }
+        }
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let mut queue = queue;
+
+        let push = queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount,
+            })
+            .await;
+
+        match push {
+            Ok(()) => {
+                debug!(
+                    target: "rebalance",
+                    %id,
+                    %amount,
+                    "Enqueued TransferUsdcToHedging job for Base->Alpaca USDC transfer",
+                );
+                true
+            }
+
+            Err(QueuePushError(error)) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    %amount,
+                    "Failed to enqueue TransferUsdcToHedging job",
+                );
+                false
+            }
+        }
     }
 
     /// Clears the in-progress flag for an equity symbol.
@@ -4591,6 +4715,20 @@ mod tests {
         make_trigger_with_inventory_and_registry_config(inventory, symbol, test_config()).await
     }
 
+    /// Counts pending `TransferUsdcToHedging` rows in the apalis Jobs table
+    /// backing this service. Used by trigger tests that previously asserted
+    /// on the mpsc receiver for Base->Alpaca and now must assert on the queue.
+    async fn count_pending_transfer_usdc_to_hedging_jobs(service: &RebalancingService) -> i64 {
+        let job_type = std::any::type_name::<TransferUsdcToHedging>();
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .expect("count pending TransferUsdcToHedging jobs")
+    }
+
     async fn make_trigger_with_inventory_and_registry_config(
         inventory: InventoryView,
         symbol: &Symbol,
@@ -6355,14 +6493,18 @@ mod tests {
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
-        // Verify imbalance triggers before reactor events
+        // Verify imbalance triggers before reactor events. Base->Alpaca is now
+        // enqueued as a TransferUsdcToHedging apalis job rather than sent via
+        // the Rebalancer mpsc channel.
         trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            1,
+            "TooMuchOnchain (900/100) should enqueue a TransferUsdcToHedging job before reactor events"
+        );
         assert!(
-            matches!(
-                receiver.try_recv(),
-                Ok(TriggeredOperation::UsdcBaseToAlpaca { .. })
-            ),
-            "TooMuchOnchain (900/100) should trigger UsdcBaseToAlpaca before reactor events"
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Base->Alpaca should not be routed through the Rebalancer mpsc channel"
         );
         trigger.clear_usdc_in_progress();
 
@@ -7079,14 +7221,18 @@ mod tests {
             owner: TEST_ORDER_OWNER,
         };
 
-        // Verify imbalance triggers before snapshot
+        // Verify imbalance triggers before snapshot. Base->Alpaca is now
+        // enqueued as a TransferUsdcToHedging apalis job rather than sent via
+        // the Rebalancer mpsc channel.
         trigger.check_and_trigger_usdc().await;
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&trigger).await,
+            1,
+            "TooMuchOnchain (90% ratio) should enqueue a TransferUsdcToHedging job before snapshot"
+        );
         assert!(
-            matches!(
-                receiver.try_recv(),
-                Ok(TriggeredOperation::UsdcBaseToAlpaca { .. })
-            ),
-            "TooMuchOnchain (90% ratio) should trigger UsdcBaseToAlpaca before snapshot"
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Base->Alpaca should not be routed through the Rebalancer mpsc channel"
         );
         trigger.clear_usdc_in_progress();
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -122,7 +122,11 @@ impl UsdcRebalanceStage {
             Bridged { .. } => Some(Self::Bridged),
             DepositInitiated { .. } => Some(Self::DepositInitiated),
             DepositConfirmed { .. } => Some(Self::DepositConfirmed),
-            ConversionConfirmed { .. }
+            // Transient intent markers: immediately superseded by Initiated /
+            // BridgingInitiated, so they emit no distinct progress stage.
+            WithdrawalSubmitting { .. }
+            | BridgingSubmitting { .. }
+            | ConversionConfirmed { .. }
             | ConversionFailed { .. }
             | WithdrawalFailed { .. }
             | BridgingFailed { .. }
@@ -560,6 +564,11 @@ impl RebalancingService {
             } => {
                 self.complete_alpaca_to_base_deposit(id).await?;
             }
+            // Transient intent markers persisted before the on-chain withdraw /
+            // burn. Detailed stage tracking starts at the subsequent Initiated /
+            // BridgingInitiated; the inventory's active-rebalance claim is set by
+            // the caller on this (first non-terminal) event, so nothing to do here.
+            WithdrawalSubmitting { .. } | BridgingSubmitting { .. } => {}
             WithdrawalFailed { .. }
             | BridgingFailed { .. }
             | DepositFailed { .. }

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -1,0 +1,162 @@
+//! Apalis job that drives a `BaseToAlpaca` USDC transfer through the
+//! `UsdcRebalance` lifecycle.
+//!
+//! Each job is keyed by a `UsdcRebalanceId` chosen at enqueue time, so apalis
+//! retries (and bot restarts that re-pick the row from the Jobs table) hit
+//! the same aggregate. The worker calls
+//! [`ResumeBaseToAlpaca::resume_base_to_alpaca`] on the trait-erased
+//! transfer, which loads the aggregate via `Store::load` and dispatches on
+//! its current state. New transfers and mid-flight resumes share the same
+//! entry point — that uniformity is what makes recovery dispatch fall out of
+//! the standard transfer lifecycle.
+//!
+//! The global `usdc_in_progress` guard is cleared event-driven when the
+//! aggregate reaches a terminal state (success or a recorded failure), not by
+//! this worker. A transient failure that only schedules a retry, or an
+//! indeterminate failure that leaves the aggregate mid-flight (e.g. stalled at
+//! `WithdrawalSubmitting`/`BridgingSubmitting`), keeps the guard latched so
+//! automation does not re-arm a fresh transfer on top of a partial one.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use st0x_evm::Wallet;
+use st0x_finance::Usdc;
+
+use super::UsdcTransferError;
+use super::manager::CrossVenueCashTransfer;
+use crate::conductor::job::{Job, JobQueue, Label};
+use crate::usdc_rebalance::UsdcRebalanceId;
+
+/// Apalis queue type for [`TransferUsdcToHedging`].
+pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
+
+/// Trait-erased entry point the apalis job calls. Erasing the `Chain` generic
+/// here lets the conductor build a single concrete `Ctx` regardless of which
+/// wallet backend is wired in.
+#[async_trait]
+pub(crate) trait ResumeBaseToAlpaca: Send + Sync + 'static {
+    async fn resume_base_to_alpaca(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError>;
+}
+
+#[async_trait]
+impl<Chain> ResumeBaseToAlpaca for CrossVenueCashTransfer<Chain>
+where
+    Chain: Wallet + Send + Sync + 'static,
+{
+    async fn resume_base_to_alpaca(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        Self::resume_base_to_alpaca(self, id, amount).await
+    }
+}
+
+/// Dependencies the job needs to resume the transfer.
+pub(crate) struct TransferUsdcToHedgingCtx {
+    pub(crate) transfer: Arc<dyn ResumeBaseToAlpaca>,
+    /// Per-attempt wall-clock bound. A resume that exceeds this is aborted so
+    /// a hung RPC fails the attempt (and retries) instead of wedging the
+    /// single-concurrency worker forever.
+    pub(crate) timeout: Duration,
+}
+
+/// Errors emitted by [`TransferUsdcToHedging::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum TransferUsdcToHedgingJobError {
+    #[error(transparent)]
+    Transfer(#[from] UsdcTransferError),
+    #[error("Base->Alpaca transfer {id} attempt exceeded the {timeout:?} per-attempt timeout")]
+    Timeout {
+        id: UsdcRebalanceId,
+        timeout: Duration,
+    },
+}
+
+/// Apalis job payload. The `id` is generated at enqueue time so retries
+/// resume the same aggregate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TransferUsdcToHedging {
+    pub(crate) id: UsdcRebalanceId,
+    pub(crate) amount: Usdc,
+}
+
+impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
+    type Output = ();
+    type Error = TransferUsdcToHedgingJobError;
+
+    const WORKER_NAME: &'static str = "transfer-usdc-to-hedging-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::TransferUsdcToHedging;
+
+    fn label(&self) -> Label {
+        Label::new(format!("TransferUsdcToHedging:{}", self.id))
+    }
+
+    async fn perform(&self, ctx: &TransferUsdcToHedgingCtx) -> Result<Self::Output, Self::Error> {
+        let resume = ctx.transfer.resume_base_to_alpaca(&self.id, self.amount);
+
+        match tokio::time::timeout(ctx.timeout, resume).await {
+            Ok(result) => Ok(result?),
+            Err(_elapsed) => Err(TransferUsdcToHedgingJobError::Timeout {
+                id: self.id.clone(),
+                timeout: ctx.timeout,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use st0x_float_macro::float;
+
+    use super::*;
+
+    /// Models a hung RPC inside the transfer: the resume future never
+    /// completes within the configured per-attempt timeout.
+    struct HangingResume;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for HangingResume {
+        async fn resume_base_to_alpaca(
+            &self,
+            _id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn perform_times_out_when_resume_hangs() {
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(HangingResume),
+            timeout: Duration::from_millis(50),
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            TransferUsdcToHedgingJobError::Timeout { .. }
+        ));
+    }
+}

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -22,7 +22,7 @@ use super::UsdcTransferError;
 use crate::alpaca_wallet::{
     AlpacaTransferId, AlpacaWalletService, TokenSymbol, Transfer, TransferStatus,
 };
-use crate::onchain::raindex::{RaindexService, RaindexVaultId};
+use crate::onchain::raindex::{RaindexService, RaindexVaultId, USDC_BASE};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
@@ -580,24 +580,307 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let burn_receipt = self.execute_cctp_burn_on_base(id, amount_u256).await?;
 
-        let attestation_response = self
-            .poll_attestation_for_base_burn(id, &burn_receipt)
-            .await?;
-
-        // Use the actual minted amount (net of CCTP fee) for downstream operations
-        let mint_receipt = self
-            .execute_cctp_mint_on_ethereum(id, attestation_response)
-            .await?;
-
-        self.poll_and_confirm_alpaca_deposit(id, mint_receipt.tx)
-            .await?;
-
-        // Convert deposited USDC to USD buying power using actual received amount
-        let amount_received = u256_to_usdc(mint_receipt.amount)?;
-        self.execute_usdc_to_usd_conversion(id, amount_received)
+        // From Bridging onward the fresh-start and resume paths are identical:
+        // poll Circle, record the attestation, mint, deposit, and convert.
+        self.continue_from_bridging(id, amount, burn_receipt.tx)
             .await?;
 
         info!(target: "rebalance", "Base to Alpaca rebalance completed successfully");
+        Ok(())
+    }
+
+    /// Resumes (or starts) a Base->Alpaca transfer from the aggregate's current
+    /// state.
+    ///
+    /// Loads the [`UsdcRebalance`] aggregate via [`Store::load`] and dispatches
+    /// on state to the appropriate phase. This single entry point handles both
+    /// the fresh-start case (aggregate doesn't exist yet) and any in-progress
+    /// state after a crash. Designed to be called from an apalis job so retries
+    /// drive a stalled aggregate to terminal without re-issuing completed
+    /// phases.
+    ///
+    /// # Resume semantics
+    ///
+    /// - `None` (no events yet): start from vault withdrawal.
+    /// - `Withdrawing`: vault withdrawal is synchronous (waits for block
+    ///   inclusion before sending `Initiate`), so only a crash between
+    ///   `Initiate` and `ConfirmWithdrawal` lands the aggregate here. Send
+    ///   `ConfirmWithdrawal` and continue.
+    /// - `WithdrawalComplete`: resume from CCTP burn.
+    /// - `Bridging` / `Attested`: resume from attestation polling. The Circle
+    ///   API is idempotent for completed attestations, so the `Attested` case
+    ///   just re-polls to get a fresh `AttestationResponse` (the aggregate
+    ///   stores attestation bytes and nonce but not the full message envelope
+    ///   needed by [`Bridge::mint`], so re-polling is cheaper than extending
+    ///   the bridge API).
+    /// - `Bridged`: resume from Alpaca deposit initiation.
+    /// - `DepositInitiated`: deposit already recorded; resume from polling
+    ///   Alpaca.
+    /// - `DepositConfirmed` (BaseToAlpaca): resume from USDC->USD conversion.
+    /// - `Converting`: indeterminate after crash (broker order ID is not
+    ///   persisted); emit `FailConversion` and return error so operator can
+    ///   reconcile manually.
+    /// - `ConversionComplete`: terminal success; no-op.
+    /// - Terminal failure states: return [`UsdcTransferError::PreviouslyFailedAggregate`]
+    ///   so the operator sees that automated recovery cannot help.
+    #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
+    pub(crate) async fn resume_base_to_alpaca(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let state = self.cqrs.load(id).await?;
+
+        info!(
+            target: "rebalance",
+            ?state,
+            "Resuming Base->Alpaca transfer from aggregate state",
+        );
+
+        match state {
+            None => self.execute_base_to_alpaca(id, amount).await,
+
+            Some(UsdcRebalance::WithdrawalSubmitting {
+                direction,
+                amount,
+                from_block,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                let amount_u256 = usdc_to_u256(amount)?;
+                self.resume_withdrawal_submitting(id, amount, amount_u256, from_block)
+                    .await?;
+                self.continue_from_withdrawal_complete(id, amount).await
+            }
+
+            Some(UsdcRebalance::Withdrawing {
+                direction, amount, ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.cqrs
+                    .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+                    .await?;
+                self.continue_from_withdrawal_complete(id, amount).await
+            }
+
+            Some(UsdcRebalance::WithdrawalComplete {
+                direction, amount, ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.continue_from_withdrawal_complete(id, amount).await
+            }
+
+            Some(UsdcRebalance::BridgingSubmitting {
+                direction,
+                amount,
+                from_block,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                let amount_u256 = usdc_to_u256(amount)?;
+                let burn_receipt = self
+                    .resume_bridging_submitting(id, amount_u256, from_block)
+                    .await?;
+                self.continue_from_bridging(id, amount, burn_receipt.tx)
+                    .await
+            }
+
+            Some(UsdcRebalance::Bridging {
+                direction,
+                amount,
+                burn_tx_hash,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.continue_from_bridging(id, amount, burn_tx_hash).await
+            }
+
+            Some(UsdcRebalance::Attested {
+                direction,
+                amount,
+                burn_tx_hash,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.continue_from_attested(id, amount, burn_tx_hash).await
+            }
+
+            Some(UsdcRebalance::Bridged {
+                direction,
+                amount_received,
+                mint_tx_hash,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.continue_from_bridged(id, amount_received, mint_tx_hash)
+                    .await
+            }
+
+            Some(UsdcRebalance::DepositInitiated {
+                direction,
+                amount,
+                deposit_ref,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                let TransferRef::OnchainTx(mint_tx) = deposit_ref else {
+                    return Err(UsdcTransferError::DepositRefMustBeOnchain { id: id.clone() });
+                };
+                self.poll_alpaca_deposit_and_confirm(id, mint_tx).await?;
+                self.execute_usdc_to_usd_conversion(id, amount).await?;
+                Ok(())
+            }
+
+            Some(UsdcRebalance::DepositConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                ..
+            }) => {
+                self.execute_usdc_to_usd_conversion(id, amount).await?;
+                Ok(())
+            }
+
+            Some(UsdcRebalance::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "resume_base_to_alpaca called on AlpacaToBase DepositConfirmed; \
+                     treating as no-op terminal",
+                );
+                Ok(())
+            }
+
+            Some(UsdcRebalance::Converting { .. }) => {
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: "resume from Converting state requires manual \
+                                     reconciliation: broker order ID not persisted"
+                                .into(),
+                        },
+                    )
+                    .await?;
+                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            }
+
+            Some(UsdcRebalance::ConversionComplete { direction, .. }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                Ok(())
+            }
+
+            Some(
+                UsdcRebalance::WithdrawalFailed { .. }
+                | UsdcRebalance::BridgingFailed { .. }
+                | UsdcRebalance::DepositFailed { .. }
+                | UsdcRebalance::ConversionFailed { .. },
+            ) => Err(UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() }),
+        }
+    }
+
+    fn require_base_to_alpaca(
+        id: &UsdcRebalanceId,
+        direction: &RebalanceDirection,
+    ) -> Result<(), UsdcTransferError> {
+        if matches!(direction, RebalanceDirection::BaseToAlpaca) {
+            Ok(())
+        } else {
+            Err(UsdcTransferError::ResumeDirectionMismatch {
+                id: id.clone(),
+                direction: direction.clone(),
+            })
+        }
+    }
+
+    /// Drives the transfer from `WithdrawalComplete` through to terminal:
+    /// burn -> attestation -> mint -> deposit -> USDC->USD conversion.
+    async fn continue_from_withdrawal_complete(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let amount_u256 = usdc_to_u256(amount)?;
+        let burn_receipt = self.execute_cctp_burn_on_base(id, amount_u256).await?;
+        self.continue_from_bridging(id, amount, burn_receipt.tx)
+            .await
+    }
+
+    /// Drives the transfer from `Bridging` through to terminal: poll Circle,
+    /// record the attestation (`Bridging` -> `Attested`), then mint and continue.
+    async fn continue_from_bridging(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+        let attestation_response = self.poll_circle_attestation(id, &burn_receipt).await?;
+
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::ReceiveAttestation {
+                    attestation: attestation_response.as_bytes().to_vec(),
+                    cctp_nonce: attestation_response.nonce(),
+                },
+            )
+            .await?;
+
+        info!(target: "rebalance", "Circle attestation received for Base burn");
+        self.mint_and_continue(id, attestation_response).await
+    }
+
+    /// Drives the transfer from `Attested` through to terminal. The attestation
+    /// is already recorded, so this re-polls Circle for a fresh
+    /// [`AttestationResponse`] (the aggregate stores the attestation bytes and
+    /// nonce but not the full message envelope [`Bridge::mint`] needs) WITHOUT
+    /// re-emitting `ReceiveAttestation` -- which the aggregate rejects from
+    /// `Attested`, fail-stopping every retry with the USDC already burned.
+    async fn continue_from_attested(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+        let attestation_response = self.poll_circle_attestation(id, &burn_receipt).await?;
+        self.mint_and_continue(id, attestation_response).await
+    }
+
+    /// Mints on the destination chain from a fresh attestation and continues to
+    /// the deposit phase. Shared by the `Bridging` and `Attested` resume paths.
+    async fn mint_and_continue(
+        &self,
+        id: &UsdcRebalanceId,
+        attestation_response: AttestationResponse,
+    ) -> Result<(), UsdcTransferError> {
+        let mint_receipt = self
+            .execute_cctp_mint_on_ethereum(id, attestation_response)
+            .await?;
+        self.continue_from_bridged(id, u256_to_usdc(mint_receipt.amount)?, mint_receipt.tx)
+            .await
+    }
+
+    /// Drives the transfer from `Bridged` through to terminal: initiate
+    /// Alpaca deposit, poll, then USDC->USD conversion.
+    async fn continue_from_bridged(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+        mint_tx: TxHash,
+    ) -> Result<(), UsdcTransferError> {
+        self.poll_and_confirm_alpaca_deposit(id, mint_tx).await?;
+        self.execute_usdc_to_usd_conversion(id, amount_received)
+            .await?;
         Ok(())
     }
 
@@ -608,6 +891,21 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         amount: Usdc,
         amount_u256: U256,
     ) -> Result<(), UsdcTransferError> {
+        // Record withdrawal intent and the chain head BEFORE the irreversible
+        // on-chain withdraw, so a crash mid-withdrawal resumes via a chain scan
+        // (`resume_withdrawal_submitting`) instead of blindly re-withdrawing.
+        let from_block = self.raindex.current_block().await?;
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::BeginWithdrawal {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    from_block,
+                },
+            )
+            .await?;
+
         let withdraw_tx = match self.raindex.withdraw_usdc(self.vault_id, amount_u256).await {
             Ok(tx) => tx,
             Err(error) => {
@@ -616,6 +914,88 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
+        self.record_vault_withdrawal(id, amount, withdraw_tx).await
+    }
+
+    /// Resumes a transfer stalled at `WithdrawalSubmitting`: scans the chain for
+    /// an already-submitted withdrawal (adopting it to avoid a double-withdraw)
+    /// and otherwise issues the withdrawal, then records and confirms it.
+    ///
+    /// The scan is finality-gated: it returns `Ok(None)` (safe to issue the
+    /// withdrawal) only when the queried node is confirmations-deep past
+    /// `from_block`; otherwise it yields a retryable error and this resume re-runs
+    /// rather than risking a double-withdraw off a stale empty `eth_getLogs`.
+    async fn resume_withdrawal_submitting(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        amount_u256: U256,
+        from_block: u64,
+    ) -> Result<(), UsdcTransferError> {
+        if let Some((existing_tx, withdrawn)) = self
+            .raindex
+            .find_recent_withdrawal(USDC_BASE, self.vault_id, from_block)
+            .await?
+        {
+            // The withdrawal for this transfer already landed on-chain; adopt it
+            // instead of re-withdrawing. If it realized a different amount than
+            // requested (vault under-funded -> partial fill), fail fast for
+            // operator reconciliation -- never burn more on Base than was actually
+            // withdrawn.
+            if withdrawn != amount_u256 {
+                warn!(target: "rebalance", %existing_tx, %withdrawn, requested = %amount_u256,
+                    "Adopted withdrawal realized a different amount than requested; failing for reconciliation");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::Initiate {
+                            direction: RebalanceDirection::BaseToAlpaca,
+                            amount,
+                            withdrawal: TransferRef::OnchainTx(existing_tx),
+                        },
+                    )
+                    .await?;
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailWithdrawal {
+                            reason: format!(
+                                "adopted withdrawal {existing_tx} realized {withdrawn}, \
+                                 requested {amount_u256}"
+                            ),
+                        },
+                    )
+                    .await?;
+                return Err(UsdcTransferError::AdoptedWithdrawalAmountMismatch {
+                    id: id.clone(),
+                    withdrawn,
+                    requested: amount_u256,
+                });
+            }
+
+            info!(target: "rebalance", %existing_tx, "Adopting already-submitted vault withdrawal on resume");
+            return self.record_vault_withdrawal(id, amount, existing_tx).await;
+        }
+
+        let withdraw_tx = match self.raindex.withdraw_usdc(self.vault_id, amount_u256).await {
+            Ok(tx) => tx,
+            Err(error) => {
+                warn!(target: "rebalance", "Vault withdrawal failed: {error}");
+                return Err(UsdcTransferError::Vault(error));
+            }
+        };
+
+        self.record_vault_withdrawal(id, amount, withdraw_tx).await
+    }
+
+    /// Records the submitted withdrawal transaction and confirms it. The vault
+    /// withdrawal waits for block inclusion, so confirmation is immediate.
+    async fn record_vault_withdrawal(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        withdraw_tx: TxHash,
+    ) -> Result<(), UsdcTransferError> {
         self.cqrs
             .send(
                 id,
@@ -626,8 +1006,6 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 },
             )
             .await?;
-
-        // Vault withdrawal function already waits for block inclusion, so confirming immediately
         self.cqrs
             .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
             .await?;
@@ -642,30 +1020,74 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         amount: U256,
     ) -> Result<BurnReceipt, UsdcTransferError> {
+        // Record bridging intent and the chain head BEFORE the irreversible burn,
+        // so a crash mid-burn resumes via a chain scan (`resume_bridging_submitting`)
+        // instead of re-burning (which would burn USDC twice with at most one mint).
+        let from_block = self.raindex.current_block().await?;
+        self.cqrs
+            .send(id, UsdcRebalanceCommand::BeginBridging { from_block })
+            .await?;
+
+        let burn_receipt = self.burn_on_base(amount).await?;
+        self.record_cctp_burn(id, burn_receipt).await
+    }
+
+    /// Resumes a transfer stalled at `BridgingSubmitting`: scans the chain for an
+    /// already-submitted burn (adopting it to avoid a double-burn) and otherwise
+    /// issues the burn, then records it. Returns the burn receipt so the caller
+    /// can continue the bridge.
+    async fn resume_bridging_submitting(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<BurnReceipt, UsdcTransferError> {
         let burn_receipt = match self
             .cctp_bridge
+            .find_recent_burn(BridgeDirection::BaseToEthereum, amount, from_block)
+            .await
+        {
+            Ok(Some(existing_tx)) => {
+                info!(target: "rebalance", %existing_tx, "Adopting already-submitted CCTP burn on resume");
+                BurnReceipt {
+                    tx: existing_tx,
+                    amount,
+                }
+            }
+            Ok(None) => self.burn_on_base(amount).await?,
+            Err(error) => {
+                warn!(target: "rebalance", "CCTP burn scan on Base failed: {error}");
+                return Err(UsdcTransferError::Cctp(Box::new(error)));
+            }
+        };
+
+        self.record_cctp_burn(id, burn_receipt).await
+    }
+
+    /// Burns USDC on Base. On failure the aggregate stays at `BridgingSubmitting`
+    /// (no terminal event is emitted) so an apalis retry re-enters the scan path
+    /// rather than re-burning, and exhausted retries latch the in-progress guard
+    /// for operator reconciliation.
+    async fn burn_on_base(&self, amount: U256) -> Result<BurnReceipt, UsdcTransferError> {
+        self.cctp_bridge
             .burn(
                 BridgeDirection::BaseToEthereum,
                 amount,
                 self.market_maker_wallet,
             )
             .await
-        {
-            Ok(receipt) => receipt,
-            Err(error) => {
+            .map_err(|error| {
                 warn!(target: "rebalance", "CCTP burn on Base failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Burn on Base failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
-            }
-        };
+                UsdcTransferError::Cctp(Box::new(error))
+            })
+    }
 
+    /// Records the submitted CCTP burn transaction, advancing to `Bridging`.
+    async fn record_cctp_burn(
+        &self,
+        id: &UsdcRebalanceId,
+        burn_receipt: BurnReceipt,
+    ) -> Result<BurnReceipt, UsdcTransferError> {
         self.cqrs
             .send(
                 id,
@@ -679,18 +1101,23 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         Ok(burn_receipt)
     }
 
+    /// Polls Circle for the attestation of a Base burn. On failure records
+    /// `FailBridging` (valid from both `Bridging` and `Attested`) and returns the
+    /// error. Does NOT emit `ReceiveAttestation` -- the caller records it only on
+    /// the `Bridging` path, where it is valid; the `Attested` resume path must
+    /// not re-emit it.
     #[instrument(target = "rebalance", skip(self, burn_receipt), fields(%id, burn_tx = %burn_receipt.tx), level = tracing::Level::DEBUG)]
-    async fn poll_attestation_for_base_burn(
+    async fn poll_circle_attestation(
         &self,
         id: &UsdcRebalanceId,
         burn_receipt: &BurnReceipt,
     ) -> Result<AttestationResponse, UsdcTransferError> {
-        let response = match self
+        match self
             .cctp_bridge
             .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
             .await
         {
-            Ok(response) => response,
+            Ok(response) => Ok(response),
             Err(error) => {
                 warn!(target: "rebalance", "Attestation polling failed: {error}");
                 self.cqrs
@@ -701,22 +1128,9 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                         },
                     )
                     .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
+                Err(UsdcTransferError::Cctp(Box::new(error)))
             }
-        };
-
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ReceiveAttestation {
-                    attestation: response.as_bytes().to_vec(),
-                    cctp_nonce: response.nonce(),
-                },
-            )
-            .await?;
-
-        info!(target: "rebalance", "Circle attestation received for Base burn");
-        Ok(response)
+        }
     }
 
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
@@ -771,7 +1185,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         mint_tx: TxHash,
     ) -> Result<(), UsdcTransferError> {
-        // Record the deposit initiation with the mint tx
+        // Record the deposit initiation with the mint tx. This is a pure
+        // intent record, never a fund-moving call: the CCTP mint already
+        // deposited the USDC directly to the Alpaca-controlled address, so the
+        // "deposit" IS the on-chain mint tx. That invariant is what makes
+        // resume from `Bridged` safe -- re-sending `InitiateDeposit` here just
+        // re-records the same mint tx, it does not move funds again. The only
+        // Alpaca interaction (below) is a read-only poll to detect the deposit.
         self.cqrs
             .send(
                 id,
@@ -781,6 +1201,19 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             )
             .await?;
 
+        self.poll_alpaca_deposit_and_confirm(id, mint_tx).await
+    }
+
+    /// Polls Alpaca for the deposit identified by `mint_tx`, then sends
+    /// `ConfirmDeposit`. Assumes the aggregate is already in
+    /// `DepositInitiated` (caller has sent `InitiateDeposit`, or we are
+    /// resuming from that state).
+    #[instrument(target = "rebalance", skip(self), fields(%id, %mint_tx), level = tracing::Level::DEBUG)]
+    async fn poll_alpaca_deposit_and_confirm(
+        &self,
+        id: &UsdcRebalanceId,
+        mint_tx: TxHash,
+    ) -> Result<(), UsdcTransferError> {
         info!(target: "rebalance", %mint_tx, "Polling Alpaca for deposit detection");
 
         let transfer = match self.alpaca_wallet.poll_deposit_by_tx_hash(&mint_tx).await {
@@ -2354,11 +2787,7 @@ mod tests {
             )
             .await;
 
-        assert!(
-            withdrawal_result.is_ok(),
-            "Initiate should succeed from ConversionComplete state, \
-             got: {withdrawal_result:?}"
-        );
+        withdrawal_result.unwrap();
     }
 
     #[tokio::test]
@@ -2407,6 +2836,348 @@ mod tests {
             filled_amount,
             usdc("999.5"),
             "Should return actual filled amount, not requested amount"
+        );
+    }
+
+    /// Builds a `CrossVenueCashTransfer` whose `cqrs` store is reachable to
+    /// the caller. Used by resume-routing tests that pre-stage aggregate
+    /// state before invoking `resume_base_to_alpaca`.
+    async fn make_resume_test_manager(
+        server: &MockServer,
+    ) -> (
+        CrossVenueCashTransfer<
+            RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>,
+        >,
+        Arc<Store<UsdcRebalance>>,
+        alloy::node_bindings::AnvilInstance,
+    ) {
+        let (anvil, endpoint, private_key) = setup_anvil();
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        (manager, cqrs, anvil)
+    }
+
+    /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
+    /// `InitiateBridging` -> `ReceiveAttestation` -> `ConfirmBridging` so
+    /// the next callable step is the Alpaca deposit initiation.
+    async fn advance_to_bridged_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        amount_received: Usdc,
+    ) -> (TxHash, TxHash) {
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0xbbbb111111111111111111111111111111111111111111111111111111111111");
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: 99_999,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received,
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
+        (burn_tx, mint_tx)
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_terminal_failure_returns_previously_failed_error() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+
+        let burn_tx =
+            fixed_bytes!("0xcccc000000000000000000000000000000000000000000000000000000000002");
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::FailBridging {
+                reason: "test-induced failure".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::PreviouslyFailedAggregate { id: ref e_id }
+                    if *e_id == id
+            ),
+            "Expected PreviouslyFailedAggregate, got: {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_conversion_complete_is_noop() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(fixed_bytes!(
+                    "0xbbbb111111111111111111111111111111111111111111111111111111111111"
+                )),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiatePostDepositConversion {
+                order_id: Uuid::new_v4(),
+                amount: amount_received,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount_received,
+            },
+        )
+        .await
+        .unwrap();
+
+        // No mocks for Alpaca or CCTP services — a no-op resume must NOT call them.
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_skips_burn_and_mint() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let (_burn_tx, mint_tx) =
+            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+
+        // Mock Alpaca deposit poll for the mint tx and the subsequent
+        // USDC->USD conversion. No CCTP mocks are configured — a resume from
+        // Bridged that tried to re-burn or re-mint would attempt to hit the
+        // (un-deployed) CCTP contracts via anvil and fail the test loud.
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{mint_tx:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected aggregate to reach ConversionComplete after resume from Bridged, \
+             got: {final_state:?}"
+        );
+    }
+
+    /// Resume from `DepositInitiated` polls the Alpaca deposit and runs the
+    /// USDC->USD conversion without re-touching CCTP -- the on-chain mint already
+    /// landed, so the deposit is a read-only poll, not a fund-moving call.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_deposit_initiated_polls_and_converts() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let (_burn_tx, mint_tx) =
+            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(mint_tx),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Mock the Alpaca deposit poll + USDC->USD conversion. No CCTP mocks --
+        // a resume from DepositInitiated that re-burned/re-minted would hit the
+        // un-deployed CCTP contracts via anvil and fail the test loud.
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{mint_tx:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected ConversionComplete after resume from DepositInitiated, got: {final_state:?}"
+        );
+    }
+
+    /// `resume_base_to_alpaca` must reject an aggregate carrying the AlpacaToBase
+    /// direction -- the guard fires before any side-effecting call, so a transfer
+    /// for the other direction can never be driven down the Base->Alpaca path.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_rejects_alpaca_to_base_direction() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: Uuid::new_v4(),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+
+        // No Alpaca/CCTP mocks: the direction guard must reject before any
+        // side-effecting call.
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::ResumeDirectionMismatch {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Expected ResumeDirectionMismatch for AlpacaToBase resume, got: {error:?}"
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -4,10 +4,15 @@
 //! directions for USDC, handling USD/USDC conversion, withdrawal, CCTP
 //! bridging, and deposit.
 
+mod job;
 mod manager;
 #[cfg(test)]
 pub(crate) mod mock;
 
+pub(crate) use job::{
+    ResumeBaseToAlpaca, TransferUsdcToHedging, TransferUsdcToHedgingCtx,
+    TransferUsdcToHedgingJobQueue,
+};
 pub(crate) use manager::{CrossVenueCashTransfer, u256_to_usdc};
 
 use rain_math_float::FloatError;
@@ -51,6 +56,42 @@ pub(crate) enum UsdcTransferError {
          filled_quantity is missing"
     )]
     MissingFilledQuantity { order_id: uuid::Uuid },
+    #[error(
+        "USDC rebalance {id} cannot resume from Converting state: \
+         broker order ID lost after crash; manual reconciliation required"
+    )]
+    ResumeIndeterminateConversion {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+    },
+    #[error("USDC rebalance {id} cannot resume: aggregate is in terminal failure state")]
+    PreviouslyFailedAggregate {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+    },
+    #[error(
+        "USDC rebalance {id} DepositInitiated has non-onchain deposit ref; \
+         BaseToAlpaca always records the mint tx as OnchainTx"
+    )]
+    DepositRefMustBeOnchain {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+    },
+    #[error(
+        "USDC rebalance {id} cannot resume via Base->Alpaca entrypoint: \
+         aggregate direction is {direction:?}"
+    )]
+    ResumeDirectionMismatch {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+        direction: crate::usdc_rebalance::RebalanceDirection,
+    },
+    #[error(
+        "USDC rebalance {id} adopted a withdrawal that realized {withdrawn} but \
+         {requested} was requested; failed for operator reconciliation rather \
+         than burning more than was withdrawn"
+    )]
+    AdoptedWithdrawalAmountMismatch {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
+        withdrawn: alloy::primitives::U256,
+        requested: alloy::primitives::U256,
+    },
 }
 
 impl From<SendError<crate::usdc_rebalance::UsdcRebalance>> for UsdcTransferError {

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -199,8 +199,18 @@ pub(crate) enum UsdcRebalanceCommand {
     /// Valid only from `DepositConfirmed` state.
     /// Amount must match the aggregate's deposit amount for consistency.
     InitiatePostDepositConversion { order_id: Uuid, amount: Usdc },
-    /// Start a new rebalancing operation. Valid only from `Uninitialized` state or
-    /// `ConversionComplete` state (for AlpacaToBase direction).
+    /// Record the intent to withdraw from source BEFORE the on-chain call.
+    /// Captures the chain head (`from_block`) so a crash mid-withdrawal can be
+    /// recovered by scanning from that block instead of blindly re-withdrawing
+    /// (which would double-spend). Valid from `Uninitialized` (BaseToAlpaca) or
+    /// `ConversionComplete` (AlpacaToBase).
+    BeginWithdrawal {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+    },
+    /// Start a new rebalancing operation by recording the submitted withdrawal
+    /// transaction. Valid only from `WithdrawalSubmitting` state.
     Initiate {
         direction: RebalanceDirection,
         amount: Usdc,
@@ -208,7 +218,11 @@ pub(crate) enum UsdcRebalanceCommand {
     },
     /// Confirm successful withdrawal from source. Valid only from `Withdrawing` state.
     ConfirmWithdrawal,
-    /// Record the CCTP burn transaction. Valid only from `WithdrawalComplete` state.
+    /// Record the intent to burn for CCTP bridging BEFORE the on-chain call.
+    /// Captures the chain head (`from_block`) for crash recovery, mirroring
+    /// [`BeginWithdrawal`]. Valid only from `WithdrawalComplete` state.
+    BeginBridging { from_block: u64 },
+    /// Record the CCTP burn transaction. Valid only from `BridgingSubmitting` state.
     InitiateBridging { burn_tx: TxHash },
     /// Record the Circle attestation. Valid only from `Bridging` state.
     /// The cctp_nonce is extracted from the attested message (not the burn tx, which has placeholder).
@@ -267,6 +281,14 @@ pub(crate) enum UsdcRebalanceEvent {
         reason: String,
         failed_at: DateTime<Utc>,
     },
+    /// Intent to withdraw from source recorded before the on-chain call.
+    /// Captures the chain head for crash-safe recovery.
+    WithdrawalSubmitting {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+        submitting_at: DateTime<Utc>,
+    },
     /// Rebalancing operation started. Records direction, amount, and withdrawal reference.
     Initiated {
         direction: RebalanceDirection,
@@ -280,6 +302,12 @@ pub(crate) enum UsdcRebalanceEvent {
     WithdrawalFailed {
         reason: String,
         failed_at: DateTime<Utc>,
+    },
+    /// Intent to burn for CCTP bridging recorded before the on-chain call.
+    /// Captures the chain head for crash-safe recovery.
+    BridgingSubmitting {
+        from_block: u64,
+        submitting_at: DateTime<Utc>,
     },
     /// CCTP burn transaction submitted. Records burn hash for attestation lookup.
     BridgingInitiated {
@@ -335,9 +363,11 @@ impl DomainEvent for UsdcRebalanceEvent {
             Self::ConversionInitiated { .. } => "UsdcRebalanceEvent::ConversionInitiated",
             Self::ConversionConfirmed { .. } => "UsdcRebalanceEvent::ConversionConfirmed",
             Self::ConversionFailed { .. } => "UsdcRebalanceEvent::ConversionFailed",
+            Self::WithdrawalSubmitting { .. } => "UsdcRebalanceEvent::WithdrawalSubmitting",
             Self::Initiated { .. } => "UsdcRebalanceEvent::Initiated",
             Self::WithdrawalConfirmed { .. } => "UsdcRebalanceEvent::WithdrawalConfirmed",
             Self::WithdrawalFailed { .. } => "UsdcRebalanceEvent::WithdrawalFailed",
+            Self::BridgingSubmitting { .. } => "UsdcRebalanceEvent::BridgingSubmitting",
             Self::BridgingInitiated { .. } => "UsdcRebalanceEvent::BridgingInitiated",
             Self::BridgeAttestationReceived { .. } => {
                 "UsdcRebalanceEvent::BridgeAttestationReceived"
@@ -388,6 +418,15 @@ pub(crate) enum UsdcRebalance {
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
+    /// Withdrawal intent recorded; the on-chain withdraw is about to be (or has
+    /// just been) submitted. `from_block` is the chain head captured before the
+    /// call so resume can scan for an already-submitted withdrawal.
+    WithdrawalSubmitting {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+        initiated_at: DateTime<Utc>,
+    },
     /// Withdrawal from source has been initiated
     Withdrawing {
         direction: RebalanceDirection,
@@ -410,6 +449,15 @@ pub(crate) enum UsdcRebalance {
         reason: String,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
+    },
+    /// Bridging intent recorded; the on-chain CCTP burn is about to be (or has
+    /// just been) submitted. `from_block` is the chain head captured before the
+    /// call so resume can scan for an already-submitted burn.
+    BridgingSubmitting {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        from_block: u64,
+        initiated_at: DateTime<Utc>,
     },
     /// CCTP bridging has been initiated (burn transaction submitted)
     /// Note: cctp_nonce is not available here - it's only known after attestation.
@@ -564,7 +612,13 @@ impl UsdcRebalance {
                 *failed_at,
             ),
 
-            Self::Withdrawing {
+            Self::WithdrawalSubmitting {
+                direction,
+                amount,
+                initiated_at,
+                ..
+            }
+            | Self::Withdrawing {
                 direction,
                 amount,
                 initiated_at,
@@ -589,6 +643,19 @@ impl UsdcRebalance {
                 UsdcBridgeStatus::Withdrawing,
                 *initiated_at,
                 *confirmed_at,
+            ),
+
+            Self::BridgingSubmitting {
+                direction,
+                amount,
+                initiated_at,
+                ..
+            } => (
+                direction,
+                *amount,
+                UsdcBridgeStatus::Bridging,
+                *initiated_at,
+                *initiated_at,
             ),
 
             Self::Bridging {
@@ -715,6 +782,18 @@ impl EventSourced for UsdcRebalance {
                 initiated_at: *initiated_at,
             }),
 
+            WithdrawalSubmitting {
+                direction,
+                amount,
+                from_block,
+                submitting_at,
+            } => Some(Self::WithdrawalSubmitting {
+                direction: direction.clone(),
+                amount: *amount,
+                from_block: *from_block,
+                initiated_at: *submitting_at,
+            }),
+
             Initiated {
                 direction,
                 amount,
@@ -792,6 +871,36 @@ impl EventSourced for UsdcRebalance {
             },
 
             (
+                WithdrawalSubmitting { from_block, .. },
+                Self::ConversionComplete {
+                    direction,
+                    filled_amount,
+                    initiated_at,
+                    ..
+                },
+            ) => Self::WithdrawalSubmitting {
+                direction: direction.clone(),
+                amount: *filled_amount,
+                from_block: *from_block,
+                initiated_at: *initiated_at,
+            },
+
+            (
+                Initiated { withdrawal_ref, .. },
+                Self::WithdrawalSubmitting {
+                    direction,
+                    amount,
+                    initiated_at,
+                    ..
+                },
+            ) => Self::Withdrawing {
+                direction: direction.clone(),
+                amount: *amount,
+                withdrawal_ref: withdrawal_ref.clone(),
+                initiated_at: *initiated_at,
+            },
+
+            (
                 Initiated { withdrawal_ref, .. },
                 Self::ConversionComplete {
                     direction,
@@ -839,11 +948,32 @@ impl EventSourced for UsdcRebalance {
             },
 
             (
+                BridgingSubmitting { from_block, .. },
+                Self::WithdrawalComplete {
+                    direction,
+                    amount,
+                    initiated_at,
+                    ..
+                },
+            ) => Self::BridgingSubmitting {
+                direction: direction.clone(),
+                amount: *amount,
+                from_block: *from_block,
+                initiated_at: *initiated_at,
+            },
+
+            (
                 BridgingInitiated {
                     burn_tx_hash,
                     burned_at,
                 },
-                Self::WithdrawalComplete {
+                Self::BridgingSubmitting {
+                    direction,
+                    amount,
+                    initiated_at,
+                    ..
+                }
+                | Self::WithdrawalComplete {
                     direction,
                     amount,
                     initiated_at,
@@ -913,6 +1043,12 @@ impl EventSourced for UsdcRebalance {
                     failed_at,
                 },
                 Self::WithdrawalComplete {
+                    direction,
+                    amount,
+                    initiated_at,
+                    ..
+                }
+                | Self::BridgingSubmitting {
                     direction,
                     amount,
                     initiated_at,
@@ -1035,6 +1171,33 @@ impl EventSourced for UsdcRebalance {
                 initiated_at: Utc::now(),
             }]),
 
+            BeginWithdrawal {
+                direction,
+                amount,
+                from_block,
+            } => {
+                // Fresh-start withdrawal intent is BaseToAlpaca-only. An
+                // AlpacaToBase transfer converts USD->USDC first and reaches
+                // `WithdrawalSubmitting` through the post-conversion path
+                // (`transition_begin_withdrawal` from `ConversionComplete`);
+                // recording a fresh AlpacaToBase intent here would materialize a
+                // withdrawal with no conversion history.
+                if direction != RebalanceDirection::BaseToAlpaca {
+                    return Err(UsdcRebalanceError::InvalidCommand {
+                        command: "BeginWithdrawal".to_string(),
+                        state: "Uninitialized (fresh withdrawal is BaseToAlpaca-only; \
+                                AlpacaToBase must convert before withdrawing)"
+                            .to_string(),
+                    });
+                }
+                Ok(vec![WithdrawalSubmitting {
+                    direction,
+                    amount,
+                    from_block,
+                    submitting_at: Utc::now(),
+                }])
+            }
+
             Initiate {
                 direction,
                 amount,
@@ -1056,7 +1219,9 @@ impl EventSourced for UsdcRebalance {
                 Err(UsdcRebalanceError::WithdrawalNotInitiated)
             }
 
-            InitiateBridging { .. } => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
+            BeginBridging { .. } | InitiateBridging { .. } => {
+                Err(UsdcRebalanceError::WithdrawalNotConfirmed)
+            }
 
             ReceiveAttestation { .. } | FailBridging { .. } => {
                 Err(UsdcRebalanceError::BridgingNotInitiated)
@@ -1085,6 +1250,11 @@ impl EventSourced for UsdcRebalance {
             InitiatePostDepositConversion { order_id, amount } => {
                 self.transition_post_deposit_conversion(order_id, amount)
             }
+            BeginWithdrawal {
+                direction,
+                amount,
+                from_block,
+            } => self.transition_begin_withdrawal(direction, amount, from_block),
             Initiate {
                 direction,
                 amount,
@@ -1092,6 +1262,7 @@ impl EventSourced for UsdcRebalance {
             } => self.transition_initiate_withdrawal(direction, amount, withdrawal),
             ConfirmWithdrawal => self.transition_confirm_withdrawal(),
             FailWithdrawal { reason } => self.transition_fail_withdrawal(reason),
+            BeginBridging { from_block } => self.transition_begin_bridging(from_block),
             InitiateBridging { burn_tx } => self.transition_initiate_bridging(burn_tx),
             ReceiveAttestation {
                 attestation,
@@ -1179,11 +1350,14 @@ impl UsdcRebalance {
         }])
     }
 
-    fn transition_initiate_withdrawal(
+    /// Records withdrawal intent (the chain head) before the on-chain
+    /// withdraw, for the AlpacaToBase post-conversion path. The BaseToAlpaca
+    /// fresh-start path records the same intent via [`Self::initialize`].
+    fn transition_begin_withdrawal(
         &self,
         direction: RebalanceDirection,
         amount: Usdc,
-        withdrawal: TransferRef,
+        from_block: u64,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         let Self::ConversionComplete {
@@ -1196,7 +1370,7 @@ impl UsdcRebalance {
         };
         if direction != *conv_direction {
             return Err(UsdcRebalanceError::InvalidCommand {
-                command: "Initiate".to_string(),
+                command: "BeginWithdrawal".to_string(),
                 state: "ConversionComplete with different \
                         direction"
                     .to_string(),
@@ -1204,7 +1378,7 @@ impl UsdcRebalance {
         }
         if amount != *conv_filled_amount {
             return Err(UsdcRebalanceError::InvalidCommand {
-                command: "Initiate".to_string(),
+                command: "BeginWithdrawal".to_string(),
                 state: format!(
                     "ConversionComplete with amount \
                      mismatch: expected {:?}, got {:?}",
@@ -1213,9 +1387,57 @@ impl UsdcRebalance {
                 ),
             });
         }
-        Ok(vec![Initiated {
+        Ok(vec![WithdrawalSubmitting {
             direction,
             amount: *conv_filled_amount,
+            from_block,
+            submitting_at: Utc::now(),
+        }])
+    }
+
+    /// Records the submitted withdrawal transaction, advancing to `Withdrawing`.
+    /// Valid from `WithdrawalSubmitting` (the crash-safe path the manager uses)
+    /// or directly from `ConversionComplete` (AlpacaToBase post-conversion).
+    fn transition_initiate_withdrawal(
+        &self,
+        direction: RebalanceDirection,
+        amount: Usdc,
+        withdrawal: TransferRef,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        use UsdcRebalanceEvent::*;
+        let (expected_direction, expected_amount) = match self {
+            Self::WithdrawalSubmitting {
+                direction, amount, ..
+            } => (direction, amount),
+            Self::ConversionComplete {
+                direction,
+                filled_amount,
+                ..
+            } => (direction, filled_amount),
+            _ => return Err(UsdcRebalanceError::AlreadyInitiated),
+        };
+        if direction != *expected_direction {
+            return Err(UsdcRebalanceError::InvalidCommand {
+                command: "Initiate".to_string(),
+                state: "withdrawal entry state with different \
+                        direction"
+                    .to_string(),
+            });
+        }
+        if amount != *expected_amount {
+            return Err(UsdcRebalanceError::InvalidCommand {
+                command: "Initiate".to_string(),
+                state: format!(
+                    "withdrawal entry state with amount \
+                     mismatch: expected {:?}, got {:?}",
+                    expected_amount.inner(),
+                    amount.inner()
+                ),
+            });
+        }
+        Ok(vec![Initiated {
+            direction,
+            amount: *expected_amount,
             withdrawal_ref: withdrawal,
             initiated_at: Utc::now(),
         }])
@@ -1228,6 +1450,7 @@ impl UsdcRebalance {
                 confirmed_at: Utc::now(),
             }]),
             Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::Attested { .. }
@@ -1251,6 +1474,7 @@ impl UsdcRebalance {
                 failed_at: Utc::now(),
             }]),
             Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::Attested { .. }
@@ -1263,6 +1487,40 @@ impl UsdcRebalance {
         }
     }
 
+    /// Records bridging intent (the chain head) before the on-chain CCTP burn.
+    /// Valid only from `WithdrawalComplete`.
+    fn transition_begin_bridging(
+        &self,
+        from_block: u64,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        use UsdcRebalanceEvent::*;
+        match self {
+            Self::Converting { .. }
+            | Self::ConversionComplete { .. }
+            | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
+            Self::WithdrawalComplete { .. } => Ok(vec![BridgingSubmitting {
+                from_block,
+                submitting_at: Utc::now(),
+            }]),
+            Self::BridgingSubmitting { .. }
+            | Self::Bridging { .. }
+            | Self::Attested { .. }
+            | Self::Bridged { .. }
+            | Self::BridgingFailed { .. }
+            | Self::DepositInitiated { .. }
+            | Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "BeginBridging".to_string(),
+                state: "bridging already started".to_string(),
+            }),
+        }
+    }
+
+    /// Records the submitted CCTP burn transaction, advancing the intent state
+    /// to `Bridging`. Valid only from `BridgingSubmitting`.
     fn transition_initiate_bridging(
         &self,
         burn_tx: TxHash,
@@ -1272,12 +1530,17 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::WithdrawalNotConfirmed),
-            Self::WithdrawalComplete { .. } => Ok(vec![BridgingInitiated {
-                burn_tx_hash: burn_tx,
-                burned_at: Utc::now(),
-            }]),
+            // Valid from `BridgingSubmitting` (the crash-safe path the manager
+            // uses) or directly from `WithdrawalComplete`.
+            Self::WithdrawalComplete { .. } | Self::BridgingSubmitting { .. } => {
+                Ok(vec![BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                }])
+            }
             Self::Bridging { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
@@ -1301,8 +1564,10 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
             Self::Bridging { .. } => Ok(vec![BridgeAttestationReceived {
                 attestation,
@@ -1332,8 +1597,10 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
             Self::Attested { .. } => Ok(vec![Bridged {
@@ -1359,16 +1626,21 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
-            // Pre-bridging failure (e.g. USDC-to-U256 conversion error after
-            // withdrawal succeeded but before CCTP burn was initiated).
-            Self::WithdrawalComplete { .. } => Ok(vec![BridgingFailed {
-                burn_tx_hash: None,
-                cctp_nonce: None,
-                reason,
-                failed_at: Utc::now(),
-            }]),
+            // Pre-burn failure: withdrawal succeeded and (for BridgingSubmitting)
+            // the burn intent was recorded, but no burn tx exists yet -- e.g. a
+            // USDC-to-U256 conversion error or a burn that failed before the
+            // BridgingInitiated event was persisted.
+            Self::WithdrawalComplete { .. } | Self::BridgingSubmitting { .. } => {
+                Ok(vec![BridgingFailed {
+                    burn_tx_hash: None,
+                    cctp_nonce: None,
+                    reason,
+                    failed_at: Utc::now(),
+                }])
+            }
             Self::Bridging { burn_tx_hash, .. } => Ok(vec![BridgingFailed {
                 burn_tx_hash: Some(*burn_tx_hash),
                 cctp_nonce: None,
@@ -1402,8 +1674,10 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::Attested { .. }
@@ -1427,8 +1701,10 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::Attested { .. }
@@ -1456,8 +1732,10 @@ impl UsdcRebalance {
             Self::Converting { .. }
             | Self::ConversionComplete { .. }
             | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
             | Self::Withdrawing { .. }
             | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
             | Self::Attested { .. }
@@ -1607,6 +1885,198 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, LifecycleError::UnexpectedEvent { .. }));
+    }
+
+    #[tokio::test]
+    async fn begin_withdrawal_from_uninitialized_records_intent_with_chain_head() {
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given_no_previous_events()
+            .when(UsdcRebalanceCommand::BeginWithdrawal {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::WithdrawalSubmitting {
+            direction,
+            amount,
+            from_block,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected WithdrawalSubmitting event, got {:?}", events[0]);
+        };
+        assert_eq!(*direction, RebalanceDirection::BaseToAlpaca);
+        assert_eq!(*amount, Usdc::new(float!(500.00)));
+        assert_eq!(*from_block, 42);
+    }
+
+    #[tokio::test]
+    async fn begin_withdrawal_from_uninitialized_rejects_alpaca_to_base() {
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given_no_previous_events()
+            .when(UsdcRebalanceCommand::BeginWithdrawal {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn initiate_from_withdrawal_submitting_advances_to_withdrawing() {
+        let tx_hash =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+                submitting_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                withdrawal: TransferRef::OnchainTx(tx_hash),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::Initiated { withdrawal_ref, .. } = &events[0] else {
+            panic!("Expected Initiated event, got {:?}", events[0]);
+        };
+        assert_eq!(*withdrawal_ref, TransferRef::OnchainTx(tx_hash));
+    }
+
+    #[tokio::test]
+    async fn initiate_with_amount_mismatch_from_withdrawal_submitting_errors() {
+        let tx_hash =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000abc");
+
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+                submitting_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(999.00)),
+                withdrawal: TransferRef::OnchainTx(tx_hash),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn begin_bridging_from_withdrawal_complete_records_intent_with_chain_head() {
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::BeginBridging { from_block: 99 })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingSubmitting { from_block, .. } = &events[0] else {
+            panic!("Expected BridgingSubmitting event, got {:?}", events[0]);
+        };
+        assert_eq!(*from_block, 99);
+    }
+
+    #[tokio::test]
+    async fn initiate_bridging_from_bridging_submitting_records_burn() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000bad");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(500.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingSubmitting {
+                    from_block: 99,
+                    submitting_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingInitiated { burn_tx_hash, .. } = &events[0] else {
+            panic!("Expected BridgingInitiated event, got {:?}", events[0]);
+        };
+        assert_eq!(*burn_tx_hash, burn_tx);
+    }
+
+    #[test]
+    fn intent_first_event_sequence_replays_through_withdrawal_and_bridging() {
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                from_block: 42,
+                submitting_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500.00)),
+                withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingSubmitting {
+                from_block: 99,
+                submitting_at: Utc::now(),
+            },
+        ])
+        .unwrap();
+
+        assert!(
+            matches!(state, Some(UsdcRebalance::BridgingSubmitting { from_block, .. }) if from_block == 99),
+            "Expected BridgingSubmitting state after intent-first sequence, got {state:?}"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -363,6 +363,7 @@ redemption_wallet = "{redemption_wallet}"
 
 [rebalancing]
 transfer_timeout_secs = 1800
+transfer_attempt_timeout_secs = 3600
 equity = {{ target = 0.5, deviation = 0.1 }}
 usdc = {{ mode = "enabled", target = 0.5, deviation = 0.1 }}
 

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -1033,8 +1033,10 @@ fn usdc_rebalance_expectations(
         },
         UsdcRebalanceType::BaseToAlpaca => UsdcRebalanceExpectations {
             event_sequence: &[
+                "UsdcRebalanceEvent::WithdrawalSubmitting",
                 "UsdcRebalanceEvent::Initiated",
                 "UsdcRebalanceEvent::WithdrawalConfirmed",
+                "UsdcRebalanceEvent::BridgingSubmitting",
                 "UsdcRebalanceEvent::BridgingInitiated",
                 "UsdcRebalanceEvent::BridgeAttestationReceived",
                 "UsdcRebalanceEvent::Bridged",

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -2531,7 +2531,6 @@ async fn active_mint_in_tokens_wrapped_recovers_into_raindex_vault() -> anyhow::
 /// Base->Alpaca direction is durably handled by the TransferUsdcToHedging
 /// apalis job.
 #[test_log::test(tokio::test)]
-#[ignore = "un-ignored and made to pass by the immediate upstack #712 (feat/usdc-to-hedging-job)"]
 async fn interrupted_usdc_base_to_alpaca_resumes_after_restart() -> anyhow::Result<()> {
     let onchain_price = float!(158.39);
     let broker_fill_price = float!(155.00);


### PR DESCRIPTION
## What

Closes [RAI-388](https://linear.app/makeitrain/issue/RAI-388/convert-base-to-alpaca-usdc-transfer-to-transferusdctohedging-apalis). Converts `CrossVenueCashTransfer::execute_base_to_alpaca` from a one-off `tokio::spawn` driven by `Rebalancer` into a state-resumable apalis job. `check_and_trigger_usdc` enqueues `TransferUsdcToHedging { id, amount }` directly; the Rebalancer mpsc channel is no longer the path for Base->Alpaca.

This is the **implementation** that satisfies the failing test in the parent PR #714. Per [docs/ttdd.md](https://github.com/ST0x-Technology/st0x.liquidity/blob/master/docs/ttdd.md), the test sits downstack of this branch so reviewers can confirm the hypothesis was failing on #714 alone and that the diff in this PR is what turns it green.

## Why

A crash mid-transfer (after Alpaca withdrawal, before CCTP mint) used to orphan in-flight capital -- there was no persistent record of "this `UsdcRebalanceId` is in flight" and nothing to resume the lifecycle on restart. The apalis queue persists the job row, and the same `perform()` that starts a new transfer also resumes a stalled one. The end-to-end proof of that durability claim is the `interrupted_usdc_base_to_alpaca_resumes_after_restart` test in #714, which is expected to fail on #714 in isolation and pass once this PR lands on top.

## How

- Extract `resume_base_to_alpaca(id, amount)` on `CrossVenueCashTransfer`. Loads the `UsdcRebalance` aggregate via `Store::load` and dispatches on state: `None` -> start fresh; `Withdrawing` -> `ConfirmWithdrawal` + continue; `WithdrawalComplete` -> CCTP burn; `Bridging`/`Attested` -> re-poll attestation + mint; `Bridged` -> initiate Alpaca deposit; `DepositInitiated` -> poll Alpaca; `DepositConfirmed` (BaseToAlpaca) -> USDC->USD conversion; `Converting` -> emit `FailConversion` (broker order ID isn't persisted, so re-issue is unsafe); terminal failure states -> propagate `PreviouslyFailedAggregate`.
- New `TransferUsdcToHedging` apalis job + `ResumeBaseToAlpaca` trait so the conductor's ctx erases the wallet `Chain` generic.
- `RebalancerServices::spawn` now returns a `SpawnedRebalancer` struct (handle, shutdown token, trait-erased resume handle) instead of an anonymous tuple.
- The `usdc_in_progress` guard is cleared event-driven only when the aggregate reaches a terminal state (success or a recorded failure). An indeterminate mid-flight failure (e.g. stalled at `WithdrawalSubmitting`/`BridgingSubmitting`) deliberately keeps the guard latched so automation does not re-arm a fresh transfer on top of a partial one -- the apalis retry re-enters the scan path rather than re-issuing.
- **Crash-safe resume of in-flight rows.** apalis's `fetch_next` only picks `Pending`/retryable-`Failed` rows, and on a quick restart its orphan sweep never fires (the deterministic worker name keeps the dead worker's heartbeat fresh), so a row left `Running` when the process died is never re-driven -- and the enqueue dedup keyed off that row then suppresses all future Base->Alpaca transfers. `Conductor::start` now resets orphaned `Running`/`Queued` `TransferUsdcToHedging` rows to `Pending` at startup, before the monitor spawns (where every such row is by definition orphaned), so the worker re-drives them. `Failed` rows (retries exhausted) are left latched for operator reconciliation.
- **Per-attempt timeout.** `perform()` bounds `resume_base_to_alpaca` with a configurable wall-clock timeout, so a hung RPC fails the attempt (and retries) instead of wedging the single-concurrency worker forever.
- The recovery scan helpers (`find_recent_burn`/`find_recent_withdrawal`) live on the `Bridge` trait, not the concrete `CctpBridge`, so callers depend only on the bridge abstraction.

## Testing

- The e2e durability claim is asserted in #714 (`interrupted_usdc_base_to_alpaca_resumes_after_restart`): it crashes the bot mid-bridge, restarts, and asserts the transfer resumes to `ConversionConfirmed` without re-issuing the vault withdrawal. Fails on #714 alone, passes on this branch.
- `requeue_orphaned` resets only this queue's `Running`/`Queued` rows (and clears their lock), leaving `Pending`/`Failed`/`Done` and other job types untouched.
- `perform()` returns the `Timeout` error when the resume future exceeds the configured per-attempt bound.
- Job-level: failure clears `usdc_in_progress`, success preserves it, payload `id`/`amount` reach the transfer.
- Resume routing: terminal failure -> `PreviouslyFailedAggregate`; `ConversionComplete` -> no-op (no service mocks needed); `Bridged` -> reaches `ConversionComplete` without re-burn (no CCTP mocks; would surface as anvil error if exercised).
- Trigger and integration tests updated: `check_and_trigger_usdc` enqueues a `TransferUsdcToHedging` row instead of sending `UsdcBaseToAlpaca` via mpsc.

## Anything else

- New required config field `rebalancing.transfer_attempt_timeout_secs` (per-attempt hang backstop, distinct from the whole-transfer `transfer_timeout_secs` stall reaper). Set to `3600` in the example/staging/prod configs -- a coarse bound that exceeds the worst-case healthy attempt (the Alpaca deposit poll alone is bounded at 1800s), so it only trips on a true hang.
- The mpsc path still carries `UsdcAlpacaToBase` until #713 (RAI-390) lands. The unused `TriggeredOperation::UsdcBaseToAlpaca` variant is kept for now to keep the diff focused; removing it depends on #713 also dropping its sibling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable, persisted TransferUsdcToHedging job and optional worker to perform Base→Alpaca USDC transfers.

* **Reliability Improvements**
  * Crash-safe resume for Base→Alpaca flows with helpers to detect/adopt prior on-chain burns/withdrawals and per-attempt timeouts.
  * Queue sweep to reset orphaned in-flight jobs on startup.

* **Behavior Changes**
  * USDC triggers now enqueue persisted jobs instead of using an in-memory channel.

* **Configuration**
  * New transfer_attempt_timeout_secs setting (default 3600s).

* **Documentation**
  * Added guidance on orphaned job behavior and restart implications.

* **Tests**
  * Updated unit and E2E tests for persisted-job and resume semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
