### PR TITLE
feat: make CCTP attestation poll timeout retryable

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1693,6 +1693,17 @@ enum UsdcRebalance {
         initiated_at: DateTime<Utc>,
         burned_at: DateTime<Utc>,
     },
+    // Non-terminal: a Circle attestation poll timed out. The transfer stays
+    // retryable (re-polled by a delayed job) until `retry_deadline_at`, after
+    // which it is marked BridgingFailed for operator reconciliation.
+    AwaitingAttestation {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+        initiated_at: DateTime<Utc>,
+        timed_out_at: DateTime<Utc>,
+        retry_deadline_at: DateTime<Utc>,
+    },
     Attested {
         direction: RebalanceDirection,
         amount: Usdc,
@@ -1800,6 +1811,9 @@ enum UsdcRebalanceCommand {
 
     // Bridging commands
     InitiateBridging { burn_tx: TxHash },
+    // Records that attestation polling timed out, moving Bridging ->
+    // AwaitingAttestation with the deadline beyond which retries stop.
+    TimeoutAttestation { retry_deadline_at: DateTime<Utc> },
     ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: u64, mint_scan_from_block: u64 },
     ConfirmBridging { mint_tx: TxHash, amount_received: Usdc, fee_collected: Usdc },
     FailBridging { reason: String },
@@ -1839,6 +1853,11 @@ enum UsdcRebalanceEvent {
 
     // Bridging events (cctp_nonce comes from attestation, not burn tx)
     BridgingInitiated { burn_tx_hash: TxHash, burned_at: DateTime<Utc> },
+    AttestationTimedOut {
+        burn_tx_hash: TxHash,
+        retry_deadline_at: DateTime<Utc>,
+        timed_out_at: DateTime<Utc>,
+    },
     BridgeAttestationReceived {
         attestation: Vec<u8>,
         cctp_nonce: u64,
@@ -1907,6 +1926,28 @@ enum BridgeStage { Burn, Attestation, Mint }
   logs
 - Attestation must be retrieved by polling Circle's REST API (~13 sec finality,
   no websocket option available)
+- **Retryable attestation timeout**: an attestation poll timeout is recoverable,
+  not a hard failure. `Bridging` moves to `AwaitingAttestation` (via
+  `TimeoutAttestation`) and a delayed job re-polls until the attestation arrives
+  or `retry_deadline_at` passes (`attestation_retry_deadline_secs`, a required
+  config field, default 24h). On deadline elapse the transfer is marked
+  `BridgingFailed` for operator reconciliation. The deadline is a soft bound:
+  checked between polls, so it can overshoot by up to one poll window plus the
+  redrive delay. Structural failures detected _after_ a `complete` attestation
+  is fetched (e.g. an all-zero placeholder nonce) fail the bridge immediately.
+  Failures _within_ the poll loop (HTTP errors, a still-`pending` or malformed
+  `complete` response) are retried and, once the per-poll attempts exhaust,
+  surface as the same retryable timeout -- so a malformed response is bounded by
+  the deadline rather than failing fast. (Failing fast on a definitively
+  malformed `complete` response is a tracked follow-up.)
+- **Post-attestation re-poll retries until success (no deadline)**: once
+  `BridgeAttestationReceived` is recorded (`Attested`), the attestation is
+  permanently retrievable from Circle. The mint needs the full message envelope,
+  which the aggregate does not persist, so resuming from `Attested` re-polls
+  Circle; a timeout there retries until success rather than failing, because the
+  USDC is already burned and bounding it would strand recoverable funds. The
+  `attestation_retry_deadline` bounds only the `AwaitingAttestation` wait (where
+  the attestation may never arrive).
 - Bridge mint transaction requires valid attestation
 - Bridge mint transaction must be confirmed before destination deposit
 - A `receiveMessage()` revert because the CCTP nonce was already used is
@@ -2469,6 +2510,9 @@ Some failure scenarios may leave assets in states requiring manual intervention:
    - USDC burned on source chain (BridgingInitiated)
    - Attestation retrieval fails or mint transaction repeatedly fails
    - USDC is neither on source nor destination chain
+   - Attestation poll _timeouts_ are retried automatically until
+     `attestation_retry_deadline_secs`; manual reconciliation is only needed
+     after the deadline elapses (BridgingFailed) or on a hard mint failure
    - **Resolution**: Retry attestation fetching or mint transaction with
      extended timeout
 

--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -50,6 +50,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 [rebalancing]
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
+attestation_retry_deadline_secs = 86400
 
 [rebalancing.usdc]
 mode = "enabled"

--- a/config/staging/st0x-hedge.toml
+++ b/config/staging/st0x-hedge.toml
@@ -49,6 +49,7 @@ redemption_wallet = "0x1c66D6708914C40239D54919320b4C48cAE3D1A9"
 [rebalancing]
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
+attestation_retry_deadline_secs = 86400
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "disabled" }
 

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1839,6 +1839,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [wallet]
             kind = "private-key"
@@ -1948,6 +1949,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [wallet]
             kind = "private-key"
@@ -2155,6 +2157,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [rebalancing.equity]
             target = "0.5"
@@ -2215,6 +2218,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [rebalancing.equity]
             target = "0.5"
@@ -2277,6 +2281,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [rebalancing.equity]
             target = "0.5"
@@ -2623,6 +2628,7 @@ mod tests {
             [rebalancing]
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [wallet]
             kind = "private-key"

--- a/crates/config/src/rebalancing.rs
+++ b/crates/config/src/rebalancing.rs
@@ -28,6 +28,8 @@ pub enum RebalancingCtxError {
     ZeroTransferTimeout,
     #[error("rebalancing transfer_attempt_timeout_secs must be non-zero")]
     ZeroTransferAttemptTimeout,
+    #[error("rebalancing attestation_retry_deadline_secs must be non-zero")]
+    ZeroAttestationRetryDeadline,
     #[error("invalid wallet config: {0}")]
     WalletConfig(#[from] toml::de::Error),
     #[error(transparent)]
@@ -58,6 +60,16 @@ pub struct RebalancingConfig {
     /// retries rather than wedging forever. Distinct from
     /// `transfer_timeout_secs`, which is the whole-transfer stall reaper.
     pub transfer_attempt_timeout_secs: u64,
+    /// How long to keep retrying Circle attestation polling after the first
+    /// poll times out before giving up and marking the bridge failed.
+    ///
+    /// This is a soft bound: the deadline is checked between redrive attempts,
+    /// not mid-poll. An in-flight poll that started before the deadline runs to
+    /// completion, so the effective cutoff is the first redrive at or after the
+    /// deadline -- up to one poll window plus the redrive delay past this value.
+    /// At the production default (24h) the overshoot is negligible; set with
+    /// that granularity in mind, not as a hard millisecond cutoff.
+    pub attestation_retry_deadline_secs: u64,
 }
 
 /// Runtime configuration for rebalancing operations.
@@ -74,6 +86,7 @@ pub struct RebalancingCtx {
     /// attempt (hung-RPC backstop). See
     /// [`RebalancingConfig::transfer_attempt_timeout_secs`].
     pub transfer_attempt_timeout: Duration,
+    pub attestation_retry_deadline: Duration,
     /// Circle attestation/fee API base URL (test-only override).
     #[cfg(feature = "test-support")]
     pub circle_api_base: String,
@@ -92,6 +105,9 @@ impl RebalancingCtx {
         if config.transfer_timeout_secs == 0 {
             return Err(RebalancingCtxError::ZeroTransferTimeout);
         }
+        if config.attestation_retry_deadline_secs == 0 {
+            return Err(RebalancingCtxError::ZeroAttestationRetryDeadline);
+        }
 
         if config.transfer_attempt_timeout_secs == 0 {
             return Err(RebalancingCtxError::ZeroTransferAttemptTimeout);
@@ -109,6 +125,7 @@ impl RebalancingCtx {
             usdc,
             transfer_timeout: Duration::from_secs(config.transfer_timeout_secs),
             transfer_attempt_timeout: Duration::from_secs(config.transfer_attempt_timeout_secs),
+            attestation_retry_deadline: Duration::from_secs(config.attestation_retry_deadline_secs),
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -132,12 +149,15 @@ impl RebalancingCtx {
         usdc: Option<ImbalanceThreshold>,
         #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
         #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
+        #[builder(default = Duration::from_secs(24 * 60 * 60))]
+        attestation_retry_deadline: Duration,
     ) -> Self {
         Self {
             equity,
             usdc,
             transfer_timeout,
             transfer_attempt_timeout,
+            attestation_retry_deadline,
             #[cfg(feature = "test-support")]
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             #[cfg(feature = "test-support")]
@@ -159,6 +179,8 @@ impl RebalancingCtx {
         usdc: UsdcRebalancing,
         #[builder(default = Duration::from_secs(30 * 60))] transfer_timeout: Duration,
         #[builder(default = Duration::from_secs(60 * 60))] transfer_attempt_timeout: Duration,
+        #[builder(default = Duration::from_secs(24 * 60 * 60))]
+        attestation_retry_deadline: Duration,
     ) -> Self {
         let usdc = match usdc {
             UsdcRebalancing::Enabled { target, deviation } => {
@@ -172,6 +194,7 @@ impl RebalancingCtx {
             usdc,
             transfer_timeout,
             transfer_attempt_timeout,
+            attestation_retry_deadline,
             circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
             token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
             message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
@@ -218,6 +241,7 @@ mod tests {
         r#"
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 86400
 
             [equity]
             target = "0.5"
@@ -244,6 +268,7 @@ mod tests {
         assert!(deviation.eq(float!(0.3)).unwrap());
         assert_eq!(config.transfer_timeout_secs, 1800);
         assert_eq!(config.transfer_attempt_timeout_secs, 3600);
+        assert_eq!(config.attestation_retry_deadline_secs, 86400);
     }
 
     #[test]
@@ -252,6 +277,7 @@ mod tests {
             r#"
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 7200
 
             [equity]
             target = "0.6"
@@ -273,6 +299,7 @@ mod tests {
         };
         assert!(target.eq(float!(0.4)).unwrap());
         assert!(deviation.eq(float!(0.15)).unwrap());
+        assert_eq!(config.attestation_retry_deadline_secs, 7200);
     }
 
     #[test]
@@ -296,9 +323,60 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_missing_attestation_retry_deadline_secs_fails() {
+        let toml_str = r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#;
+
+        let error = toml::from_str::<RebalancingConfig>(toml_str).unwrap_err();
+        assert!(
+            error.message().contains("attestation_retry_deadline_secs"),
+            "Expected missing attestation_retry_deadline_secs error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn zero_attestation_retry_deadline_secs_fails_validation() {
+        let config: RebalancingConfig = toml::from_str(
+            r#"
+            transfer_timeout_secs = 1800
+            transfer_attempt_timeout_secs = 3600
+            attestation_retry_deadline_secs = 0
+
+            [equity]
+            target = "0.5"
+            deviation = "0.2"
+
+            [usdc]
+            mode = "enabled"
+            target = "0.5"
+            deviation = "0.3"
+        "#,
+        )
+        .unwrap();
+
+        let error = RebalancingCtx::new(&config).unwrap_err();
+        assert!(matches!(
+            error,
+            RebalancingCtxError::ZeroAttestationRetryDeadline
+        ));
+    }
+
+    #[test]
     fn deserialize_missing_equity_fails() {
         let toml_str = r#"
             transfer_timeout_secs = 1800
+            attestation_retry_deadline_secs = 86400
 
             [usdc]
             mode = "enabled"
@@ -317,6 +395,7 @@ mod tests {
     fn deserialize_missing_usdc_fails() {
         let toml_str = r#"
             transfer_timeout_secs = 1800
+            attestation_retry_deadline_secs = 86400
 
             [equity]
             target = "0.5"
@@ -358,6 +437,7 @@ mod tests {
             r#"
             transfer_timeout_secs = 1800
             transfer_attempt_timeout_secs = 0
+            attestation_retry_deadline_secs = 86400
 
             [equity]
             target = "0.5"

--- a/example.config.toml
+++ b/example.config.toml
@@ -59,6 +59,9 @@ transfer_timeout_secs = 1800
 # (CCTP attestation + Alpaca deposit polling); only trips on a true hang.
 # 3600 = 60 minutes.
 transfer_attempt_timeout_secs = 3600
+# CCTP attestation polling timeouts stay retryable until this deadline.
+# 86400 = 24 hours.
+attestation_retry_deadline_secs = 86400
 equity = { target = 0.5, deviation = 0.2 }
 usdc = { mode = "enabled", target = 0.5, deviation = 0.3 }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -265,6 +265,8 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         .build(())
         .await?;
 
+    let attestation_retry_deadline = ctx.rebalancing_ctx()?.attestation_retry_deadline;
+
     let rebalance_manager = CrossVenueCashTransfer::new(
         alpaca_broker,
         alpaca_wallet,
@@ -273,6 +275,7 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         usdc_store,
         owner,
         RaindexVaultId(usdc_vault_id),
+        attestation_retry_deadline,
     );
 
     writeln!(stdout, "   Transfer may take several minutes...")?;

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -830,6 +830,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             .cloned()
             .collect();
 
+        let transfer_usdc_to_hedging_queue = deps.schedulers.transfer_usdc_to_hedging.clone();
+        let transfer_usdc_to_market_making_queue =
+            deps.schedulers.transfer_usdc_to_market_making.clone();
+
         let rebalancing_service = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
                 equity: rebalancing_ctx.equity,
@@ -946,10 +950,12 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let transfer_usdc_to_hedging_ctx = Arc::new(TransferUsdcToHedgingCtx {
             transfer: spawned.resume_base_to_alpaca,
             timeout: rebalancing_ctx.transfer_attempt_timeout,
+            job_queue: transfer_usdc_to_hedging_queue,
         });
 
         let transfer_usdc_to_market_making_ctx = Arc::new(TransferUsdcToMarketMakingCtx {
             transfer: spawned.resume_alpaca_to_base,
+            job_queue: transfer_usdc_to_market_making_queue,
         });
 
         Ok(RebalancingInfrastructure {

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -3,6 +3,7 @@
 use alloy::primitives::Address;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -67,6 +68,7 @@ pub(crate) struct RebalancerServices<Chain: Wallet> {
     raindex: Arc<RaindexService<Chain>>,
     tokenizer: Arc<dyn Tokenizer>,
     wrapper: Arc<WrapperService<Chain>>,
+    attestation_retry_deadline: Duration,
 }
 
 impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
@@ -85,11 +87,8 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         raindex: Arc<RaindexService<Chain>>,
         tokenizer: Arc<dyn Tokenizer>,
     ) -> Result<Self, SpawnRebalancerError> {
-        // ctx is only consumed behind #[cfg(feature = "test-support")]
-        #[cfg(not(feature = "test-support"))]
-        let _ = ctx;
-
         let broker = Arc::new(AlpacaBrokerApi::try_from_ctx(broker_auth).await?);
+        let attestation_retry_deadline = ctx.attestation_retry_deadline;
 
         let cctp = Arc::new(
             CctpBridge::try_from_ctx(CctpCtx {
@@ -116,6 +115,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             raindex,
             tokenizer,
             wrapper,
+            attestation_retry_deadline,
         })
     }
 
@@ -149,6 +149,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             frameworks.usdc,
             market_maker_wallet,
             usdc_vault_id,
+            self.attestation_retry_deadline,
         ));
 
         let resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca> = usdc.clone();
@@ -377,6 +378,7 @@ mod tests {
             raindex,
             tokenizer: tokenization,
             wrapper,
+            attestation_retry_deadline: rebalancing_ctx.attestation_retry_deadline,
         };
 
         (services, rebalancing_ctx)

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -167,6 +167,7 @@ impl UsdcRebalanceStage {
             // BridgingInitiated, so they emit no distinct progress stage.
             WithdrawalSubmitting { .. }
             | BridgingSubmitting { .. }
+            | AttestationTimedOut { .. }
             | ConversionConfirmed { .. }
             | ConversionFailed { .. }
             | WithdrawalFailed { .. }
@@ -695,7 +696,9 @@ impl RebalancingService {
             // burn. Detailed stage tracking starts at the subsequent Initiated /
             // BridgingInitiated; the inventory's active-rebalance claim is set by
             // the caller on this (first non-terminal) event, so nothing to do here.
-            WithdrawalSubmitting { .. } | BridgingSubmitting { .. } => {}
+            WithdrawalSubmitting { .. }
+            | BridgingSubmitting { .. }
+            | AttestationTimedOut { .. } => {}
             // Withdrawal failure is always pre-burn -> reconcile to source.
             WithdrawalFailed { .. } => {
                 self.cancel_tracked_usdc_rebalance(id).await?;

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -22,14 +22,17 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tracing::warn;
 
 use st0x_evm::Wallet;
 use st0x_finance::Usdc;
 
 use super::UsdcTransferError;
 use super::manager::CrossVenueCashTransfer;
-use crate::conductor::job::{Job, JobQueue, Label};
+use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::usdc_rebalance::UsdcRebalanceId;
+
+const ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 
 /// Apalis queue type for [`TransferUsdcToHedging`].
 pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
@@ -95,6 +98,7 @@ pub(crate) struct TransferUsdcToHedgingCtx {
     /// a hung RPC fails the attempt (and retries) instead of wedging the
     /// single-concurrency worker forever.
     pub(crate) timeout: Duration,
+    pub(crate) job_queue: TransferUsdcToHedgingJobQueue,
 }
 
 /// Errors emitted by [`TransferUsdcToHedging::perform`].
@@ -107,6 +111,8 @@ pub(crate) enum TransferUsdcToHedgingJobError {
         id: UsdcRebalanceId,
         timeout: Duration,
     },
+    #[error(transparent)]
+    Enqueue(#[from] QueuePushError),
 }
 
 /// Apalis job payload. The `id` is generated at enqueue time so retries
@@ -132,28 +138,180 @@ impl Job<TransferUsdcToHedgingCtx> for TransferUsdcToHedging {
     }
 
     async fn perform(&self, ctx: &TransferUsdcToHedgingCtx) -> Result<Self::Output, Self::Error> {
+        // Per-attempt timeout wrapper (hedging only): abort a hung resume so the
+        // attempt fails and retries instead of wedging the single-concurrency
+        // worker. The inner result is then classified for redrive/terminal
+        // handling.
         let resume = ctx.transfer.resume_base_to_alpaca(&self.id, self.amount);
+        let result = match tokio::time::timeout(ctx.timeout, resume).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                return Err(TransferUsdcToHedgingJobError::Timeout {
+                    id: self.id.clone(),
+                    timeout: ctx.timeout,
+                });
+            }
+        };
 
-        match tokio::time::timeout(ctx.timeout, resume).await {
-            Ok(result) => Ok(result?),
-            Err(_elapsed) => Err(TransferUsdcToHedgingJobError::Timeout {
-                id: self.id.clone(),
-                timeout: ctx.timeout,
-            }),
+        match result {
+            Ok(()) => {}
+            Err(UsdcTransferError::AttestationTimedOut { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    delay = ?ATTESTATION_REDRIVE_DELAY,
+                    "Rescheduling Base->Alpaca USDC transfer after attestation timeout"
+                );
+                let mut job_queue = ctx.job_queue.clone();
+                job_queue
+                    .push_with_delay(self.clone(), ATTESTATION_REDRIVE_DELAY)
+                    .await?;
+            }
+            Err(UsdcTransferError::AttestationRetryDeadlineElapsed { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "Base->Alpaca USDC transfer attestation retry deadline elapsed; \
+                     bridge marked failed for operator reconciliation"
+                );
+            }
+            Err(UsdcTransferError::PreviouslyFailedAggregate { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "Base->Alpaca USDC transfer already in a terminal failed state; \
+                     nothing to redrive, leaving for operator reconciliation"
+                );
+            }
+            Err(error) => return Err(error.into()),
         }
+
+        Ok(())
+    }
+}
+
+/// Dependencies the Alpaca->Base job needs. Symmetric to
+/// [`TransferUsdcToHedgingCtx`].
+pub(crate) struct TransferUsdcToMarketMakingCtx {
+    pub(crate) transfer: Arc<dyn ResumeAlpacaToBase>,
+    pub(crate) job_queue: TransferUsdcToMarketMakingJobQueue,
+}
+
+/// Errors emitted by [`TransferUsdcToMarketMaking::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum TransferUsdcToMarketMakingJobError {
+    #[error(transparent)]
+    Transfer(#[from] UsdcTransferError),
+    #[error(transparent)]
+    Enqueue(#[from] QueuePushError),
+}
+
+/// Apalis job payload for the Alpaca->Base direction. The `id` is generated
+/// at enqueue time so retries resume the same aggregate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TransferUsdcToMarketMaking {
+    pub(crate) id: UsdcRebalanceId,
+    pub(crate) amount: Usdc,
+}
+
+impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
+    type Output = ();
+    type Error = TransferUsdcToMarketMakingJobError;
+
+    const WORKER_NAME: &'static str = "transfer-usdc-to-market-making-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::TransferUsdcToMarketMaking;
+
+    fn label(&self) -> Label {
+        Label::new(format!("TransferUsdcToMarketMaking:{}", self.id))
+    }
+
+    async fn perform(
+        &self,
+        ctx: &TransferUsdcToMarketMakingCtx,
+    ) -> Result<Self::Output, Self::Error> {
+        match ctx
+            .transfer
+            .resume_alpaca_to_base(&self.id, self.amount)
+            .await
+        {
+            Ok(()) => {}
+            Err(UsdcTransferError::AttestationTimedOut { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    delay = ?ATTESTATION_REDRIVE_DELAY,
+                    "Rescheduling Alpaca->Base USDC transfer after attestation timeout"
+                );
+                let mut job_queue = ctx.job_queue.clone();
+                job_queue
+                    .push_with_delay(self.clone(), ATTESTATION_REDRIVE_DELAY)
+                    .await?;
+            }
+            Err(UsdcTransferError::AttestationRetryDeadlineElapsed { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "Alpaca->Base USDC transfer attestation retry deadline elapsed; \
+                     bridge marked failed for operator reconciliation"
+                );
+            }
+            Err(UsdcTransferError::PreviouslyFailedAggregate { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    "Alpaca->Base USDC transfer already in a terminal failed state; \
+                     nothing to redrive, leaving for operator reconciliation"
+                );
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+    use sqlx::SqlitePool;
     use uuid::Uuid;
 
     use st0x_float_macro::float;
 
     use super::*;
+    use crate::conductor::setup_apalis_tables;
 
-    /// Models a hung RPC inside the transfer: the resume future never
-    /// completes within the configured per-attempt timeout.
+    struct TimeoutBaseToAlpaca;
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for TimeoutBaseToAlpaca {
+        async fn resume_base_to_alpaca(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::AttestationTimedOut { id: id.clone() })
+        }
+    }
+
+    struct TimeoutAlpacaToBase;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for TimeoutAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::AttestationTimedOut { id: id.clone() })
+        }
+    }
+
+    /// Models a hung RPC inside the transfer: the resume future never completes
+    /// within the configured per-attempt timeout.
     struct HangingResume;
 
     #[async_trait]
@@ -168,11 +326,135 @@ mod tests {
         }
     }
 
+    /// Terminal outcomes a resume can report that the job must treat as a clean
+    /// `Ok(())` (no redrive, no error) because the aggregate is already in a
+    /// durable terminal state needing only operator reconciliation.
+    #[derive(Clone, Copy)]
+    enum TerminalOutcome {
+        DeadlineElapsed,
+        PreviouslyFailed,
+    }
+
+    impl TerminalOutcome {
+        fn into_error(self, id: &UsdcRebalanceId) -> UsdcTransferError {
+            match self {
+                Self::DeadlineElapsed => {
+                    UsdcTransferError::AttestationRetryDeadlineElapsed { id: id.clone() }
+                }
+                Self::PreviouslyFailed => {
+                    UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() }
+                }
+            }
+        }
+    }
+
+    struct TerminalBaseToAlpaca(TerminalOutcome);
+
+    #[async_trait]
+    impl ResumeBaseToAlpaca for TerminalBaseToAlpaca {
+        async fn resume_base_to_alpaca(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(self.0.into_error(id))
+        }
+    }
+
+    struct TerminalAlpacaToBase(TerminalOutcome);
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for TerminalAlpacaToBase {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(self.0.into_error(id))
+        }
+    }
+
+    async fn setup_queue_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        setup_apalis_tables(&pool).await.unwrap();
+        pool
+    }
+
+    async fn pending_job_count<Task>(pool: &SqlitePool) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs \
+             WHERE job_type = ? AND status = 'Pending'",
+        )
+        .bind(std::any::type_name::<Task>())
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    /// Returns the serialized payload (apalis stores it as a `serde_json` BLOB
+    /// via `JsonCodec`) and the `run_at` unix-second timestamp of the single
+    /// pending row of the given task type.
+    async fn pending_job_row<Task>(pool: &SqlitePool) -> (Vec<u8>, i64) {
+        sqlx::query_as(
+            "SELECT job, run_at FROM Jobs \
+             WHERE job_type = ? AND status = 'Pending'",
+        )
+        .bind(std::any::type_name::<Task>())
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn hedging_job_reschedules_attestation_timeout() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(TimeoutBaseToAlpaca),
+            timeout: Duration::from_secs(3600),
+            job_queue,
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            1,
+            "attestation timeout should enqueue a delayed replacement job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToHedging>(&pool).await;
+        let rescheduled: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + 55 && run_at <= after + 65,
+            "redrive must be delayed by ~{ATTESTATION_REDRIVE_DELAY:?} -- neither immediate nor \
+             excessive: run_at={run_at} before={before} after={after}"
+        );
+    }
+
     #[tokio::test]
     async fn perform_times_out_when_resume_hangs() {
+        let pool = setup_queue_pool().await;
         let ctx = TransferUsdcToHedgingCtx {
             transfer: Arc::new(HangingResume),
             timeout: Duration::from_millis(50),
+            job_queue: TransferUsdcToHedgingJobQueue::new(&pool),
         };
         let job = TransferUsdcToHedging {
             id: UsdcRebalanceId(Uuid::new_v4()),
@@ -185,6 +467,146 @@ mod tests {
             error,
             TransferUsdcToHedgingJobError::Timeout { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn market_making_job_reschedules_attestation_timeout() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(TimeoutAlpacaToBase),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "attestation timeout should enqueue a delayed replacement job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + 55 && run_at <= after + 65,
+            "redrive must be delayed by ~{ATTESTATION_REDRIVE_DELAY:?} -- neither immediate nor \
+             excessive: run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hedging_job_treats_deadline_elapsed_as_clean_terminal() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(TerminalBaseToAlpaca(TerminalOutcome::DeadlineElapsed)),
+            timeout: Duration::from_secs(3600),
+            job_queue,
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("deadline-elapsed must be a clean terminal outcome, not a job error");
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "a deadline-elapsed transfer is terminally failed; the job must not redrive it"
+        );
+    }
+
+    #[tokio::test]
+    async fn hedging_job_treats_previously_failed_as_clean_terminal() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToHedgingJobQueue::new(&pool);
+        let ctx = TransferUsdcToHedgingCtx {
+            transfer: Arc::new(TerminalBaseToAlpaca(TerminalOutcome::PreviouslyFailed)),
+            timeout: Duration::from_secs(3600),
+            job_queue,
+        };
+        let job = TransferUsdcToHedging {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        job.perform(&ctx).await.expect(
+            "a previously-failed aggregate must be a clean terminal outcome, not a job error",
+        );
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToHedging>(&pool).await,
+            0,
+            "a previously-failed transfer must not be redriven and must not trip the breaker"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_job_treats_deadline_elapsed_as_clean_terminal() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::DeadlineElapsed)),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        job.perform(&ctx)
+            .await
+            .expect("deadline-elapsed must be a clean terminal outcome, not a job error");
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "a deadline-elapsed transfer is terminally failed; the job must not redrive it"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_making_job_treats_previously_failed_as_clean_terminal() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(TerminalAlpacaToBase(TerminalOutcome::PreviouslyFailed)),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        job.perform(&ctx).await.expect(
+            "a previously-failed aggregate must be a clean terminal outcome, not a job error",
+        );
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            0,
+            "a previously-failed transfer must not be redriven and must not trip the breaker"
+        );
     }
 
     /// Records the resume call and returns a configurable outcome, so the
@@ -214,12 +636,14 @@ mod tests {
 
     #[tokio::test]
     async fn market_making_perform_forwards_id_and_amount_to_resume() {
+        let pool = setup_queue_pool().await;
         let stub = Arc::new(RecordingResume {
             fail: false,
             captured: std::sync::Mutex::new(None),
         });
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: stub.clone(),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
         };
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = Usdc::new(float!(250));
@@ -240,11 +664,13 @@ mod tests {
 
     #[tokio::test]
     async fn market_making_perform_returns_ok_on_successful_resume() {
+        let pool = setup_queue_pool().await;
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(RecordingResume {
                 fail: false,
                 captured: std::sync::Mutex::new(None),
             }),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
         };
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
@@ -256,11 +682,13 @@ mod tests {
 
     #[tokio::test]
     async fn market_making_perform_propagates_resume_failure() {
+        let pool = setup_queue_pool().await;
         let ctx = TransferUsdcToMarketMakingCtx {
             transfer: Arc::new(RecordingResume {
                 fail: true,
                 captured: std::sync::Mutex::new(None),
             }),
+            job_queue: TransferUsdcToMarketMakingJobQueue::new(&pool),
         };
         let job = TransferUsdcToMarketMaking {
             id: UsdcRebalanceId(Uuid::new_v4()),
@@ -277,51 +705,5 @@ mod tests {
             matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
             "perform must propagate the resume failure as a Transfer error, got {error:?}",
         );
-    }
-}
-
-/// Dependencies the Alpaca->Base job needs. Symmetric to
-/// [`TransferUsdcToHedgingCtx`].
-pub(crate) struct TransferUsdcToMarketMakingCtx {
-    pub(crate) transfer: Arc<dyn ResumeAlpacaToBase>,
-}
-
-/// Errors emitted by [`TransferUsdcToMarketMaking::perform`].
-#[derive(Debug, Error)]
-pub(crate) enum TransferUsdcToMarketMakingJobError {
-    #[error(transparent)]
-    Transfer(#[from] UsdcTransferError),
-}
-
-/// Apalis job payload for the Alpaca->Base direction. The `id` is generated
-/// at enqueue time so retries resume the same aggregate.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct TransferUsdcToMarketMaking {
-    pub(crate) id: UsdcRebalanceId,
-    pub(crate) amount: Usdc,
-}
-
-impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
-    type Output = ();
-    type Error = TransferUsdcToMarketMakingJobError;
-
-    const WORKER_NAME: &'static str = "transfer-usdc-to-market-making-worker";
-
-    #[cfg(any(test, feature = "test-support"))]
-    const JOB_KIND: crate::conductor::job::JobKind =
-        crate::conductor::job::JobKind::TransferUsdcToMarketMaking;
-
-    fn label(&self) -> Label {
-        Label::new(format!("TransferUsdcToMarketMaking:{}", self.id))
-    }
-
-    async fn perform(
-        &self,
-        ctx: &TransferUsdcToMarketMakingCtx,
-    ) -> Result<Self::Output, Self::Error> {
-        ctx.transfer
-            .resume_alpaca_to_base(&self.id, self.amount)
-            .await?;
-        Ok(())
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -5,12 +5,14 @@
 //! execute USDC transfers between Alpaca and Base.
 
 use alloy::primitives::{Address, TxHash, U256};
+use chrono::{DateTime, Utc};
+use rain_math_float::Float;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{info, instrument, warn};
 use uuid::Uuid;
 
-use rain_math_float::Float;
-use st0x_bridge::cctp::{AttestationResponse, CctpBridge};
+use st0x_bridge::cctp::{AttestationResponse, CctpBridge, CctpError};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
@@ -41,6 +43,12 @@ pub(crate) struct CrossVenueCashTransfer<Chain: Wallet> {
     cqrs: Arc<Store<UsdcRebalance>>,
     market_maker_wallet: Address,
     vault_id: RaindexVaultId,
+    attestation_retry_deadline: Duration,
+}
+
+enum AttestationPollOutcome {
+    Received(AttestationResponse),
+    TimedOut,
 }
 
 impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
@@ -52,6 +60,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         cqrs: Arc<Store<UsdcRebalance>>,
         market_maker_wallet: Address,
         vault_id: RaindexVaultId,
+        attestation_retry_deadline: Duration,
     ) -> Self {
         Self {
             alpaca_broker,
@@ -61,7 +70,175 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             cqrs,
             market_maker_wallet,
             vault_id,
+            attestation_retry_deadline,
         }
+    }
+
+    fn attestation_retry_deadline_at(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<DateTime<Utc>, UsdcTransferError> {
+        let duration =
+            chrono::Duration::from_std(self.attestation_retry_deadline).map_err(|_| {
+                UsdcTransferError::AttestationRetryDeadlineOverflow {
+                    id: id.clone(),
+                    retry_deadline: self.attestation_retry_deadline,
+                }
+            })?;
+
+        Utc::now().checked_add_signed(duration).ok_or_else(|| {
+            UsdcTransferError::AttestationRetryDeadlineOverflow {
+                id: id.clone(),
+                retry_deadline: self.attestation_retry_deadline,
+            }
+        })
+    }
+
+    async fn record_attestation_timeout(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<(), UsdcTransferError> {
+        let retry_deadline_at = self.attestation_retry_deadline_at(id)?;
+
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::TimeoutAttestation { retry_deadline_at },
+            )
+            .await?;
+
+        warn!(
+            target: "rebalance",
+            %id,
+            %retry_deadline_at,
+            "Circle attestation poll timed out; leaving USDC rebalance retryable until the deadline"
+        );
+
+        Ok(())
+    }
+
+    /// Polls Circle for the attestation, classifying the result.
+    ///
+    /// A `CctpError::AttestationTimeout` is a recoverable, retryable condition
+    /// (the attestation simply has not arrived yet) and maps to
+    /// [`AttestationPollOutcome::TimedOut`]. Any other `CctpError` is a hard
+    /// failure (malformed response, placeholder nonce, transport error): the
+    /// USDC is already burned, so the aggregate is moved to `BridgingFailed`
+    /// via `FailBridging` -- surfacing a durable terminal state for operator
+    /// reconciliation rather than wedging the rebalance in a non-terminal state
+    /// while the worker exhausts retries and fail-stops.
+    async fn poll_cctp_attestation(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: BridgeDirection,
+        burn_tx: TxHash,
+    ) -> Result<AttestationPollOutcome, UsdcTransferError> {
+        match self.cctp_bridge.poll_attestation(direction, burn_tx).await {
+            Ok(response) => Ok(AttestationPollOutcome::Received(response)),
+            Err(CctpError::AttestationTimeout { attempts, source }) => {
+                warn!(
+                    target: "rebalance",
+                    attempts,
+                    ?source,
+                    "Circle attestation poll timed out"
+                );
+                Ok(AttestationPollOutcome::TimedOut)
+            }
+            Err(error) => {
+                warn!(target: "rebalance", %id, ?error, "Attestation polling failed");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailBridging {
+                            reason: format!("attestation polling failed: {error}"),
+                        },
+                    )
+                    .await?;
+                Err(UsdcTransferError::Cctp(Box::new(error)))
+            }
+        }
+    }
+
+    /// Polls Circle once, failing the bridge if the retry deadline has already
+    /// elapsed.
+    ///
+    /// The deadline is a soft bound: it is checked here, between redrive
+    /// attempts, not inside the poll. A poll that begins before the deadline
+    /// runs to completion (up to its own internal timeout), so the effective
+    /// cutoff is the first redrive at or after `retry_deadline_at`, which can
+    /// overshoot by one poll window plus the redrive delay. Negligible at the
+    /// production 24h default.
+    async fn poll_cctp_attestation_until_deadline(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: BridgeDirection,
+        burn_tx: TxHash,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> Result<AttestationPollOutcome, UsdcTransferError> {
+        if Utc::now() >= retry_deadline_at {
+            warn!(
+                target: "rebalance",
+                %id,
+                %retry_deadline_at,
+                "Circle attestation retry deadline elapsed"
+            );
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailBridging {
+                        reason: "attestation retry deadline elapsed".to_string(),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::AttestationRetryDeadlineElapsed { id: id.clone() });
+        }
+
+        self.poll_cctp_attestation(id, direction, burn_tx).await
+    }
+
+    async fn record_attestation(
+        &self,
+        id: &UsdcRebalanceId,
+        direction: BridgeDirection,
+        response: &AttestationResponse,
+    ) -> Result<(), UsdcTransferError> {
+        // Capture the destination head before minting so a crash before
+        // `ConfirmBridging` resumes by scanning for the already-submitted mint
+        // instead of re-minting, which reverts on the already-used CCTP nonce.
+        // A lookup failure here is transient (a destination RPC/read hiccup):
+        // the aggregate is still in `Bridging`/`AwaitingAttestation` with no
+        // attestation recorded yet, and both directions have resume entry points
+        // for those states that re-poll the attestation idempotently. So
+        // propagate the error and let the job retry rather than latching a
+        // terminal `FailBridging` and stranding already-burned USDC behind manual
+        // reconciliation.
+        let mint_scan_from_block = match self.cctp_bridge.destination_block(direction).await {
+            Ok(block) => block,
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    ?error,
+                    "Destination head lookup failed; leaving aggregate in \
+                     Bridging/AwaitingAttestation for retry"
+                );
+                return Err(UsdcTransferError::Cctp(Box::new(error)));
+            }
+        };
+
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::ReceiveAttestation {
+                    attestation: response.as_bytes().to_vec(),
+                    cctp_nonce: response.nonce(),
+                    mint_scan_from_block,
+                },
+            )
+            .await?;
+
+        info!(target: "rebalance", "Circle attestation received");
+        Ok(())
     }
 
     /// Converts USD buying power to USDC in the crypto wallet.
@@ -344,6 +521,22 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                     .await
             }
 
+            Some(UsdcRebalance::AwaitingAttestation {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                burn_tx_hash,
+                retry_deadline_at,
+                ..
+            }) => {
+                self.continue_alpaca_to_base_from_awaiting_attestation(
+                    id,
+                    amount,
+                    burn_tx_hash,
+                    retry_deadline_at,
+                )
+                .await
+            }
+
             // `Attested` must NOT route through the `Bridging` path: that re-emits
             // `ReceiveAttestation`, which the aggregate rejects from `Attested`,
             // stranding the already-burned USDC. Reconstruct the mint instead --
@@ -448,6 +641,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                     direction: BaseToAlpaca,
                     ..
                 }
+                | AwaitingAttestation {
+                    direction: BaseToAlpaca,
+                    ..
+                }
                 | Attested {
                     direction: BaseToAlpaca,
                     ..
@@ -549,7 +746,61 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             amount: usdc_to_u256(amount)?,
         };
 
-        let attestation_response = self.poll_attestation(id, &burn_receipt).await?;
+        let attestation_response = match self
+            .poll_cctp_attestation(id, BridgeDirection::EthereumToBase, burn_receipt.tx)
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => {
+                self.record_attestation(id, BridgeDirection::EthereumToBase, &response)
+                    .await?;
+                response
+            }
+            AttestationPollOutcome::TimedOut => {
+                self.record_attestation_timeout(id).await?;
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
+
+        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
+
+        self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
+            .await
+    }
+
+    /// Drives an Alpaca->Base transfer after a previous attestation timeout.
+    /// Success records the delayed attestation and continues; another timeout
+    /// stays retryable without appending another timeout event.
+    async fn continue_alpaca_to_base_from_awaiting_attestation(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+
+        let attestation_response = match self
+            .poll_cctp_attestation_until_deadline(
+                id,
+                BridgeDirection::EthereumToBase,
+                burn_receipt.tx,
+                retry_deadline_at,
+            )
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => {
+                self.record_attestation(id, BridgeDirection::EthereumToBase, &response)
+                    .await?;
+                response
+            }
+            AttestationPollOutcome::TimedOut => {
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
+
         let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
@@ -620,9 +871,15 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
         };
-        let attestation_response = self
-            .poll_circle_attestation(id, BridgeDirection::EthereumToBase, &burn_receipt)
-            .await?;
+        let attestation_response = match self
+            .poll_cctp_attestation(id, BridgeDirection::EthereumToBase, burn_receipt.tx)
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => response,
+            AttestationPollOutcome::TimedOut => {
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
         let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
@@ -675,14 +932,8 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         };
         let burn_receipt = self.execute_cctp_burn(id, burn_amount).await?;
 
-        let attestation_response = self.poll_attestation(id, &burn_receipt).await?;
-
-        // Use the actual minted amount (net of CCTP fee) for vault deposit
-        let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
-
-        self.deposit_to_vault(id, mint_receipt.amount).await?;
-
-        self.confirm_deposit(id).await?;
+        self.continue_alpaca_to_base_from_bridging(id, usdc_amount, burn_receipt.tx)
+            .await?;
 
         info!(target: "rebalance", "Alpaca to Base rebalance completed successfully");
         Ok(())
@@ -812,62 +1063,6 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         info!(target: "rebalance", burn_tx = %burn_receipt.tx, "CCTP burn executed");
         Ok(burn_receipt)
-    }
-
-    #[instrument(target = "rebalance", skip(self, burn_receipt), fields(%id, burn_tx = %burn_receipt.tx), level = tracing::Level::DEBUG)]
-    async fn poll_attestation(
-        &self,
-        id: &UsdcRebalanceId,
-        burn_receipt: &BurnReceipt,
-    ) -> Result<AttestationResponse, UsdcTransferError> {
-        let response = match self
-            .cctp_bridge
-            .poll_attestation(BridgeDirection::EthereumToBase, burn_receipt.tx)
-            .await
-        {
-            Ok(response) => response,
-            Err(error) => {
-                warn!(target: "rebalance", "Attestation polling failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Attestation polling failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
-            }
-        };
-
-        // Capture the destination (Base) head before minting so a crash before
-        // `ConfirmBridging` resumes by scanning for the already-submitted mint
-        // (`continue_alpaca_to_base_from_attested`) instead of re-minting, which
-        // reverts on the already-used CCTP nonce. Fail on a head-lookup error
-        // rather than recording a sentinel: now that AlpacaToBase has a resume
-        // entry point that reads this bound, a sentinel of 0 would scan from
-        // genesis on resume and risk adopting an unrelated mint. A transient
-        // failure here leaves the aggregate in `Bridging`, which resumes safely
-        // by re-polling.
-        let mint_scan_from_block = self
-            .cctp_bridge
-            .destination_block(BridgeDirection::EthereumToBase)
-            .await
-            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
-
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ReceiveAttestation {
-                    attestation: response.as_bytes().to_vec(),
-                    cctp_nonce: response.nonce(),
-                    mint_scan_from_block,
-                },
-            )
-            .await?;
-
-        info!(target: "rebalance", "Circle attestation received");
-        Ok(response)
     }
 
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
@@ -1100,6 +1295,18 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 self.continue_from_bridging(id, amount, burn_tx_hash).await
             }
 
+            Some(UsdcRebalance::AwaitingAttestation {
+                direction,
+                amount,
+                burn_tx_hash,
+                retry_deadline_at,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.continue_from_awaiting_attestation(id, amount, burn_tx_hash, retry_deadline_at)
+                    .await
+            }
+
             Some(UsdcRebalance::Attested {
                 direction,
                 amount,
@@ -1329,32 +1536,59 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
         };
-        let attestation_response = self
-            .poll_circle_attestation(id, BridgeDirection::BaseToEthereum, &burn_receipt)
-            .await?;
-
-        // Capture the destination (Ethereum) head before minting so a crash
-        // before `ConfirmBridging` resumes by scanning for the already-submitted
-        // mint (`continue_from_attested`) instead of re-minting, which reverts on
-        // the already-used CCTP nonce.
-        let mint_scan_from_block = self
-            .cctp_bridge
-            .destination_block(BridgeDirection::BaseToEthereum)
-            .await
-            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
-
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::ReceiveAttestation {
-                    attestation: attestation_response.as_bytes().to_vec(),
-                    cctp_nonce: attestation_response.nonce(),
-                    mint_scan_from_block,
-                },
-            )
-            .await?;
+        let attestation_response = match self
+            .poll_cctp_attestation(id, BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => {
+                self.record_attestation(id, BridgeDirection::BaseToEthereum, &response)
+                    .await?;
+                response
+            }
+            AttestationPollOutcome::TimedOut => {
+                self.record_attestation_timeout(id).await?;
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
 
         info!(target: "rebalance", "Circle attestation received for Base burn");
+        self.mint_and_continue(id, attestation_response).await
+    }
+
+    /// Drives the transfer from `AwaitingAttestation`: re-poll Circle until the
+    /// retry deadline, recording `ReceiveAttestation` only when the attestation
+    /// actually arrives.
+    async fn continue_from_awaiting_attestation(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> Result<(), UsdcTransferError> {
+        let burn_receipt = BurnReceipt {
+            tx: burn_tx_hash,
+            amount: usdc_to_u256(amount)?,
+        };
+
+        let attestation_response = match self
+            .poll_cctp_attestation_until_deadline(
+                id,
+                BridgeDirection::BaseToEthereum,
+                burn_receipt.tx,
+                retry_deadline_at,
+            )
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => {
+                self.record_attestation(id, BridgeDirection::BaseToEthereum, &response)
+                    .await?;
+                response
+            }
+            AttestationPollOutcome::TimedOut => {
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
+
         self.mint_and_continue(id, attestation_response).await
     }
 
@@ -1369,6 +1603,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// aggregate stores the attestation bytes and nonce but not the full message
     /// envelope [`Bridge::mint`] needs) and mints, WITHOUT re-emitting
     /// `ReceiveAttestation` -- which the aggregate rejects from `Attested`.
+    ///
+    /// A re-poll timeout here retries until success (no deadline) by design:
+    /// reaching `Attested` means Circle already issued an attestation once, so a
+    /// re-poll timeout is transient and bounding it would strand already-burned
+    /// USDC. The `attestation_retry_deadline` bounds only the
+    /// `AwaitingAttestation` wait. A hard (non-timeout) poll error still fails
+    /// the bridge -- see [`Self::poll_cctp_attestation`].
     async fn continue_from_attested(
         &self,
         id: &UsdcRebalanceId,
@@ -1427,9 +1668,15 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             tx: burn_tx_hash,
             amount: usdc_to_u256(amount)?,
         };
-        let attestation_response = self
-            .poll_circle_attestation(id, BridgeDirection::BaseToEthereum, &burn_receipt)
-            .await?;
+        let attestation_response = match self
+            .poll_cctp_attestation(id, BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .await?
+        {
+            AttestationPollOutcome::Received(response) => response,
+            AttestationPollOutcome::TimedOut => {
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+        };
         self.mint_and_continue(id, attestation_response).await
     }
 
@@ -1699,39 +1946,6 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         Ok(burn_receipt)
     }
 
-    /// Polls Circle for the attestation of a Base burn. On failure records
-    /// `FailBridging` (valid from both `Bridging` and `Attested`) and returns the
-    /// error. Does NOT emit `ReceiveAttestation` -- the caller records it only on
-    /// the `Bridging` path, where it is valid; the `Attested` resume path must
-    /// not re-emit it.
-    #[instrument(target = "rebalance", skip(self, burn_receipt), fields(%id, burn_tx = %burn_receipt.tx), level = tracing::Level::DEBUG)]
-    async fn poll_circle_attestation(
-        &self,
-        id: &UsdcRebalanceId,
-        direction: BridgeDirection,
-        burn_receipt: &BurnReceipt,
-    ) -> Result<AttestationResponse, UsdcTransferError> {
-        match self
-            .cctp_bridge
-            .poll_attestation(direction, burn_receipt.tx)
-            .await
-        {
-            Ok(response) => Ok(response),
-            Err(error) => {
-                warn!(target: "rebalance", "Attestation polling failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Attestation polling failed: {error}"),
-                        },
-                    )
-                    .await?;
-                Err(UsdcTransferError::Cctp(Box::new(error)))
-            }
-        }
-    }
-
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
     async fn execute_cctp_mint_on_ethereum(
         &self,
@@ -1911,6 +2125,7 @@ mod tests {
     const TEST_VAULT_ID: RaindexVaultId = RaindexVaultId(b256!(
         "0x0000000000000000000000000000000000000000000000000000000000000001"
     ));
+    const TEST_ATTESTATION_RETRY_DEADLINE: Duration = Duration::from_secs(24 * 60 * 60);
 
     async fn create_test_store_instance() -> Arc<Store<UsdcRebalance>> {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
@@ -2491,6 +2706,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -2546,6 +2762,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -2608,6 +2825,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -2664,6 +2882,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -2703,6 +2922,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -2741,6 +2961,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock the conversion order placement (POST)
@@ -2786,6 +3007,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock the conversion order - will be called but CQRS command will fail
@@ -2839,6 +3061,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Order starts as pending
@@ -2883,6 +3106,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Order starts as pending
@@ -2998,6 +3222,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Order starts as pending then gets rejected
@@ -3049,6 +3274,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock order placement to fail with 500 error
@@ -3116,6 +3342,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock conversion order - MUST be called before withdrawal
@@ -3187,6 +3414,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let conversion_mock = server.mock(|when, then| {
@@ -3254,6 +3482,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Order starts as pending
@@ -3328,6 +3557,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock that should NOT be called - if InitiateConversion fails, no order should be placed
@@ -3392,6 +3622,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Mock order placement to fail with API error
@@ -3455,6 +3686,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let _order_mock = create_conversion_order_mock(&server, "1000");
@@ -3508,6 +3740,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Request 1000, but only 999.5 fills due to slippage
@@ -3563,6 +3796,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         (manager, cqrs, anvil)
@@ -3598,6 +3832,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         (manager, cqrs, anvil)
@@ -3646,6 +3881,271 @@ mod tests {
         .await
         .unwrap();
         burn_tx
+    }
+
+    async fn advance_to_awaiting_attestation_base_to_alpaca(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> TxHash {
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000002");
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::TimeoutAttestation { retry_deadline_at },
+        )
+        .await
+        .unwrap();
+
+        burn_tx
+    }
+
+    async fn advance_to_awaiting_attestation_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> TxHash {
+        let burn_tx =
+            fixed_bytes!("0xbbbb000000000000000000000000000000000000000000000000000000000002");
+
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::TimeoutAttestation { retry_deadline_at },
+        )
+        .await
+        .unwrap();
+
+        burn_tx
+    }
+
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_awaiting_attestation_after_deadline_fails_bridging() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let retry_deadline_at = Utc::now() - chrono::Duration::seconds(1);
+        let burn_tx =
+            advance_to_awaiting_attestation_base_to_alpaca(&cqrs, &id, amount, retry_deadline_at)
+                .await;
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UsdcTransferError::AttestationRetryDeadlineElapsed { .. }
+        ));
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::BridgingFailed {
+                    burn_tx_hash: Some(state_burn_tx),
+                    ..
+                } if state_burn_tx == burn_tx
+            ),
+            "Expected BridgingFailed with burn tx after deadline, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_awaiting_attestation_after_deadline_fails_bridging() {
+        let server = MockServer::start();
+        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let retry_deadline_at = Utc::now() - chrono::Duration::seconds(1);
+        let burn_tx =
+            advance_to_awaiting_attestation_alpaca_to_base(&cqrs, &id, amount, retry_deadline_at)
+                .await;
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UsdcTransferError::AttestationRetryDeadlineElapsed { .. }
+        ));
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::BridgingFailed {
+                    burn_tx_hash: Some(state_burn_tx),
+                    ..
+                } if state_burn_tx == burn_tx
+            ),
+            "Expected BridgingFailed with burn tx after deadline, got {state:?}"
+        );
+    }
+
+    /// Mocks Circle's `/v2/messages/` lookup to return a `complete` attestation
+    /// immediately, so a re-poll from `AwaitingAttestation` resolves without the
+    /// 5-minute real-API retry. The message just needs to be >=
+    /// MIN_MESSAGE_LENGTH (44 bytes) for nonce extraction.
+    fn mock_complete_attestation(server: &MockServer) -> httpmock::Mock<'_> {
+        let mut message = vec![0u8; 100];
+        message[43] = 1;
+        let message_hex = format!("0x{}", alloy::hex::encode(&message));
+        let attestation_hex = format!("0x{}", "ab".repeat(65));
+        server.mock(|when, then| {
+            when.method(GET).path_includes("/v2/messages/");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "messages": [{
+                        "status": "complete",
+                        "message": message_hex,
+                        "attestation": attestation_hex,
+                    }]
+                }));
+        })
+    }
+
+    /// Happy path of the feature: resuming from `AwaitingAttestation` while the
+    /// retry deadline is still in the future and the attestation has now
+    /// arrived must record `ReceiveAttestation` (advancing past
+    /// `AwaitingAttestation`) and proceed to mint -- NOT time out again and NOT
+    /// fail on the deadline. The mint then fails in the local test harness, but
+    /// the recorded `cctp_nonce` surviving into the failed state is the proof
+    /// the attestation was received first: a timeout would leave the nonce
+    /// `None` (and the aggregate still in `AwaitingAttestation`).
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_awaiting_attestation_before_deadline_records_attestation() {
+        let server = MockServer::start();
+        let _attestation_mock = mock_complete_attestation(&server);
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let retry_deadline_at = Utc::now() + chrono::Duration::hours(1);
+        let burn_tx =
+            advance_to_awaiting_attestation_base_to_alpaca(&cqrs, &id, amount, retry_deadline_at)
+                .await;
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "attestation arriving before the deadline must record it and proceed to \
+             mint, not time out or fail on the deadline, got: {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                &state,
+                UsdcRebalance::BridgingFailed {
+                    burn_tx_hash: Some(state_burn_tx),
+                    cctp_nonce: Some(_),
+                    ..
+                } if *state_burn_tx == burn_tx
+            ),
+            "the recorded cctp_nonce must survive into the failed state, proving the \
+             attestation was received (a timeout would leave it None), got {state:?}"
+        );
+    }
+
+    /// Symmetric to the Base->Alpaca happy-path resume above, for the
+    /// Alpaca->Base direction.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_alpaca_to_base_from_awaiting_attestation_before_deadline_records_attestation() {
+        let server = MockServer::start();
+        let _attestation_mock = mock_complete_attestation(&server);
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let retry_deadline_at = Utc::now() + chrono::Duration::hours(1);
+        let burn_tx =
+            advance_to_awaiting_attestation_alpaca_to_base(&cqrs, &id, amount, retry_deadline_at)
+                .await;
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "attestation arriving before the deadline must record it and proceed to \
+             mint, not time out or fail on the deadline, got: {error:?}"
+        );
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                &state,
+                UsdcRebalance::BridgingFailed {
+                    burn_tx_hash: Some(state_burn_tx),
+                    cctp_nonce: Some(_),
+                    ..
+                } if *state_burn_tx == burn_tx
+            ),
+            "the recorded cctp_nonce must survive into the failed state, proving the \
+             attestation was received (a timeout would leave it None), got {state:?}"
+        );
     }
 
     /// Drives the aggregate through `Initiate` -> `ConfirmWithdrawal` ->
