### PR TITLE
feat: enqueue unwrapped equity recovery from rebalancing reactor

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -197,6 +197,23 @@ where
     Ok(())
 }
 
+async fn requeue_backfill_orphans(backfill_queue: &BackfillJobQueue) -> anyhow::Result<()> {
+    let count = backfill_queue
+        .requeue_orphaned()
+        .await
+        .context("failed to re-queue orphaned backfill jobs at startup")?;
+
+    if count > 0 {
+        info!(
+            target: "backfill",
+            count,
+            "Re-queued orphaned backfill range job(s) for crash-safe resume",
+        );
+    }
+
+    Ok(())
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -308,26 +325,7 @@ impl Conductor {
                 .await?;
         }
 
-        // The backfill queue has the same orphan hazard. `OrderFillMonitor`
-        // skips enqueuing while `backfill_queue.has_in_flight()` is true, and a
-        // `BackfillRange` row left `Running`/`Queued` by a dead process never
-        // ages out (the worker name is deterministic), so the poller would stop
-        // ingesting on-chain events indefinitely. Reset orphans before the
-        // monitor spawns -- backfill is core ingestion, always wired, so this is
-        // unconditional. Fail startup fast if the reset fails rather than coming
-        // up with event ingestion silently wedged.
-        let backfill_orphans = backfill_queue
-            .requeue_orphaned()
-            .await
-            .context("failed to re-queue orphaned backfill jobs at startup")?;
-
-        if backfill_orphans > 0 {
-            info!(
-                target: "backfill",
-                count = backfill_orphans,
-                "Re-queued orphaned backfill range job(s) for crash-safe resume",
-            );
-        }
+        requeue_backfill_orphans(&backfill_queue).await?;
 
         // Hydrate the in-memory InventoryView from persisted snapshot
         // state so the runtime projection has the same data as the
@@ -335,6 +333,9 @@ impl Conductor {
         // no events (unchanged values are deduplicated), leaving the
         // view empty and potentially causing incorrect rebalancing.
         hydrate_inventory_from_snapshot(&pool, &inventory).await;
+        if let Some(service) = &rebalancing_service {
+            service.enqueue_recovery_for_current_wallet_balances().await;
+        }
 
         let order_placer: Arc<dyn OrderPlacer> = Arc::new(ExecutorOrderPlacer(executor.clone()));
 
@@ -378,6 +379,8 @@ impl Conductor {
                     mint_store,
                     redemption_store,
                     equity_in_progress: service.equity_in_progress.clone(),
+                    queue: wrapped_equity_recovery_queue.clone(),
+                    reschedule_interval: Duration::from_secs(ctx.inventory_poll_interval),
                 }))
             }
             _ => None,

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -7,7 +7,7 @@ use alloy::primitives::{Address, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -30,6 +30,7 @@ use crate::equity_redemption::{
 };
 use crate::inventory::projection::InventoryProjectionError;
 use crate::inventory::snapshot::{InventorySnapshot, InventorySnapshotEvent};
+use crate::inventory::view::InFlightEquityLocation;
 use crate::inventory::{
     BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, InventoryViewError,
     Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
@@ -41,6 +42,10 @@ use crate::rebalancing::usdc::{
 };
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand, TokenizedEquityMintEvent,
+};
+use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
+use crate::unwrapped_equity_recovery::{
+    UnwrappedEquityRecoveryJob, UnwrappedEquityRecoveryJobQueue,
 };
 use crate::usdc_rebalance::{
     InterruptedUsdcRebalances, RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent,
@@ -61,6 +66,7 @@ pub(crate) struct RebalancingSchedulers {
     pub(crate) equity: EquityRebalancingCheckScheduler,
     pub(crate) usdc: UsdcRebalancingCheckScheduler,
     pub(crate) wrapped_equity_recovery: WrappedEquityRecoveryJobQueue,
+    pub(crate) unwrapped_equity_recovery: UnwrappedEquityRecoveryJobQueue,
     pub(crate) transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue,
     pub(crate) transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue,
 }
@@ -71,6 +77,7 @@ impl RebalancingSchedulers {
             equity: EquityRebalancingCheckScheduler::new(pool),
             usdc: UsdcRebalancingCheckScheduler::new(pool),
             wrapped_equity_recovery: WrappedEquityRecoveryJobQueue::new(pool),
+            unwrapped_equity_recovery: UnwrappedEquityRecoveryJobQueue::new(pool),
             transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue::new(pool),
             transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue::new(pool),
         }
@@ -448,6 +455,7 @@ pub(crate) struct RebalancingService {
     pub(super) equity_scheduler: EquityRebalancingCheckScheduler,
     pub(super) usdc_scheduler: UsdcRebalancingCheckScheduler,
     pub(super) wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
+    pub(super) unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
     /// Queues for the USDC transfer apalis jobs that drive each rebalancing
     /// direction. `check_and_trigger_usdc` enqueues into one of these
     /// directly rather than dispatching through the `Rebalancer` mpsc channel.
@@ -532,6 +540,7 @@ impl RebalancingService {
             equity: equity_scheduler,
             usdc: usdc_scheduler,
             wrapped_equity_recovery: wrapped_equity_recovery_queue,
+            unwrapped_equity_recovery: unwrapped_equity_recovery_queue,
             transfer_usdc_to_hedging: transfer_usdc_to_hedging_queue,
             transfer_usdc_to_market_making: transfer_usdc_to_market_making_queue,
         } = schedulers;
@@ -549,6 +558,7 @@ impl RebalancingService {
             equity_scheduler,
             usdc_scheduler,
             wrapped_equity_recovery_queue,
+            unwrapped_equity_recovery_queue,
             transfer_usdc_to_hedging_queue,
             transfer_usdc_to_market_making_queue,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
@@ -1487,17 +1497,22 @@ impl RebalancingService {
                     if !self.is_wrapped_equity_recovery_enabled(symbol) {
                         continue;
                     }
+
                     let mut queue = self.wrapped_equity_recovery_queue.clone();
                     let job_type = std::any::type_name::<WrappedEquityRecoveryJob>();
-                    let symbol_pattern = format!("%{symbol}%");
+
+                    // Match the serialized `symbol` field exactly (json_extract, not
+                    // a LIKE substring) so a queued job for a ticker that contains
+                    // this symbol as a substring (e.g. GOOGL vs GOOG) can't suppress
+                    // a distinct recovery.
                     let existing: Result<(i64,), _> = sqlx::query_as(
                         "SELECT COUNT(*) FROM Jobs \
                          WHERE job_type = ? \
                          AND status IN ('Pending', 'Queued', 'Running') \
-                         AND job LIKE ?",
+                         AND json_extract(job, '$.symbol') = ?",
                     )
                     .bind(job_type)
-                    .bind(&symbol_pattern)
+                    .bind(symbol.to_string())
                     .fetch_one(queue.pool())
                     .await;
 
@@ -1539,6 +1554,83 @@ impl RebalancingService {
                     }
                 }
             }
+            // Unwrapped equity (tSTOCK) in the bot wallet triggers a
+            // recovery dispatch per symbol with a positive balance.
+            // Gated per-symbol on `wrapped_equity_recovery` -- the same
+            // config flag covers both detection paths since they share
+            // the same "auto-recover misplaced equity" intent.
+            BaseWalletUnwrappedEquity { balances, .. } => {
+                for (symbol, amount) in balances {
+                    if *amount == FractionalShares::ZERO {
+                        continue;
+                    }
+                    if !self.is_wrapped_equity_recovery_enabled(symbol) {
+                        continue;
+                    }
+
+                    let mut queue = self.unwrapped_equity_recovery_queue.clone();
+                    let job_type = std::any::type_name::<UnwrappedEquityRecoveryJob>();
+
+                    // Status-scoped dedup, mirroring the wrapped path: only a
+                    // non-terminal row blocks a re-enqueue. apalis's
+                    // `ON CONFLICT(job_type, idempotency_key) DO NOTHING` never
+                    // surfaces a unique-violation, and its index spans all
+                    // statuses, so an idempotency key would silently wedge a
+                    // symbol behind its own `Done` row until the hourly cleanup
+                    // -- starving the next-poll re-dispatch the guard-contention
+                    // skip relies on. Match the serialized `symbol` field
+                    // exactly (json_extract, not a LIKE substring) so a queued
+                    // job for a ticker that contains this symbol as a substring
+                    // (e.g. GOOGL vs GOOG) can't suppress a distinct recovery.
+                    let existing: Result<(i64,), _> = sqlx::query_as(
+                        "SELECT COUNT(*) FROM Jobs \
+                         WHERE job_type = ? \
+                         AND status IN ('Pending', 'Queued', 'Running') \
+                         AND json_extract(job, '$.symbol') = ?",
+                    )
+                    .bind(job_type)
+                    .bind(symbol.to_string())
+                    .fetch_one(queue.pool())
+                    .await;
+
+                    match existing {
+                        Ok((count,)) if count > 0 => {
+                            debug!(
+                                target: "rebalance",
+                                %symbol, %count,
+                                "Skipped UnwrappedEquityRecoveryJob enqueue: a non-terminal \
+                                 row for this symbol already exists",
+                            );
+                            continue;
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            warn!(
+                                target: "rebalance",
+                                %symbol, %error,
+                                "Failed to query existing UnwrappedEquityRecoveryJob rows; \
+                                 skipping enqueue to avoid duplicates",
+                            );
+                            continue;
+                        }
+                    }
+
+                    let recovery_id = UnwrappedEquityRecoveryId(Uuid::new_v4());
+                    if let Err(error) = queue
+                        .push(UnwrappedEquityRecoveryJob {
+                            symbol: symbol.clone(),
+                            recovery_id: recovery_id.clone(),
+                        })
+                        .await
+                    {
+                        warn!(
+                            target: "rebalance",
+                            %symbol, %recovery_id, ?error,
+                            "Failed to enqueue UnwrappedEquityRecoveryJob",
+                        );
+                    }
+                }
+            }
             // Wallet-read USDC events update `inflight_cash` for
             // visibility but don't drive triggers here.
             // Suppression-aware re-triggering will be added once
@@ -1546,7 +1638,6 @@ impl RebalancingService {
             EthereumUsdc { .. }
             | BaseWalletUsdc { .. }
             | AlpacaUsdc { .. }
-            | BaseWalletUnwrappedEquity { .. }
             // Buying power is display-only and doesn't feed any rebalance
             // decision.
             | OffchainCashBuyingPower { .. }
@@ -1554,6 +1645,53 @@ impl RebalancingService {
             // indicate transfers already in progress, not new balances
             // to rebalance.
             | InflightEquity { .. } => {}
+        }
+    }
+
+    /// Re-drives recovery producers from the already-hydrated inventory view.
+    ///
+    /// Startup hydration updates the in-memory view directly instead of
+    /// dispatching snapshot reactor events. Wallet polls also suppress unchanged
+    /// balances, so a positive tSTOCK/wtSTOCK balance that was persisted before
+    /// restart would otherwise wait forever for a new event.
+    pub(crate) async fn enqueue_recovery_for_current_wallet_balances(&self) {
+        let (wrapped, unwrapped) = {
+            let view = self.inventory.read().await;
+            let mut wrapped = BTreeMap::new();
+            let mut unwrapped = BTreeMap::new();
+
+            for symbol in self.config.assets.equities.symbols.keys() {
+                if let Some(amount) =
+                    view.inflight_equity_at(symbol, InFlightEquityLocation::BaseWalletWrapped)
+                {
+                    wrapped.insert(symbol.clone(), amount);
+                }
+                if let Some(amount) =
+                    view.inflight_equity_at(symbol, InFlightEquityLocation::BaseWalletUnwrapped)
+                {
+                    unwrapped.insert(symbol.clone(), amount);
+                }
+            }
+
+            (wrapped, unwrapped)
+        };
+
+        let fetched_at = Utc::now();
+
+        if !wrapped.is_empty() {
+            self.enqueue_checks_for_snapshot(&InventorySnapshotEvent::BaseWalletWrappedEquity {
+                balances: wrapped,
+                fetched_at,
+            })
+            .await;
+        }
+
+        if !unwrapped.is_empty() {
+            self.enqueue_checks_for_snapshot(&InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+                balances: unwrapped,
+                fetched_at,
+            })
+            .await;
         }
     }
 }
@@ -3498,7 +3636,9 @@ mod tests {
     use tokio::sync::mpsc::error::TryRecvError;
     use uuid::Uuid;
 
-    use st0x_config::{CashAssetConfig, EquitiesConfig, ExecutionThreshold, OperationMode};
+    use st0x_config::{
+        CashAssetConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
+    };
     use st0x_dto::Statement;
     use st0x_event_sorcery::{
         EntityList, Never, Reactor, ReactorHarness, TestStore, deps, test_store,
@@ -3516,7 +3656,7 @@ mod tests {
     use crate::inventory::snapshot::{
         InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
     };
-    use crate::inventory::view::Operator;
+    use crate::inventory::view::{InFlightEquityLocation, Operator};
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
@@ -3579,6 +3719,62 @@ mod tests {
             RebalancingSchedulers::new(&pool),
         ));
         (service, receiver)
+    }
+
+    #[tokio::test]
+    async fn startup_recovery_scan_enqueues_persisted_unwrapped_wallet_balance() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol.clone(), FractionalShares::new(float!(5)));
+        let now = Utc::now();
+        let inventory_view = InventoryView::default().set_inflight_equity_at_location(
+            InFlightEquityLocation::BaseWalletUnwrapped,
+            &balances,
+            now,
+            now,
+        );
+
+        let mut config = test_config();
+        config.assets.equities.symbols.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: Address::random(),
+                tokenized_equity_derivative: Address::random(),
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Enabled,
+                wrapped_equity_recovery: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        let pool = crate::test_utils::setup_test_db().await;
+        crate::conductor::setup_apalis_tables(&pool).await.unwrap();
+        let (sender, _receiver) = mpsc::channel(10);
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
+        let service = RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            sender,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&pool),
+        );
+
+        service.enqueue_recovery_for_current_wallet_balances().await;
+
+        let (jobs,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+            .fetch_one(service.unwrapped_equity_recovery_queue.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            jobs, 1,
+            "startup recovery scan must enqueue persisted positive unwrapped wallet balances",
+        );
     }
 
     #[tokio::test]

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -10,8 +10,8 @@
 //! Steps:
 //!
 //! 1. Claim the `equity_in_progress` guard for the symbol. If another task
