### PR TITLE
fix: keep usdc guard latched on timeout while transfer job in flight

### DIFF
--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -2275,4 +2275,94 @@ mod tests {
             assert_eq!(receipt.amount, amount, "Burn {i}: amount should match");
         }
     }
+
+    #[tokio::test]
+    async fn find_recent_burn_returns_tx_of_real_burn() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+        let recipient = bridge.ethereum.owner();
+        let amount = U256::from(25_000_000u64);
+
+        let base_provider = ProviderBuilder::new()
+            .connect(cctp.base_endpoint.as_str())
+            .await
+            .unwrap();
+        let from_block = base_provider.get_block_number().await.unwrap();
+
+        let receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::BaseToEthereum, amount, recipient)
+            .await
+            .unwrap();
+
+        let found = bridge
+            .find_recent_burn(
+                BridgeDirection::BaseToEthereum,
+                amount,
+                recipient,
+                from_block,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            found,
+            Some(receipt.tx),
+            "scan must return the real burn's tx for the matching amount + recipient",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_burn_returns_none_for_wrong_amount_or_recipient() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+        let recipient = bridge.ethereum.owner();
+        let amount = U256::from(25_000_000u64);
+
+        let base_provider = ProviderBuilder::new()
+            .connect(cctp.base_endpoint.as_str())
+            .await
+            .unwrap();
+        let from_block = base_provider.get_block_number().await.unwrap();
+
+        // Burn a few times to advance the Base head past from_block + the scan
+        // finality margin so the non-matching scans below conclude a true absence.
+        for _ in 0..3 {
+            bridge
+                .burn_internal::<NoOpErrorRegistry>(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    recipient,
+                )
+                .await
+                .unwrap();
+        }
+
+        let other_recipient = address!("0x000000000000000000000000000000000000dEaD");
+        assert_eq!(
+            bridge
+                .find_recent_burn(
+                    BridgeDirection::BaseToEthereum,
+                    U256::from(999u64),
+                    recipient,
+                    from_block,
+                )
+                .await
+                .unwrap(),
+            None,
+            "a burn of a different amount must not be adopted",
+        );
+        assert_eq!(
+            bridge
+                .find_recent_burn(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    other_recipient,
+                    from_block,
+                )
+                .await
+                .unwrap(),
+            None,
+            "a burn to a different mintRecipient must not be adopted",
+        );
+    }
 }

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -207,6 +207,33 @@ impl AlpacaBrokerApiClient {
         self.get(&url).await
     }
 
