### PR TITLE
feat: crash-safe resume for Base->Alpaca USDC transfers (Converting/Attested via order lookup)

### DIFF
--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -1326,7 +1326,7 @@ mod tests {
     /// Full CCTP test infrastructure with two chains (simulating Ethereum and Base)
     struct LocalCctp {
         _ethereum_anvil: AnvilInstance,
-        _base_anvil: AnvilInstance,
+        base_anvil: AnvilInstance,
         ethereum_endpoint: String,
         base_endpoint: String,
         ethereum: DeployedCctpChain,
@@ -1432,7 +1432,7 @@ mod tests {
 
             Ok(Self {
                 _ethereum_anvil: ethereum_anvil,
-                _base_anvil: base_anvil,
+                base_anvil,
                 ethereum_endpoint,
                 base_endpoint,
                 ethereum,
@@ -1638,15 +1638,30 @@ mod tests {
             >,
             Box<dyn std::error::Error>,
         > {
+            self.create_bridge_with_key(&self.deployer_key).await
+        }
+
+        /// Builds a bridge whose wallet is `private_key` rather than the deployer.
+        /// Used to simulate a burn submitted by a different depositor so the
+        /// depositor clause in `find_recent_burn`'s predicate can be exercised.
+        async fn create_bridge_with_key(
+            &self,
+            private_key: &B256,
+        ) -> Result<
+            CctpBridge<
+                RawPrivateKeyWallet<impl Provider + Clone + use<>>,
+                RawPrivateKeyWallet<impl Provider + Clone + use<>>,
+            >,
+            Box<dyn std::error::Error>,
+        > {
             let ethereum_provider = ProviderBuilder::new()
                 .connect(&self.ethereum_endpoint)
                 .await?;
 
             let base_provider = ProviderBuilder::new().connect(&self.base_endpoint).await?;
 
-            let ethereum_wallet =
-                RawPrivateKeyWallet::new(&self.deployer_key, ethereum_provider, 1)?;
-            let base_wallet = RawPrivateKeyWallet::new(&self.deployer_key, base_provider, 1)?;
+            let ethereum_wallet = RawPrivateKeyWallet::new(private_key, ethereum_provider, 1)?;
+            let base_wallet = RawPrivateKeyWallet::new(private_key, base_provider, 1)?;
 
             let ethereum = CctpEndpoint::new(
                 self.ethereum.usdc,
@@ -2387,6 +2402,7 @@ mod tests {
             .unwrap();
 
         let other_recipient = address!("0x000000000000000000000000000000000000dEaD");
+
         assert_eq!(
             bridge
                 .find_recent_mint(BridgeDirection::BaseToEthereum, other_recipient, from_block)
@@ -2412,6 +2428,7 @@ mod tests {
             .destination_block(BridgeDirection::BaseToEthereum)
             .await
             .unwrap();
+
         assert_eq!(
             bridge
                 .find_recent_mint(BridgeDirection::BaseToEthereum, recipient, head_above_mint)
@@ -2443,5 +2460,154 @@ mod tests {
             assert!(!receipt.tx.is_zero(), "Burn {i}: tx hash should be set");
             assert_eq!(receipt.amount, amount, "Burn {i}: amount should match");
         }
+    }
+
+    #[tokio::test]
+    async fn find_recent_burn_returns_tx_of_real_burn() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+        let recipient = bridge.ethereum.owner();
+        let amount = U256::from(25_000_000u64);
+
+        let base_provider = ProviderBuilder::new()
+            .connect(cctp.base_endpoint.as_str())
+            .await
+            .unwrap();
+        let from_block = base_provider.get_block_number().await.unwrap();
+
+        let receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(BridgeDirection::BaseToEthereum, amount, recipient)
+            .await
+            .unwrap();
+
+        let found = bridge
+            .find_recent_burn(
+                BridgeDirection::BaseToEthereum,
+                amount,
+                recipient,
+                from_block,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            found,
+            Some(receipt.tx),
+            "scan must return the real burn's tx for the matching amount + recipient",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_burn_returns_none_for_wrong_amount_or_recipient() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+        let recipient = bridge.ethereum.owner();
+        let amount = U256::from(25_000_000u64);
+
+        let base_provider = ProviderBuilder::new()
+            .connect(cctp.base_endpoint.as_str())
+            .await
+            .unwrap();
+        let from_block = base_provider.get_block_number().await.unwrap();
+
+        // Burn a few times to advance the Base head past from_block + the scan
+        // finality margin so the non-matching scans below conclude a true absence.
+        for _ in 0..3 {
+            bridge
+                .burn_internal::<NoOpErrorRegistry>(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    recipient,
+                )
+                .await
+                .unwrap();
+        }
+
+        let other_recipient = address!("0x000000000000000000000000000000000000dEaD");
+        assert_eq!(
+            bridge
+                .find_recent_burn(
+                    BridgeDirection::BaseToEthereum,
+                    U256::from(999u64),
+                    recipient,
+                    from_block,
+                )
+                .await
+                .unwrap(),
+            None,
+            "a burn of a different amount must not be adopted",
+        );
+        assert_eq!(
+            bridge
+                .find_recent_burn(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    other_recipient,
+                    from_block,
+                )
+                .await
+                .unwrap(),
+            None,
+            "a burn to a different mintRecipient must not be adopted",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_burn_ignores_burn_from_a_different_depositor() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+        let recipient = bridge.ethereum.owner();
+        let amount = U256::from(25_000_000u64);
+
+        let base_provider = ProviderBuilder::new()
+            .connect(cctp.base_endpoint.as_str())
+            .await
+            .unwrap();
+        let from_block = base_provider.get_block_number().await.unwrap();
+
+        // A different EOA burns the same amount to the same recipient on Base.
+        // Depositor is the only field separating it from our own burn, so this
+        // pins the depositor clause in find_recent_burn's predicate: dropping it
+        // would let us adopt another sender's burn and mint against a burn we
+        // never made.
+        let other_key = B256::from_slice(&cctp.base_anvil.keys()[2].to_bytes());
+        let other_address = PrivateKeySigner::from_bytes(&other_key).unwrap().address();
+        LocalCctp::mint_usdc(
+            &cctp.base_endpoint,
+            &cctp.deployer_key,
+            cctp.base.usdc,
+            other_address,
+        )
+        .await
+        .unwrap();
+        let other_bridge = cctp.create_bridge_with_key(&other_key).await.unwrap();
+
+        // Burn a few times so the Base head advances past from_block + the scan
+        // finality margin, so the scan below concludes a true absence rather than
+        // a retryable ScanInconclusive.
+        for _ in 0..3 {
+            other_bridge
+                .burn_internal::<NoOpErrorRegistry>(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    recipient,
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            bridge
+                .find_recent_burn(
+                    BridgeDirection::BaseToEthereum,
+                    amount,
+                    recipient,
+                    from_block,
+                )
+                .await
+                .unwrap(),
+            None,
+            "a burn from a different depositor must not be adopted",
+        );
     }
 }

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -15,7 +15,7 @@ use super::journal::{JournalRequest, JournalResponse};
 use super::order::{
     CryptoOrderRequest, CryptoOrderResponse, LimitOrderRequest, OrderRequest, OrderResponse,
 };
-use crate::{FractionalShares, Positive, Symbol};
+use crate::{ClientOrderId, FractionalShares, Positive, Symbol};
 
 /// Alpaca Broker API HTTP client with Basic authentication
 pub(crate) struct AlpacaBrokerApiClient {
@@ -205,6 +205,39 @@ impl AlpacaBrokerApiClient {
         debug!("Fetching crypto order {} from {}", order_id, url);
 
         self.get(&url).await
+    }
+
+    /// Get a crypto order by its `client_order_id`. Returns `None` only on a 404
+    /// (Alpaca's documented not-found response for this lookup) -- i.e. the order
+    /// was never placed.
+    ///
+    /// Every other error status is propagated rather than mapped to `None`. This is
+    /// deliberate: a transient failure (5xx, rate limit) on an order that WAS placed
+    /// must retry, not be mistaken for "never placed" -- mapping it to `None` would
+    /// wrongly fail a still-settling conversion and lose the converted USDC.
+    pub(crate) async fn get_crypto_order_by_client_order_id(
+        &self,
+        client_order_id: &ClientOrderId,
+    ) -> Result<Option<CryptoOrderResponse>, AlpacaBrokerApiError> {
+        let url = format!(
+            "{}/v1/trading/accounts/{}/orders:by_client_order_id?client_order_id={}",
+            self.base_url, self.account_id, client_order_id
+        );
+
+        debug!(
+            "Fetching crypto order by client_order_id {} from {}",
+            client_order_id, url
+        );
+
+        match self.get::<CryptoOrderResponse>(&url).await {
+            Ok(order) => Ok(Some(order)),
+            Err(AlpacaBrokerApiError::ApiError { status, .. })
+                if status == reqwest::StatusCode::NOT_FOUND =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Create a security journal (JNLS) to transfer equities between accounts.

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -13,12 +13,14 @@ use st0x_float_serde::format_float_with_fallback;
 use super::auth::{AccountStatus, AlpacaAccountId, AlpacaBrokerApiCtx};
 use super::client::AlpacaBrokerApiClient;
 use super::journal::JournalResponse;
-use super::order::{AlpacaLimitOrder, ConversionDirection, CryptoOrderResponse};
+use super::order::{
+    AlpacaLimitOrder, ConversionDirection, CryptoOrderOutcome, CryptoOrderResponse,
+};
 use super::{AlpacaBrokerApiError, AssetStatus, TimeInForce};
 use crate::{
-    CounterTradePreflight, Direction, Executor, FractionalShares, InventoryResult, MarketOrder,
-    OrderPlacement, OrderState, OrderStatus, Positive, SupportedExecutor, Symbol, TryIntoExecutor,
-    buying_power_counter_trade_preflight, estimate_buffered_cost_cents,
+    ClientOrderId, CounterTradePreflight, Direction, Executor, FractionalShares, InventoryResult,
+    MarketOrder, OrderPlacement, OrderState, OrderStatus, Positive, SupportedExecutor, Symbol,
+    TryIntoExecutor, buying_power_counter_trade_preflight, estimate_buffered_cost_cents,
 };
 
 /// Response from the asset endpoint
@@ -249,8 +251,11 @@ impl AlpacaBrokerApi {
         &self,
         amount: Float,
         direction: ConversionDirection,
+        client_order_id: &ClientOrderId,
     ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
-        let order = super::order::convert_usdc_usd(&self.client, amount, direction).await?;
+        let order =
+            super::order::convert_usdc_usd(&self.client, amount, direction, client_order_id)
+                .await?;
 
         info!(
             order_id = %order.id,
@@ -260,6 +265,42 @@ impl AlpacaBrokerApi {
         );
 
         super::order::poll_crypto_order_until_filled(&self.client, order.id).await
+    }
+
+    /// Looks up a previously-placed conversion order by its `client_order_id`
+    /// (the correlation id recorded before placement), for crash-safe resume.
+    /// Returns the current snapshot, or `None` if the order never reached Alpaca.
+    pub async fn find_conversion_order(
+        &self,
+        client_order_id: &ClientOrderId,
+    ) -> Result<Option<CryptoOrderResponse>, AlpacaBrokerApiError> {
+        self.client
+            .get_crypto_order_by_client_order_id(client_order_id)
+            .await
+    }
+
+    /// Polls a previously-placed conversion order until it reaches a terminal
+    /// state (filled or terminally failed), returning the final snapshot.
+    ///
+    /// Crash-safe resume uses this to await a still-settling conversion -- the
+    /// same wait the original placement performs in `convert_usdc_usd` -- instead
+    /// of failing the job. Failing a healthy-but-slow conversion would burn the
+    /// finite apalis retry budget and risk the timeout sweep clearing the
+    /// in-progress guard while the conversion is still settling.
+    pub async fn poll_conversion_to_terminal(
+        &self,
+        order_id: Uuid,
+    ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
+        loop {
+            let order = self.client.get_crypto_order(order_id).await?;
+
+            match order.classify() {
+                CryptoOrderOutcome::Filled | CryptoOrderOutcome::Failed(_) => return Ok(order),
+                CryptoOrderOutcome::Pending => {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
     }
 
     /// Journal (transfer) equities from the configured account to a

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -53,8 +53,8 @@ pub use auth::{AccountStatus, AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerA
 pub use executor::AlpacaBrokerApi;
 pub use journal::{JournalResponse, JournalStatus};
 pub use order::{
-    AlpacaLimitOrder, AlpacaLimitPrice, ConversionDirection, CryptoOrderResponse,
-    ParseAlpacaLimitPriceError,
+    AlpacaLimitOrder, AlpacaLimitPrice, ConversionDirection, CryptoOrderOutcome,
+    CryptoOrderResponse, ParseAlpacaLimitPriceError,
 };
 
 impl fmt::Display for TimeInForce {
@@ -96,12 +96,20 @@ impl TimeInForce {
     }
 }
 
-/// Terminal failure states for crypto orders
+/// Terminal failure states for crypto orders.
+///
+/// Every non-fill terminal `BrokerOrderStatus` maps to one of these so the
+/// conversion resume path never treats an unexpected terminal status as
+/// still-pending (which would retry forever).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CryptoOrderFailureReason {
     Canceled,
     Expired,
     Rejected,
+    DoneForDay,
+    Replaced,
+    Suspended,
+    Calculated,
 }
 
 #[derive(Debug, Error)]

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -7,10 +7,10 @@ use tracing::{debug, trace};
 use uuid::Uuid;
 
 use super::client::AlpacaBrokerApiClient;
-use super::{AlpacaBrokerApiError, TimeInForce};
+use super::{AlpacaBrokerApiError, CryptoOrderFailureReason, TimeInForce};
 use crate::{
-    Direction, FractionalShares, MarketOrder, OrderPlacement, OrderStatus, OrderUpdate, Positive,
-    Symbol, Usd, deserialize_float_from_number_or_string,
+    ClientOrderId, Direction, FractionalShares, MarketOrder, OrderPlacement, OrderStatus,
+    OrderUpdate, Positive, Symbol, Usd, deserialize_float_from_number_or_string,
     deserialize_option_float_from_number_or_string, serialize_float_as_string,
 };
 
@@ -203,6 +203,9 @@ pub(crate) struct CryptoOrderRequest {
     #[serde(rename = "type")]
     pub order_type: &'static str,
     pub time_in_force: &'static str,
+    /// Caller-supplied idempotency/correlation key. Recorded before placement
+    /// so a crashed conversion can be looked up by this key on resume.
+    pub client_order_id: ClientOrderId,
 }
 
 /// Response from a crypto order placement
@@ -231,20 +234,56 @@ pub struct CryptoOrderResponse {
     pub created_at: DateTime<Utc>,
 }
 
+/// Terminal/intermediate decision for a crypto order, exposing the outcome
+/// without leaking the private `BrokerOrderStatus`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CryptoOrderOutcome {
+    Filled,
+    Pending,
+    Failed(CryptoOrderFailureReason),
+}
+
 impl CryptoOrderResponse {
     /// Returns the status as a display-friendly string.
     pub fn status_display(&self) -> &'static str {
+        use BrokerOrderStatus::*;
+
         match self.status {
-            BrokerOrderStatus::Filled => "filled",
-            BrokerOrderStatus::New => "new",
-            BrokerOrderStatus::PendingNew => "pending_new",
-            BrokerOrderStatus::PartiallyFilled => "partially_filled",
-            BrokerOrderStatus::Canceled => "canceled",
-            BrokerOrderStatus::Expired => "expired",
-            BrokerOrderStatus::Rejected => "rejected",
-            BrokerOrderStatus::Accepted => "accepted",
+            Filled => "filled",
+            New => "new",
+            PendingNew => "pending_new",
+            PartiallyFilled => "partially_filled",
+            Canceled => "canceled",
+            Expired => "expired",
+            Rejected => "rejected",
+            Accepted => "accepted",
             _ => "other",
         }
+    }
+
+    /// Classifies the order's current status into a fill/pending/failed outcome,
+    /// consistent with the terminal mapping in `map_broker_status_to_order_status`.
+    ///
+    /// The match is exhaustive (no wildcard) so a newly added Alpaca status forces
+    /// a compile error here rather than silently mapping to `Pending` and retrying
+    /// forever.
+    pub fn classify(&self) -> CryptoOrderOutcome {
+        use BrokerOrderStatus::*;
+
+        let reason = match self.status {
+            Filled => return CryptoOrderOutcome::Filled,
+            New | PendingNew | PartiallyFilled | Accepted | AcceptedForBidding | PendingCancel
+            | PendingReplace | Stopped => return CryptoOrderOutcome::Pending,
+            Canceled => CryptoOrderFailureReason::Canceled,
+            Expired => CryptoOrderFailureReason::Expired,
+            Rejected => CryptoOrderFailureReason::Rejected,
+            DoneForDay => CryptoOrderFailureReason::DoneForDay,
+            Replaced => CryptoOrderFailureReason::Replaced,
+            Suspended => CryptoOrderFailureReason::Suspended,
+            Calculated => CryptoOrderFailureReason::Calculated,
+        };
+
+        CryptoOrderOutcome::Failed(reason)
     }
 }
 
@@ -478,6 +517,7 @@ pub(crate) async fn convert_usdc_usd(
     client: &AlpacaBrokerApiClient,
     amount: Float,
     direction: ConversionDirection,
+    client_order_id: &ClientOrderId,
 ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
     let placed_amount = validate_usdc_amount_for_alpaca_precision(amount)?;
     let side = match direction {
@@ -485,7 +525,7 @@ pub(crate) async fn convert_usdc_usd(
         ConversionDirection::UsdToUsdc => OrderSide::Buy,
     };
 
-    debug!(?side, amount = ?placed_amount, "Placing USDC/USD conversion order");
+    debug!(?side, amount = ?placed_amount, %client_order_id, "Placing USDC/USD conversion order");
 
     let request = CryptoOrderRequest {
         symbol: "USDCUSD".to_string(),
@@ -493,6 +533,7 @@ pub(crate) async fn convert_usdc_usd(
         side,
         order_type: "market",
         time_in_force: "gtc",
+        client_order_id: client_order_id.clone(),
     };
 
     client.place_crypto_order(&request).await
@@ -503,27 +544,29 @@ pub(crate) async fn poll_crypto_order_until_filled(
     client: &AlpacaBrokerApiClient,
     order_id: Uuid,
 ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
+    use BrokerOrderStatus::*;
+
     loop {
         let order = client.get_crypto_order(order_id).await?;
 
         match order.status {
-            BrokerOrderStatus::Filled => return Ok(order),
-            BrokerOrderStatus::Canceled => {
+            Filled => return Ok(order),
+            Canceled => {
                 return Err(AlpacaBrokerApiError::CryptoOrderFailed {
                     order_id,
-                    reason: super::CryptoOrderFailureReason::Canceled,
+                    reason: CryptoOrderFailureReason::Canceled,
                 });
             }
-            BrokerOrderStatus::Expired => {
+            Expired => {
                 return Err(AlpacaBrokerApiError::CryptoOrderFailed {
                     order_id,
-                    reason: super::CryptoOrderFailureReason::Expired,
+                    reason: CryptoOrderFailureReason::Expired,
                 });
             }
-            BrokerOrderStatus::Rejected => {
+            Rejected => {
                 return Err(AlpacaBrokerApiError::CryptoOrderFailed {
                     order_id,
-                    reason: super::CryptoOrderFailureReason::Rejected,
+                    reason: CryptoOrderFailureReason::Rejected,
                 });
             }
             _ => {
@@ -563,6 +606,64 @@ mod tests {
             asset_cache_ttl: std::time::Duration::from_secs(3600),
             time_in_force: TimeInForce::Day,
             counter_trade_slippage_bps: crate::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        }
+    }
+
+    #[test]
+    fn classify_maps_every_broker_status_to_its_outcome() {
+        use crate::alpaca_broker_api::CryptoOrderFailureReason;
+
+        let cases = [
+            ("filled", CryptoOrderOutcome::Filled),
+            ("new", CryptoOrderOutcome::Pending),
+            ("pending_new", CryptoOrderOutcome::Pending),
+            ("partially_filled", CryptoOrderOutcome::Pending),
+            ("accepted", CryptoOrderOutcome::Pending),
+            ("accepted_for_bidding", CryptoOrderOutcome::Pending),
+            ("pending_cancel", CryptoOrderOutcome::Pending),
+            ("pending_replace", CryptoOrderOutcome::Pending),
+            ("stopped", CryptoOrderOutcome::Pending),
+            (
+                "canceled",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Canceled),
+            ),
+            (
+                "expired",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Expired),
+            ),
+            (
+                "rejected",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Rejected),
+            ),
+            (
+                "done_for_day",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::DoneForDay),
+            ),
+            (
+                "replaced",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Replaced),
+            ),
+            (
+                "suspended",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Suspended),
+            ),
+            (
+                "calculated",
+                CryptoOrderOutcome::Failed(CryptoOrderFailureReason::Calculated),
+            ),
+        ];
+
+        for (status, expected) in cases {
+            let order: CryptoOrderResponse = serde_json::from_value(json!({
+                "id": "904837e3-3b76-47ec-b432-046db621571b",
+                "symbol": "USDCUSD",
+                "qty": "100",
+                "status": status,
+                "created_at": "2025-01-06T12:00:00Z"
+            }))
+            .unwrap();
+
+            assert_eq!(order.classify(), expected, "status {status} misclassified");
         }
     }
 
@@ -974,6 +1075,9 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
+        let client_order_id =
+            ClientOrderId::from_uuid(uuid!("11111111-1111-4111-8111-111111111111"));
+
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
@@ -982,7 +1086,8 @@ mod tests {
                     "qty": "1000.5",
                     "side": "sell",
                     "type": "market",
-                    "time_in_force": "gtc"
+                    "time_in_force": "gtc",
+                    "client_order_id": "11111111-1111-4111-8111-111111111111"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1001,9 +1106,14 @@ mod tests {
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let amount = float!(1000.5);
 
-        let order = convert_usdc_usd(&client, amount, ConversionDirection::UsdcToUsd)
-            .await
-            .unwrap();
+        let order = convert_usdc_usd(
+            &client,
+            amount,
+            ConversionDirection::UsdcToUsd,
+            &client_order_id,
+        )
+        .await
+        .unwrap();
 
         mock.assert();
         assert_eq!(order.id.to_string(), "904837e3-3b76-47ec-b432-046db621571b");
@@ -1017,6 +1127,9 @@ mod tests {
         let server = MockServer::start();
         let ctx = create_test_ctx(AlpacaBrokerApiMode::Mock(server.base_url()));
 
+        let client_order_id =
+            ClientOrderId::from_uuid(uuid!("22222222-2222-4222-8222-222222222222"));
+
         let mock = server.mock(|when, then| {
             when.method(POST)
                 .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders")
@@ -1025,7 +1138,8 @@ mod tests {
                     "qty": "500",
                     "side": "buy",
                     "type": "market",
-                    "time_in_force": "gtc"
+                    "time_in_force": "gtc",
+                    "client_order_id": "22222222-2222-4222-8222-222222222222"
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1044,9 +1158,14 @@ mod tests {
         let client = AlpacaBrokerApiClient::new(&ctx).unwrap();
         let amount = float!(500);
 
-        let order = convert_usdc_usd(&client, amount, ConversionDirection::UsdToUsdc)
-            .await
-            .unwrap();
+        let order = convert_usdc_usd(
+            &client,
+            amount,
+            ConversionDirection::UsdToUsdc,
+            &client_order_id,
+        )
+        .await
+        .unwrap();
 
         mock.assert();
         assert_eq!(order.id.to_string(), "61e7b016-9c91-4a97-b912-615c9d365c9d");
@@ -1065,6 +1184,7 @@ mod tests {
             &client,
             float!(1000.1234567),
             ConversionDirection::UsdToUsdc,
+            &ClientOrderId::from_uuid(Uuid::new_v4()),
         )
         .await
         .unwrap_err();

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -24,7 +24,8 @@ pub mod order;
 
 pub use alpaca_broker_api::{
     AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
-    AlpacaBrokerApiMode, ConversionDirection, JournalResponse, JournalStatus, TimeInForce,
+    AlpacaBrokerApiMode, ConversionDirection, CryptoOrderOutcome, JournalResponse, JournalStatus,
+    TimeInForce,
 };
 pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -3,11 +3,12 @@
 
 use alloy::primitives::Address;
 use std::io::Write;
+use uuid::Uuid;
 
 use st0x_evm::{Evm, IntoErrorRegistry, Wallet};
 use st0x_execution::{
-    AlpacaAccountId, AlpacaBrokerApi, ConversionDirection, Executor, FractionalShares, Positive,
-    Symbol,
+    AlpacaAccountId, AlpacaBrokerApi, ClientOrderId, ConversionDirection, Executor,
+    FractionalShares, Positive, Symbol,
 };
 use st0x_finance::Usdc;
 use st0x_float_serde::format_float_with_fallback;
@@ -618,11 +619,12 @@ pub(super) async fn alpaca_convert_command<W: Write>(
     };
 
     let amount_exact = amount.inner();
+    let correlation_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
     writeln!(stdout, "   Placing market order...")?;
 
     let order = executor
-        .convert_usdc_usd(amount_exact, conversion_direction)
+        .convert_usdc_usd(amount_exact, conversion_direction, &correlation_id)
         .await?;
 
     writeln!(stdout, "Conversion completed successfully!")?;
@@ -641,11 +643,11 @@ pub(super) async fn alpaca_convert_command<W: Write>(
             format_float_with_fallback(&price)
         )?;
     }
-    if let Some(filled_qty) = order.filled_quantity {
+    if let Some(filled_quantity) = order.filled_quantity {
         writeln!(
             stdout,
             "   Filled Quantity: {}",
-            format_float_with_fallback(&filled_qty)
+            format_float_with_fallback(&filled_quantity)
         )?;
     }
     if let (Some(price), Some(quantity)) = (order.filled_average_price, order.filled_quantity) {

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -1095,6 +1095,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn find_recent_withdrawal_returns_tx_and_amount_of_real_withdrawal() {
+        let local_evm = LocalEvm::new().await.unwrap();
+        let service = create_test_raindex_service(&local_evm).await;
+
+        let deposit_amount = U256::from(1000) * U256::from(10).pow(U256::from(18));
+        local_evm
+            .approve_tokens(
+                local_evm.token_address,
+                local_evm.orderbook_address,
+                deposit_amount,
+            )
+            .await
+            .unwrap();
+        service
+            .deposit::<NoOpErrorRegistry>(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                deposit_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let from_block = service.current_block().await.unwrap();
+
+        let withdraw_amount = U256::from(400) * U256::from(10).pow(U256::from(18));
+        let withdraw_tx = service
+            .withdraw(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                withdraw_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let found = service
+            .find_recent_withdrawal(local_evm.token_address, TEST_VAULT_ID, from_block)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            found,
+            Some((withdraw_tx, withdraw_amount)),
+            "scan must return the real withdrawal's tx and actual on-chain withdrawn amount",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_withdrawal_returns_none_for_non_matching_vault_or_token() {
+        let local_evm = LocalEvm::new().await.unwrap();
+        let service = create_test_raindex_service(&local_evm).await;
+
+        // Capture from_block BEFORE the approve/deposit/withdraw txs so those three
+        // blocks advance the head past from_block + SCAN_FINALITY_MARGIN, letting
+        // the non-matching scans below conclude a true absence (None) rather than
+        // ScanInconclusive.
+        let from_block = service.current_block().await.unwrap();
+
+        let deposit_amount = U256::from(1000) * U256::from(10).pow(U256::from(18));
+        local_evm
+            .approve_tokens(
+                local_evm.token_address,
+                local_evm.orderbook_address,
+                deposit_amount,
+            )
+            .await
+            .unwrap();
+        service
+            .deposit::<NoOpErrorRegistry>(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                deposit_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let withdraw_amount = U256::from(400) * U256::from(10).pow(U256::from(18));
+        service
+            .withdraw(
+                local_evm.token_address,
+                TEST_VAULT_ID,
+                withdraw_amount,
+                TEST_TOKEN_DECIMALS,
+            )
+            .await
+            .unwrap();
+
+        let other_vault = RaindexVaultId(b256!(
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+        ));
+        assert_eq!(
+            service
+                .find_recent_withdrawal(local_evm.token_address, other_vault, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a withdrawal on a different vault must not be adopted",
+        );
+        assert_eq!(
+            service
+                .find_recent_withdrawal(USDC_BASE, TEST_VAULT_ID, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a withdrawal of a different token must not be adopted",
+        );
+    }
+
+    #[tokio::test]
     async fn test_withdraw_succeeds_with_deployed_contract() {
         let local_evm = LocalEvm::new().await.unwrap();
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -771,6 +771,22 @@ impl RebalancingService {
         };
 
         for id in timed_out_ids {
+            // A timed-out transfer whose apalis row is still in flight is NOT
+            // abandoned: the job will resume and may have an irreversible on-chain
+            // withdraw/burn already submitted. Skip the cleanup entirely so we
+            // neither clear the in-progress guard / inventory inflight nor mark it
+            // timed-out (which would make the reactor ignore its eventual terminal
+            // event and latch the guard forever). Let apalis drive it to terminal.
+            if self.transfer_usdc_to_hedging_in_flight(&id).await {
+                warn!(
+                    target: "rebalance",
+                    aggregate_id = %id,
+                    "USDC transfer exceeded its timeout but its apalis row is still in \
+                     flight; deferring cleanup to the job rather than clearing the guard"
+                );
+                continue;
+            }
+
             let Some((tracking, elapsed)) = self.cleanup_timed_out_usdc_rebalance(&id, now).await?
             else {
                 continue;
@@ -789,6 +805,54 @@ impl RebalancingService {
         }
 
         Ok(())
+    }
+
+    /// Returns true if a `TransferUsdcToHedging` apalis row for `id` is still
+    /// non-terminal (Pending/Queued/Running). The timeout sweeper must not clear
+    /// the `usdc_in_progress` guard while such a row exists: the resuming job may
+    /// have an irreversible withdraw/burn already submitted, and clearing the guard
+    /// would let a second transfer touch the same vault/wallet.
+    ///
+    /// Scoped to the aggregate `id` (carried in the job payload) so an unrelated
+    /// in-flight transfer never defers this id's cleanup -- decoupling the sweep
+    /// from the single-in-flight invariant. On query/decode failure the safe
+    /// default is to report "in flight" so automation stays latched.
+    async fn transfer_usdc_to_hedging_in_flight(&self, id: &UsdcRebalanceId) -> bool {
+        let job_type = std::any::type_name::<TransferUsdcToHedging>();
+        let rows: Result<Vec<(Vec<u8>,)>, _> = sqlx::query_as(
+            "SELECT job FROM Jobs \
+             WHERE job_type = ? \
+             AND status IN ('Pending', 'Queued', 'Running')",
+        )
+        .bind(job_type)
+        .fetch_all(self.transfer_usdc_to_hedging_queue.pool())
+        .await;
+
+        match rows {
+            Ok(rows) => rows.iter().any(|(payload,)| {
+                match serde_json::from_slice::<TransferUsdcToHedging>(payload) {
+                    Ok(job) => job.id == *id,
+                    Err(error) => {
+                        warn!(
+                            target: "rebalance",
+                            %error,
+                            "Failed to deserialize a non-terminal TransferUsdcToHedging payload \
+                             during timeout sweep; treating as in flight to stay latched"
+                        );
+                        true
+                    }
+                }
+            }),
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    "Failed to query in-flight TransferUsdcToHedging rows during timeout \
+                     sweep; keeping the in-progress guard latched to avoid re-arming"
+                );
+                true
+            }
+        }
     }
 
     async fn retire_stale_suppression_and_collect_active_symbols(
@@ -7825,6 +7889,165 @@ mod tests {
         assert!(
             !trigger.usdc_tracking.read().await.contains_key(&id),
             "late terminal events must not recreate timed-out USDC tracking"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_does_not_clear_guard_while_transfer_job_in_flight() {
+        let inventory = InventoryView::default()
+            .with_usdc(usdc(900), usdc(100))
+            .update_usdc(
+                Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(400)),
+                Utc::now(),
+            )
+            .unwrap();
+        let (trigger, _receiver) = make_trigger_with_inventory_config(
+            inventory,
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // A Base->Alpaca transfer whose apalis row is still in flight: a crash mid
+        // withdraw/burn leaves the aggregate at a *Submitting state with an
+        // irreversible effect possibly already submitted, and apalis will resume.
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+            })
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger.check_and_trigger_usdc().await;
+
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "timeout must NOT clear the in-progress guard while the apalis transfer \
+             job is in flight -- an irreversible withdraw/burn may be pending and \
+             clearing would let a second transfer touch the same vault/wallet",
+        );
+        assert!(
+            trigger.usdc_tracking.read().await.contains_key(&id),
+            "timeout must not drop tracking for an in-flight transfer",
+        );
+        assert!(
+            !trigger
+                .timed_out_usdc_rebalances
+                .read()
+                .await
+                .contains_key(&id),
+            "timeout must not mark an in-flight transfer timed-out (the reactor would \
+             then ignore its terminal event and latch the guard forever)",
+        );
+
+        let marketmaking_inflight = trigger
+            .inventory
+            .read()
+            .await
+            .usdc_inflight(Venue::MarketMaking);
+
+        assert_eq!(
+            marketmaking_inflight,
+            Some(usdc(400)),
+            "timeout must preserve the Base->Alpaca source-side inflight on \
+             MarketMaking while the apalis transfer job is still in flight",
+        );
+    }
+
+    #[tokio::test]
+    async fn transfer_in_flight_check_is_scoped_to_aggregate_id() {
+        let (trigger, _receiver) = make_trigger_with_inventory_config(
+            InventoryView::default(),
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let other_id = UsdcRebalanceId(Uuid::new_v4());
+
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            trigger.transfer_usdc_to_hedging_in_flight(&id).await,
+            "a non-terminal transfer row for this id must report in flight",
+        );
+        assert!(
+            !trigger.transfer_usdc_to_hedging_in_flight(&other_id).await,
+            "a transfer row for a different aggregate id must NOT report this id as in flight",
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_clears_guard_once_transfer_job_reaches_terminal_status() {
+        let (trigger, _receiver) = make_trigger_with_inventory_config(
+            InventoryView::default(),
+            test_config_with_timeout(Duration::from_secs(1)),
+        )
+        .await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // The transfer's apalis row has reached a terminal status: the job is no
+        // longer in flight, so the sweep must proceed to cleanup and clear the
+        // guard -- the "eventually released, not latched forever" property that is
+        // the whole safety argument for skipping cleanup while a job is in flight.
+        let mut queue = trigger.transfer_usdc_to_hedging_queue.clone();
+        queue
+            .push(TransferUsdcToHedging {
+                id: id.clone(),
+                amount: usdc(400),
+            })
+            .await
+            .unwrap();
+        sqlx::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+            .bind(std::any::type_name::<TransferUsdcToHedging>())
+            .execute(queue.pool())
+            .await
+            .unwrap();
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        trigger.usdc_tracking.write().await.insert(
+            id.clone(),
+            usdc::UsdcRebalanceTracking {
+                direction: RebalanceDirection::BaseToAlpaca,
+                initiated_amount: usdc(400),
+                bridged_amount_received: None,
+                stage: usdc::UsdcRebalanceStage::Initiated,
+                last_progress_at: Utc::now() - ChronoDuration::minutes(31),
+            },
+        );
+
+        trigger
+            .expire_stuck_usdc_rebalances(Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "timeout must clear the guard once the transfer job reaches a terminal status",
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "timeout must drop tracking once the transfer job is terminal",
         );
     }
 

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -15,7 +15,9 @@ use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
-use st0x_execution::{AlpacaBrokerApi, ClientOrderId, ConversionDirection, Positive};
+use st0x_execution::{
+    AlpacaBrokerApi, ClientOrderId, ConversionDirection, CryptoOrderOutcome, Positive,
+};
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
@@ -110,7 +112,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let order = match self
             .alpaca_broker
-            .convert_usdc_usd(alpaca_amount, ConversionDirection::UsdToUsdc)
+            .convert_usdc_usd(
+                alpaca_amount,
+                ConversionDirection::UsdToUsdc,
+                &correlation_id,
+            )
             .await
         {
             Ok(order) => order,
@@ -128,13 +134,14 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
-        let filled_qty =
+        let filled_quantity =
             order
                 .filled_quantity
                 .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
                     order_id: correlation_id.clone(),
                 })?;
-        let filled_amount = Usdc::new(filled_qty);
+
+        let filled_amount = Usdc::new(filled_quantity);
 
         self.cqrs
             .send(
@@ -197,7 +204,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let order = match self
             .alpaca_broker
-            .convert_usdc_usd(alpaca_amount, ConversionDirection::UsdcToUsd)
+            .convert_usdc_usd(
+                alpaca_amount,
+                ConversionDirection::UsdcToUsd,
+                &correlation_id,
+            )
             .await
         {
             Ok(order) => order,
@@ -783,18 +794,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 Ok(())
             }
 
-            Some(UsdcRebalance::Converting { .. }) => {
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailConversion {
-                            reason: "resume from Converting state requires manual \
-                                     reconciliation: broker order ID not persisted"
-                                .into(),
-                        },
-                    )
-                    .await?;
-                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            Some(UsdcRebalance::Converting {
+                direction,
+                order_id,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.resume_converting(id, order_id).await
             }
 
             Some(UsdcRebalance::ConversionComplete { direction, .. }) => {
@@ -822,6 +828,107 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 id: id.clone(),
                 direction: direction.clone(),
             })
+        }
+    }
+
+    /// Resumes a transfer stalled at `Converting` (the post-deposit USDC->USD
+    /// conversion). The conversion's correlation id is the Alpaca
+    /// `client_order_id`, recorded before the order was placed, so resume looks
+    /// the order up and resolves deterministically instead of blindly failing:
+    /// a filled order confirms the conversion, a terminally-failed order fails
+    /// it, a still-settling order is retried, and an order that never reached
+    /// Alpaca (crash before placement) fails for operator reconciliation.
+    async fn resume_converting(
+        &self,
+        id: &UsdcRebalanceId,
+        correlation_id: ClientOrderId,
+    ) -> Result<(), UsdcTransferError> {
+        let Some(order) = self
+            .alpaca_broker
+            .find_conversion_order(&correlation_id)
+            .await?
+        else {
+            warn!(target: "rebalance", %correlation_id, "Conversion order never reached Alpaca on resume; failing for reconciliation");
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailConversion {
+                        reason: format!("conversion order {correlation_id} never reached Alpaca"),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() });
+        };
+
+        // Mirror the normal placement flow: a still-settling conversion is awaited
+        // to a terminal state rather than failing the job. Failing here would burn
+        // the finite apalis retry budget -- the order can settle slower than the
+        // per-attempt window -- and let the timeout sweep clear the in-progress
+        // guard while the conversion is still healthy, the partial-completion clobber
+        // this resume path exists to prevent.
+        let order = match order.classify() {
+            CryptoOrderOutcome::Pending => {
+                warn!(target: "rebalance", order_id = %order.id, "Resumed conversion still settling; awaiting terminal state");
+                self.alpaca_broker
+                    .poll_conversion_to_terminal(order.id)
+                    .await?
+            }
+            _ => order,
+        };
+
+        match order.classify() {
+            CryptoOrderOutcome::Filled => {
+                let filled_quantity =
+                    order
+                        .filled_quantity
+                        .ok_or(UsdcTransferError::MissingFilledQuantity {
+                            order_id: correlation_id,
+                        })?;
+
+                let filled_amount = Usdc::new(filled_quantity);
+
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::ConfirmConversion { filled_amount },
+                    )
+                    .await?;
+                info!(target: "rebalance", order_id = %order.id, %filled_amount, "Resumed conversion confirmed from already-filled order");
+                Ok(())
+            }
+            CryptoOrderOutcome::Pending => {
+                // `poll_conversion_to_terminal` returns only on a terminal state, so a
+                // Pending classification here is unreachable; fail indeterminate for
+                // operator follow-up rather than silently looping.
+                warn!(target: "rebalance", order_id = %order.id, "Resumed conversion still pending after awaiting terminal state");
+                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            }
+            CryptoOrderOutcome::Failed(reason) => {
+                // Alpaca terminal statuses can carry a nonzero partial fill: real USDC
+                // converted before the order terminated. Surface it in the failure
+                // reason and logs so an operator reconciles the converted amount rather
+                // than recording a clean full failure that hides it. Conservatively
+                // treat an un-checkable fill as needing reconciliation.
+                let partial_fill = order
+                    .filled_quantity
+                    .filter(|filled| filled.is_zero().map(|zero| !zero).unwrap_or(true));
+
+                warn!(target: "rebalance", order_id = %order.id, ?reason, ?partial_fill, "Resumed conversion order failed terminally");
+                let partial_suffix = partial_fill
+                    .map(|filled| {
+                        format!(" (partial fill {} needs reconciliation)", Usdc::new(filled))
+                    })
+                    .unwrap_or_default();
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailConversion {
+                            reason: format!("conversion order failed: {reason:?}{partial_suffix}"),
+                        },
+                    )
+                    .await?;
+                Err(UsdcTransferError::ResumeIndeterminateConversion { id: id.clone() })
+            }
         }
     }
 
@@ -964,8 +1071,24 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .await
     }
 
-    /// Drives the transfer from `Bridged` through to terminal: initiate
-    /// Alpaca deposit, poll, then USDC->USD conversion.
+    /// Drives the transfer from `Bridged` through to terminal: re-record the
+    /// Alpaca deposit intent, poll Alpaca for the credit, then convert USDC->USD.
+    ///
+    /// # Crash-safety invariant (load-bearing)
+    ///
+    /// Unlike the `DepositInitiated` resume arm, this path has no guard
+    /// preventing a re-send of `InitiateDeposit`. It is safe to resume from
+    /// `Bridged` only because the BaseToAlpaca deposit is effected by the CCTP
+    /// mint itself: [`execute_cctp_burn_on_base`](Self::execute_cctp_burn_on_base)
+    /// sets the burn's `mintRecipient` to `self.market_maker_wallet`, so the
+    /// Ethereum-side mint credits USDC directly to the address Alpaca monitors as
+    /// the deposit source. No Alpaca deposit API call moves funds. This function
+    /// therefore only RE-RECORDS intent via `InitiateDeposit` (an idempotent
+    /// aggregate event) and POLLS Alpaca read-only via `poll_deposit_by_tx_hash`
+    /// (a GET). Resuming from `Bridged` issues no new fund-moving call, so
+    /// re-execution cannot double-spend and the missing guard is safe. If the
+    /// mint-deposits-directly assumption ever changes (e.g. an explicit Alpaca
+    /// deposit POST is introduced), this arm must gain a guard or idempotency key.
     async fn continue_from_bridged(
         &self,
         id: &UsdcRebalanceId,
@@ -1612,6 +1735,39 @@ mod tests {
         (cctp_bridge, vault_service)
     }
 
+    /// Like [`create_test_onchain_services`] but points the CCTP bridge's Circle
+    /// attestation polling at `circle_api_base` (a local mock), so attestation
+    /// polling resolves immediately instead of retrying the real Circle endpoint
+    /// for ~5 minutes. Test-support only.
+    #[cfg(feature = "test-support")]
+    async fn create_test_onchain_services_with_circle_api<Chain: Wallet + Clone>(
+        wallet: Chain,
+        circle_api_base: String,
+    ) -> (CctpBridge<Chain, Chain>, RaindexService<Chain>) {
+        let cctp_bridge = CctpBridge::try_from_ctx(CctpCtx {
+            usdc_ethereum: USDC_ADDRESS,
+            usdc_base: USDC_ADDRESS,
+            ethereum_wallet: wallet.clone(),
+            base_wallet: wallet.clone(),
+            circle_api_base,
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        })
+        .unwrap();
+
+        let pool = crate::test_utils::setup_test_db().await;
+        let (_vault_registry_store, vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool)
+                .build(())
+                .await
+                .unwrap();
+        let owner = wallet.address();
+        let vault_service =
+            RaindexService::new(wallet, ORDERBOOK_ADDRESS, vault_registry_projection, owner);
+
+        (cctp_bridge, vault_service)
+    }
+
     fn create_conversion_order_mock<'a>(
         server: &'a MockServer,
         amount: &str,
@@ -1676,13 +1832,13 @@ mod tests {
         })
     }
 
-    /// Creates a mock where filled_qty differs from requested qty to
-    /// simulate slippage.
+    /// Creates a mock where the filled quantity differs from the requested
+    /// quantity to simulate slippage.
     fn create_get_order_mock_with_slippage<'a>(
         server: &'a MockServer,
         order_id: &str,
-        requested_qty: &str,
-        filled_qty: &str,
+        requested_quantity: &str,
+        filled_quantity: &str,
     ) -> httpmock::Mock<'a> {
         server.mock(|when, then| {
             when.method(GET).path(format!(
@@ -1693,10 +1849,10 @@ mod tests {
                 .json_body(json!({
                     "id": order_id,
                     "symbol": "USDCUSD",
-                    "qty": requested_qty,
+                    "qty": requested_quantity,
                     "status": "filled",
                     "filled_avg_price": "1.0001",
-                    "filled_qty": filled_qty,
+                    "filled_qty": filled_quantity,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         })
@@ -2979,6 +3135,86 @@ mod tests {
         (manager, cqrs, anvil)
     }
 
+    /// Like [`make_resume_test_manager`] but with the CCTP bridge's Circle
+    /// attestation polling pointed at a local mock so attestation resolves fast.
+    #[cfg(feature = "test-support")]
+    async fn make_resume_test_manager_with_circle_api(
+        server: &MockServer,
+        circle_api_base: String,
+    ) -> (
+        CrossVenueCashTransfer<
+            RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>,
+        >,
+        Arc<Store<UsdcRebalance>>,
+        alloy::node_bindings::AnvilInstance,
+    ) {
+        let (anvil, endpoint, private_key) = setup_anvil();
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(server));
+        let wallet = create_test_wallet(&endpoint, &private_key);
+        let (cctp_bridge, vault_service) =
+            create_test_onchain_services_with_circle_api(wallet, circle_api_base).await;
+        let cqrs = create_test_store_instance().await;
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        (manager, cqrs, anvil)
+    }
+
+    /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
+    /// `InitiateBridging` -> `ReceiveAttestation` so it lands at `Attested`
+    /// (stops before `ConfirmBridging`).
+    async fn advance_to_attested_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) -> TxHash {
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: 99_999,
+                // Scan from genesis, not the sibling helpers' `100`: the resume test
+                // built on this helper actually scans from this block for an
+                // already-submitted mint, and the fresh test chain (advanced only via
+                // event-store commands) sits below 100. 0 makes that scan a valid
+                // range that genuinely finds no mint, so resume proceeds to mint.
+                mint_scan_from_block: 0,
+            },
+        )
+        .await
+        .unwrap();
+        burn_tx
+    }
+
     /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
     /// `InitiateBridging` -> `ReceiveAttestation` -> `ConfirmBridging` so
     /// the next callable step is the Alpaca deposit initiation.
@@ -3030,6 +3266,156 @@ mod tests {
         .await
         .unwrap();
         (burn_tx, mint_tx)
+    }
+
+    /// Drives a BaseToAlpaca transfer all the way to `Converting`, recording
+    /// `correlation_id` as the conversion order's correlation key. This is the
+    /// post-deposit state a crash can strand once the Alpaca conversion order is
+    /// placed but `ConfirmConversion` has not yet been emitted.
+    async fn advance_to_converting_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        amount_received: Usdc,
+        correlation_id: &ClientOrderId,
+    ) {
+        advance_to_bridged_base_to_alpaca(cqrs, id, amount, amount_received).await;
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::InitiateDeposit {
+                deposit: TransferRef::OnchainTx(fixed_bytes!(
+                    "0xbbbb111111111111111111111111111111111111111111111111111111111111"
+                )),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmDeposit)
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::InitiatePostDepositConversion {
+                order_id: correlation_id.clone(),
+                amount: amount_received,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Mocks the Alpaca `orders:by_client_order_id` lookup the `Converting`
+    /// resume uses, returning a crypto order with the given status/fill so each
+    /// resume-from-`Converting` test can pick the outcome it exercises.
+    fn mock_conversion_lookup<'server>(
+        server: &'server MockServer,
+        correlation_id: &ClientOrderId,
+        status: &str,
+        filled_quantity: &str,
+    ) -> httpmock::Mock<'server> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id")
+                .query_param("client_order_id", correlation_id.to_string());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "symbol": "USDCUSD",
+                    "qty": "99.99",
+                    "status": status,
+                    "filled_avg_price": "1.0001",
+                    "filled_qty": filled_quantity,
+                    "created_at": "2025-01-06T12:00:00Z"
+                }));
+        })
+    }
+
+    /// Mocks the by-id crypto-order GET that `poll_conversion_to_terminal` polls
+    /// (the order id matches the one `mock_conversion_lookup` returns), so a
+    /// resume that awaits a settling order can pick the terminal outcome it sees.
+    fn mock_get_crypto_order<'server>(
+        server: &'server MockServer,
+        status: &str,
+        filled_quantity: &str,
+    ) -> httpmock::Mock<'server> {
+        server.mock(|when, then| {
+            when.method(GET).path(
+                "/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders/904837e3-3b76-47ec-b432-046db621571b",
+            );
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "symbol": "USDCUSD",
+                    "qty": "99.99",
+                    "status": status,
+                    "filled_avg_price": "1.0001",
+                    "filled_qty": filled_quantity,
+                    "created_at": "2025-01-06T12:00:00Z"
+                }));
+        })
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation() {
+        let server = MockServer::start();
+
+        // Return a `complete` attestation for any /v2/messages request so
+        // poll_circle_attestation resolves immediately (no 5-minute real-API
+        // retry). The message must be >= 44 bytes with the upper 24 bytes of the
+        // 32-byte nonce (offset 12..36) zero so AttestationResponse::new's u64
+        // nonce check passes -- a mostly-zero 100-byte message with one low byte.
+        let mut message = vec![0u8; 100];
+        message[43] = 1;
+        let message_hex = format!("0x{}", alloy::hex::encode(&message));
+        let attestation_hex = format!("0x{}", "ab".repeat(65));
+        let _attestation_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/v2/messages/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "messages": [{
+                        "status": "complete",
+                        "message": message_hex,
+                        "attestation": attestation_hex,
+                    }]
+                }));
+        });
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        let staged = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(staged, UsdcRebalance::Attested { .. }),
+            "staging must land at Attested, got {staged:?}",
+        );
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        // The OLD (buggy) behavior re-sent ReceiveAttestation from Attested, which
+        // the aggregate rejects -> UsdcTransferError::Aggregate(InvalidCommand).
+        // The fix routes Attested through continue_from_attested (poll -> mint, no
+        // ReceiveAttestation), so resume gets PAST the Attested gate and instead
+        // fails at the mint on the undeployed contract -> Cctp.
+        assert!(
+            !matches!(&error, UsdcTransferError::Aggregate(_)),
+            "resume from Attested must NOT re-emit ReceiveAttestation (the aggregate \
+             rejects it from Attested); got: {error:?}",
+        );
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "resume from Attested should proceed to mint and fail with a Cctp contract \
+             error; got: {error:?}",
+        );
     }
 
     #[tokio::test]
@@ -3123,6 +3509,285 @@ mod tests {
 
         // No mocks for Alpaca or CCTP services — a no-op resume must NOT call them.
         manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_confirms_from_filled_order() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        // Correlation id persisted before the conversion order was placed; it is
+        // the Alpaca client_order_id the resume looks the order up by.
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("33333333-3333-4333-8333-333333333333"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // The crash happened after the conversion order was placed at Alpaca but
+        // before `ConfirmConversion` was emitted. On resume the order is found
+        // filled by its client_order_id and the conversion is confirmed without
+        // placing a second order (no POST /orders mock is configured, so a
+        // re-placement would 501 and fail the test loud).
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "filled", "99.99");
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        lookup_mock.assert();
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(
+                &state,
+                Some(UsdcRebalance::ConversionComplete { filled_amount, .. })
+                    if *filled_amount == usdc("99.99")
+            ),
+            "expected ConversionComplete with filled_amount 99.99, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_errors_when_filled_order_lacks_filled_qty() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("66666666-6666-4666-8666-666666666666"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // A `filled` order whose `filled_qty` is absent must surface
+        // MissingFilledQuantity rather than confirming an unknown amount: the
+        // converted USDC is genuinely unknown and needs operator reconciliation,
+        // not a silently-fabricated confirmation.
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id")
+                .query_param("client_order_id", correlation_id.to_string());
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": "904837e3-3b76-47ec-b432-046db621571b",
+                    "symbol": "USDCUSD",
+                    "qty": "99.99",
+                    "status": "filled",
+                    "filled_avg_price": "1.0001",
+                    "created_at": "2025-01-06T12:00:00Z"
+                }));
+        });
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::MissingFilledQuantity { ref order_id } if *order_id == correlation_id),
+            "expected MissingFilledQuantity for {correlation_id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::Converting { .. })),
+            "aggregate must remain Converting when the fill amount is unknown, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_awaits_settling_order_then_confirms() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("44444444-4444-4444-8444-444444444444"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // The order is still settling when first looked up. Resume must await it to
+        // a terminal state (mirroring the normal placement flow) rather than failing
+        // the job; the poll then observes the fill and the conversion is confirmed.
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "new", "0");
+        let poll_mock = mock_get_crypto_order(&server, "filled", "99.99");
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        lookup_mock.assert();
+        poll_mock.assert();
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(
+                &state,
+                Some(UsdcRebalance::ConversionComplete { filled_amount, .. })
+                    if *filled_amount == usdc("99.99")
+            ),
+            "expected ConversionComplete with filled_amount 99.99 after awaiting settle, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_awaits_settling_order_then_fails() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("44444444-4444-4444-8444-444444444444"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // Still settling at lookup, then the poll observes a terminal failure: the
+        // conversion fails for operator follow-up instead of confirming.
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "new", "0");
+        let poll_mock = mock_get_crypto_order(&server, "canceled", "0");
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        poll_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
+            "aggregate must be ConversionFailed after the awaited order terminates failed, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_fails_on_terminally_failed_order() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("55555555-5555-4555-8555-555555555555"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // A rejected order is terminal: resume fails the conversion in the
+        // aggregate and returns the indeterminate error for operator follow-up.
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "rejected", "0");
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
+            "aggregate must be ConversionFailed after a rejected order, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_surfaces_partial_fill_in_failure_reason() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("77777777-7777-4777-8777-777777777777"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // A canceled order that partially filled: real USDC converted before the
+        // order terminated. The conversion still fails for operator follow-up, but
+        // the recorded reason must surface the partial fill so the converted USDC is
+        // not silently lost.
+        let lookup_mock = mock_conversion_lookup(&server, &correlation_id, "canceled", "42.5");
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        let Some(UsdcRebalance::ConversionFailed { reason, .. }) = state else {
+            panic!(
+                "aggregate must be ConversionFailed after a partial-then-canceled order, got {state:?}"
+            );
+        };
+        assert!(
+            reason.contains("reconciliation"),
+            "failure reason must surface the partial fill for reconciliation, got: {reason}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_converting_fails_when_order_never_reached_alpaca() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let correlation_id =
+            ClientOrderId::from_uuid(uuid!("66666666-6666-4666-8666-666666666666"));
+
+        advance_to_converting_base_to_alpaca(&cqrs, &id, amount, amount_received, &correlation_id)
+            .await;
+
+        // 404 means the crash happened before the order ever reached Alpaca:
+        // resume fails the conversion rather than blindly re-placing it.
+        let lookup_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/trading/accounts/904837e3-3b76-47ec-b432-046db621571b/orders:by_client_order_id")
+                .query_param("client_order_id", correlation_id.to_string());
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({ "message": "order not found" }));
+        });
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        lookup_mock.assert();
+        assert!(
+            matches!(error, UsdcTransferError::ResumeIndeterminateConversion { id: ref erred } if *erred == id),
+            "expected ResumeIndeterminateConversion for {id}, got {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            matches!(state, Some(UsdcRebalance::ConversionFailed { .. })),
+            "aggregate must be ConversionFailed when the order never reached Alpaca, got {state:?}"
+        );
     }
 
     #[tokio::test]
@@ -3589,6 +4254,88 @@ mod tests {
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected ConversionComplete after adopting the existing mint on resume, \
              got: {final_state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_makes_no_fund_moving_deposit_call() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let (_burn_tx, mint_tx) =
+            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+
+        // The CCTP mint already credited the Alpaca-monitored address, so resume
+        // only OBSERVES the deposit via this GET poll, never re-issues a transfer.
+        let deposit_poll_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{mint_tx:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0.5",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        // A fund-moving Alpaca transfer is a POST to /wallets/transfers, and the
+        // withdrawal path GETs /wallets/whitelists. Resume from Bridged must do
+        // NEITHER -- the deposit was effected by the mint, not an Alpaca API call.
+        let transfers_post_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({}));
+        });
+        let whitelist_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        deposit_poll_mock.assert();
+        assert_eq!(
+            transfers_post_mock.calls(),
+            0,
+            "resume from Bridged must NOT POST a fund-moving Alpaca transfer; the CCTP \
+             mint already deposited directly to the Alpaca address",
+        );
+        assert_eq!(
+            whitelist_mock.calls(),
+            0,
+            "resume from Bridged must NOT touch the withdrawal whitelist path",
+        );
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected ConversionComplete after resume from Bridged, got: {final_state:?}",
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -58,8 +58,9 @@ pub(crate) enum UsdcTransferError {
     )]
     MissingFilledQuantity { order_id: ClientOrderId },
     #[error(
-        "USDC rebalance {id} cannot resume from Converting state: \
-         broker order ID lost after crash; manual reconciliation required"
+        "USDC rebalance {id} conversion could not be completed on resume \
+         (order not found at Alpaca or terminally failed); failed for \
+         operator reconciliation"
     )]
     ResumeIndeterminateConversion { id: UsdcRebalanceId },
     #[error(

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -747,10 +747,11 @@ async fn full_system() -> anyhow::Result<()> {
     let pool = connect_db(&infra.db_path).await?;
     let usdc_events = count_events(&pool, "UsdcRebalance").await?;
     assert!(
-        usdc_events >= 9,
-        "USDC rebalance should emit at least Initiated + WithdrawalConfirmed + \
-         BridgingInitiated + BridgeAttestationReceived + Bridged + DepositInitiated + \
-         DepositConfirmed + ConversionInitiated + ConversionConfirmed, got {usdc_events}",
+        usdc_events >= 11,
+        "USDC rebalance should emit at least WithdrawalSubmitting + Initiated + \
+         WithdrawalConfirmed + BridgingSubmitting + BridgingInitiated + \
+         BridgeAttestationReceived + Bridged + DepositInitiated + DepositConfirmed + \
+         ConversionInitiated + ConversionConfirmed, got {usdc_events}",
     );
     pool.close().await;
 

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -1024,9 +1024,10 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
 /// transfer from Base to Alpaca via CCTP bridge.
 ///
 /// Expected CQRS event flow:
-/// - `UsdcRebalance`: Initiated -> WithdrawalConfirmed -> BridgingInitiated
-///   -> BridgeAttestationReceived -> Bridged -> DepositInitiated
-///   -> DepositConfirmed -> ConversionInitiated -> ConversionConfirmed
+/// - `UsdcRebalance`: WithdrawalSubmitting -> Initiated -> WithdrawalConfirmed
+///   -> BridgingSubmitting -> BridgingInitiated -> BridgeAttestationReceived
+///   -> Bridged -> DepositInitiated -> DepositConfirmed -> ConversionInitiated
+///   -> ConversionConfirmed
 ///
 /// Infrastructure: Same as `usdc_imbalance_triggers_alpaca_to_base` but the
 /// Raindex USDC vault is pre-funded so the bot can withdraw from it.


### PR DESCRIPTION
## What

Closes [RAI-822](https://linear.app/makeitrain/issue/RAI-822/base-alpaca-usdc-transfer-cannot-crash-resume-from-converting-or). Adds crash-safe resume for the later phases of a Base->Alpaca USDC transfer — resuming from `Converting` (the Alpaca USDC->USD conversion) and from `Attested` (post-burn, pre-mint) — and keeps the `usdc_in_progress` guard latched while a `TransferUsdcToHedging` job is still in flight.

## Why

A crash mid-conversion or mid-attestation previously could not resume deterministically:

- Resuming from `Converting` recorded `ConversionFailed` unconditionally, even if the Alpaca order actually filled — losing the conversion result.
- The inflight-timeout sweep could clear `usdc_in_progress` while the transfer job was still retrying, letting a fresh transfer re-arm on top of a partially-completed one.
- Resuming from `Attested` re-emitted `ReceiveAttestation`, which the aggregate rejects from `Attested`, fail-stopping a transfer whose USDC is already burned.

## How

- **Converting resume**: look up the Alpaca conversion order by its client order id (`get_crypto_order_by_client_order_id` / `find_conversion_order`), classify the broker status (`CryptoOrderOutcome::classify`), and deterministically pick `ConfirmConversion` (filled), `FailConversion` (terminally failed / never reached Alpaca), or retry (still settling).
- **Attested resume**: routes through `continue_from_attested` (re-poll Circle, then mint) without re-emitting `ReceiveAttestation`.
- **Guard latch**: `usdc_in_progress` stays latched while a non-terminal `TransferUsdcToHedging` row exists (`transfer_usdc_to_hedging_in_flight`), so the timeout sweep can't clear it and let automation re-arm a duplicate transfer.
- Adds negative-case coverage for `find_recent_burn` adoption matching, which already keys on `(depositor, amount, destinationDomain, mintRecipient)` — including a burn from a different depositor that must not be adopted. No predicate change.

## Testing

- Resume-arm tests: `resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation`; `resume_base_to_alpaca_from_converting_{confirms_from_filled_order, still_settling_retries, fails_on_terminally_failed_order, fails_when_order_never_reached_alpaca}`; `resume_base_to_alpaca_from_bridged_makes_no_fund_moving_deposit_call`.
- `timeout_does_not_clear_guard_while_transfer_job_in_flight`.
- `find_recent_burn` / `find_recent_withdrawal` scan tests (real-burn match, wrong-amount/wrong-recipient/different-depositor rejection, vault/token mismatch).
- `CryptoOrderOutcome::classify` maps every broker status to its outcome.

## Anything else

Stacked on #723 (finality-gate burn/withdrawal scan). Resolves several #712 review threads immediately upstack of #712: Converting resume, Attested re-emit, Bridged no-fund-move test, and the guard-latch-on-timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved crash-safe resumption for USDC conversions by tracking and resuming previously-placed conversion orders (including per-conversion correlation IDs) and polling until terminal outcomes.
* **Bug Fixes**
  * Prevent premature cleanup of in-flight USDC transfers when an associated transfer job is still running; defer cleanup and log a warning.
* **Tests**
  * Expanded tests: burn scanning, withdrawal lookups, conversion resumption, and rebalancing/in-flight transfer behaviors.
* **Documentation**
  * Clarified resume/continuation invariants and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