@@ -3795,26 +4295,9 @@ mod tests {
     async fn resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation() {
         let server = MockServer::start();
 
-        // Return a `complete` attestation for any /v2/messages request so
-        // poll_circle_attestation resolves immediately (no 5-minute real-API
-        // retry). The message just needs to be >= MIN_MESSAGE_LENGTH (44 bytes)
-        // for nonce extraction to succeed -- a mostly-zero 100-byte message.
-        let mut message = vec![0u8; 100];
-        message[43] = 1;
-        let message_hex = format!("0x{}", alloy::hex::encode(&message));
-        let attestation_hex = format!("0x{}", "ab".repeat(65));
-        let _attestation_mock = server.mock(|when, then| {
-            when.method(GET).path_includes("/v2/messages/");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "messages": [{
-                        "status": "complete",
-                        "message": message_hex,
-                        "attestation": attestation_hex,
-                    }]
-                }));
-        });
+        // Return a `complete` attestation immediately so poll_cctp_attestation
+        // resolves without the 5-minute real-API retry.
+        let _attestation_mock = mock_complete_attestation(&server);
 
         let (manager, cqrs, _anvil) =
             make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
@@ -4608,6 +5091,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         // Drive the aggregate to `Attested`, recording the real burn tx and the
@@ -4800,6 +5284,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -4854,6 +5339,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -4975,6 +5461,85 @@ mod tests {
             matches!(final_state, UsdcRebalance::Bridged { .. }),
             "a failed deposit submission must leave the aggregate in `Bridged` for safe \
              retry (no half-recorded deposit), got: {final_state:?}",
+        );
+    }
+
+    /// A destination-head lookup failure inside `record_attestation` is a
+    /// transient RPC error: the attestation has not been recorded yet, so the
+    /// aggregate is still in `Bridging` and resumable. It must NOT latch a
+    /// terminal `BridgingFailed` -- doing so would strand already-burned USDC
+    /// behind manual reconciliation for a momentary destination RPC hiccup.
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn resume_alpaca_to_base_destination_block_failure_stays_bridging() {
+        let server = MockServer::start();
+        let _attestation_mock = mock_complete_attestation(&server);
+        let (manager, cqrs, anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+
+        // Drive to `Bridging` (burn recorded, attestation not yet received) so
+        // the resume re-polls the attestation and then performs the destination
+        // head lookup.
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+
+        // Kill the chain so the post-attestation `destination_block` lookup
+        // fails with a transient RPC error. Attestation polling hits the Circle
+        // HTTP mock, not the chain, so it still resolves.
+        drop(anvil);
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "a destination head lookup failure must surface as a transient Cctp error, \
+             got: {error:?}",
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::Bridging { .. }),
+            "a transient destination head lookup failure must leave the aggregate in \
+             `Bridging` for retry, not latch a terminal `BridgingFailed`, got: {state:?}",
         );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -15,18 +15,19 @@ pub(crate) use job::{
 };
 pub(crate) use manager::{CrossVenueCashTransfer, u256_to_usdc};
 
