### PR TITLE
feat: crash-safe post-mint resume for Base->Alpaca USDC transfers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1662,12 +1662,15 @@ enum UsdcRebalance {
         burn_tx_hash: TxHash,
         cctp_nonce: u64,
         attestation: Vec<u8>,
+        mint_scan_from_block: u64,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
     },
     Bridged {
         direction: RebalanceDirection,
         amount: Usdc,
+        amount_received: Usdc,
+        fee_collected: Usdc,
         burn_tx_hash: TxHash,
         mint_tx_hash: TxHash,
         initiated_at: DateTime<Utc>,
@@ -1714,6 +1717,26 @@ enum UsdcRebalance {
 }
 ```
 
+##### Crash-safe resume
+
+Resuming a transfer after a crash must never re-execute an irreversible on-chain
+action that already succeeded. Each phase records its intent (and the relevant
+chain head) before the action, so resume can scan the chain to adopt an
+already-submitted action instead of re-issuing it:
+
+- `WithdrawalSubmitting` / `BridgingSubmitting`: scan the source chain for an
+  already-submitted withdrawal / burn (`find_recent_withdrawal` /
+  `find_recent_burn`) from the captured head and adopt it rather than
+  withdrawing / burning twice.
+- `Attested`: the CCTP mint is irreversible -- re-calling `receiveMessage`
+  reverts on the already-used nonce, which would otherwise turn a successfully
+  minted transfer into a terminal `BridgingFailed`. Resume must scan the
+  destination chain for the already-submitted mint (`find_recent_mint`, matching
+  the `MintAndWithdraw` event) and adopt it -- recording `ConfirmBridging` with
+  the existing mint tx, amount, and fee -- before attempting a fresh mint. The
+  destination chain head is captured when the attestation is recorded so the
+  scan is bounded.
+
 ##### Commands
 
 ```rust
@@ -1740,8 +1763,8 @@ enum UsdcRebalanceCommand {
 
     // Bridging commands
     InitiateBridging { burn_tx: TxHash },
-    ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: u64 },
-    ConfirmBridging { mint_tx: TxHash },
+    ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: u64, mint_scan_from_block: u64 },
+    ConfirmBridging { mint_tx: TxHash, amount_received: Usdc, fee_collected: Usdc },
     FailBridging { reason: String },
 
     // Deposit commands
