### PR TITLE
docs: track work in Linear, add issue-vs-project policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ the limit:
 
 - **README.md** — if project structure, features, commands, or architecture
   changed
-- **ROADMAP.md** — mark completed issues, link PRs. When a PR is chained
-  (depends on a parent PR), mark both as done in the roadmap so it's up to date
-  by the time they merge.
+- **Linear** — move completed issues to Done and link the PR. When a PR is
+  chained (depends on a parent PR), close both so status is current by the time
+  they merge.
 - **`docs/`** — when research or trial-and-error reveals non-obvious patterns,
   pitfalls, or framework behavior, document it in the relevant `docs/` file (or
   create a new one) to prevent rediscovery. Prioritize documenting:
@@ -84,14 +84,13 @@ The project uses a strict document hierarchy:
 
 1. **SPEC.md** - Source of truth for system behavior. Features documented here
    before implementation.
-2. **ROADMAP.md / GitHub Issues** - Downstream from spec. Describe problems, not
-   solutions.
+2. **Linear issues/projects** - Downstream from spec. Describe problems, not
+   solutions. See [docs/linear-workflow.md](docs/linear-workflow.md).
 3. **Planning** - Downstream from issues. Implementation plans before coding.
 4. **Tests** - Downstream from plan. Written before implementation (TDD).
 5. **Implementation** - Makes the tests pass.
 
-**Before implementing:** Ensure feature is in SPEC.md -> has GitHub issue ->
-plan the implementation.
+**Before implementing:** SPEC.md -> Linear issue -> plan.
 
 ### Goal-Oriented Planning
 
@@ -117,19 +116,19 @@ Decompose epics to maximize independent parallel execution:
 7. **Converge to a single terminal node.** One final PR depends on all parallel
    streams for integration.
 
-### Managing Epics in the Roadmap
+### Managing Epics in Linear
 
-An epic is a roadmap subsection grouping related issues toward a single goal.
+An epic is a Linear project grouping related issues toward a single goal. See
+[docs/linear-workflow.md](docs/linear-workflow.md) for issue-vs-project rules.
 
-- **Lead with motivation**: One or two sentences explaining why this work
-  matters and what the end state looks like.
-- **Show the dependency structure**: Use a Mermaid diagram (GitHub renders them
-  natively) to make the execution order and parallelism obvious at a glance.
-- **Reference issues, not solutions**: Each item links to a GitHub issue. The
-  issue describes the desired outcome; the PR (added later) describes the
-  solution.
-- **Mark progress inline**: `[x]` with PR link as branches merge. When all items
-  complete, move the section to "Completed."
+- **Lead with motivation**: the project description states why this work matters
+  and what the end state looks like.
+- **Show the dependency structure**: use issue relations (blocks/blocked-by) and
+  sub-issues so execution order and parallelism are explicit.
+- **Reference issues, not solutions**: each issue describes the desired outcome;
+  the PR (linked later) describes the solution.
+- **Mark progress via status**: advance issues through workflow states and link
+  the PR as branches merge; the project completes when its issues do.
 
 ## Plan & Review
 
@@ -169,7 +168,7 @@ immediately. Do not paraphrase the request back as a confirmation step.
 When the user points out an issue, bug, or problem - fix it immediately. Do not
 ask "Want me to fix this?" or "Should I address this?". The user never sends
 messages just for the sake of it; when they point out issues, they expect action