+use std::time::Duration;
+
 use rain_math_float::FloatError;
 use thiserror::Error;
 
 use st0x_bridge::cctp::CctpError;
 use st0x_event_sorcery::SendError;
 use st0x_execution::{AlpacaBrokerApiError, ClientOrderId, InvalidSharesError, NotPositive};
-use st0x_finance::Usdc;
+use st0x_finance::{Usdc, UsdcConversionError};
 
 use crate::alpaca_wallet::AlpacaWalletError;
 use crate::onchain::raindex::RaindexError;
 use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
-use st0x_finance::UsdcConversionError;
 
 #[derive(Debug, Error)]
 pub(crate) enum UsdcTransferError {
@@ -69,6 +70,24 @@ pub(crate) enum UsdcTransferError {
          required"
     )]
     ResumeWithoutMintScanBound { id: UsdcRebalanceId },
+    #[error(
+        "USDC rebalance {id} attestation polling timed out; retrying until \
+         attestation retry deadline"
+    )]
+    AttestationTimedOut { id: UsdcRebalanceId },
+    #[error(
+        "USDC rebalance {id} attestation retry deadline elapsed; failed for \
+         operator reconciliation"
+    )]
+    AttestationRetryDeadlineElapsed { id: UsdcRebalanceId },
+    #[error(
+        "USDC rebalance {id} attestation retry deadline duration {retry_deadline:?} \
+         cannot be represented as an absolute timestamp"
+    )]
+    AttestationRetryDeadlineOverflow {
+        id: UsdcRebalanceId,
+        retry_deadline: Duration,
+    },
     #[error("USDC rebalance {id} cannot resume: aggregate is in terminal failure state")]
     PreviouslyFailedAggregate { id: UsdcRebalanceId },
     #[error(

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -3,7 +3,7 @@
 //!
 //! # State Flow
 //!
