### PR TITLE
feat: Alpaca placement idempotency via client_order_id + chaos test for transient 5xx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6867,6 +6867,7 @@ dependencies = [
  "rain-error-decoding",
  "rain-math-float",
  "rand 0.8.6",
+ "regex",
  "reqwest 0.12.28",
  "rsa",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,7 @@ bon.workspace = true
 httpmock.workspace = true
 proptest.workspace = true
 rain-math-float.workspace = true
+regex = "1.12.3"
 rsa.workspace = true
 serial_test.workspace = true
 st0x-bridge = { workspace = true, features = ["mock"] }

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -167,6 +167,35 @@ impl AlpacaBrokerApiClient {
         self.get(&url).await
     }
 
+    /// Get an order by its `client_order_id`. Returns `None` if Alpaca has no
+    /// such order (404) -- i.e. it was never recorded. Used to reconcile a
+    /// placement that the broker rejected as a duplicate `client_order_id`
+    /// (it already accepted the original attempt, whose response was lost).
+    pub(super) async fn get_order_by_client_order_id(
+        &self,
+        client_order_id: &ClientOrderId,
+    ) -> Result<Option<OrderResponse>, AlpacaBrokerApiError> {
+        let url = format!(
+            "{}/v1/trading/accounts/{}/orders:by_client_order_id?client_order_id={}",
+            self.base_url, self.account_id, client_order_id
+        );
+
+        debug!(
+            "Fetching order by client_order_id {} from {}",
+            client_order_id, url
+        );
+
+        match self.get::<OrderResponse>(&url).await {
+            Ok(order) => Ok(Some(order)),
+            Err(AlpacaBrokerApiError::ApiError { status, .. })
+                if status == reqwest::StatusCode::NOT_FOUND =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Get asset information by symbol
     pub(super) async fn get_asset(
         &self,

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -386,8 +386,8 @@ mod tests {
     };
     use crate::alpaca_broker_api::order::AlpacaLimitPrice;
     use crate::{
-        CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason, Direction,
-        FractionalShares, Positive, Usd,
+        ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
+        Direction, FractionalShares, Positive, Usd,
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
@@ -737,6 +737,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
                 direction: Direction::Buy,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -781,6 +782,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: Positive::new(FractionalShares::new(float!(2))).unwrap(),
                 direction: Direction::Buy,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -878,6 +880,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let result = executor.place_market_order(order).await;
@@ -912,6 +915,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let result = executor.place_market_order(order).await;
@@ -946,6 +950,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let result = executor.place_market_order(order).await;
@@ -1004,6 +1009,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
         executor.place_market_order(order1).await.unwrap();
 
@@ -1015,6 +1021,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
         executor.place_market_order(order2).await.unwrap();
 
@@ -1080,6 +1087,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
         executor.place_market_order(order1).await.unwrap();
 
@@ -1094,6 +1102,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
         executor.place_market_order(order2).await.unwrap();
 

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -102,6 +102,7 @@ struct MockOrder {
     status: OrderStatus,
     poll_count: usize,
     filled_price: Option<Float>,
+    client_order_id: Option<String>,
 }
 
 /// A single calendar entry controlling market open/close times.
@@ -144,6 +145,13 @@ struct MockState {
     wallet_balances: HashMap<String, Float>,
     /// Whitelisted withdrawal addresses.
     whitelisted_addresses: Vec<WhitelistEntry>,
+    /// Number of upcoming `place_order` requests that should be answered
+    /// with a 5xx *after* the order has already been recorded in
+    /// [`MockState::orders`]. Models the adversarial case where the
+    /// broker processes the request but the response is lost in flight:
+    /// any caller-side retry creates a second order even though one
+    /// already exists. Decrements per request until zero.
+    transient_placement_failures_remaining: usize,
 }
 
 /// Status of a whitelisted address.
@@ -305,6 +313,7 @@ impl AlpacaBrokerMock {
             alpaca_deposit_address: String::new(),
             wallet_balances: HashMap::new(),
             whitelisted_addresses: Vec::new(),
+            transient_placement_failures_remaining: 0,
         }));
 
         let server = MockServer::start_async().await;
@@ -336,6 +345,16 @@ impl AlpacaBrokerMock {
     /// Changes the mock mode for subsequent requests.
     pub fn set_mode(&self, mode: MockMode) {
         lock(&self.state).mode = mode;
+    }
+
+    /// Arms the mock to answer the next `count` `place_order` requests
+    /// with a 5xx *after* the order has already been recorded in the
+    /// mock's internal state. Models adversarial broker behaviour where
+    /// the request reaches the upstream and is processed but the
+    /// response is lost in flight; any caller-side retry creates a
+    /// second order with the same intent.
+    pub fn set_transient_placement_failures(&self, count: usize) {
+        lock(&self.state).transient_placement_failures_remaining = count;
     }
 
     /// Sets a per-symbol fill delay: the order stays "new" for
@@ -694,6 +713,7 @@ fn register_endpoints(server: &MockServer, state: &Arc<Mutex<MockState>>) {
     register_latest_trade_endpoint(server, state);
     register_asset_endpoint(server);
     register_order_placement_endpoint(server, state);
+    register_order_by_client_order_id_endpoint(server, state);
     register_order_status_endpoint(server, state);
 }
 
@@ -907,6 +927,7 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                     );
                 }
             };
+            let client_order_id = body["client_order_id"].as_str().map(str::to_owned);
             let order_id = Uuid::new_v4().to_string();
 
             let mut state = lock(&state);
@@ -919,6 +940,25 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                 return handle_crypto_order(&mut state, &order_id, &symbol, quantity, side);
             }
 
+            // Real Alpaca rejects a re-used `client_order_id` on an active order
+            // with a 422 ("client_order_id must be unique") rather than deduping
+            // to a 2xx. Mirror that so the executor's recovery path -- look the
+            // order up by client_order_id and adopt it -- is exercised
+            // end-to-end instead of being papered over by a mock-only 200.
+            if let Some(client_id) = client_order_id.as_deref() {
+                let already_recorded = state
+                    .orders
+                    .values()
+                    .any(|order| order.client_order_id.as_deref() == Some(client_id));
+                if already_recorded {
+                    drop(state);
+                    return json_response(
+                        422,
+                        &json!({"message": "client_order_id must be unique"}),
+                    );
+                }
+            }
+
             state.orders.insert(
                 order_id.clone(),
                 MockOrder {
@@ -928,8 +968,19 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                     status: OrderStatus::New,
                     poll_count: 0,
                     filled_price: None,
+                    client_order_id: client_order_id.clone(),
                 },
             );