-(usually a fix, sometimes reproducing, opening a GitHub issue, etc. based on
+(usually a fix, sometimes reproducing, opening a Linear issue, etc. based on
 context).
 
 **CRITICAL: Re-evaluate all work when a pattern is identified.** When the user
@@ -370,49 +369,18 @@ the existing message stays. If amended work has different scope than the
 branch's message, it belongs on a different branch -- don't rewrite the message
 to absorb it.
 
-### Updating ROADMAP.md
+### Updating Linear
 
-After completing work or creating new issues, update ROADMAP.md:
+After completing work or creating issues, keep Linear current:
 
-**Section ordering (newest first):**
-
-The roadmap is ordered with highest priority / most recent work at the top:
-
-1. **Current Development Focus** - Active work and immediate priorities
-2. **Backlog sections** - Planned future work by category
-3. **Completed sections** - Finished work, ordered newest to oldest
-
-This ordering ensures readers see current priorities immediately without
-scrolling past historical work. When adding new "Completed" sections, add them
-above older completed sections.
-
-**After completing a plan:**
-
-1. Mark completed issues as `[x]` with PR link
-2. Use this format:
-   ```markdown
-   - [x] [#N Issue title](https://github.com/ST0x-Technology/st0x.liquidity/issues/N)
-     - PR: [#M PR title](https://github.com/ST0x-Technology/st0x.liquidity/pull/M)
-   ```
-3. Move completed items from "Current Development Focus" to the appropriate
-   "Completed" section (or create a new one if it represents a milestone)
-
-**When creating new issues:**
-
-1. Add the issue to the appropriate **existing** roadmap section. Do not create
-   a new section for a single issue — only create subsections when grouping
-   multiple related items. If no existing section fits, add to the closest
-   match.
-2. Use this format:
-   ```markdown
-   - [ ] [#N Issue title](https://github.com/ST0x-Technology/st0x.liquidity/issues/N)
-   ```
-
-**Verification:**
-
-- Use `gh issue list --state all` and `gh pr list --state all` to cross-check
-- Ensure no issues are marked `[x]` in ROADMAP.md but still open on GitHub
-- Ensure all recent closed issues/PRs are reflected in the roadmap
+- **Completed work**: move the issue to Done and link the merged PR. If a PR is
+  chained on a parent, close both so status reflects reality at merge time.
+- **New issues**: file under the right project/milestone per
+  [docs/linear-workflow.md](docs/linear-workflow.md). Bundle a tight cluster of
+  related issues under one parent issue.
+- **Verification**: cross-check with `linear issue list` (issues) and
+  `gh pr list --state all` (PRs). No issue should sit Done with its PR unmerged,
+  and no merged PR should leave its issue open.
 
 ## Architecture Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,9 @@ agent) would benefit from knowing.
   others; `docs/` entries are mutable references describing _what_ the system
   currently does and _how_ to work with it.
 - **The product specification.** That lives in [SPEC.md](../SPEC.md).
-- **The roadmap.** That lives in [ROADMAP.md](../ROADMAP.md).
+- **The roadmap.** Work is planned and tracked in Linear; see
+  [linear-workflow.md](linear-workflow.md) for how we organize issues and
+  projects.
 
 ## Lifecycle
 

--- a/docs/linear-workflow.md
+++ b/docs/linear-workflow.md
@@ -1,0 +1,42 @@
+# Linear workflow: issue vs project
+
+How we decide where new work lives in Linear. The default is cheap (an issue);
+escalate to a project only when the work justifies it.
+
+## Decision rule
+
+Start from conceptual fit, not a time estimate -- estimates are unreliable, and
+"does this belong to an existing project's goal?" is the stronger signal.
+
+1. **Fits an existing project?** Put it there. Add it under an existing
+   milestone (if the project uses them), or file it directly in the project.
+2. **Doesn't fit, but it's small (roughly <= 1-2 weeks)?** Make it an issue.
+3. **Doesn't fit, and it's large (roughly > 1-2 weeks)?** Create a project --
+   but only when ALL of these hold:
+   - it doesn't fit any existing project's scope, AND
+   - it's larger than ~1-2 weeks of work, AND
+   - it has a distinct owner OR a standalone reason to track it separately (e.g.
+     someone else is driving it).
+
+If only some of those hold, prefer an issue (or a milestone inside an existing
+project) over spinning up a new project.
+
+## Bundling related issues
+
+When several issues will be completed in quick succession -- possibly under a
+single PR, though not necessarily -- group them under one **parent issue**. The
+parent issue is the unit that a PR or roadmap entry points at; the children are
+the granular steps.
+
+## Graduation
+
+Classification isn't permanent. An issue that grows beyond its original scope
+can graduate into a project later. Don't over-classify up front to avoid this --
+start small and promote when the work actually outgrows an issue.
+
+## Why these thresholds
+
+The 1-2 week boundary is a heuristic, not a gate. It exists to keep the tracker
+flat: most work is an issue, projects are reserved for genuinely separable,
+multi-week efforts with their own owner or rationale. When in doubt, file an
+issue -- promoting later is cheap; a graveyard of half-used projects is not.

--- a/docs/ttdd.md
+++ b/docs/ttdd.md
@@ -119,4 +119,4 @@ _before_ implementation begins — not after. The sequence is:
    behavior, then run the **full test suite** to ensure nothing else broke
 4. **Refine and clean up**: refactor, fix clippy warnings, improve code quality.
    Re-validate SPEC.md — refine any details that became clearer during
-   implementation. Update ROADMAP.md and AGENTS.md to reflect what changed
+   implementation. Update Linear and AGENTS.md to reflect what changed


### PR DESCRIPTION
## What

Resolves [RAI-786](https://linear.app/makeitrain/issue/RAI-786).

Adds `docs/linear-workflow.md` — a written policy for when new work should be a Linear **issue** vs a **project** — and reconciles `AGENTS.md` so agents treat Linear as the work tracker instead of GitHub Issues and a `ROADMAP.md` file that no longer exists in the repo.

## Why

The team is standardizing issue/project/milestone tracking on Linear, but `AGENTS.md` still directed agents to GitHub Issues and to maintain a `ROADMAP.md` that has since been deleted from the repo — stale guidance pointing at a tracker we no longer use and a file that isn't there. We also wanted an agent-readable rule for the recurring "issue or project?" decision so it's applied consistently rather than re-litigated each time.

## How

- **`docs/linear-workflow.md`** (new): default to an issue; escalate to a project only when *all* of (>1–2 weeks **AND** doesn't fit an existing project **AND** has a distinct owner or standalone reason) hold. Covers parent-issue bundling for tight clusters of related issues, and a "graduation" path so an issue can become a project later instead of over-classifying up front. Leads with conceptual fit over time estimates.
- **`AGENTS.md`** reconciliation (GitHub/ROADMAP → Linear, scoped to tracking):
  - Planning Hierarchy level 2: `ROADMAP.md / GitHub Issues` → `Linear issues/projects`, with a pointer to the new doc; tightened the "Before implementing" line to fit under the file's 40,000-char cap.
  - "Update at the end" bullet: maintaining `ROADMAP.md` → updating Linear (move issues to Done, link the PR).
  - "Managing Epics in the Roadmap" → "Managing Epics in Linear": an epic is a Linear project; dependency structure via issue relations/sub-issues instead of a Mermaid diagram in a markdown file; progress via issue status.
  - "Updating ROADMAP.md" → "Updating Linear": replaced the verbose GitHub-URL/`gh issue list` workflow with concise Linear guidance. Issues are cross-checked with `linear issue list`; **PRs stay on `gh pr list`**.
  - Inline: "opening a GitHub issue" → "opening a Linear issue".

## Testing

Docs-only change — no code, no tests. Verified `AGENTS.md` stays under its 40,000-char limit (38,982 after the edits).

## Screenshots

N/A

## Anything else

- **GitHub references kept where still correct**: PRs and code review remain on GitHub (e.g. `.github/PULL_REQUEST_TEMPLATE.md`, `gh pr list`). Only the *work-tracking* references moved to Linear.
- `docs/linear-workflow.md` is the canonical, agent-followed source of truth; it could optionally be mirrored into a Linear document for human onboarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated process documentation** to prioritize Linear workflow for issue and project management throughout the development lifecycle.
* **Added guidance** on determining when to create Linear issues versus projects, including decision criteria and workflow recommendations for tracking work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->