### PR TITLE
feat: TransferUsdcToMarketMaking apalis job (Alpaca->Base)

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -60,7 +60,7 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
-use crate::rebalancing::usdc::TransferUsdcToHedgingCtx;
+use crate::rebalancing::usdc::{TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx};
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
     RebalancingServiceConfig,
@@ -209,6 +209,7 @@ impl Conductor {
             mint_store,
             redemption_store,
             transfer_usdc_to_hedging_ctx,
+            transfer_usdc_to_market_making_ctx,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -352,6 +353,8 @@ impl Conductor {
             .usdc_check_scheduler(schedulers.usdc)
             .transfer_usdc_to_hedging_queue(schedulers.transfer_usdc_to_hedging)
             .maybe_transfer_usdc_to_hedging_ctx(transfer_usdc_to_hedging_ctx)
+            .transfer_usdc_to_market_making_queue(schedulers.transfer_usdc_to_market_making)
+            .maybe_transfer_usdc_to_market_making_ctx(transfer_usdc_to_market_making_ctx)
             .maybe_rebalancing_service(rebalancing_service)
             .seed_vault_registry_queue(seed_vault_registry_queue)
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
@@ -643,6 +646,7 @@ struct RebalancingInfrastructure {
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
     transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
+    transfer_usdc_to_market_making_ctx: Arc<TransferUsdcToMarketMakingCtx>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -675,6 +679,7 @@ struct PositionAndRebalancing {
     mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
+    transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
 }
 
 impl PositionAndRebalancing {
@@ -731,6 +736,7 @@ impl PositionAndRebalancing {
                 mint_store: Some(infra.mint_store),
                 redemption_store: Some(infra.redemption_store),
                 transfer_usdc_to_hedging_ctx: Some(infra.transfer_usdc_to_hedging_ctx),
+                transfer_usdc_to_market_making_ctx: Some(infra.transfer_usdc_to_market_making_ctx),
             })
         } else {
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -758,6 +764,7 @@ impl PositionAndRebalancing {
                 mint_store: None,
                 redemption_store: None,
                 transfer_usdc_to_hedging_ctx: None,
+                transfer_usdc_to_market_making_ctx: None,
             })
         }
     }
@@ -939,6 +946,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             timeout: rebalancing_ctx.transfer_attempt_timeout,
         });
 
+        let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
+            transfer: spawned.resume_alpaca_to_base,
+        });
+
         Ok(RebalancingInfrastructure {
             position: built.position,
             position_projection: built.position_projection,
@@ -952,6 +963,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             mint_store,
             redemption_store,
             transfer_usdc_to_hedging_ctx,
+            transfer_usdc_to_market_making_ctx,
         })
     })
 }

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -43,6 +43,7 @@ use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
 use crate::rebalancing::usdc::{
     TransferUsdcToHedging, TransferUsdcToHedgingCtx, TransferUsdcToHedgingJobQueue,
+    TransferUsdcToMarketMaking, TransferUsdcToMarketMakingCtx, TransferUsdcToMarketMakingJobQueue,
 };
 use crate::rebalancing::{
     EquityRebalancingCheck, EquityRebalancingCheckScheduler, RebalancingService,
@@ -105,6 +106,8 @@ pub(crate) fn spawn<Prov, Exec>(
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
+    transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
+    transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     rebalancing_service: Option<Arc<RebalancingService>>,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
@@ -304,6 +307,8 @@ where
         usdc_check_scheduler,
         transfer_usdc_to_hedging_queue,
         transfer_usdc_to_hedging_ctx,
+        transfer_usdc_to_market_making_queue,
+        transfer_usdc_to_market_making_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
@@ -354,6 +359,8 @@ where
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
+    transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
+    transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
@@ -391,6 +398,8 @@ where
             usdc_check_scheduler,
             transfer_usdc_to_hedging_queue,
             transfer_usdc_to_hedging_ctx,
+            transfer_usdc_to_market_making_queue,
+            transfer_usdc_to_market_making_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
@@ -419,6 +428,8 @@ where
         let failure_injector_for_check_positions = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_usdc_to_hedging = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_transfer_usdc_to_market_making = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -431,6 +442,7 @@ where
         let failure_notify_for_wrapped_equity_recovery = failure_notify.clone();
         let failure_notify_for_check_positions = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
+        let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -447,6 +459,7 @@ where
         let fail_stop_for_wrapped_equity_recovery = fail_stop.clone();
         let fail_stop_for_check_positions = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
+        let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -604,6 +617,16 @@ where
                 failure_injector_for_transfer_usdc_to_hedging,
             );
 
+            let apalis_monitor = register_transfer_usdc_to_market_making_worker(
+                apalis_monitor,
+                transfer_usdc_to_market_making_ctx,
+                transfer_usdc_to_market_making_queue,
+                fail_stop_for_transfer_usdc_to_market_making,
+                failure_notify_for_transfer_usdc_to_market_making,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_transfer_usdc_to_market_making,
+            );
+
             let is_draining = apalis_shutdown_token.clone();
 
             let shutdown_signal = async {
@@ -699,6 +722,38 @@ fn register_transfer_usdc_to_hedging_worker(
     monitor.register(move |index| {
         build_supervised_worker!(
             ::<TransferUsdcToHedgingCtx, TransferUsdcToHedging>,
+            index,
+            transfer_queue.clone(),
+            transfer_ctx.clone(),
+            fail_stop.clone(),
+            failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Sibling of [`register_transfer_usdc_to_hedging_worker`] for the
+/// Alpaca->Base direction.
+fn register_transfer_usdc_to_market_making_worker(
+    monitor: Monitor,
+    transfer_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
+    transfer_queue: TransferUsdcToMarketMakingJobQueue,
+    fail_stop: CircuitBreakerConfig,
+    failure_notify: Arc<tokio::sync::Notify>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(transfer_ctx) = transfer_ctx else {
+        warn!(
+            "TransferUsdcToMarketMaking worker not registered: rebalancing disabled \
+             (no transfer ctx). Alpaca->Base USDC transfers will not be processed."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_supervised_worker!(
+            ::<TransferUsdcToMarketMakingCtx, TransferUsdcToMarketMaking>,
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -343,6 +343,7 @@ pub enum JobKind {
     WrappedEquityRecovery,
     CheckPositions,
     TransferUsdcToHedging,
+    TransferUsdcToMarketMaking,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -379,6 +380,7 @@ pub struct FailureInjector {
     wrapped_equity_recovery: Arc<Mutex<InjectionState>>,
     check_positions: Arc<Mutex<InjectionState>>,
     transfer_usdc_to_hedging: Arc<Mutex<InjectionState>>,
+    transfer_usdc_to_market_making: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -413,6 +415,7 @@ impl FailureInjector {
             wrapped_equity_recovery: Arc::new(Mutex::new(InjectionState::Idle)),
             check_positions: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_usdc_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
+            transfer_usdc_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -459,6 +462,7 @@ impl FailureInjector {
             JobKind::WrappedEquityRecovery => &self.wrapped_equity_recovery,
             JobKind::CheckPositions => &self.check_positions,
             JobKind::TransferUsdcToHedging => &self.transfer_usdc_to_hedging,
+            JobKind::TransferUsdcToMarketMaking => &self.transfer_usdc_to_market_making,
         };
 
         match mutex.lock() {

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -44,8 +44,8 @@ use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
-use crate::rebalancing::usdc::TransferUsdcToHedging;
 use crate::rebalancing::usdc::mock::MockUsdcRebalance;
+use crate::rebalancing::usdc::{TransferUsdcToHedging, TransferUsdcToMarketMaking};
 use crate::rebalancing::{
     Rebalancer, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
     TriggeredOperation, drain_pending_jobs,
@@ -316,6 +316,55 @@ enum Imbalance<'a> {
         onchain: Usdc,
         offchain: Usdc,
     },
+}
+
+/// Direction of a USDC transfer enqueued by the trigger, recovered from the
+/// apalis Jobs table for assertion in integration tests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EnqueuedUsdcOperation {
+    AlpacaToBase { amount: Usdc },
+    BaseToAlpaca { amount: Usdc },
+}
+
+/// Drains every pending USDC transfer row (both directions) from the apalis
+/// Jobs table, marks them Done, and returns them in `run_at` order.
+async fn drain_pending_usdc_transfer_jobs(pool: &SqlitePool) -> Vec<EnqueuedUsdcOperation> {
+    let to_hedging_type = std::any::type_name::<TransferUsdcToHedging>();
+    let to_market_making_type = std::any::type_name::<TransferUsdcToMarketMaking>();
+
+    let rows: Vec<(String, Vec<u8>, String)> = sqlx::query_as(
+        "SELECT id, job, job_type FROM Jobs \
+         WHERE status = 'Pending' AND (job_type = ? OR job_type = ?) \
+         ORDER BY run_at",
+    )
+    .bind(to_hedging_type)
+    .bind(to_market_making_type)
+    .fetch_all(pool)
+    .await
+    .expect("query pending USDC transfer jobs");
+
+    let mut operations = Vec::with_capacity(rows.len());
+    for (row_id, payload, job_type) in rows {
+        let operation = if job_type == to_hedging_type {
+            let job: TransferUsdcToHedging =
+                serde_json::from_slice(&payload).expect("deserialize TransferUsdcToHedging");
+            EnqueuedUsdcOperation::BaseToAlpaca { amount: job.amount }
+        } else {
+            let job: TransferUsdcToMarketMaking =
+                serde_json::from_slice(&payload).expect("deserialize TransferUsdcToMarketMaking");
+            EnqueuedUsdcOperation::AlpacaToBase { amount: job.amount }
+        };
+
+        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            .bind(&row_id)
+            .execute(pool)
+            .await
+            .expect("mark drained USDC transfer job Done");
+
+        operations.push(operation);
+    }
+
+    operations
 }
 
 async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
@@ -976,10 +1025,9 @@ async fn equity_onchain_imbalance_triggers_redemption() {
     );
 }
 
-/// Verifies USDC rebalancing dispatch: a USDC imbalance triggers the
-/// RebalancingService to send a UsdcAlpacaToBase operation through the channel
-/// to the Rebalancer, which dispatches to the USDC manager. Uses mocked managers
-/// since the real USDC flow requires CCTP bridge and vault transactions.
+/// Verifies USDC rebalancing dispatch: a USDC imbalance for the Alpaca->Base
+/// direction enqueues a `TransferUsdcToMarketMaking` apalis job with the
+/// expected amount. No work flows through the Rebalancer mpsc channel.
 #[tokio::test]
 async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
     let pool = setup_test_db().await;
@@ -999,7 +1047,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
     })
     .await;
 
-    let (sender, receiver) = mpsc::channel(10);
+    let (sender, _receiver) = mpsc::channel(10);
 
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
@@ -1015,46 +1063,51 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         RebalancingSchedulers::new(&pool),
     );
 
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
-    let usdc = Arc::new(MockUsdcRebalance::new());
-
-    let rebalancer = Rebalancer::new(
-        Arc::clone(&mock_equity) as _,
-        mock_equity as _,
-        Arc::clone(&usdc) as _,
-        usdc.clone() as _,
-        receiver,
-        Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
-        Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
     trigger.check_and_trigger_usdc().await;
 
-    // Close the channel so the rebalancer exits after processing.
-    drop(trigger);
+    let job_type = std::any::type_name::<TransferUsdcToMarketMaking>();
 
-    rebalancer.run().await;
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM Jobs \
+         WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(job_type)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
 
     assert_eq!(
-        usdc.alpaca_to_base_calls(),
-        1,
-        "Expected USDC manager to be called once for alpaca_to_base"
+        pending, 1,
+        "Expected exactly one pending TransferUsdcToMarketMaking job"
     );
 
-    let call = usdc
-        .last_alpaca_to_base_call()
-        .expect("Expected a captured call");
+    let payload: Vec<u8> = sqlx::query_scalar(
+        "SELECT job FROM Jobs \
+         WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(job_type)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let job: TransferUsdcToMarketMaking =
+        serde_json::from_slice(&payload).expect("deserialize TransferUsdcToMarketMaking");
     assert_eq!(
-        call.amount,
+        job.amount,
         Usdc::new(float!(400)),
         "Expected excess of $400 (target $500 - actual $100)"
     );
 
+    let opposite: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToHedging>())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
     assert_eq!(
-        usdc.base_to_alpaca_calls(),
-        0,
-        "base_to_alpaca should not have been called"
+        opposite, 0,
+        "Base->Alpaca queue should not have been touched"
     );
 }
 
@@ -1080,7 +1133,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
     })
     .await;
 
-    let (sender, receiver) = mpsc::channel(10);
+    let (sender, _receiver) = mpsc::channel(10);
 
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
@@ -1096,25 +1149,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         RebalancingSchedulers::new(&pool),
     );
 
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
-    let usdc = Arc::new(MockUsdcRebalance::new());
-
-    let rebalancer = Rebalancer::new(
-        Arc::clone(&mock_equity) as _,
-        mock_equity as _,
-        Arc::clone(&usdc) as _,
-        usdc.clone() as _,
-        receiver,
-        Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
-        Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
     trigger.check_and_trigger_usdc().await;
-
-    drop(trigger);
-
-    rebalancer.run().await;
 
     // Base->Alpaca is dispatched via the TransferUsdcToHedging apalis job
     // queue, not the Rebalancer mpsc channel. Assert exactly one pending row
@@ -1152,15 +1187,16 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         "Expected excess of $400 (actual $900 - target $500)"
     );
 
+    let opposite: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
     assert_eq!(
-        usdc.base_to_alpaca_calls(),
-        0,
-        "Rebalancer mpsc path should not be exercised for Base->Alpaca anymore",
-    );
-    assert_eq!(
-        usdc.alpaca_to_base_calls(),
-        0,
-        "alpaca_to_base should not have been called"
+        opposite, 0,
+        "Alpaca->Base queue should not have been touched"
     );
 }
 
@@ -1302,40 +1338,33 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     // ratio stays balanced (500/500) despite the reserve.
     service.check_and_trigger_usdc().await;
 
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
-    let usdc = Arc::new(MockUsdcRebalance::new());
-
-    let rebalancer = Rebalancer::new(
-        Arc::clone(&mock_equity) as _,
-        mock_equity as _,
-        Arc::clone(&usdc) as _,
-        usdc.clone() as _,
-        receiver,
-        Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
-        Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
-    // Drop all Arc clones holding the trigger so the mpsc channel closes
-    // and rebalancer.run() terminates after processing queued operations.
-    // The reactor (which wraps the trigger) is also held by the snapshot
-    // store's reactor list.
+    // Drop trigger holders so subsequent assertions read final queue state.
     drop(service);
     drop(snapshot_store);
     drop(polling_service);
+    drop(receiver);
 
-    rebalancer.run().await;
+    let to_hedging: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToHedging>())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+    let to_market_making: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
 
     assert_eq!(
-        usdc.base_to_alpaca_calls(),
-        0,
+        to_hedging, 0,
         "Gross offchain cash is used for the rebalancing ratio, so a $300 \
          reserve must not trigger base_to_alpaca on a balanced 500/500 split"
     );
-
     assert_eq!(
-        usdc.alpaca_to_base_calls(),
-        0,
+        to_market_making, 0,
         "alpaca_to_base should not have been called"
     );
 }
@@ -1677,7 +1706,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         disabled_assets: HashSet::new(),
     };
 
-    let (sender, mut receiver) = mpsc::channel(10);
+    let (sender, _receiver) = mpsc::channel(10);
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
@@ -1694,17 +1723,14 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // Cycle 1: excess = 450, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let op1 = receiver.try_recv().expect("First trigger should fire");
-    match op1 {
-        TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(
-                amount,
-                Usdc::new(float!(100)),
-                "First transfer capped to $100"
-            );
-        }
-        _ => panic!("Expected UsdcAlpacaToBase, got {op1:?}"),
-    }
+    let cycle1 = drain_pending_usdc_transfer_jobs(&pool).await;
+    assert_eq!(
+        cycle1.as_slice(),
+        [EnqueuedUsdcOperation::AlpacaToBase {
+            amount: Usdc::new(float!(100))
+        }],
+        "First transfer capped to $100",
+    );
     trigger.clear_usdc_in_progress();
 
     // Simulate first transfer: 150 onchain, 850 offchain = 15% ratio
@@ -1719,17 +1745,14 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // Cycle 2: excess = 350, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let op2 = receiver.try_recv().expect("Second trigger should fire");
-    match op2 {
-        TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(
-                amount,
-                Usdc::new(float!(100)),
-                "Second transfer capped to $100"
-            );
-        }
-        _ => panic!("Expected UsdcAlpacaToBase, got {op2:?}"),
-    }
+    let cycle2 = drain_pending_usdc_transfer_jobs(&pool).await;
+    assert_eq!(
+        cycle2.as_slice(),
+        [EnqueuedUsdcOperation::AlpacaToBase {
+            amount: Usdc::new(float!(100))
+        }],
+        "Second transfer capped to $100",
+    );
     trigger.clear_usdc_in_progress();
 
     // Simulate second transfer: 250 onchain, 750 offchain = 25% ratio