@@ -1782,10 +1805,13 @@ enum UsdcRebalanceEvent {
     BridgeAttestationReceived {
         attestation: Vec<u8>,
         cctp_nonce: u64,
+        mint_scan_from_block: u64,
         attested_at: DateTime<Utc>,
     },
     Bridged {
         mint_tx_hash: TxHash,
+        amount_received: Usdc,
+        fee_collected: Usdc,
         minted_at: DateTime<Utc>,
     },
     BridgingFailed {

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -175,6 +175,58 @@ impl<W: Wallet> CctpEndpoint<W> {
         Ok(None)
     }
 
+    /// Scans for a `MintAndWithdraw` event minting to `recipient` strictly after
+    /// `from_block`, returning the receipt of the most recent match.
+    ///
+    /// Used for crash-safe mint recovery: a transfer records the destination
+    /// chain head before submitting the mint, so on resume this detects an
+    /// already-submitted mint instead of re-minting (which reverts on the
+    /// already-used CCTP nonce). The mint is recorded strictly after the captured
+    /// head, so the scan excludes the head block itself -- this bounds the window
+    /// to blocks mined after capture and prevents adopting an earlier mint to the
+    /// same wallet. Matching on `mintRecipient` and `mintToken` plus this bound
+    /// and the single-in-flight invariant (one USDC rebalance at a time) guarantees the
+    /// match is the resuming transfer's mint. The event carries the actual amount
+    /// received and fee collected, so the adopted mint records the same inventory
+    /// figures a fresh mint would.
+    pub(super) async fn find_recent_mint(
+        &self,
+        recipient: Address,
+        from_block: u64,
+    ) -> Result<Option<MintReceipt>, CctpError> {
+        let filter = Filter::new()
+            .from_block(from_block)
+            .address(self.token_messenger_address)
+            .event_signature(TokenMessengerV2::MintAndWithdraw::SIGNATURE_HASH);
+
+        let logs = self.wallet.provider().get_logs(&filter).await?;
+
+        for log in logs.iter().rev() {
+            let decoded = log.log_decode::<TokenMessengerV2::MintAndWithdraw>()?;
+            let event = decoded.data();
+
+            if event.mintRecipient == recipient
+                && event.mintToken == self.usdc_address
+                && log.block_number.is_some_and(|block| block > from_block)
+                && let Some(tx_hash) = log.transaction_hash
+            {
+                debug!(target: "bridge", %tx_hash, from_block, "Found existing mint during resume");
+                return Ok(Some(MintReceipt {
+                    tx: tx_hash,
+                    amount: event.amount,
+                    fee_collected: event.feeCollected,
+                }));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Returns the current head of this endpoint's chain.
+    pub(super) async fn current_block(&self) -> Result<u64, CctpError> {
+        Ok(self.wallet.provider().get_block_number().await?)
+    }
+
     /// Claims USDC on this chain by submitting the attestation.
     ///
     /// Parses the `MintAndWithdraw` event from the transaction receipt to extract

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -686,6 +686,40 @@ where
             BridgeDirection::BaseToEthereum => self.base.find_recent_burn(amount, from_block).await,
         }
     }
+
+    /// Scans the mint destination chain for an already-submitted mint to
+    /// `recipient` strictly after `from_block`, for crash-safe resume. Delegates
+    /// to the destination endpoint for the given direction.
+    async fn find_recent_mint(
+        &self,
+        direction: BridgeDirection,
+        recipient: Address,
+        from_block: u64,
+    ) -> Result<Option<crate::MintReceipt>, Self::Error> {
+        let receipt = match direction {
+            BridgeDirection::EthereumToBase => {
+                self.base.find_recent_mint(recipient, from_block).await?
+            }
+            BridgeDirection::BaseToEthereum => {
+                self.ethereum
+                    .find_recent_mint(recipient, from_block)
+                    .await?
+            }
+        };
+
+        Ok(receipt.map(|receipt| crate::MintReceipt {
+            tx: receipt.tx,
+            amount: receipt.amount,
+            fee: receipt.fee_collected,
+        }))
+    }
+
+    async fn destination_block(&self, direction: BridgeDirection) -> Result<u64, Self::Error> {
+        match direction {
+            BridgeDirection::EthereumToBase => self.base.current_block().await,
+            BridgeDirection::BaseToEthereum => self.ethereum.current_block().await,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -706,6 +740,7 @@ mod tests {
     use st0x_evm::local::RawPrivateKeyWallet;
 
     use super::*;
+    use crate::Bridge;
 
     const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
@@ -2236,6 +2271,140 @@ mod tests {
             mint_receipt.fee_collected,
             U256::ZERO,
             "Fee should be zero in mock contracts"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_mint_returns_receipt_of_real_mint() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.ethereum.owner();
+        let burn_amount = U256::from(5_000_000u64);
+
+        // Capture the destination (Ethereum) head before minting, exactly as the
+        // resume path does via `Bridge::destination_block`.
+        let from_block = bridge
+            .destination_block(BridgeDirection::BaseToEthereum)
+            .await
+            .unwrap();
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                burn_amount,
+                recipient,
+            )
+            .await
+            .unwrap();
+
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, false)
+            .await
+            .unwrap();
+
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        let mint_receipt = bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                message_with_nonce,
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        let found = bridge
+            .find_recent_mint(BridgeDirection::BaseToEthereum, recipient, from_block)
+            .await
+            .unwrap()
+            .expect("scan must find the submitted mint");
+
+        assert_eq!(
+            found.tx, mint_receipt.tx,
+            "scan must return the real mint's tx"
+        );
+        assert_eq!(
+            found.amount, mint_receipt.amount,
+            "adopted amount must match the mint",
+        );
+        assert_eq!(
+            found.fee, mint_receipt.fee_collected,
+            "adopted fee must match the mint",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_mint_returns_none_for_wrong_recipient_or_below_scan_bound() {
+        let cctp = LocalCctp::new().await.unwrap();
+        let bridge = cctp.create_bridge().await.unwrap();
+
+        let recipient = bridge.ethereum.owner();
+        let burn_amount = U256::from(5_000_000u64);
+
+        let from_block = bridge
+            .destination_block(BridgeDirection::BaseToEthereum)
+            .await
+            .unwrap();
+
+        let burn_receipt = bridge
+            .burn_internal::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                burn_amount,
+                recipient,
+            )
+            .await
+            .unwrap();
+
+        let message = cctp
+            .extract_message_from_burn_tx(burn_receipt.tx, false)
+            .await
+            .unwrap();
+
+        let (attestation, message_with_nonce) = cctp.sign_message(&message).await.unwrap();
+
+        bridge
+            .mint_internal::<NoOpErrorRegistry>(
+                BridgeDirection::BaseToEthereum,
+                message_with_nonce,
+                attestation,
+            )
+            .await
+            .unwrap();
+
+        let other_recipient = address!("0x000000000000000000000000000000000000dEaD");
+        assert_eq!(
+            bridge
+                .find_recent_mint(BridgeDirection::BaseToEthereum, other_recipient, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a mint to a different recipient must not be adopted",
+        );
+
+        // Advance the Ethereum head past the mint with an unrelated burn, then
+        // scan from the new head: the mint now sits below the scan bound and must
+        // not be adopted (as a prior transfer's mint would be excluded on resume).
+        bridge
+            .burn_internal::<NoOpErrorRegistry>(
+                BridgeDirection::EthereumToBase,
+                burn_amount,
+                recipient,
+            )
+            .await
+            .unwrap();
+
+        let head_above_mint = bridge
+            .destination_block(BridgeDirection::BaseToEthereum)
+            .await
+            .unwrap();
+        assert_eq!(
+            bridge
+                .find_recent_mint(BridgeDirection::BaseToEthereum, recipient, head_above_mint)
+                .await
+                .unwrap(),
+            None,
+            "a mint below the scan bound must not be adopted",
         );
     }
 

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -31,7 +31,7 @@ pub struct BurnReceipt {
 }
 
 /// Receipt from minting USDC on the destination chain.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MintReceipt {
     /// Transaction hash of the mint transaction
     pub tx: TxHash,
@@ -91,4 +91,22 @@ pub trait Bridge: Send + Sync + 'static {
         amount: U256,
         from_block: u64,
     ) -> Result<Option<TxHash>, Self::Error>;
+
+    /// Scans the mint destination chain for an already-submitted mint to
+    /// `recipient` strictly after `from_block`, for crash-safe resume. Returns
+    /// the receipt so the caller can adopt the existing mint instead of
+    /// re-minting, which reverts on the already-used CCTP nonce and otherwise
+    /// fails the transfer for USDC that was in fact minted.
+    async fn find_recent_mint(
+        &self,
+        direction: BridgeDirection,
+        recipient: Address,
+        from_block: u64,
+    ) -> Result<Option<MintReceipt>, Self::Error>;
+
+    /// Returns the current head of the mint destination chain for `direction`.
+    /// Captured when the attestation is recorded -- before the mint -- so the
+    /// crash-safe resume scan in [`Bridge::find_recent_mint`] is bounded to
+    /// blocks mined strictly after it.
+    async fn destination_block(&self, direction: BridgeDirection) -> Result<u64, Self::Error>;
 }

--- a/crates/execution/src/alpaca_broker_api/executor.rs
+++ b/crates/execution/src/alpaca_broker_api/executor.rs
@@ -337,6 +337,7 @@ mod tests {
     use serde_json::json;
     use st0x_float_macro::float;
     use std::thread;
+    use uuid::uuid;
 
     use super::*;
     use crate::alpaca_broker_api::auth::{
@@ -349,7 +350,7 @@ mod tests {
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
 
     #[test]
     fn test_asset_status_deserialize_active() {

--- a/crates/execution/src/alpaca_broker_api/market_hours.rs
+++ b/crates/execution/src/alpaca_broker_api/market_hours.rs
@@ -82,6 +82,7 @@ async fn get_calendar(
 mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
+    use uuid::uuid;
 
     use super::*;
     use crate::alpaca_broker_api::TimeInForce;
@@ -90,7 +91,7 @@ mod tests {
     };
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
 
     fn create_test_ctx(mode: AlpacaBrokerApiMode) -> AlpacaBrokerApiCtx {
         AlpacaBrokerApiCtx {

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -543,6 +543,7 @@ pub(crate) async fn poll_crypto_order_until_filled(
 mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
+    use uuid::uuid;
 
     use super::*;
     use crate::alpaca_broker_api::auth::{
@@ -551,7 +552,7 @@ mod tests {
     use st0x_float_macro::float;
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
 
     fn create_test_ctx(mode: AlpacaBrokerApiMode) -> AlpacaBrokerApiCtx {
         AlpacaBrokerApiCtx {

--- a/crates/execution/src/alpaca_broker_api/positions.rs
+++ b/crates/execution/src/alpaca_broker_api/positions.rs
@@ -259,6 +259,7 @@ fn to_cash_value_cents(cash: Float) -> Result<i64, AlpacaBrokerApiError> {
 mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
+    use uuid::uuid;
 
     use super::*;
     use crate::alpaca_broker_api::TimeInForce;
@@ -280,7 +281,7 @@ mod tests {
     }
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
 
     fn create_test_ctx(mode: AlpacaBrokerApiMode) -> AlpacaBrokerApiCtx {
         AlpacaBrokerApiCtx {

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -28,7 +28,10 @@ pub use alpaca_broker_api::{
 };
 pub use error::PersistenceError;
 pub use mock::{MockExecutor, MockExecutorCtx};
-pub use order::{MarketOrder, OrderPlacement, OrderState, OrderStatus, OrderUpdate};
+pub use order::{
+    ClientOrderId, ClientOrderIdError, MarketOrder, OrderPlacement, OrderState, OrderStatus,
+    OrderUpdate,
+};
 
 pub use st0x_finance::{
     EmptySymbolError, FractionalShares, HasZero, NotPositive, Positive, Symbol, ToWholeSharesError,

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -1,7 +1,11 @@
-use std::fmt::Debug;
+use std::fmt::{self, Debug, Display};
+use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
 use st0x_float_serde::DebugOptionFloat;
 
 use crate::{Direction, FractionalShares, Positive, Symbol};
@@ -11,6 +15,78 @@ pub mod status;
 
 pub use state::OrderState;
 pub use status::OrderStatus;
+
+/// Caller-supplied idempotency key forwarded to the broker so retries of
+/// the same logical order do not double-submit.
+///
+/// The underlying value is always a UUID; the broker's `client_order_id`
+/// string is *derived* from it via [`Display`]. The variant records the
+/// order's provenance, which selects the rendered prefix.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ClientOrderId {
+    /// Automated placement (e.g. a conversion correlation id or an offchain
+    /// order id). Renders as the bare hyphenated UUID.
+    Automated(Uuid),
+    /// Operator-initiated CLI placement. Renders as `cli-{uuid}` so manual
+    /// orders are distinguishable in the broker dashboard.
+    Cli(Uuid),
+}
+
+/// Prefix rendered for [`ClientOrderId::Cli`].
+const CLI_PREFIX: &str = "cli-";
+
+impl ClientOrderId {
+    /// Idempotency key for an automated placement keyed by `uuid` (e.g. a
+    /// conversion correlation id or an offchain order id).
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self::Automated(uuid)
+    }
+
+    /// Idempotency key for an operator-initiated CLI placement; renders with
+    /// the `cli-` prefix.
+    pub fn cli(uuid: Uuid) -> Self {
+        Self::Cli(uuid)
+    }
+}
+
+impl Display for ClientOrderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Automated(uuid) => Display::fmt(uuid, f),
+            Self::Cli(uuid) => write!(f, "{CLI_PREFIX}{uuid}"),
+        }
+    }
+}
+
+impl FromStr for ClientOrderId {
+    type Err = ClientOrderIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.strip_prefix(CLI_PREFIX) {
+            Some(rest) => Ok(Self::Cli(rest.parse()?)),
+            None => Ok(Self::Automated(value.parse()?)),
+        }
+    }
+}
+
+impl Serialize for ClientOrderId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for ClientOrderId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        raw.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientOrderIdError {
+    #[error("client_order_id is not a valid UUID")]
+    InvalidUuid(#[from] uuid::Error),
+}
 
 #[derive(Debug)]
 pub struct OrderPlacement<OrderId> {
@@ -50,4 +126,68 @@ pub struct MarketOrder {
     pub symbol: Symbol,
     pub shares: Positive<FractionalShares>,
     pub direction: Direction,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use uuid::{Uuid, uuid};
+
+    use super::*;
+
+    const ID: Uuid = uuid!("11111111-1111-4111-8111-111111111111");
+    const BARE: &str = "11111111-1111-4111-8111-111111111111";
+    const PREFIXED: &str = "cli-11111111-1111-4111-8111-111111111111";
+
+    #[test]
+    fn automated_renders_as_bare_uuid() {
+        assert_eq!(ClientOrderId::from_uuid(ID).to_string(), BARE);
+    }
+
+    #[test]
+    fn cli_renders_with_prefix() {
+        assert_eq!(ClientOrderId::cli(ID).to_string(), PREFIXED);
+    }
+
+    #[test]
+    fn parses_bare_uuid_as_automated() {
+        let parsed: ClientOrderId = BARE.parse().unwrap();
+        assert_eq!(parsed, ClientOrderId::Automated(ID));
+    }
+
+    #[test]
+    fn parses_cli_prefixed_uuid_as_cli() {
+        let parsed: ClientOrderId = PREFIXED.parse().unwrap();
+        assert_eq!(parsed, ClientOrderId::Cli(ID));
+    }
+
+    #[test]
+    fn rejects_non_uuid() {
+        let error = "not-a-uuid".parse::<ClientOrderId>().unwrap_err();
+        assert!(
+            matches!(error, ClientOrderIdError::InvalidUuid(_)),
+            "expected InvalidUuid, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn serializes_to_derived_string() {
+        assert_eq!(
+            serde_json::to_value(ClientOrderId::from_uuid(ID)).unwrap(),
+            json!(BARE)
+        );
+        assert_eq!(
+            serde_json::to_value(ClientOrderId::cli(ID)).unwrap(),
+            json!(PREFIXED)
+        );
+    }
+
+    #[test]
+    fn deserializes_from_string_form() {
+        let automated: ClientOrderId = serde_json::from_value(json!(BARE)).unwrap();
+        assert_eq!(automated, ClientOrderId::Automated(ID));
+
+        let cli: ClientOrderId = serde_json::from_value(json!(PREFIXED)).unwrap();
+        assert_eq!(cli, ClientOrderId::Cli(ID));
+    }
 }

--- a/src/alpaca_wallet/mod.rs
+++ b/src/alpaca_wallet/mod.rs
@@ -232,7 +232,7 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
     use std::time::Duration;
-    use uuid::uuid;
+    use uuid::{Uuid, uuid};
 
     use st0x_execution::AlpacaAccountId;
 
@@ -393,7 +393,7 @@ mod tests {
 
         let service = AlpacaWalletService::new_with_client(client, Some(polling_config));
 
-        let transfer_id = uuid::Uuid::new_v4();
+        let transfer_id = Uuid::new_v4();
 
         let status_mock = server.mock(|when, then| {
             when.method(GET)

--- a/src/alpaca_wallet/whitelist.rs
+++ b/src/alpaca_wallet/whitelist.rs
@@ -60,7 +60,7 @@ mod tests {
     use alloy::primitives::address;
     use httpmock::prelude::*;
     use serde_json::json;
-    use uuid::uuid;
+    use uuid::{Uuid, uuid};
 
     use st0x_execution::AlpacaAccountId;
 
@@ -352,8 +352,7 @@ mod tests {
         let api_key = std::env::var("ALPACA_BROKER_API_KEY").ok()?;
         let api_secret = std::env::var("ALPACA_BROKER_API_SECRET").ok()?;
         let account_id_str = std::env::var("ALPACA_BROKER_ACCOUNT_ID").ok()?;
-        let account_id =
-            AlpacaAccountId::new(account_id_str.parse::<uuid::Uuid>().expect("valid UUID"));
+        let account_id = AlpacaAccountId::new(account_id_str.parse::<Uuid>().expect("valid UUID"));
 
         Some(AlpacaWalletClient::new(
             "https://broker-api.sandbox.alpaca.markets".to_string(),

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -5,6 +5,7 @@ use alloy::providers::Provider;
 use sqlx::SqlitePool;
 use std::io::{self, Write};
 use std::sync::Arc;
+use uuid::Uuid;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
 use st0x_event_sorcery::StoreBuilder;
@@ -352,7 +353,7 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
 
     writeln!(stdout, "   Sending mint request to Alpaca...")?;
 
-    let issuer_request_id = IssuerRequestId::new(uuid::Uuid::new_v4().to_string());
+    let issuer_request_id = IssuerRequestId::new(Uuid::new_v4().to_string());
     let request = tokenization_service
         .request_mint(
             symbol.clone(),

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -642,6 +642,7 @@ mod tests {
     use httpmock::MockServer;
     use serde_json::json;
     use url::Url;
+    use uuid::uuid;
 
     use st0x_config::{
         AssetsConfig, BrokerCtx, EquitiesConfig, EvmCtx, ExecutionThreshold, LogLevel, TradingMode,
@@ -652,7 +653,7 @@ mod tests {
     use crate::test_utils::{positive_shares, setup_test_db};
 
     const TEST_ACCOUNT_ID: AlpacaAccountId =
-        AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
 
     fn create_base_test_ctx() -> Ctx {
         Ctx {

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -351,7 +351,7 @@ mod tests {
         EquityRedemptionStatus, EquityRedemptionTag, TransferOperation, TransferWarning,
         UsdcBridgeDirection, UsdcBridgeOperation, UsdcBridgeStatus, UsdcBridgeTag,
     };
-    use st0x_execution::{FractionalShares, Symbol};
+    use st0x_execution::{ClientOrderId, FractionalShares, Symbol};
     use st0x_finance::{Id, Usdc};
     use st0x_float_macro::float;
 
@@ -574,7 +574,7 @@ mod tests {
             serde_json::to_value(UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(500)),
-                order_id: usdc_id,
+                order_id: ClientOrderId::from_uuid(usdc_id),
                 initiated_at: one_hour_ago,
             })
             .unwrap(),

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -320,16 +320,20 @@ impl<E: Evm> RaindexService<E> {
         Ok(Usdc::new(exact))
     }
 
-    /// Scans for a `WithdrawV2` event from this owner's vault at or after
+    /// Scans for a `WithdrawV2` event from this owner's vault strictly after
     /// `from_block`, returning the most recent match's `(tx_hash, withdrawn_amount)`.
     ///
     /// Crash-safe withdrawal recovery: a transfer records the chain head before
     /// the on-chain withdraw, so on resume this detects an already-submitted
     /// withdrawal and the caller adopts it instead of re-issuing (which would
-    /// double-spend the vault). Matches on `(sender == self.owner, token, vaultId)`
-    /// -- never on amount, so a partial fill is still detected -- and returns the
-    /// actual on-chain `withdrawAmountUint256` so the caller can reconcile a
-    /// partial withdrawal rather than laundering it into a full-amount burn.
+    /// double-spend the vault). The head is captured before submitting, so this
+    /// transfer's withdraw lands strictly after `from_block`; the scan excludes the
+    /// `from_block` block itself so an earlier withdrawal from the same vault (which
+    /// matches on the same `(sender, token, vaultId)`) is never adopted. Matches on
+    /// `(sender == self.owner, token, vaultId)` -- never on amount, so a partial
+    /// fill is still detected -- and returns the actual on-chain
+    /// `withdrawAmountUint256` so the caller can reconcile a partial withdrawal
+    /// rather than laundering it into a full-amount burn.
     ///
     /// Returns `Ok(None)` ONLY when the queried node is confirmations-deep past
     /// `from_block` and repeated scans agree the effect is absent. A node that may
@@ -361,6 +365,7 @@ impl<E: Evm> RaindexService<E> {
                 if event.sender == self.owner
                     && event.token == token
                     && event.vaultId == vault_id
+                    && log.block_number.is_some_and(|block| block > from_block)
                     && let Some(tx_hash) = log.transaction_hash
                 {
                     debug!(target: "orderbook", %tx_hash, from_block, "Found existing withdrawal during resume");

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1284,7 +1284,7 @@ impl RebalancingService {
                         }
                     }
 
-                    let recovery_id = WrappedEquityRecoveryId(uuid::Uuid::new_v4());
+                    let recovery_id = WrappedEquityRecoveryId(Uuid::new_v4());
                     if let Err(error) = queue
                         .push(WrappedEquityRecoveryJob {
                             symbol: symbol.clone(),
@@ -2978,7 +2978,9 @@ mod tests {
     use st0x_event_sorcery::{
         EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
     };
-    use st0x_execution::{Direction, ExecutorOrderId, HasZero, Positive, SupportedExecutor};
+    use st0x_execution::{
+        ClientOrderId, Direction, ExecutorOrderId, HasZero, Positive, SupportedExecutor,
+    };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
 
@@ -7424,7 +7426,7 @@ mod tests {
         UsdcRebalanceEvent::ConversionInitiated {
             direction,
             amount,
-            order_id: Uuid::new_v4(),
+            order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             initiated_at: Utc::now(),
         }
     }
@@ -7453,6 +7455,7 @@ mod tests {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![1, 2, 3, 4],
             cctp_nonce: 42,
+            mint_scan_from_block: Some(100),
             attested_at: Utc::now(),
         }
     }
@@ -7861,7 +7864,7 @@ mod tests {
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::BaseToAlpaca,
                     amount: usdc(400),
-                    order_id: Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                     initiated_at: refreshed_at,
                 },
             )
@@ -7918,7 +7921,7 @@ mod tests {
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::AlpacaToBase,
                     amount: usdc(400),
-                    order_id: Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                     initiated_at,
                 },
             )
@@ -8286,6 +8289,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: 100,
                 },
             )
             .await
@@ -8337,7 +8341,7 @@ mod tests {
         let store = TestStore::<UsdcRebalance>::with_reactor(Arc::clone(&spy));
 
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let transfer_id = AlpacaTransferId::from(uuid::Uuid::new_v4());
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let tx_hash =
             fixed_bytes!("0x2222222222222222222222222222222222222222222222222222222222222222");
 
@@ -8372,6 +8376,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: 67890,
+                    mint_scan_from_block: 100,
                 },
             )
             .await
@@ -8421,7 +8426,7 @@ mod tests {
         let store = TestStore::<UsdcRebalance>::with_reactor(Arc::clone(&spy));
 
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let transfer_id = AlpacaTransferId::from(uuid::Uuid::new_v4());
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
 
         store
             .send(
@@ -8462,7 +8467,7 @@ mod tests {
         let store = TestStore::<UsdcRebalance>::with_reactor(Arc::clone(&spy));
 
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let transfer_id = crate::alpaca_wallet::AlpacaTransferId::from(uuid::Uuid::new_v4());
+        let transfer_id = crate::alpaca_wallet::AlpacaTransferId::from(Uuid::new_v4());
         let tx_hash =
             fixed_bytes!("0x3333333333333333333333333333333333333333333333333333333333333333");
 
@@ -8525,7 +8530,7 @@ mod tests {
                 UsdcRebalanceCommand::InitiateConversion {
                     direction: RebalanceDirection::AlpacaToBase,
                     amount: Usdc::new(float!(100)),
-                    order_id: uuid::Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 },
             )
             .await
@@ -8669,6 +8674,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: 99999,
+                    mint_scan_from_block: 100,
                 },
             )
             .await
@@ -8708,7 +8714,7 @@ mod tests {
             .send(
                 &id,
                 UsdcRebalanceCommand::InitiatePostDepositConversion {
-                    order_id: uuid::Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                     amount: Usdc::new(float!(99.99)),
                 },
             )
@@ -10642,7 +10648,7 @@ mod tests {
                 UsdcRebalanceEvent::ConversionInitiated {
                     direction: RebalanceDirection::BaseToAlpaca,
                     amount: usdc(700),
-                    order_id: Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                     initiated_at: now,
                 },
             )
@@ -10729,7 +10735,7 @@ mod tests {
                     UsdcRebalanceEvent::ConversionInitiated {
                         direction: RebalanceDirection::BaseToAlpaca,
                         amount: usdc(700),
-                        order_id: Uuid::new_v4(),
+                        order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                         initiated_at: Utc::now(),
                     },
                 )

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -967,6 +967,7 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_dto::Statement;
+    use st0x_execution::ClientOrderId;
     use st0x_float_macro::float;
 
     use super::*;
@@ -1518,7 +1519,7 @@ mod tests {
         UsdcRebalanceEvent::ConversionInitiated {
             direction,
             amount,
-            order_id: Uuid::nil(),
+            order_id: ClientOrderId::from_uuid(Uuid::nil()),
             initiated_at: ts(101),
         }
     }
@@ -1551,6 +1552,7 @@ mod tests {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![],
             cctp_nonce: 0,
+            mint_scan_from_block: Some(100),
             attested_at: ts(105),
         }
     }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -15,7 +15,7 @@ use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
-use st0x_execution::{AlpacaBrokerApi, ConversionDirection, Positive};
+use st0x_execution::{AlpacaBrokerApi, ClientOrderId, ConversionDirection, Positive};
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
@@ -90,7 +90,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         amount: Usdc,
     ) -> Result<Usdc, UsdcTransferError> {
-        let correlation_id = Uuid::new_v4();
+        let correlation_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         info!(target: "rebalance", %amount, %correlation_id, "Starting USD to USDC conversion");
 
@@ -101,7 +101,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 UsdcRebalanceCommand::InitiateConversion {
                     direction: RebalanceDirection::AlpacaToBase,
                     amount,
-                    order_id: correlation_id,
+                    order_id: correlation_id.clone(),
                 },
             )
             .await?;
@@ -128,9 +128,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
-        let filled_qty = order
-            .filled_quantity
-            .ok_or_else(|| UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
+        let filled_qty =
+            order
+                .filled_quantity
+                .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
+                    order_id: correlation_id.clone(),
+                })?;
         let filled_amount = Usdc::new(filled_qty);
 
         self.cqrs
@@ -175,7 +178,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         id: &UsdcRebalanceId,
         amount: Usdc,
     ) -> Result<Usdc, UsdcTransferError> {
-        let correlation_id = Uuid::new_v4();
+        let correlation_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         info!(target: "rebalance", %amount, %correlation_id, "Starting USDC to USD conversion");
 
@@ -184,7 +187,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             .send(
                 id,
                 UsdcRebalanceCommand::InitiatePostDepositConversion {
-                    order_id: correlation_id,
+                    order_id: correlation_id.clone(),
                     amount,
                 },
             )
@@ -212,9 +215,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
-        let filled_amount = order
-            .filled_quantity
-            .ok_or_else(|| UsdcTransferError::MissingFilledQuantity { order_id: order.id })?;
+        let filled_amount =
+            order
+                .filled_quantity
+                .ok_or_else(|| UsdcTransferError::MissingFilledQuantity {
+                    order_id: correlation_id.clone(),
+                })?;
         let filled_usdc = Usdc::new(filled_amount);
 
         self.cqrs
@@ -446,12 +452,28 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }
         };
 
+        // Capture the destination (Base) head before minting so a crash before
+        // `ConfirmBridging` resumes by scanning for the already-submitted mint
+        // instead of re-minting, which reverts on the already-used CCTP nonce.
+        // AlpacaToBase has no resume entry point (`resume_base_to_alpaca` rejects
+        // it), so this bound is never read on resume: on a transient head-lookup
+        // error, continue with a sentinel rather than failing a healthy transfer.
+        let mint_scan_from_block = self
+            .cctp_bridge
+            .destination_block(BridgeDirection::EthereumToBase)
+            .await
+            .unwrap_or_else(|error| {
+                warn!(target: "rebalance", "Destination head lookup failed, using sentinel (AlpacaToBase has no resume): {error}");
+                0
+            });
+
         self.cqrs
             .send(
                 id,
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: response.as_bytes().to_vec(),
                     cctp_nonce: response.nonce(),
+                    mint_scan_from_block,
                 },
             )
             .await?;
@@ -699,10 +721,18 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 direction,
                 amount,
                 burn_tx_hash,
+                mint_scan_from_block,
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, &direction)?;
-                self.continue_from_attested(id, amount, burn_tx_hash).await
+                self.continue_from_attested(
+                    id,
+                    direction,
+                    amount,
+                    burn_tx_hash,
+                    mint_scan_from_block,
+                )
+                .await
             }
 
             Some(UsdcRebalance::Bridged {
@@ -822,12 +852,23 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         };
         let attestation_response = self.poll_circle_attestation(id, &burn_receipt).await?;
 
+        // Capture the destination (Ethereum) head before minting so a crash
+        // before `ConfirmBridging` resumes by scanning for the already-submitted
+        // mint (`continue_from_attested`) instead of re-minting, which reverts on
+        // the already-used CCTP nonce.
+        let mint_scan_from_block = self
+            .cctp_bridge
+            .destination_block(BridgeDirection::BaseToEthereum)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
         self.cqrs
             .send(
                 id,
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: attestation_response.as_bytes().to_vec(),
                     cctp_nonce: attestation_response.nonce(),
+                    mint_scan_from_block,
                 },
             )
             .await?;
@@ -836,18 +877,71 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         self.mint_and_continue(id, attestation_response).await
     }
 
-    /// Drives the transfer from `Attested` through to terminal. The attestation
-    /// is already recorded, so this re-polls Circle for a fresh
-    /// [`AttestationResponse`] (the aggregate stores the attestation bytes and
-    /// nonce but not the full message envelope [`Bridge::mint`] needs) WITHOUT
-    /// re-emitting `ReceiveAttestation` -- which the aggregate rejects from
-    /// `Attested`, fail-stopping every retry with the USDC already burned.
+    /// Drives the transfer from `Attested` through to terminal.
+    ///
+    /// The mint may already have been submitted before a crash, so this first
+    /// scans the destination chain (bounded by `mint_scan_from_block`) for an
+    /// already-submitted mint to the market maker wallet and adopts it via
+    /// `ConfirmBridging` -- re-minting would revert on the already-used CCTP
+    /// nonce and fail a transfer whose USDC was in fact minted. When no mint is
+    /// found, it re-polls Circle for a fresh [`AttestationResponse`] (the
+    /// aggregate stores the attestation bytes and nonce but not the full message
+    /// envelope [`Bridge::mint`] needs) and mints, WITHOUT re-emitting
+    /// `ReceiveAttestation` -- which the aggregate rejects from `Attested`.
     async fn continue_from_attested(
         &self,
         id: &UsdcRebalanceId,
+        direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: TxHash,
+        mint_scan_from_block: Option<u64>,
     ) -> Result<(), UsdcTransferError> {
+        // Events persisted before crash-safe resume carry no scan bound. Scanning
+        // from genesis could adopt an unrelated mint to the same wallet, so refuse
+        // to auto-resume and surface for manual reconciliation instead.
+        let Some(mint_scan_from_block) = mint_scan_from_block else {
+            warn!(target: "rebalance", %id, "Cannot resume Attested transfer: no mint scan bound captured");
+            return Err(UsdcTransferError::ResumeWithoutMintScanBound { id: id.clone() });
+        };
+
+        // The mint lands on the destination chain of `direction`; scanning the
+        // wrong chain would miss the already-submitted mint and fall through to a
+        // double-mint that reverts on the used CCTP nonce.
+        let mint_direction = match direction {
+            RebalanceDirection::BaseToAlpaca => BridgeDirection::BaseToEthereum,
+            RebalanceDirection::AlpacaToBase => BridgeDirection::EthereumToBase,
+        };
+
+        if let Some(mint_receipt) = self
+            .cctp_bridge
+            .find_recent_mint(
+                mint_direction,
+                self.market_maker_wallet,
+                mint_scan_from_block,
+            )
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
+        {
+            let amount_received = u256_to_usdc(mint_receipt.amount)?;
+
+            info!(target: "rebalance", mint_tx = %mint_receipt.tx, %amount_received, "Adopting already-submitted CCTP mint on resume");
+
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::ConfirmBridging {
+                        mint_tx: mint_receipt.tx,
+                        amount_received,
+                        fee_collected: u256_to_usdc(mint_receipt.fee)?,
+                    },
+                )
+                .await?;
+
+            return self
+                .continue_from_bridged(id, amount_received, mint_receipt.tx)
+                .await;
+        }
+
         let burn_receipt = BurnReceipt {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
@@ -1298,9 +1392,11 @@ impl<Chain: Wallet> CrossVenueTransfer<MarketMakingVenue, HedgingVenue>
 
 #[cfg(test)]
 mod tests {
-    use alloy::node_bindings::Anvil;
+    use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::{B256, address, b256, fixed_bytes};
     use alloy::providers::ProviderBuilder;
+    use alloy::providers::ext::AnvilApi as _;
+    use alloy::signers::local::PrivateKeySigner;
     use httpmock::prelude::*;
     use reqwest::StatusCode;
     use serde_json::json;
@@ -1315,7 +1411,11 @@ mod tests {
         TimeInForce,
     };
 
-    use st0x_bridge::cctp::{CctpBridge, CctpCtx};
+    use st0x_bridge::Bridge;
+    use st0x_bridge::cctp::{
+        CctpAttestationMock, CctpBridge, CctpCtx, TestMintBurnToken, deploy_cctp_on_chain,
+        link_chains, mint_usdc, set_max_burn_amount,
+    };
     use st0x_event_sorcery::{AggregateError, LifecycleError, StoreBuilder, test_store};
     use st0x_evm::Wallet;
     use st0x_evm::local::RawPrivateKeyWallet;
@@ -1382,6 +1482,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: 99999,
+                mint_scan_from_block: 100,
             },
         )
         .await
@@ -2265,6 +2366,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             },
         )
         .await
@@ -2378,7 +2480,7 @@ mod tests {
                 UsdcRebalanceCommand::InitiateConversion {
                     direction: RebalanceDirection::AlpacaToBase,
                     amount,
-                    order_id: Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 },
             )
             .await;
@@ -2618,7 +2720,7 @@ mod tests {
             UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount,
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             },
         )
         .await
@@ -2718,7 +2820,7 @@ mod tests {
                 UsdcRebalanceCommand::InitiateConversion {
                     direction: RebalanceDirection::AlpacaToBase,
                     amount,
-                    order_id: Uuid::new_v4(),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 },
             )
             .await;
@@ -2907,6 +3009,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: 99_999,
+                mint_scan_from_block: 100,
             },
         )
         .await
@@ -2998,7 +3101,7 @@ mod tests {
         cqrs.send(
             &id,
             UsdcRebalanceCommand::InitiatePostDepositConversion {
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 amount: amount_received,
             },
         )
@@ -3149,7 +3252,7 @@ mod tests {
             UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount,
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             },
         )
         .await
@@ -3178,6 +3281,309 @@ mod tests {
                 }
             ),
             "Expected ResumeDirectionMismatch for AlpacaToBase resume, got: {error:?}"
+        );
+    }
+
+    struct DualChainCctp {
+        _base_anvil: AnvilInstance,
+        _ethereum_anvil: AnvilInstance,
+        base_endpoint: String,
+        ethereum_endpoint: String,
+        token_messenger: Address,
+        message_transmitter: Address,
+        bot_key: B256,
+        bot_address: Address,
+        attester_key: B256,
+    }
+
+    /// Deploys CCTP V2 on two fresh Anvil chains (Base + Ethereum), points the
+    /// canonical USDC address at a mint/burn token on both, links them, and
+    /// funds the bot wallet with USDC to burn. Deterministic deploys give
+    /// identical contract addresses on both chains, so one token messenger /
+    /// message transmitter pair drives the bridge.
+    async fn deploy_dual_chain_cctp() -> DualChainCctp {
+        let base_anvil = Anvil::new().spawn();
+        let ethereum_anvil = Anvil::new().chain_id(1u64).spawn();
+        let base_endpoint = base_anvil.endpoint();
+        let ethereum_endpoint = ethereum_anvil.endpoint();
+
+        // Account 0 is the bot wallet (burns/mints); account 1 is the CCTP
+        // deployer, kept distinct to avoid nonce collisions on Base's instant
+        // mining.
+        let bot_key = B256::from_slice(&base_anvil.keys()[0].to_bytes());
+        let deployer_key = B256::from_slice(&base_anvil.keys()[1].to_bytes());
+        let bot_address = PrivateKeySigner::from_bytes(&bot_key).unwrap().address();
+
+        let attester_key = B256::random();
+        let attester_address = PrivateKeySigner::from_bytes(&attester_key)
+            .unwrap()
+            .address();
+
+        // Fund the deployer on Base (Ethereum Anvil pre-funds its own accounts).
+        let base_provider = ProviderBuilder::new()
+            .connect(&base_endpoint)
+            .await
+            .unwrap();
+        let ethereum_provider = ProviderBuilder::new()
+            .connect(&ethereum_endpoint)
+            .await
+            .unwrap();
+        let deployer_address = PrivateKeySigner::from_bytes(&deployer_key)
+            .unwrap()
+            .address();
+        base_provider
+            .anvil_set_balance(deployer_address, U256::from(10).pow(U256::from(20)))
+            .await
+            .unwrap();
+
+        let mut ethereum_cctp =
+            deploy_cctp_on_chain(&ethereum_endpoint, &deployer_key, 0, attester_address)
+                .await
+                .unwrap();
+        let mut base_cctp =
+            deploy_cctp_on_chain(&base_endpoint, &deployer_key, 6, attester_address)
+                .await
+                .unwrap();
+
+        // The bridge uses USDC at the canonical address; place the mint/burn
+        // token bytecode there on both chains so CCTP can mint/burn it.
+        ethereum_provider
+            .anvil_set_code(USDC_ADDRESS, TestMintBurnToken::DEPLOYED_BYTECODE.clone())
+            .await
+            .unwrap();
+        base_provider
+            .anvil_set_code(USDC_ADDRESS, TestMintBurnToken::DEPLOYED_BYTECODE.clone())
+            .await
+            .unwrap();
+        set_max_burn_amount(
+            &ethereum_endpoint,
+            &deployer_key,
+            ethereum_cctp.token_minter,
+            USDC_ADDRESS,
+            U256::from(1_000_000_000_000u64),
+        )
+        .await
+        .unwrap();
+        set_max_burn_amount(
+            &base_endpoint,
+            &deployer_key,
+            base_cctp.token_minter,
+            USDC_ADDRESS,
+            U256::from(1_000_000_000_000u64),
+        )
+        .await
+        .unwrap();
+        ethereum_cctp.usdc = USDC_ADDRESS;
+        base_cctp.usdc = USDC_ADDRESS;
+
+        link_chains(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &deployer_key,
+            &ethereum_cctp,
+            &base_cctp,
+        )
+        .await
+        .unwrap();
+
+        // Fund the bot's Base wallet so it can burn.
+        mint_usdc(
+            &base_endpoint,
+            &deployer_key,
+            USDC_ADDRESS,
+            bot_address,
+            U256::from(1_000_000_000_000u64),
+        )
+        .await
+        .unwrap();
+
+        DualChainCctp {
+            token_messenger: base_cctp.token_messenger,
+            message_transmitter: base_cctp.message_transmitter,
+            base_endpoint,
+            ethereum_endpoint,
+            bot_key,
+            bot_address,
+            attester_key,
+            _base_anvil: base_anvil,
+            _ethereum_anvil: ethereum_anvil,
+        }
+    }
+
+    /// Resume from `Attested` after the CCTP mint already landed on-chain must
+    /// ADOPT that mint (scan + `ConfirmBridging`) rather than re-calling
+    /// `receiveMessage`, which reverts on the already-used nonce and would latch
+    /// a terminal `BridgingFailed` for a transfer whose USDC was in fact minted.
+    ///
+    /// Deterministically reproduces the post-mint crash window (mint on-chain,
+    /// aggregate still `Attested`, `ConfirmBridging` not yet persisted) by
+    /// producing a real mint over dual-chain CCTP, then driving the aggregate to
+    /// `Attested` and resuming. Reaching `ConversionComplete` proves adoption: a
+    /// re-mint would revert on the used nonce and never get past the bridge.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_attested_adopts_existing_mint() {
+        let chains = deploy_dual_chain_cctp().await;
+
+        let attestation = CctpAttestationMock::start().await;
+        let _watcher = attestation
+            .start_watcher(
+                ProviderBuilder::new()
+                    .connect(&chains.ethereum_endpoint)
+                    .await
+                    .unwrap(),
+                ProviderBuilder::new()
+                    .connect(&chains.base_endpoint)
+                    .await
+                    .unwrap(),
+                chains.attester_key,
+            )
+            .await
+            .unwrap();
+
+        let cctp_bridge = Arc::new(
+            CctpBridge::try_from_ctx(CctpCtx {
+                usdc_ethereum: USDC_ADDRESS,
+                usdc_base: USDC_ADDRESS,
+                ethereum_wallet: create_test_wallet(&chains.ethereum_endpoint, &chains.bot_key),
+                base_wallet: create_test_wallet(&chains.base_endpoint, &chains.bot_key),
+                circle_api_base: attestation.base_url(),
+                token_messenger: chains.token_messenger,
+                message_transmitter: chains.message_transmitter,
+            })
+            .unwrap(),
+        );
+
+        // Produce a real on-chain mint to the market maker wallet.
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let amount = usdc("100");
+        let amount_u256 = usdc_to_u256(amount).unwrap();
+        let burn_receipt = cctp_bridge
+            .burn(
+                BridgeDirection::BaseToEthereum,
+                amount_u256,
+                market_maker_wallet,
+            )
+            .await
+            .unwrap();
+        let attestation_response = cctp_bridge
+            .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .await
+            .unwrap();
+        // Capture the scan bound where production does -- after attestation,
+        // immediately before minting -- so the adopt window matches the real
+        // flow and a mint that landed earlier would fall outside it.
+        let mint_scan_from_block = cctp_bridge
+            .destination_block(BridgeDirection::BaseToEthereum)
+            .await
+            .unwrap();
+        let mint_receipt = cctp_bridge
+            .mint(BridgeDirection::BaseToEthereum, &attestation_response)
+            .await
+            .unwrap();
+
+        // Build the manager on the same bridge with Alpaca mocked.
+        let server = MockServer::start();
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let pool = crate::test_utils::setup_test_db().await;
+        let (_vault_registry_store, vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool)
+                .build(())
+                .await
+                .unwrap();
+        let vault_service = RaindexService::new(
+            create_test_wallet(&chains.base_endpoint, &chains.bot_key),
+            ORDERBOOK_ADDRESS,
+            vault_registry_projection,
+            chains.bot_address,
+        );
+        let cqrs = create_test_store_instance().await;
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::clone(&cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+        );
+
+        // Drive the aggregate to `Attested`, recording the real burn tx and the
+        // captured scan bound. cctp_nonce is irrelevant to the adopt path.
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_receipt.tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateBridging {
+                burn_tx: burn_receipt.tx,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                attestation: attestation_response.as_bytes().to_vec(),
+                cctp_nonce: attestation_response.nonce(),
+                mint_scan_from_block,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Downstream Alpaca legs after adoption: deposit detection (by the mint
+        // tx) then the USDC->USD conversion.
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{:#x}", mint_receipt.tx),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "100");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "100",
+        );
+
+        // A re-mint here would revert on the already-used nonce and latch
+        // `BridgingFailed`; reaching `ConversionComplete` proves the mint was
+        // adopted from the chain scan instead.
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected ConversionComplete after adopting the existing mint on resume, \
+             got: {final_state:?}"
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -20,11 +20,12 @@ use thiserror::Error;
 
 use st0x_bridge::cctp::CctpError;
 use st0x_event_sorcery::SendError;
-use st0x_execution::{AlpacaBrokerApiError, InvalidSharesError, NotPositive};
+use st0x_execution::{AlpacaBrokerApiError, ClientOrderId, InvalidSharesError, NotPositive};
 use st0x_finance::Usdc;
 
 use crate::alpaca_wallet::AlpacaWalletError;
 use crate::onchain::raindex::RaindexError;
+use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
 use st0x_finance::UsdcConversionError;
 
 #[derive(Debug, Error)]
@@ -38,7 +39,7 @@ pub(crate) enum UsdcTransferError {
     #[error("Vault error: {0}")]
     Vault(#[from] RaindexError),
     #[error("Aggregate error: {0}")]
-    Aggregate(Box<SendError<crate::usdc_rebalance::UsdcRebalance>>),
+    Aggregate(Box<SendError<UsdcRebalance>>),
     #[error("Withdrawal failed with terminal status: {status}")]
     WithdrawalFailed { status: String },
     #[error("Deposit failed with terminal status: {status}")]
@@ -55,32 +56,32 @@ pub(crate) enum UsdcTransferError {
         "Conversion order {order_id} filled but \
          filled_quantity is missing"
     )]
-    MissingFilledQuantity { order_id: uuid::Uuid },
+    MissingFilledQuantity { order_id: ClientOrderId },
     #[error(
         "USDC rebalance {id} cannot resume from Converting state: \
          broker order ID lost after crash; manual reconciliation required"
     )]
-    ResumeIndeterminateConversion {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    ResumeIndeterminateConversion { id: UsdcRebalanceId },
+    #[error(
+        "USDC rebalance {id} cannot resume from Attested state: no mint scan \
+         bound was captured (pre-resume-hardening event); manual reconciliation \
+         required"
+    )]
+    ResumeWithoutMintScanBound { id: UsdcRebalanceId },
     #[error("USDC rebalance {id} cannot resume: aggregate is in terminal failure state")]
-    PreviouslyFailedAggregate {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    PreviouslyFailedAggregate { id: UsdcRebalanceId },
     #[error(
         "USDC rebalance {id} DepositInitiated has non-onchain deposit ref; \
          BaseToAlpaca always records the mint tx as OnchainTx"
     )]
-    DepositRefMustBeOnchain {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-    },
+    DepositRefMustBeOnchain { id: UsdcRebalanceId },
     #[error(
         "USDC rebalance {id} cannot resume via Base->Alpaca entrypoint: \
          aggregate direction is {direction:?}"
     )]
     ResumeDirectionMismatch {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
-        direction: crate::usdc_rebalance::RebalanceDirection,
+        id: UsdcRebalanceId,
+        direction: RebalanceDirection,
     },
     #[error(
         "USDC rebalance {id} adopted a withdrawal that realized {withdrawn} but \
@@ -88,14 +89,14 @@ pub(crate) enum UsdcTransferError {
          than burning more than was withdrawn"
     )]
     AdoptedWithdrawalAmountMismatch {
-        id: crate::usdc_rebalance::UsdcRebalanceId,
+        id: UsdcRebalanceId,
         withdrawn: alloy::primitives::U256,
         requested: alloy::primitives::U256,
     },
 }
 
-impl From<SendError<crate::usdc_rebalance::UsdcRebalance>> for UsdcTransferError {
-    fn from(error: SendError<crate::usdc_rebalance::UsdcRebalance>) -> Self {
+impl From<SendError<UsdcRebalance>> for UsdcTransferError {
+    fn from(error: SendError<UsdcRebalance>) -> Self {
         Self::Aggregate(Box::new(error))
     }
 }

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -75,6 +75,7 @@ use uuid::Uuid;
 
 use st0x_dto::{TransferOperation, UsdcBridgeOperation, UsdcBridgeStatus};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_execution::ClientOrderId;
 use st0x_finance::{Id, Usdc};
 
 use crate::alpaca_wallet::AlpacaTransferId;
@@ -182,7 +183,7 @@ pub(crate) enum UsdcRebalanceCommand {
     InitiateConversion {
         direction: RebalanceDirection,
         amount: Usdc,
-        order_id: Uuid,
+        order_id: ClientOrderId,
     },
     /// Confirm successful conversion. Valid only from `Converting` state.
     /// Contains filled_amount for accurate inventory tracking.
@@ -198,7 +199,10 @@ pub(crate) enum UsdcRebalanceCommand {
     /// Converts USDC (deposited via CCTP) to USD buying power for trading.
     /// Valid only from `DepositConfirmed` state.
     /// Amount must match the aggregate's deposit amount for consistency.
-    InitiatePostDepositConversion { order_id: Uuid, amount: Usdc },
+    InitiatePostDepositConversion {
+        order_id: ClientOrderId,
+        amount: Usdc,
+    },
     /// Record the intent to withdraw from source BEFORE the on-chain call.
     /// Captures the chain head (`from_block`) so a crash mid-withdrawal can be
     /// recovered by scanning from that block instead of blindly re-withdrawing
@@ -226,9 +230,12 @@ pub(crate) enum UsdcRebalanceCommand {
     InitiateBridging { burn_tx: TxHash },
     /// Record the Circle attestation. Valid only from `Bridging` state.
     /// The cctp_nonce is extracted from the attested message (not the burn tx, which has placeholder).
+    /// `mint_scan_from_block` is the destination chain head captured before the mint,
+    /// bounding the crash-safe resume scan that adopts an already-submitted mint.
     ReceiveAttestation {
         attestation: Vec<u8>,
         cctp_nonce: u64,
+        mint_scan_from_block: u64,
     },
     /// Confirm the CCTP mint transaction. Valid only from `Attested` state.
     /// Includes actual amounts from the MintAndWithdraw event for accurate inventory tracking.
@@ -261,7 +268,7 @@ pub(crate) enum UsdcRebalanceEvent {
     ConversionInitiated {
         direction: RebalanceDirection,
         amount: Usdc,
-        order_id: Uuid,
+        order_id: ClientOrderId,
         initiated_at: DateTime<Utc>,
     },
     /// Conversion completed successfully.
@@ -316,9 +323,16 @@ pub(crate) enum UsdcRebalanceEvent {
     },
     /// Circle attestation received. Enables minting on destination chain.
     /// The cctp_nonce is extracted from the attested message (the real nonce, not the placeholder).
+    /// `mint_scan_from_block` is the destination chain head captured before the mint,
+    /// persisted so a crash-safe resume scan for an already-submitted mint is bounded.
+    /// It is `None` for events persisted before this field existed: such a resume
+    /// has no bound and must reconcile manually rather than scan from genesis,
+    /// which could adopt an unrelated mint to the same wallet.
     BridgeAttestationReceived {
         attestation: Vec<u8>,
         cctp_nonce: u64,
+        #[serde(default)]
+        mint_scan_from_block: Option<u64>,
         attested_at: DateTime<Utc>,
     },
     /// CCTP mint transaction confirmed on destination chain.
@@ -396,7 +410,7 @@ pub(crate) enum UsdcRebalance {
     Converting {
         direction: RebalanceDirection,
         amount: Usdc,
-        order_id: Uuid,
+        order_id: ClientOrderId,
         initiated_at: DateTime<Utc>,
     },
     /// Conversion has completed, ready for next phase
@@ -413,7 +427,7 @@ pub(crate) enum UsdcRebalance {
     ConversionFailed {
         direction: RebalanceDirection,
         amount: Usdc,
-        order_id: Uuid,
+        order_id: ClientOrderId,
         reason: String,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
@@ -475,6 +489,10 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: TxHash,
         cctp_nonce: u64,
         attestation: Vec<u8>,
+        /// Destination chain head captured before the mint, bounding the
+        /// crash-safe resume scan that adopts an already-submitted mint. `None`
+        /// for transfers whose `BridgeAttestationReceived` predates this field.
+        mint_scan_from_block: Option<u64>,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
     },
@@ -778,7 +796,7 @@ impl EventSourced for UsdcRebalance {
             } => Some(Self::Converting {
                 direction: direction.clone(),
                 amount: *amount,
-                order_id: *order_id,
+                order_id: order_id.clone(),
                 initiated_at: *initiated_at,
             }),
 
@@ -829,7 +847,7 @@ impl EventSourced for UsdcRebalance {
             ) => Self::Converting {
                 direction: direction.clone(),
                 amount: *amount,
-                order_id: *order_id,
+                order_id: order_id.clone(),
                 initiated_at: *initiated_at,
             },
 
@@ -864,7 +882,7 @@ impl EventSourced for UsdcRebalance {
             ) => Self::ConversionFailed {
                 direction: direction.clone(),
                 amount: *amount,
-                order_id: *order_id,
+                order_id: order_id.clone(),
                 reason: reason.clone(),
                 initiated_at: *initiated_at,
                 failed_at: *failed_at,
@@ -991,6 +1009,7 @@ impl EventSourced for UsdcRebalance {
                 BridgeAttestationReceived {
                     attestation,
                     cctp_nonce,
+                    mint_scan_from_block,
                     attested_at,
                 },
                 Self::Bridging {
@@ -1006,6 +1025,7 @@ impl EventSourced for UsdcRebalance {
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
                 attestation: attestation.clone(),
+                mint_scan_from_block: *mint_scan_from_block,
                 initiated_at: *initiated_at,
                 attested_at: *attested_at,
             },
@@ -1267,7 +1287,8 @@ impl EventSourced for UsdcRebalance {
             ReceiveAttestation {
                 attestation,
                 cctp_nonce,
-            } => self.transition_receive_attestation(attestation, cctp_nonce),
+                mint_scan_from_block,
+            } => self.transition_receive_attestation(attestation, cctp_nonce, mint_scan_from_block),
             ConfirmBridging {
                 mint_tx,
                 amount_received,
@@ -1323,7 +1344,7 @@ impl UsdcRebalance {
 
     fn transition_post_deposit_conversion(
         &self,
-        order_id: Uuid,
+        order_id: ClientOrderId,
         command_amount: Usdc,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
@@ -1558,6 +1579,7 @@ impl UsdcRebalance {
         &self,
         attestation: Vec<u8>,
         cctp_nonce: u64,
+        mint_scan_from_block: u64,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
@@ -1572,6 +1594,7 @@ impl UsdcRebalance {
             Self::Bridging { .. } => Ok(vec![BridgeAttestationReceived {
                 attestation,
                 cctp_nonce,
+                mint_scan_from_block: Some(mint_scan_from_block),
                 attested_at: Utc::now(),
             }]),
             Self::Attested { .. } => Err(UsdcRebalanceError::InvalidCommand {
@@ -1759,12 +1782,40 @@ impl UsdcRebalance {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::fixed_bytes;
+    use serde_json::{from_value, json};
     use uuid::Uuid;
 
     use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
 
     use super::*;
     use st0x_float_macro::float;
+
+    // An event persisted before `mint_scan_from_block` existed must still
+    // deserialize on replay -- to `None`, not a hard error -- so older aggregates
+    // can be rebuilt after this field was added (the `#[serde(default)]`).
+    #[test]
+    fn bridge_attestation_received_without_mint_scan_from_block_deserializes_to_none() {
+        let old_event = json!({
+            "BridgeAttestationReceived": {
+                "attestation": [1, 2, 3],
+                "cctp_nonce": 42,
+                "attested_at": "2026-01-01T00:00:00Z"
+            }
+        });
+
+        let event: UsdcRebalanceEvent =
+            from_value(old_event).expect("pre-field event must still deserialize");
+
+        let UsdcRebalanceEvent::BridgeAttestationReceived {
+            mint_scan_from_block,
+            ..
+        } = event
+        else {
+            panic!("expected BridgeAttestationReceived");
+        };
+
+        assert_eq!(mint_scan_from_block, None);
+    }
 
     #[tokio::test]
     async fn test_initiate_alpaca_to_base() {
@@ -2409,6 +2460,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: attestation.clone(),
                 cctp_nonce: 12345,
+                mint_scan_from_block: 8_675_309,
             })
             .await
             .events();
@@ -2416,6 +2468,7 @@ mod tests {
         assert_eq!(events.len(), 1);
         let UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: event_attestation,
+            mint_scan_from_block,
             ..
         } = &events[0]
         else {
@@ -2423,6 +2476,51 @@ mod tests {
         };
 
         assert_eq!(*event_attestation, attestation);
+        assert_eq!(
+            *mint_scan_from_block,
+            Some(8_675_309),
+            "ReceiveAttestation must persist the destination-chain scan bound into the event",
+        );
+    }
+
+    #[test]
+    fn evolve_carries_mint_scan_from_block_into_attested() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let initiated_at = Utc::now();
+        let bridging = UsdcRebalance::Bridging {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(1000)),
+            burn_tx_hash: burn_tx,
+            initiated_at,
+            burned_at: initiated_at,
+        };
+
+        let attested = UsdcRebalance::evolve(
+            &bridging,
+            &UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![0x01],
+                cctp_nonce: 42,
+                mint_scan_from_block: Some(8_675_309),
+                attested_at: Utc::now(),
+            },
+        )
+        .unwrap()
+        .expect("Bridging must evolve to Attested on BridgeAttestationReceived");
+
+        let UsdcRebalance::Attested {
+            mint_scan_from_block,
+            ..
+        } = attested
+        else {
+            panic!("expected Attested state");
+        };
+
+        assert_eq!(
+            mint_scan_from_block,
+            Some(8_675_309),
+            "evolve must carry the scan bound into the Attested state",
+        );
     }
 
     #[tokio::test]
@@ -2432,6 +2530,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -2456,6 +2555,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -2485,6 +2585,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -2515,6 +2616,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -2549,12 +2651,14 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x03, 0x04],
                 cctp_nonce: 99999,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -2591,6 +2695,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02, 0x03, 0x04],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
             ])
@@ -2759,6 +2864,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
             ])
@@ -2858,6 +2964,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -2909,6 +3016,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -2999,6 +3107,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3056,6 +3165,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3108,6 +3218,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
             ])
@@ -3152,6 +3263,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3203,6 +3315,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3251,6 +3364,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3314,6 +3428,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3373,6 +3488,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0xAB, 0xCD, 0xEF],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3425,6 +3541,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x11, 0x22, 0x33, 0x44],
                     cctp_nonce: 67890,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3532,6 +3649,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: 12345,
+                mint_scan_from_block: 100,
             })
             .await
             .then_expect_error();
@@ -3610,6 +3728,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3663,6 +3782,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3719,6 +3839,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -3748,14 +3869,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_initiate_conversion_from_uninitialized() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
-                order_id,
+                order_id: order_id.clone(),
             })
             .await
             .events();
@@ -3778,7 +3899,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_initiate_conversion_twice() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
@@ -3790,7 +3911,7 @@ mod tests {
             .when(UsdcRebalanceCommand::InitiateConversion {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(500.00)),
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             })
             .await
             .then_expect_error();
@@ -3803,7 +3924,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_confirm_conversion_from_converting_state() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let filled_amount = Usdc::new(float!(998));
 
         let events = TestHarness::<UsdcRebalance>::with(())
@@ -3842,7 +3963,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_confirm_conversion_twice() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -3872,7 +3993,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fail_conversion_from_converting_state() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![UsdcRebalanceEvent::ConversionInitiated {
@@ -3912,7 +4033,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cannot_fail_already_completed_conversion() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let error = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -3942,7 +4063,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_initiate_withdrawal_after_conversion_complete() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let filled_amount = Usdc::new(float!(998));
 
@@ -3974,7 +4095,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_initiate_with_mismatched_amount_from_conversion_complete_fails() {
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
         let filled_amount = Usdc::new(float!(998));
 
@@ -4016,7 +4137,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -4036,6 +4157,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -4054,7 +4176,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
-                order_id,
+                order_id: order_id.clone(),
                 // Must match deposit amount (amount_received from bridging, not original)
                 amount: Usdc::new(float!(99.99)),
             })
@@ -4102,6 +4224,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -4120,7 +4243,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 amount: Usdc::new(float!(1000.00)),
             })
             .await
@@ -4137,7 +4260,7 @@ mod tests {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 amount: Usdc::new(float!(1000.00)),
             })
             .await
@@ -4174,6 +4297,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -4192,7 +4316,7 @@ mod tests {
                 },
             ])
             .when(UsdcRebalanceCommand::InitiatePostDepositConversion {
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 amount: Usdc::new(float!(500.00)),
             })
             .await
@@ -4215,7 +4339,7 @@ mod tests {
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let mint_tx =
             fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -4235,6 +4359,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: 12345,
+                    mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
                 UsdcRebalanceEvent::Bridged {
@@ -4274,7 +4399,7 @@ mod tests {
     #[test]
     fn to_dto_preserves_original_initiated_at_when_post_deposit_conversion_begins() {
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let original_initiated_at = Utc::now();
         let withdrawal_confirmed_at = original_initiated_at + chrono::Duration::seconds(30);
         let bridged_at = original_initiated_at + chrono::Duration::seconds(90);
@@ -4302,6 +4427,7 @@ mod tests {
             UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01],
                 cctp_nonce: 12345,
+                mint_scan_from_block: Some(100),
                 attested_at: withdrawal_confirmed_at + chrono::Duration::seconds(15),
             },
             UsdcRebalanceEvent::Bridged {
@@ -4348,7 +4474,7 @@ mod tests {
     #[test]
     fn to_dto_preserves_original_initiated_at_when_withdrawal_begins_after_conversion() {
         let id = UsdcRebalanceId(Uuid::new_v4());
-        let order_id = Uuid::new_v4();
+        let order_id = ClientOrderId::from_uuid(Uuid::new_v4());
         let original_initiated_at = Utc::now();
         let conversion_completed_at = original_initiated_at + chrono::Duration::seconds(30);
         let state = replay::<UsdcRebalance>(vec![
@@ -4410,7 +4536,7 @@ mod tests {
             UsdcRebalanceEvent::ConversionInitiated {
                 direction: RebalanceDirection::AlpacaToBase,
                 amount: Usdc::new(float!(1000.00)),
-                order_id: Uuid::new_v4(),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
                 initiated_at: Utc::now(),
             },
         ])
@@ -4426,7 +4552,7 @@ mod tests {
         let state = UsdcRebalance::Converting {
             direction: RebalanceDirection::AlpacaToBase,
             amount: Usdc::new(float!(500)),
-            order_id: Uuid::new_v4(),
+            order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
             initiated_at,
         };
 
@@ -4681,6 +4807,7 @@ mod tests {
             burn_tx_hash: burn_tx,
             cctp_nonce: 42,
             attestation: vec![0xAA, 0xBB],
+            mint_scan_from_block: Some(100),
             initiated_at,
             attested_at,
         };

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -573,6 +573,7 @@ mod tests {
     use alloy::primitives::{Address, TxHash, fixed_bytes};
     use chrono::Utc;
     use rain_math_float::Float;
+    use uuid::Uuid;
 
     use st0x_event_sorcery::EventSourced;
     use st0x_execution::{FractionalShares, Symbol};
@@ -840,7 +841,7 @@ mod tests {
 
     #[test]
     fn id_roundtrips_through_string() {
-        let id = WrappedEquityRecoveryId(uuid::Uuid::new_v4());
+        let id = WrappedEquityRecoveryId(Uuid::new_v4());
         let parsed = id.to_string().parse::<WrappedEquityRecoveryId>().unwrap();
         assert_eq!(id, parsed);
     }


### PR DESCRIPTION
## What

Closes [RAI-825](https://linear.app/makeitrain/issue/RAI-825/resuming-base-alpaca-usdc-transfer-from-attested-re-mints-and-reverts). Specs the crash-safe resume requirement for a Base->Alpaca USDC transfer that crashes after the CCTP mint (aggregate state `Attested`): resume must adopt the already-submitted mint rather than re-minting.

## Why

Re-minting from `Attested` re-calls `receiveMessage`, which reverts on the already-used CCTP nonce; after retries this records a terminal `BridgingFailed` for a transfer whose USDC was actually minted — stranding the bridged funds and reporting a false failure. Unlike the withdrawal and burn phases (`find_recent_withdrawal` / `find_recent_burn`), resume from `Attested` has no destination-chain adoption step.

## How

Adds a "Crash-safe resume" subsection under the `UsdcRebalance` state machine in SPEC.md documenting the scan-and-adopt requirement across all irreversible phases: withdrawal and burn (existing), and the `Attested` mint via a new `find_recent_mint` matching the `MintAndWithdraw` event, with the destination chain head captured when the attestation is recorded so the scan is bounded.

## Testing

Spec only; implementation lands in follow-up commits on this branch.

## Anything else

Stacked immediately on #712. Addresses the post-mint resume gap raised in #712's review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crash-safe resume for USDC CCTP bridging: on restart the system scans the destination chain (bounded by a captured head) to detect and adopt already-submitted mints, and records adopted outcomes (amount received and fee collected).

* **API / IDs**
  * Introduced a stable ClientOrderId representation for broker order idempotency; surfaces in conversion flows and public re-exports.

* **Tests**
  * Added/updated unit and integration tests validating post-mint crash recovery and adoption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->