### PR TITLE
test: chaos harness scaffold + failing RPC empty-getLogs e2e 

### DIFF
--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -1,0 +1,74 @@
+//! WebSocket-level chaos proxy for the e2e Anvil provider.
+//!
+//! Sits between the bot's `ws_rpc_url` and the real Anvil node. Forwards
+//! JSON-RPC traffic by default; when configured, returns empty
+//! `eth_getLogs` results that model load-balancer inconsistency where
+//! one node in the upstream pool is behind on indexing.
+//!
+//! Used by the chaos test suite to validate the bot's recovery paths
+//! against adversarial RPC behaviour without modifying the production
+//! code paths. Additional behaviours (drop, error, stall) land
+//! alongside the chaos sub-issues that need them.
+
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use url::Url;
+
+/// Active behaviour the chaos proxy applies to JSON-RPC requests
+/// matching [`ChaosConfig::method`].
+#[derive(Debug, Clone)]
+pub(crate) enum ChaosBehaviour {
+    /// Reply with `{"result": []}` regardless of what the upstream would
+    /// have returned. Models load-balancer inconsistency where one node
+    /// in the pool is behind and answers `eth_getLogs` with no events.
+    EmptyResult,
+}
+
+/// Knob describing which method to perturb and for how many calls.
+///
+/// Fields are wired by [`ChaosProxy::empty_get_logs`] but not yet read --
+/// the proxy implementation that consumes them lands in the next upstack
+/// PR per TTDD types-first sequencing.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) struct ChaosConfig {
+    pub method: String,
+    pub behaviour: ChaosBehaviour,
+    pub remaining: usize,
+}
+
+/// Spawned proxy. Holds the listening port and a handle the test can use
+/// to mutate the active [`ChaosConfig`] mid-run.
+#[derive(Debug)]
+pub(crate) struct ChaosProxy {
+    /// `ws://127.0.0.1:<port>` the bot should connect to instead of the
+    /// real Anvil endpoint.
+    pub endpoint: Url,
+    /// Shared mutable config; `None` means transparent forwarding.
+    config: Arc<Mutex<Option<ChaosConfig>>>,
+}
+
+impl ChaosProxy {
+    /// Spawn a chaos proxy in front of `upstream_ws` and start listening
+    /// on a free local port. The proxy keeps running until the returned
+    /// handle is dropped (the listener task ends with its parent).
+    pub(crate) async fn start(_upstream_ws: Url) -> anyhow::Result<Self> {
+        // No-op await so the stub still satisfies `clippy::unused_async`
+        // until the implementation PR lands real async work here.
+        tokio::task::yield_now().await;
+        todo!(
+            "chaos proxy: bind a tokio TcpListener on 127.0.0.1:0, accept connections, upgrade to WebSocket via tokio-tungstenite, open a parallel WS connection to upstream_ws, and forward frames in both directions while applying the active ChaosConfig to matching JSON-RPC requests"
+        )
+    }
+
+    /// Convenience: reply to the next `count` `eth_getLogs` calls with
+    /// an empty `result`, modelling a load-balancer node that is
+    /// behind on indexing.
+    pub(crate) async fn empty_get_logs(&self, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour: ChaosBehaviour::EmptyResult,
+            remaining: count,
+        });
+    }
+}