+
+            if state.transient_placement_failures_remaining > 0 {
+                state.transient_placement_failures_remaining -= 1;
+                drop(state);
+                return json_response(
+                    503,
+                    &json!({"message": "transient upstream failure (chaos)"}),
+                );
+            }
+
             drop(state);
             json_response(
                 200,
@@ -940,6 +991,7 @@ fn register_order_placement_endpoint(server: &MockServer, state: &Arc<Mutex<Mock
                     "side": side.to_string(),
                     "status": "new",
                     "filled_avg_price": null,
+                    "client_order_id": client_order_id,
                 }),
             )
         });
@@ -1068,6 +1120,7 @@ fn handle_crypto_order(
             status: OrderStatus::Filled,
             poll_count: 0,
             filled_price: Some(fill_price),
+            client_order_id: None,
         },
     );
 
@@ -1083,6 +1136,49 @@ fn handle_crypto_order(
             "created_at": "2025-01-06T12:00:00Z"
         })
     })
+}
+
+fn register_order_by_client_order_id_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>) {
+    let state = Arc::clone(state);
+    let path = format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders:by_client_order_id");
+
+    server.mock(|when, then| {
+        when.method(GET).path(path.clone());
+        then.respond_with(move |request: &HttpMockRequest| {
+            let Some(client_order_id) = request.uri().query().and_then(|query| {
+                query
+                    .split('&')
+                    .find_map(|pair| pair.strip_prefix("client_order_id=").map(str::to_owned))
+            }) else {
+                return json_response(
+                    400,
+                    &json!({"message": "missing client_order_id query param"}),
+                );
+            };
+
+            let found = lock(&state).orders.iter().find_map(|(id, order)| {
+                (order.client_order_id.as_deref() == Some(client_order_id.as_str())).then(|| {
+                    json!({
+                        "id": id,
+                        "symbol": order.symbol.to_string(),
+                        "qty": format_float_with_fallback(&order.quantity),
+                        "side": order.side.to_string(),
+                        "status": order.status.to_string(),
+                        "filled_avg_price": order
+                            .filled_price
+                            .as_ref()
+                            .map(format_float_with_fallback),
+                        "client_order_id": client_order_id,
+                    })
+                })
+            });
+
+            found.map_or_else(
+                || json_response(404, &json!({"message": "order not found"})),
+                |payload| json_response(200, &payload),
+            )
+        });
+    });
 }
 
 fn register_order_status_endpoint(server: &MockServer, state: &Arc<Mutex<MockState>>) {
@@ -1695,6 +1791,7 @@ mod tests {
             alpaca_deposit_address: format!("{:#x}", Address::ZERO),
             wallet_balances: HashMap::new(),
             whitelisted_addresses: vec![],
+            transient_placement_failures_remaining: 0,
         };
 
         let response = handle_crypto_order(
@@ -1739,6 +1836,7 @@ mod tests {
             alpaca_deposit_address: format!("{:#x}", Address::ZERO),
             wallet_balances: HashMap::from([("USDC".to_string(), float!(20))]),
             whitelisted_addresses: vec![],
+            transient_placement_failures_remaining: 0,
         };
 
         let response = handle_crypto_order(
@@ -1790,6 +1888,7 @@ mod tests {
             alpaca_deposit_address: format!("{:#x}", Address::ZERO),
             wallet_balances: HashMap::new(),
             whitelisted_addresses: vec![],
+            transient_placement_failures_remaining: 0,
         };
 
         let response = handle_crypto_order(

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::alpaca_market_data::AlpacaMarketDataError;
-use crate::{CounterTradeCostError, FractionalShares, Positive, Symbol, Usd};
+use crate::{ClientOrderId, CounterTradeCostError, FractionalShares, Positive, Symbol, Usd};
 
 /// Time-in-force specifies how long an order remains active before it expires.
 ///
@@ -149,6 +149,13 @@ pub enum AlpacaBrokerApiError {
         order_id: Uuid,
         reason: CryptoOrderFailureReason,
     },
+
+    #[error(
+        "Broker rejected client_order_id {client_order_id} as a duplicate (422) but no \
+         order with that id was found on lookup; broker state is inconsistent and the \
+         placement must be retried"
+    )]
+    DuplicateOrderNotFound { client_order_id: ClientOrderId },
 
     #[error("Internal error: calendar was non-empty but iteration returned None")]
     CalendarIterationInvariantViolation,

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -120,6 +120,7 @@ pub(super) struct OrderRequest {
     pub order_type: &'static str,
     pub time_in_force: &'static str,
     pub extended_hours: bool,
+    pub client_order_id: ClientOrderId,
 }
 
 /// Order request for placing limit orders.
@@ -344,17 +345,83 @@ pub(super) async fn place_market_order(
         time_in_force: time_in_force.as_api_str(),
         // Alpaca only allows extended_hours=true for limit orders, not market orders
         extended_hours: false,
+        client_order_id: market_order.client_order_id.clone(),
     };
 
-    let response = client.place_order(&request).await?;
+    // Alpaca rejects a re-used `client_order_id` on an active order with a 422
+    // ("client_order_id must be unique"), not a duplicate-tolerant 2xx. That is
+    // not a real failure: it means a prior attempt's 2xx response was lost after
+    // the broker already recorded the order. Reconcile by adopting the order the
+    // broker actually accepted (looked up by `client_order_id`), so the retry is
+    // idempotent instead of failing and leaving the position un-hedged. The
+    // adopted order's quantity is the broker's recorded intent, which may differ
+    // from this attempt's recomputed `placed_shares`; any residual is picked up
+    // by the next position scan.
+    let (order_id, shares) = match client.place_order(&request).await {
+        Ok(response) => (response.id, placed_shares),
+        Err(error) if is_duplicate_client_order_id(&error) => {
+            debug!(
+                client_order_id = %market_order.client_order_id,
+                "Broker rejected duplicate client_order_id; reconciling the order it already accepted"
+            );
+            let existing = client
+                .get_order_by_client_order_id(&market_order.client_order_id)
+                .await?
+                .ok_or_else(|| AlpacaBrokerApiError::DuplicateOrderNotFound {
+                    client_order_id: market_order.client_order_id.clone(),
+                })?;
+            (existing.id, existing.quantity)
+        }
+        Err(error) => return Err(error),
+    };
 
     Ok(OrderPlacement {
-        order_id: response.id.to_string(),
+        order_id: order_id.to_string(),
         symbol: market_order.symbol,
-        shares: placed_shares,
+        shares,
         direction: market_order.direction,
         placed_at: Utc::now(),
     })
+}
+
+/// Alpaca returns a 422 with "client_order_id must be unique" when a placement
+/// re-uses a `client_order_id` already attached to an active order. This is the
+/// recoverable duplicate-submission case (the original 2xx was lost in flight),
+/// distinct from other 422s such as insufficient buying power or invalid order.
+fn is_duplicate_client_order_id(error: &AlpacaBrokerApiError) -> bool {
+    use AlpacaBrokerApiError::*;
+
+    match error {
+        ApiError {
+            status, message, ..
+        } => {
+            *status == reqwest::StatusCode::UNPROCESSABLE_ENTITY
+                && message.contains("client_order_id must be unique")
+        }
+        HttpClient(_)
+        | JsonParse(_)
+        | InvalidHeader(_)
+        | InvalidOrderId(_)
+        | IncompleteFilledOrder { .. }
+        | AccountNotActive { .. }
+        | CryptoOrderFailed { .. }
+        | DuplicateOrderNotFound { .. }
+        | CalendarIterationInvariantViolation
+        | AssetNotActive { .. }
+        | AssetNotTradable { .. }
+        | InvalidLimitPricePrecision { .. }
+        | UsdBalanceConversion(_)
+        | FractionalCents(_)
+        | InvalidSymbol(_)
+        | MissingPositionQuantity
+        | BelowPrecision { .. }
+        | UsdcBelowPrecision { .. }
+        | UsdcPrecisionExceeded { .. }
+        | NotPositive(_)
+        | FloatConversion(_)
+        | LatestTrade(_)
+        | CounterTradeCost(_) => false,
+    }
 }
 
 pub(super) async fn place_limit_order(
@@ -589,6 +656,7 @@ mod tests {
     use uuid::uuid;
 
     use super::*;
+    use crate::ClientOrderId;
     use crate::alpaca_broker_api::auth::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
     };
@@ -681,7 +749,8 @@ mod tests {
                     "side": "buy",
                     "type": "market",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "33333333-3333-4333-8333-333333333333"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -700,6 +769,9 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "33333333-3333-4333-8333-333333333333"
+            )),
         };
 
         let placement = place_market_order(&client, market_order, TimeInForce::Day)