-//! The aggregate progresses through 10 states grouped into three phases:
+//! The aggregate progresses through states grouped into three phases:
 //!
 //! ```text
 //! WITHDRAWAL PHASE:
@@ -15,8 +15,11 @@
 //!                                                                          |
 //!                                                          FailBridging    v
 //!   Bridging --ReceiveAttestation--> Attested --ConfirmBridging--> Bridged
-//!       |                                |                             |
-//!       +----------FailBridging----------+--> BridgingFailed           |
+//!       |              |                 |                             |
+//!       |              +--FailBridging---+--> BridgingFailed           |
+//!       +--TimeoutAttestation--> AwaitingAttestation                   |
+//!                                      |                               |
+//!                                      +--ReceiveAttestation--> Attested
 //!                                                                      |
 //! DEPOSIT PHASE:                                             InitiateDeposit
 //!                                                                      |
@@ -230,7 +233,8 @@ pub(crate) enum UsdcRebalanceCommand {
     BeginBridging { from_block: u64 },
     /// Record the CCTP burn transaction. Valid only from `BridgingSubmitting` state.
     InitiateBridging { burn_tx: TxHash },
-    /// Record the Circle attestation. Valid only from `Bridging` state.
+    /// Record the Circle attestation. Valid from `Bridging` or
+    /// `AwaitingAttestation` state.
     /// The cctp_nonce is extracted from the attested message (not the burn tx, which has placeholder).
     /// `mint_scan_from_block` is the destination chain head captured before the mint,
     /// bounding the crash-safe resume scan that adopts an already-submitted mint.
@@ -239,6 +243,9 @@ pub(crate) enum UsdcRebalanceCommand {
         cctp_nonce: B256,
         mint_scan_from_block: u64,
     },
+    /// Record that Circle attestation polling timed out while the burn remains
+    /// recoverable. Valid only from `Bridging` state.
+    TimeoutAttestation { retry_deadline_at: DateTime<Utc> },
     /// Confirm the CCTP mint transaction. Valid only from `Attested` state.
     /// Includes actual amounts from the MintAndWithdraw event for accurate inventory tracking.
     ConfirmBridging {
@@ -337,6 +344,13 @@ pub(crate) enum UsdcRebalanceEvent {
         mint_scan_from_block: Option<u64>,
         attested_at: DateTime<Utc>,
     },
+    /// Circle attestation polling timed out, but the burn remains recoverable
+    /// until the retry deadline.
+    AttestationTimedOut {
+        burn_tx_hash: TxHash,
+        retry_deadline_at: DateTime<Utc>,
+        timed_out_at: DateTime<Utc>,
+    },
     /// CCTP mint transaction confirmed on destination chain.
     /// Contains actual amount received (after CCTP fees) for accurate inventory tracking.
     Bridged {
@@ -388,6 +402,7 @@ impl DomainEvent for UsdcRebalanceEvent {
             Self::BridgeAttestationReceived { .. } => {
                 "UsdcRebalanceEvent::BridgeAttestationReceived"
             }
+            Self::AttestationTimedOut { .. } => "UsdcRebalanceEvent::AttestationTimedOut",
             Self::Bridged { .. } => "UsdcRebalanceEvent::Bridged",
             Self::BridgingFailed { .. } => "UsdcRebalanceEvent::BridgingFailed",
             Self::DepositInitiated { .. } => "UsdcRebalanceEvent::DepositInitiated",
@@ -483,6 +498,17 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: TxHash,
         initiated_at: DateTime<Utc>,
         burned_at: DateTime<Utc>,
+    },
+    /// CCTP burn has succeeded and Circle attestation has not arrived within
+    /// the per-poll timeout. The burn remains recoverable, so the aggregate is
+    /// non-terminal and the apalis transfer job can retry until the deadline.
+    AwaitingAttestation {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        burn_tx_hash: TxHash,
+        initiated_at: DateTime<Utc>,
+        timed_out_at: DateTime<Utc>,
+        retry_deadline_at: DateTime<Utc>,
     },
     /// Circle attestation has been received, ready for minting on destination chain
     Attested {
@@ -682,42 +708,35 @@ impl UsdcRebalance {
                 direction,
                 amount,
                 initiated_at,
-                burned_at,
+                burned_at: updated_at,
                 ..
-            } => (
-                direction,
-                *amount,
-                UsdcBridgeStatus::Bridging,
-                *initiated_at,
-                *burned_at,
-            ),
-
-            Self::Attested {
+            }
+            | Self::AwaitingAttestation {
                 direction,
                 amount,
                 initiated_at,
-                attested_at,
+                timed_out_at: updated_at,
+                ..
+            }
+            | Self::Attested {
+                direction,
+                amount,
+                initiated_at,
+                attested_at: updated_at,
+                ..
+            }
+            | Self::Bridged {
+                direction,
+                amount_received: amount,
+                initiated_at,
+                minted_at: updated_at,
                 ..
             } => (
                 direction,
                 *amount,
                 UsdcBridgeStatus::Bridging,
                 *initiated_at,
-                *attested_at,
-            ),
-
-            Self::Bridged {
-                direction,
-                amount_received,
-                initiated_at,
-                minted_at,
-                ..
-            } => (
-                direction,
-                *amount_received,
-                UsdcBridgeStatus::Bridging,
-                *initiated_at,
-                *minted_at,
+                *updated_at,
             ),
 
             Self::DepositInitiated {
@@ -795,6 +814,7 @@ impl UsdcRebalance {
             | Self::WithdrawalSubmitting { .. }
             | Self::BridgingSubmitting { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
             | Self::DepositInitiated { .. }
@@ -882,6 +902,7 @@ pub(crate) async fn interrupted_usdc_rebalance_ids(
                'UsdcRebalanceEvent::BridgingSubmitting', \
                'UsdcRebalanceEvent::BridgingInitiated', \
                'UsdcRebalanceEvent::BridgeAttestationReceived', \
+               'UsdcRebalanceEvent::AttestationTimedOut', \
                'UsdcRebalanceEvent::Bridged', \
                'UsdcRebalanceEvent::BridgingFailed', \
                'UsdcRebalanceEvent::DepositInitiated', \
@@ -929,7 +950,9 @@ impl EventSourced for UsdcRebalance {
     // so they rebuild from events. No event upcaster needed: persisted events
     // only ever stored cctp_nonce=null (the nonce bug prevented any successful
     // attestation), which deserializes unchanged into Option<B256>.
-    const SCHEMA_VERSION: u64 = 2;
+    // v3: added the non-terminal AwaitingAttestation state so attestation
+    // timeouts replay as retryable instead of terminal bridge failures.
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1164,6 +1187,13 @@ impl EventSourced for UsdcRebalance {
                     burn_tx_hash,
                     initiated_at,
                     ..
+                }
+                | Self::AwaitingAttestation {
+                    direction,
+                    amount,
+                    burn_tx_hash,
+                    initiated_at,
+                    ..
                 },
             ) => Self::Attested {
                 direction: direction.clone(),
@@ -1174,6 +1204,28 @@ impl EventSourced for UsdcRebalance {
                 mint_scan_from_block: *mint_scan_from_block,
                 initiated_at: *initiated_at,
                 attested_at: *attested_at,
+            },
+
+            (
+                AttestationTimedOut {
+                    burn_tx_hash,
+                    retry_deadline_at,
+                    timed_out_at,
+                },
+                Self::Bridging {
+                    direction,
+                    amount,
+                    burn_tx_hash: state_burn_tx_hash,
+                    initiated_at,
+                    ..
+                },
+            ) if burn_tx_hash == state_burn_tx_hash => Self::AwaitingAttestation {
+                direction: direction.clone(),
+                amount: *amount,
+                burn_tx_hash: *burn_tx_hash,
+                initiated_at: *initiated_at,
+                timed_out_at: *timed_out_at,
+                retry_deadline_at: *retry_deadline_at,
             },
 
             (
@@ -1221,6 +1273,12 @@ impl EventSourced for UsdcRebalance {
                     ..
                 }
                 | Self::Bridging {
+                    direction,
+                    amount,
+                    initiated_at,
+                    ..
+                }
+                | Self::AwaitingAttestation {
                     direction,
                     amount,
                     initiated_at,
@@ -1389,7 +1447,7 @@ impl EventSourced for UsdcRebalance {
                 Err(UsdcRebalanceError::WithdrawalNotConfirmed)
             }
 
-            ReceiveAttestation { .. } | FailBridging { .. } => {
+            ReceiveAttestation { .. } | TimeoutAttestation { .. } | FailBridging { .. } => {
                 Err(UsdcRebalanceError::BridgingNotInitiated)
             }
 
@@ -1435,6 +1493,9 @@ impl EventSourced for UsdcRebalance {
                 cctp_nonce,
                 mint_scan_from_block,
             } => self.transition_receive_attestation(attestation, cctp_nonce, mint_scan_from_block),
+            TimeoutAttestation { retry_deadline_at } => {
+                self.transition_timeout_attestation(retry_deadline_at)
+            }
             ConfirmBridging {
                 mint_tx,
                 amount_received,
@@ -1620,6 +1681,7 @@ impl UsdcRebalance {
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
             | Self::BridgingFailed { .. }
@@ -1644,6 +1706,7 @@ impl UsdcRebalance {
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
             | Self::BridgingFailed { .. }
@@ -1674,6 +1737,7 @@ impl UsdcRebalance {
             }]),
             Self::BridgingSubmitting { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
             | Self::BridgingFailed { .. }
@@ -1709,6 +1773,7 @@ impl UsdcRebalance {
                 }])
             }
             Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::Bridged { .. }
             | Self::BridgingFailed { .. }
@@ -1737,14 +1802,51 @@ impl UsdcRebalance {
             | Self::WithdrawalComplete { .. }
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
-            Self::Bridging { .. } => Ok(vec![BridgeAttestationReceived {
-                attestation,
-                cctp_nonce,
-                mint_scan_from_block: Some(mint_scan_from_block),
-                attested_at: Utc::now(),
-            }]),
+            Self::Bridging { .. } | Self::AwaitingAttestation { .. } => {
+                Ok(vec![BridgeAttestationReceived {
+                    attestation,
+                    cctp_nonce,
+                    mint_scan_from_block: Some(mint_scan_from_block),
+                    attested_at: Utc::now(),
+                }])
+            }
             Self::Attested { .. } => Err(UsdcRebalanceError::InvalidCommand {
                 command: "ReceiveAttestation".to_string(),
+                state: "Attested".to_string(),
+            }),
+            Self::Bridged { .. }
+            | Self::BridgingFailed { .. }
+            | Self::DepositInitiated { .. }
+            | Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+        }
+    }
+
+    fn transition_timeout_attestation(
+        &self,
+        retry_deadline_at: DateTime<Utc>,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        use UsdcRebalanceEvent::*;
+        match self {
+            Self::Converting { .. }
+            | Self::ConversionComplete { .. }
+            | Self::ConversionFailed { .. }
+            | Self::WithdrawalSubmitting { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
+            | Self::WithdrawalFailed { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
+            Self::Bridging { burn_tx_hash, .. } => Ok(vec![AttestationTimedOut {
+                burn_tx_hash: *burn_tx_hash,
+                retry_deadline_at,
+                timed_out_at: Utc::now(),
+            }]),
+            Self::AwaitingAttestation { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "TimeoutAttestation".to_string(),
+                state: "AwaitingAttestation".to_string(),
+            }),
+            Self::Attested { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "TimeoutAttestation".to_string(),
                 state: "Attested".to_string(),
             }),
             Self::Bridged { .. }
@@ -1771,7 +1873,8 @@ impl UsdcRebalance {
             | Self::WithdrawalComplete { .. }
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
-            | Self::Bridging { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
+            | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
             Self::Attested { .. } => Ok(vec![Bridged {
                 mint_tx_hash: mint_tx,
                 amount_received,
@@ -1810,7 +1913,8 @@ impl UsdcRebalance {
                     failed_at: Utc::now(),
                 }])
             }
-            Self::Bridging { burn_tx_hash, .. } => Ok(vec![BridgingFailed {
+            Self::Bridging { burn_tx_hash, .. }
+            | Self::AwaitingAttestation { burn_tx_hash, .. } => Ok(vec![BridgingFailed {
                 burn_tx_hash: Some(*burn_tx_hash),
                 cctp_nonce: None,
                 reason,
@@ -1849,6 +1953,7 @@ impl UsdcRebalance {
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::BridgingFailed { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
             Self::Bridged { .. } => Ok(vec![DepositInitiated {
@@ -1876,6 +1981,7 @@ impl UsdcRebalance {
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::BridgingFailed { .. }
             | Self::Bridged { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
@@ -1907,6 +2013,7 @@ impl UsdcRebalance {
             | Self::BridgingSubmitting { .. }
             | Self::WithdrawalFailed { .. }
             | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
             | Self::Attested { .. }
             | Self::BridgingFailed { .. }
             | Self::Bridged { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
@@ -2481,6 +2588,138 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_timeout_attestation_after_bridging_initiated() {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx_hash =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let retry_deadline_at = Utc::now() + chrono::Duration::hours(24);
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(1000.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash,
+                    burned_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::TimeoutAttestation { retry_deadline_at })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::AttestationTimedOut {
+            burn_tx_hash: event_burn_tx_hash,
+            retry_deadline_at: event_retry_deadline_at,
+            ..
+        } = events[0]
+        else {
+            panic!("Expected AttestationTimedOut event");
+        };
+        assert_eq!(event_burn_tx_hash, burn_tx_hash);
+        assert_eq!(event_retry_deadline_at, retry_deadline_at);
+    }
+
+    #[test]
+    fn replay_timeout_attestation_enters_awaiting_attestation() {
+        let initiated_at = Utc::now();
+        let timed_out_at = initiated_at + chrono::Duration::minutes(5);
+        let retry_deadline_at = initiated_at + chrono::Duration::hours(24);
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(1000.00)),
+                withdrawal_ref: TransferRef::OnchainTx(BURN_TX),
+                initiated_at,
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: initiated_at,
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: BURN_TX,
+                burned_at: initiated_at,
+            },
+            UsdcRebalanceEvent::AttestationTimedOut {
+                burn_tx_hash: BURN_TX,
+                retry_deadline_at,
+                timed_out_at,
+            },
+        ])
+        .expect("event stream should replay")
+        .expect("event stream should materialize aggregate state");
+
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::AwaitingAttestation {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    burn_tx_hash: BURN_TX,
+                    retry_deadline_at: deadline,
+                    timed_out_at: timeout,
+                    ..
+                } if deadline == retry_deadline_at && timeout == timed_out_at
+            ),
+            "Expected AwaitingAttestation state, got {state:?}"
+        );
+    }
+
+    #[test]
+    fn receive_attestation_after_timeout_advances_to_attested() {
+        let initiated_at = Utc::now();
+        let attested_at = initiated_at + chrono::Duration::minutes(6);
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(1000.00)),
+                withdrawal_ref: TransferRef::OnchainTx(BURN_TX),
+                initiated_at,
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: initiated_at,
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: BURN_TX,
+                burned_at: initiated_at,
+            },
+            UsdcRebalanceEvent::AttestationTimedOut {
+                burn_tx_hash: BURN_TX,
+                retry_deadline_at: initiated_at + chrono::Duration::hours(24),
+                timed_out_at: initiated_at + chrono::Duration::minutes(5),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![0x01, 0x02],
+                cctp_nonce: TEST_CCTP_NONCE,
+                mint_scan_from_block: Some(100),
+                attested_at,
+            },
+        ])
+        .expect("event stream should replay")
+        .expect("event stream should materialize aggregate state");
+
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Attested {
+                    burn_tx_hash: BURN_TX,
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    attested_at: state_attested_at,
+                    ..
+                } if state_attested_at == attested_at
+            ),
+            "Expected Attested state, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_cannot_initiate_bridging_before_withdrawal() {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
@@ -2996,6 +3235,60 @@ mod tests {
         assert_eq!(*event_burn_tx, Some(burn_tx_hash));
         assert_eq!(*event_nonce, None);
         assert_eq!(reason, "CCTP timeout");
+    }
+
+    /// Failing from `AwaitingAttestation` (reached after an attestation timeout,
+    /// e.g. when the retry deadline elapses) must retain `burn_tx_hash` with a
+    /// `None` nonce. That populated burn tx is what keeps `holds_rebalance_guard`
+    /// latched on restart -- a regression to the pre-burn shape would clear the
+    /// guard and reopen the re-burn window on already-burned USDC.
+    #[tokio::test]
+    async fn test_fail_bridging_from_awaiting_attestation() {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+        let burn_tx_hash =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(1000.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::AttestationTimedOut {
+                    burn_tx_hash,
+                    retry_deadline_at: Utc::now() + chrono::Duration::hours(1),
+                    timed_out_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::FailBridging {
+                reason: "attestation retry deadline elapsed".to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingFailed {
+            burn_tx_hash: event_burn_tx,
+            cctp_nonce: event_nonce,
+            reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BridgingFailed event");
+        };
+
+        assert_eq!(*event_burn_tx, Some(burn_tx_hash));
+        assert_eq!(*event_nonce, None);
+        assert_eq!(reason, "attestation retry deadline elapsed");
     }
 
     #[tokio::test]
@@ -4762,6 +5055,30 @@ mod tests {
     }
 
     #[test]
+    fn to_dto_awaiting_attestation_maps_to_bridging_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let timed_out_at = initiated_at + chrono::Duration::minutes(5);
+        let state = UsdcRebalance::AwaitingAttestation {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(2000)),
+            burn_tx_hash: BURN_TX,
+            initiated_at,
+            timed_out_at,
+            retry_deadline_at: initiated_at + chrono::Duration::hours(24),
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        assert!(matches!(bridge.status, UsdcBridgeStatus::Bridging));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, timed_out_at);
+    }
+
+    #[test]
     fn to_dto_deposit_confirmed_maps_to_completed_status() {
         let id = UsdcRebalanceId(Uuid::new_v4());
         let initiated_at = Utc::now();
@@ -5109,13 +5426,24 @@ mod tests {
             .holds_rebalance_guard()
         );
         assert!(
+            AwaitingAttestation {
+                direction: BaseToAlpaca,
+                amount,
+                burn_tx_hash: BURN_TX,
+                initiated_at: now,
+                timed_out_at: now,
+                retry_deadline_at: now + chrono::Duration::hours(24),
+            }
+            .holds_rebalance_guard()
+        );
+        assert!(
             Attested {
                 direction: AlpacaToBase,
                 amount,
                 burn_tx_hash: BURN_TX,
                 cctp_nonce: TEST_CCTP_NONCE,
                 attestation: vec![],
-                mint_scan_from_block: Some(0),
+                mint_scan_from_block: Some(100),
                 initiated_at: now,
                 attested_at: now,
             }
@@ -5346,6 +5674,43 @@ mod tests {
             .await
             .unwrap();
 
+        // Awaiting attestation after a post-burn timeout -- must be included.
+        let awaiting_attestation = UsdcRebalanceId(Uuid::new_v4());
+        store
+            .send(
+                &awaiting_attestation,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(BURN_TX),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &awaiting_attestation,
+                UsdcRebalanceCommand::ConfirmWithdrawal,
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &awaiting_attestation,
+                UsdcRebalanceCommand::InitiateBridging { burn_tx: BURN_TX },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &awaiting_attestation,
+                UsdcRebalanceCommand::TimeoutAttestation {
+                    retry_deadline_at: Utc::now() + chrono::Duration::hours(24),
+                },
+            )
+            .await
+            .unwrap();
+
         // In-progress (mid-withdrawal) -- must be included.
         let withdrawing = UsdcRebalanceId(Uuid::new_v4());
         store
@@ -5363,7 +5728,10 @@ mod tests {
         let interrupted = interrupted_usdc_rebalance_ids(&pool).await.unwrap();
         let got: HashSet<UsdcRebalanceId> = interrupted.ids.into_iter().collect();
 
-        assert_eq!(got, HashSet::from([bridge_failed, withdrawing]));
+        assert_eq!(
+            got,
+            HashSet::from([bridge_failed, awaiting_attestation, withdrawing])
+        );
         assert!(
             interrupted.unparseable.is_empty(),
             "well-formed UUID aggregate_ids must not be reported as unparseable"

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -364,6 +364,7 @@ redemption_wallet = "{redemption_wallet}"
 [rebalancing]
 transfer_timeout_secs = 1800
 transfer_attempt_timeout_secs = 3600
+attestation_retry_deadline_secs = 86400
 equity = {{ target = 0.5, deviation = 0.1 }}
 usdc = {{ mode = "enabled", target = 0.5, deviation = 0.1 }}
 


### PR DESCRIPTION
Resolves RAI-787

## What

Adds a non-terminal `AwaitingAttestation` state to the `UsdcRebalance` aggregate so a Circle attestation poll timeout no longer hard-fails the bridge. Introduces `TimeoutAttestation` command, `AttestationTimedOut` event, and a required `attestation_retry_deadline_secs` config field (production default: 86400 = 24h). Both USDC transfer Apalis jobs (`TransferUsdcToHedging`, `TransferUsdcToMarketMaking`) are extended to re-enqueue themselves with a 60-second delay on timeout, and to treat deadline-elapsed and already-failed aggregates as clean terminal outcomes rather than job errors.

## Why

A Circle attestation poll timeout is a transient condition (Circle's REST API has ~13s finality but can be slow), not a permanent bridge failure. Previously any timeout fell through to `FailBridging`, losing automatic recovery of already-burned USDC. The USDC is burned before the attestation poll, so stranding it in a terminal failure state on a transient network hiccup is unacceptable. This change makes timeouts retryable up to the configured deadline, after which the bridge moves to `BridgingFailed` for operator reconciliation.

## How

**New aggregate state and transitions** (`src/usdc_rebalance.rs`): `Bridging --TimeoutAttestation--> AwaitingAttestation --ReceiveAttestation--> Attested`. The `AwaitingAttestation` variant carries `retry_deadline_at` (computed at first timeout from `attestation_retry_deadline_secs`). `ReceiveAttestation` is now valid from both `Bridging` and `AwaitingAttestation`. `FailBridging` is valid from both. Schema version bumped to v3. `interrupted_usdc_rebalance_ids` extended to include `AttestationTimedOut` events so stalled `AwaitingAttestation` rebalances are surfaced on resume.

**Attestation polling split** (`src/rebalancing/usdc/manager.rs`): the old `poll_attestation` / `poll_circle_attestation` monoliths (which called `FailBridging` unconditionally on any `CctpError`) are replaced by `poll_cctp_attestation` (maps `CctpError::AttestationTimeout` to `AttestationPollOutcome::TimedOut`, hard-fails on everything else) and `poll_cctp_attestation_until_deadline` (checks `Utc::now() >= retry_deadline_at` before each attempt, calls `FailBridging` and returns `AttestationRetryDeadlineElapsed` on expiry). `record_attestation` extracts the destination-block snapshot and `ReceiveAttestation` command emission. New resume entry points `continue_from_awaiting_attestation` (both directions) re-poll with the deadline. The `Attested` resume path intentionally has no deadline: once Circle has issued an attestation once, a re-poll timeout is always transient, and bounding it would strand already-burned USDC.

**Job redrive** (`src/rebalancing/usdc/job.rs`): both job `perform` implementations now pattern-match the `UsdcTransferError` outcome. `AttestationTimedOut` pushes a delayed replacement job (`ATTESTATION_REDRIVE_DELAY = 60s`) via the job queue, which is now threaded into both `TransferUsdcToHedgingCtx` and `TransferUsdcToMarketMakingCtx`. `AttestationRetryDeadlineElapsed` and `PreviouslyFailedAggregate` log a warning and return `Ok(())` — the aggregate is already in a durable terminal state needing only operator reconciliation, so the job must not surface as a failure.

**Config** (`crates/config/src/rebalancing.rs`): `attestation_retry_deadline_secs` is a required non-zero field on `RebalancingConfig`, validated in `RebalancingCtx::new`, threaded through all constructors and test builders with a default of 24h. Set to 86400 in `config/prod/`, `config/staging/`, `example.config.toml`, and all test fixtures.

**Deadline semantics**: the deadline is a soft bound — checked between job redrive attempts, not inside the Circle poll itself. An in-flight poll that started before the deadline runs to completion, so the effective cutoff is the first redrive at or after `retry_deadline_at`, which can overshoot by one poll window plus the 60-second redrive delay. Negligible at the 24h production default.

## Testing

- `src/rebalancing/usdc/job.rs`: 6 new unit tests — `hedging_job_reschedules_attestation_timeout`, `market_making_job_reschedules_attestation_timeout`, `hedging_job_treats_deadline_elapsed_as_clean_terminal`, `hedging_job_treats_previously_failed_as_clean_terminal`, and symmetric tests for the market-making direction. All verify that the correct pending-job count is written to an in-memory SQLite apalis queue and that the rescheduled job's `id`/`amount` match the original and `run_at` is delayed by ~60s.
- `src/rebalancing/usdc/manager.rs`: 4 integration tests (2 gated on `feature = "test-support"` for the real-Circle-API mock path) — deadline-elapsed fails the bridge and leaves `BridgingFailed` for both directions; attestation-arrives-before-deadline records `ReceiveAttestation` and proceeds to mint (verified by `cctp_nonce: Some(_)` surviving into the failed-mint state) for both directions.
- `src/usdc_rebalance.rs`: 4 new unit tests — `test_timeout_attestation_after_bridging_initiated` (command round-trip), `replay_timeout_attestation_enters_awaiting_attestation` (event replay), `receive_attestation_after_timeout_advances_to_attested` (full `Bridging -> AwaitingAttestation -> Attested` replay), `to_dto_awaiting_attestation_maps_to_bridging_status` (DTO mapping). `AwaitingAttestation` added to `interrupted_usdc_rebalance_ids` test. `holds_rebalance_guard` test extended.
- `crates/config/src/rebalancing.rs`: 2 new unit tests — `deserialize_missing_attestation_retry_deadline_secs_fails`, `zero_attestation_retry_deadline_secs_fails_validation`.

## Anything else

**Follow-up (tracked)**: a `complete` Circle attestation response with a malformed payload is currently bounded by the retry deadline rather than failing fast. The SPEC notes this as a tracked follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable CCTP attestation retry deadline (24-hour default) to rebalancing configuration.
  * Implemented automatic retry of USDC bridge transfers when attestation polling times out.
  * Enhanced attestation timeout handling with deadline-bounded retries until configured deadline.

* **Improvements**
  * Improved error categorization for attestation failures and deadline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->