### PR TITLE
fix: recreate DB as st0x-owned in db-reset to prevent crash loop

### DIFF
--- a/infra/default.nix
+++ b/infra/default.nix
@@ -322,6 +322,16 @@ let
           echo "Deleting live database..."
           ssh_remote "rm -f $db_path $db_path-wal $db_path-shm $db_path-journal"
 
+          # Recreate the DB as an empty st0x-owned file immediately. Leaving the
+          # path empty opens a window where any root process that touches it
+          # (a manual sqlite3 inspection, a status query, monitoring) creates a
+          # root:root database the st0x service can never write to, sending the
+          # unit into a SQLITE_READONLY crash loop. SQLite treats a zero-length
+          # file as a valid empty database, so the bot still runs migrations on
+          # next start -- it just inherits an already-correctly-owned file.
+          echo "Recreating empty database owned by st0x:st0x..."
+          ssh_remote "install -o st0x -g st0x -m 644 /dev/null $db_path"
+
           echo "Updating deployment_block to $target_block..."
           ssh_remote "sed -i 's/^deployment_block = .*/deployment_block = $target_block/' $config"
           ssh_remote "grep -q '^deployment_block = $target_block$' $config"


### PR DESCRIPTION
## What

`<env>-db-reset` (the `${env}DbReset` shim in `infra/default.nix`) now recreates the SQLite database as an empty `st0x:st0x`-owned file immediately after deleting it, instead of leaving the path empty until the service's next start.

## Why

A `prod-db-reset` run took prod down with an `st0x-hedge` crash loop. Root cause: the script deletes `/mnt/data/st0x-hedge.db` and leaves the path nonexistent until the service restarts. In that window, any process running as **root** that touches the path (a manual `sqlite3` inspection, a status query, monitoring) makes SQLite create a fresh `root:root` database. The service runs as `User=st0x`, so it can read but not write that file — every start exits immediately with `error returned from database: (code: 8) attempt to write a readonly database`, and systemd's `Restart=always` turns it into a 30s crash loop.

## How

After `rm -f $db_path ...`, recreate the file with correct ownership in one step:

```sh
install -o st0x -g st0x -m 644 /dev/null $db_path
```

SQLite treats a zero-length file as a valid empty database, so the bot still runs all migrations on next start — it just inherits an already-`st0x`-owned file instead of racing some other process to create one. Mirrors the existing `chown st0x:st0x /mnt/data/*.db` idiom in `deploy.nix`.

## Testing

No automated tests — this is a deploy-time shell script embedded in Nix, not unit-testable in the cargo suite. Verified:
- `nix-instantiate --parse infra/default.nix` — passes
- `nixfmt --check infra/default.nix` — passes
- The equivalent corrected sequence was run manually against prod during incident recovery: the live DB was recreated as a 0-byte `st0x:st0x` file and ownership confirmed via `ls -la`.

## Anything else

- The `<env>-db-reset` binary on a developer's PATH won't pick up this fix until their dev shell rebuilds; prod was already corrected manually during incident recovery, so it is not in the broken state.
- `install` is part of coreutils and is available in the NixOS host's root environment.
- This closes the ownership window opened by `db-reset`. A root user manually running `sqlite3` against a live, correctly-owned DB can still create root-owned `-wal`/`-shm` sidecars — the systematic guard is to not poke the DB path as root.

RAI-757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database reset process that could cause the service to enter a crash loop due to file permission issues. The database is now properly initialized with correct ownership during reset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->