@@ -727,7 +799,8 @@ mod tests {
                     "side": "sell",
                     "type": "market",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "44444444-4444-4444-8444-444444444444"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -746,6 +819,9 @@ mod tests {
             symbol: Symbol::new("TSLA").unwrap(),
             shares: Positive::new(FractionalShares::new(float!(50))).unwrap(),
             direction: Direction::Sell,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "44444444-4444-4444-8444-444444444444"
+            )),
         };
 
         let placement = place_market_order(&client, market_order, TimeInForce::Day)
@@ -757,6 +833,155 @@ mod tests {
         assert_eq!(placement.symbol.to_string(), "TSLA");
         assert_eq!(placement.shares.inner(), FractionalShares::new(float!(50)));
         assert_eq!(placement.direction, Direction::Sell);
+    }
+
+    #[tokio::test]
+    async fn place_market_order_reconciles_duplicate_client_order_id() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("66666666-6666-4666-8666-666666666666");
+        let client_order_id = client_order_uuid.to_string();
+        let existing_order_id = "904837e3-3b76-47ec-b432-046db621571b";
+
+        // The broker rejects the re-used client_order_id with a 422 because it
+        // already recorded the original attempt (whose 2xx was lost in flight).
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        // We reconcile by adopting the order the broker actually accepted.
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(
+                    "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+                )
+                .query_param("client_order_id", client_order_id.as_str());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": existing_order_id,
+                    "symbol": "AAPL",
+                    "qty": "7",
+                    "side": "buy",
+                    "status": "new",
+                    "filled_avg_price": null
+                }));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let market_order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            // This attempt's recomputed intent is 10 shares, but the broker
+            // already holds the original 7-share order under this key.
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let placement = place_market_order(&client, market_order, TimeInForce::Day)
+            .await
+            .unwrap();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        // Adopts the broker's recorded order id and its recorded quantity (7),
+        // not this attempt's recomputed 10 shares -- the residual is left for
+        // the next position scan to hedge.
+        assert_eq!(placement.order_id, existing_order_id);
+        assert_eq!(placement.shares.inner(), FractionalShares::new(float!(7)));
+        assert_eq!(placement.direction, Direction::Buy);
+    }
+
+    #[tokio::test]
+    async fn place_market_order_errors_when_duplicate_order_not_found() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+        let client_order_uuid = uuid!("77777777-7777-4777-8777-777777777777");
+
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "client_order_id must be unique"}));
+        });
+
+        // The broker reported a duplicate but the lookup finds nothing -- an
+        // inconsistent state that must surface as an error so the job retries.
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET).path(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id",
+            );
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({"code": 40_410_000_u64, "message": "order not found"}));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let market_order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(client_order_uuid),
+        };
+
+        let error = place_market_order(&client, market_order, TimeInForce::Day)
+            .await
+            .unwrap_err();
+
+        place_mock.assert();
+        lookup_mock.assert();
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::DuplicateOrderNotFound { ref client_order_id }
+                    if client_order_id == &ClientOrderId::from_uuid(client_order_uuid)
+            ),
+            "expected DuplicateOrderNotFound, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn place_market_order_propagates_non_duplicate_422() {
+        let server = MockServer::start();
+        let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
+
+        // A 422 that is NOT the duplicate-key case must propagate unchanged and
+        // must not trigger the by-client-order-id reconciliation lookup.
+        let place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders");
+            then.status(422)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "insufficient buying power"}));
+        });
+
+        let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
+        let market_order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "88888888-8888-4888-8888-888888888888"
+            )),
+        };
+
+        let error = place_market_order(&client, market_order, TimeInForce::Day)
+            .await
+            .unwrap_err();
+
+        place_mock.assert();
+        assert!(
+            matches!(
+                error,
+                AlpacaBrokerApiError::ApiError { status, .. } if status.as_u16() == 422
+            ),
+            "expected a propagated 422 ApiError, got {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -1215,7 +1440,8 @@ mod tests {
                     "side": "sell",
                     "type": "market",
                     "time_in_force": "day",
-                    "extended_hours": false
+                    "extended_hours": false,
+                    "client_order_id": "55555555-5555-4555-8555-555555555555"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1237,6 +1463,9 @@ mod tests {
             symbol: Symbol::new("RKLB").unwrap(),
             shares: Positive::new(FractionalShares::new(onchain_shares)).unwrap(),
             direction: Direction::Sell,
+            client_order_id: ClientOrderId::from_uuid(uuid!(
+                "55555555-5555-4555-8555-555555555555"
+            )),
         };
 
         let placement = place_market_order(&client, market_order, TimeInForce::Day)
@@ -1267,6 +1496,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: Positive::new(FractionalShares::new(tiny)).unwrap(),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let err = place_market_order(&client, market_order, TimeInForce::Day)

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -582,6 +582,7 @@ impl Display for ExecutorOrderId {
 mod tests {
     use alloy::primitives::U256;
     use std::str::FromStr;
+    use uuid::Uuid;
 
     use super::*;
 
@@ -907,6 +908,7 @@ mod tests {
             ))
             .unwrap(),
             direction: Direction::Sell,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         }
     }
 

