### PR TITLE
refactor: extract st0x-raindex crate with the Raindex trait and domain types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6883,6 +6883,7 @@ dependencies = [
  "st0x-float-macro",
  "st0x-float-serde",
  "st0x-hedge",
+ "st0x-raindex",
  "task-supervisor",
  "temp-env",
  "tempfile",
@@ -6903,6 +6904,17 @@ dependencies = [
  "urlencoding",
  "uuid",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "st0x-raindex"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "async-trait",
+ "rain-math-float",
+ "st0x-evm",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/evm",
   "crates/float-macro",
   "crates/float-serde",
+  "crates/raindex",
 ]
 resolver = "2"
 exclude = ["lib"]
@@ -102,6 +103,7 @@ st0x-finance = { path = "crates/finance" }
 st0x-float-macro = { path = "crates/float-macro" }
 st0x-float-serde = { path = "crates/float-serde" }
 st0x-hedge = { path = "." }
+st0x-raindex = { path = "crates/raindex" }
 temp-env = "0.3.6"
 tempfile = "3.24.0"
 test-log = { version = "0.2.19", features = ["trace"] }
@@ -208,6 +210,7 @@ st0x-execution.workspace = true
 st0x-finance.workspace = true
 st0x-float-macro.workspace = true
 st0x-float-serde.workspace = true
+st0x-raindex.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -185,6 +185,32 @@ pub enum EvmError {
 }
 
 impl EvmError {
+    /// `true` if this reports a transaction dropped from the mempool (it will
+    /// never mine) -- a terminal failure, distinct from a still-pending tx that
+    /// merely has not confirmed yet. Only the wallet builds (`turnkey` /
+    /// `local-signer`), which run the confirm loop, can produce it.
+    pub fn is_transaction_dropped(&self) -> bool {
+        match self {
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::TransactionDropped { .. } => true,
+            Self::Transaction(_)
+            | Self::Transport(_)
+            | Self::Contract(_)
+            | Self::AbiDecode(_)
+            | Self::DecodedRevert(_)
+            | Self::Reverted { .. }
+            | Self::WalletConfigParse(_) => false,
+            #[cfg(any(feature = "turnkey", feature = "local-signer"))]
+            Self::ReceiptTimeout { .. } => false,
+            #[cfg(feature = "local-signer")]
+            Self::InvalidPrivateKey(_) => false,
+            #[cfg(feature = "turnkey")]
+            Self::Turnkey(_) => false,
+        }
+    }
+}
+
+impl EvmError {
     /// Returns `true` if this is a "nonce too low" RPC error, which
     /// occurs when an external process (e.g. CLI) submitted
     /// transactions from the same wallet, advancing the chain nonce

--- a/crates/raindex/Cargo.toml
+++ b/crates/raindex/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "st0x-raindex"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+alloy.workspace = true
+async-trait.workspace = true
+rain-math-float.workspace = true
+st0x-evm.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/raindex/src/lib.rs
+++ b/crates/raindex/src/lib.rs
@@ -1,0 +1,111 @@
+//! Raindex (Rain OrderBook V6) abstraction.
+//!
+//! This crate provides the generic [`Raindex`] trait for Rain OrderBook vault
+//! operations (deposit, withdraw, confirm) plus the shared domain types
+//! ([`RaindexVaultId`], [`RaindexError`], [`USDC_BASE`]) used across consumers.
+//!
+//! The concrete Rain implementation lives in the application crate while this
+//! crate owns the shared trait, errors, and identifier types used by consumers.
+
+use alloy::primitives::{Address, B256, TxHash, U256, address};
+use alloy::rpc::types::TransactionReceipt;
+use alloy::transports::{RpcError, TransportErrorKind};
+use async_trait::async_trait;
+
+use st0x_evm::EvmError;
+
+/// Base USDC token address.
+pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+
+/// Vault identifier for Rain OrderBook vaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RaindexVaultId(pub B256);
+
+#[derive(Debug, thiserror::Error)]
+pub enum RaindexError {
+    #[error("EVM error: {0}")]
+    Evm(#[from] EvmError),
+    #[error("Contract error: {0}")]
+    Contract(#[from] alloy::contract::Error),
+    #[error("Float error: {0}")]
+    Float(#[from] rain_math_float::FloatError),
+    #[error("Amount cannot be zero")]
+    ZeroAmount,
+    #[error("RPC transport error: {0}")]
+    RpcTransport(#[from] RpcError<TransportErrorKind>),
+    #[error("ABI decode error: {0}")]
+    SolType(#[from] alloy::sol_types::Error),
+    /// A withdrawal scan could not confirm presence or absence: the queried node
+    /// is not confirmations-deep past `from_block`, so an empty result may be RPC
+    /// lag rather than a true absence. Retryable -- the caller must NOT re-execute
+    /// the irreversible withdraw on this.
+    #[error("withdrawal scan inconclusive: node not caught up past block {from_block}")]
+    ScanInconclusive { from_block: u64 },
+}
+
+impl RaindexError {
+    /// `true` if this error reports that a submitted transaction was dropped from
+    /// the mempool and will never mine -- a terminal failure, distinct from a
+    /// still-pending transaction that simply has not confirmed yet.
+    pub fn is_transaction_dropped(&self) -> bool {
+        match self {
+            Self::Evm(evm_error) => evm_error.is_transaction_dropped(),
+            Self::Contract(_)
+            | Self::Float(_)
+            | Self::ZeroAmount
+            | Self::RpcTransport(_)
+            | Self::SolType(_)
+            | Self::ScanInconclusive { .. } => false,
+        }
+    }
+}
+
+/// Abstraction for Raindex (Rain OrderBook) operations.
+///
+/// This trait abstracts deposit and withdraw operations for Raindex,
+/// allowing different implementations (real service, mock) to be used interchangeably.
+#[async_trait]
+pub trait Raindex: Send + Sync {
+    /// Withdraws tokens from a Rain OrderBook vault (atomic submit + confirm).
+    async fn withdraw(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        target_amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError>;
+
+    /// Submit a vault deposit without waiting for confirmation.
+    ///
+    /// Handles approval if needed, submits the deposit4 transaction,
+    /// and returns the tx hash immediately. Use
+    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
+    async fn submit_deposit(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError>;
+
+    /// Submit a vault withdrawal without waiting for confirmation.
+    ///
+    /// Returns the tx hash immediately. Use
+    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
+    async fn submit_withdraw(
+        &self,
+        token: Address,
+        vault_id: RaindexVaultId,
+        target_amount: U256,
+        decimals: u8,
+    ) -> Result<TxHash, RaindexError>;
+
+    /// Wait for a previously submitted transaction to be confirmed.
+    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError> {
+        self.confirm_tx_receipt(tx_hash).await.map(|_| ())
+    }
+
+    /// Wait for a previously submitted transaction to be confirmed and return the receipt.
+    async fn confirm_tx_receipt(&self, tx_hash: TxHash)
+    -> Result<TransactionReceipt, RaindexError>;
+}

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -11,67 +11,22 @@
 //! OrderBook V6 uses a custom float format (B256) for amounts. All conversions between
 //! standard fixed-point amounts (U256) and the float format MUST use rain-math-float.
 
-use alloy::primitives::{Address, B256, TxHash, U256, address};
+use alloy::primitives::{Address, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, TransactionReceipt};
 use alloy::sol_types::SolEvent;
-use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use rain_math_float::Float;
 use tracing::{debug, info};
 
-use st0x_evm::{Evm, EvmError, IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
+use st0x_evm::{Evm, IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
 use st0x_execution::FractionalShares;
 use st0x_finance::Usdc;
+pub(crate) use st0x_raindex::{Raindex, RaindexError, RaindexVaultId, USDC_BASE};
 
 use crate::bindings::{IERC20, IOrderBookV6};
 
-pub(crate) const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 const USDC_DECIMALS: u8 = 6;
-
-/// Vault identifier for Rain OrderBook vaults.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RaindexVaultId(pub(crate) B256);
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum RaindexError {
-    #[error("EVM error: {0}")]
-    Evm(#[from] EvmError),
-    #[error("Contract error: {0}")]
-    Contract(#[from] alloy::contract::Error),
-    #[error("Float error: {0}")]
-    Float(#[from] rain_math_float::FloatError),
-    #[error("Amount cannot be zero")]
-    ZeroAmount,
-    #[error("RPC transport error: {0}")]
-    RpcTransport(#[from] RpcError<TransportErrorKind>),
-    #[error("ABI decode error: {0}")]
-    SolType(#[from] alloy::sol_types::Error),
-    /// A withdrawal scan could not confirm presence or absence: the queried node
-    /// is not confirmations-deep past `from_block`, so an empty result may be RPC
-    /// lag rather than a true absence. Retryable -- the caller must NOT re-execute
-    /// the irreversible withdraw on this.
-    #[error("withdrawal scan inconclusive: node not caught up past block {from_block}")]
-    ScanInconclusive { from_block: u64 },
-}
-
-impl RaindexError {
-    /// `true` if this error reports that a submitted transaction was dropped from
-    /// the mempool and will never mine -- a terminal failure, distinct from a
-    /// still-pending transaction that simply has not confirmed yet.
-    pub(crate) fn is_transaction_dropped(&self) -> bool {
-        match self {
-            Self::Evm(EvmError::TransactionDropped { .. }) => true,
-            Self::Evm(_)
-            | Self::Contract(_)
-            | Self::Float(_)
-            | Self::ZeroAmount
-            | Self::RpcTransport(_)
-            | Self::SolType(_)
-            | Self::ScanInconclusive { .. } => false,
-        }
-    }
-}
 
 /// Number of `eth_getLogs` scans that must agree the effect is absent before a
 /// resume re-executes an irreversible withdraw. Defends against a single
@@ -411,56 +366,6 @@ impl<E: Evm> RaindexService<E> {
     }
 }
 
-/// Abstraction for Raindex (Rain OrderBook) operations.
-///
-/// This trait abstracts deposit and withdraw operations for Raindex,
-/// allowing different implementations (real service, mock) to be used interchangeably.
-#[async_trait]
-pub(crate) trait Raindex: Send + Sync {
-    /// Withdraws tokens from a Rain OrderBook vault (atomic submit + confirm).
-    async fn withdraw(
-        &self,
-        token: Address,
-        vault_id: RaindexVaultId,
-        target_amount: U256,
-        decimals: u8,
-    ) -> Result<TxHash, RaindexError>;
-
-    /// Submit a vault deposit without waiting for confirmation.
-    ///
-    /// Handles approval if needed, submits the deposit4 transaction,
-    /// and returns the tx hash immediately. Use
-    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
-    async fn submit_deposit(
-        &self,
-        token: Address,
-        vault_id: RaindexVaultId,
-        amount: U256,
-        decimals: u8,
-    ) -> Result<TxHash, RaindexError>;
-
-    /// Submit a vault withdrawal without waiting for confirmation.
-    ///
-    /// Returns the tx hash immediately. Use
-    /// [`confirm_tx`](Raindex::confirm_tx) to wait for confirmation.
-    async fn submit_withdraw(
-        &self,
-        token: Address,
-        vault_id: RaindexVaultId,
-        target_amount: U256,
-        decimals: u8,
-    ) -> Result<TxHash, RaindexError>;
-
-    /// Wait for a previously submitted transaction to be confirmed.
-    async fn confirm_tx(&self, tx_hash: TxHash) -> Result<(), RaindexError> {
-        self.confirm_tx_receipt(tx_hash).await.map(|_| ())
-    }
-
-    /// Wait for a previously submitted transaction to be confirmed and return the receipt.
-    async fn confirm_tx_receipt(&self, tx_hash: TxHash)
-    -> Result<TransactionReceipt, RaindexError>;
-}
-
 #[async_trait]
 impl<W: Wallet> Raindex for RaindexService<W> {
     async fn withdraw(
@@ -559,7 +464,7 @@ mod tests {
     use alloy::network::Ethereum;
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::Log as PrimitiveLog;
-    use alloy::primitives::{B256, b256};
+    use alloy::primitives::{B256, address, b256};
     use alloy::providers::Provider;
     use alloy::providers::fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
@@ -573,6 +478,7 @@ mod tests {
     use alloy::providers::mock::Asserter;
     use serde_json::json;
 
+    use st0x_evm::EvmError;
     use st0x_evm::NoOpErrorRegistry;
     use st0x_evm::ReadOnlyEvm;
     use st0x_evm::Wallet;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -87,13 +87,10 @@ pub(crate) struct WrappedEquityRecoveryServices {
 pub(crate) enum WrappedEquityRecoveryError {
     #[error("recovery already initialized")]
     AlreadyInitialized,
-
     #[error("recovery not yet initialized; only Detect is valid")]
     Uninitialized,
-
     #[error("command not valid from state {state:?}")]
     InvalidTransition { state: Box<WrappedEquityRecovery> },
-
     #[error("recovery is already in terminal state")]
     Terminal,
 }

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -69,10 +69,8 @@ pub(crate) struct WrappedEquityRecoveryCtx {
 pub(crate) enum WrappedEquityRecoveryJobError {
     #[error("recovery aggregate error: {0}")]
     Aggregate(#[from] SendError<WrappedEquityRecovery>),
-
     #[error(transparent)]
     Domain(#[from] WrappedEquityRecoveryError),
-
     #[error(
         "inventory view reports both an active mint ({mint_id}) and active redemption \
          ({redemption_id}) for symbol {symbol} -- aborting recovery"
@@ -82,7 +80,6 @@ pub(crate) enum WrappedEquityRecoveryJobError {
         mint_id: IssuerRequestId,
         redemption_id: RedemptionAggregateId,
     },
-
     #[error(
         "active mint {mint_id} for symbol {symbol} carries quantity {aggregate_shares}, \
          which does not match the wrapped-equity wallet snapshot {snapshot_shares} -- \
@@ -94,7 +91,6 @@ pub(crate) enum WrappedEquityRecoveryJobError {
         snapshot_shares: FractionalShares,
         aggregate_shares: FractionalShares,
     },
-
     #[error(
         "active redemption {redemption_id} for symbol {symbol} carries quantity \
          {aggregate_shares}, which does not match the wrapped-equity wallet snapshot \
@@ -106,13 +102,11 @@ pub(crate) enum WrappedEquityRecoveryJobError {
         snapshot_shares: FractionalShares,
         aggregate_shares: FractionalShares,
     },
-
     #[error("active mint {mint_id} for symbol {symbol} is missing from the mint store")]
     ActiveMintMissing {
         symbol: Symbol,
         mint_id: IssuerRequestId,
     },
-
     #[error(
         "active redemption {redemption_id} for symbol {symbol} is missing from the \
          redemption store"
@@ -121,7 +115,6 @@ pub(crate) enum WrappedEquityRecoveryJobError {
         symbol: Symbol,
         redemption_id: RedemptionAggregateId,
     },
-
     #[error("active mint store error: {0}")]
     ActiveMintAggregate(
         #[from]
@@ -129,7 +122,6 @@ pub(crate) enum WrappedEquityRecoveryJobError {
             st0x_event_sorcery::LifecycleError<crate::tokenized_equity_mint::TokenizedEquityMint>,
         >,
     ),
-
     #[error("active redemption store error: {0}")]
     ActiveRedemptionAggregate(
         #[from]
@@ -137,7 +129,6 @@ pub(crate) enum WrappedEquityRecoveryJobError {
             st0x_event_sorcery::LifecycleError<crate::equity_redemption::EquityRedemption>,
         >,
     ),
-
     #[error("failed to reschedule recovery job after guard contention: {0}")]
     Reschedule(#[from] QueuePushError),
 }


### PR DESCRIPTION
## What

[RAI-830](https://linear.app/makeitrain/issue/RAI-830)

Extracts a new `st0x-raindex` workspace crate that owns the `Raindex` trait and its shared domain types (`RaindexVaultId`, `RaindexError`, `USDC_BASE`). `src/onchain/raindex.rs` now re-exports them from the crate instead of defining them locally.

## Why

The `Raindex` trait and its domain types are a reusable abstraction that consumers other than the hedge bot will need, so they should live in a standalone crate rather than inside the application crate.

## How

- New `crates/raindex` crate (`st0x-raindex`) holding the `Raindex` trait, `RaindexVaultId`, `RaindexError`, and the `USDC_BASE` constant.
- `src/onchain/raindex.rs` drops the local definitions and `pub(crate) use`s them from `st0x-raindex`, keeping the existing `RaindexService` implementation in place.
- Crate ships only the trait and domain types in its default build; the Rain `RaindexService` implementation is slated to move behind a `rain` feature as a follow-up.
- Workspace wiring: registers the crate as a member, adds the `st0x-raindex` workspace dependency, and depends on it from the hedge crate.

## Testing

- No behavior change; existing `src/onchain/raindex.rs` tests continue to exercise `RaindexService` against the re-exported trait and types.

## Screenshots

N/A

## Anything else

- Pure extraction/move: the public surface of the types is unchanged from the consumer's perspective.
- Follow-up: relocate `RaindexService` into the crate behind a `rain` feature so the trait and impl share one home.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783132084&installation_id=125569124&pr_number=739&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F739&signature=e0f1f0d98251b4aa7fb0cbdf264b2119d6ab0b1212401619b5de6ee9b371ce27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced new workspace crate for vault operations infrastructure
  * Enhanced error detection for dropped transactions

* **Refactor**
  * Consolidated vault operation abstractions into centralized module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->