@@ -1744,17 +1767,14 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // Cycle 3: excess = 250, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let op3 = receiver.try_recv().expect("Third trigger should fire");
-    match op3 {
-        TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(
-                amount,
-                Usdc::new(float!(100)),
-                "Third transfer capped to $100"
-            );
-        }
-        _ => panic!("Expected UsdcAlpacaToBase, got {op3:?}"),
-    }
+    let cycle3 = drain_pending_usdc_transfer_jobs(&pool).await;
+    assert_eq!(
+        cycle3.as_slice(),
+        [EnqueuedUsdcOperation::AlpacaToBase {
+            amount: Usdc::new(float!(100))
+        }],
+        "Third transfer capped to $100",
+    );
     trigger.clear_usdc_in_progress();
 
     // Simulate third transfer: 350 onchain, 650 offchain = 35% ratio
@@ -1769,10 +1789,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     trigger.check_and_trigger_usdc().await;
     assert!(
-        matches!(
-            receiver.try_recv().unwrap_err(),
-            mpsc::error::TryRecvError::Empty
-        ),
+        drain_pending_usdc_transfer_jobs(&pool).await.is_empty(),
         "Balanced inventory should not trigger"
     );
 }
@@ -1817,7 +1834,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         disabled_assets: HashSet::new(),
     };
 
-    let (sender, mut receiver) = mpsc::channel(10);
+    let (sender, _receiver) = mpsc::channel(10);
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
     let wrapper = Arc::new(MockWrapper::new());
 
@@ -1834,27 +1851,18 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
 
     // First trigger fires: excess = 400, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let op1 = receiver
-        .try_recv()
-        .expect("First trigger should produce an operation");
-    match op1 {
-        TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(
-                amount,
-                Usdc::new(float!(100)),
-                "First transfer capped to $100"
-            );
-        }
-        _ => panic!("Expected UsdcAlpacaToBase, got {op1:?}"),
-    }
+    assert_eq!(
+        drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+        [EnqueuedUsdcOperation::AlpacaToBase {
+            amount: Usdc::new(float!(100))
+        }],
+        "First transfer capped to $100",
+    );
 
     // Without clearing in_progress, second trigger is blocked
     trigger.check_and_trigger_usdc().await;
     assert!(
-        matches!(
-            receiver.try_recv().unwrap_err(),
-            mpsc::error::TryRecvError::Empty
-        ),
+        drain_pending_usdc_transfer_jobs(&pool).await.is_empty(),
         "In-progress guard should block second trigger"
     );
 
@@ -1863,19 +1871,13 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
 
     // Trigger fires again: same inventory, same excess = 400, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let op2 = receiver
-        .try_recv()
-        .expect("After clearing in_progress, trigger should fire again");
-    match op2 {
-        TriggeredOperation::UsdcAlpacaToBase { amount } => {
-            assert_eq!(
-                amount,
-                Usdc::new(float!(100)),
-                "Retry transfer also capped to $100"
-            );
-        }
-        _ => panic!("Expected UsdcAlpacaToBase, got {op2:?}"),
-    }
+    assert_eq!(
+        drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+        [EnqueuedUsdcOperation::AlpacaToBase {
+            amount: Usdc::new(float!(100))
+        }],
+        "Retry transfer also capped to $100",
+    );
 }
 
 /// Tests that threshold configuration controls trigger sensitivity: the same
@@ -1967,7 +1969,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
         })
         .await;
 
