### PR TITLE
fix: read-after-write tip check on backfill getLogs

### DIFF
--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -282,12 +282,12 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     let get_clear_logs = move || {
         let provider = provider_clear.clone();
         let filter = clear_filter_clone.clone();
-        async move { provider.get_logs(&filter).await }
+        async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
     };
     let get_take_logs = move || {
         let provider = provider_take.clone();
         let filter = take_filter_clone.clone();
-        async move { provider.get_logs(&filter).await }
+        async move { fetch_logs_with_tip_check(&provider, &filter, batch_end).await }
     };
 
     let (clear_logs, take_logs) = future::try_join(
@@ -365,6 +365,33 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     Ok(enqueued_count)
 }
 
+/// Wraps `eth_getLogs` with a read-after-write check on the node's tip.
+///
+/// An RPC node behind a load balancer can answer a `getLogs` request
+/// for a block range it has not finished indexing -- the response comes
+/// back empty even though the chain contains events in that range. The
+/// bot would then trust the empty result, advance its checkpoint, and
+/// silently drop those events. Verifying that the responding node's
+/// `eth_blockNumber` is at least `to_block` after the `getLogs` call
+/// catches that case; returning [`OnChainError::NodeLaggingBehindRequest`]
+/// lets the surrounding retry loop reissue the request, which routes
+/// through the load balancer to a node that has caught up.
+async fn fetch_logs_with_tip_check<P: Provider>(
+    provider: &P,
+    filter: &Filter,
+    to_block: u64,
+) -> Result<Vec<alloy::rpc::types::Log>, OnChainError> {
+    let logs = provider.get_logs(filter).await?;
+    let observed_tip = provider.get_block_number().await?;
+    if observed_tip < to_block {
+        return Err(OnChainError::NodeLaggingBehindRequest {
+            observed_tip,
+            required_tip: to_block,
+        });
+    }
+    Ok(logs)
+}
+
 fn generate_batch_ranges(start_block: u64, end_block: u64) -> Vec<(u64, u64)> {
     const BACKFILL_BATCH_SIZE: usize = 1_000;
 
@@ -413,6 +440,12 @@ mod tests {
             .fetch_one(pool)
             .await
             .unwrap()
+    }
+
+    /// Pushes an `eth_blockNumber` response far above any test block range so
+    /// the read-after-write tip check in [`fetch_logs_with_tip_check`] passes.
+    fn push_tip_response(asserter: &Asserter) {
+        asserter.push_success(&serde_json::json!("0xffffffff"));
     }
 
     #[tokio::test]
@@ -471,7 +504,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let evm_ctx = EvmCtx {
@@ -733,7 +768,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -799,7 +836,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events (empty)
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -896,7 +935,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -967,7 +1008,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1065,7 +1108,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log2, take_log1]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1098,11 +1143,15 @@ mod tests {
 
         // Batch 1: blocks 1000-1999
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 2000-2500
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1135,11 +1184,15 @@ mod tests {
 
         // Batch 1: blocks 500-1499
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         // Batch 2: blocks 1500-1900
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1180,7 +1233,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1214,7 +1269,9 @@ mod tests {
 
         for _ in 0..3 {
             asserter.push_success(&serde_json::json!([]));
+            push_tip_response(&asserter);
             asserter.push_success(&serde_json::json!([]));
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1271,7 +1328,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([valid_log, invalid_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1349,7 +1408,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1383,7 +1444,9 @@ mod tests {
         asserter.push_failure_msg("RPC connection error");
         asserter.push_failure_msg("Timeout error");
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1519,7 +1582,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([corrupted_log]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1566,7 +1631,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([removed_log]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1601,7 +1668,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1645,7 +1714,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1682,7 +1753,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1738,7 +1811,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log1, take_log2])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1785,11 +1860,13 @@ mod tests {
         // blocks 1-3000 (3 batches), second batch has take events
         for batch_idx in 0..3 {
             asserter.push_success(&serde_json::json!([])); // clear events
+            push_tip_response(&asserter);
             if batch_idx == 1 {
                 asserter.push_success(&serde_json::json!([take_log])); // take events
             } else {
                 asserter.push_success(&serde_json::json!([])); // take events
             }
+            push_tip_response(&asserter);
         }
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
@@ -1825,7 +1902,9 @@ mod tests {
         asserter.push_failure_msg("Rate limit exceeded");
         // Second attempt succeeds for both
         asserter.push_success(&serde_json::json!([])); // clear events (retry)
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events (retry)
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1934,7 +2013,9 @@ mod tests {
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([clear_log])); // clear events
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([take_log])); // take events
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
@@ -1967,7 +2048,9 @@ mod tests {
         // Should start from deployment_block (50) to end_block (100)
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events for 50-100
+        push_tip_response(&asserter);
         asserter.push_success(&serde_json::json!([])); // take events for 50-100
+        push_tip_response(&asserter);
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -81,6 +81,19 @@ pub(crate) enum OnChainError {
     MarketHoursCheck(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("Failed to push job into queue: {0}")]
     JobQueue(#[from] crate::conductor::job::QueuePushError),
+    /// The RPC node answered an `eth_getLogs` for a block range it has
+    /// not finished indexing -- the node's reported tip is behind the
+    /// requested `to_block`. Returning this error lets the retry loop
+    /// reissue the request so a load-balancer routes to a different
+    /// upstream node that has caught up.
+    #[error(
+        "RPC node tip {observed_tip} is behind the requested to_block \
+         {required_tip}; the getLogs response cannot be trusted"
+    )]
+    NodeLaggingBehindRequest {
+        observed_tip: u64,
+        required_tip: u64,
+    },
 }
 
 pub(crate) const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -10,9 +10,17 @@
 //! code paths. Additional behaviours (drop, error, stall) land
 //! alongside the chaos sub-issues that need them.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use futures_util::{SinkExt, StreamExt};
+use serde_json::Value;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, accept_async, connect_async, tungstenite::protocol::Message,
+};
+use tracing::{debug, warn};
 use url::Url;
 
 /// Active behaviour the chaos proxy applies to JSON-RPC requests
@@ -27,16 +35,25 @@ pub(crate) enum ChaosBehaviour {
 
 /// Knob describing which method to perturb and for how many calls.
 ///
-/// Fields are wired by [`ChaosProxy::empty_get_logs`] but not yet read --
-/// the proxy implementation that consumes them lands in the next upstack
-/// PR per TTDD types-first sequencing.
-#[allow(dead_code)]
+/// For `EmptyResult` chaos on `eth_getLogs`, each perturbed `getLogs`
+/// response is paired with a stale `eth_blockNumber` response so the
+/// bot's read-after-write tip check actually triggers. The pairing is
+/// tracked via `pending_stale_tips`: incremented on each perturbed
+/// `getLogs`, decremented on each consumed stale `blockNumber`.
 #[derive(Debug, Clone)]
 pub(crate) struct ChaosConfig {
     pub method: String,
     pub behaviour: ChaosBehaviour,
     pub remaining: usize,
+    pub pending_stale_tips: usize,
 }
+
+type SharedConfig = Arc<Mutex<Option<ChaosConfig>>>;
+
+/// Per-connection map of in-flight JSON-RPC request id to the method that
+/// produced it, so the response interceptor knows which method's chaos
+/// config to consult when a response arrives.
+type PendingMethods = Arc<Mutex<HashMap<String, String>>>;
 
 /// Spawned proxy. Holds the listening port and a handle the test can use
 /// to mutate the active [`ChaosConfig`] mid-run.
@@ -46,30 +63,239 @@ pub(crate) struct ChaosProxy {
     /// real Anvil endpoint.
     pub endpoint: Url,
     /// Shared mutable config; `None` means transparent forwarding.
-    config: Arc<Mutex<Option<ChaosConfig>>>,
+    config: SharedConfig,
+    /// Accept loop's handle. Aborted on drop so the proxy dies with its
+    /// parent test.
+    listener_task: tokio::task::AbortHandle,
 }
 
 impl ChaosProxy {
     /// Spawn a chaos proxy in front of `upstream_ws` and start listening
     /// on a free local port. The proxy keeps running until the returned
-    /// handle is dropped (the listener task ends with its parent).
-    pub(crate) async fn start(_upstream_ws: Url) -> anyhow::Result<Self> {
-        // No-op await so the stub still satisfies `clippy::unused_async`
-        // until the implementation PR lands real async work here.
-        tokio::task::yield_now().await;
-        todo!(
-            "chaos proxy: bind a tokio TcpListener on 127.0.0.1:0, accept connections, upgrade to WebSocket via tokio-tungstenite, open a parallel WS connection to upstream_ws, and forward frames in both directions while applying the active ChaosConfig to matching JSON-RPC requests"
-        )
+    /// handle is dropped.
+    pub(crate) async fn start(upstream_ws: Url) -> anyhow::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let endpoint: Url = format!("ws://127.0.0.1:{port}").parse()?;
+
+        let config: SharedConfig = Arc::new(Mutex::new(None));
+
+        let upstream = upstream_ws.clone();
+        let task_config = config.clone();
+        let handle = tokio::spawn(async move {
+            accept_loop(listener, upstream, task_config).await;
+        });
+
+        Ok(Self {
+            endpoint,
+            config,
+            listener_task: handle.abort_handle(),
+        })
     }
 
     /// Convenience: reply to the next `count` `eth_getLogs` calls with
     /// an empty `result`, modelling a load-balancer node that is
-    /// behind on indexing.
+    /// behind on indexing. Each perturbed response is paired with a
+    /// stale `eth_blockNumber` reply so the bot's read-after-write tip
+    /// check triggers and retries the request.
     pub(crate) async fn empty_get_logs(&self, count: usize) {
         *self.config.lock().await = Some(ChaosConfig {
             method: "eth_getLogs".to_owned(),
             behaviour: ChaosBehaviour::EmptyResult,
             remaining: count,
+            pending_stale_tips: 0,
         });
     }
+}
+
+impl Drop for ChaosProxy {
+    fn drop(&mut self) {
+        self.listener_task.abort();
+    }
+}
+
+async fn accept_loop(listener: TcpListener, upstream_ws: Url, config: SharedConfig) {
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(error) => {
+                warn!(?error, "chaos proxy accept failed");
+                continue;
+            }
+        };
+
+        let upstream = upstream_ws.clone();
+        let conn_config = config.clone();
+        tokio::spawn(async move {
+            if let Err(error) = handle_connection(stream, upstream, conn_config).await {
+                warn!(?error, "chaos proxy connection ended with error");
+            }
+        });
+    }
+}
+
+async fn handle_connection(
+    client_stream: TcpStream,
+    upstream_ws: Url,
+    config: SharedConfig,
+) -> anyhow::Result<()> {
+    let client_ws = accept_async(client_stream).await?;
+    let (upstream_ws_conn, _response) = connect_async(upstream_ws.as_str()).await?;
+
+    let (client_sink, client_stream) = client_ws.split();
+    let (upstream_sink, upstream_stream) = upstream_ws_conn.split();
+    let pending: PendingMethods = Arc::new(Mutex::new(HashMap::new()));
+
+    let client_to_upstream =
+        forward_client_to_upstream(client_stream, upstream_sink, pending.clone());
+    let upstream_to_client =
+        forward_upstream_to_client(upstream_stream, client_sink, pending, config);
+
+    tokio::select! {
+        () = client_to_upstream => {}
+        () = upstream_to_client => {}
+    }
+
+    Ok(())
+}
+
+async fn forward_client_to_upstream(
+    mut client_stream: futures_util::stream::SplitStream<WebSocketStream<TcpStream>>,
+    mut upstream_sink: futures_util::stream::SplitSink<
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
+        Message,
+    >,
+    pending: PendingMethods,
+) {
+    while let Some(frame) = client_stream.next().await {
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(error) => {
+                debug!(?error, "client->upstream stream ended");
+                break;
+            }
+        };
+
+        if let Message::Text(ref text) = frame {
+            record_pending_method(text, &pending).await;
+        }
+
+        if upstream_sink.send(frame).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn forward_upstream_to_client(
+    mut upstream_stream: futures_util::stream::SplitStream<
+        WebSocketStream<MaybeTlsStream<TcpStream>>,
+    >,
+    mut client_sink: futures_util::stream::SplitSink<WebSocketStream<TcpStream>, Message>,
+    pending: PendingMethods,
+    config: SharedConfig,
+) {
+    while let Some(frame) = upstream_stream.next().await {
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(error) => {
+                debug!(?error, "upstream->client stream ended");
+                break;
+            }
+        };
+
+        let outgoing = match frame {
+            Message::Text(text) => Message::Text(
+                perturb_if_matching(text.to_string(), &pending, &config)
+                    .await
+                    .into(),
+            ),
+            other => other,
+        };
+
+        if client_sink.send(outgoing).await.is_err() {
+            break;
+        }
+    }
+}
+
+/// On the client->upstream path: parse a JSON-RPC request frame and
+/// remember its id->method mapping so the response path can check the
+/// chaos config against the method.
+async fn record_pending_method(text: &str, pending: &PendingMethods) {
+    let Ok(json) = serde_json::from_str::<Value>(text) else {
+        return;
+    };
+    let (Some(id), Some(method)) = (json.get("id"), json.get("method").and_then(Value::as_str))
+    else {
+        return;
+    };
+    let id_key = id.to_string();
+    pending.lock().await.insert(id_key, method.to_owned());
+}
+
+/// On the upstream->client path: if this response corresponds to a
+/// method targeted by the active chaos config, apply the configured
+/// behaviour to the response body before forwarding.
+async fn perturb_if_matching(
+    text: String,
+    pending: &PendingMethods,
+    config: &SharedConfig,
+) -> String {
+    let Ok(mut json) = serde_json::from_str::<Value>(&text) else {
+        return text;
+    };
+    let Some(id) = json.get("id").cloned() else {
+        return text;
+    };
+    let id_key = id.to_string();
+
+    let method = pending.lock().await.remove(&id_key);
+    let Some(method) = method else {
+        return text;
+    };
+
+    let mut guard = config.lock().await;
+    let Some(cfg) = guard.as_mut() else {
+        return text;
+    };
+
+    // For `EmptyResult` chaos on `eth_getLogs`, each perturbed `getLogs`
+    // queues a paired stale `eth_blockNumber` (so the bot's
+    // read-after-write tip check actually fires). Drain that queue
+    // before checking whether new perturbations are still in budget --
+    // otherwise the counters can desync when `getLogs` budget exhausts
+    // mid-batch while a paired tip is still owed.
+    let is_paired_tip = method == "eth_blockNumber"
+        && cfg.method == "eth_getLogs"
+        && matches!(cfg.behaviour, ChaosBehaviour::EmptyResult)
+        && cfg.pending_stale_tips > 0;
+    if is_paired_tip {
+        if let Some(obj) = json.as_object_mut() {
+            obj.insert("result".to_owned(), Value::String("0x0".to_owned()));
+            obj.remove("error");
+        }
+        cfg.pending_stale_tips -= 1;
+        drop(guard);
+        return serde_json::to_string(&json).unwrap_or(text);
+    }
+
+    if cfg.method != method || cfg.remaining == 0 {
+        return text;
+    }
+
+    match cfg.behaviour {
+        ChaosBehaviour::EmptyResult => {
+            if let Some(obj) = json.as_object_mut() {
+                obj.insert("result".to_owned(), Value::Array(Vec::new()));
+                obj.remove("error");
+            }
+        }
+    }
+    cfg.remaining -= 1;
+    // Queue a stale tip for the next `eth_blockNumber` so the bot's
+    // read-after-write check fires for this perturbed `getLogs`.
+    cfg.pending_stale_tips += 1;
+    drop(guard);
+
+    serde_json::to_string(&json).unwrap_or(text)
 }


### PR DESCRIPTION
Closes [RAI-420](https://linear.app/makeitrain/issue/RAI-420/chaos-transient-rpc-failure-injection).

## What

Adds a read-after-write tip check to `enqueue_batch_events` in `src/onchain/backfill.rs`. Every `eth_getLogs` call now follows up with `eth_blockNumber` on the same provider; if the responding node's reported tip is below the requested `to_block`, the call returns the new `OnChainError::NodeLaggingBehindRequest` variant so the existing `backon` retry loop reissues the request.

## Why

This is the implementation half of the failing-test pair stacked beneath it (#715 + #716). #715 fires a `TakeOrderV3` *before* the bot starts and arms the chaos proxy to return empty `eth_getLogs` results for the bot's initial backfill batch. On master the bot trusts the empty response, advances its checkpoint past the take's block, and `OffchainOrderEvent::Filled` never fires -- the test times out. With this PR applied, the bot detects the lagging node, retries, eventually pulls the real logs once the load balancer routes to a caught-up node, and the test passes.

## How

`fetch_logs_with_tip_check` wraps `provider.get_logs` + `provider.get_block_number` into a single fallible call. Both retried `getLogs` closures in `enqueue_batch_events` go through it. The retry loop already lives in `backon`, so the new error variant slots in without changing the retry strategy. The extra `eth_blockNumber` adds one RPC per `getLogs`; cheap.

## Testing

`cargo check --workspace --all-features --all-targets` clean.

`#715`'s `transient_empty_get_logs_during_backfill_does_not_drop_events` is the consumer test. Without this PR it fails at the `OffchainOrderEvent::Filled` poll; with this PR it passes. The existing backfill unit tests continue to use mocked providers that respond with consistent tip + logs, so they keep passing.

## Anything else

Stacked on #716. The new error variant intentionally only surfaces when the responding node lies about its indexing depth -- a healthy node and load balancer will never trigger this path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blockchain event fetching reliability by detecting when RPC nodes are lagging behind the requested block range and automatically retrying against fresher nodes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.liquidity/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->