### PR TITLE
refactor: QueuePushError struct to single-variant enum

### DIFF
--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -78,8 +78,10 @@ pub(crate) struct JobQueue<Task>(Storage<Task>);
 /// Wrapping [`TaskSinkError`] keeps the failure chain typed so callers can
 /// `#[from]` it into their own error enums instead of boxing.
 #[derive(Debug, thiserror::Error)]
-#[error("Failed to enqueue apalis job: {0}")]
-pub(crate) struct QueuePushError(#[from] pub(crate) TaskSinkError<sqlx::Error>);
+pub(crate) enum QueuePushError {
+    #[error("failed to enqueue apalis job: {0}")]
+    Sink(#[from] TaskSinkError<sqlx::Error>),
+}
 
 impl<Task> Clone for JobQueue<Task> {
     fn clone(&self) -> Self {

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 use st0x_execution::{FractionalShares, Positive, Symbol};
 
 use super::{RebalancingService, TokenAddressError, TriggeredOperation};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{Job, JobQueue, Label};
 use crate::inventory::{
     BroadcastingInventory, EquityImbalanceError, Imbalance, ImbalanceThreshold,
 };
@@ -256,7 +256,7 @@ impl EquityRebalancingCheckScheduler {
     /// re-trigger.
     pub(super) async fn enqueue_check(&self, symbol: Symbol) {
         let mut queue = self.queue.clone();
-        if let Err(QueuePushError(error)) = queue.push(EquityRebalancingCheck { symbol }).await {
+        if let Err(error) = queue.push(EquityRebalancingCheck { symbol }).await {
             warn!(target: "rebalance", %error, "Failed to enqueue EquityRebalancingCheck job");
         }
     }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -24,7 +24,6 @@ use st0x_execution::{FractionalShares, Positive, SharesBlockchain, SharesConvers
 use st0x_finance::{HasZero, Usd, Usdc};
 
 use self::usdc::UsdcRebalanceOperation;
-use crate::conductor::job::QueuePushError;
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, EquityRedemptionEvent, RedemptionAggregateId,
 };
@@ -2226,7 +2225,7 @@ impl RebalancingService {
                 true
             }
 
-            Err(QueuePushError(error)) => {
+            Err(error) => {
                 warn!(
                     target: "rebalance",
                     %error,
@@ -2294,7 +2293,7 @@ impl RebalancingService {
                 true
             }
 
-            Err(QueuePushError(error)) => {
+            Err(error) => {
                 warn!(
                     target: "rebalance",
                     %error,

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 use st0x_finance::{Usd, Usdc};
 
 use super::{RebalancingService, RebalancingServiceError};
-use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
+use crate::conductor::job::{Job, JobQueue, Label};
 use crate::inventory::{
     BroadcastingInventory, Imbalance, ImbalanceThreshold, Inventory, TransferOp, Venue,
 };
@@ -1061,7 +1061,7 @@ impl UsdcRebalancingCheckScheduler {
     /// re-trigger.
     pub(super) async fn enqueue_check(&self) {
         let mut queue = self.queue.clone();
-        if let Err(QueuePushError(error)) = queue.push(UsdcRebalancingCheck).await {
+        if let Err(error) = queue.push(UsdcRebalancingCheck).await {
             warn!(target: "rebalance", %error, "Failed to enqueue UsdcRebalancingCheck job");
         }
     }


### PR DESCRIPTION
> [!WARNING]
> **Intended CI failure on this branch.**
> `rebalancing::unwrapped_equity_in_bot_wallet_recovers_into_raindex` (an e2e from
> the test-first branch below) is red here by design — the recovery pipeline is not
> complete until #734, where it turns green. All other tests, clippy, and hooks pass.

## What

Converts `QueuePushError` from a single-field tuple struct into a single-variant enum and updates the rebalancing-trigger call sites that destructure it.

## Why

Aligns queue-push failures with the error-enum style used across the crate and leaves room to add further enqueue failure modes as variants without changing the `#[from]` / match surface at the call sites.

## How

- `conductor/job.rs`: `QueuePushError` becomes `enum QueuePushError { Sink(TaskSinkError<sqlx::Error>) }`.
- `rebalancing/trigger/{equity,usdc,mod}.rs`: updated to the new type at the `enqueue_check` / dispatch sites.

## Testing

Type-only refactor with no behavior change; covered by the existing rebalancing-trigger unit tests.
