### PR TITLE
refactor: introduce VaultLookup abstraction and route vault resolution through it

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -48,6 +48,27 @@ correctness guarantees and/or code quality.
 method won't exist in unit test builds but will exist in e2e builds where
 dev-deps enable `test-support`.
 
+### Dead code across a stacked PR: forward vs backward
+
+When work is split into a Graphite stack, `deny(dead_code)` forces a choice
+about temporarily-unused code. Distinguish code that is _not yet born_ from code
+that _has died_:
+
+- **Forward-dead** — introduced ahead of its consumer, which lands in the next
+  upstack PR. Acceptable to keep behind `#[allow(dead_code)]` **only** with a
+  comment naming the exact upstack issue + branch (and the PR once it exists)
+  that consumes it. That upstack PR must be the _immediate next_ one in the
+  stack, so the allow is never stranded. This is how a stack stays small: a base
+  PR can introduce a type/trait/method whose first caller arrives one PR later.
+- **Backward-dead** — superseded, i.e. a new path replaced it. MUST be removed
+  in the same PR that introduces the replacement. Never annotate-and-keep
+  superseded code; an `#[allow(dead_code)]` on a corpse is forbidden. When the
+  replacement lands, the replaced code dies with it.
+
+The test is simple: is the code waiting to be _born_ (a consumer is coming) or
+has it _died_ (its consumers left)? Forward-dead may wait one PR behind an
+attributed allow; backward-dead goes now.
+
 ### Pattern: zero-size prod / functional test type
 
 When a type needs to exist in all builds (to avoid `#[cfg]` on every function

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use tokenization::mock_api;
 mod tokenized_equity_mint;
 mod unwrapped_equity_recovery;
 mod usdc_rebalance;
+mod vault_lookup;
 mod vault_registry;
 mod wrapped_equity_recovery;
 mod wrapper;

--- a/src/vault_lookup.rs
+++ b/src/vault_lookup.rs
@@ -1,0 +1,396 @@
+//! Vault resolution over the [`VaultRegistry`] projection.
+//!
+//! Separates "which vault holds this token/symbol" (a registry read) from Rain
+//! OrderBook chain operations. Upstack routing moves registry-backed lookups
+//! here first; later branches can make the chain layer take explicit vault IDs
+//! without knowing about the [`VaultRegistry`] projection.
+
+// Forward-dead in this PR: nothing consumes `VaultLookup` yet. The equity-mint,
+// wrapped-equity-recovery, and equity-redemption flows are routed through it --
+// and this allow is removed -- in the immediate upstack PR (RAI-831, branch
+// refactor/route-vaults-through-vault-lookup).
+#![allow(dead_code)]
+
+use alloy::primitives::Address;
+use async_trait::async_trait;
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use st0x_event_sorcery::ProjectionError;
+use st0x_execution::Symbol;
+
+use crate::onchain::raindex::RaindexVaultId;
+use crate::vault_registry::{VaultRegistry, VaultRegistryId, VaultRegistryProjection};
+
+/// Resolves Raindex vault ids from the [`VaultRegistry`] projection.
+///
+/// Consumers that must act on a vault (deposit, withdraw, recover) but only
+/// know a token address or trading symbol use this to discover the primary
+/// vault before invoking chain operations.
+#[async_trait]
+pub(crate) trait VaultLookup: Send + Sync {
+    /// Returns the primary vault id registered for `token`.
+    async fn vault_id_for_token(&self, token: Address) -> Result<RaindexVaultId, VaultLookupError>;
+
+    /// Returns the wrapped equity token address registered for `symbol`.
+    async fn vault_token_for_symbol(&self, symbol: &Symbol) -> Result<Address, VaultLookupError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum VaultLookupError {
+    #[error("Vault registry not found for aggregate {0}")]
+    RegistryNotFound(VaultRegistryId),
+    #[error(transparent)]
+    Projection(#[from] ProjectionError<VaultRegistry>),
+    #[error("Vault not found for token {0}")]
+    VaultNotFound(Address),
+    #[error("Token not found for symbol {0}")]
+    TokenNotFound(Symbol),
+    #[error("Multiple vault tokens found for symbol {symbol}: {tokens:?}")]
+    AmbiguousTokenForSymbol {
+        symbol: Symbol,
+        tokens: Vec<Address>,
+    },
+}
+
+/// [`VaultLookup`] backed by the live [`VaultRegistry`] projection for a single
+/// orderbook/owner pair.
+pub(crate) struct VaultRegistryLookup {
+    projection: Arc<VaultRegistryProjection>,
+    orderbook: Address,
+    owner: Address,
+}
+
+impl VaultRegistryLookup {
+    pub(crate) fn new(
+        projection: Arc<VaultRegistryProjection>,
+        orderbook: Address,
+        owner: Address,
+    ) -> Self {
+        Self {
+            projection,
+            orderbook,
+            owner,
+        }
+    }
+
+    async fn load_registry(&self) -> Result<VaultRegistry, VaultLookupError> {
+        let id = VaultRegistryId {
+            orderbook: self.orderbook,
+            owner: self.owner,
+        };
+
+        self.projection
+            .load(&id)
+            .await?
+            .ok_or(VaultLookupError::RegistryNotFound(id))
+    }
+}
+
+#[async_trait]
+impl VaultLookup for VaultRegistryLookup {
+    async fn vault_id_for_token(&self, token: Address) -> Result<RaindexVaultId, VaultLookupError> {
+        let registry = self.load_registry().await?;
+        registry
+            .primary_vault_id_by_token(token)
+            .map(RaindexVaultId)
+            .ok_or(VaultLookupError::VaultNotFound(token))
+    }
+
+    async fn vault_token_for_symbol(&self, symbol: &Symbol) -> Result<Address, VaultLookupError> {
+        let registry = self.load_registry().await?;
+        let tokens: Vec<_> = registry
+            .equity_vaults
+            .iter()
+            .filter_map(|(token, vaults)| {
+                vaults
+                    .values()
+                    .any(|vault| vault.symbol == *symbol)
+                    .then_some(*token)
+            })
+            .collect();
+
+        match tokens.as_slice() {
+            [] => Err(VaultLookupError::TokenNotFound(symbol.clone())),
+            [token] => Ok(*token),
+            _ => Err(VaultLookupError::AmbiguousTokenForSymbol {
+                symbol: symbol.clone(),
+                tokens,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct MockVaultLookup {
+    vaults: BTreeMap<Address, RaindexVaultId>,
+    tokens: BTreeMap<Symbol, Address>,
+}
+
+#[cfg(test)]
+impl MockVaultLookup {
+    pub(crate) fn new() -> Self {
+        Self {
+            vaults: BTreeMap::new(),
+            tokens: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn with_token(mut self, token: Address) -> Self {
+        self.tokens.insert(Symbol::new("AAPL").unwrap(), token);
+        self
+    }
+
+    pub(crate) fn with_symbol_token(mut self, symbol: Symbol, token: Address) -> Self {
+        self.tokens.insert(symbol, token);
+        self
+    }
+
+    pub(crate) fn with_vault(mut self, token: Address, vault_id: RaindexVaultId) -> Self {
+        self.vaults.insert(token, vault_id);
+        self
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl VaultLookup for MockVaultLookup {
+    async fn vault_id_for_token(&self, token: Address) -> Result<RaindexVaultId, VaultLookupError> {
+        self.vaults
+            .get(&token)
+            .copied()
+            .ok_or(VaultLookupError::VaultNotFound(token))
+    }
+
+    async fn vault_token_for_symbol(&self, symbol: &Symbol) -> Result<Address, VaultLookupError> {
+        self.tokens
+            .get(symbol)
+            .copied()
+            .ok_or_else(|| VaultLookupError::TokenNotFound(symbol.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{B256, address, b256};
+
+    use st0x_event_sorcery::StoreBuilder;
+
+    use super::*;
+    use crate::test_utils::setup_test_db;
+    use crate::vault_registry::VaultRegistryCommand;
+
+    const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");
+    const TEST_OWNER: Address = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+    const TEST_TOKEN: Address = address!("0x9876543210987654321098765432109876543210");
+    const OTHER_TOKEN: Address = address!("0x2222222222222222222222222222222222222222");
+    const TEST_VAULT_ID: B256 =
+        b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
+    const EARLIER_SORTING_VAULT_ID: B256 =
+        b256!("0x0000000000000000000000000000000000000000000000000000000000000000");
+
+    fn test_symbol() -> Symbol {
+        Symbol::new("AAPL").unwrap()
+    }
+
+    async fn seeded_lookup() -> VaultRegistryLookup {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+
+        store
+            .send(
+                &VaultRegistryId {
+                    orderbook: TEST_ORDERBOOK,
+                    owner: TEST_OWNER,
+                },
+                VaultRegistryCommand::SeedEquityVaultFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    symbol: test_symbol(),
+                },
+            )
+            .await
+            .unwrap();
+
+        VaultRegistryLookup::new(projection, TEST_ORDERBOOK, TEST_OWNER)
+    }
+
+    #[tokio::test]
+    async fn vault_id_for_token_returns_primary_vault() {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+        let registry_id = VaultRegistryId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_OWNER,
+        };
+
+        store
+            .send(
+                &registry_id,
+                VaultRegistryCommand::SeedEquityVaultFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    symbol: test_symbol(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &registry_id,
+                VaultRegistryCommand::SeedEquityVaultFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: EARLIER_SORTING_VAULT_ID,
+                    symbol: test_symbol(),
+                },
+            )
+            .await
+            .unwrap();
+        let lookup = VaultRegistryLookup::new(projection, TEST_ORDERBOOK, TEST_OWNER);
+
+        assert_eq!(
+            lookup.vault_id_for_token(TEST_TOKEN).await.unwrap(),
+            RaindexVaultId(TEST_VAULT_ID),
+            "primary vault must preserve first-seeded config order, not BTreeMap ordering",
+        );
+    }
+
+    #[tokio::test]
+    async fn vault_token_for_symbol_returns_registered_token() {
+        let lookup = seeded_lookup().await;
+
+        assert_eq!(
+            lookup.vault_token_for_symbol(&test_symbol()).await.unwrap(),
+            TEST_TOKEN
+        );
+    }
+
+    #[tokio::test]
+    async fn vault_token_for_symbol_rejects_ambiguous_tokens() {
+        let pool = setup_test_db().await;
+        let (store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+        let registry_id = VaultRegistryId {
+            orderbook: TEST_ORDERBOOK,
+            owner: TEST_OWNER,
+        };
+
+        for (token, vault_id) in [
+            (TEST_TOKEN, TEST_VAULT_ID),
+            (OTHER_TOKEN, EARLIER_SORTING_VAULT_ID),
+        ] {
+            store
+                .send(
+                    &registry_id,
+                    VaultRegistryCommand::SeedEquityVaultFromConfig {
+                        token,
+                        vault_id,
+                        symbol: test_symbol(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let lookup = VaultRegistryLookup::new(projection, TEST_ORDERBOOK, TEST_OWNER);
+        let error = lookup
+            .vault_token_for_symbol(&test_symbol())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                VaultLookupError::AmbiguousTokenForSymbol { ref symbol, ref tokens }
+                    if symbol == &test_symbol()
+                        && *tokens == vec![OTHER_TOKEN, TEST_TOKEN]
+            ),
+            "expected ambiguous token error with both tokens, got: {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn vault_id_for_unknown_token_is_vault_not_found() {
+        let lookup = seeded_lookup().await;
+        let other = address!("0x2222222222222222222222222222222222222222");
+
+        let error = lookup.vault_id_for_token(other).await.unwrap_err();
+
+        assert!(
+            matches!(error, VaultLookupError::VaultNotFound(token) if token == other),
+            "expected VaultNotFound for unregistered token, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_for_unknown_symbol_is_token_not_found() {
+        let lookup = seeded_lookup().await;
+        let symbol = Symbol::new("MSFT").unwrap();
+
+        let error = lookup.vault_token_for_symbol(&symbol).await.unwrap_err();
+
+        assert!(
+            matches!(&error, VaultLookupError::TokenNotFound(unknown) if unknown == &symbol),
+            "expected TokenNotFound for unregistered symbol, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_registry_is_registry_not_found() {
+        let pool = setup_test_db().await;
+        let (_store, projection) = StoreBuilder::<VaultRegistry>::new(pool)
+            .build(())
+            .await
+            .unwrap();
+        let lookup = VaultRegistryLookup::new(projection, TEST_ORDERBOOK, TEST_OWNER);
+
+        let error = lookup.vault_id_for_token(TEST_TOKEN).await.unwrap_err();
+
+        let VaultLookupError::RegistryNotFound(id) = error else {
+            panic!("expected RegistryNotFound for empty registry, got: {error:?}");
+        };
+        assert_eq!(id.orderbook, TEST_ORDERBOOK);
+        assert_eq!(id.owner, TEST_OWNER);
+    }
+
+    #[tokio::test]
+    async fn mock_vault_lookup_rejects_unconfigured_inputs() {
+        let lookup = MockVaultLookup::new()
+            .with_symbol_token(test_symbol(), TEST_TOKEN)
+            .with_vault(TEST_TOKEN, RaindexVaultId(TEST_VAULT_ID));
+
+        assert_eq!(
+            lookup.vault_token_for_symbol(&test_symbol()).await.unwrap(),
+            TEST_TOKEN,
+        );
+        assert_eq!(
+            lookup.vault_id_for_token(TEST_TOKEN).await.unwrap(),
+            RaindexVaultId(TEST_VAULT_ID),
+        );
+
+        let other_symbol = Symbol::new("MSFT").unwrap();
+        let token_error = lookup
+            .vault_token_for_symbol(&other_symbol)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&token_error, VaultLookupError::TokenNotFound(symbol) if symbol == &other_symbol),
+            "mock must reject unconfigured symbols, got: {token_error:?}",
+        );
+
+        let vault_error = lookup.vault_id_for_token(OTHER_TOKEN).await.unwrap_err();
+        assert!(
+            matches!(vault_error, VaultLookupError::VaultNotFound(token) if token == OTHER_TOKEN),
+            "mock must reject unconfigured tokens, got: {vault_error:?}",
+        );
+    }
+}


### PR DESCRIPTION
## What

[RAI-829](https://linear.app/makeitrain/issue/RAI-829)

Introduce a `VaultLookup` abstraction and a `VaultRegistry`-backed implementation that resolves Raindex vault ids from a token address or trading symbol, so consumers no longer reach into `Raindex`/`RaindexService` to resolve vaults.

## Why

Vault resolution ("which vault holds this token/symbol") was coupled to the Rain OrderBook chain layer. Separating the registry read from the chain operations lets the chain layer take an explicit vault id and live in a standalone crate independent of `st0x-config`.

## How

- Define a `VaultLookup` trait with `vault_id_for_token` and `token_for_symbol`.
- Back it with `VaultRegistryLookup`, which reads the `VaultRegistry` projection for a single orderbook/owner pair.
- Model failures as a typed `VaultLookupError` (`RegistryNotFound`, `Projection`, `VaultNotFound`, `TokenNotFound`) rather than opaque strings.
- Keep the chain layer ignorant of the projection: it receives a resolved vault id instead of the registry.
- Gate the not-yet-consumed type behind an attributed `#![allow(dead_code)]` (forward-dead), removed in the immediate upstack PR.
- Document the forward-dead vs backward-dead distinction for stacked PRs in `docs/feature-flags.md`.

## Testing

- Unit tests over a seeded `VaultRegistry` projection cover the happy path (`vault_id_for_token`, `token_for_symbol`).
- Error-variant coverage for unknown token (`VaultNotFound`), unknown symbol (`TokenNotFound`), and empty registry (`RegistryNotFound`).
- `MockVaultLookup` test double added for upstack consumer tests.

## Screenshots

N/A

## Anything else

- The `#![allow(dead_code)]` is forward-dead: the equity-mint, wrapped-equity-recovery, and equity-redemption flows are routed through `VaultLookup` in the immediate upstack PR (RAI-831, branch `refactor/route-vaults-through-vault-lookup`), which removes the allow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783120441&installation_id=125569124&pr_number=736&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F736&signature=70c1c884138d9d944bd4b756bb08d21ed83c86b7f856f2d463180280a182ee56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->