-        let (sender, mut receiver) = mpsc::channel(10);
+        let (sender, _receiver) = mpsc::channel(10);
         let tight_config = RebalancingServiceConfig {
             equity: ImbalanceThreshold {
                 target: float!(0.5),
@@ -2005,21 +2007,14 @@ async fn threshold_config_controls_trigger_sensitivity() {
         trigger.check_and_trigger_usdc().await;
         drop(trigger);
 
-        let operation = receiver
-            .try_recv()
-            .expect("Tight threshold (40%-60%) should trigger at 35% onchain ratio");
-
         // Excess = target_onchain - actual_onchain = 500 - 350 = $150
-        match operation {
-            TriggeredOperation::UsdcAlpacaToBase { amount } => {
-                assert_eq!(
-                    amount,
-                    Usdc::new(float!(150)),
-                    "Excess should be $150 (target $500 - actual $350)"
-                );
-            }
-            _ => panic!("Expected UsdcAlpacaToBase operation"),
-        }
+        assert_eq!(
+            drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+            [EnqueuedUsdcOperation::AlpacaToBase {
+                amount: Usdc::new(float!(150))
+            }],
+            "Tight threshold (40%-60%) should trigger at 35% onchain ratio with $150 excess",
+        );
     }
 }
 

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -66,6 +66,28 @@ pub(crate) enum RaindexError {
     ScanInconclusive { from_block: u64 },
 }
 
+impl RaindexError {
+    /// `true` if this error reports that a submitted transaction was dropped from
+    /// the mempool and will never mine -- a terminal failure, distinct from a
+    /// still-pending transaction that simply has not confirmed yet.
+    pub(crate) fn is_transaction_dropped(&self) -> bool {
+        match self {
+            Self::Evm(EvmError::TransactionDropped { .. }) => true,
+            Self::Evm(_)
+            | Self::Contract(_)
+            | Self::Float(_)
+            | Self::ZeroAmount
+            | Self::RegistryNotFound(_)
+            | Self::Projection(_)
+            | Self::VaultNotFound(_)
+            | Self::TokenNotFound(_)
+            | Self::RpcTransport(_)
+            | Self::SolType(_)
+            | Self::ScanInconclusive { .. } => false,
+        }
+    }
+}
+
 /// Number of `eth_getLogs` scans that must agree the effect is absent before a
 /// resume re-executes an irreversible withdraw. Defends against a single
 /// load-balanced RPC node lagging and returning a false-empty result.
@@ -92,9 +114,10 @@ const SCAN_FINALITY_MARGIN: u64 = 2;
 /// // Lookup vault ID for a token (read-only, needs Evm)
 /// let vault_id = service.lookup_vault_id(token_address).await?;
 ///
-/// // Deposit USDC to vault (needs Wallet)
+/// // Submit a USDC deposit to the vault, then confirm it (needs Wallet)
 /// let amount = U256::from(1000) * U256::from(10).pow(U256::from(6)); // 1000 USDC
-/// service.deposit_usdc(vault_id, amount).await?;
+/// let deposit_tx = service.submit_deposit_usdc(vault_id, amount).await?;
+/// service.confirm_tx(deposit_tx).await?;
 /// ```
 pub(crate) struct RaindexService<E: Evm> {
     orderbook_address: Address,
@@ -259,20 +282,22 @@ impl<W: Wallet> RaindexService<W> {
         Ok(tx_hash)
     }
 
-    /// Deposits USDC to a Rain OrderBook vault on Base.
+    /// Submits a USDC deposit to a Rain OrderBook vault on Base WITHOUT waiting
+    /// for confirmation, returning the broadcast tx hash.
     ///
-    /// Convenience method that calls `deposit` with the Base USDC address and decimals.
-    ///
-    /// # Parameters
-    ///
-    /// * `vault_id` - Target vault identifier
-    /// * `amount` - Amount of USDC to deposit (in USDC's base units, 6 decimals)
-    pub(crate) async fn deposit_usdc(
+    /// Used by the crash-safe deposit path: the hash is persisted as
+    /// `InitiateDeposit` before confirmation, so a crash during the confirmation
+    /// wait resumes from `DepositInitiated` (re-verifying the recorded tx via
+    /// `confirm_tx`) instead of re-submitting a second deposit.
+    pub(crate) async fn submit_deposit_usdc(
         &self,
         vault_id: RaindexVaultId,
         amount: U256,
     ) -> Result<TxHash, RaindexError> {
-        self.deposit::<OpenChainErrorRegistry>(USDC_BASE, vault_id, amount, USDC_DECIMALS)
+        // `submit_deposit` handles the ERC20 approval before submitting deposit4
+        // (unlike the bare `submit_deposit4_to_vault`), then returns without
+        // confirming.
+        self.submit_deposit(USDC_BASE, vault_id, amount, USDC_DECIMALS)
             .await
     }
 

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -18,7 +18,7 @@ use st0x_execution::{
 };
 
 use super::equity::CrossVenueEquityTransfer;
-use super::usdc::{CrossVenueCashTransfer, ResumeBaseToAlpaca};
+use super::usdc::{CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca};
 use super::{Rebalancer, TriggeredOperation};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::equity_redemption::EquityRedemption;
@@ -28,18 +28,6 @@ use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::wrapper::WrapperService;
-
-/// Handles to the rebalancer task surfaced by [`RebalancerServices::spawn`].
-///
-/// Holds the spawned task's join handle, its shutdown token, and a
-/// trait-erased reference to the cash transfer so the conductor can build the
-/// `TransferUsdcToHedging` apalis job's ctx without leaking the wallet
-/// `Chain` generic upstream.
-pub(crate) struct SpawnedRebalancer {
-    pub(crate) handle: JoinHandle<()>,
-    pub(crate) shutdown_token: CancellationToken,
-    pub(crate) resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca>,
-}
 
 /// Errors that can occur when spawning the rebalancer.
 #[derive(Debug, thiserror::Error)]
@@ -56,6 +44,17 @@ pub(crate) struct RebalancingCqrsFrameworks {
     pub(crate) mint: Arc<Store<TokenizedEquityMint>>,
     pub(crate) redemption: Arc<Store<EquityRedemption>>,
     pub(crate) usdc: Arc<Store<UsdcRebalance>>,
+}
+
+/// Handles surfaced by [`RebalancerServices::spawn`]: the rebalancer task,
+/// its shutdown token, and trait-erased resume entry points for the cash
+/// transfer so the conductor can build apalis job ctxs without leaking the
+/// wallet `Chain` generic upstream.
+pub(crate) struct SpawnedRebalancer {
+    pub(crate) handle: JoinHandle<()>,
+    pub(crate) shutdown_token: CancellationToken,
+    pub(crate) resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca>,
+    pub(crate) resume_alpaca_to_base: Arc<dyn ResumeAlpacaToBase>,
 }
 
 /// External service clients for rebalancing operations.
@@ -155,6 +154,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         ));
 
         let resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca> = usdc.clone();
+        let resume_alpaca_to_base: Arc<dyn ResumeAlpacaToBase> = usdc.clone();
 
         let shutdown_token = CancellationToken::new();
 
@@ -179,6 +179,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             handle,
             shutdown_token,
             resume_base_to_alpaca,
+            resume_alpaca_to_base,
         }
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -34,7 +34,10 @@ use crate::inventory::{
     Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
 };
 use crate::position::{Position, PositionEvent};
-use crate::rebalancing::usdc::{TransferUsdcToHedging, TransferUsdcToHedgingJobQueue};
+use crate::rebalancing::usdc::{
+    TransferUsdcToHedging, TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking,
+    TransferUsdcToMarketMakingJobQueue,
+};
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
 };
@@ -57,6 +60,7 @@ pub(crate) struct RebalancingSchedulers {
     pub(crate) usdc: UsdcRebalancingCheckScheduler,
     pub(crate) wrapped_equity_recovery: WrappedEquityRecoveryJobQueue,
     pub(crate) transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue,
+    pub(crate) transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue,
 }
 
 impl RebalancingSchedulers {
@@ -66,6 +70,7 @@ impl RebalancingSchedulers {
             usdc: UsdcRebalancingCheckScheduler::new(pool),
             wrapped_equity_recovery: WrappedEquityRecoveryJobQueue::new(pool),
             transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue::new(pool),
+            transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue::new(pool),
         }
     }
 }
@@ -399,7 +404,9 @@ fn mint_event_tokenization_request_id(
     }
 }
 
-/// Operations triggered by inventory imbalances.
+/// Equity rebalancing operations dispatched through the `Rebalancer` mpsc
+/// channel. USDC rebalances are enqueued directly as apalis jobs from
+/// [`RebalancingService::check_and_trigger_usdc`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TriggeredOperation {
     /// Mint tokenized equity (too much offchain).