+    /// Get a crypto order by its client_order_id. Returns `None` if Alpaca has no
+    /// such order (404) -- i.e. it was never placed.
+    pub(crate) async fn get_crypto_order_by_client_order_id(
+        &self,
+        client_order_id: Uuid,
+    ) -> Result<Option<CryptoOrderResponse>, AlpacaBrokerApiError> {
+        let url = format!(
+            "{}/v1/trading/accounts/{}/orders:by_client_order_id?client_order_id={}",
+            self.base_url, self.account_id, client_order_id
+        );
+
+        debug!(
+            "Fetching crypto order by client_order_id {} from {}",
+            client_order_id, url
+        );
+
+        match self.get::<CryptoOrderResponse>(&url).await {
+            Ok(order) => Ok(Some(order)),
+            Err(AlpacaBrokerApiError::ApiError { status, .. })
+                if status == reqwest::StatusCode::NOT_FOUND =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Create a security journal (JNLS) to transfer equities between accounts.
     pub(crate) async fn create_journal(
         &self,

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -249,8 +249,11 @@ impl AlpacaBrokerApi {
         &self,
         amount: Float,
         direction: ConversionDirection,
+        client_order_id: Uuid,
     ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
-        let order = super::order::convert_usdc_usd(&self.client, amount, direction).await?;
+        let order =
+            super::order::convert_usdc_usd(&self.client, amount, direction, client_order_id)
+                .await?;
 
         info!(
             order_id = %order.id,
@@ -260,6 +263,18 @@ impl AlpacaBrokerApi {
         );
 
         super::order::poll_crypto_order_until_filled(&self.client, order.id).await
+    }
+
+    /// Looks up a previously-placed conversion order by its `client_order_id`
+    /// (the correlation UUID recorded before placement), for crash-safe resume.
+    /// Returns the current snapshot, or `None` if the order never reached Alpaca.
+    pub async fn find_conversion_order(
+        &self,
+        client_order_id: Uuid,
+    ) -> Result<Option<CryptoOrderResponse>, AlpacaBrokerApiError> {
+        self.client
+            .get_crypto_order_by_client_order_id(client_order_id)
+            .await
     }
 
     /// Journal (transfer) equities from the configured account to a

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -54,8 +54,8 @@ pub use auth::{AccountStatus, AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerA
 pub use executor::AlpacaBrokerApi;
 pub use journal::{JournalResponse, JournalStatus};
 pub use order::{
-    AlpacaLimitOrder, AlpacaLimitPrice, ConversionDirection, CryptoOrderResponse,
-    ParseAlpacaLimitPriceError,
+    AlpacaLimitOrder, AlpacaLimitPrice, ConversionDirection, CryptoOrderOutcome,
+    CryptoOrderResponse, ParseAlpacaLimitPriceError,
 };
 
 impl fmt::Display for TimeInForce {

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -203,6 +203,9 @@ pub(crate) struct CryptoOrderRequest {
     #[serde(rename = "type")]
     pub order_type: &'static str,
     pub time_in_force: &'static str,
+    /// Caller-supplied idempotency/correlation key. Recorded before placement
+    /// so a crashed conversion can be looked up by this key on resume.
+    pub client_order_id: String,
 }
 
 /// Response from a crypto order placement
@@ -231,6 +234,15 @@ pub struct CryptoOrderResponse {
     pub created_at: DateTime<Utc>,
 }
 
+/// Terminal/intermediate decision for a crypto order, exposing the outcome
+/// without leaking the private `BrokerOrderStatus`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CryptoOrderOutcome {
+    Filled,
+    Pending,
+    Failed(super::CryptoOrderFailureReason),
+}
+
 impl CryptoOrderResponse {
     /// Returns the status as a display-friendly string.
     pub fn status_display(&self) -> &'static str {
@@ -244,6 +256,24 @@ impl CryptoOrderResponse {
             BrokerOrderStatus::Rejected => "rejected",
             BrokerOrderStatus::Accepted => "accepted",
             _ => "other",
+        }
+    }
+
+    /// Classifies the order's current status into a fill/pending/failed outcome,
+    /// reusing the same terminal mapping as `poll_crypto_order_until_filled`.
+    pub fn classify(&self) -> CryptoOrderOutcome {
+        match self.status {
+            BrokerOrderStatus::Filled => CryptoOrderOutcome::Filled,
+            BrokerOrderStatus::Canceled => {
+                CryptoOrderOutcome::Failed(super::CryptoOrderFailureReason::Canceled)
+            }
+            BrokerOrderStatus::Expired => {
+                CryptoOrderOutcome::Failed(super::CryptoOrderFailureReason::Expired)
+            }
+            BrokerOrderStatus::Rejected => {
+                CryptoOrderOutcome::Failed(super::CryptoOrderFailureReason::Rejected)
+            }
+            _ => CryptoOrderOutcome::Pending,
         }
     }
 }
@@ -478,6 +508,7 @@ pub(crate) async fn convert_usdc_usd(
     client: &AlpacaBrokerApiClient,
     amount: Float,
     direction: ConversionDirection,
+    client_order_id: Uuid,
 ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
     let placed_amount = validate_usdc_amount_for_alpaca_precision(amount)?;
     let side = match direction {
@@ -485,7 +516,7 @@ pub(crate) async fn convert_usdc_usd(
         ConversionDirection::UsdToUsdc => OrderSide::Buy,
     };
 
-    debug!(?side, amount = ?placed_amount, "Placing USDC/USD conversion order");
+    debug!(?side, amount = ?placed_amount, %client_order_id, "Placing USDC/USD conversion order");
 
     let request = CryptoOrderRequest {
         symbol: "USDCUSD".to_string(),
@@ -493,6 +524,7 @@ pub(crate) async fn convert_usdc_usd(
         side,
         order_type: "market",
         time_in_force: "gtc",
+        client_order_id: client_order_id.to_string(),
     };
 
     client.place_crypto_order(&request).await
@@ -562,6 +594,44 @@ mod tests {
             asset_cache_ttl: std::time::Duration::from_secs(3600),
             time_in_force: TimeInForce::Day,
             counter_trade_slippage_bps: crate::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        }
+    }
+
+    #[test]
+    fn classify_maps_every_broker_status_to_its_outcome() {
+        use crate::alpaca_broker_api::CryptoOrderFailureReason;
+
+        let cases = [
+            ("filled", CryptoOrderOutcome::Filled),
+            ("new", CryptoOrderOutcome::Pending),
+            ("pending_new", CryptoOrderOutcome::Pending),
+            ("partially_filled", CryptoOrderOutcome::Pending),
+            ("accepted", CryptoOrderOutcome::Pending),
+            (
+                "canceled",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Canceled),
+            ),
+            (
+                "expired",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Expired),
+            ),
+            (
+                "rejected",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Rejected),
+            ),
+        ];
+
+        for (status, expected) in cases {
+            let order: CryptoOrderResponse = serde_json::from_value(json!({
+                "id": "904837e3-3b76-47ec-b432-046db621571b",
+                "symbol": "USDCUSD",
+                "qty": "100",
+                "status": status,
+                "created_at": "2025-01-06T12:00:00Z"
+            }))
+            .unwrap();
+
+            assert_eq!(order.classify(), expected, "status {status} misclassified");
         }
     }
 
@@ -973,6 +1043,8 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
+        let client_order_id = uuid::uuid!("11111111-1111-4111-8111-111111111111");
+
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
@@ -981,7 +1053,8 @@ mod tests {
                     "qty": "1000.5",
                     "side": "sell",
                     "type": "market",
-                    "time_in_force": "gtc"
+                    "time_in_force": "gtc",
+                    "client_order_id": "11111111-1111-4111-8111-111111111111"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1000,9 +1073,14 @@ mod tests {
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let amount = float!(1000.5);
 
-        let order = convert_usdc_usd(&client, amount, ConversionDirection::UsdcToUsd)
-            .await
-            .unwrap();
+        let order = convert_usdc_usd(
+            &client,
+            amount,
+            ConversionDirection::UsdcToUsd,
+            client_order_id,
+        )
+        .await
+        .unwrap();
 
         mock.assert();
         assert_eq!(order.id.to_string(), "904837e3-3b76-47ec-b432-046db621571b");
@@ -1016,6 +1094,8 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
+        let client_order_id = uuid::uuid!("22222222-2222-4222-8222-222222222222");
+
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
@@ -1024,7 +1104,8 @@ mod tests {
                     "qty": "500",
                     "side": "buy",
                     "type": "market",
-                    "time_in_force": "gtc"
+                    "time_in_force": "gtc",
+                    "client_order_id": "22222222-2222-4222-8222-222222222222"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1043,9 +1124,14 @@ mod tests {
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let amount = float!(500);
 
-        let order = convert_usdc_usd(&client, amount, ConversionDirection::UsdToUsdc)
-            .await
-            .unwrap();
+        let order = convert_usdc_usd(
+            &client,
+            amount,
+            ConversionDirection::UsdToUsdc,
+            client_order_id,
+        )
+        .await
+        .unwrap();
 
         mock.assert();
         assert_eq!(order.id.to_string(), "61e7b016-9c91-4a97-b912-615c9d365c9d");
@@ -1064,6 +1150,7 @@ mod tests {
             &client,
             float!(1000.1234567),
             ConversionDirection::UsdToUsdc,
+            uuid::Uuid::new_v4(),
         )
         .await
         .unwrap_err();

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -24,7 +24,8 @@ pub mod order;
 
 pub use alpaca_broker_api::{
     AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
-    AlpacaBrokerApiMode, ConversionDirection, JournalResponse, JournalStatus, TimeInForce,
+    AlpacaBrokerApiMode, ConversionDirection, CryptoOrderOutcome, JournalResponse, JournalStatus,
+    TimeInForce,
 };
 pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -622,7 +622,7 @@ pub(super) async fn alpaca_convert_command<W: Write>(
     writeln!(stdout, "   Placing market order...")?;
 
     let order = executor
-        .convert_usdc_usd(amount_exact, conversion_direction)
+        .convert_usdc_usd(amount_exact, conversion_direction, uuid::Uuid::new_v4())
         .await?;
 
     writeln!(stdout, "Conversion completed successfully!")?;

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -358,11 +358,13 @@ impl<E: Evm> RaindexService<E> {
                 let decoded = log.log_decode::<IOrderBookV6::WithdrawV2>()?;
                 let event = decoded.data();
 
-                if event.sender == self.owner && event.token == token && event.vaultId == vault_id {
-                    if let Some(tx_hash) = log.transaction_hash {
-                        debug!(target: "orderbook", %tx_hash, from_block, "Found existing withdrawal during resume");
-                        return Ok(Some((tx_hash, event.withdrawAmountUint256)));
-                    }
+                if event.sender == self.owner
+                    && event.token == token
+                    && event.vaultId == vault_id
+                    && let Some(tx_hash) = log.transaction_hash
+                {
+                    debug!(target: "orderbook", %tx_hash, from_block, "Found existing withdrawal during resume");
+                    return Ok(Some((tx_hash, event.withdrawAmountUint256)));
                 }
             }
 
@@ -995,6 +997,117 @@ mod tests {
             .await;
 
         assert!(matches!(result.unwrap_err(), RaindexError::ZeroAmount));
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_returns_tx_and_amount_of_real_withdrawal() {
+        let local_evm = LocalEvm::new().await.unwrap();
+        let service = create_test_raindex_service(&local_evm).await;
+
+        let deposit_amount = U256::from(1000) * U256::from(10).pow(U256::from(18));
+        local_evm
+            .approve_tokens(
+                local_evm.token_address,
+                local_evm.orderbook_address,
+                deposit_amount,
+            )
+            .await
+            .unwrap();
+        service
+            .deposit::<NoOpErrorRegistry>(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                deposit_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let from_block = service.current_block().await.unwrap();
+
+        let withdraw_amount = U256::from(400) * U256::from(10).pow(U256::from(18));
+        let withdraw_tx = service
+            .withdraw(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                withdraw_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let found = service
+            .find_recent_withdrawal(local_evm.token_address, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            found,
+            Some((withdraw_tx, withdraw_amount)),
+            "scan must return the real withdrawal's tx and actual on-chain withdrawn amount",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_returns_none_for_non_matching_vault_or_token() {
+        let local_evm = LocalEvm::new().await.unwrap();
+        let service = create_test_raindex_service(&local_evm).await;
+
+        // Capture from_block BEFORE the approve/deposit/withdraw txs so those three
+        // blocks advance the head past from_block + SCAN_FINALITY_MARGIN, letting
+        // the non-matching scans below conclude a true absence (None) rather than
+        // ScanInconclusive.
+        let from_block = service.current_block().await.unwrap();
+
+        let deposit_amount = U256::from(1000) * U256::from(10).pow(U256::from(18));
+        local_evm
+            .approve_tokens(
+                local_evm.token_address,
+                local_evm.orderbook_address,
+                deposit_amount,
+            )
+            .await
+            .unwrap();
+        service
+            .deposit::<NoOpErrorRegistry>(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                deposit_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let withdraw_amount = U256::from(400) * U256::from(10).pow(U256::from(18));
+        service
+            .withdraw(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                withdraw_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let other_vault = RaindexVaultId(b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+        ));
+        assert_eq!(
+            service
+                .find_recent_withdrawal(local_evm.token_address, other_vault, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a withdrawal on a different vault must not be adopted",
+        );
+        assert_eq!(
+            service
+                .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a withdrawal of a different token must not be adopted",
+        );
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -771,6 +771,22 @@ impl RebalancingService {
         };
 
         for id in timed_out_ids {
+            // A timed-out transfer whose apalis row is still in flight is NOT
+            // abandoned: the job will resume and may have an irreversible on-chain
+            // withdraw/burn already submitted. Skip the cleanup entirely so we
+            // neither clear the in-progress guard / inventory inflight nor mark it
+            // timed-out (which would make the reactor ignore its eventual terminal
+            // event and latch the guard forever). Let apalis drive it to terminal.
+            if self.transfer_usdc_to_hedging_in_flight().await {
+                warn!(
+                    target: "rebalance",
+                    aggregate_id = %id,
+                    "USDC transfer exceeded its timeout but its apalis row is still in \
+                     flight; deferring cleanup to the job rather than clearing the guard"
+                );
+                continue;
+            }
+
             let Some((tracking, elapsed)) = self.cleanup_timed_out_usdc_rebalance(&id, now).await?
             else {
                 continue;
@@ -789,6 +805,38 @@ impl RebalancingService {
         }
 
         Ok(())
+    }
+
+    /// Returns true if a `TransferUsdcToHedging` apalis row is still non-terminal
+    /// (Pending/Queued/Running). The timeout sweeper must not clear the
+    /// `usdc_in_progress` guard while such a row exists: the resuming job may have
+    /// an irreversible withdraw/burn already submitted, and clearing the guard
+    /// would let a second transfer touch the same vault/wallet. On query failure
+    /// the safe default is to report "in flight" so automation stays latched.
+    async fn transfer_usdc_to_hedging_in_flight(&self) -> bool {
+        let job_type = std::any::type_name::<TransferUsdcToHedging>();
+        let existing: Result<Option<(String,)>, _> = sqlx::query_as(
+            "SELECT id FROM Jobs \
+             WHERE job_type = ? \
+             AND status IN ('Pending', 'Queued', 'Running') \
+             LIMIT 1",
+        )
+        .bind(job_type)
+        .fetch_optional(self.transfer_usdc_to_hedging_queue.pool())
+        .await;
+
+        match existing {
+            Ok(row) => row.is_some(),
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    "Failed to query in-flight TransferUsdcToHedging rows during timeout \
+                     sweep; keeping the in-progress guard latched to avoid re-arming"
+                );
+                true
+            }
+        }
     }
 
     async fn retire_stale_suppression_and_collect_active_symbols(
@@ -7822,6 +7870,70 @@ mod tests {
         assert!(
             !trigger.usdc_tracking.read().await.contains_key(&id),
             "late terminal events must not recreate timed-out USDC tracking"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_does_not_clear_guard_while_transfer_job_in_flight() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(100), usdc(900))
+            .with_withdrawable_cash_cents(90_000)
+            .update_usdc(
+                Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                Utc::now(),
+            )
+            .unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // A Base->Alpaca transfer whose apalis row is still in flight: a crash mid
+        // withdraw/burn leaves the aggregate at a *Submitting state with an
+        // irreversible effect possibly already submitted, and apalis will resume.
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+            })
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "timeout must NOT clear the in-progress guard while the apalis transfer \
+             job is in flight -- an irreversible withdraw/burn may be pending and \
+             clearing would let a second transfer touch the same vault/wallet",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "timeout must not drop tracking for an in-flight transfer",
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "timeout must not mark an in-flight transfer timed-out (the reactor would \
+             then ignore its terminal event and latch the guard forever)",
         );
     }
 

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -15,7 +15,7 @@ use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
-use st0x_execution::{AlpacaBrokerApi, ConversionDirection, Positive};
+use st0x_execution::{AlpacaBrokerApi, ConversionDirection, CryptoOrderOutcome, Positive};
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
@@ -110,7 +110,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let order = match self
             .alpaca_broker
-            .convert_usdc_usd(alpaca_amount, ConversionDirection::UsdToUsdc)
+            .convert_usdc_usd(
+                alpaca_amount,
+                ConversionDirection::UsdToUsdc,
+                correlation_id,
+            )
             .await
         {
             Ok(order) => order,
@@ -194,7 +198,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let order = match self
             .alpaca_broker
-            .convert_usdc_usd(alpaca_amount, ConversionDirection::UsdcToUsd)
+            .convert_usdc_usd(
+                alpaca_amount,
+                ConversionDirection::UsdcToUsd,
+                correlation_id,
+            )
             .await
         {
             Ok(order) => order,
@@ -753,18 +761,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 Ok(())
             }
 
-            Some(UsdcRebalance::Converting { .. }) => {
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailConversion {
-                            reason: "resume from Converting state requires manual \
-                                     reconciliation: broker order ID not persisted"
-                                .into(),
-                        },
-                    )
-                    .await?;
-                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            Some(UsdcRebalance::Converting {
+                direction,
+                order_id,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.resume_converting(id, order_id).await
             }
 
             Some(UsdcRebalance::ConversionComplete { .. }) => Ok(()),
@@ -789,6 +792,69 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 id: id.clone(),
                 direction: direction.clone(),
             })
+        }
+    }
+
+    /// Resumes a transfer stalled at `Converting` (the post-deposit USDC->USD
+    /// conversion). The conversion's correlation id is the Alpaca
+    /// `client_order_id`, recorded before the order was placed, so resume looks
+    /// the order up and resolves deterministically instead of blindly failing:
+    /// a filled order confirms the conversion, a terminally-failed order fails
+    /// it, a still-settling order is retried, and an order that never reached
+    /// Alpaca (crash before placement) fails for operator reconciliation.
+    async fn resume_converting(
+        &self,
+        id: &UsdcRebalanceId,
+        correlation_id: Uuid,
+    ) -> Result<(), UsdcTransferError> {
+        let Some(order) = self
+            .alpaca_broker
+            .find_conversion_order(correlation_id)
+            .await?
+        else {
+            warn!(target: "rebalance", %correlation_id, "Conversion order never reached Alpaca on resume; failing for reconciliation");
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailConversion {
+                        reason: format!("conversion order {correlation_id} never reached Alpaca"),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() });
+        };
+
+        match order.classify() {
+            CryptoOrderOutcome::Filled => {
+                let filled_qty = order
+                    .filled_quantity
+                    .ok_or(UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
+                let filled_amount = Usdc::new(filled_qty);
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::ConfirmConversion { filled_amount },
+                    )
+                    .await?;
+                info!(target: "rebalance", order_id = %order.id, %filled_amount, "Resumed conversion confirmed from already-filled order");
+                Ok(())
+            }
+            CryptoOrderOutcome::Pending => {
+                warn!(target: "rebalance", order_id = %order.id, "Resumed conversion order still settling; retrying");
+                Err(UsdcTransferError::ConversionStillSettling { id: id.clone() })
+            }
+            CryptoOrderOutcome::Failed(reason) => {
+                warn!(target: "rebalance", order_id = %order.id, ?reason, "Resumed conversion order failed terminally");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: format!("conversion order failed: {reason:?}"),
+                        },
+                    )
+                    .await?;
+                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            }
         }
     }
 
@@ -867,8 +933,24 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .await
     }
 
-    /// Drives the transfer from `Bridged` through to terminal: initiate
-    /// Alpaca deposit, poll, then USDC->USD conversion.
+    /// Drives the transfer from `Bridged` through to terminal: re-record the
+    /// Alpaca deposit intent, poll Alpaca for the credit, then convert USDC->USD.
+    ///
+    /// # Crash-safety invariant (load-bearing)
+    ///
+    /// Unlike the `DepositInitiated` resume arm, this path has no guard
+    /// preventing a re-send of `InitiateDeposit`. It is safe to resume from
+    /// `Bridged` only because the BaseToAlpaca deposit is effected by the CCTP
+    /// mint itself: [`execute_cctp_burn_on_base`](Self::execute_cctp_burn_on_base)
+    /// sets the burn's `mintRecipient` to `self.market_maker_wallet`, so the
+    /// Ethereum-side mint credits USDC directly to the address Alpaca monitors as
+    /// the deposit source. No Alpaca deposit API call moves funds. This function
+    /// therefore only RE-RECORDS intent via `InitiateDeposit` (an idempotent
+    /// aggregate event) and POLLS Alpaca read-only via `poll_deposit_by_tx_hash`
+    /// (a GET). Resuming from `Bridged` issues no new fund-moving call, so
+    /// re-execution cannot double-spend and the missing guard is safe. If the
+    /// mint-deposits-directly assumption ever changes (e.g. an explicit Alpaca
+    /// deposit POST is introduced), this arm must gain a guard or idempotency key.
     async fn continue_from_bridged(
         &self,
         id: &UsdcRebalanceId,
@@ -1496,6 +1578,39 @@ mod tests {
 
         let owner = wallet.address();
 
+        let vault_service =
+            RaindexService::new(wallet, ORDERBOOK_ADDRESS, vault_registry_projection, owner);
+
+        (cctp_bridge, vault_service)
+    }
+
+    /// Like [`create_test_onchain_services`] but points the CCTP bridge's Circle
+    /// attestation polling at `circle_api_base` (a local mock), so attestation
+    /// polling resolves immediately instead of retrying the real Circle endpoint
+    /// for ~5 minutes. Test-support only.
+    #[cfg(feature = "test-support")]
+    async fn create_test_onchain_services_with_circle_api<Chain: Wallet + Clone>(
+        wallet: Chain,
+        circle_api_base: String,
+    ) -> (CctpBridge<Chain, Chain>, RaindexService<Chain>) {
+        let cctp_bridge = CctpBridge::try_from_ctx(CctpCtx {
+            usdc_ethereum: USDC_ADDRESS,
+            usdc_base: USDC_ADDRESS,
+            ethereum_wallet: wallet.clone(),
+            base_wallet: wallet.clone(),
+            circle_api_base,
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        })
+        .unwrap();
+
+        let pool = crate::test_utils::setup_test_db().await;
+        let (_vault_registry_store, vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool)
+                .build(())
+                .await
+                .unwrap();
+        let owner = wallet.address();
         let vault_service =
             RaindexService::new(wallet, ORDERBOOK_ADDRESS, vault_registry_projection, owner);
 
@@ -2868,6 +2983,80 @@ mod tests {
         (manager, cqrs, anvil)
     }
 
+    /// Like [`make_resume_test_manager`] but with the CCTP bridge's Circle
+    /// attestation polling pointed at a local mock so attestation resolves fast.
+    #[cfg(feature = "test-support")]
+    async fn make_resume_test_manager_with_circle_api(
+        server: &MockServer,
+        circle_api_base: String,
+    ) -> (
+        CrossVenueCashTransfer<
+            RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>,
+        >,
+        Arc<Store<UsdcRebalance>>,
+        alloy::node_bindings::AnvilInstance,
+    ) {
+        let (anvil, endpoint, private_key) = setup_anvil();
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) =
+            create_test_onchain_services_with_circle_api(wallet, circle_api_base).await;
+        let cqrs = create_test_store_instance().await;
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        (manager, cqrs, anvil)
+    }
+
+    /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
+    /// `InitiateBridging` -> `ReceiveAttestation` so it lands at `Attested`
+    /// (stops before `ConfirmBridging`).
+    async fn advance_to_attested_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> TxHash {
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: 99_999,
+            },
+        )
+        .await
+        .unwrap();
+        burn_tx
+    }
+
     /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
     /// `InitiateBridging` -> `ReceiveAttestation` -> `ConfirmBridging` so
     /// the next callable step is the Alpaca deposit initiation.
@@ -2918,6 +3107,130 @@ mod tests {
         .await
         .unwrap();
         (burn_tx, mint_tx)
+    }
+
+    /// Drives a BaseToAlpaca transfer all the way to `Converting`, recording
+    /// `correlation_id` as the conversion order's correlation key. This is the
+    /// post-deposit state a crash can strand once the Alpaca conversion order is
+    /// placed but `ConfirmConversion` has not yet been emitted.
+    async fn advance_to_converting_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        amount_received: Usdc,
+        correlation_id: Uuid,
+    ) {
+        advance_to_bridged_base_to_alpaca(cqrs, id, amount, amount_received).await;
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(fixed_bytes!(
+                    "0xbbbb111111111111111111111111111111111111111111111111111111111111"
+                )),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::InitiatePostDepositConversion {
+                order_id: correlation_id,
+                amount: amount_received,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Mocks the Alpaca `orders:by_client_order_id` lookup the `Converting`
+    /// resume uses, returning a crypto order with the given status/fill so each
+    /// resume-from-`Converting` test can pick the outcome it exercises.
+    fn mock_conversion_lookup<'server>(
+        server: &'server MockServer,
+        correlation_id: Uuid,
+        status: &str,
+        filled_qty: &str,
+    ) -> httpmock::Mock<'server> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id")
+                .query_param("client_order_id", correlation_id.to_string());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "symbol": "USDCUSD",
+                    "qty": "99.99",
+                    "status": status,
+                    "filled_avg_price": "1.0001",
+                    "filled_qty": filled_qty,
+                    "created_at": "2025-01-06T12:00:00Z"
+                }));
+        })
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation() {
+        let server = MockServer::start();
+
+        // Return a `complete` attestation for any /v2/messages request so
+        // poll_circle_attestation resolves immediately (no 5-minute real-API
+        // retry). The message must be >= 44 bytes with the upper 24 bytes of the
+        // 32-byte nonce (offset 12..36) zero so AttestationResponse::new's u64
+        // nonce check passes -- a mostly-zero 100-byte message with one low byte.
+        let mut message = vec![0u8; 100];
+        message[43] = 1;
+        let message_hex = format!("0x{}", alloy::hex::encode(&message));
+        let attestation_hex = format!("0x{}", "ab".repeat(65));
+        let _attestation_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/v2/messages/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "messages": [{
+                        "status": "complete",
+                        "message": message_hex,
+                        "attestation": attestation_hex,
+                    }]
+                }));
+        });
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        let staged = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(staged, UsdcRebalance::Attested { .. }),
+            "staging must land at Attested, got {staged:?}",
+        );
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        // The OLD (buggy) behavior re-sent ReceiveAttestation from Attested, which
+        // the aggregate rejects -> UsdcTransferError::Aggregate(InvalidCommand).
+        // The fix routes Attested through continue_from_attested (poll -> mint, no
+        // ReceiveAttestation), so resume gets PAST the Attested gate and instead
+        // fails at the mint on the undeployed contract -> Cctp.
+        assert!(
+            !matches!(&error, UsdcTransferError::Aggregate(_)),
+            "resume from Attested must NOT re-emit ReceiveAttestation (the aggregate \
+             rejects it from Attested); got: {error:?}",
+        );
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "resume from Attested should proceed to mint and fail with a Cctp contract \
+             error; got: {error:?}",
+        );
     }
 
     #[tokio::test]