--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -254,8 +254,10 @@ impl TryIntoExecutor for MockExecutorCtx {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use super::*;
-    use crate::{Direction, FractionalShares, Positive, Symbol};
+    use crate::{ClientOrderId, Direction, FractionalShares, Positive, Symbol};
 
     fn shares(value: &str) -> FractionalShares {
         FractionalShares::new(Float::parse(value.to_string()).unwrap())
@@ -293,6 +295,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: positive_shares("10"),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         let placement = executor.place_market_order(order).await.unwrap();
@@ -310,6 +313,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             shares: positive_shares("10"),
             direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         };
 
         assert!(matches!(
@@ -424,6 +428,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: positive_shares("2"),
                 direction: Direction::Sell,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -456,6 +461,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: positive_shares("20"),
                 direction: Direction::Sell,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -493,6 +499,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: positive_shares("5"),
                 direction: Direction::Sell,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -523,6 +530,7 @@ mod tests {
                 symbol: Symbol::new("AAPL").unwrap(),
                 shares: positive_shares("2"),
                 direction: Direction::Buy,
+                client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .unwrap();
@@ -546,6 +554,7 @@ mod tests {
                     symbol: Symbol::new("AAPL").unwrap(),
                     shares: positive_shares("2"),
                     direction: Direction::Buy,
+                    client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 })
                 .await
                 .unwrap_err(),

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -126,6 +126,11 @@ pub struct MarketOrder {
     pub symbol: Symbol,
     pub shares: Positive<FractionalShares>,
     pub direction: Direction,
+    /// Forwarded to the broker so that retries of a logically identical
+    /// placement (e.g. apalis re-running a job after a transient 5xx whose
+    /// response was lost in flight) are deduped by the broker rather than
+    /// submitting a second order.
+    pub client_order_id: ClientOrderId,
 }
 
 #[cfg(test)]

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -9,13 +9,15 @@ use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
 use tracing::{error, info};
+use uuid::Uuid;
 
 use st0x_event_sorcery::{Store, StoreBuilder};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::alpaca_broker_api::{AlpacaLimitOrder, AlpacaLimitPrice};
 use st0x_execution::{
-    Direction, Executor, ExecutorOrderId, FractionalShares, MarketOrder, MockExecutor,
-    MockExecutorCtx, OrderPlacement, OrderState, Positive, Symbol, TimeInForce, TryIntoExecutor,
+    ClientOrderId, Direction, Executor, ExecutorOrderId, FractionalShares, MarketOrder,
+    MockExecutor, MockExecutorCtx, OrderPlacement, OrderState, Positive, Symbol, TimeInForce,
+    TryIntoExecutor,
 };
 
 use crate::offchain::order::{
@@ -264,6 +266,10 @@ async fn execute_market_order<W: Write>(
         symbol: request.symbol.clone(),
         shares: request.shares,
         direction: request.direction,
+        // Manual CLI placement; generate a fresh idempotency key so an
+        // operator-issued retry cannot accidentally dedupe against an
+        // unrelated earlier placement.
+        client_order_id: ClientOrderId::cli(Uuid::new_v4()),
     };
 
     execute_broker_order(ctx, pool, market_order, time_in_force, stdout).await
@@ -520,6 +526,19 @@ pub(super) async fn process_found_trade<W: Write>(
         error!(%offchain_order_id, symbol = %params.symbol, "Failed to execute Position::PlaceOffChainOrder: {error}");
     }
 
+    // Reuse a prior failed attempt's stashed OffchainOrderId as the broker-side
+    // idempotency anchor (mirroring the automated `execute_create_offchain_order`
+    // path) so a CLI retry after a transient broker failure dedupes instead of
+    // placing a second order. Fall back to this attempt's id when there is none.
+    let anchor = match position_store.load(&params.symbol).await {
+        Ok(position) => position.and_then(|position| position.last_failed_offchain_order_id),
+        Err(error) => {
+            error!(%offchain_order_id, symbol = %params.symbol, %error, "Failed to load position for the idempotency anchor; placing under a fresh key");
+            None
+        }
+    };
+    let client_order_id_source = anchor.unwrap_or(offchain_order_id);
+
     if let Err(error) = offchain_order_store
         .send(
             &offchain_order_id,
@@ -528,6 +547,7 @@ pub(super) async fn process_found_trade<W: Write>(
                 shares: params.shares,
                 direction: params.direction,
                 executor: params.executor,
+                client_order_id: ClientOrderId::from_uuid(client_order_id_source.as_uuid()),
             },
         )
         .await
@@ -640,6 +660,7 @@ fn display_trade_details<W: Write>(
 mod tests {
     use alloy::primitives::{Address, address};
     use httpmock::MockServer;
+    use regex::Regex;
     use serde_json::json;
     use url::Url;
     use uuid::uuid;
@@ -789,17 +810,32 @@ mod tests {
                 }));
         });
 
+        // The broker-side `client_order_id` is a fresh UUID per CLI invocation,
+        // so its exact value cannot be pinned. Assert the value is a well-formed
+        // CLI idempotency key (`cli-{uuid}`) so a placement can never be issued
+        // with a missing or malformed key (the chaos tests use the broker mock,
+        // not this httpmock, so they do not cover it); `json_body_includes`
+        // covers the static fields.
+        let client_order_id_pattern = Regex::new(
+            r#""client_order_id":"cli-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""#,
+        )
+        .unwrap();
+
         let order_mock = server.mock(|when, then| {
             when.method(httpmock::Method::POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
-                .json_body(json!({
-                    "symbol": symbol,
-                    "qty": quantity,
-                    "side": side,
-                    "type": "market",
-                    "time_in_force": "day",
-                    "extended_hours": false
-                }));
+                .body_matches(client_order_id_pattern.clone())
+                .json_body_includes(
+                    json!({
+                        "symbol": symbol,
+                        "qty": quantity,
+                        "side": side,
+                        "type": "market",
+                        "time_in_force": "day",
+                        "extended_hours": false
+                    })
+                    .to_string(),
+                );
             then.status(200)
                 .header("content-type", "application/json")
                 .json_body(json!({

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -30,8 +30,8 @@ use st0x_event_sorcery::{
 };
 use st0x_evm::Wallet;
 use st0x_execution::{
-    CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason, ExecutionError,
-    Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
+    ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
+    ExecutionError, Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
 };
 
 use crate::alpaca_wallet::AlpacaWalletService;
@@ -1661,10 +1661,14 @@ async fn preflight_counter_trade_submission<E: Executor>(
 where
     TradeAccountingError: From<E::Error>,
 {
+    // Preflight does not submit; the client_order_id is irrelevant for the
+    // check but the type requires it. Use a fresh value so callers cannot
+    // accidentally reuse it as a real placement key.
     let order = MarketOrder {
         symbol: execution.symbol.clone(),
         shares: execution.shares,
         direction: execution.direction,
+        client_order_id: ClientOrderId::from_uuid(uuid::Uuid::new_v4()),
     };
 
     match executor.preflight_counter_trade(order).await? {
@@ -1689,6 +1693,10 @@ async fn place_offchain_order(
     execution: &ExecutionCtx,
     cqrs: &TradeProcessingCqrs,
 ) -> Result<Option<OffchainOrderId>, TradeAccountingError> {
+    // Always mint a fresh OffchainOrderId for the new aggregate — the
+    // prior aggregate may be in `Failed` state and cannot be revived. The
+    // broker-side dedupe relies on `last_failed_offchain_order_id` being
+    // reused as `client_order_id`, not on aggregate identity.
     let offchain_order_id = OffchainOrderId::new();
 
     if !execute_place_offchain_order(execution, cqrs, offchain_order_id).await {
@@ -1838,11 +1846,29 @@ async fn execute_create_offchain_order(
     cqrs: &TradeProcessingCqrs,
     offchain_order_id: OffchainOrderId,
 ) {
+    // Derive the broker-side client_order_id from the live position aggregate
+    // (read after PlaceOffChainOrder claimed it), reusing a prior failed
+    // attempt's stashed OffchainOrderId as the idempotency anchor so the broker
+    // dedupes the retry. Fall back to this attempt's id when there is no anchor.
+    let anchor = match cqrs.position.load(&execution.symbol).await {
+        Ok(position) => position.and_then(|position| position.last_failed_offchain_order_id),
+        Err(error) => {
+            warn!(
+                %offchain_order_id,
+                symbol = %execution.symbol,
+                %error,
+                "Failed to load position for the idempotency anchor; placing under a fresh key"
+            );
+            None
+        }
+    };
+    let client_order_id_source = anchor.unwrap_or(offchain_order_id);
     let command = OffchainOrderCommand::Place {
         symbol: execution.symbol.clone(),
         shares: execution.shares,
         direction: execution.direction,
         executor: execution.executor,
+        client_order_id: ClientOrderId::from_uuid(client_order_id_source.as_uuid()),
     };
 
     match cqrs.offchain_order.send(&offchain_order_id, command).await {
@@ -1947,11 +1973,30 @@ where
             "Position::PlaceOffChainOrder succeeded"
         );
 
+        // Derive the broker-side client_order_id from the live position aggregate,
+        // reusing a prior failed attempt's stashed OffchainOrderId as the
+        // idempotency anchor (mirroring `execute_create_offchain_order`) so this
+        // path exercises the same broker dedupe the production reactor relies on.
+        let anchor = match position.load(&execution.symbol).await {
+            Ok(loaded) => loaded.and_then(|loaded| loaded.last_failed_offchain_order_id),
+            Err(error) => {
+                warn!(
+                    %offchain_order_id,
+                    symbol = %execution.symbol,
+                    %error,
+                    "Failed to load position for the idempotency anchor; placing under a fresh key"
+                );
+                None
+            }
+        };
+        let client_order_id_source = anchor.unwrap_or(offchain_order_id);
+
         let command = OffchainOrderCommand::Place {
             symbol: execution.symbol.clone(),
             shares: execution.shares,
             direction: execution.direction,
             executor: execution.executor,
+            client_order_id: ClientOrderId::from_uuid(client_order_id_source.as_uuid()),
         };
 
         let place_result = offchain_order.send(&offchain_order_id, command).await;
@@ -4587,6 +4632,7 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await
@@ -4776,6 +4822,7 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await
@@ -4870,6 +4917,7 @@ mod tests {
                     shares,
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -264,6 +264,7 @@ mod tests {
                     .unwrap(),
                     direction: st0x_execution::Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: st0x_execution::ClientOrderId::from_uuid(id.as_uuid()),
                 },
             )
             .await

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -80,7 +80,7 @@ async fn load_offchain_trades(pool: &SqlitePool) -> Vec<Trade> {
 mod tests {
     use chrono::Utc;
 
-    use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
+    use st0x_execution::{ClientOrderId, Direction, FractionalShares, Positive, Symbol};
     use st0x_float_macro::float;
 
     use super::*;
@@ -153,6 +153,7 @@ mod tests {
                     shares: Positive::new(FractionalShares::new(float!(50))).unwrap(),
                     direction: Direction::Sell,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
                 },
             )
             .await
@@ -292,6 +293,7 @@ mod tests {
                     shares: Positive::new(FractionalShares::new(float!(10))).unwrap(),
                     direction: Direction::Buy,
                     executor: st0x_execution::SupportedExecutor::AlpacaBrokerApi,
+                    client_order_id: ClientOrderId::from_uuid(id.as_uuid()),
                 },
             )
             .await

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -41,8 +41,8 @@ use uuid::Uuid;
 use st0x_dto::{Direction, Trade, TradingVenue};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Projection, Store, StoreBuilder, Table};
 use st0x_execution::{
-    AlpacaBrokerApiError, ExecutionError, Executor, ExecutorOrderId, FractionalShares, MarketOrder,
-    PersistenceError, Positive, SupportedExecutor, Symbol,
+    AlpacaBrokerApiError, ClientOrderId, ExecutionError, Executor, ExecutorOrderId,
+    FractionalShares, MarketOrder, PersistenceError, Positive, SupportedExecutor, Symbol,
 };
 use st0x_finance::Usd;
 
@@ -329,12 +329,14 @@ impl EventSourced for OffchainOrder {
                 shares,
                 direction,
                 executor,
+                client_order_id,
             } => {
                 let now = Utc::now();
                 let market_order = MarketOrder {
                     symbol: symbol.clone(),
                     shares,
                     direction,
+                    client_order_id,
                 };
 
                 match services.place_market_order(market_order).await {
@@ -620,6 +622,10 @@ pub enum OffchainOrderCommand {
         shares: Positive<FractionalShares>,
         direction: Direction,
         executor: SupportedExecutor,
+        /// Idempotency key forwarded to the broker so apalis retries of
+        /// the same `PlaceHedge` job do not produce a second order if the
+        /// first placement's response is lost in flight.
+        client_order_id: ClientOrderId,
     },
     UpdatePartialFill {
         shares_filled: FractionalShares,
@@ -699,6 +705,13 @@ impl OffchainOrderId {
     pub(crate) fn new() -> Self {
         Self(Uuid::new_v4())
     }
+
+    /// Exposes the wrapped UUID so callers can derive other identifiers
+    /// (e.g. a broker-side `client_order_id`) without going through a
+    /// fallible string roundtrip.
+    pub(crate) fn as_uuid(&self) -> Uuid {
+        self.0
+    }
 }
 
 /// Returned by [`OffchainOrder::try_to_trade`] when the order isn't in the
@@ -764,6 +777,7 @@ mod tests {
             shares: Positive::new(FractionalShares::new(float!(100))).unwrap(),
             direction: Direction::Buy,
             executor: SupportedExecutor::DryRun,
+            client_order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
         }
     }
 

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -130,7 +130,9 @@ mod tests {
     use chrono::Utc;
 
     use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_execution::{
+        ClientOrderId, Direction, FractionalShares, Positive, SupportedExecutor, Symbol,
+    };
     use st0x_float_macro::float;
 
     use super::*;
@@ -228,6 +230,7 @@ mod tests {
                     shares,
                     direction,
                     executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -351,9 +351,10 @@ mod tests {
     use chrono::Utc;
     use sqlx::SqlitePool;
 
+    use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{
-        Direction, ExecutionError, FractionalShares, MockExecutor, Positive, Symbol,
+        ClientOrderId, Direction, ExecutionError, FractionalShares, MockExecutor, Positive, Symbol,
     };
     use st0x_float_macro::float;
 
@@ -362,7 +363,6 @@ mod tests {
     use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
     use crate::position::{Position, PositionCommand, TradeId};
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
-    use st0x_config::ExecutionThreshold;
 
     const TEST_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
@@ -485,6 +485,7 @@ mod tests {
                     shares,
                     direction,
                     executor: order_executor,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -140,7 +140,9 @@ mod tests {
     use chrono::Utc;
 
     use st0x_event_sorcery::StoreBuilder;
-    use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+    use st0x_execution::{
+        ClientOrderId, Direction, FractionalShares, Positive, SupportedExecutor, Symbol,
+    };
     use st0x_float_macro::float;
 
     use super::*;
@@ -238,6 +240,7 @@ mod tests {
                     shares,
                     direction,
                     executor: SupportedExecutor::DryRun,
+                    client_order_id: ClientOrderId::from_uuid(offchain_order_id.as_uuid()),
                 },
             )
             .await

--- a/src/position.rs
+++ b/src/position.rs
@@ -29,6 +29,17 @@ pub struct Position {
     pub accumulated_long: FractionalShares,
     pub accumulated_short: FractionalShares,
     pub pending_offchain_order_id: Option<OffchainOrderId>,
+    /// Idempotency anchor: the `OffchainOrderId` from the last failed
+    /// placement that has not yet been followed by a successful fill.
+    /// Subsequent placement attempts reuse this id as their broker-side
+    /// `client_order_id` so the broker dedupes the duplicate submission
+    /// when the first attempt's response was lost in flight (e.g. 5xx
+    /// after the broker recorded the order).
+    ///
+    /// Cleared on any successful `OffChainOrderFilled` event so the next
+    /// rebalance cycle gets a fresh idempotency key.
+    #[serde(default)]
+    pub last_failed_offchain_order_id: Option<OffchainOrderId>,
     pub threshold: ExecutionThreshold,
     #[serde(
         serialize_with = "st0x_float_serde::serialize_option_float",
@@ -46,6 +57,10 @@ impl std::fmt::Debug for Position {
             .field("accumulated_long", &self.accumulated_long)
             .field("accumulated_short", &self.accumulated_short)
             .field("pending_offchain_order_id", &self.pending_offchain_order_id)
+            .field(
+                "last_failed_offchain_order_id",
+                &self.last_failed_offchain_order_id,
+            )
             .field("threshold", &self.threshold)
             .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
@@ -79,6 +94,7 @@ impl EventSourced for Position {
                 accumulated_long: FractionalShares::ZERO,
                 accumulated_short: FractionalShares::ZERO,
                 pending_offchain_order_id: None,
+                last_failed_offchain_order_id: None,
                 threshold: *threshold,
                 last_price_usdc: None,
                 last_updated: Some(*initialized_at),
@@ -145,6 +161,9 @@ impl EventSourced for Position {
             } => Ok(Some(Self {
                 net: (entity.net + shares_filled.inner())?,
                 pending_offchain_order_id: None,
+                // Successful fill: drop the failed-attempt anchor so the
+                // next rebalance cycle gets a fresh idempotency key.
+                last_failed_offchain_order_id: None,
                 last_updated: Some(*broker_timestamp),
                 ..entity.clone()
             })),
@@ -157,6 +176,7 @@ impl EventSourced for Position {
             } => Ok(Some(Self {
                 net: (entity.net - shares_filled.inner())?,
                 pending_offchain_order_id: None,
+                last_failed_offchain_order_id: None,
                 last_updated: Some(*broker_timestamp),
                 ..entity.clone()
             })),
@@ -165,8 +185,25 @@ impl EventSourced for Position {
                 offchain_order_id, ..
             } if entity.pending_offchain_order_id != Some(*offchain_order_id) => Ok(None),
 
-            OffChainOrderFailed { failed_at, .. } => Ok(Some(Self {
+            OffChainOrderFailed {
+                offchain_order_id,
+                failed_at,
+                ..
+            } => Ok(Some(Self {
                 pending_offchain_order_id: None,
+                // Stash the failed OID so the next placement attempt can
+                // reuse it as `client_order_id` and let the broker dedupe.
+                //
+                // Preserve the *first* failed anchor across a chain of
+                // failures: the broker recorded the original attempt under
+                // that key, so a later attempt whose own response was also
+                // lost must keep deduping against the original key. Overwriting
+                // with each new OID would point the next retry at a key the
+                // broker never saw, double-submitting the order. Cleared only
+                // by a successful fill.
+                last_failed_offchain_order_id: entity
+                    .last_failed_offchain_order_id
+                    .or(Some(*offchain_order_id)),
                 last_updated: Some(*failed_at),
                 ..entity.clone()
             })),
@@ -1412,15 +1449,17 @@ mod tests {
 
     #[test]
     fn offchain_failed_clears_pending() {
+        use PositionEvent::*;
+
         let offchain_order_id = OffchainOrderId::new();
 
         let position = replay::<Position>(vec![
-            PositionEvent::Initialized {
+            Initialized {
                 symbol: Symbol::new("AAPL").unwrap(),
                 threshold: one_share_threshold(),
                 initialized_at: Utc::now(),
             },
-            PositionEvent::OnChainOrderFilled {
+            OnChainOrderFilled {
                 trade_id: TradeId {
                     tx_hash: TxHash::random(),
                     log_index: 1,
@@ -1431,7 +1470,7 @@ mod tests {
                 block_timestamp: Utc::now(),
                 seen_at: Utc::now(),
             },
-            PositionEvent::OffChainOrderPlaced {
+            OffChainOrderPlaced {
                 offchain_order_id,
                 shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
                 direction: Direction::Sell,
@@ -1442,7 +1481,7 @@ mod tests {
                 },
                 placed_at: Utc::now(),
             },
-            PositionEvent::OffChainOrderFailed {
+            OffChainOrderFailed {
                 offchain_order_id,
                 error: "Market closed".to_string(),
                 failed_at: Utc::now(),
@@ -1456,6 +1495,152 @@ mod tests {
             position.pending_offchain_order_id.is_none(),
             "pending_offchain_order_id should be cleared \
              after OffChainOrderFailed"
+        );
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(offchain_order_id),
+            "the failed order id should be stashed as the idempotency anchor \
+             so the next placement attempt reuses it as client_order_id"
+        );
+    }
+
+    #[test]
+    fn offchain_failed_preserves_first_failed_anchor() {
+        use PositionEvent::*;
+
+        let first_order_id = OffchainOrderId::new();
+        let second_order_id = OffchainOrderId::new();
+
+        let position = replay::<Position>(vec![
+            Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: first_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id: first_order_id,
+                error: "Market closed".to_string(),
+                failed_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: second_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id: second_order_id,
+                error: "Market closed".to_string(),
+                failed_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            position.last_failed_offchain_order_id,
+            Some(first_order_id),
+            "a chain of failures must keep the first anchor: the broker \
+             recorded the original attempt under that key, so later retries \
+             must keep deduping against it rather than a key the broker \
+             never saw"
+        );
+    }
+
+    #[test]
+    fn offchain_filled_clears_failed_anchor() {
+        use PositionEvent::*;
+
+        let failed_order_id = OffchainOrderId::new();
+        let retry_order_id = OffchainOrderId::new();
+
+        let position = replay::<Position>(vec![
+            Initialized {
+                symbol: Symbol::new("AAPL").unwrap(),
+                threshold: one_share_threshold(),
+                initialized_at: Utc::now(),
+            },
+            OnChainOrderFilled {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(1.5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: Utc::now(),
+                seen_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: failed_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFailed {
+                offchain_order_id: failed_order_id,
+                error: "Market closed".to_string(),
+                failed_at: Utc::now(),
+            },
+            OffChainOrderPlaced {
+                offchain_order_id: retry_order_id,
+                shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor: SupportedExecutor::DryRun,
+                trigger_reason: TriggerReason::SharesThreshold {
+                    net_position_shares: float!(1.5),
+                    threshold_shares: float!(1),
+                },
+                placed_at: Utc::now(),
+            },
+            OffChainOrderFilled {
+                offchain_order_id: retry_order_id,
+                shares_filled: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                direction: Direction::Sell,
+                executor_order_id: ExecutorOrderId::new("ORDER-RETRY"),
+                price: Usd::new(float!(150.50)),
+                broker_timestamp: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            position.last_failed_offchain_order_id.is_none(),
+            "a successful fill must clear the failed-attempt anchor so the \
+             next rebalance cycle starts from a fresh idempotency key"
         );
     }
 
@@ -1597,6 +1782,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(1.212)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1623,6 +1809,7 @@ mod tests {
             accumulated_long: FractionalShares::ZERO,
             accumulated_short: FractionalShares::new(float!(2.567)),
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1649,6 +1836,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(100)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1678,6 +1866,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(30)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1707,6 +1896,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(100)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1735,6 +1925,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(10)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1764,6 +1955,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(10)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -1793,6 +1985,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(100)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: None,
             last_updated: Some(Utc::now()),
@@ -1872,6 +2065,7 @@ mod tests {
             accumulated_long: FractionalShares::new(float!(120)),
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
+            last_failed_offchain_order_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, warn};
 
 use st0x_config::Ctx;
 use st0x_event_sorcery::Projection;
-use st0x_execution::{CounterTradePreflight, Executor, MarketOrder, Symbol};
+use st0x_execution::{ClientOrderId, CounterTradePreflight, Executor, MarketOrder, Symbol};
 
 use crate::conductor::clamp_shares_to_reservation;
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
@@ -165,6 +165,9 @@ where
             symbol: ready.symbol.clone(),
             shares: ready.shares,
             direction: ready.direction,
+            // Preflight only; this id is never sent to the broker. Use a
+            // fresh value so callers cannot mistake it for a real key.
+            client_order_id: ClientOrderId::from_uuid(uuid::Uuid::new_v4()),
         };
 
         match self.executor.preflight_counter_trade(order).await {

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -9,8 +9,11 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
+use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{AggregateError, LifecycleError, Store};
-use st0x_execution::{Direction, FractionalShares, Positive, SupportedExecutor, Symbol};
+use st0x_execution::{
+    ClientOrderId, Direction, FractionalShares, Positive, SupportedExecutor, Symbol,
+};
 
 use crate::conductor::job::{Job, JobQueue, Label};
 use crate::offchain::order::{
@@ -18,7 +21,6 @@ use crate::offchain::order::{
 };
 use crate::position::{Position, PositionCommand, PositionError};
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
-use st0x_config::ExecutionThreshold;
 
 /// Persistent job queue for hedge placement.
 pub(crate) type HedgeJobQueue = JobQueue<PlaceHedge>;
@@ -146,6 +148,24 @@ impl Job<HedgeCtx> for PlaceHedge {
             Err(error) => return Err(error.into()),
         }
 
+        // Derive the broker-side `client_order_id` from the *live* position
+        // aggregate, read after `PlaceOffChainOrder` has claimed it -- never
+        // captured at enqueue. If a prior attempt failed, the aggregate holds
+        // its `OffchainOrderId` as the idempotency anchor, so this retry reuses
+        // the same key and the broker dedupes the duplicate submission (a 422
+        // the executor reconciles by adopting the order it already accepted).
+        // Reading it live means a failure recorded *after* this job was enqueued
+        // is still honored, instead of placing under a fresh key and
+        // double-submitting. Falls back to this attempt's own id on the first
+        // try, when no anchor exists yet.
+        let anchor = ctx
+            .position
+            .load(&self.symbol)
+            .await?
+            .and_then(|position| position.last_failed_offchain_order_id);
+        let client_order_id_source = anchor.unwrap_or(self.offchain_order_id);
+        let client_order_id = ClientOrderId::from_uuid(client_order_id_source.as_uuid());
+
         ctx.offchain_order
             .send(
                 &self.offchain_order_id,
@@ -154,6 +174,7 @@ impl Job<HedgeCtx> for PlaceHedge {
                     shares: self.shares,
                     direction: self.direction,
                     executor: self.executor,
+                    client_order_id,
                 },
             )
             .await?;

--- a/tests/e2e/chaos_alpaca/mod.rs
+++ b/tests/e2e/chaos_alpaca/mod.rs
@@ -1,0 +1,117 @@
+//! Chaos tests for Alpaca broker fault tolerance.
+//!
+//! Drives the bot through scenarios where the Alpaca broker mock returns
+//! a 5xx after recording the order in its internal state. Asserts the
+//! bot does not double-submit hedges when retrying a placement whose
+//! response was lost in flight.
+
+use st0x_float_macro::float;
+use std::time::Duration;
+
+use crate::hedging::assertions::*;
+use crate::poll::{connect_db, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot};
+
+/// Top-level hypothesis: an Alpaca placement that the broker processed but
+/// failed to acknowledge (5xx in flight) must not produce two orders when the
+/// bot recovers.
+///
+/// Mechanism under test: the mock records the first placement then returns 503.
+/// The placement's `OffchainOrder` aggregate goes `Failed` and the position
+/// stashes that attempt's id as its idempotency anchor; the periodic
+/// `CheckPositions` scan then re-enqueues a fresh `PlaceHedge` (recovery is
+/// driven by the scan, not by apalis retrying the failed job, which returned
+/// `Ok` after recording the failure). The retry derives its broker-side
+/// `client_order_id` from the live anchor, so the broker recognizes the
+/// duplicate and rejects it with a 422 ("client_order_id must be unique"); the
+/// executor reconciles by looking the order up by `client_order_id` and
+/// adopting the one the broker already accepted. Net result: exactly one broker
+/// order despite the lost-in-flight response.
+#[test_log::test(tokio::test)]
+async fn transient_alpaca_5xx_after_record_does_not_double_submit() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    // Arm the mock to record the first placement then fail its response with a
+    // 503. The placement is marked Failed (the hedge job returns Ok, not an
+    // apalis retry) and the CheckPositions scan re-enqueues a fresh hedge; one
+    // transient failure is enough to drive the dedupe-on-retry recovery path.
+    infra.broker_service.set_transient_placement_failures(1);
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let _take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // Assert the recovery path actually ran, so this can't pass trivially: the
+    // first attempt must have Failed (the lost-in-flight 503), and a second
+    // OffchainOrder aggregate must exist (the CheckPositions re-enqueue). The
+    // broker dedupe is only exercised when both happened.
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
+    pool.close().await;
+
+    let failed_count = offchain_order_events
+        .iter()
+        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
+        .count();
+    assert_eq!(
+        failed_count, 1,
+        "Expected exactly one OffchainOrder failure (the transient 503) before \
+         recovery; got {failed_count}",
+    );
+
+    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert!(
+        distinct_aggregates.len() >= 2,
+        "Expected at least two OffchainOrder aggregates -- the failed first \
+         attempt and the re-enqueued retry that reconciled the broker's \
+         existing order; got {}",
+        distinct_aggregates.len(),
+    );
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one order on the broker after a transient 5xx \
+         on the placement response; got {order_count}. More than one \
+         means the bot retried without an idempotency key and the \
+         broker has no way to dedupe the second submission.",
+    );
+
+    bot.abort();
+    Ok(())
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -13,6 +13,7 @@ mod assert;
 mod base_chain;
 mod cctp;
 mod chaos;
+mod chaos_alpaca;
 mod chaos_rpc;
 mod full_system;
 mod hedging;


### PR DESCRIPTION
[RAI-75](https://linear.app/makeitrain/issue/RAI-75/chaos-adversarial-external-behavior-in-e2e-harness) (harness extension) + [RAI-421](https://linear.app/makeitrain/issue/RAI-421/chaos-exchange-api-fault-injection-alpaca) (Alpaca double-submit scenario).

## Failing test, on purpose

Per [docs/ttdd.md](https://github.com/ST0x-Technology/st0x.liquidity/blob/master/docs/ttdd.md), the failing test goes in first. This PR alone is **expected to fail CI**: it adds the `AlpacaBrokerMock` knob for transient placement failures and the e2e test that uses it. The assertion `orders.len() == 1` fails on the current bot because `OrderRequest` has no `client_order_id` and the apalis retry path creates a second order on the mock after the 5xx-after-record. The upstack PR adds end-to-end idempotency-key plumbing and turns this green.

## What

- `crates/execution/src/alpaca_broker_api/mock_api.rs`:
  - New `MockState::transient_placement_failures_remaining: usize`.
  - New `AlpacaBrokerMock::set_transient_placement_failures(count)`.
  - `place_order` handler now records the order in state *then* returns 503 while the counter is positive, decrementing per request. Models "broker processed it but the response was lost in flight."
- `tests/e2e/chaos_alpaca/mod.rs`: new `transient_alpaca_5xx_after_record_does_not_double_submit` e2e test. Arms one transient failure, fires a SellEquity take, polls for `OffchainOrderEvent::Filled`, and asserts the broker ended with exactly one order.

## Why

RAI-421 calls out 4xx/5xx fault injection on the Alpaca side and explicitly wants the bot to *not* double-submit and to reconcile pending orders. Today the bot retries failed `place_order` calls without an idempotency key, so any 5xx that occurs after the broker processed the request leaves the broker with two orders for the same intent. The test makes that observable.

## How

The 5xx is returned *after* the order has been inserted into `MockState::orders`, mirroring the real-world "request reached upstream, response was lost." That single difference is what creates the duplicate when apalis retries the `PlaceHedge` job: the second placement creates a second order in the mock because there is no key the broker can use to deduplicate.

## Testing

`cargo check --workspace --all-features --all-targets` clean.

CI's e2e job is expected to fail this test on this branch alone -- the assertion `orders.len() == 1` finds 2. Once the upstack PR plumbs `client_order_id` end-to-end (`OrderRequest`, the bot's hedge job, the mock's dedup table), the same test passes.

## Anything else

Stacked on #717 to share the chaos harness conventions established by #715 / #716. The bot-side idempotency-key fix is the next PR upstack of this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added order idempotency support with unique client identifiers to prevent duplicate submissions on retry.
  * Automatic broker-side deduplication of retried orders for more reliable order placement.
  * Graceful recovery from transient broker failures with improved retry handling.

* **Tests**
  * Added chaos testing to validate system fault tolerance under broker failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->