### PR TITLE
test: e2e for base unwrapped equity recovery into Raindex

### DIFF
--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -35,68 +35,9 @@ pub use order::{
 };
 
 pub use st0x_finance::{
-    EmptySymbolError, FractionalShares, HasZero, NotPositive, Positive, Symbol, ToWholeSharesError,
-    Usd, Usdc,
+    EmptySymbolError, FractionalShares, HasZero, NotPositive, Positive, SharesConversionError,
+    Symbol, ToWholeSharesError, Usd, Usdc,
 };
-
-/// Extension trait for U256 conversions on `FractionalShares`.
-///
-/// These depend on alloy types and therefore live in st0x-execution
-/// rather than the leaf st0x-finance crate.
-pub trait SharesBlockchain {
-    /// Converts to U256 with 18 decimal places (standard ERC20 decimals).
-    ///
-    /// Uses lossy conversion because Float's 224-bit coefficient may carry
-    /// more than 18 decimal places of precision, but ERC-20 tokens are 18
-    /// decimals so the extra precision is representational noise.
-    fn to_u256_18_decimals(self) -> Result<alloy::primitives::U256, SharesConversionError>;
-
-    /// Creates `FractionalShares` from a U256 value with 18 decimal places.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SharesConversionError`] if the Float conversion fails.
-    fn from_u256_18_decimals(
-        value: alloy::primitives::U256,
-    ) -> Result<FractionalShares, SharesConversionError>;
-}
-
-impl SharesBlockchain for FractionalShares {
-    fn to_u256_18_decimals(self) -> Result<alloy::primitives::U256, SharesConversionError> {
-        if self.is_negative()? {
-            return Err(SharesConversionError::NegativeValue(self.inner()));
-        }
-
-        if self.is_zero()? {
-            return Ok(alloy::primitives::U256::ZERO);
-        }
-
-        self.inner()
-            .to_fixed_decimal_lossy(18)
-            .map(|(fixed, _lossless)| fixed)
-            .map_err(SharesConversionError::FloatConversion)
-    }
-
-    fn from_u256_18_decimals(
-        value: alloy::primitives::U256,
-    ) -> Result<FractionalShares, SharesConversionError> {
-        if value.is_zero() {
-            return Ok(Self::ZERO);
-        }
-
-        Float::from_fixed_decimal(value, 18)
-            .map(Self::new)
-            .map_err(SharesConversionError::FloatConversion)
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum SharesConversionError {
-    #[error("shares value cannot be negative: {0:?}")]
-    NegativeValue(Float),
-    #[error("Float conversion failed: {0}")]
-    FloatConversion(#[from] FloatError),
-}
 
 /// Alpaca supports a maximum of 9 decimal places for order quantities.
 pub(crate) const ALPACA_MAX_DECIMAL_PLACES: u8 = 9;
@@ -580,8 +521,6 @@ impl Display for ExecutorOrderId {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::U256;
-    use std::str::FromStr;
     use uuid::Uuid;
 
     use super::*;
@@ -666,39 +605,6 @@ mod tests {
     }
 
     #[test]
-    fn to_u256_18_decimals_zero_returns_zero() {
-        let result = FractionalShares::ZERO.to_u256_18_decimals().unwrap();
-        assert_eq!(result, U256::ZERO);
-    }
-
-    #[test]
-    fn to_u256_18_decimals_one_returns_10_pow_18() {
-        let result = FractionalShares::new(float!(1))
-            .to_u256_18_decimals()
-            .unwrap();
-        assert_eq!(result, U256::from_str("1000000000000000000").unwrap());
-    }
-
-    #[test]
-    fn to_u256_18_decimals_fractional_value() {
-        let result = FractionalShares::new(float!(1.5))
-            .to_u256_18_decimals()
-            .unwrap();
-        assert_eq!(result, U256::from_str("1500000000000000000").unwrap());
-    }
-
-    #[test]
-    fn to_u256_18_decimals_negative_returns_error() {
-        let err = FractionalShares::new(float!(-1))
-            .to_u256_18_decimals()
-            .unwrap_err();
-        assert!(
-            matches!(err, SharesConversionError::NegativeValue(_)),
-            "Expected NegativeValue error, got: {err:?}"
-        );
-    }
-
-    #[test]
     fn test_symbol_new_valid() {
         let symbol = Symbol::new("AAPL").unwrap();
         assert_eq!(symbol.to_string(), "AAPL");
@@ -747,26 +653,6 @@ mod tests {
     fn test_shares_new_one() {
         let shares = Shares::new(1).unwrap();
         assert_eq!(shares.to_string(), "1");
-    }
-
-    #[test]
-    fn from_u256_18_decimals_zero_returns_zero() {
-        let result = FractionalShares::from_u256_18_decimals(U256::ZERO).unwrap();
-        assert_eq!(result, FractionalShares::ZERO);
-    }
-
-    #[test]
-    fn from_u256_18_decimals_one_whole_share() {
-        let one_share = U256::from_str("1000000000000000000").unwrap();
-        let result = FractionalShares::from_u256_18_decimals(one_share).unwrap();
-        assert!(result.inner().eq(float!(1)).unwrap());
-    }
-
-    #[test]
-    fn from_u256_18_decimals_fractional_amount() {
-        let one_and_a_half = U256::from_str("1500000000000000000").unwrap();
-        let result = FractionalShares::from_u256_18_decimals(one_and_a_half).unwrap();
-        assert!(result.inner().eq(float!(1.5)).unwrap());
     }
 
     #[test]

--- a/crates/finance/src/lib.rs
+++ b/crates/finance/src/lib.rs
@@ -17,7 +17,7 @@ mod usd;
 mod usdc;
 
 pub use id::{BlankIdError, Id};
-pub use shares::FractionalShares;
+pub use shares::{FractionalShares, SharesConversionError};
 pub use symbol::{EmptySymbolError, Symbol};
 pub use usd::{Usd, UsdToCentsError};
 pub use usdc::{Usdc, UsdcConversionError};

--- a/crates/finance/src/shares.rs
+++ b/crates/finance/src/shares.rs
@@ -1,5 +1,6 @@
 //! Fractional share quantity newtype with checked arithmetic.
 
+use alloy_primitives::U256;
 use rain_math_float::{Float, FloatError};
 use serde::Serialize;
 use st0x_float_macro::float;
@@ -68,6 +69,50 @@ impl FractionalShares {
         let frac = self.0.frac()?;
         frac.is_zero()
     }
+
+    /// Converts to U256 with 18 decimal places (standard ERC20 decimals).
+    ///
+    /// Uses lossy conversion because Float's 224-bit coefficient may carry
+    /// more than 18 decimal places of precision, but ERC-20 tokens are 18
+    /// decimals so the extra precision is representational noise.
+    pub fn to_u256_18_decimals(self) -> Result<U256, SharesConversionError> {
+        if self.is_negative()? {
+            return Err(SharesConversionError::NegativeValue(self.0));
+        }
+
+        if self.is_zero()? {
+            return Ok(U256::ZERO);
+        }
+
+        self.0
+            .to_fixed_decimal_lossy(18)
+            .map(|(fixed, _lossless)| fixed)
+            .map_err(SharesConversionError::FloatConversion)
+    }
+
+    /// Creates `FractionalShares` from a U256 value with 18 decimal places.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SharesConversionError`] if the Float conversion fails.
+    pub fn from_u256_18_decimals(value: U256) -> Result<Self, SharesConversionError> {
+        if value.is_zero() {
+            return Ok(Self::ZERO);
+        }
+
+        Float::from_fixed_decimal(value, 18)
+            .map(Self)
+            .map_err(SharesConversionError::FloatConversion)
+    }
+}
+
+/// Errors converting between `FractionalShares` and 18-decimal U256 amounts.
+#[derive(Debug, thiserror::Error)]
+pub enum SharesConversionError {
+    #[error("shares value cannot be negative: {0:?}")]
+    NegativeValue(Float),
+    #[error("Float conversion failed: {0}")]
+    FloatConversion(#[from] FloatError),
 }
 
 impl PartialEq for FractionalShares {
@@ -198,6 +243,59 @@ mod tests {
     #[test]
     fn zero_constant_is_zero() {
         assert!(FractionalShares::ZERO.is_zero().unwrap());
+    }
+
+    #[test]
+    fn to_u256_18_decimals_zero_returns_zero() {
+        let result = FractionalShares::ZERO.to_u256_18_decimals().unwrap();
+        assert_eq!(result, U256::ZERO);
+    }
+
+    #[test]
+    fn to_u256_18_decimals_one_returns_10_pow_18() {
+        let result = FractionalShares::new(float!(1))
+            .to_u256_18_decimals()
+            .unwrap();
+        assert_eq!(result, U256::from_str("1000000000000000000").unwrap());
+    }
+
+    #[test]
+    fn to_u256_18_decimals_fractional_value() {
+        let result = FractionalShares::new(float!(1.5))
+            .to_u256_18_decimals()
+            .unwrap();
+        assert_eq!(result, U256::from_str("1500000000000000000").unwrap());
+    }
+
+    #[test]
+    fn to_u256_18_decimals_negative_returns_error() {
+        let err = FractionalShares::new(float!(-1))
+            .to_u256_18_decimals()
+            .unwrap_err();
+        assert!(
+            matches!(err, SharesConversionError::NegativeValue(_)),
+            "Expected NegativeValue error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_u256_18_decimals_zero_returns_zero() {
+        let result = FractionalShares::from_u256_18_decimals(U256::ZERO).unwrap();
+        assert_eq!(result, FractionalShares::ZERO);
+    }
+
+    #[test]
+    fn from_u256_18_decimals_one_whole_share() {
+        let one_share = U256::from_str("1000000000000000000").unwrap();
+        let result = FractionalShares::from_u256_18_decimals(one_share).unwrap();
+        assert!(result.inner().eq(float!(1)).unwrap());
+    }
+
+    #[test]
+    fn from_u256_18_decimals_fractional_amount() {
+        let one_and_a_half = U256::from_str("1500000000000000000").unwrap();
+        let result = FractionalShares::from_u256_18_decimals(one_and_a_half).unwrap();
+        assert!(result.inner().eq(float!(1.5)).unwrap());
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,7 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use st0x_dto::TradingVenue;
-use st0x_execution::{FractionalShares, SharesBlockchain};
+use st0x_execution::FractionalShares;
 
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -14,8 +14,8 @@ use st0x_bridge::cctp::{CctpBridge, CctpCtx};
 use st0x_event_sorcery::StoreBuilder;
 use st0x_evm::{Evm, OpenChainErrorRegistry, ReadOnlyEvm};
 use st0x_execution::{
-    AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, Executor, FractionalShares,
-    SharesBlockchain, Symbol, TimeInForce,
+    AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, Executor, FractionalShares, Symbol,
+    TimeInForce,
 };
 use st0x_finance::Usdc;
 

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -4,7 +4,7 @@ use alloy::primitives::Address;
 use std::io::Write;
 
 use st0x_config::Ctx;
-use st0x_execution::{FractionalShares, Positive, SharesBlockchain, Symbol};
+use st0x_execution::{FractionalShares, Positive, Symbol};
 
 use crate::wrapper::{Wrapper, WrapperService};
 

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -18,9 +18,7 @@ use tracing::{debug, warn};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
-use st0x_execution::{
-    Executor, FractionalShares, InventoryResult, SharesBlockchain, SharesConversionError, Symbol,
-};
+use st0x_execution::{Executor, FractionalShares, InventoryResult, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, UsdToCentsError};
 
 use crate::bindings::IERC20;

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
-use st0x_execution::{FractionalShares, SharesBlockchain, SharesConversionError, Symbol};
+use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
 
 use super::RebalancingService;
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -20,7 +20,7 @@ use st0x_config::{AssetsConfig, OperationMode};
 use st0x_event_sorcery::{
     AggregateError, EntityList, LifecycleError, Projection, ProjectionError, Reactor, Store, deps,
 };
-use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConversionError, Symbol};
+use st0x_execution::{FractionalShares, Positive, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, Usdc};
 
 use self::usdc::UsdcRebalanceOperation;

--- a/src/shares.rs
+++ b/src/shares.rs
@@ -1,4 +1,3 @@
 //! Re-exports from the execution crate for share types and utilities.
 
-pub(crate) use st0x_execution::SharesBlockchain;
 pub use st0x_execution::{FractionalShares, SharesConversionError};

--- a/src/tokenization/mock_api.rs
+++ b/src/tokenization/mock_api.rs
@@ -26,7 +26,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, TEST_ACCOUNT_ID};
-use st0x_execution::{FractionalShares, SharesBlockchain, Symbol};
+use st0x_execution::{FractionalShares, Symbol};
 use st0x_float_serde::format_float_with_fallback;
 
 use crate::bindings::DeployableERC20;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -40,7 +40,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
-use st0x_execution::{FractionalShares, SharesBlockchain, Symbol};
+use st0x_execution::{FractionalShares, Symbol};
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::onchain::raindex::Raindex;

--- a/src/wrapper/ratio.rs
+++ b/src/wrapper/ratio.rs
@@ -6,7 +6,7 @@
 
 use alloy::primitives::U256;
 
-use crate::shares::{FractionalShares, SharesBlockchain, SharesConversionError};
+use crate::shares::{FractionalShares, SharesConversionError};
 
 /// One unit in ratio representation (10^18).
 pub(crate) const RATIO_ONE: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -208,6 +208,12 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
     usdc_rebalancing: UsdcRebalancing,
     cash_rebalancing: OperationMode,
     wrapped_equity_recovery: OperationMode,
+    // Equity imbalance threshold. Defaults to the standard (0.5 target, 0.1
+    // deviation). Recovery tests pass a huge deviation to suppress equity
+    // rebalancing transfers (which would churn the wallet/vault and starve a
+    // second recovery) while keeping `rebalancing: Enabled` so the wallet
+    // poller still emits the events that dispatch recovery jobs.
+    equity_imbalance: Option<ImbalanceThreshold>,
     redemption_wallet: Address,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
@@ -243,8 +249,13 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         TestWallet::new(&chain.owner_key, chain.endpoint().parse()?, 1)?,
     );
 
+    let equity_threshold = match equity_imbalance {
+        Some(threshold) => threshold,
+        None => ImbalanceThreshold::new(float!(0.5), float!(0.1))?,
+    };
+
     let rebalancing_ctx = st0x_hedge::RebalancingCtx::with_wallets()
-        .equity(ImbalanceThreshold::new(float!(0.5), float!(0.1))?)
+        .equity(equity_threshold)
         .usdc(usdc_rebalancing)
         .call();
 

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -31,9 +31,9 @@ use rain_math_float::Float;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::collections::HashMap;
 
-use st0x_execution::SharesBlockchain;
 use st0x_finance::{FractionalShares, Positive, Usd};
 use st0x_float_macro::float;
+use st0x_hedge::ImbalanceThreshold;
 use st0x_hedge::OperationMode;
 use st0x_hedge::bindings::IOrderBookV6;
 use st0x_hedge::cli::seed_mint_at_tokens_wrapped_for_test;
@@ -2339,6 +2339,230 @@ async fn wrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<
     );
     assert_single_clean_aggregate(
         &recovery_events,
+        &["WrappedEquityRecoveryEvent::RecoveryFailed"],
+    );
+
+    bot.abort();
+    Ok(())
+}
+
+/// Orphan recovery for unwrapped equity (tSTOCK) found on the bot wallet.
+///
+/// Mirrors `wrapped_equity_in_bot_wallet_recovers_into_raindex` but for the
+/// unwrapped path: the wallet starts with leftover tSTOCK (unwrapped) from
+/// vault deployment, no in-flight mint or redemption owns it, so the
+/// UnwrappedEquityRecoveryJob takes the orphan path and runs the full
+/// four-step sequence (wrap submit + confirm, then deposit submit + confirm).
+///
+/// Asserts: the bot wallet ends up with zero tSTOCK and zero wtSTOCK (both
+/// drained), the configured Raindex vault is topped up by at least the
+/// originally-unwrapped balance, and the recovery aggregate's event stream
+/// records the full orphan sequence `Detected -> OrphanWrapSubmitted ->
+/// OrphanWrapped -> OrphanDepositSubmitted -> OrphanDeposited`.
+#[test_log::test(tokio::test)]
+#[ignore = "TTDD red state: nothing enqueues UnwrappedEquityRecoveryJob until the rebalancing \
+            reactor trigger lands upstack; feat/unwrapped-equity-recovery-trigger removes this \
+            ignore"]
+async fn unwrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<()> {
+    let onchain_price = float!("150.00");
+    let broker_fill_price = float!("150.00");
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price)],
+        vec![("AAPL", float!("1"))],
+    )
+    .await?;
+
+    let wrapped_token = infra.equity_addresses[0].1;
+    let unwrapped_token = infra.equity_addresses[0].2;
+
+    // Register a Raindex vault for AAPL via setup_order so the bot knows
+    // where to deposit recovered shares. The order is never taken; we only
+    // need the vault ID and the side-effect of leaving tSTOCK in the owner
+    // wallet from deploy_equity_vault.
+    let prepared = infra
+        .base_chain
+        .setup_order()
+        .symbol("AAPL")
+        .amount(float!("1"))
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    let owner_unwrapped_balance_before =
+        crate::base_chain::IERC20::new(unwrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+    let owner_wrapped_balance_before =
+        crate::base_chain::IERC20::new(wrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+
+    assert!(
+        owner_unwrapped_balance_before > U256::ZERO,
+        "Test precondition violated: owner wallet should hold tSTOCK after vault deployment",
+    );
+    assert!(
+        owner_wrapped_balance_before > U256::ZERO,
+        "Test precondition violated: owner wallet should hold wtSTOCK after vault deployment",
+    );
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let cash_vault_id = prepared.input_vault_id;
+    let equity_vault_id = prepared.output_vault_id;
+    let equity_vault_ids = HashMap::from([("AAPL".to_owned(), equity_vault_id)]);
+
+    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(
+        infra.base_chain.orderbook,
+        &infra.base_chain.provider,
+    );
+
+    let vault_balance_before_raw = orderbook
+        .vaultBalance2(infra.base_chain.owner, wrapped_token, equity_vault_id)
+        .call()
+        .await?;
+
+    let ctx = build_rebalancing_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .equity_tokens(&infra.equity_addresses)
+        .equity_vault_ids(&equity_vault_ids)
+        .cash_vault_id(cash_vault_id)
+        .usdc_rebalancing(UsdcRebalancing::Disabled)
+        .cash_rebalancing(OperationMode::Disabled)
+        // Suppress equity rebalancing with an unreachable imbalance deviation so
+        // this test isolates recovery. Equity rebalancing must stay `Enabled`
+        // (the wallet poller only emits the events that dispatch recovery jobs
+        // for rebalancing-enabled symbols), but with it actively transferring,
+        // the wtSTOCK the recovery deposits into the vault creates an imbalance
+        // that fires a Raindex->Alpaca transfer. That transfer holds the per-symbol
+        // `equity_in_progress` guard and starves the wrapped recovery (and
+        // drains the vault the assertions check). A huge deviation keeps the
+        // imbalance check from ever triggering a transfer. The recovery<->
+        // rebalancing interaction itself is a separate integration concern.
+        .equity_imbalance(ImbalanceThreshold::new(float!(0.5), float!(100))?)
+        .wrapped_equity_recovery(OperationMode::Enabled)
+        .redemption_wallet(REDEMPTION_WALLET)
+        .call()?;
+
+    let mut bot = spawn_bot(ctx);
+
+    // The bot wallet holds BOTH unwrapped tSTOCK and pre-existing wtSTOCK for
+    // AAPL, so two recovery jobs are enqueued: the unwrapped recovery (wraps the
+    // tSTOCK and deposits exactly that wrapped amount) and the wrapped recovery
+    // (deposits the pre-existing wtSTOCK). Both claim the same per-symbol
+    // `equity_in_progress` guard, so they run serially -- whichever wins the
+    // guard first runs to completion while the other silently skips, and the
+    // skipped one is only re-dispatched on the next inventory poll once the
+    // guard is free. We must therefore wait for BOTH terminal events before
+    // asserting the wallet is fully drained; waiting only for the unwrapped
+    // terminal races the wrapped recovery, which has not run yet.
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "UnwrappedEquityRecoveryEvent::OrphanDeposited",
+        1,
+        Duration::from_secs(60),
+    )
+    .await;
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "WrappedEquityRecoveryEvent::OrphanDeposited",
+        1,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    let owner_unwrapped_balance_after =
+        crate::base_chain::IERC20::new(unwrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+    let owner_wrapped_balance_after =
+        crate::base_chain::IERC20::new(wrapped_token, &infra.base_chain.provider)
+            .balanceOf(infra.base_chain.owner)
+            .call()
+            .await?;
+
+    assert_eq!(
+        owner_unwrapped_balance_after,
+        U256::ZERO,
+        "Recovery should have wrapped every tSTOCK out of the owner wallet \
+         (started with {owner_unwrapped_balance_before}, still holding \
+         {owner_unwrapped_balance_after})",
+    );
+
+    assert_eq!(
+        owner_wrapped_balance_after,
+        U256::ZERO,
+        "Recovery should have deposited every wtSTOCK into the vault, leaving \
+         the owner wallet empty (still holding {owner_wrapped_balance_after})",
+    );
+
+    let vault_balance_after_raw = orderbook
+        .vaultBalance2(infra.base_chain.owner, wrapped_token, equity_vault_id)
+        .call()
+        .await?;
+
+    let (vault_balance_before, _lossless_before) =
+        Float::from_raw(vault_balance_before_raw).to_fixed_decimal_lossy(18)?;
+    let (vault_balance_after, _lossless_after) =
+        Float::from_raw(vault_balance_after_raw).to_fixed_decimal_lossy(18)?;
+    let vault_delta = vault_balance_after.saturating_sub(vault_balance_before);
+
+    // Vault delta must cover BOTH the pre-existing wtSTOCK (which the wrapped
+    // recovery deposits) AND the wtSTOCK produced by wrapping the tSTOCK (which
+    // the unwrapped recovery is responsible for). Asserting the lower bound at
+    // `owner_unwrapped_balance_before` alone would pass even if the unwrapped
+    // path did nothing, because the wrapped path would still deposit the
+    // pre-existing balance.
+    let expected_min_delta = owner_unwrapped_balance_before
+        .checked_add(owner_wrapped_balance_before)
+        .expect("snapshot sum fits in U256");
+    assert!(
+        vault_delta >= expected_min_delta,
+        "Recovery should have deposited at least {expected_min_delta} into the configured \
+         Raindex vault (pre-existing wtSTOCK={owner_wrapped_balance_before} plus the \
+         wrapped equivalent of {owner_unwrapped_balance_before} recovered tSTOCK) \
+         (before={vault_balance_before}, after={vault_balance_after}, delta={vault_delta})",
+    );
+
+    let pool = connect_db(&infra.db_path).await?;
+    let unwrapped_recovery_events = fetch_events_by_type(&pool, "UnwrappedEquityRecovery").await?;
+    let wrapped_recovery_events = fetch_events_by_type(&pool, "WrappedEquityRecovery").await?;
+    pool.close().await;
+
+    assert_event_subsequence(
+        &unwrapped_recovery_events,
+        &[
+            "UnwrappedEquityRecoveryEvent::Detected",
+            "UnwrappedEquityRecoveryEvent::OrphanWrapSubmitted",
+            "UnwrappedEquityRecoveryEvent::OrphanWrapped",
+            "UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted",
+            "UnwrappedEquityRecoveryEvent::OrphanDeposited",
+        ],
+    );
+    assert_single_clean_aggregate(
+        &unwrapped_recovery_events,
+        &["UnwrappedEquityRecoveryEvent::RecoveryFailed"],
+    );
+
+    assert_event_subsequence(
+        &wrapped_recovery_events,
+        &[
+            "WrappedEquityRecoveryEvent::Detected",
+            "WrappedEquityRecoveryEvent::OrphanDepositSubmitted",
+            "WrappedEquityRecoveryEvent::OrphanDeposited",
+        ],
+    );
+    assert_single_clean_aggregate(
+        &wrapped_recovery_events,
         &["WrappedEquityRecoveryEvent::RecoveryFailed"],
     );
 


### PR DESCRIPTION
> [!WARNING]
> **Intended CI failure on this branch (TTDD test-first).** The e2e test
> `rebalancing::unwrapped_equity_in_bot_wallet_recovers_into_raindex` is **red here
> by design** — the recovery pipeline does not exist yet. It is red on **#728, #729,
> and #733** and only goes **green from #734** (the rebalancing-reactor trigger
> completes the pipeline). Everything else on this branch — all other tests, clippy,
> and hooks — passes.

## What

[RAI-854](https://linear.app/makeitrain/issue/RAI-854/e2e-test-base-unwrapped-equity-recovery-into-raindex)

A failing e2e test for Base unwrapped-equity (tSTOCK) recovery, asserting the desired behavior ahead of the implementation.

## Why

The test pins the desired end-to-end recovery behavior before the implementation exists, so it is red on this branch by design and turns green once the full recovery pipeline lands at #734.

## How

Adds `unwrapped_equity_in_bot_wallet_recovers_into_raindex` to the rebalancing e2e suite: stages leftover tSTOCK on the bot wallet, runs the bot, and asserts the wallet drains (zero tSTOCK + wtSTOCK), the Raindex vault is topped up, and the recovery aggregate emits `Detected → OrphanWrapSubmitted → OrphanWrapped → OrphanDepositSubmitted → OrphanDeposited`. Uses string-based event assertions so it compiles standalone. Adds an optional `equity_imbalance` knob to the shared `build_rebalancing_ctx` helper to isolate recovery from equity rebalancing.

## Testing

This PR *is* the test. Red on #728/#729/#733; green from #734 upward.

## Anything else

Stacked on #727 (spec), below the recovery implementation (#733 aggregate/worker, #734 reactor trigger). The red CI on this branch is intentional and clears at #734.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ERC-20-style 18-decimal fixed-point conversion methods for fractional shares.
  * Introduced public error type for handling shares conversion failures.

* **Tests**
  * Enhanced equity recovery test coverage with improved test fixtures.

* **Refactor**
  * Streamlined internal imports and removed unused dependencies across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->