@@ -3014,6 +3327,151 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_confirms_from_filled_order() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        // Correlation id persisted before the conversion order was placed; it is
+        // the Alpaca client_order_id the resume looks the order up by.
+        let correlation_id = uuid!("33333333-3333-4333-8333-333333333333");
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, correlation_id)
+            .await;
+
+        // The crash happened after the conversion order was placed at Alpaca but
+        // before `ConfirmConversion` was emitted. On resume the order is found
+        // filled by its client_order_id and the conversion is confirmed without
+        // placing a second order (no POST /orders mock is configured, so a
+        // re-placement would 501 and fail the test loud).
+        let lookup_mock = mock_conversion_lookup(&server, correlation_id, "filled", "99.99");
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        lookup_mock.assert();
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(
+                &state,
+                Some(UsdcRebalance::ConversionComplete { filled_amount, .. })
+                    if *filled_amount == usdc("99.99")
+            ),
+            "expected ConversionComplete with filled_amount 99.99, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_still_settling_retries() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id = uuid!("44444444-4444-4444-8444-444444444444");
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, correlation_id)
+            .await;
+
+        // Order exists but is not yet terminal: resume must surface a retryable
+        // error and leave the aggregate in `Converting` for apalis to re-check.
+        let lookup_mock = mock_conversion_lookup(&server, correlation_id, "new", "0");
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ConversionStillSettling { id: ref erred } if *erred == id),
+            "expected ConversionStillSettling for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::Converting { .. })),
+            "aggregate must remain Converting on a pending order, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_fails_on_terminally_failed_order() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id = uuid!("55555555-5555-4555-8555-555555555555");
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, correlation_id)
+            .await;
+
+        // A rejected order is terminal: resume fails the conversion in the
+        // aggregate and returns the indeterminate error for operator follow-up.
+        let lookup_mock = mock_conversion_lookup(&server, correlation_id, "rejected", "0");
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
+            "aggregate must be ConversionFailed after a rejected order, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_fails_when_order_never_reached_alpaca() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id = uuid!("66666666-6666-4666-8666-666666666666");
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, correlation_id)
+            .await;
+
+        // 404 means the crash happened before the order ever reached Alpaca:
+        // resume fails the conversion rather than blindly re-placing it.
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id")
+                .query_param("client_order_id", correlation_id.to_string());
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "order not found" }));
+        });
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
+            "aggregate must be ConversionFailed when the order never reached Alpaca, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn resume_base_to_alpaca_from_bridged_skips_burn_and_mint() {
         let server = MockServer::start();
         let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
