### PR TITLE
test: finality-gate withdrawal scan against RPC node lag

### DIFF
--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -22,6 +22,18 @@ sol!(
     IERC20, env!("ST0X_IERC20_ABI")
 );
 
+/// Number of `eth_getLogs` scans that must agree a burn is absent before a
+/// resume re-issues an irreversible burn. Defends against a single load-balanced
+/// RPC node lagging and returning a false-empty result.
+const SCAN_ATTEMPTS: u32 = 5;
+
+/// Backoff between scan retries; different load-balanced nodes may answer each.
+const SCAN_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(150);
+
+/// Blocks the chain head must be past `from_block` before an empty scan is
+/// trusted as a true absence (the burn lands at/after `from_block`).
+const SCAN_FINALITY_MARGIN: u64 = 2;
+
 /// Single-chain CCTP endpoint with contract instances for cross-chain operations.
 ///
 /// The wallet's provider is used for read-only view calls (e.g. allowance
@@ -140,39 +152,72 @@ impl<W: Wallet> CctpEndpoint<W> {
     /// after `from_block`, returning the transaction hash of the most recent
     /// match.
     ///
-    /// Used for crash-safe burn recovery: a transfer records the chain head
-    /// before submitting the burn, so on resume this detects an already-
-    /// submitted burn instead of re-burning (which would burn USDC twice with at
-    /// most one mint). Matches on `(depositor, amount)` -- CCTP burns are exact,
-    /// and the single-in-flight invariant guarantees the newest match at/after
-    /// the captured chain head is the resuming transfer's burn.
+    /// Crash-safe burn recovery: a transfer records the chain head before the
+    /// burn, so on resume this detects an already-submitted burn instead of
+    /// re-burning (which would burn USDC twice with at most one mint). Matches on
+    /// `(depositor, amount, destinationDomain, mintRecipient)` so an adopted burn
+    /// is provably this transfer's -- not merely a same-amount burn from the same
+    /// wallet to a different destination. The head is captured before the burn, so
+    /// this transfer's burn lands strictly after `from_block`; the scan excludes the
+    /// `from_block` block itself so an earlier identical burn is never adopted --
+    /// consistent with [`find_recent_mint`](Self::find_recent_mint).
+    ///
+    /// Returns `Ok(None)` ONLY when the queried node is confirmations-deep past
+    /// `from_block` and repeated scans agree the burn is absent; a node that may
+    /// be lagging (the dRPC load-balancing hazard) yields a retryable
+    /// [`CctpError::ScanInconclusive`] instead, so the caller never re-burns off a
+    /// single stale empty `eth_getLogs`.
     pub(super) async fn find_recent_burn(
         &self,
         amount: U256,
+        dest_domain: u32,
+        recipient: Address,
         from_block: u64,
     ) -> Result<Option<TxHash>, CctpError> {
         let depositor = self.wallet.address();
+        let mint_recipient = FixedBytes::<32>::left_padding_from(recipient.as_slice());
         let filter = Filter::new()
             .from_block(from_block)
             .address(self.token_messenger_address)
             .event_signature(TokenMessengerV2::DepositForBurn::SIGNATURE_HASH);
 
-        let logs = self.wallet.provider().get_logs(&filter).await?;
+        for attempt in 1..=SCAN_ATTEMPTS {
+            let logs = self.wallet.provider().get_logs(&filter).await?;
 
-        for log in logs.iter().rev() {
-            let decoded = log.log_decode::<TokenMessengerV2::DepositForBurn>()?;
-            let event = decoded.data();
+            for log in logs.iter().rev() {
+                let decoded = log.log_decode::<TokenMessengerV2::DepositForBurn>()?;
+                let event = decoded.data();
 
-            if event.depositor == depositor
-                && event.amount == amount
-                && let Some(tx_hash) = log.transaction_hash
-            {
-                debug!(target: "bridge", %tx_hash, from_block, "Found existing burn during resume");
-                return Ok(Some(tx_hash));
+                if event.depositor == depositor
+                    && event.amount == amount
+                    && event.destinationDomain == dest_domain
+                    && event.mintRecipient == mint_recipient
+                    && log.block_number.is_some_and(|block| block > from_block)
+                    && let Some(tx_hash) = log.transaction_hash
+                {
+                    debug!(target: "bridge", %tx_hash, from_block, "Found existing burn during resume");
+                    return Ok(Some(tx_hash));
+                }
+            }
+
+            // A single empty eth_getLogs from a load-balanced node is not
+            // authoritative (dRPC lag). Only conclude a true absence once the head
+            // is confirmations-deep past from_block AND repeated scans agree; else
+            // retry, and if still inconclusive return a retryable error so the
+            // caller never re-burns off a stale empty result.
+            let head = self.wallet.provider().get_block_number().await?;
+            let caught_up = head >= from_block.saturating_add(SCAN_FINALITY_MARGIN);
+
+            if caught_up && attempt == SCAN_ATTEMPTS {
+                return Ok(None);
+            }
+
+            if attempt < SCAN_ATTEMPTS {
+                tokio::time::sleep(SCAN_RETRY_BACKOFF).await;
             }
         }
 
-        Ok(None)
+        Err(CctpError::ScanInconclusive { from_block })
     }
 
     /// Scans for a `MintAndWithdraw` event minting to `recipient` strictly after

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -301,6 +301,11 @@ pub enum CctpError {
     RpcTransport(#[from] RpcError<TransportErrorKind>),
     #[error("ABI decode error: {0}")]
     SolType(#[from] alloy::sol_types::Error),
+    /// A burn scan could not confirm presence or absence: the queried node is not
+    /// confirmations-deep past `from_block`, so an empty result may be RPC lag
+    /// rather than a true absence. Retryable -- the caller must NOT re-burn on it.
+    #[error("burn scan inconclusive: node not caught up past block {from_block}")]
+    ScanInconclusive { from_block: u64 },
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("Attestation timeout after {attempts} attempts: {source}")]
@@ -671,19 +676,28 @@ where
     }
 
     /// Scans the burn source chain for an already-submitted burn matching
-    /// `amount` at or after `from_block`, for crash-safe resume. Delegates to
-    /// the source endpoint for the given direction.
+    /// `(amount, destinationDomain, recipient)` at or after `from_block`, for
+    /// crash-safe resume. Delegates to the source endpoint for the given
+    /// direction.
     async fn find_recent_burn(
         &self,
         direction: BridgeDirection,
         amount: U256,
+        recipient: Address,
         from_block: u64,
     ) -> Result<Option<TxHash>, Self::Error> {
+        let dest_domain = direction.dest_domain();
         match direction {
             BridgeDirection::EthereumToBase => {
-                self.ethereum.find_recent_burn(amount, from_block).await
+                self.ethereum
+                    .find_recent_burn(amount, dest_domain, recipient, from_block)
+                    .await
             }
-            BridgeDirection::BaseToEthereum => self.base.find_recent_burn(amount, from_block).await,
+            BridgeDirection::BaseToEthereum => {
+                self.base
+                    .find_recent_burn(amount, dest_domain, recipient, from_block)
+                    .await
+            }
         }
     }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -84,11 +84,13 @@ pub trait Bridge: Send + Sync + 'static {
     ) -> Result<MintReceipt, Self::Error>;
 
     /// Scans the burn source chain for an already-submitted burn matching
-    /// `amount` at or after `from_block`, for crash-safe resume.
+    /// `(amount, destinationDomain, recipient)` at or after `from_block`, for
+    /// crash-safe resume.
     async fn find_recent_burn(
         &self,
         direction: BridgeDirection,
         amount: U256,
+        recipient: Address,
         from_block: u64,
     ) -> Result<Option<TxHash>, Self::Error>;
 

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -601,17 +601,23 @@ impl<W: Wallet> Raindex for RaindexService<W> {
 mod tests {
     use alloy::network::Ethereum;
     use alloy::node_bindings::{Anvil, AnvilInstance};
+    use alloy::primitives::Log as PrimitiveLog;
     use alloy::primitives::{B256, b256};
     use alloy::providers::Provider;
     use alloy::providers::fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
     };
     use alloy::providers::{Identity, ProviderBuilder, RootProvider};
+    use alloy::rpc::types::Log;
     use alloy::transports::{RpcError, TransportErrorKind};
     use proptest::prelude::*;
     use tracing_test::traced_test;
 
+    use alloy::providers::mock::Asserter;
+    use serde_json::json;
+
     use st0x_evm::NoOpErrorRegistry;
+    use st0x_evm::ReadOnlyEvm;
     use st0x_evm::Wallet;
     use st0x_evm::local::RawPrivateKeyWallet;
 
@@ -783,6 +789,164 @@ mod tests {
             vault_registry_projection,
             owner,
         )
+    }
+
+    /// Empty vault-registry projection for scan tests that never load the
+    /// registry (`find_recent_withdrawal` only reads logs).
+    async fn empty_vault_registry_projection() -> Arc<VaultRegistryProjection> {
+        let pool = crate::test_utils::setup_test_db().await;
+        let (_store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+        projection
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_is_inconclusive_when_node_lags() {
+        let asserter = Asserter::new();
+        let from_block = 100u64;
+        // Every scan attempt sees an empty get_logs and a head BELOW from_block --
+        // a lagging load-balanced node. The scan must NOT report absence (which
+        // would let the caller re-withdraw and double-spend); it must surface a
+        // retryable error so the resume re-runs instead.
+        for _ in 0..SCAN_ATTEMPTS {
+            asserter.push_success(&json!([]));
+            asserter.push_success(&json!("0x32")); // head = 50 < from_block
+        }
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let service = RaindexService::new(
+            ReadOnlyEvm::new(provider),
+            Address::ZERO,
+            empty_vault_registry_projection().await,
+            Address::ZERO,
+        );
+
+        let error = service
+            .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, RaindexError::ScanInconclusive { from_block: fb } if fb == from_block),
+            "lagging node must yield retryable ScanInconclusive, got: {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_is_none_when_caught_up_and_absent() {
+        let asserter = Asserter::new();
+        let from_block = 100u64;
+        // Empty get_logs corroborated across every attempt, with a head well past
+        // from_block: the withdrawal is genuinely absent, so re-issuing is safe.
+        for _ in 0..SCAN_ATTEMPTS {
+            asserter.push_success(&json!([]));
+            asserter.push_success(&json!("0x200")); // head = 512 >> from_block
+        }
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let service = RaindexService::new(
+            ReadOnlyEvm::new(provider),
+            Address::ZERO,
+            empty_vault_registry_projection().await,
+            Address::ZERO,
+        );
+
+        let result = service
+            .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    /// A `WithdrawV2` from this owner's vault, mined at `block_number`, that
+    /// `find_recent_withdrawal` will see for `(USDC_BASE, TEST_VAULT_ID)`.
+    fn withdraw_log(block_number: u64, withdraw_amount: U256) -> Log {
+        let event = IOrderBookV6::WithdrawV2 {
+            sender: Address::ZERO,
+            token: USDC_BASE,
+            vaultId: TEST_VAULT_ID.0,
+            targetAmount: B256::ZERO,
+            withdrawAmount: B256::ZERO,
+            withdrawAmountUint256: withdraw_amount,
+        };
+
+        Log {
+            inner: PrimitiveLog {
+                address: Address::ZERO,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(block_number),
+            block_timestamp: None,
+            transaction_hash: Some(b256!(
+                "0x00000000000000000000000000000000000000000000000000000000000000aa"
+            )),
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_excludes_match_at_from_block() {
+        let asserter = Asserter::new();
+        let from_block = 100u64;
+        // A matching withdrawal mined AT from_block belongs to an earlier transfer:
+        // from_block is the head captured *before* this transfer's withdraw, so this
+        // transfer's withdraw can only land strictly after it. Adopting the at-block
+        // log would make the resume skip a withdraw it never issued.
+        let stale = json!([withdraw_log(from_block, U256::from(7u64))]);
+        for _ in 0..SCAN_ATTEMPTS {
+            asserter.push_success(&stale);
+            asserter.push_success(&json!("0x200")); // head = 512 >> from_block
+        }
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let service = RaindexService::new(
+            ReadOnlyEvm::new(provider),
+            Address::ZERO,
+            empty_vault_registry_projection().await,
+            Address::ZERO,
+        );
+
+        let result = service
+            .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "a withdrawal mined at from_block must be excluded (strictly-after semantics)",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_adopts_match_after_from_block() {
+        let asserter = Asserter::new();
+        let from_block = 100u64;
+        let amount = U256::from(7u64);
+        let log = withdraw_log(from_block + 1, amount);
+        let expected_tx = log.transaction_hash.unwrap();
+        // The very first scan finds the strictly-after match and adopts it.
+        asserter.push_success(&json!([log]));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let service = RaindexService::new(
+            ReadOnlyEvm::new(provider),
+            Address::ZERO,
+            empty_vault_registry_projection().await,
+            Address::ZERO,
+        );
+
+        let result = service
+            .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some((expected_tx, amount)));
     }
 
     #[tokio::test]

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1138,7 +1138,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     ) -> Result<BurnReceipt, UsdcTransferError> {
         let burn_receipt = match self
             .cctp_bridge
-            .find_recent_burn(BridgeDirection::BaseToEthereum, amount, from_block)
+            .find_recent_burn(
+                BridgeDirection::BaseToEthereum,
+                amount,
+                self.market_maker_wallet,
+                from_block,
+            )
             .await
         {
             Ok(Some(existing_tx)) => {


### PR DESCRIPTION
## What

Closes [RAI-823](https://linear.app/makeitrain/issue/RAI-823/crash-safe-burnwithdrawal-resume-can-re-issue-an-irreversible-action). Hardens the crash-safe burn/withdrawal resume scan against false-empty `eth_getLogs` responses from lagging load-balanced RPC nodes (e.g. dRPC).

## Why

A load-balanced RPC node may return an empty `eth_getLogs` result not because the burn is absent, but because that particular node is behind the chain head. Previously, a single empty scan was enough to conclude no burn existed, which could cause the resume path to re-issue a burn — burning USDC twice with at most one mint.

## How

- `find_recent_burn` now retries up to `SCAN_ATTEMPTS` (5) times with a `SCAN_RETRY_BACKOFF` (150ms) between attempts, so different load-balanced nodes are likely to answer each request.
- An empty scan is only treated as a true absence when the node's reported head is at least `SCAN_FINALITY_MARGIN` (2) blocks past `from_block` **and** all retry attempts agree the burn is absent.
- If the node appears to be lagging (head not yet past `from_block`) after all attempts, the function returns a new retryable `CctpError::ScanInconclusive { from_block }` error instead of `Ok(None)`, ensuring the caller never re-burns based on a stale empty result.
- The burn match criteria are tightened from `(depositor, amount)` to `(depositor, amount, destinationDomain, mintRecipient)`, so an adopted burn is provably this transfer's and not a same-amount burn to a different destination.
- The same `ScanInconclusive` guard is applied to `find_recent_withdrawal` in the Raindex service.
- The `find_recent_burn` public API now requires `recipient` to be passed explicitly, and the `BaseToEthereum` resume path passes `market_maker_wallet` as the recipient.

## Testing

Two new unit tests cover the key safety properties of `find_recent_withdrawal`:

- `find_recent_withdrawal_is_inconclusive_when_node_lags`: mocks every scan attempt returning an empty log set with a head below `from_block`, and asserts that `ScanInconclusive` is returned rather than `None`.
- `find_recent_withdrawal_is_none_when_caught_up_and_absent`: mocks every scan attempt returning an empty log set with a head well past `from_block`, and asserts that `Ok(None)` is correctly returned, allowing a safe re-issue.

## Anything else

The `ScanInconclusive` error is explicitly documented as retryable — callers must not re-burn or re-withdraw on receiving it. This is a defence-in-depth measure against the dRPC load-balancing hazard where different nodes in a pool may be at different chain heights.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783034241&installation_id=125569124&pr_number=723&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F723&signature=ae0168a634eb3a60e23930835de182f5df6232bbace9d96ba7029444d2e6d629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Burn-detection now matches by recipient and destination, improving adoption of existing burns.
* **Bug Fixes**
  * Improved scan reliability with retry/backoff and a finality margin to distinguish true absences from RPC lag.
  * When scans are inconclusive due to node lag, the system returns a retriable "inconclusive" outcome instead of falsely reporting no burn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