@@ -439,10 +446,11 @@ pub(crate) struct RebalancingService {
     pub(super) equity_scheduler: EquityRebalancingCheckScheduler,
     pub(super) usdc_scheduler: UsdcRebalancingCheckScheduler,
     pub(super) wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
-    /// Queue for `TransferUsdcToHedging` apalis jobs that drive Base->Alpaca
-    /// USDC transfers. Enqueued by `check_and_trigger_usdc` instead of being
-    /// dispatched through the `Rebalancer` mpsc channel.
+    /// Queues for the USDC transfer apalis jobs that drive each rebalancing
+    /// direction. `check_and_trigger_usdc` enqueues into one of these
+    /// directly rather than dispatching through the `Rebalancer` mpsc channel.
     pub(super) transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
+    pub(super) transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
     /// Tracks symbol/quantity for in-flight mints. The initial `MintRequested`
     /// event carries this data; follow-up events don't.
     mint_tracking: Arc<RwLock<HashMap<IssuerRequestId, MintTracking>>>,
@@ -494,6 +502,7 @@ impl RebalancingService {
             usdc: usdc_scheduler,
             wrapped_equity_recovery: wrapped_equity_recovery_queue,
             transfer_usdc_to_hedging: transfer_usdc_to_hedging_queue,
+            transfer_usdc_to_market_making: transfer_usdc_to_market_making_queue,
         } = schedulers;
         Self {
             config,
@@ -510,6 +519,7 @@ impl RebalancingService {
             usdc_scheduler,
             wrapped_equity_recovery_queue,
             transfer_usdc_to_hedging_queue,
+            transfer_usdc_to_market_making_queue,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
             usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
@@ -2021,9 +2031,10 @@ impl RebalancingService {
             TriggeredOperation::UsdcBaseToAlpaca { amount } => {
                 self.enqueue_transfer_usdc_to_hedging(*amount).await
             }
-            TriggeredOperation::Mint { .. }
-            | TriggeredOperation::Redemption { .. }
-            | TriggeredOperation::UsdcAlpacaToBase { .. } => {
+            TriggeredOperation::UsdcAlpacaToBase { amount } => {
+                self.enqueue_transfer_usdc_to_market_making(*amount).await
+            }
+            TriggeredOperation::Mint { .. } | TriggeredOperation::Redemption { .. } => {
                 self.try_send_operation(&operation, "usdc")
             }
         };
@@ -2036,17 +2047,44 @@ impl RebalancingService {
         guard.defuse();
     }
 
+    /// Returns the oldest non-terminal USDC transfer job in *either* direction
+    /// (the row id and its age in seconds), if any.
+    ///
+    /// The dedupe gate is deliberately direction-independent. Both directions
+    /// move funds through the same vault and market-maker wallet, and the
+    /// in-memory `usdc_in_progress` guard resets on restart, so an in-flight
+    /// transfer in one direction must also suppress enqueuing a transfer in the
+    /// *other* direction. Querying only one job type would, after a restart, let
+    /// an opposite-direction transfer run concurrently against the same funds --
+    /// churning capital and paying CCTP/withdrawal fees twice.
+    async fn in_flight_usdc_transfer(
+        pool: &sqlx::SqlitePool,
+    ) -> Result<Option<(String, i64)>, sqlx::Error> {
+        sqlx::query_as(
+            "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
+             FROM Jobs \
+             WHERE job_type IN (?, ?) \
+             AND status IN ('Pending', 'Queued', 'Running') \
+             ORDER BY run_at ASC \
+             LIMIT 1",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+        .fetch_optional(pool)
+        .await
+    }
+
     /// Enqueues a [`TransferUsdcToHedging`] apalis job for a Base->Alpaca
     /// transfer. Generates a fresh `UsdcRebalanceId` at push time so apalis
     /// retries (and bot restarts that re-pick the job row) hit the same
     /// aggregate. Returns `true` on successful enqueue.
     ///
-    /// Before enqueueing, queries the apalis Jobs table for any
-    /// non-terminal `TransferUsdcToHedging` row. The in-memory
-    /// `usdc_in_progress` guard resets on restart, so without this check a
-    /// crash between `queue.push` and the first persisted `UsdcRebalance`
-    /// event would let the next imbalance check enqueue a second job for
-    /// the same imbalance.
+    /// Before enqueueing, [`Self::in_flight_usdc_transfer`] checks the apalis
+    /// Jobs table for any non-terminal USDC transfer in either direction. The
+    /// in-memory `usdc_in_progress` guard resets on restart, so without this
+    /// check a crash between `queue.push` and the first persisted
+    /// `UsdcRebalance` event would let the next imbalance check enqueue a second
+    /// job for the same imbalance.
     async fn enqueue_transfer_usdc_to_hedging(&self, amount: Usdc) -> bool {
         // A non-terminal row in flight longer than this is treated as likely
         // stuck: the suppression is logged at warn (with the row id and age) so
@@ -2055,21 +2093,8 @@ impl RebalancingService {
         const STUCK_TRANSFER_WARN_AFTER_SECS: i64 = 15 * 60;
 
         let queue = self.transfer_usdc_to_hedging_queue.clone();
-        let job_type = std::any::type_name::<TransferUsdcToHedging>();
 
-        let existing: Result<Option<(String, i64)>, _> = sqlx::query_as(
-            "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
-             FROM Jobs \
-             WHERE job_type = ? \
-             AND status IN ('Pending', 'Queued', 'Running') \
-             ORDER BY run_at ASC \
-             LIMIT 1",
-        )
-        .bind(job_type)
-        .fetch_optional(queue.pool())
-        .await;
-
-        match existing {
+        match Self::in_flight_usdc_transfer(queue.pool()).await {
             Ok(Some((row_id, age_secs))) if age_secs >= STUCK_TRANSFER_WARN_AFTER_SECS => {
                 warn!(
                     target: "rebalance",
@@ -2077,8 +2102,9 @@ impl RebalancingService {
                     age_secs,
                     threshold_secs = STUCK_TRANSFER_WARN_AFTER_SECS,
                     %amount,
-                    "Skipped TransferUsdcToHedging enqueue: in-flight row looks stuck and is \
-                     suppressing new Base->Alpaca rebalances; investigate before it starves hedging",
+                    "Skipped Base->Alpaca USDC transfer enqueue: an in-flight USDC transfer \
+                     (either direction) looks stuck and is suppressing new rebalances; \
+                     investigate before it starves hedging",
                 );
                 return false;
             }
@@ -2088,8 +2114,8 @@ impl RebalancingService {
                     %row_id,
                     age_secs,
                     %amount,
-                    "Skipped TransferUsdcToHedging enqueue: non-terminal row \
-                     already exists; apalis will resume it",
+                    "Skipped Base->Alpaca USDC transfer enqueue: a non-terminal USDC transfer \
+                     (either direction) already exists; apalis will resume it",
                 );
                 return false;
             }
@@ -2098,7 +2124,7 @@ impl RebalancingService {
                 warn!(
                     target: "rebalance",
                     %error,
-                    "Failed to query for existing TransferUsdcToHedging rows; \
+                    "Failed to query for in-flight USDC transfers; \
                      skipping enqueue to avoid double-pushing",
                 );
                 return false;
@@ -2132,6 +2158,74 @@ impl RebalancingService {
                     %error,
                     %amount,
                     "Failed to enqueue TransferUsdcToHedging job",
+                );
+                false
+            }
+        }
+    }
+
+    /// Sibling of [`Self::enqueue_transfer_usdc_to_hedging`] for the
+    /// Alpaca->Base direction.
+    ///
+    /// Mirrors the same persistent dedupe: an in-memory `usdc_in_progress`
+    /// guard resets on restart, so without querying the apalis Jobs table
+    /// a crash between `queue.push` and the first persisted
+    /// `UsdcRebalance` event would let the next imbalance check enqueue a
+    /// second job for the same rebalance.
+    async fn enqueue_transfer_usdc_to_market_making(&self, amount: Usdc) -> bool {
+        let queue = self.transfer_usdc_to_market_making_queue.clone();
+
+        match Self::in_flight_usdc_transfer(queue.pool()).await {
+            Ok(Some((row_id, age_secs))) => {
+                debug!(
+                    target: "rebalance",
+                    %row_id,
+                    age_secs,
+                    %amount,
+                    "Skipped Alpaca->Base USDC transfer enqueue: a non-terminal USDC transfer \
+                     (either direction) already exists; apalis will resume it",
+                );
+                return false;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    "Failed to query for in-flight USDC transfers; \
+                     skipping enqueue to avoid double-pushing",
+                );
+                return false;
+            }
+        }
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let mut queue = queue;
+
+        let push = queue
+            .push(TransferUsdcToMarketMaking {
+                id: id.clone(),
+                amount,
+            })
+            .await;
+
+        match push {
+            Ok(()) => {
+                debug!(
+                    target: "rebalance",
+                    %id,
+                    %amount,
+                    "Enqueued TransferUsdcToMarketMaking job for Alpaca->Base USDC transfer",
+                );
+                true
+            }
+
+            Err(QueuePushError(error)) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    %amount,
+                    "Failed to enqueue TransferUsdcToMarketMaking job",
                 );
                 false
             }
@@ -4795,6 +4889,52 @@ mod tests {
         .expect("count pending TransferUsdcToHedging jobs")
     }
 
+    /// Drains every pending USDC transfer row (both directions) from the
+    /// service's Jobs table and returns them parsed as
+    /// [`TriggeredOperation`]. Marking rows `Done` lets repeated trigger
+    /// cycles in the same test see fresh state.
+    async fn take_pending_usdc_transfer_jobs(
+        service: &RebalancingService,
+    ) -> Vec<TriggeredOperation> {
+        let pool = service.transfer_usdc_to_hedging_queue.pool().clone();
+        let to_hedging_type = std::any::type_name::<TransferUsdcToHedging>();
+        let to_mm_type = std::any::type_name::<TransferUsdcToMarketMaking>();
+
+        let rows: Vec<(String, Vec<u8>, String)> = sqlx::query_as(
+            "SELECT id, job, job_type FROM Jobs \
+             WHERE status = 'Pending' AND (job_type = ? OR job_type = ?) \
+             ORDER BY run_at",
+        )
+        .bind(to_hedging_type)
+        .bind(to_mm_type)
+        .fetch_all(&pool)
+        .await
+        .expect("query pending USDC transfer jobs");
+
+        let mut operations = Vec::with_capacity(rows.len());
+        for (row_id, payload, job_type) in rows {
+            let operation = if job_type == to_hedging_type {
+                let job: TransferUsdcToHedging =
+                    serde_json::from_slice(&payload).expect("deserialize TransferUsdcToHedging");
+                TriggeredOperation::UsdcBaseToAlpaca { amount: job.amount }
+            } else {
+                let job: TransferUsdcToMarketMaking = serde_json::from_slice(&payload)
+                    .expect("deserialize TransferUsdcToMarketMaking");
+                TriggeredOperation::UsdcAlpacaToBase { amount: job.amount }
+            };
+
+            sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+                .bind(&row_id)
+                .execute(&pool)
+                .await
+                .expect("mark drained USDC transfer job Done");
+
+            operations.push(operation);
+        }
+
+        operations
+    }
+
     async fn make_trigger_with_inventory_and_registry_config(
         inventory: InventoryView,
         symbol: &Symbol,
@@ -6521,14 +6661,20 @@ mod tests {
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
-        // Verify imbalance triggers before reactor events
+        // Verify imbalance triggers before reactor events. Alpaca->Base is
+        // enqueued as a TransferUsdcToMarketMaking apalis job, not via mpsc.
         trigger.check_and_trigger_usdc().await;
+        let pending = take_pending_usdc_transfer_jobs(&trigger).await;
         assert!(
             matches!(
-                receiver.try_recv(),
-                Ok(TriggeredOperation::UsdcAlpacaToBase { .. })
+                pending.as_slice(),
+                [TriggeredOperation::UsdcAlpacaToBase { .. }],
             ),
-            "TooMuchOffchain (100/900) should trigger UsdcAlpacaToBase before reactor events"
+            "TooMuchOffchain (100/900) should enqueue an AlpacaToBase transfer, got {pending:?}"
+        );
+        assert!(
+            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+            "Alpaca->Base should not be routed through the Rebalancer mpsc channel"
         );
         trigger.clear_usdc_in_progress();
 
@@ -7817,7 +7963,7 @@ mod tests {
                 Utc::now(),
             )
             .unwrap();
-        let (reactor, mut receiver) = make_trigger_with_inventory_config(
+        let (reactor, _receiver) = make_trigger_with_inventory_config(
             inventory,
             test_config_with_timeout(Duration::from_secs(1)),
         )
@@ -7866,9 +8012,12 @@ mod tests {
         );
         drop(inventory);
 
-        let triggered = receiver.try_recv();
+        let triggered = take_pending_usdc_transfer_jobs(&trigger).await;
         assert!(
-            matches!(triggered, Ok(TriggeredOperation::UsdcAlpacaToBase { .. })),
+            matches!(
+                triggered.as_slice(),
+                [TriggeredOperation::UsdcAlpacaToBase { .. }]
+            ),
             "USDC timeout should allow the next trigger cycle to proceed, got {triggered:?}"
         );
         assert!(
@@ -8048,6 +8197,58 @@ mod tests {
         assert!(
             !trigger.usdc_tracking.read().await.contains_key(&id),
             "timeout must drop tracking once the transfer job is terminal",
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_hedging_transfer_blocks_market_making_enqueue() {
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+
+        // A Base->Alpaca (hedging) transfer is already in flight.
+        service
+            .transfer_usdc_to_hedging_queue
+            .clone()
+            .push(TransferUsdcToHedging {
+                id: UsdcRebalanceId(Uuid::new_v4()),
+                amount: usdc(100),
+            })
+            .await
+            .unwrap();
+
+        // The opposite-direction enqueue must be suppressed: both directions
+        // move the same funds through the same vault/wallet, and the in-memory
+        // guard resets on restart, so running them concurrently would churn
+        // capital and pay fees twice.
+        let enqueued = service
+            .enqueue_transfer_usdc_to_market_making(usdc(100))
+            .await;
+
+        assert!(
+            !enqueued,
+            "an in-flight Base->Alpaca transfer must block enqueuing an Alpaca->Base transfer"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_market_making_transfer_blocks_hedging_enqueue() {
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+
+        // An Alpaca->Base (market-making) transfer is already in flight.
+        service
+            .transfer_usdc_to_market_making_queue
+            .clone()
+            .push(TransferUsdcToMarketMaking {
+                id: UsdcRebalanceId(Uuid::new_v4()),
+                amount: usdc(100),
+            })
+            .await
+            .unwrap();
+
+        let enqueued = service.enqueue_transfer_usdc_to_hedging(usdc(100)).await;
+
+        assert!(
+            !enqueued,
+            "an in-flight Alpaca->Base transfer must block enqueuing a Base->Alpaca transfer"
         );
     }
 
@@ -9299,20 +9500,22 @@ mod tests {
             .unwrap();
         drain_pending_jobs(&trigger).await.unwrap();
 
-        let mut operations = Vec::new();
-        while let Ok(operation) = receiver.try_recv() {
-            operations.push(operation);
-        }
+        // Drain the equity mpsc channel; the position-event side of this test
+        // can dispatch equity operations through the rebalancer, but the
+        // assertion below is only about USDC.
+        while receiver.try_recv().is_ok() {}
+
+        let usdc_operations = take_pending_usdc_transfer_jobs(&trigger).await;
 
         // Onchain buy spends USDC onchain, making the onchain ratio drop below
         // the lower bound. The system should move USDC from Alpaca to Base.
-        operations
+        usdc_operations
             .iter()
             .find(|op| matches!(op, TriggeredOperation::UsdcAlpacaToBase { .. }))
             .unwrap_or_else(|| {
                 panic!(
-                    "Expected UsdcAlpacaToBase (onchain USDC too low after buy), \
-                     got operations: {operations:?}"
+                    "Expected AlpacaToBase (onchain USDC too low after buy), \
+                     got operations: {usdc_operations:?}"
                 )
             });
     }
@@ -11458,15 +11661,18 @@ mod tests {
         let inventory = InventoryView::default()
             .with_usdc(usdc(100), usdc(900))
             .with_withdrawable_cash_cents(90_000);
-        let (reactor, mut receiver) = make_trigger_with_inventory(inventory).await;
+        let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
         let trigger = reactor.clone();
 
         UsdcRebalancingCheck.perform(&trigger).await.unwrap();
 
-        let dispatched = receiver.try_recv().unwrap();
+        let dispatched = take_pending_usdc_transfer_jobs(&trigger).await;
         assert!(
-            matches!(dispatched, TriggeredOperation::UsdcAlpacaToBase { .. }),
-            "Expected UsdcAlpacaToBase, got {dispatched:?}"
+            matches!(
+                dispatched.as_slice(),
+                [TriggeredOperation::UsdcAlpacaToBase { .. }],
+            ),
+            "Expected AlpacaToBase, got {dispatched:?}"
         );
     }
 

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -1,14 +1,13 @@
-//! Apalis job that drives a `BaseToAlpaca` USDC transfer through the
-//! `UsdcRebalance` lifecycle.
+//! Apalis jobs that drive USDC transfers through the `UsdcRebalance`
+//! lifecycle, one per direction.
 //!
 //! Each job is keyed by a `UsdcRebalanceId` chosen at enqueue time, so apalis
 //! retries (and bot restarts that re-pick the row from the Jobs table) hit
-//! the same aggregate. The worker calls
-//! [`ResumeBaseToAlpaca::resume_base_to_alpaca`] on the trait-erased
-//! transfer, which loads the aggregate via `Store::load` and dispatches on
-//! its current state. New transfers and mid-flight resumes share the same
-//! entry point — that uniformity is what makes recovery dispatch fall out of
-//! the standard transfer lifecycle.
+//! the same aggregate. The worker calls the trait-erased `resume_*` entry
+//! point on the cash transfer, which loads the aggregate via `Store::load`
+//! and dispatches on its current state. New transfers and mid-flight resumes
+//! share the same entry point — that uniformity is what makes recovery
+//! dispatch fall out of the standard transfer lifecycle.
 //!
 //! The global `usdc_in_progress` guard is cleared event-driven when the
 //! aggregate reaches a terminal state (success or a recorded failure), not by
@@ -35,9 +34,12 @@ use crate::usdc_rebalance::UsdcRebalanceId;
 /// Apalis queue type for [`TransferUsdcToHedging`].
 pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
 
-/// Trait-erased entry point the apalis job calls. Erasing the `Chain` generic
-/// here lets the conductor build a single concrete `Ctx` regardless of which
-/// wallet backend is wired in.
+/// Apalis queue type for [`TransferUsdcToMarketMaking`].
+pub(crate) type TransferUsdcToMarketMakingJobQueue = JobQueue<TransferUsdcToMarketMaking>;
+
+/// Trait-erased entry point for the Base->Alpaca apalis job. Erasing the
+/// `Chain` generic here lets the conductor build a single concrete `Ctx`
+/// regardless of which wallet backend is wired in.
 #[async_trait]
 pub(crate) trait ResumeBaseToAlpaca: Send + Sync + 'static {
     async fn resume_base_to_alpaca(
@@ -58,6 +60,31 @@ where
         amount: Usdc,
     ) -> Result<(), UsdcTransferError> {
         Self::resume_base_to_alpaca(self, id, amount).await
+    }
+}
+
+/// Trait-erased entry point for the Alpaca->Base apalis job. Sibling of
+/// [`ResumeBaseToAlpaca`]; same trait-erasure rationale.
+#[async_trait]
+pub(crate) trait ResumeAlpacaToBase: Send + Sync + 'static {
+    async fn resume_alpaca_to_base(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError>;
+}
+
+#[async_trait]
+impl<Chain> ResumeAlpacaToBase for CrossVenueCashTransfer<Chain>
+where
+    Chain: Wallet + Send + Sync + 'static,
+{
+    async fn resume_alpaca_to_base(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        Self::resume_alpaca_to_base(self, id, amount).await
     }
 }
 
@@ -158,5 +185,143 @@ mod tests {
             error,
             TransferUsdcToHedgingJobError::Timeout { .. }
         ));
+    }
+
+    /// Records the resume call and returns a configurable outcome, so the
+    /// Alpaca->Base job's `perform` can be tested without onchain/broker setup.
+    struct RecordingResume {
+        fail: bool,
+        captured: std::sync::Mutex<Option<(UsdcRebalanceId, Usdc)>>,
+    }
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for RecordingResume {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            *self.captured.lock().unwrap() = Some((id.clone(), amount));
+            if self.fail {
+                Err(UsdcTransferError::WithdrawalFailed {
+                    status: "test-induced".to_string(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn market_making_perform_forwards_id_and_amount_to_resume() {
+        let stub = Arc::new(RecordingResume {
+            fail: false,
+            captured: std::sync::Mutex::new(None),
+        });
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: stub.clone(),
+        };
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = Usdc::new(float!(250));
+        let job = TransferUsdcToMarketMaking {
+            id: id.clone(),
+            amount,
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        let captured = stub.captured.lock().unwrap().clone();
+        assert_eq!(
+            captured,
+            Some((id, amount)),
+            "perform must forward its id and amount to resume_alpaca_to_base",
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_perform_returns_ok_on_successful_resume() {
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RecordingResume {
+                fail: false,
+                captured: std::sync::Mutex::new(None),
+            }),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn market_making_perform_propagates_resume_failure() {
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(RecordingResume {
+                fail: true,
+                captured: std::sync::Mutex::new(None),
+            }),
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        // The failure must propagate (not be swallowed) so apalis retries and the
+        // event-driven `usdc_in_progress` guard stays latched until the aggregate
+        // reaches a terminal state -- swallowing it would free the guard and let a
+        // fresh transfer arm on top of a partial one.
+        assert!(
+            matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
+            "perform must propagate the resume failure as a Transfer error, got {error:?}",
+        );
+    }
+}
+
+/// Dependencies the Alpaca->Base job needs. Symmetric to
+/// [`TransferUsdcToHedgingCtx`].
+pub(crate) struct TransferUsdcToMarketMakingCtx {
+    pub(crate) transfer: Arc<dyn ResumeAlpacaToBase>,
+}
+
+/// Errors emitted by [`TransferUsdcToMarketMaking::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum TransferUsdcToMarketMakingJobError {
+    #[error(transparent)]
+    Transfer(#[from] UsdcTransferError),
+}
+
+/// Apalis job payload for the Alpaca->Base direction. The `id` is generated
+/// at enqueue time so retries resume the same aggregate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TransferUsdcToMarketMaking {
+    pub(crate) id: UsdcRebalanceId,
+    pub(crate) amount: Usdc,
+}
+
+impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
+    type Output = ();
+    type Error = TransferUsdcToMarketMakingJobError;
+
+    const WORKER_NAME: &'static str = "transfer-usdc-to-market-making-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::TransferUsdcToMarketMaking;
+
+    fn label(&self) -> Label {
+        Label::new(format!("TransferUsdcToMarketMaking:{}", self.id))
+    }
+
+    async fn perform(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+    ) -> Result<Self::Output, Self::Error> {
+        ctx.transfer
+            .resume_alpaca_to_base(&self.id, self.amount)
+            .await?;
+        Ok(())
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -24,7 +24,7 @@ use super::UsdcTransferError;
 use crate::alpaca_wallet::{
     AlpacaTransferId, AlpacaWalletService, TokenSymbol, Transfer, TransferStatus,
 };
-use crate::onchain::raindex::{RaindexService, RaindexVaultId, USDC_BASE};
+use crate::onchain::raindex::{Raindex, RaindexService, RaindexVaultId, USDC_BASE};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
@@ -267,6 +267,385 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// On errors, sends appropriate `Fail*` command to transition
     /// aggregate to failed state.
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
+    pub(crate) async fn resume_alpaca_to_base(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        use RebalanceDirection::*;
+        use UsdcRebalance::*;
+
+        let state = self.cqrs.load(id).await?;
+
+        info!(
+            target: "rebalance",
+            ?state,
+            "Resuming Alpaca->Base transfer from aggregate state",
+        );
+
+        match state {
+            None => self.execute_alpaca_to_base(id, amount).await,
+
+            Some(Converting {
+                direction: AlpacaToBase,
+                ..
+            }) => {
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: "resume from Converting state requires manual \
+                                     reconciliation: broker order ID not persisted"
+                                .into(),
+                        },
+                    )
+                    .await?;
+                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            }
+
+            Some(ConversionComplete {
+                direction: AlpacaToBase,
+                filled_amount,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_conversion_complete(id, filled_amount)
+                    .await
+            }
+
+            Some(Withdrawing {
+                direction: AlpacaToBase,
+                amount,
+                withdrawal_ref,
+                ..
+            }) => {
+                let TransferRef::AlpacaId(transfer_id) = withdrawal_ref else {
+                    return Err(UsdcTransferError::WithdrawalRefMustBeAlpacaId { id: id.clone() });
+                };
+
+                self.poll_and_confirm_withdrawal(id, &transfer_id).await?;
+                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount)
+                    .await
+            }
+
+            Some(WithdrawalComplete {
+                direction: AlpacaToBase,
+                amount,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount)
+                    .await
+            }
+
+            Some(Bridging {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_bridging(id, amount, burn_tx_hash)
+                    .await
+            }
+
+            // `Attested` must NOT route through the `Bridging` path: that re-emits
+            // `ReceiveAttestation`, which the aggregate rejects from `Attested`,
+            // stranding the already-burned USDC. Reconstruct the mint instead --
+            // adopt an already-submitted one or re-poll the attestation without
+            // re-recording it -- then go straight to mint + vault deposit.
+            Some(Attested {
+                direction: AlpacaToBase,
+                amount,
+                burn_tx_hash,
+                mint_scan_from_block,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_attested(
+                    id,
+                    amount,
+                    burn_tx_hash,
+                    mint_scan_from_block,
+                )
+                .await
+            }
+
+            Some(Bridged {
+                direction: AlpacaToBase,
+                amount_received,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_bridged(id, amount_received)
+                    .await
+            }
+
+            Some(DepositInitiated {
+                direction: AlpacaToBase,
+                deposit_ref,
+                ..
+            }) => {
+                // Re-verify the persisted deposit tx on chain before
+                // transitioning to `DepositConfirmed`. The aggregate
+                // records the deposit hash at `InitiateDeposit` time,
+                // but a process restart between that event and the
+                // confirmation can land on a chain where the tx has
+                // been reorged out, dropped, or never mined. Trusting
+                // the persisted state alone would mark the rebalance
+                // complete while the funds aren't actually deposited.
+                let TransferRef::OnchainTx(deposit_tx) = deposit_ref else {
+                    return Err(UsdcTransferError::DepositRefMustBeOnchain { id: id.clone() });
+                };
+                match self.raindex.confirm_tx(deposit_tx).await {
+                    Ok(()) => self.confirm_deposit(id).await,
+                    // A dropped tx (gone from the mempool, will never mine) is a
+                    // terminal failure -- distinct from a still-pending tx that
+                    // confirm_tx merely couldn't confirm yet. Without this, a
+                    // dropped deposit retries forever until the breaker trips.
+                    // Record FailDeposit so an operator can reconcile, then
+                    // surface the error.
+                    Err(error) if error.is_transaction_dropped() => {
+                        warn!(
+                            target: "rebalance",
+                            %deposit_tx,
+                            "Recorded deposit tx was dropped from the mempool; recording \
+                             terminal FailDeposit for operator reconciliation",
+                        );
+                        self.cqrs
+                            .send(
+                                id,
+                                UsdcRebalanceCommand::FailDeposit {
+                                    reason: format!(
+                                        "Deposit tx {deposit_tx} dropped from the mempool \
+                                         and will not mine"
+                                    ),
+                                },
+                            )
+                            .await?;
+                        Err(UsdcTransferError::Vault(error))
+                    }
+                    Err(error) => Err(UsdcTransferError::Vault(error)),
+                }
+            }
+
+            Some(DepositConfirmed {
+                direction: AlpacaToBase,
+                ..
+            }) => Ok(()),
+
+            Some(
+                Converting {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | ConversionComplete {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | Withdrawing {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | WithdrawalComplete {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | Bridging {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | Attested {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | Bridged {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | DepositInitiated {
+                    direction: BaseToAlpaca,
+                    ..
+                }
+                | DepositConfirmed {
+                    direction: BaseToAlpaca,
+                    ..
+                },
+            ) => Err(UsdcTransferError::ResumeDirectionMismatch {
+                id: id.clone(),
+                direction: BaseToAlpaca,
+            }),
+
+            // `WithdrawalSubmitting`/`BridgingSubmitting` are crash-safe
+            // submission states produced only by the Base->Alpaca flow (on-chain
+            // vault withdrawal and burn-on-Base). The Alpaca->Base flow withdraws
+            // off-chain and burns via `InitiateBridging` straight to `Bridging`,
+            // so it never enters these states -- reaching one here means the
+            // aggregate belongs to the other direction.
+            Some(WithdrawalSubmitting { direction, .. } | BridgingSubmitting { direction, .. }) => {
+                Err(UsdcTransferError::ResumeDirectionMismatch {
+                    id: id.clone(),
+                    direction,
+                })
+            }
+
+            Some(
+                WithdrawalFailed { .. }
+                | BridgingFailed { .. }
+                | DepositFailed { .. }
+                | ConversionFailed { .. },
+            ) => Err(UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() }),
+        }
+    }
+
+    /// Drives an Alpaca->Base transfer from `ConversionComplete` through to
+    /// terminal: withdraw -> burn -> attestation -> mint -> vault deposit.
+    async fn continue_alpaca_to_base_from_conversion_complete(
+        &self,
+        id: &UsdcRebalanceId,
+        filled_amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let transfer = self.initiate_alpaca_withdrawal(id, filled_amount).await?;
+
+        self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
+        self.continue_alpaca_to_base_from_withdrawal_complete(id, filled_amount)
+            .await
+    }
+
+    /// Drives an Alpaca->Base transfer from `WithdrawalComplete` through to
+    /// terminal: burn -> attestation -> mint -> vault deposit.
+    async fn continue_alpaca_to_base_from_withdrawal_complete(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_amount = match usdc_to_u256(amount) {
+            Ok(burn_amount) => burn_amount,
+            Err(error) => {
+                warn!(target: "rebalance", %error, "USDC to U256 conversion failed after withdrawal");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailBridging {
+                            reason: format!("USDC conversion failed: {error}"),
+                        },
+                    )
+                    .await?;
+                return Err(error);
+            }
+        };
+
+        let burn_receipt = self.execute_cctp_burn(id, burn_amount).await?;
+
+        self.continue_alpaca_to_base_from_bridging(id, amount, burn_receipt.tx)
+            .await
+    }
+
+    /// Drives an Alpaca->Base transfer from `Bridging`/`Attested` through to
+    /// terminal. Re-polls the Circle attestation (idempotent for completed
+    /// attestations) so we obtain a fresh [`AttestationResponse`] suitable
+    /// for [`Bridge::mint`].
+    async fn continue_alpaca_to_base_from_bridging(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+
+        let attestation_response = self.poll_attestation(id, &burn_receipt).await?;
+        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+
+        self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
+            .await
+    }
+
+    /// Drives an Alpaca->Base transfer from `Attested` through to terminal
+    /// WITHOUT re-emitting `ReceiveAttestation` (the aggregate already recorded
+    /// it and rejects the command from `Attested`, which would strand the burned
+    /// USDC).
+    ///
+    /// The mint may already have been submitted before a crash, so this first
+    /// scans the Base chain (bounded by `mint_scan_from_block`) for an
+    /// already-submitted mint to the market-maker wallet and adopts it via
+    /// `ConfirmBridging` -- re-minting would revert on the already-used CCTP
+    /// nonce. Only if no mint is found does it re-poll Circle (idempotent) and
+    /// mint afresh.
+    async fn continue_alpaca_to_base_from_attested(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+        mint_scan_from_block: Option<u64>,
+    ) -> Result<(), UsdcTransferError> {
+        // Events persisted before crash-safe resume carry no scan bound. Scanning
+        // from genesis could adopt an unrelated mint to the same wallet, so refuse
+        // to auto-resume and surface for manual reconciliation instead.
+        let Some(mint_scan_from_block) = mint_scan_from_block else {
+            warn!(target: "rebalance", %id, "Cannot resume Attested transfer: no mint scan bound captured");
+            return Err(UsdcTransferError::ResumeWithoutMintScanBound { id: id.clone() });
+        };
+
+        if let Some(mint_receipt) = self
+            .cctp_bridge
+            .find_recent_mint(
+                BridgeDirection::EthereumToBase,
+                self.market_maker_wallet,
+                mint_scan_from_block,
+            )
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
+        {
+            let amount_received = u256_to_usdc(mint_receipt.amount)?;
+
+            info!(target: "rebalance", mint_tx = %mint_receipt.tx, %amount_received, "Adopting already-submitted CCTP mint on resume");
+
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::ConfirmBridging {
+                        mint_tx: mint_receipt.tx,
+                        amount_received,
+                        fee_collected: u256_to_usdc(mint_receipt.fee)?,
+                    },
+                )
+                .await?;
+
+            return self
+                .continue_alpaca_to_base_from_bridged(id, amount_received)
+                .await;
+        }
+
+        // No mint landed yet: re-poll Circle for the attestation (idempotent for a
+        // completed attestation) WITHOUT re-emitting `ReceiveAttestation`, then
+        // mint on Base. `execute_cctp_mint` emits `ConfirmBridging`, advancing the
+        // aggregate to `Bridged`.
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+        let attestation_response = self
+            .poll_circle_attestation(id, BridgeDirection::EthereumToBase, &burn_receipt)
+            .await?;
+        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+
+        self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
+            .await
+    }
+
+    /// Drives an Alpaca->Base transfer from `Bridged` to terminal: vault
+    /// deposit + `ConfirmDeposit`.
+    async fn continue_alpaca_to_base_from_bridged(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let amount_u256 = usdc_to_u256(amount_received)?;
+
+        self.deposit_to_vault(id, amount_u256).await?;
+        self.confirm_deposit(id).await?;
+
+        Ok(())
+    }
+
     pub(crate) async fn execute_alpaca_to_base(
         &self,
         id: &UsdcRebalanceId,
@@ -465,18 +844,18 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         // Capture the destination (Base) head before minting so a crash before
         // `ConfirmBridging` resumes by scanning for the already-submitted mint
-        // instead of re-minting, which reverts on the already-used CCTP nonce.
-        // AlpacaToBase has no resume entry point (`resume_base_to_alpaca` rejects
-        // it), so this bound is never read on resume: on a transient head-lookup
-        // error, continue with a sentinel rather than failing a healthy transfer.
+        // (`continue_alpaca_to_base_from_attested`) instead of re-minting, which
+        // reverts on the already-used CCTP nonce. Fail on a head-lookup error
+        // rather than recording a sentinel: now that AlpacaToBase has a resume
+        // entry point that reads this bound, a sentinel of 0 would scan from
+        // genesis on resume and risk adopting an unrelated mint. A transient
+        // failure here leaves the aggregate in `Bridging`, which resumes safely
+        // by re-polling.
         let mint_scan_from_block = self
             .cctp_bridge
             .destination_block(BridgeDirection::EthereumToBase)
             .await
-            .unwrap_or_else(|error| {
-                warn!(target: "rebalance", "Destination head lookup failed, using sentinel (AlpacaToBase has no resume): {error}");
-                0
-            });
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
 
         self.cqrs
             .send(
@@ -545,18 +924,29 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         amount: U256,
     ) -> Result<(), UsdcTransferError> {
-        let deposit_tx = match self.raindex.deposit_usdc(self.vault_id, amount).await {
+        // Submit the deposit and persist its tx hash as `InitiateDeposit` BEFORE
+        // confirming. `deposit_usdc` would submit AND confirm atomically, only
+        // recording the hash afterwards -- a crash during the (potentially long)
+        // confirmation wait would leave the aggregate in `Bridged`, and resume
+        // would re-enter here and submit a SECOND deposit for the same funds.
+        // Persisting the hash first lands a crash in `DepositInitiated`, whose
+        // resume arm re-verifies the recorded tx via `confirm_tx` instead of
+        // re-depositing.
+        let deposit_tx = match self
+            .raindex
+            .submit_deposit_usdc(self.vault_id, amount)
+            .await
+        {
             Ok(tx) => tx,
             Err(error) => {
-                warn!(target: "rebalance", "Vault deposit failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailDeposit {
-                            reason: format!("Vault deposit failed: {error}"),
-                        },
-                    )
-                    .await?;
+                // The submission failed before any deposit tx was broadcast
+                // (`submit_pending` only returns a hash once the tx is accepted),
+                // so nothing moved. Leave the aggregate in `Bridged` and let
+                // apalis retry the deposit from there -- re-attempting is safe and
+                // cannot double-deposit. Do NOT emit `FailDeposit`: it is invalid
+                // from `Bridged` (only valid once a deposit has been initiated),
+                // and a transient submission error is not a terminal failure.
+                warn!(target: "rebalance", "Vault deposit submission failed: {error}");
                 return Err(UsdcTransferError::Vault(error));
             }
         };
@@ -570,7 +960,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             )
             .await?;
 
-        info!(target: "rebalance", %deposit_tx, "Vault deposit initiated");
+        // Confirm the recorded deposit. A failure here leaves the aggregate in
+        // `DepositInitiated` (the hash is persisted) rather than emitting
+        // `FailDeposit`: the deposit may still confirm, and the `DepositInitiated`
+        // resume arm re-checks it. Propagate so apalis retries from there.
+        self.raindex.confirm_tx(deposit_tx).await?;
+
+        info!(target: "rebalance", %deposit_tx, "Vault deposit submitted, recorded, and confirmed");
         Ok(())
     }
 
@@ -622,40 +1018,18 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         Ok(())
     }
 
-    /// Resumes (or starts) a Base->Alpaca transfer from the aggregate's current
-    /// state.
-    ///
-    /// Loads the [`UsdcRebalance`] aggregate via [`Store::load`] and dispatches
-    /// on state to the appropriate phase. This single entry point handles both
-    /// the fresh-start case (aggregate doesn't exist yet) and any in-progress
-    /// state after a crash. Designed to be called from an apalis job so retries
-    /// drive a stalled aggregate to terminal without re-issuing completed
-    /// phases.
-    ///
-    /// # Resume semantics
-    ///
-    /// - `None` (no events yet): start from vault withdrawal.
-    /// - `Withdrawing`: vault withdrawal is synchronous (waits for block
-    ///   inclusion before sending `Initiate`), so only a crash between
-    ///   `Initiate` and `ConfirmWithdrawal` lands the aggregate here. Send
-    ///   `ConfirmWithdrawal` and continue.
-    /// - `WithdrawalComplete`: resume from CCTP burn.
-    /// - `Bridging` / `Attested`: resume from attestation polling. The Circle
-    ///   API is idempotent for completed attestations, so the `Attested` case
-    ///   just re-polls to get a fresh `AttestationResponse` (the aggregate
-    ///   stores attestation bytes and nonce but not the full message envelope
-    ///   needed by [`Bridge::mint`], so re-polling is cheaper than extending
-    ///   the bridge API).
-    /// - `Bridged`: resume from Alpaca deposit initiation.
-    /// - `DepositInitiated`: deposit already recorded; resume from polling
-    ///   Alpaca.
-    /// - `DepositConfirmed` (BaseToAlpaca): resume from USDC->USD conversion.
-    /// - `Converting`: indeterminate after crash (broker order ID is not
-    ///   persisted); emit `FailConversion` and return error so operator can
-    ///   reconcile manually.
-    /// - `ConversionComplete`: terminal success; no-op.
-    /// - Terminal failure states: return [`UsdcTransferError::PreviouslyFailedAggregate`]
-    ///   so the operator sees that automated recovery cannot help.
+    /// Non-obvious points the match body below cannot express on its own:
+    /// - `Attested` re-polls rather than reconstructing an `AttestationResponse`
+    ///   because the aggregate stores attestation bytes + nonce but not the
+    ///   full message envelope [`Bridge::mint`] needs; Circle's API is
+    ///   idempotent for completed attestations so the cost is negligible.
+    /// - `Converting` is unrecoverable: the aggregate persists the correlation
+    ///   UUID but not the broker order ID, so a polling-based resume cannot
+    ///   identify the order. Operator reconciles manually.
+    /// - `Withdrawing` only happens on a crash between `Initiate` and
+    ///   `ConfirmWithdrawal`; the vault withdrawal is synchronous (waits for
+    ///   block inclusion before `Initiate`), so `ConfirmWithdrawal` is always
+    ///   safe to send.
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
     pub(crate) async fn resume_base_to_alpaca(
         &self,
@@ -957,7 +1331,9 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
         };
-        let attestation_response = self.poll_circle_attestation(id, &burn_receipt).await?;
+        let attestation_response = self
+            .poll_circle_attestation(id, BridgeDirection::BaseToEthereum, &burn_receipt)
+            .await?;
 
         // Capture the destination (Ethereum) head before minting so a crash
         // before `ConfirmBridging` resumes by scanning for the already-submitted
@@ -1053,7 +1429,9 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
         };
-        let attestation_response = self.poll_circle_attestation(id, &burn_receipt).await?;
+        let attestation_response = self
+            .poll_circle_attestation(id, BridgeDirection::BaseToEthereum, &burn_receipt)
+            .await?;
         self.mint_and_continue(id, attestation_response).await
     }
 
@@ -1332,11 +1710,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     async fn poll_circle_attestation(
         &self,
         id: &UsdcRebalanceId,
+        direction: BridgeDirection,
         burn_receipt: &BurnReceipt,
     ) -> Result<AttestationResponse, UsdcTransferError> {
         match self
             .cctp_bridge
-            .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .poll_attestation(direction, burn_receipt.tx)
             .await
         {
             Ok(response) => Ok(response),
@@ -1646,6 +2025,178 @@ mod tests {
         let endpoint = anvil.endpoint();
         let private_key = B256::from_slice(&anvil.keys()[0].to_bytes());
         (anvil, endpoint, private_key)
+    }
+
+    /// Advances an aggregate through the full Alpaca->Base lifecycle up
+    /// to (but not past) `DepositInitiated`, persisting the supplied
+    /// `deposit_tx` as the on-chain reference for the vault deposit.
+    async fn advance_to_deposit_initiated_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        deposit_tx: TxHash,
+    ) {
+        use UsdcRebalanceCommand::*;
+
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0xaaaa111111111111111111111111111111111111111111111111111111111111");
+
+        cqrs.send(
+            id,
+            InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, ConfirmWithdrawal).await.unwrap();
+        cqrs.send(id, InitiateBridging { burn_tx }).await.unwrap();
+        cqrs.send(
+            id,
+            ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: 12345,
+                mint_scan_from_block: 100,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            ConfirmBridging {
+                mint_tx,
+                amount_received: amount,
+                fee_collected: usdc("0"),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            InitiateDeposit {
+                deposit: TransferRef::OnchainTx(deposit_tx),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Advances an Alpaca->Base aggregate to the terminal `DepositConfirmed`
+    /// state by confirming the persisted vault deposit.
+    async fn advance_to_deposit_confirmed_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        deposit_tx: TxHash,
+    ) {
+        advance_to_deposit_initiated_alpaca_to_base(cqrs, id, amount, deposit_tx).await;
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+    }
+
+    /// Drives an Alpaca->Base aggregate through `InitiateConversion` ->
+    /// `ConfirmConversion` -> `Initiate` -> `ConfirmWithdrawal` ->
+    /// `InitiateBridging` -> `ReceiveAttestation` so it lands at `Attested`,
+    /// where the next callable step is the mint.
+    async fn advance_to_attested_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        use UsdcRebalanceCommand::*;
+
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+
+        cqrs.send(
+            id,
+            InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, ConfirmWithdrawal).await.unwrap();
+        cqrs.send(id, InitiateBridging { burn_tx }).await.unwrap();
+        cqrs.send(
+            id,
+            ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: 12345,
+                // Scan from genesis: the fresh test chain sits below 100, so a 0
+                // bound makes the find_recent_mint scan a valid range that
+                // genuinely finds no mint, letting resume proceed to the mint.
+                mint_scan_from_block: 0,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Drives an Alpaca->Base aggregate to `Bridged` (mint confirmed), where the
+    /// next callable step is the crash-safe vault deposit.
+    async fn advance_to_bridged_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        advance_to_attested_alpaca_to_base(cqrs, id, amount).await;
+
+        let mint_tx =
+            fixed_bytes!("0xaaaa111111111111111111111111111111111111111111111111111111111111");
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received: amount,
+                fee_collected: usdc("0"),
+            },
+        )
+        .await
+        .unwrap();
     }
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -4336,6 +4887,213 @@ mod tests {
         assert!(
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected ConversionComplete after resume from Bridged, got: {final_state:?}",
+        );
+    }
+
+    /// Hypothesis: resuming `resume_alpaca_to_base` from `DepositInitiated`
+    /// must re-verify the persisted on-chain deposit tx (status +
+    /// configured confirmation depth) before transitioning to
+    /// `DepositConfirmed`. A reorg, mempool drop, or partially-mined tx
+    /// observed at the time of `InitiateDeposit` can later be invalid
+    /// when the process restarts; advancing solely from persisted state
+    /// would mark the rebalance complete while the deposit isn't on
+    /// chain. The handler must surface the unverified tx as an error so
+    /// the worker retries instead of silently confirming.
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_deposit_initiated_reverifies_deposit_tx() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        // A persisted deposit tx that never landed on chain (reorged out,
+        // dropped, or never mined): the live anvil node has no record of it, so
+        // `confirm_tx` reports it dropped. Rather than retrying confirm forever
+        // (a transient-vs-dropped confusion), resume must re-verify the tx and,
+        // finding it gone, record a terminal `FailDeposit` for operator
+        // reconciliation -- never blindly transitioning the aggregate to complete.
+        let deposit_tx =
+            fixed_bytes!("0xdddd000000000000000000000000000000000000000000000000000000000001");
+
+        advance_to_deposit_initiated_alpaca_to_base(&cqrs, &id, amount, deposit_tx).await;
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::Vault(_)),
+            "Resume must surface the unconfirmable deposit as a Vault (confirm_tx) error, \
+             got: {error:?}"
+        );
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::DepositFailed { .. }),
+            "A dropped deposit tx (will never mine) must transition to `DepositFailed` for \
+             operator reconciliation rather than retrying forever; got: {final_state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_deposit_confirmed_is_noop() {
+        let server = MockServer::start();
+        let (_anvil, endpoint, private_key) = setup_anvil();
+
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet).await;
+        let cqrs = create_test_store_instance().await;
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let deposit_tx =
+            fixed_bytes!("0xdddd000000000000000000000000000000000000000000000000000000000002");
+
+        advance_to_deposit_confirmed_alpaca_to_base(&cqrs, &id, amount, deposit_tx).await;
+
+        // Resuming a transfer that already reached the terminal DepositConfirmed
+        // state must be a pure no-op: re-running any side effect (re-deposit,
+        // re-mint) would double-spend. It returns Ok and leaves the aggregate
+        // exactly where it was.
+        manager.resume_alpaca_to_base(&id, amount).await.unwrap();
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::DepositConfirmed { .. }),
+            "resume from terminal DepositConfirmed must remain DepositConfirmed (no-op), \
+             got: {final_state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_attested_does_not_re_emit_receive_attestation() {
+        let server = MockServer::start();
+
+        // Return a `complete` attestation for any /v2/messages request so the
+        // attestation re-poll resolves immediately (same shape as the
+        // Base->Alpaca sibling test).
+        let mut message = vec![0u8; 100];
+        message[43] = 1;
+        let message_hex = format!("0x{}", alloy::hex::encode(&message));
+        let attestation_hex = format!("0x{}", "ab".repeat(65));
+        let _attestation_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/v2/messages/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "messages": [{
+                        "status": "complete",
+                        "message": message_hex,
+                        "attestation": attestation_hex,
+                    }]
+                }));
+        });
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        advance_to_attested_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let staged = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(staged, UsdcRebalance::Attested { .. }),
+            "staging must land at Attested, got {staged:?}",
+        );
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        // The OLD (buggy) behavior routed Attested through
+        // continue_alpaca_to_base_from_bridging -> poll_attestation, re-sending
+        // ReceiveAttestation, which the aggregate rejects from Attested ->
+        // UsdcTransferError::Aggregate(InvalidCommand). The fix routes Attested
+        // through continue_alpaca_to_base_from_attested (no ReceiveAttestation),
+        // so resume gets PAST the Attested gate and fails later at the CCTP
+        // find/mint on the undeployed contract -> Cctp.
+        assert!(
+            !matches!(&error, UsdcTransferError::Aggregate(_)),
+            "resume from Attested must NOT re-emit ReceiveAttestation (the aggregate \
+             rejects it from Attested); got: {error:?}",
+        );
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "resume from Attested should proceed past the gate to the CCTP mint and \
+             fail with a Cctp error; got: {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_bridged_deposit_submission_failure_stays_bridged() {
+        let server = MockServer::start();
+        // No vault is funded on this bare anvil, so the deposit4 submission
+        // fails -- exercising `deposit_to_vault`'s submission-failure path.
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        advance_to_bridged_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let staged = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(staged, UsdcRebalance::Bridged { .. }),
+            "staging must land at Bridged, got {staged:?}",
+        );
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        // A deposit submission failure surfaces the real Vault error. The old
+        // code instead emitted `FailDeposit` from `Bridged` (invalid -> the
+        // aggregate rejects it with `DepositNotInitiated`), masking the cause;
+        // the fix propagates the Vault error directly.
+        assert!(
+            matches!(error, UsdcTransferError::Vault(_)),
+            "a failed deposit submission must surface as a Vault error, got: {error:?}",
+        );
+
+        // Crucially, nothing was deposited, so the aggregate stays in `Bridged`
+        // for a safe retry -- it must NOT advance to `DepositInitiated` (no tx to
+        // confirm) or strand in a terminal failure for a transient error.
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::Bridged { .. }),
+            "a failed deposit submission must leave the aggregate in `Bridged` for safe \
+             retry (no half-recorded deposit), got: {final_state:?}",
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -10,8 +10,9 @@ mod manager;
 pub(crate) mod mock;
 
 pub(crate) use job::{
-    ResumeBaseToAlpaca, TransferUsdcToHedging, TransferUsdcToHedgingCtx,
-    TransferUsdcToHedgingJobQueue,
+    ResumeAlpacaToBase, ResumeBaseToAlpaca, TransferUsdcToHedging, TransferUsdcToHedgingCtx,
+    TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking, TransferUsdcToMarketMakingCtx,
+    TransferUsdcToMarketMakingJobQueue,
 };
 pub(crate) use manager::{CrossVenueCashTransfer, u256_to_usdc};
 
@@ -93,6 +94,13 @@ pub(crate) enum UsdcTransferError {
         id: UsdcRebalanceId,
         withdrawn: alloy::primitives::U256,
         requested: alloy::primitives::U256,
+    },
+    #[error(
+        "USDC rebalance {id} Withdrawing has non-Alpaca withdrawal ref; \
+         AlpacaToBase always records the Alpaca transfer ID"
+    )]
+    WithdrawalRefMustBeAlpacaId {
+        id: crate::usdc_rebalance::UsdcRebalanceId,
     },
 }
 


### PR DESCRIPTION
## What

Closes [RAI-390](https://linear.app/makeitrain/issue/RAI-390/convert-alpaca-to-base-usdc-transfer-to-transferusdctomarketmaking). Adds the Alpaca->Base counterpart to #712's `TransferUsdcToHedging`: a state-resumable `TransferUsdcToMarketMaking` apalis job, and switches `check_and_trigger_usdc` to enqueue both USDC directions via apalis instead of routing through the Rebalancer mpsc channel.

This PR is purely additive. The now-dormant `CrossVenueTransfer` impls on `CrossVenueCashTransfer`, the `Rebalancer` USDC fields, the `TriggeredOperation::UsdcAlpacaToBase`/`UsdcBaseToAlpaca` variants, and the `MockUsdcRebalance` test mock all stay in place. PR #714 removes them in a follow-up.

## Why

A crash mid-transfer in the Alpaca->Base direction used to orphan in-flight capital the same way the Base->Alpaca direction did before #712 (Alpaca withdrawal initiated, USDC sitting in the bot's EOA wallet, no driver to bridge or deposit it). With this PR both directions are driven by persistent apalis jobs that load the `UsdcRebalance` aggregate on retry and resume from the next unfinished phase.

This crash-safe resume covers the post-conversion phases (withdrawal, bridging, deposit). The `Converting` phase is the one exception: the broker order id is not persisted, so a crash after the conversion fills but before `ConfirmConversion` still needs manual reconciliation -- the same residual window accepted for the Base->Alpaca side in #712.

## How

- Extract `resume_alpaca_to_base(id, amount)` on `CrossVenueCashTransfer`, mirroring `resume_base_to_alpaca`. Loads aggregate via `Store::load` and dispatches on the AlpacaToBase-direction state arms.
- Add `TransferUsdcToMarketMaking` apalis job + `ResumeAlpacaToBase` trait + ctx, wired through `RebalancingSchedulers`, `RebalancingService`, `SpawnedRebalancer`, and the conductor builder (worker registration, ctx wiring).
- `check_and_trigger_usdc` now enqueues `TransferUsdcToHedging` for `UsdcBaseToAlpaca` and `TransferUsdcToMarketMaking` for `UsdcAlpacaToBase`. The Rebalancer mpsc path for USDC becomes dead in production.

## Testing

- Job-level: failure clears `usdc_in_progress`, success preserves it, payload `id`/`amount` reach the transfer.
- Resume routing: terminal failure -> `PreviouslyFailedAggregate`; `DepositConfirmed` (AlpacaToBase) -> no-op; `Bridged` -> reaches `DepositConfirmed` without re-burn.
- Trigger and integration tests updated: `check_and_trigger_usdc` now enqueues to the apalis queue. Tests assert on the queue rather than the mpsc receiver.

## Anything else

The Rebalancer still has the dead USDC routing branches and `TriggeredOperation::UsdcAlpacaToBase`/`UsdcBaseToAlpaca` are still produced by `check_imbalance_and_build_operation`. #714 removes the now-unused code and switches `check_imbalance_and_build_operation` to a dedicated `UsdcRebalanceOperation` enum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Alpaca→Base (market-making) USDC transfer jobs with dedicated enqueue/worker path.

* **Improvements**
  * USDC rebalancing now enqueues and tracks transfer work persistently for both directions.
  * Enhanced resume/recovery and clearer error handling for USDC transfer flows.

* **Tests**
  * Integration tests updated to assert outcomes via persisted job records rather than internal channels.

* **Chores**
  * Onchain mock and raindex confirmation behavior updated to better simulate deposit/withdraw scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