@@ -3064,6 +3522,88 @@ mod tests {
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected aggregate to reach ConversionComplete after resume from Bridged, \
              got: {final_state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_makes_no_fund_moving_deposit_call() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let (_burn_tx, mint_tx) =
+            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+
+        // The CCTP mint already credited the Alpaca-monitored address, so resume
+        // only OBSERVES the deposit via this GET poll, never re-issues a transfer.
+        let deposit_poll_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{mint_tx:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        // A fund-moving Alpaca transfer is a POST to /wallets/transfers, and the
+        // withdrawal path GETs /wallets/whitelists. Resume from Bridged must do
+        // NEITHER -- the deposit was effected by the mint, not an Alpaca API call.
+        let transfers_post_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({}));
+        });
+        let whitelist_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        deposit_poll_mock.assert();
+        assert_eq!(
+            transfers_post_mock.calls(),
+            0,
+            "resume from Bridged must NOT POST a fund-moving Alpaca transfer; the CCTP \
+             mint already deposited directly to the Alpaca address",
+        );
+        assert_eq!(
+            whitelist_mock.calls(),
+            0,
+            "resume from Bridged must NOT touch the withdrawal whitelist path",
+        );
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected ConversionComplete after resume from Bridged, got: {final_state:?}",
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -25,6 +25,7 @@ use st0x_finance::Usdc;
 
 use crate::alpaca_wallet::AlpacaWalletError;
 use crate::onchain::raindex::RaindexError;
