### PR TITLE
config: enable SGOV in prod, disable in staging

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -94,8 +94,8 @@ tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
 tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
 
 [assets.equities.SGOV]
-trading = "disabled"
-rebalancing = "disabled"
+trading = "enabled"
+rebalancing = "enabled"
 wrapped_equity_recovery = "disabled"
 vault_id = "0xfab4"
 tokenized_equity = "0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -81,8 +81,8 @@ tokenized_equity = "0xf6744fd94e27c2f58f6110aa9fdc77a87e41766b"
 tokenized_equity_derivative = "0xf4f8c66085910d583c01f3b4e44bf731d4e2c565"
 
 [assets.equities.SGOV]
-trading = "enabled"
-rebalancing = "enabled"
+trading = "disabled"
+rebalancing = "disabled"
 wrapped_equity_recovery = "disabled"
 vault_id = "0xfab"
 tokenized_equity = "0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612"


### PR DESCRIPTION
## What

[RAI-751](https://linear.app/makeitrain/issue/RAI-751)

Flips the SGOV (tSGOV) operational config across environments:

- `config/prod/st0x-hedge.toml` — `[assets.equities.SGOV]`: `trading` and `rebalancing` `disabled` → `enabled`.
- `config/staging/st0x-hedge.toml` — `[assets.equities.SGOV]`: `trading` and `rebalancing` `enabled` → `disabled`.

No other SGOV fields change (`vault_id`, `tokenized_equity`, `tokenized_equity_derivative` are untouched in both environments).

## Why

SGOV was previously enabled only in staging for testing. Now that it's validated, we want to offer it as a tradeable asset on the st0x platform, so production takes over live SGOV market-making and hedging while staging stops trading and rebalancing it.

## How

Pure configuration change. `OperationMode::Enabled`/`Disabled` per symbol gates runtime behavior: `is_trading_enabled` / `is_rebalancing_enabled` (`src/config.rs`) drive execution readiness, position monitoring, wallet token tracking, and CLI trade guards. Symbols default to fail-closed (disabled) when absent, so explicitly setting both flags is what toggles the symbol on/off in each environment.

## Testing

No new tests — config-only change. The values are validated at deploy time: `deploy.nix` loads `config/<env>/st0x-hedge.toml` and runs `validate-config` before the systemd restart, rolling back on failure.

## Anything else

Takes effect on the next deploy of each environment. No schema, dependency, or code changes; no migrations.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933351&installation_id=125569124&pr_number=722&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F722&signature=694f020b17ad95e5e7a15f7625feed5233590a1cda451f4b944856f17b7e5f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled trading and rebalancing for the SGOV equity in production.
  * Disabled trading and rebalancing for the SGOV equity in staging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->