--- a/tests/e2e/chaos_rpc/mod.rs
+++ b/tests/e2e/chaos_rpc/mod.rs
@@ -1,0 +1,113 @@
+//! Chaos tests for RPC fault tolerance.
+//!
+//! These tests wire the bot's onchain provider through a [`ChaosProxy`]
+//! so the test harness can inject transient RPC failures (dropped
+//! responses, 5xx errors, empty `eth_getLogs` results modelling a
+//! load-balancer that routed to a lagging node) and assert the bot's
+//! recovery logic delivers the correct end state without losing or
+//! duplicating events.
+
+use std::time::Duration;
+
+use st0x_float_macro::float;
+
+use crate::chaos::ChaosProxy;
+use crate::hedging::assertions::*;
+use crate::poll::{poll_for_events_with_timeout, spawn_bot};
+
+/// Top-level hypothesis: a SellEquity onchain trade observed
+/// only in the bot's initial `eth_getLogs` backfill window still produces
+/// `OffchainOrderEvent::Filled` even when the first batch of backfill
+/// responses come back empty -- the load-balancer-inconsistency case.
+///
+/// Scenario: the take fires *before* the bot is up. When the bot starts,
+/// its initial backfill from `deployment_block` to chain head is the
+/// only thing that can surface the take -- the WS subscription only
+/// delivers events that happen after the subscribe handshake. The
+/// chaos proxy is armed to return empty `eth_getLogs` results for the
+/// next batches, modelling a load-balancer node that has not finished
+/// indexing the block range covering the take. On master, backfill
+/// trusts the empty response, advances its checkpoint past the
+/// take's block, and `OffchainOrderEvent::Filled` is never reached --
+/// the test times out at `poll_for_events_with_timeout`. The upstack
+/// implementation must add a read-after-write tip check (or equivalent
+/// reconciliation) so the empty response is detected as unauthoritative
+/// and retried.
+#[test_log::test(tokio::test)]
+#[ignore = "un-ignored and made to pass by the immediate upstack #716 (feat/chaos-ws-proxy-impl)"]
+async fn transient_empty_get_logs_during_backfill_does_not_drop_events() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.ws_endpoint()?).await?;
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    // Take the order BEFORE the bot starts. The WS subscribe path will
+    // not deliver this event (it predates the subscription), so the bot
+    // must catch it via `eth_getLogs` backfill -- exactly the path the
+    // chaos proxy targets.
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // Arm the proxy to nuke the next batch of `eth_getLogs` responses
+    // before the bot can run its initial backfill. The bot's first two
+    // `eth_getLogs` calls (one for ClearV3, one for TakeOrderV3) cover
+    // the deployment_block..head range, so 4 empty responses cover the
+    // initial sync plus a paranoid retry margin.
+    chaos.empty_get_logs(4).await;
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .ws_rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -35,6 +35,10 @@ pub(crate) fn build_ctx<P: Provider + Clone>(
     deployment_block: u64,
     assets: AssetsConfig,
     execution_threshold_override: Option<st0x_hedge::ExecutionThreshold>,
+    /// Override the WebSocket RPC URL the bot connects to. Default is
+    /// `chain.ws_endpoint()`. Used by chaos tests to route the bot
+    /// through a fault-injecting proxy.
+    ws_rpc_url_override: Option<url::Url>,
 ) -> anyhow::Result<Ctx> {
     let broker_ctx = BrokerCtx::AlpacaBrokerApi(AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -46,9 +50,14 @@ pub(crate) fn build_ctx<P: Provider + Clone>(
         counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
     });
 
+    let ws_rpc_url = match ws_rpc_url_override {
+        Some(url) => url,
+        None => chain.ws_endpoint()?,
+    };
+
     Ctx::for_test()
         .database_url(db_path.display().to_string())
-        .ws_rpc_url(chain.ws_endpoint()?)
+        .ws_rpc_url(ws_rpc_url)
         .orderbook(chain.orderbook)
         .deployment_block(deployment_block)
         .broker(broker_ctx)

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -12,6 +12,8 @@
 mod assert;
 mod base_chain;
 mod cctp;
+mod chaos;
+mod chaos_rpc;
 mod full_system;
 mod hedging;
 mod poll;


### PR DESCRIPTION
[RAI-75](https://linear.app/makeitrain/issue/RAI-75/chaos-adversarial-external-behavior-in-e2e-harness) (harness foundation) + [RAI-420](https://linear.app/makeitrain/issue/RAI-420/chaos-transient-rpc-failure-injection) (load-balancer-inconsistency scenario).

## Failing test, on purpose

Per [docs/ttdd.md](https://github.com/ST0x-Technology/st0x.liquidity/blob/master/docs/ttdd.md), the test goes in first. This PR alone is **expected to fail CI**: it lands the harness API surface (`ChaosProxy`, `ChaosConfig`, `ChaosBehaviour::EmptyResult`) and the failing-test scaffolding, but `ChaosProxy::start` is `todo!()`. The test panics in setup, not in the system-behavior assertion, so the next upstack PR turns it green by:

1. Implementing the chaos WebSocket proxy.
2. Adding the bot-side recovery logic that the proxy's empty `eth_getLogs` responses currently expose as a missing-events bug.

The stack is: this PR (test + types) -> proxy implementation PR -> recovery-logic PR. Each upstack PR turns red->green for a different reason and the test surface stays the same.

## What

- `tests/e2e/chaos.rs`: `ChaosProxy` + `ChaosConfig` + `ChaosBehaviour` public API. Only the `EmptyResult` behaviour is exposed here -- additional variants (drop, error, stall) land alongside the chaos sub-issues that need them.
- `tests/e2e/chaos_rpc/mod.rs`: `transient_empty_get_logs_during_backfill_does_not_drop_events`. Models RAI-420's load-balancer inconsistency case: spawns the bot through the proxy, fires a SellEquity take, configures the next three `eth_getLogs` responses to come back empty, and asserts the bot still reaches `OffchainOrderEvent::Filled`.
- `tests/e2e/hedging/assertions.rs`: `build_ctx` grows a `ws_rpc_url_override` parameter so chaos tests can route the bot through the proxy without forking the builder.
- `tests/e2e/main.rs`: wires the two new modules.

## Why

RAI-75 calls out that the e2e layer assumes external services always behave correctly. RAI-420 specifically wants validation of load-balancer inconsistency, where one node in the upstream pool is behind on indexing and answers `eth_getLogs` with no events while the chain has actually advanced. The bot's backfill checkpoint must not silently advance past blocks it never inspected.

## How

The chaos proxy is a WebSocket-level man-in-the-middle in front of Anvil. `ChaosProxy::start(upstream_ws)` binds a free local port; the test then passes `chaos.endpoint` as `ws_rpc_url_override` so the bot's `eth_subscribe` and `eth_getLogs` traffic both flow through the proxy. The shared `Arc<Mutex<Option<ChaosConfig>>>` lets the test mutate the active behaviour mid-run. Concrete behaviours are method-scoped (`eth_getLogs` only, for this PR).

The current `todo!()` in `start()` documents the exact shape of the proxy work that the next PR will fill in.

## Testing

`cargo check --workspace --all-features --all-targets` clean.

CI's e2e job is expected to fail this test on this branch alone -- the proxy panics in setup. Once the proxy implementation lands upstack, the panic moves to the `OffchainOrderEvent::Filled` poll (the actual hypothesis); once the recovery logic lands, the test passes.

## Anything else

Stacked on #712 to share the test infra updates and avoid colliding with #714. Subsequent chaos sub-issues (RAI-421 Alpaca, RAI-422 latency, RAI-428 partial network) reuse this proxy shape with additional behaviour variants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end chaos proxy scaffold to simulate and inject RPC response perturbations.
  * New E2E test ensures transient empty RPC responses during initial backfill do not drop events and validates the full hedging/onchain flow.
  * Test context builder accepts an optional RPC URL override for flexible test endpoints.
  * Registered new E2E test modules to include these scenarios in the harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->