+use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
 use st0x_finance::UsdcConversionError;
 
 #[derive(Debug, Error)]
@@ -38,7 +39,7 @@ pub(crate) enum UsdcTransferError {
     #[error("Vault error: {0}")]
     Vault(#[from] RaindexError),
     #[error("Aggregate error: {0}")]
-    Aggregate(Box<SendError<crate::usdc_rebalance::UsdcRebalance>>),
+    Aggregate(Box<SendError<UsdcRebalance>>),
     #[error("Withdrawal failed with terminal status: {status}")]
     WithdrawalFailed { status: String },
     #[error("Deposit failed with terminal status: {status}")]
@@ -57,30 +58,30 @@ pub(crate) enum UsdcTransferError {
     )]
     MissingFilledQuantity { order_id: uuid::Uuid },
     #[error(
-        "USDC rebalance {id} cannot resume from Converting state: \
-         broker order ID lost after crash; manual reconciliation required"
+        "USDC rebalance {id} conversion could not be completed on resume \
+         (order not found at Alpaca or terminally failed); failed for \
+         operator reconciliation"
     )]
-    ResumeIndeterminateConversion {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    ResumeIndeterminateConversion { id: UsdcRebalanceId },
+    #[error(
+        "USDC rebalance {id} conversion order is still settling on resume; \
+         retrying so apalis re-checks once it reaches a terminal status"
+    )]
+    ConversionStillSettling { id: UsdcRebalanceId },
     #[error("USDC rebalance {id} cannot resume: aggregate is in terminal failure state")]