-//!    already holds it, the job exits at debug log; the next inventory
-//!    poll re-evaluates.
+//!    already holds it, the job reschedules itself with a delay so an
+//!    unchanged wallet balance is not stranded waiting for another snapshot.
 //! 2. Read the inventory view's wallet balance + active mint/redemption
 //!    maps to pick a `DispatchDecision`.
 //! 3. Send `Detect` followed by the path-specific command sequence:
@@ -27,6 +27,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
@@ -37,7 +38,7 @@ use super::aggregate::{
     WrappedEquityRecovery, WrappedEquityRecoveryCommand, WrappedEquityRecoveryError,
     WrappedEquityRecoveryId,
 };
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::{EquityRedemption, RedemptionAggregateId};
 use crate::inventory::BroadcastingInventory;
 use crate::inventory::view::{InFlightEquityLocation, InventoryView};
@@ -55,6 +56,10 @@ pub(crate) struct WrappedEquityRecoveryCtx {
     pub(crate) mint_store: Arc<Store<TokenizedEquityMint>>,
     pub(crate) redemption_store: Arc<Store<EquityRedemption>>,
     pub(crate) equity_in_progress: Arc<RwLock<HashSet<Symbol>>>,
+    /// Queue used for delayed self-reschedule when the shared equity guard is
+    /// held by another recovery/transfer job.
+    pub(crate) queue: WrappedEquityRecoveryJobQueue,
+    pub(crate) reschedule_interval: Duration,
 }
 
 /// Why a single recovery job attempt failed. Errors propagate up through
