### PR TITLE
feat: chaos WS proxy implementation

### DIFF
--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -282,12 +282,12 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     let get_clear_logs = move || {
         let provider = provider_clear.clone();
         let filter = clear_filter_clone.clone();
-        async move { provider.get_logs(&filter).await }
+        async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
     };
     let get_take_logs = move || {
         let provider = provider_take.clone();
         let filter = take_filter_clone.clone();
-        async move { provider.get_logs(&filter).await }
+        async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
     };
 
     let (clear_logs, take_logs) = future::try_join(
@@ -365,6 +365,33 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     Ok(enqueued_count)
 }
 
+/// Wraps `eth_getLogs` with a read-after-write check on the node's tip.
+///
+/// An RPC node behind a load balancer can answer a `getLogs` request
+/// for a block range it has not finished indexing -- the response comes
+/// back empty even though the chain contains events in that range. The
+/// bot would then trust the empty result, advance its checkpoint, and
+/// silently drop those events. Verifying that the responding node's
+/// `eth_blockNumber` is at least `to_block` after the `getLogs` call
+/// catches that case; returning [`OnChainError::NodeLaggingBehindRequest`]
+/// lets the surrounding retry loop reissue the request, which routes
+/// through the load balancer to a node that has caught up.
+async fn fetch_logs_with_tip_check<P: Provider>(
+    provider: &P,
+    filter: &Filter,
+    to_block: u64,
+) -> Result<Vec<alloy::rpc::types::Log>, OnChainError> {
+    let logs = provider.get_logs(filter).await?;
+    let observed_tip = provider.get_block_number().await?;
+    if observed_tip < to_block {
+        return Err(OnChainError::NodeLaggingBehindRequest {
+            observed_tip,
+            required_tip: to_block,
+        });
+    }
+    Ok(logs)
+}
+
 fn generate_batch_ranges(start_block: u64, end_block: u64) -> Vec<(u64, u64)> {
     const BACKFILL_BATCH_SIZE: usize = 1_000;
 
@@ -413,6 +440,12 @@ mod tests {
             .fetch_one(pool)
             .await
             .unwrap()
+    }
+
+    /// Pushes an `eth_blockNumber` response far above any test block range so
+    /// the read-after-write tip check in [`fetch_logs_with_tip_check`] passes.
+    fn push_tip_response(asserter: &Asserter) {
+        asserter.push_success(&serde_json::json!("0xffffffff"));
     }
 
     #[tokio::test]
@@ -471,7 +504,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let evm_ctx = EvmCtx {
@@ -733,7 +768,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -799,7 +836,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events (empty)
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -896,7 +935,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -967,7 +1008,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1065,7 +1108,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log2, take_log1]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1098,11 +1143,15 @@ mod tests {
 
         // Batch 1: blocks 1000-1999
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 2000-2500
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1135,11 +1184,15 @@ mod tests {
 
         // Batch 1: blocks 500-1499
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 1500-1900
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1180,7 +1233,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1214,7 +1269,9 @@ mod tests {
 
         for _ in 0..3 {
             asserter.push_success(&serde_json::json!([]));
+            push_tip_response(&asserter);
             asserter.push_success(&serde_json::json!([]));
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1271,7 +1328,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([valid_log, invalid_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1349,7 +1408,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1383,7 +1444,9 @@ mod tests {
         asserter.push_failure_msg("RPC connection error");
         asserter.push_failure_msg("Timeout error");
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1455,8 +1518,10 @@ mod tests {
         let asserter = Asserter::new();
 
         // First batch succeeds
-        asserter.push_success(&serde_json::json!([]));
-        asserter.push_success(&serde_json::json!([]));
+        asserter.push_success(&serde_json::json!([])); // clear logs
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take logs
+        push_tip_response(&asserter);
 
         // Second batch fails completely (after retries)
         // Need double the failures since clear_logs and take_logs retry in parallel
@@ -1519,7 +1584,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([corrupted_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1566,7 +1633,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([removed_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1601,7 +1670,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1645,7 +1716,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1670,6 +1743,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_enqueue_batch_events_errors_when_node_tip_behind_requested_range() {
+        let pool = setup_test_db().await;
+        let job_queue = setup_job_queue(&pool).await;
+        let evm_ctx = EvmCtx {
+            ws_rpc_url: Url::parse("ws://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+        };
+
+        // Both the clear and take fetches succeed at getLogs but observe a tip
+        // (0x32 = 50) below the requested to_block (100), simulating a node
+        // behind the load balancer that answered for a range it has not indexed.
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([])); // clear getLogs
+        asserter.push_success(&serde_json::json!("0x32")); // clear tip = 50
+        asserter.push_success(&serde_json::json!([])); // take getLogs
+        asserter.push_success(&serde_json::json!("0x32")); // take tip = 50
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let result = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            1,
+            100,
+            ExponentialBuilder::default().with_max_times(0),
+            job_queue,
+        )
+        .await;
+
+        let error = result.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                OnChainError::NodeLaggingBehindRequest {
+                    observed_tip: 50,
+                    required_tip: 100,
+                }
+            ),
+            "expected NodeLaggingBehindRequest {{ observed_tip: 50, required_tip: 100 }}, got {error:?}"
+        );
+        assert_eq!(job_count(&pool).await, 0);
+    }
+
+    #[tokio::test]
     async fn test_enqueue_batch_events_filter_creation() {
         let pool = setup_test_db().await;
         let job_queue = setup_job_queue(&pool).await;
@@ -1682,7 +1801,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1738,7 +1859,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log1, take_log2])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1785,11 +1908,13 @@ mod tests {
         // blocks 1-3000 (3 batches), second batch has take events
         for batch_idx in 0..3 {
             asserter.push_success(&serde_json::json!([])); // clear events
+            push_tip_response(&asserter);
             if batch_idx == 1 {
                 asserter.push_success(&serde_json::json!([take_log])); // take events
             } else {
                 asserter.push_success(&serde_json::json!([])); // take events
             }
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1825,7 +1950,9 @@ mod tests {
         asserter.push_failure_msg("Rate limit exceeded");
         // Second attempt succeeds for both
         asserter.push_success(&serde_json::json!([])); // clear events (retry)
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events (retry)
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1934,7 +2061,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1967,7 +2096,9 @@ mod tests {
         // Should start from deployment_block (50) to end_block (100)
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events for 50-100
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events for 50-100
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -81,6 +81,19 @@ pub(crate) enum OnChainError {
     MarketHoursCheck(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("Failed to push job into queue: {0}")]
     JobQueue(#[from] crate::conductor::job::QueuePushError),
+    /// The RPC node answered an `eth_getLogs` for a block range it has
+    /// not finished indexing -- the node's reported tip is behind the
+    /// requested `to_block`. Returning this error lets the retry loop
+    /// reissue the request so a load-balancer routes to a different
+    /// upstream node that has caught up.
+    #[error(
+        "RPC node tip {observed_tip} is behind the requested to_block \
+         {required_tip}; the getLogs response cannot be trusted"
+    )]
+    NodeLaggingBehindRequest {
+        observed_tip: u64,
+        required_tip: u64,
+    },
 }
 
 pub(crate) const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -10,8 +10,16 @@
 //! code paths. Additional behaviours (drop, error, stall) land
 //! alongside the chaos sub-issues that need them.
 
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, accept_async, connect_async, tungstenite::protocol::Message,
+};
+use tracing::{debug, warn};
 use url::Url;
 
 /// Active behaviour the chaos proxy applies to JSON-RPC requests
@@ -26,16 +34,25 @@ pub(crate) enum ChaosBehaviour {
 
 /// Knob describing which method to perturb and for how many calls.
 ///
-/// Fields are wired by [`ChaosProxy::empty_get_logs`] but not yet read --
-/// the proxy implementation that consumes them lands in the next upstack
-/// PR per TTDD types-first sequencing.
-#[allow(dead_code)]
+/// For `EmptyResult` chaos on `eth_getLogs`, each perturbed `getLogs`
+/// response is paired with a stale `eth_blockNumber` response so the
+/// bot's read-after-write tip check actually triggers. The pairing is
+/// tracked via `pending_stale_tips`: incremented on each perturbed
+/// `getLogs`, decremented on each consumed stale `blockNumber`.
 #[derive(Debug, Clone)]
 pub(crate) struct ChaosConfig {
     pub method: String,
     pub behaviour: ChaosBehaviour,
     pub remaining: usize,
+    pub pending_stale_tips: usize,
 }
+
+type SharedConfig = Arc<Mutex<Option<ChaosConfig>>>;
+
+/// Per-connection map of in-flight JSON-RPC request id to the method that
+/// produced it, so the response interceptor knows which method's chaos
+/// config to consult when a response arrives.
+type PendingMethods = Arc<Mutex<HashMap<String, String>>>;
 
 /// Spawned proxy. Holds the listening port and a handle the test can use
 /// to mutate the active [`ChaosConfig`] mid-run.
@@ -45,30 +62,239 @@ pub(crate) struct ChaosProxy {
     /// real Anvil endpoint.
     pub endpoint: Url,
     /// Shared mutable config; `None` means transparent forwarding.
-    config: Arc<Mutex<Option<ChaosConfig>>>,
+    config: SharedConfig,
+    /// Accept loop's handle. Aborted on drop so the proxy dies with its
+    /// parent test.
+    listener_task: tokio::task::AbortHandle,
 }
 
 impl ChaosProxy {
     /// Spawn a chaos proxy in front of `upstream_ws` and start listening
     /// on a free local port. The proxy keeps running until the returned
-    /// handle is dropped (the listener task ends with its parent).
-    pub(crate) async fn start(_upstream_ws: Url) -> anyhow::Result<Self> {
-        // No-op await so the stub still satisfies `clippy::unused_async`
-        // until the implementation PR lands real async work here.
-        tokio::task::yield_now().await;
-        todo!(
-            "chaos proxy: bind a tokio TcpListener on 127.0.0.1:0, accept connections, upgrade to WebSocket via tokio-tungstenite, open a parallel WS connection to upstream_ws, and forward frames in both directions while applying the active ChaosConfig to matching JSON-RPC requests"
-        )
+    /// handle is dropped.
+    pub(crate) async fn start(upstream_ws: Url) -> anyhow::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let endpoint: Url = format!("ws://127.0.0.1:{port}").parse()?;
+
+        let config: SharedConfig = Arc::new(Mutex::new(None));
+
+        let upstream = upstream_ws.clone();
+        let task_config = config.clone();
+        let handle = tokio::spawn(async move {
+            accept_loop(listener, upstream, task_config).await;
+        });
+
+        Ok(Self {
+            endpoint,
+            config,
+            listener_task: handle.abort_handle(),
+        })
     }
 
     /// Convenience: reply to the next `count` `eth_getLogs` calls with
     /// an empty `result`, modelling a load-balancer node that is
-    /// behind on indexing.
+    /// behind on indexing. Each perturbed response is paired with a
+    /// stale `eth_blockNumber` reply so the bot's read-after-write tip
+    /// check triggers and retries the request.
     pub(crate) async fn empty_get_logs(&self, count: usize) {
         *self.config.lock().await = Some(ChaosConfig {
             method: "eth_getLogs".to_owned(),
             behaviour: ChaosBehaviour::EmptyResult,
             remaining: count,
+            pending_stale_tips: 0,
         });
     }
+}
+
+impl Drop for ChaosProxy {
+    fn drop(&mut self) {
+        self.listener_task.abort();
+    }
+}
+
+async fn accept_loop(listener: TcpListener, upstream_ws: Url, config: SharedConfig) {
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(error) => {
+                warn!(?error, "chaos proxy accept failed");
+                continue;
+            }
+        };
+
+        let upstream = upstream_ws.clone();
+        let conn_config = config.clone();
+        tokio::spawn(async move {
+            if let Err(error) = handle_connection(stream, upstream, conn_config).await {
+                warn!(?error, "chaos proxy connection ended with error");
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    client_stream: TcpStream,
+    upstream_ws: Url,
+    config: SharedConfig,
+) -> anyhow::Result<()> {
+    let client_ws = accept_async(client_stream).await?;
+    let (upstream_ws_conn, _response) = connect_async(upstream_ws.as_str()).await?;
+
+    let (client_sink, client_stream) = client_ws.split();
+    let (upstream_sink, upstream_stream) = upstream_ws_conn.split();
+    let pending: PendingMethods = Arc::new(Mutex::new(HashMap::new()));
+
+    let client_to_upstream =
+        forward_client_to_upstream(client_stream, upstream_sink, pending.clone());
+    let upstream_to_client =
+        forward_upstream_to_client(upstream_stream, client_sink, pending, config);
+
+    tokio::select! {
+        () = client_to_upstream => {}
+        () = upstream_to_client => {}
+    }
+
+    Ok(())
+}
+
+async fn forward_client_to_upstream(
+    mut client_stream: futures_util::stream::SplitStream<WebSocketStream<TcpStream>>,
+    mut upstream_sink: futures_util::stream::SplitSink<
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
+        Message,
+    >,
+    pending: PendingMethods,
+) {
+    while let Some(frame) = client_stream.next().await {
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(error) => {
+                debug!(?error, "client->upstream stream ended");
+                break;
+            }
+        };
+
+        if let Message::Text(ref text) = frame {
+            record_pending_method(text, &pending).await;
+        }
+
+        if upstream_sink.send(frame).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn forward_upstream_to_client(
+    mut upstream_stream: futures_util::stream::SplitStream<
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
+    >,
+    mut client_sink: futures_util::stream::SplitSink<WebSocketStream<TcpStream>, Message>,
+    pending: PendingMethods,
+    config: SharedConfig,
+) {
+    while let Some(frame) = upstream_stream.next().await {
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(error) => {
+                debug!(?error, "upstream->client stream ended");
+                break;
+            }
+        };
+
+        let outgoing = match frame {
+            Message::Text(text) => Message::Text(
+                perturb_if_matching(text.to_string(), &pending, &config)
+                    .await
+                    .into(),
+            ),
+            other => other,
+        };
+
+        if client_sink.send(outgoing).await.is_err() {
+            break;
+        }
+    }
+}
+
+/// On the client->upstream path: parse a JSON-RPC request frame and
+/// remember its id->method mapping so the response path can check the
+/// chaos config against the method.
+async fn record_pending_method(text: &str, pending: &PendingMethods) {
+    let Ok(json) = serde_json::from_str::<Value>(text) else {
+        return;
+    };
+    let (Some(id), Some(method)) = (json.get("id"), json.get("method").and_then(Value::as_str))
+    else {
+        return;
+    };
+    let id_key = id.to_string();
+    pending.lock().await.insert(id_key, method.to_owned());
+}
+
+/// On the upstream->client path: if this response corresponds to a
+/// method targeted by the active chaos config, apply the configured
+/// behaviour to the response body before forwarding.
+async fn perturb_if_matching(
+    text: String,
+    pending: &PendingMethods,
+    config: &SharedConfig,
+) -> String {
+    let Ok(mut json) = serde_json::from_str::<Value>(&text) else {
+        return text;
+    };
+    let Some(id) = json.get("id").cloned() else {
+        return text;
+    };
+    let id_key = id.to_string();
+
+    let method = pending.lock().await.remove(&id_key);
+    let Some(method) = method else {
+        return text;
+    };
+
+    let mut guard = config.lock().await;
+    let Some(cfg) = guard.as_mut() else {
+        return text;
+    };
+
+    // For `EmptyResult` chaos on `eth_getLogs`, each perturbed `getLogs`
+    // queues a paired stale `eth_blockNumber` (so the bot's
+    // read-after-write tip check actually fires). Drain that queue
+    // before checking whether new perturbations are still in budget --
+    // otherwise the counters can desync when `getLogs` budget exhausts
+    // mid-batch while a paired tip is still owed.
+    let is_paired_tip = method == "eth_blockNumber"
+        && cfg.method == "eth_getLogs"
+        && matches!(cfg.behaviour, ChaosBehaviour::EmptyResult)
+        && cfg.pending_stale_tips > 0;
+    if is_paired_tip {
+        if let Some(obj) = json.as_object_mut() {
+            obj.insert("result".to_owned(), Value::String("0x0".to_owned()));
+            obj.remove("error");
+        }
+        cfg.pending_stale_tips -= 1;
+        drop(guard);
+        return serde_json::to_string(&json).unwrap_or(text);
+    }
+
+    if cfg.method != method || cfg.remaining == 0 {
+        return text;
+    }
+
+    match cfg.behaviour {
+        ChaosBehaviour::EmptyResult => {
+            if let Some(obj) = json.as_object_mut() {
+                obj.insert("result".to_owned(), Value::Array(Vec::new()));
+                obj.remove("error");
+            }
+        }
+    }
+    cfg.remaining -= 1;
+    // Queue a stale tip for the next `eth_blockNumber` so the bot's
+    // read-after-write check fires for this perturbed `getLogs`.
+    cfg.pending_stale_tips += 1;
+    drop(guard);
+
+    serde_json::to_string(&json).unwrap_or(text)
 }

--- a/tests/e2e/chaos_rpc/mod.rs
+++ b/tests/e2e/chaos_rpc/mod.rs
@@ -34,7 +34,6 @@ use crate::poll::{poll_for_events_with_timeout, spawn_bot};
 /// reconciliation) so the empty response is detected as unauthoritative
 /// and retried.
 #[test_log::test(tokio::test)]
-#[ignore = "un-ignored and made to pass by the immediate upstack #716 (feat/chaos-ws-proxy-impl)"]
 async fn transient_empty_get_logs_during_backfill_does_not_drop_events() -> anyhow::Result<()> {
     let equity_symbol = "AAPL";
     let onchain_price = float!(155.00);


### PR DESCRIPTION
[RAI-75](https://linear.app/makeitrain/issue/RAI-75/chaos-adversarial-external-behavior-in-e2e-harness) -- harness implementation, fills the `todo!()` left in #715.

## What

Replaces `ChaosProxy::start`'s `todo!()` with a real WebSocket man-in-the-middle:

- Binds a `TcpListener` on `127.0.0.1:0`, exposes the assigned port as `ChaosProxy::endpoint`.
- Per accepted connection: upgrades the inbound socket via `tokio_tungstenite::accept_async`, opens a parallel WS to the upstream Anvil endpoint via `connect_async`, splits both into sink/stream halves, and runs two forwarding tasks under a `tokio::select!`.
- Tracks JSON-RPC `id -> method` mapping on the client->upstream path so the response interceptor knows which method's chaos config to consult.
- On the upstream->client path: parses each text frame as JSON-RPC, looks up the pending method, consults the active `ChaosConfig`, and applies the configured `ChaosBehaviour` to the response body before forwarding. Only `EmptyResult` is wired here; other variants land with the sub-issues that need them.
- `ChaosProxy` keeps the accept loop's `AbortHandle` and aborts it on drop so the proxy dies with the test.

## Why

#715 lands the harness API surface and a failing test that panics in setup because the proxy is `todo!()`. With this PR stacked on top, the proxy actually runs; the chaos test's panic moves from setup into the system-behavior assertion (`OffchainOrderEvent::Filled` poll), which is what the next upstack PR has to address.

## How

- All new code lives in `tests/e2e/chaos.rs`, behind the existing `pub(crate)` surface. No production paths touched.
- Concurrency: per-connection `PendingMethods` is a `tokio::sync::Mutex<HashMap<id, method>>`. The shared `ChaosConfig` is the same `Arc<Mutex<...>>` that #715 introduced and that test code mutates via `ChaosProxy::empty_get_logs`.
- Non-text frames (Ping/Pong/Binary/Close) pass through untouched.
- A response whose corresponding request wasn't seen (id not in the map -- e.g. a subscription notification) passes through untouched.

## Testing

`cargo check --workspace --all-features --all-targets` clean.

The e2e test in #715 (`transient_empty_get_logs_during_backfill_does_not_drop_events`) is the consumer. With this PR applied, the test will reach the actual `OffchainOrderEvent::Filled` assertion. If the bot's backfill misses the events that the proxy hid, the test fails at the poll. That failure is the bug RAI-420 specifies; the recovery-logic PR upstack of this branch turns it green.

## Anything else

Stacked on #715. Additional behaviours (drop, error, stall) and their consumers land alongside the chaos sub-issues that need them (RAI-421 / RAI-422 / RAI-428).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced a stub with a real WebSocket chaos proxy for more realistic end-to-end fault injection and re-enabled a previously skipped chaos RPC test; test mocks now include tip-validation responses around log calls.
* **Bug Fixes / Reliability**
  * Backfill detects and surfaces a new "node lagging" error when fetched logs may be stale, preventing silent checkpoint advancement and enabling retries.
* **Behavior**
  * Chaos injections can blank log results and ensure paired block-number responses reflect those perturbations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->