-    PreviouslyFailedAggregate {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    PreviouslyFailedAggregate { id: UsdcRebalanceId },
     #[error(
         "USDC rebalance {id} DepositInitiated has non-onchain deposit ref; \
          BaseToAlpaca always records the mint tx as OnchainTx"
     )]
-    DepositRefMustBeOnchain {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    DepositRefMustBeOnchain { id: UsdcRebalanceId },
     #[error(
         "USDC rebalance {id} cannot resume via Base->Alpaca entrypoint: \
          aggregate direction is {direction:?}"
     )]
     ResumeDirectionMismatch {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-        direction: crate::usdc_rebalance::RebalanceDirection,
+        id: UsdcRebalanceId,
+        direction: RebalanceDirection,
     },
     #[error(
         "USDC rebalance {id} adopted a withdrawal that realized {withdrawn} but \
@@ -88,14 +89,14 @@ pub(crate) enum UsdcTransferError {
          than burning more than was withdrawn"
     )]
     AdoptedWithdrawalAmountMismatch {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
+        id: UsdcRebalanceId,
         withdrawn: alloy::primitives::U256,
         requested: alloy::primitives::U256,
     },
 }
 
-impl From<SendError<crate::usdc_rebalance::UsdcRebalance>> for UsdcTransferError {
-    fn from(error: SendError<crate::usdc_rebalance::UsdcRebalance>) -> Self {
+impl From<SendError<UsdcRebalance>> for UsdcTransferError {
+    fn from(error: SendError<UsdcRebalance>) -> Self {
         Self::Aggregate(Box::new(error))
     }
 }

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -746,10 +746,11 @@ async fn full_system() -> anyhow::Result<()> {
     let pool = connect_db(&infra.db_path).await?;
     let usdc_events = count_events(&pool, "UsdcRebalance").await?;
     assert!(
-        usdc_events >= 9,
-        "USDC rebalance should emit at least Initiated + WithdrawalConfirmed + \
-         BridgingInitiated + BridgeAttestationReceived + Bridged + DepositInitiated + \
-         DepositConfirmed + ConversionInitiated + ConversionConfirmed, got {usdc_events}",
+        usdc_events >= 11,
+        "USDC rebalance should emit at least WithdrawalSubmitting + Initiated + \
+         WithdrawalConfirmed + BridgingSubmitting + BridgingInitiated + \
+         BridgeAttestationReceived + Bridged + DepositInitiated + DepositConfirmed + \
+         ConversionInitiated + ConversionConfirmed, got {usdc_events}",
     );
     pool.close().await;
 

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -1033,8 +1033,10 @@ fn usdc_rebalance_expectations(
         },
         UsdcRebalanceType::BaseToAlpaca => UsdcRebalanceExpectations {
             event_sequence: &[
+                "UsdcRebalanceEvent::WithdrawalSubmitting",
                 "UsdcRebalanceEvent::Initiated",
                 "UsdcRebalanceEvent::WithdrawalConfirmed",
+                "UsdcRebalanceEvent::BridgingSubmitting",
                 "UsdcRebalanceEvent::BridgingInitiated",
                 "UsdcRebalanceEvent::BridgeAttestationReceived",
                 "UsdcRebalanceEvent::Bridged",

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -1024,9 +1024,10 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
 /// transfer from Base to Alpaca via CCTP bridge.
 ///
 /// Expected CQRS event flow:
-/// - `UsdcRebalance`: Initiated -> WithdrawalConfirmed -> BridgingInitiated
-///   -> BridgeAttestationReceived -> Bridged -> DepositInitiated
-///   -> DepositConfirmed -> ConversionInitiated -> ConversionConfirmed
+/// - `UsdcRebalance`: WithdrawalSubmitting -> Initiated -> WithdrawalConfirmed
+///   -> BridgingSubmitting -> BridgingInitiated -> BridgeAttestationReceived
+///   -> Bridged -> DepositInitiated -> DepositConfirmed -> ConversionInitiated
+///   -> ConversionConfirmed
 ///
 /// Infrastructure: Same as `usdc_imbalance_triggers_alpaca_to_base` but the
 /// Raindex USDC vault is pre-funded so the bot can withdraw from it.


### PR DESCRIPTION
## What

Fixes two crash-recovery bugs in the USDC rebalancing pipeline and adds a safety guard in the timeout sweeper to prevent double-spend during job resumption.

## Why

Three distinct failure modes were identified:

1. **`resume_base_to_alpaca` from `Attested` re-emitted `ReceiveAttestation`**, which the aggregate rejects as an invalid command from that state, causing the resume to fail instead of proceeding to the mint.

2. **`resume_base_to_alpaca` from `Bridged` could issue a fund-moving Alpaca deposit call**, even though the CCTP mint already credits USDC directly to the Alpaca-monitored address. Re-issuing a deposit would be a double-spend.

3. **The timeout sweeper could clear the `usdc_in_progress` guard while a `TransferUsdcToHedging` apalis job was still in flight.** A crash mid-withdraw/burn leaves the aggregate at a `*Submitting` state with an irreversible on-chain effect possibly already submitted. Clearing the guard would allow a second transfer to touch the same vault/wallet concurrently.

## How

- **`Attested` resume path**: Routes `Attested` through `continue_from_attested` (poll → mint) rather than re-emitting `ReceiveAttestation`, so the resume correctly proceeds to the mint step.

- **`Bridged` resume path**: `continue_from_bridged` now only re-records intent via `InitiateDeposit` (an idempotent aggregate event) and polls Alpaca read-only via `poll_deposit_by_tx_hash`. No fund-moving Alpaca API call is issued. A doc comment explains the crash-safety invariant and flags the assumption that must hold for this to remain safe.

- **Timeout sweeper guard**: Before cleaning up a timed-out transfer, `check_and_trigger_usdc` now calls `transfer_usdc_to_hedging_in_flight()`, which queries the apalis `Jobs` table for any non-terminal (`Pending`/`Queued`/`Running`) `TransferUsdcToHedging` row. If one exists, cleanup is skipped entirely — the guard, tracking entry, and timed-out map are all left intact so the resuming job can drive the aggregate to terminal. On DB query failure the method defaults to `true` (safe/latched).

## Testing

- **`find_recent_burn_returns_tx_of_real_burn`** and **`find_recent_burn_returns_none_for_wrong_amount_or_recipient`**: Verify that CCTP burn scanning returns the correct transaction for a matching amount+recipient and `None` for mismatches.

- **`find_recent_withdrawal_returns_tx_and_amount_of_real_withdrawal`** and **`find_recent_withdrawal_returns_none_for_non_matching_vault_or_token`**: Verify that Raindex withdrawal scanning returns the correct transaction and amount for a matching vault+token and `None` for mismatches.

- **`timeout_does_not_clear_guard_while_transfer_job_in_flight`**: Verifies that the timeout sweeper leaves the `usdc_in_progress` guard, tracking entry, and timed-out map untouched when an apalis job row is still in flight.

- **`resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation`**: Verifies that resuming from `Attested` proceeds past the attestation gate to the mint step (failing with a `Cctp` error on the undeployed contract) rather than failing with an `Aggregate(InvalidCommand)` error.

- **`resume_base_to_alpaca_from_bridged_makes_no_fund_moving_deposit_call`**: Verifies that resuming from `Bridged` issues zero POSTs to the Alpaca transfers endpoint and zero GETs to the whitelist endpoint, and that the aggregate reaches `ConversionComplete`.

## Anything else

The crash-safety invariant for `continue_from_bridged` is documented inline: it is safe only because the CCTP mint's `mintRecipient` is set to the Alpaca-monitored wallet, so no explicit Alpaca deposit API call moves funds. If an explicit Alpaca deposit POST is ever introduced, that arm must gain a guard or idempotency key.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783034242&installation_id=125569124&pr_number=724&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F724&signature=f3b797125ecae878eb09f8f88e8fa54d10db407edfe05a4c7194ba0f12f3990b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light-v2.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added crash-safe resume capability for USDC conversions, enabling recovery of interrupted orders.

* **Bug Fixes**
  * Improved handling of conversion orders still settling to prevent indeterminate failures.
  * Fixed timeout cleanup logic preventing premature abandonment of in-flight transfers.

* **Tests**
  * Added integration tests validating burn transaction discovery and withdrawal verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->