@@ -132,6 +137,9 @@ pub(crate) enum WrappedEquityRecoveryJobError {
             st0x_event_sorcery::LifecycleError<crate::equity_redemption::EquityRedemption>,
         >,
     ),
+
+    #[error("failed to reschedule recovery job after guard contention: {0}")]
+    Reschedule(#[from] QueuePushError),
 }
 
 /// Apalis job payload. The reactor pushes one of these per symbol with a
@@ -168,8 +176,12 @@ impl Job<WrappedEquityRecoveryCtx> for WrappedEquityRecoveryJob {
                 target: "rebalance",
                 %symbol,
                 recovery_id = %self.recovery_id,
-                "Skipping wrapped equity recovery: equity_in_progress already held",
+                "Rescheduling wrapped equity recovery: equity_in_progress already held",
             );
+            ctx.queue
+                .clone()
+                .push_with_delay(self.clone(), ctx.reschedule_interval)
+                .await?;
             return Ok(());
         };
 
@@ -439,4 +451,137 @@ fn claim_guard(set: &Arc<RwLock<HashSet<Symbol>>>, symbol: &Symbol) -> Option<In
         symbol: symbol.clone(),
         set: Arc::clone(set),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Address;
+    use std::sync::{Arc, RwLock};
+    use tokio::sync::broadcast;
+    use uuid::Uuid;
+
+    use st0x_event_sorcery::test_store;
+
+    use super::super::aggregate::WrappedEquityRecoveryServices;
+    use super::*;
+    use crate::conductor::setup_apalis_tables;
+    use crate::inventory::BroadcastingInventory;
+    use crate::inventory::view::InventoryView;
+    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::raindex::Raindex;
+    use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+    use crate::tokenization::mock::MockTokenizer;
+    use crate::wrapper::Wrapper;
+    use crate::wrapper::mock::MockWrapper;
+
+    #[tokio::test]
+    async fn guard_contention_reschedules_without_dropping_the_recovery() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let equity_in_progress = Arc::new(RwLock::new(HashSet::from([symbol.clone()])));
+
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
+        let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
+        let transfer_services = EquityTransferServices {
+            raindex: raindex.clone(),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: wrapper.clone(),
+        };
+        let mint_store = Arc::new(test_store(pool.clone(), transfer_services.clone()));
+        let redemption_store = Arc::new(test_store(pool.clone(), transfer_services));
+        let transfer = Arc::new(CrossVenueEquityTransfer::new(
+            raindex.clone(),
+            Arc::new(MockTokenizer::new()),
+            wrapper.clone(),
+            Address::random(),
+            mint_store.clone(),
+            redemption_store.clone(),
+        ));
+        let store = Arc::new(test_store(
+            pool.clone(),
+            WrappedEquityRecoveryServices {
+                raindex,
+                wrapper,
+                transfer,
+            },
+        ));
+
+        let (sender, _receiver) = broadcast::channel(16);
+        let inventory = Arc::new(BroadcastingInventory::new(InventoryView::default(), sender));
+        let ctx = WrappedEquityRecoveryCtx {
+            inventory,
+            store,
+            mint_store,
+            redemption_store,
+            equity_in_progress,
+            queue: WrappedEquityRecoveryJobQueue::new(&pool),
+            reschedule_interval: Duration::from_secs(1),
+        };
+        let job = WrappedEquityRecoveryJob {
+            symbol: symbol.clone(),
+            recovery_id: WrappedEquityRecoveryId(Uuid::new_v4()),
+        };
+
+        job.perform(&ctx).await.unwrap();
+
+        let state = ctx.store.load(&job.recovery_id).await.unwrap();
+        assert!(
+            state.is_none(),
+            "guard-held perform() must not start recovery; aggregate should be absent, got {state:?}",
+        );
+
+        let (rescheduled,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
+            .fetch_one(ctx.queue.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            rescheduled, 1,
+            "guard contention must reschedule the wrapped recovery job, not mark it done",
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_dedup_matches_symbol_exactly_not_as_substring() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        setup_apalis_tables(&pool).await.unwrap();
+
+        let mut queue = WrappedEquityRecoveryJobQueue::new(&pool);
+        queue
+            .push(WrappedEquityRecoveryJob {
+                symbol: Symbol::new("GOOGL").unwrap(),
+                recovery_id: WrappedEquityRecoveryId(Uuid::new_v4()),
+            })
+            .await
+            .unwrap();
+
+        // The exact query the reactor uses to dedupe wrapped-recovery enqueues.
+        const DEDUP_QUERY: &str = "SELECT COUNT(*) FROM Jobs \
+             WHERE job_type = ? \
+             AND status IN ('Pending', 'Queued', 'Running') \
+             AND json_extract(job, '$.symbol') = ?";
+        let job_type = std::any::type_name::<WrappedEquityRecoveryJob>();
+
+        let (exact,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+            .bind(job_type)
+            .bind("GOOGL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(exact, 1, "exact symbol must match the queued GOOGL job");
+
+        let (substring,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+            .bind(job_type)
+            .bind("GOOG")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            substring, 0,
+            "a substring ticker (GOOG) must not match the queued GOOGL job",
+        );
+    }
 }

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -2360,9 +2360,6 @@ async fn wrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<
 /// records the full orphan sequence `Detected -> OrphanWrapSubmitted ->
 /// OrphanWrapped -> OrphanDepositSubmitted -> OrphanDeposited`.
 #[test_log::test(tokio::test)]
-#[ignore = "TTDD red state: nothing enqueues UnwrappedEquityRecoveryJob until the rebalancing \
-            reactor trigger lands upstack; feat/unwrapped-equity-recovery-trigger removes this \
-            ignore"]
 async fn unwrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<()> {
     let onchain_price = float!("150.00");
     let broker_fill_price = float!("150.00");


### PR DESCRIPTION
## What

[RAI-857](https://linear.app/makeitrain/issue/RAI-857)

Handles the `BaseWalletUnwrappedEquity` event in the rebalancing trigger, enqueueing one `UnwrappedEquityRecoveryJob` per symbol that has a positive Base wallet tSTOCK balance.

## Why

Unwrapped equity (tSTOCK) sitting in the bot wallet is misplaced inventory that needs to be re-wrapped and returned to the market-making position. Without a trigger, the recovery aggregate and worker added upstack never get driven from live wallet reads.

## How

- Wires an `UnwrappedEquityRecoveryJobQueue` into `RebalancingSchedulers` and `RebalancingService`.
- On `BaseWalletUnwrappedEquity`, iterates each symbol/amount pair and skips zero balances.
- Gates each symbol on the existing `wrapped_equity_recovery` config flag, since both detection paths share the same "auto-recover misplaced equity" intent.
- Dedups by counting non-terminal (`Pending`/`Queued`/`Running`) rows for the symbol rather than using an apalis idempotency key, so a terminal `Done` row can't wedge a symbol until cleanup.
- Matches the serialized `symbol` field with exact `json_extract` equality, not a `LIKE` substring, so a queued job for a superstring ticker (e.g. GOOGL vs GOOG) can't suppress a distinct recovery.
- On a failed dedup query, skips the enqueue and warns rather than risk duplicates.

## Testing

Covered by the upstack aggregate/worker/e2e suite; this PR's trigger wiring rides the existing rebalancing-trigger tests and the Base unwrapped-equity recovery e2e.

## Screenshots

N/A

## Anything else

- Stacks on the unwrapped-equity recovery aggregate, job, and worker registration PRs.
- Per-symbol dedup relies on the next-poll re-dispatch behavior the guard-contention skip already assumes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114788&installation_id=125569124&pr_number=734&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F734&signature=64cc855958828f835e49227a36139b34ed0f18125da4c5098b3e52437c2e6989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equity recovery now triggers automatically on startup based on current wallet balances.
  * Added support for unwrapped equity recovery operations.

* **Improvements**
  * Recovery jobs now automatically reschedule under contention instead of exiting early.
  * Enhanced job deduplication accuracy.

* **Tests**
  * Re-enabled unwrapped equity recovery test for execution in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->