### PR TITLE
chore: bump rain.orderbook to RaindexV6 (Soldeer vendoring, drop submodules)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 4
 
 [[package]]
-name = "addchain"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
-dependencies = [
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -141,7 +130,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.6",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -297,7 +286,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "thiserror 2.0.18",
 ]
 
@@ -1202,7 +1191,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -1219,7 +1208,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1239,7 +1228,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1260,7 +1249,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -1302,7 +1291,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1314,7 +1303,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1327,7 +1316,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1360,7 +1349,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1396,7 +1385,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1409,7 +1398,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1692,15 +1681,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,68 +1740,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2072,7 +1996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "proptest",
  "serde_core",
 ]
@@ -2103,12 +2027,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2155,15 +2073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cqrs-es"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,25 +2114,6 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2463,7 +2353,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -2541,12 +2431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elf"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
-
-[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,9 +2439,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2710,41 +2594,12 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "bitvec",
- "byteorder",
- "ff_derive",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "ff_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
-dependencies = [
- "addchain",
- "num-bigint 0.3.3",
- "num-integer",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2952,12 +2807,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
-name = "gcd"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,23 +2887,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "memuse",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3095,29 +2932,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "halo2"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
-dependencies = [
- "halo2_proofs",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "pasta_curves 0.4.1",
- "rand_core 0.6.4",
- "rayon",
 ]
 
 [[package]]
@@ -3757,26 +3571,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
-dependencies = [
- "bitvec",
- "bls12_381",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -3790,7 +3592,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3799,7 +3601,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -3826,20 +3628,6 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
-name = "kzg-rs"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8b4f55c3dedcfaa8668de1dfc8469e7a32d441c28edf225ed1f566fb32977d"
-dependencies = [
- "ff 0.13.1",
- "hex",
- "serde_arrays",
- "sha2 0.10.9",
- "sp1_bls12_381",
- "spin",
-]
 
 [[package]]
 name = "lazy_static"
@@ -3878,52 +3666,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.5",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
-dependencies = [
- "arrayref",
- "base64 0.22.1",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.6",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]
@@ -4022,12 +3764,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memuse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,22 +3822,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -4152,7 +3877,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8783636b20810a87540f59d19858498a987d7fcdc6555e62f2c99d6ca8a84b61"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-rational",
  "num-traits",
  "serde",
@@ -4184,7 +3909,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -4390,168 +4115,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p3-bn254-fr"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
-dependencies = [
- "ff 0.13.1",
- "num-bigint 0.4.6",
- "p3-field",
- "p3-poseidon2",
- "p3-symmetric",
- "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-challenger"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
-dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
-dependencies = [
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
- "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-util",
- "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-koala-bear"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
-dependencies = [
- "cfg-if",
- "num-bigint 0.4.6",
- "p3-field",
- "p3-mds",
- "p3-poseidon2",
- "p3-symmetric",
- "rand 0.8.6",
- "rustc_version 0.4.1",
- "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
-dependencies = [
- "itertools 0.12.1",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
- "rand 0.8.6",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
-
-[[package]]
-name = "p3-mds"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-symmetric",
- "p3-util",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
-dependencies = [
- "gcd",
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
-dependencies = [
- "itertools 0.12.1",
- "p3-field",
- "serde",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.3.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
-]
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group 0.13.0",
+ "sha2",
 ]
 
 [[package]]
@@ -4609,36 +4173,6 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff 0.13.1",
- "group 0.13.0",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -4706,17 +4240,6 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared 0.11.3",
- "serde",
-]
-
-[[package]]
-name = "phf"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
@@ -4725,23 +4248,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf_generator"
-version = "0.11.3"
+name = "phf"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4749,18 +4283,18 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4837,7 +4371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5127,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "rain-math-float"
-version = "0.1.4"
+version = "0.1.7"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5137,6 +4671,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "wasm-bindgen",
  "wasm-bindgen-utils",
 ]
 
@@ -5219,26 +4754,6 @@ checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rand 0.9.4",
  "rustversion",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -5402,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "25.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fd78df29217546ddfd587fe313aff2bf86e57cfe0f18d16cb326d9f50ba54d"
+checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -5421,23 +4936,23 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.1.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
- "once_cell",
- "phf 0.11.3",
+ "phf 0.13.1",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "6.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190f211f04c8030f5393cfcfa1569b88d5649f0f266bf4291981ba879fa6c5d1"
+checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
 dependencies = [
+ "bitvec",
  "cfg-if",
  "derive-where",
  "revm-bytecode",
@@ -5450,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "6.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7e7ff1154e6460cec025fe20dfe45f3325bbb905718643b6d053ec49da6e8"
+checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -5466,9 +4981,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "5.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9456d5cb165fef91c8b538d0115de50059d1cf352d160a1396894eac017a2a34"
+checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -5480,23 +4995,26 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "5.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaeb608de31bfd0e64bf9b5b18ee70ac70094c8c045b28ae8ae8701608d17d34"
+checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "6.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfeaecd909e6be655c36d21032ca932b347e60ec5849ee29e670d63aa97b6adb"
+checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
 dependencies = [
  "auto_impl",
+ "derive-where",
  "revm-bytecode",
  "revm-context",
  "revm-context-interface",
@@ -5510,11 +5028,12 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "6.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de1c6cddc7d62364dc9fa2f405c2c4637c933c5591addf09977ec8a156e4b23"
+checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
 dependencies = [
  "auto_impl",
+ "either",
  "revm-context",
  "revm-database-interface",
  "revm-handler",
@@ -5527,59 +5046,60 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "21.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c3ca670eee335d9268a9100932ec1e09638bdd9b31eac9e22dec4de00f2cba"
+checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "22.0.0"
+version = "32.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4330c6982a2ef1d318cb10ce7e726a64e11e44fe1eac29d055de849a5e1e080e"
+checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "arrayref",
  "aurora-engine-modexp",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
- "kzg-rs",
- "libsecp256k1",
- "once_cell",
  "p256",
  "revm-primitives",
  "ripemd",
- "secp256k1",
- "sha2 0.10.9",
+ "secp256k1 0.31.1",
+ "sha2",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "19.2.0"
+version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
+checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
+ "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "revm-state"
-version = "5.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44320ccf53067136a83cdbc54f4b7529e8f61497666f31d6f5cfd9035a1cc08f"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
+ "alloy-eip7928",
  "bitflags 2.11.1",
  "revm-bytecode",
  "revm-primitives",
@@ -5663,7 +5183,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -5875,8 +5395,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -5884,6 +5415,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -5971,15 +5511,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_arrays"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6153,21 +5684,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -6177,7 +5695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest 0.10.7",
 ]
 
@@ -6261,88 +5779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slop-algebra"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
-dependencies = [
- "itertools 0.14.0",
- "p3-field",
- "serde",
-]
-
-[[package]]
-name = "slop-bn254"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3ca8edc31419a3e33a9f4b9e11f072caf5fd6e2b32f2b9fcaa5b0863f3da66"
-dependencies = [
- "ff 0.13.1",
- "p3-bn254-fr",
- "serde",
- "slop-algebra",
- "slop-challenger",
- "slop-poseidon2",
- "slop-symmetric",
- "zkhash",
-]
-
-[[package]]
-name = "slop-challenger"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144e5c2ed52b6499792c98262b8bbeb435c361d005caa6f2a6c9ecb8529915b4"
-dependencies = [
- "futures",
- "p3-challenger",
- "serde",
- "slop-algebra",
- "slop-symmetric",
-]
-
-[[package]]
-name = "slop-koala-bear"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ca44a6d3457836c6a1685dcb27b3f64c0b6f555ade06dd2a8fda5003e7594e"
-dependencies = [
- "lazy_static",
- "p3-koala-bear",
- "serde",
- "slop-algebra",
- "slop-challenger",
- "slop-poseidon2",
- "slop-symmetric",
-]
-
-[[package]]
-name = "slop-poseidon2"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
-dependencies = [
- "p3-poseidon2",
-]
-
-[[package]]
-name = "slop-primitives"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20475296d399080467eb486e6063967e85d3d13200301275e56541c356f96bd"
-dependencies = [
- "slop-algebra",
-]
-
-[[package]]
-name = "slop-symmetric"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
-dependencies = [
- "p3-symmetric",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6370,56 +5806,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce7f8d6098c930fb0c03c60f1c8b0ef61b6625811b210b2c694801ceb62f78"
-dependencies = [
- "bincode",
- "serde",
- "sp1-primitives",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03476134330b0677d5eee5dec288cf2b0f883511c7496e55dcc9c15cf8debb47"
-dependencies = [
- "bincode",
- "blake3",
- "elf",
- "hex",
- "itertools 0.14.0",
- "lazy_static",
- "num-bigint 0.4.6",
- "serde",
- "sha2 0.10.9",
- "slop-algebra",
- "slop-bn254",
- "slop-challenger",
- "slop-koala-bear",
- "slop-poseidon2",
- "slop-primitives",
- "slop-symmetric",
-]
-
-[[package]]
-name = "sp1_bls12_381"
-version = "0.8.0-sp1-6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23e41cd36168cc2e51e5d3e35ff0c34b204d945769a65591a76286d04b51e43"
-dependencies = [
- "cfg-if",
- "ff 0.13.1",
- "group 0.13.0",
- "pairing 0.23.0",
- "rand_core 0.6.4",
- "sp1-lib",
- "subtle",
 ]
 
 [[package]]
@@ -6497,7 +5883,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -6535,7 +5921,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -6579,7 +5965,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6617,7 +6003,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8103,48 +7489,32 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8152,31 +7522,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-utils"
-version = "0.0.11"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbbd367f4921f4e3291bc0e789de16303a2dcfcf8b3b11e0c21f4ed4cefba93"
+checksum = "6ec45201ec48a021de21357beca43a1c93669e68eeae5deca5e3ba6b4b4fd4d6"
 dependencies = [
  "js-sys",
  "paste",
@@ -8190,9 +7560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-utils-macros"
-version = "0.0.6"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fed599c9e990172750babd2e8b880c70bb796b170ff3f1ae0b8aed16279303a"
+checksum = "d5bf3e098464ba4e518a659f81794d58c043b8d144f8c29c11fbb488d75264f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8249,9 +7619,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8885,33 +8255,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2",
- "bls12_381",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.6",
- "serde",
- "sha2 0.10.9",
- "sha3",
- "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,9 @@ url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1"
 uuid = { version = "1.11", features = ["serde", "v4"] }
 # Pin wasm-bindgen version for compatibility with rain.wasm transitive dependency
-wasm-bindgen = "=0.2.100"
+# (bumped in lockstep with the rain.orderbook / rain.math.float bump, whose
+# newer crates require >=0.2.122).
+wasm-bindgen = "=0.2.122"
 
 [workspace.dependencies.sqlite-es]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"

--- a/flake.lock
+++ b/flake.lock
@@ -563,16 +563,16 @@
     "rain-math-float": {
       "flake": false,
       "locked": {
-        "lastModified": 1779905451,
-        "narHash": "sha256-cEU1a1amEAgFxNNkEa1CvteDFlkbgrTSlPcTu7t/hI4=",
+        "lastModified": 1780066222,
+        "narHash": "sha256-LALVrtIfJDLDo7HSK8eSPF5AqwpK9TWjTxT6rpYbWzs=",
         "ref": "refs/heads/main",
-        "rev": "5a12bf839bea0ce9528a0e1810d620c44812283a",
-        "revCount": 1011,
+        "rev": "e226e5a27125e75208e3e709e1c5eee128bd8b3b",
+        "revCount": 1025,
         "type": "git",
         "url": "https://github.com/rainlanguage/rain.math.float"
       },
       "original": {
-        "rev": "5a12bf839bea0ce9528a0e1810d620c44812283a",
+        "rev": "e226e5a27125e75208e3e709e1c5eee128bd8b3b",
         "type": "git",
         "url": "https://github.com/rainlanguage/rain.math.float"
       }
@@ -580,18 +580,16 @@
     "rain-orderbook": {
       "flake": false,
       "locked": {
-        "lastModified": 1773775933,
-        "narHash": "sha256-vBmhB2R8b708o1fLzcig3vQ7ZMPUqwd6rwAIQtgJYIo=",
+        "lastModified": 1780493855,
+        "narHash": "sha256-jJeOALjKlLx55QLry6QQ3OOH9yWE3QWP9wIYZWhCXYU=",
         "ref": "refs/heads/main",
-        "rev": "f7bf51ab3db0bac4f8551b91000c69cc5ba0db71",
-        "revCount": 11468,
-        "submodules": true,
+        "rev": "29219ff36170224786025b5c9e8fef2e460638b3",
+        "revCount": 11979,
         "type": "git",
         "url": "https://github.com/rainlanguage/rain.orderbook"
       },
       "original": {
-        "rev": "f7bf51ab3db0bac4f8551b91000c69cc5ba0db71",
-        "submodules": true,
+        "rev": "29219ff36170224786025b5c9e8fef2e460638b3",
         "type": "git",
         "url": "https://github.com/rainlanguage/rain.orderbook"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,15 +18,14 @@
     rain-math-float = {
       type = "git";
       url = "https://github.com/rainlanguage/rain.math.float";
-      rev = "5a12bf839bea0ce9528a0e1810d620c44812283a";
+      rev = "e226e5a27125e75208e3e709e1c5eee128bd8b3b";
       flake = false;
     };
 
     rain-orderbook = {
       type = "git";
       url = "https://github.com/rainlanguage/rain.orderbook";
-      rev = "f7bf51ab3db0bac4f8551b91000c69cc5ba0db71";
-      submodules = true;
+      rev = "29219ff36170224786025b5c9e8fef2e460638b3";
       flake = false;
     };
 

--- a/nix/abis.nix
+++ b/nix/abis.nix
@@ -22,7 +22,7 @@ let
       src = sources.rain-math-float;
     };
     rainOrderbook = import ./rain-orderbook.nix {
-      inherit mkAbi;
+      inherit pkgs mkAbi;
       src = sources.rain-orderbook;
     };
     pyth = import ./pyth.nix { inherit pkgs; };

--- a/nix/rain-orderbook.nix
+++ b/nix/rain-orderbook.nix
@@ -1,39 +1,85 @@
-{ mkAbi, src }:
+{
+  pkgs,
+  mkAbi,
+  src,
+}:
 
-rec {
+# rain.orderbook (now "raindex") dropped git submodules in favour of Soldeer.
+# Soldeer fetches the Solidity dependency closure over the network, so we isolate
+# that in a fixed-output derivation and let the offline `forge build` consume the
+# vendored result for the orderbook's own contracts (RaindexV6, the subparser,
+# ArbTest's test token, TOFUTokenDecimals).
+#
+# The rainlang interpreter stack (interpreter/store/parser/expression deployer)
+# is NOT rebuilt here: those contracts embed codegen'd function-pointer tables
+# whose jump offsets only match bytecode compiled with rainlang's own optimizer
+# profile. Recompiling them under rain.orderbook's profile yields runtime
+# `InvalidJump`s. We therefore consume rainlang's shipped canonical artifacts
+# (under its Soldeer package's crates/abi), whose bytecode matches the
+# deterministic "zoltu" deploy addresses the expression deployer hardcodes.
+
+let
+  # Vendor the Soldeer closure deterministically: every dependency is pinned in
+  # soldeer.lock with its registry URL and the raw sha256 of its zip (the
+  # `checksum` field), so we fetch each one individually rather than trusting a
+  # non-reproducible `forge soldeer install`. Each archive unpacks at its root
+  # into dependencies/<name>-<version>/, matching the repo's remappings.txt.
+  soldeerLock = builtins.fromTOML (builtins.readFile (src + "/soldeer.lock"));
+
+  unpackDep =
+    dep:
+    let
+      archive = pkgs.fetchurl {
+        inherit (dep) url;
+        sha256 = dep.checksum;
+        name = pkgs.lib.strings.sanitizeDerivationName "${dep.name}-${dep.version}.zip";
+      };
+    in
+    ''
+      mkdir -p "$out/${dep.name}-${dep.version}"
+      unzip -q ${archive} -d "$out/${dep.name}-${dep.version}"
+    '';
+
+  soldeerDeps = pkgs.runCommand "raindex-soldeer-deps" { nativeBuildInputs = [ pkgs.unzip ]; } (
+    "mkdir -p $out\n" + pkgs.lib.concatMapStrings unpackDep soldeerLock.dependencies
+  );
+
+  rainlangAbi = "${soldeerDeps}/rainlang-0.1.2/crates/abi";
+
   abi = mkAbi {
     pname = "rain-orderbook-abi";
     inherit src;
 
-    # rain.interpreter ships as a submodule and is built separately so its
-    # contracts (Rainterpreter, Store, Parser, Deployer, TestERC20) end up
-    # alongside the orderbook artifacts under a stable layout.
     buildPhase = ''
       runHook preBuild
       export HOME="$TMPDIR"
+      cp -r ${soldeerDeps} dependencies
+      chmod -R +w dependencies
       forge build
-      (cd lib/rain.interpreter && forge build)
       runHook postBuild
     '';
 
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/orderbook $out/interpreter
-      cp -r out/. $out/orderbook/
-      cp -r lib/rain.interpreter/out/. $out/interpreter/
+      mkdir -p $out
+      cp -r out/. $out/
       runHook postInstall
     '';
   };
 
+in
+rec {
+  inherit abi soldeerDeps;
+
   abiEnv = {
-    ST0X_IORDERBOOK_V6_ABI = "${abi}/orderbook/IOrderBookV6.sol/IOrderBookV6.json";
-    ST0X_ORDERBOOK_ABI = "${abi}/orderbook/OrderBookV6.sol/OrderBookV6.json";
-    ST0X_TEST_ERC20_ABI = "${abi}/orderbook/ArbTest.sol/Token.json";
-    ST0X_TOFU_TOKEN_DECIMALS_ABI = "${abi}/orderbook/TOFUTokenDecimals.sol/TOFUTokenDecimals.json";
-    ST0X_INTERPRETER_ABI = "${abi}/interpreter/Rainterpreter.sol/Rainterpreter.json";
-    ST0X_STORE_ABI = "${abi}/interpreter/RainterpreterStore.sol/RainterpreterStore.json";
-    ST0X_PARSER_ABI = "${abi}/interpreter/RainterpreterParser.sol/RainterpreterParser.json";
-    ST0X_DEPLOYER_ABI = "${abi}/interpreter/RainterpreterExpressionDeployer.sol/RainterpreterExpressionDeployer.json";
-    ST0X_DEPLOYABLE_ERC20_ABI = "${abi}/interpreter/TestERC20.sol/TestERC20.json";
+    ST0X_IORDERBOOK_V6_ABI = "${abi}/IRaindexV6.sol/IRaindexV6.json";
+    ST0X_ORDERBOOK_ABI = "${abi}/RaindexV6.sol/RaindexV6.json";
+    ST0X_TEST_ERC20_ABI = "${abi}/ArbTest.sol/Token.json";
+    ST0X_TOFU_TOKEN_DECIMALS_ABI = "${abi}/TOFUTokenDecimals.sol/TOFUTokenDecimals.json";
+    ST0X_INTERPRETER_ABI = "${rainlangAbi}/RainlangInterpreter.json";
+    ST0X_STORE_ABI = "${rainlangAbi}/RainlangStore.json";
+    ST0X_PARSER_ABI = "${rainlangAbi}/RainlangParser.json";
+    ST0X_DEPLOYER_ABI = "${rainlangAbi}/RainlangExpressionDeployer.json";
+    ST0X_DEPLOYABLE_ERC20_ABI = "${rainlangAbi}/TestERC20.json";
   };
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -6,7 +6,7 @@ use alloy::sol;
 sol!(
     #![sol(all_derives = true, rpc)]
     #[derive(serde::Serialize, serde::Deserialize)]
-    IOrderBookV6, env!("ST0X_IORDERBOOK_V6_ABI")
+    IRaindexV6, env!("ST0X_IORDERBOOK_V6_ABI")
 );
 
 sol!(
@@ -32,7 +32,7 @@ sol!(
 sol!(
     #![sol(all_derives = true, rpc)]
     #[derive(serde::Serialize, serde::Deserialize)]
-    OrderBook, env!("ST0X_ORDERBOOK_ABI")
+    RaindexV6, env!("ST0X_ORDERBOOK_ABI")
 );
 
 #[cfg(any(test, feature = "test-support"))]

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -264,10 +264,9 @@ impl Conductor {
                 .await?;
 
         let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&pool);
-        let seed_vault_registry_ctx = Arc::new(SeedVaultRegistryCtx::from_config(
-            vault_registry.clone(),
-            &ctx,
-        )?);
+        let seed_vault_registry_ctx = Arc::new(
+            SeedVaultRegistryCtx::from_config(vault_registry.clone(), &ctx).map_err(|err| *err)?,
+        );
 
         // Run the seeding logic inline at startup so downstream wiring
         // (RaindexService, trade accounting, inventory polling) starts
@@ -2245,7 +2244,7 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::bindings::IOrderBookV6::{
+    use crate::bindings::IRaindexV6::{
         ClearConfigV2, ClearV3, EvaluableV4, IOV2, OrderV4, TakeOrderConfigV4, TakeOrderV3,
     };
     use crate::conductor::builder::CqrsFrameworks;

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -34,10 +34,9 @@ use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
 
 use super::{ExpectedEvent, assert_events, fetch_events};
-use crate::bindings::IOrderBookV6::{self, TakeOrderV3};
+use crate::bindings::IRaindexV6::{self, TakeOrderV3};
 use crate::bindings::{
-    DeployableERC20, Deployer, Interpreter, OrderBook, Parser, Store as RainStore,
-    TOFUTokenDecimals,
+    DeployableERC20, Deployer, Interpreter, Parser, RaindexV6, Store as RainStore,
 };
 use crate::conductor::{
     AccumulatedPositionExecutionCtx, TradeProcessingCqrs, VaultDiscoveryCtx,
@@ -52,7 +51,7 @@ use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
-use crate::test_utils::setup_test_db;
+use crate::test_utils::{deploy_tofu_singleton, setup_test_db};
 use crate::tokenization::alpaca::tests::setup_anvil;
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
@@ -61,8 +60,17 @@ use crate::vault_registry::VaultRegistryId;
 const TEST_AAPL: &str = "AAPL";
 const TEST_MSFT: &str = "MSFT";
 const AAPL_PRICE: u32 = 100;
-const TOFU_TOKEN_DECIMALS: Address = address!("0xF66761F6b5F58202998D6Cd944C81b22Dc6d4f1E");
 const MSFT_PRICE: u32 = 200;
+
+// Rainlang interpreter components deploy to deterministic "zoltu" addresses; the
+// expression deployer references the parser/store/interpreter by these hardcoded
+// constants (see LibInterpreterDeploy in rainlang). Tests therefore etch each
+// runtime at its canonical address rather than deploying to sequential ones.
+const RAINLANG_INTERPRETER: Address = address!("0xb3A710b89A5569893dA4Ca0dB7D178593b5BE8a0");
+const RAINLANG_STORE: Address = address!("0x1Aa775533E28B1D843e1A589034984E3a62005DC");
+const RAINLANG_PARSER: Address = address!("0x9179445a637E6Ae72Bb38273944FAB96834488dd");
+const RAINLANG_EXPRESSION_DEPLOYER: Address =
+    address!("0xC9e1D673eD122193b28376016AC506De2fA20beE");
 
 /// Loads a position and asserts it matches the expected field values.
 ///
@@ -293,6 +301,33 @@ async fn deploy_usdc_at_base<P: Provider>(provider: &P, owner: Address) {
         .unwrap();
 }
 
+/// Etches the Rainlang interpreter, store, parser, and expression deployer
+/// runtimes at their deterministic deployment addresses. The expression deployer
+/// hardcodes these addresses, so order evaluation only works when each runtime
+/// lives at its canonical address -- the alloy/anvil equivalent of upstream's
+/// `LibInterpreterDeploy.etchRainlang`.
+async fn etch_rainlang<P: Provider>(provider: &P) {
+    provider
+        .anvil_set_code(RAINLANG_INTERPRETER, Interpreter::DEPLOYED_BYTECODE.clone())
+        .await
+        .unwrap();
+    provider
+        .anvil_set_code(RAINLANG_STORE, RainStore::DEPLOYED_BYTECODE.clone())
+        .await
+        .unwrap();
+    provider
+        .anvil_set_code(RAINLANG_PARSER, Parser::DEPLOYED_BYTECODE.clone())
+        .await
+        .unwrap();
+    provider
+        .anvil_set_code(
+            RAINLANG_EXPRESSION_DEPLOYER,
+            Deployer::DEPLOYED_BYTECODE.clone(),
+        )
+        .await
+        .unwrap();
+}
+
 async fn setup_anvil_orderbook() -> AnvilOrderBook<impl alloy::providers::Provider + Clone> {
     let (anvil, endpoint, key) = setup_anvil();
     let signer = PrivateKeySigner::from_bytes(&key).unwrap();
@@ -304,38 +339,20 @@ async fn setup_anvil_orderbook() -> AnvilOrderBook<impl alloy::providers::Provid
         .unwrap();
     let owner = signer.address();
 
-    provider
-        .anvil_set_code(
-            TOFU_TOKEN_DECIMALS,
-            TOFUTokenDecimals::DEPLOYED_BYTECODE.clone(),
-        )
-        .await
-        .unwrap();
+    deploy_tofu_singleton(&provider).await;
 
-    let interpreter = Interpreter::deploy(&provider).await.unwrap();
-    let store = RainStore::deploy(&provider).await.unwrap();
-    let parser = Parser::deploy(&provider).await.unwrap();
-    let deployer = Deployer::deploy(
-        &provider,
-        Deployer::RainterpreterExpressionDeployerConstructionConfigV2 {
-            interpreter: *interpreter.address(),
-            store: *store.address(),
-            parser: *parser.address(),
-        },
-    )
-    .await
-    .unwrap();
+    etch_rainlang(&provider).await;
 
-    let orderbook = OrderBook::deploy(&provider).await.unwrap();
+    let orderbook = RaindexV6::deploy(&provider).await.unwrap();
 
     // Place USDC contract directly at USDC_BASE so vault discovery recognizes it.
     deploy_usdc_at_base(&provider, owner).await;
 
     // Extract addresses before moving provider into the struct
     let orderbook_addr = *orderbook.address();
-    let deployer_addr = *deployer.address();
-    let interpreter_addr = *interpreter.address();
-    let store_addr = *store.address();
+    let deployer_addr = RAINLANG_EXPRESSION_DEPLOYER;
+    let interpreter_addr = RAINLANG_INTERPRETER;
+    let store_addr = RAINLANG_STORE;
 
     AnvilOrderBook {
         _anvil: anvil,
@@ -450,8 +467,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
         // which hold immutable references to self.provider.
         let equity_addr = self.ensure_equity_token(symbol).await;
 
-        let orderbook =
-            IOrderBookV6::IOrderBookV6Instance::new(self.orderbook_addr, &self.provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook_addr, &self.provider);
         let deployer_instance = Deployer::DeployerInstance::new(self.deployer_addr, &self.provider);
 
         let is_sell = direction == Direction::Sell;
@@ -496,17 +512,17 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
         let input_vault_id = B256::random();
         let output_vault_id = B256::random();
 
-        let order_config = IOrderBookV6::OrderConfigV4 {
-            evaluable: IOrderBookV6::EvaluableV4 {
+        let order_config = IRaindexV6::OrderConfigV4 {
+            evaluable: IRaindexV6::EvaluableV4 {
                 interpreter: self.interpreter_addr,
                 store: self.store_addr,
                 bytecode: Bytes::from(parsed_bytecode),
             },
-            validInputs: vec![IOrderBookV6::IOV2 {
+            validInputs: vec![IRaindexV6::IOV2 {
                 token: input_token,
                 vaultId: input_vault_id,
             }],
-            validOutputs: vec![IOrderBookV6::IOV2 {
+            validOutputs: vec![IRaindexV6::IOV2 {
                 token: output_token,
                 vaultId: output_vault_id,
             }],
@@ -528,7 +544,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
             .inner
             .logs()
             .iter()
-            .find_map(|log| log.log_decode::<IOrderBookV6::AddOrderV3>().ok())
+            .find_map(|log| log.log_decode::<IRaindexV6::AddOrderV3>().ok())
             .expect("AddOrderV3 event not found");
         let order = add_order_event.data().order.clone();
 
@@ -585,7 +601,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
             .unwrap();
 
         // Take the order with permissive bounds (large maximumIO/maximumIORatio)
-        let take_config = IOrderBookV6::TakeOrdersConfigV5 {
+        let take_config = IRaindexV6::TakeOrdersConfigV5 {
             minimumIO: B256::ZERO,
             maximumIO: Float::from_fixed_decimal_lossy(U256::from(1_000_000), 0)
                 .unwrap()
@@ -596,7 +612,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
                 .0
                 .get_inner(),
             IOIsInput: true,
-            orders: vec![IOrderBookV6::TakeOrderConfigV4 {
+            orders: vec![IRaindexV6::TakeOrderConfigV4 {
                 order: order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(0),

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -21,7 +21,7 @@ use st0x_evm::Evm;
 use st0x_execution::Executor;
 
 use super::OnChainError;
-use crate::bindings::IOrderBookV6::{ClearV3, TakeOrderV3};
+use crate::bindings::IRaindexV6::{ClearV3, TakeOrderV3};
 use crate::conductor::job::{Job, Label};
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::trading::onchain::inclusion::EmittedOnChain;
@@ -418,7 +418,7 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::bindings::IOrderBookV6;
+    use crate::bindings::IRaindexV6;
     use crate::conductor::setup_apalis_tables;
     use crate::test_utils::{get_test_order, setup_test_db};
     use st0x_config::EvmCtx;
@@ -734,7 +734,7 @@ mod tests {
             required_confirmations: 0,
         };
 
-        let clear_config = IOrderBookV6::ClearConfigV2 {
+        let clear_config = IRaindexV6::ClearConfigV2 {
             aliceInputIOIndex: U256::from(0),
             aliceOutputIOIndex: U256::from(1),
             bobInputIOIndex: U256::from(1),
@@ -743,7 +743,7 @@ mod tests {
             bobBountyVaultId: B256::ZERO,
         };
 
-        let clear_event = IOrderBookV6::ClearV3 {
+        let clear_event = IRaindexV6::ClearV3 {
             sender: address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
             alice: order.clone(),
             bob: order.clone(),
@@ -800,9 +800,9 @@ mod tests {
             required_confirmations: 0,
         };
 
-        let take_event = IOrderBookV6::TakeOrderV3 {
+        let take_event = IRaindexV6::TakeOrderV3 {
             sender: address!("0x1111111111111111111111111111111111111111"),
-            config: IOrderBookV6::TakeOrderConfigV4 {
+            config: IRaindexV6::TakeOrderConfigV4 {
                 order: order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(1),
@@ -868,11 +868,11 @@ mod tests {
         };
 
         let different_order = get_test_order();
-        let clear_event = IOrderBookV6::ClearV3 {
+        let clear_event = IRaindexV6::ClearV3 {
             sender: address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
             alice: different_order.clone(),
             bob: different_order.clone(),
-            clearConfig: IOrderBookV6::ClearConfigV2 {
+            clearConfig: IRaindexV6::ClearConfigV2 {
                 aliceInputIOIndex: U256::from(0),
                 aliceOutputIOIndex: U256::from(1),
                 bobInputIOIndex: U256::from(1),
@@ -882,9 +882,9 @@ mod tests {
             },
         };
 
-        let take_event = IOrderBookV6::TakeOrderV3 {
+        let take_event = IRaindexV6::TakeOrderV3 {
             sender: address!("0x1111111111111111111111111111111111111111"),
-            config: IOrderBookV6::TakeOrderConfigV4 {
+            config: IRaindexV6::TakeOrderConfigV4 {
                 order: different_order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(1),
@@ -1029,13 +1029,13 @@ mod tests {
     }
 
     fn create_test_take_event(
-        order: &IOrderBookV6::OrderV4,
+        order: &IRaindexV6::OrderV4,
         input: U256,
         output: U256,
-    ) -> IOrderBookV6::TakeOrderV3 {
-        IOrderBookV6::TakeOrderV3 {
+    ) -> IRaindexV6::TakeOrderV3 {
+        IRaindexV6::TakeOrderV3 {
             sender: address!("0x1111111111111111111111111111111111111111"),
-            config: IOrderBookV6::TakeOrderConfigV4 {
+            config: IRaindexV6::TakeOrderConfigV4 {
                 order: order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(1),
@@ -1056,7 +1056,7 @@ mod tests {
 
     fn create_test_log(
         orderbook: Address,
-        event: &IOrderBookV6::TakeOrderV3,
+        event: &IRaindexV6::TakeOrderV3,
         block_number: u64,
         tx_hash: FixedBytes<32>,
     ) -> Log {
@@ -1349,8 +1349,8 @@ mod tests {
         assert_eq!(job_count(&pool).await, 2);
     }
 
-    fn create_clear_log(orderbook: Address, order: &IOrderBookV6::OrderV4, tx_hash: TxHash) -> Log {
-        let clear_config = IOrderBookV6::ClearConfigV2 {
+    fn create_clear_log(orderbook: Address, order: &IRaindexV6::OrderV4, tx_hash: TxHash) -> Log {
+        let clear_config = IRaindexV6::ClearConfigV2 {
             aliceInputIOIndex: U256::from(0),
             aliceOutputIOIndex: U256::from(1),
             bobInputIOIndex: U256::from(1),
@@ -1359,7 +1359,7 @@ mod tests {
             bobBountyVaultId: B256::ZERO,
         };
 
-        let clear_event = IOrderBookV6::ClearV3 {
+        let clear_event = IRaindexV6::ClearV3 {
             sender: address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
             alice: order.clone(),
             bob: order.clone(),
@@ -2017,11 +2017,11 @@ mod tests {
 
         let order = get_test_order();
 
-        let clear_event = IOrderBookV6::ClearV3 {
+        let clear_event = IRaindexV6::ClearV3 {
             sender: address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
             alice: order.clone(),
             bob: order.clone(),
-            clearConfig: IOrderBookV6::ClearConfigV2 {
+            clearConfig: IRaindexV6::ClearConfigV2 {
                 aliceInputIOIndex: U256::from(0),
                 aliceOutputIOIndex: U256::from(1),
                 bobInputIOIndex: U256::from(1),

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -11,7 +11,7 @@ use st0x_config::EvmCtx;
 use st0x_evm::Evm;
 
 use super::OnChainError;
-use crate::bindings::IOrderBookV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2, ClearV3};
+use crate::bindings::IRaindexV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2, ClearV3};
 use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::trade::TradeValidationError;
 use crate::onchain::trade::{OnchainTrade, OrderFill};
@@ -239,8 +239,8 @@ mod tests {
 
     use super::*;
     use crate::bindings::IERC20::{decimalsCall, symbolCall};
-    use crate::bindings::IOrderBookV6;
-    use crate::bindings::IOrderBookV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2};
+    use crate::bindings::IRaindexV6;
+    use crate::bindings::IRaindexV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2};
     use crate::onchain::io::WrappedTokenizedShares;
     use crate::onchain::pyth::FeedIdCache;
     use crate::symbol::cache::SymbolCache;
@@ -258,8 +258,8 @@ mod tests {
     }
 
     fn create_clear_event(
-        alice_order: IOrderBookV6::OrderV4,
-        bob_order: IOrderBookV6::OrderV4,
+        alice_order: IRaindexV6::OrderV4,
+        bob_order: IRaindexV6::OrderV4,
     ) -> ClearV3 {
         ClearV3 {
             sender: address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),

--- a/src/onchain/raindex.rs
+++ b/src/onchain/raindex.rs
@@ -24,7 +24,7 @@ use st0x_execution::FractionalShares;
 use st0x_finance::Usdc;
 pub(crate) use st0x_raindex::{Raindex, RaindexError, RaindexVaultId, USDC_BASE};
 
-use crate::bindings::{IERC20, IOrderBookV6};
+use crate::bindings::{IERC20, IRaindexV6};
 
 const USDC_DECIMALS: u8 = 6;
 
@@ -156,7 +156,7 @@ impl<W: Wallet> RaindexService<W> {
 
         debug!(target: "orderbook", %token, ?vault_id, %amount, "Sending deposit4");
 
-        let calldata = IOrderBookV6::deposit4Call {
+        let calldata = IRaindexV6::deposit4Call {
             token,
             vaultId: vault_id.0,
             depositAmount: amount_float.get_inner(),
@@ -184,7 +184,7 @@ impl<W: Wallet> RaindexService<W> {
 
         debug!(target: "orderbook", %token, ?vault_id, %amount, "Sending deposit4");
 
-        let calldata = IOrderBookV6::deposit4Call {
+        let calldata = IRaindexV6::deposit4Call {
             token,
             vaultId: vault_id.0,
             depositAmount: amount_float.get_inner(),
@@ -293,7 +293,7 @@ impl<E: Evm> RaindexService<E> {
         let filter = Filter::new()
             .from_block(from_block)
             .address(self.orderbook_address)
-            .event_signature(IOrderBookV6::WithdrawV2::SIGNATURE_HASH);
+            .event_signature(IRaindexV6::WithdrawV2::SIGNATURE_HASH);
 
         for attempt in 1..=SCAN_ATTEMPTS {
             let logs = self.evm.provider().get_logs(&filter).await?;
@@ -302,7 +302,7 @@ impl<E: Evm> RaindexService<E> {
             // most recent matching withdrawal wins -- under single-in-flight that
             // is this transfer's withdrawal.
             for log in logs.iter().rev() {
-                let decoded = log.log_decode::<IOrderBookV6::WithdrawV2>()?;
+                let decoded = log.log_decode::<IRaindexV6::WithdrawV2>()?;
                 let event = decoded.data();
 
                 if event.sender == self.owner
@@ -354,7 +354,7 @@ impl<E: Evm> RaindexService<E> {
             .evm
             .call::<Registry, _>(
                 self.orderbook_address,
-                IOrderBookV6::vaultBalance2Call {
+                IRaindexV6::vaultBalance2Call {
                     owner,
                     token,
                     vaultId: vault_id.0,
@@ -385,7 +385,7 @@ impl<W: Wallet> Raindex for RaindexService<W> {
             .evm
             .submit::<OpenChainErrorRegistry, _>(
                 self.orderbook_address,
-                IOrderBookV6::withdraw4Call {
+                IRaindexV6::withdraw4Call {
                     token,
                     vaultId: vault_id.0,
                     targetAmount: amount_float.get_inner(),
@@ -434,7 +434,7 @@ impl<W: Wallet> Raindex for RaindexService<W> {
             .evm
             .submit_pending(
                 self.orderbook_address,
-                IOrderBookV6::withdraw4Call {
+                IRaindexV6::withdraw4Call {
                     token,
                     vaultId: vault_id.0,
                     targetAmount: amount_float.get_inner(),
@@ -485,9 +485,8 @@ mod tests {
     use st0x_evm::local::RawPrivateKeyWallet;
 
     use super::*;
-    use crate::bindings::{IOrderBookV6, OrderBook, TOFUTokenDecimals, TestERC20};
-    /// Address where LibTOFUTokenDecimals expects the singleton contract to be deployed.
-    const TOFU_DECIMALS_ADDRESS: Address = address!("0xF66761F6b5F58202998D6Cd944C81b22Dc6d4f1E");
+    use crate::bindings::{IRaindexV6, RaindexV6, TestERC20};
+    use crate::test_utils::deploy_tofu_singleton;
 
     type BaseProvider = FillProvider<
         JoinFill<
@@ -516,7 +515,7 @@ mod tests {
             let base_provider = ProviderBuilder::new().connect_http(endpoint.parse()?);
             let wallet = RawPrivateKeyWallet::new(&private_key, base_provider, 1)?;
 
-            Self::deploy_tofu_decimals(wallet.signing_provider()).await?;
+            deploy_tofu_singleton(wallet.signing_provider()).await;
 
             let orderbook_address = Self::deploy_orderbook(wallet.signing_provider()).await?;
 
@@ -532,22 +531,8 @@ mod tests {
             })
         }
 
-        async fn deploy_tofu_decimals(provider: &impl Provider) -> Result<(), LocalEvmError> {
-            let tofu = TOFUTokenDecimals::deploy(provider).await?;
-            let deployed_code = provider.get_code_at(*tofu.address()).await?;
-
-            provider
-                .raw_request::<_, ()>(
-                    "anvil_setCode".into(),
-                    (TOFU_DECIMALS_ADDRESS, deployed_code),
-                )
-                .await?;
-
-            Ok(())
-        }
-
         async fn deploy_orderbook(provider: &impl Provider) -> Result<Address, LocalEvmError> {
-            let orderbook = OrderBook::deploy(provider).await?;
+            let orderbook = RaindexV6::deploy(provider).await?;
 
             Ok(*orderbook.address())
         }
@@ -597,7 +582,7 @@ mod tests {
                 .wallet
                 .call::<NoOpErrorRegistry, _>(
                     self.orderbook_address,
-                    IOrderBookV6::vaultBalance2Call {
+                    IRaindexV6::vaultBalance2Call {
                         owner: self.wallet.address(),
                         token,
                         vaultId: vault_id,
@@ -693,7 +678,7 @@ mod tests {
     /// A `WithdrawV2` from this owner's vault, mined at `block_number`, that
     /// `find_recent_withdrawal` will see for `(USDC_BASE, TEST_VAULT_ID)`.
     fn withdraw_log(block_number: u64, withdraw_amount: U256) -> Log {
-        let event = IOrderBookV6::WithdrawV2 {
+        let event = IRaindexV6::WithdrawV2 {
             sender: Address::ZERO,
             token: USDC_BASE,
             vaultId: TEST_VAULT_ID.0,

--- a/src/onchain/take_order.rs
+++ b/src/onchain/take_order.rs
@@ -6,7 +6,7 @@ use alloy::rpc::types::Log;
 use st0x_evm::Evm;
 
 use super::OnChainError;
-use crate::bindings::IOrderBookV6::{TakeOrderConfigV4, TakeOrderV3};
+use crate::bindings::IRaindexV6::{TakeOrderConfigV4, TakeOrderV3};
 use crate::onchain::pyth::FeedIdCache;
 use crate::onchain::trade::{OnchainTrade, OrderFill};
 use crate::symbol::cache::SymbolCache;
@@ -33,7 +33,7 @@ impl OnchainTrade {
             signedContext: _,
         } = event.config;
 
-        // Per IOrderBookV6.sol lines 385-386, TakeOrderV3's `input`/`output` are
+        // Per IRaindexV6.sol lines 385-386, TakeOrderV3's `input`/`output` are
         // "from the perspective of sender" (the taker), NOT the order:
         // - event.input = what taker received = what order GAVE (order's output)
         // - event.output = what taker gave = what order RECEIVED (order's input)
@@ -61,7 +61,7 @@ mod tests {
 
     use super::*;
     use crate::bindings::IERC20::{decimalsCall, symbolCall};
-    use crate::bindings::IOrderBookV6::{SignedContextV1, TakeOrderConfigV4, TakeOrderV3};
+    use crate::bindings::IRaindexV6::{SignedContextV1, TakeOrderConfigV4, TakeOrderV3};
     use crate::onchain::io::WrappedTokenizedShares;
     use crate::onchain::pyth::FeedIdCache;
     use crate::symbol::cache::SymbolCache;
@@ -70,9 +70,9 @@ mod tests {
     use st0x_float_macro::float;
 
     fn create_take_order_event_with_order(
-        order: crate::bindings::IOrderBookV6::OrderV4,
+        order: crate::bindings::IRaindexV6::OrderV4,
     ) -> TakeOrderV3 {
-        // Per IOrderBookV6.sol lines 385-386, input/output are from taker's perspective.
+        // Per IRaindexV6.sol lines 385-386, input/output are from taker's perspective.
         // For a trade where order receives 100 USDC and gives 9 shares:
         // - input = 9 (taker received 9 shares = order gave 9 shares)
         // - output = 100 (taker gave 100 USDC = order received 100 USDC)

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -19,7 +19,7 @@ use st0x_execution::{Direction, FractionalShares, HasZero};
 use st0x_float_serde::format_float_with_fallback;
 
 use super::pyth::{extract_pyth_price, raw_price_to_pyth_price};
-use crate::bindings::IOrderBookV6::{ClearV3, OrderV4, TakeOrderV3};
+use crate::bindings::IRaindexV6::{ClearV3, OrderV4, TakeOrderV3};
 use crate::onchain::OnChainError;
 use crate::onchain::io::{TokenizedSymbol, TradeDetails, Usdc, WrappedTokenizedShares};
 use crate::onchain::pyth::FeedIdCache;
@@ -432,7 +432,7 @@ mod tests {
     use st0x_evm::ReadOnlyEvm;
 
     use super::*;
-    use crate::bindings::IOrderBookV6;
+    use crate::bindings::IRaindexV6;
     use crate::symbol::cache::SymbolCache;
     use st0x_config::EvmCtx;
     use st0x_float_macro::float;
@@ -657,8 +657,8 @@ mod tests {
         ));
     }
 
-    fn make_io(token: Address, vault_id: B256) -> IOrderBookV6::IOV2 {
-        IOrderBookV6::IOV2 {
+    fn make_io(token: Address, vault_id: B256) -> IRaindexV6::IOV2 {
+        IRaindexV6::IOV2 {
             token,
             vaultId: vault_id,
         }
@@ -666,12 +666,12 @@ mod tests {
 
     fn make_order(
         owner: Address,
-        inputs: Vec<IOrderBookV6::IOV2>,
-        outputs: Vec<IOrderBookV6::IOV2>,
-    ) -> IOrderBookV6::OrderV4 {
-        IOrderBookV6::OrderV4 {
+        inputs: Vec<IRaindexV6::IOV2>,
+        outputs: Vec<IRaindexV6::IOV2>,
+    ) -> IRaindexV6::OrderV4 {
+        IRaindexV6::OrderV4 {
             owner,
-            evaluable: IOrderBookV6::EvaluableV4::default(),
+            evaluable: IRaindexV6::EvaluableV4::default(),
             validInputs: inputs,
             validOutputs: outputs,
             nonce: B256::ZERO,
@@ -764,11 +764,11 @@ mod tests {
             )],
         );
 
-        let event = IOrderBookV6::ClearV3 {
+        let event = IRaindexV6::ClearV3 {
             sender: address!("0x0000000000000000000000000000000000000000"),
             alice,
             bob,
-            clearConfig: IOrderBookV6::ClearConfigV2 {
+            clearConfig: IRaindexV6::ClearConfigV2 {
                 aliceInputIOIndex: uint!(0_U256),
                 aliceOutputIOIndex: uint!(0_U256),
                 bobInputIOIndex: uint!(0_U256),

--- a/src/symbol/cache.rs
+++ b/src/symbol/cache.rs
@@ -12,7 +12,7 @@ use std::{
 
 use st0x_evm::{Evm, OpenChainErrorRegistry};
 
-use crate::bindings::{IERC20, IOrderBookV6::IOV2};
+use crate::bindings::{IERC20, IRaindexV6::IOV2};
 use crate::onchain::OnChainError;
 
 #[derive(Debug, Default, Clone)]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,10 +1,12 @@
 //! Shared test fixtures: database setup, stub orders/logs,
 //! and builders for onchain trades and offchain executions.
 
+use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, B256, Bytes, LogData, TxHash, address, bytes, fixed_bytes};
-use alloy::providers::RootProvider;
+use alloy::providers::ext::AnvilApi as _;
+use alloy::providers::{Provider, RootProvider};
 use alloy::rpc::client::RpcClient;
-use alloy::rpc::types::{Log, TransactionReceipt};
+use alloy::rpc::types::{Log, TransactionReceipt, TransactionRequest};
 use async_trait::async_trait;
 use chrono::Utc;
 use rain_math_float::Float;
@@ -14,9 +16,45 @@ use std::sync::Arc;
 use st0x_evm::{Evm, EvmError, Wallet};
 use st0x_execution::{Direction, FractionalShares, Positive};
 
-use crate::bindings::IOrderBookV6::{EvaluableV4, IOV2, OrderV4};
+use crate::bindings::IRaindexV6::{EvaluableV4, IOV2, OrderV4};
 use crate::onchain::OnchainTrade;
 use crate::onchain::io::{TokenizedSymbol, Usdc, WrappedTokenizedShares};
+
+/// Deterministic singleton address of the TOFUTokenDecimals contract. The
+/// orderbook's `LibTOFUTokenDecimals.ensureDeployed` hardcodes this address and
+/// checks the codehash, so any test exercising deposits, withdrawals, or order
+/// takes must place the canonical runtime here.
+pub(crate) const TOFU_TOKEN_DECIMALS: Address =
+    address!("0x200e12D10bb0c5E4a17e7018f0F1161919bb9389");
+
+/// Canonical TOFUTokenDecimals init bytecode, copied from
+/// rain-tofu-erc20-decimals' `LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE`.
+/// Deploying this and etching the resulting runtime at `TOFU_TOKEN_DECIMALS` yields the
+/// codehash `ensureDeployed` requires; rain.orderbook's own recompile of TOFUTokenDecimals.sol
+/// does not match that hash, so its artifact bytecode cannot be used directly.
+const TOFU_DECIMALS_CREATION_CODE: &str = "0x6080604052348015600e575f80fd5b5061044b8061001c5f395ff3fe608060405234801561000f575f80fd5b506004361061004a575f3560e01c80630782d7e11461004e57806354636d2b14610078578063b7bad1b11461009d578063f5c36eaf146100b0575b5f80fd5b61006161005c366004610363565b6100c3565b60405161006f929190610403565b60405180910390f35b61008b610086366004610363565b6100d8565b60405160ff909116815260200161006f565b6100616100ab366004610363565b6100e9565b61008b6100be366004610363565b6100f5565b5f806100cf5f84610100565b91509150915091565b5f6100e35f836101f0565b92915050565b5f806100cf5f84610281565b5f6100e35f83610356565b73ffffffffffffffffffffffffffffffffffffffff81165f9081526020838152604080832081518083019092525460ff8082161515835261010090910416818301527f313ce56700000000000000000000000000000000000000000000000000000000808452839283908190816004818a5afa915060203d1015610182575f91505b811561019857505f5160ff811115610198575f91505b816101af57505050602001516003925090506101e9565b83516101c3575f955093506101e992505050565b836020015160ff1681146101d85760026101db565b60015b846020015195509550505050505b9250929050565b5f805f6101fd8585610281565b909250905060018260038111156102165761021661039d565b1415801561023557505f8260038111156102325761023261039d565b14155b156102795783826040517fee07877f000000000000000000000000000000000000000000000000000000008152600401610270929190610421565b60405180910390fd5b949350505050565b5f805f8061028f8686610100565b90925090505f8260038111156102a7576102a761039d565b0361034b576040805180820182526001815260ff838116602080840191825273ffffffffffffffffffffffffffffffffffffffff8a165f908152908b9052939093209151825493517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00009094169015157fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff161761010093909116929092029190911790555b909590945092505050565b5f805f6101fd8585610100565b5f60208284031215610373575f80fd5b813573ffffffffffffffffffffffffffffffffffffffff81168114610396575f80fd5b9392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b600481106103ff577f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9052565b6040810161041182856103ca565b60ff831660208301529392505050565b73ffffffffffffffffffffffffffffffffffffffff831681526040810161039660208301846103ca56";
+
+/// Deploys the canonical TOFUTokenDecimals init bytecode and etches the resulting
+/// runtime at [`TOFU_TOKEN_DECIMALS`]. The orderbook checks both the address and
+/// the codehash, so the runtime must come from executing the canonical creation
+/// code rather than from a recompiled artifact.
+pub(crate) async fn deploy_tofu_singleton<P: Provider>(provider: &P) {
+    let creation_code = alloy::hex::decode(TOFU_DECIMALS_CREATION_CODE).unwrap();
+    let deployed = provider
+        .send_transaction(TransactionRequest::default().with_deploy_code(creation_code))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap()
+        .contract_address
+        .unwrap();
+    let runtime = provider.get_code_at(deployed).await.unwrap();
+    provider
+        .anvil_set_code(TOFU_TOKEN_DECIMALS, runtime)
+        .await
+        .unwrap();
+}
 
 /// Panicking wallet stub for tests that construct `RebalancingCtx`
 /// without needing real chain connectivity. Provider type matches

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -246,8 +246,8 @@ mod tests {
 
     use super::*;
     use crate::bindings::IERC20::{decimalsCall, symbolCall};
-    use crate::bindings::IOrderBookV6;
-    use crate::bindings::IOrderBookV6::{
+    use crate::bindings::IRaindexV6;
+    use crate::bindings::IRaindexV6::{
         ClearConfigV2, SignedContextV1, TakeOrderConfigV4, TakeOrderV3 as TakeOrderV3Event,
     };
     use crate::offchain::order::OffchainOrder;
@@ -259,7 +259,7 @@ mod tests {
 
     fn test_job() -> AccountForDexTrade {
         let log = get_test_log();
-        let event = RaindexTradeEvent::ClearV3(Box::new(IOrderBookV6::ClearV3 {
+        let event = RaindexTradeEvent::ClearV3(Box::new(IRaindexV6::ClearV3 {
             sender: address!("0x1111111111111111111111111111111111111111"),
             alice: get_test_order(),
             bob: get_test_order(),

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -497,12 +497,12 @@ impl SeedVaultRegistryCtx {
     pub(crate) fn from_config(
         vault_registry: Arc<Store<VaultRegistry>>,
         ctx: &Ctx,
-    ) -> Result<Self, CtxError> {
+    ) -> Result<Self, Box<CtxError>> {
         for (symbol, equity_config) in &ctx.assets.equities.symbols {
             if equity_config.vault_ids.is_empty() && ctx.is_rebalancing_enabled(symbol) {
-                return Err(CtxError::MissingEquityVaultId {
+                return Err(Box::new(CtxError::MissingEquityVaultId {
                     symbol: symbol.clone(),
-                });
+                }));
             }
         }
 
@@ -1292,7 +1292,7 @@ mod tests {
             .expect("should fail when vault_id is missing for TSLA");
 
         assert!(
-            matches!(&error, CtxError::MissingEquityVaultId { symbol } if symbol.to_string() == "TSLA"),
+            matches!(&*error, CtxError::MissingEquityVaultId { symbol } if symbol.to_string() == "TSLA"),
             "expected MissingEquityVaultId for TSLA, got: {error:?}"
         );
     }

--- a/tests/e2e/base_chain.rs
+++ b/tests/e2e/base_chain.rs
@@ -6,11 +6,12 @@
 //! (Interpreter, Store, Parser, Deployer) for compiling order expressions
 //! used in `take_order()`.
 
-use alloy::network::EthereumWallet;
+use alloy::network::{EthereumWallet, TransactionBuilder};
 use alloy::node_bindings::{Anvil, AnvilInstance};
 use alloy::primitives::{Address, B256, Bytes, U256, address, utils::parse_units};
 use alloy::providers::ext::AnvilApi as _;
 use alloy::providers::{Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
 use alloy::sol_types::SolEvent as _;
@@ -18,11 +19,9 @@ use rain_math_float::Float;
 use std::collections::HashMap;
 
 use st0x_evm::test_chain::{evm_mapping_slot, solidity_short_string};
-use st0x_hedge::bindings::IOrderBookV6::{self, TakeOrderV3};
+use st0x_hedge::bindings::IRaindexV6::{self, TakeOrderV3};
 pub use st0x_hedge::bindings::{DeployableERC20, IERC20};
-use st0x_hedge::bindings::{
-    Deployer, Interpreter, OrderBook, Parser, Store as RainStore, TOFUTokenDecimals,
-};
+use st0x_hedge::bindings::{Deployer, Interpreter, Parser, RaindexV6, Store as RainStore};
 
 /// Rounds a Float to `decimals` decimal places and formats as a string.
 fn round_and_format(value: Float, decimals: u8) -> anyhow::Result<String> {
@@ -48,6 +47,69 @@ fn format_float(value: Float) -> anyhow::Result<String> {
 /// Base chain USDC address, defined locally so e2e tests don't
 /// need `st0x_hedge` to export the constant.
 pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+
+// Rainlang interpreter components deploy to deterministic "zoltu" addresses; the
+// expression deployer references the parser/store/interpreter by these hardcoded
+// constants (see LibInterpreterDeploy in rainlang). Tests therefore etch each
+// runtime at its canonical address rather than deploying to sequential ones.
+const RAINLANG_INTERPRETER: Address = address!("0xb3A710b89A5569893dA4Ca0dB7D178593b5BE8a0");
+const RAINLANG_STORE: Address = address!("0x1Aa775533E28B1D843e1A589034984E3a62005DC");
+const RAINLANG_PARSER: Address = address!("0x9179445a637E6Ae72Bb38273944FAB96834488dd");
+const RAINLANG_EXPRESSION_DEPLOYER: Address =
+    address!("0xC9e1D673eD122193b28376016AC506De2fA20beE");
+
+/// Etches the Rainlang interpreter, store, parser, and expression deployer
+/// runtimes at their deterministic deployment addresses. The expression deployer
+/// hardcodes these addresses, so order evaluation only works when each runtime
+/// lives at its canonical address -- the alloy/anvil equivalent of upstream's
+/// `LibInterpreterDeploy.etchRainlang`.
+async fn etch_rainlang<P: Provider>(provider: &P) -> anyhow::Result<()> {
+    provider
+        .anvil_set_code(RAINLANG_INTERPRETER, Interpreter::DEPLOYED_BYTECODE.clone())
+        .await?;
+    provider
+        .anvil_set_code(RAINLANG_STORE, RainStore::DEPLOYED_BYTECODE.clone())
+        .await?;
+    provider
+        .anvil_set_code(RAINLANG_PARSER, Parser::DEPLOYED_BYTECODE.clone())
+        .await?;
+    provider
+        .anvil_set_code(
+            RAINLANG_EXPRESSION_DEPLOYER,
+            Deployer::DEPLOYED_BYTECODE.clone(),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Deterministic singleton address of the TOFUTokenDecimals contract, hardcoded by
+/// the orderbook's `LibTOFUTokenDecimals.ensureDeployed` (which checks address + codehash).
+const TOFU_TOKEN_DECIMALS: Address = address!("0x200e12D10bb0c5E4a17e7018f0F1161919bb9389");
+
+/// Canonical TOFUTokenDecimals init bytecode, copied from rain-tofu-erc20-decimals'
+/// `LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE`. Deploying it and etching the
+/// resulting runtime at `TOFU_TOKEN_DECIMALS` yields the codehash `ensureDeployed` requires;
+/// rain.orderbook's own recompile of TOFUTokenDecimals.sol does not match that hash.
+const TOFU_DECIMALS_CREATION_CODE: &str = "0x6080604052348015600e575f80fd5b5061044b8061001c5f395ff3fe608060405234801561000f575f80fd5b506004361061004a575f3560e01c80630782d7e11461004e57806354636d2b14610078578063b7bad1b11461009d578063f5c36eaf146100b0575b5f80fd5b61006161005c366004610363565b6100c3565b60405161006f929190610403565b60405180910390f35b61008b610086366004610363565b6100d8565b60405160ff909116815260200161006f565b6100616100ab366004610363565b6100e9565b61008b6100be366004610363565b6100f5565b5f806100cf5f84610100565b91509150915091565b5f6100e35f836101f0565b92915050565b5f806100cf5f84610281565b5f6100e35f83610356565b73ffffffffffffffffffffffffffffffffffffffff81165f9081526020838152604080832081518083019092525460ff8082161515835261010090910416818301527f313ce56700000000000000000000000000000000000000000000000000000000808452839283908190816004818a5afa915060203d1015610182575f91505b811561019857505f5160ff811115610198575f91505b816101af57505050602001516003925090506101e9565b83516101c3575f955093506101e992505050565b836020015160ff1681146101d85760026101db565b60015b846020015195509550505050505b9250929050565b5f805f6101fd8585610281565b909250905060018260038111156102165761021661039d565b1415801561023557505f8260038111156102325761023261039d565b14155b156102795783826040517fee07877f000000000000000000000000000000000000000000000000000000008152600401610270929190610421565b60405180910390fd5b949350505050565b5f805f8061028f8686610100565b90925090505f8260038111156102a7576102a761039d565b0361034b576040805180820182526001815260ff838116602080840191825273ffffffffffffffffffffffffffffffffffffffff8a165f908152908b9052939093209151825493517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00009094169015157fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff161761010093909116929092029190911790555b909590945092505050565b5f805f6101fd8585610100565b5f60208284031215610373575f80fd5b813573ffffffffffffffffffffffffffffffffffffffff81168114610396575f80fd5b9392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b600481106103ff577f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9052565b6040810161041182856103ca565b60ff831660208301529392505050565b73ffffffffffffffffffffffffffffffffffffffff831681526040810161039660208301846103ca56";
+
+/// Deploys the canonical TOFUTokenDecimals init bytecode and etches the resulting
+/// runtime at [`TOFU_TOKEN_DECIMALS`]. The orderbook checks both the address and the
+/// codehash, so the runtime must come from executing the canonical creation code.
+async fn deploy_tofu_singleton<P: Provider>(provider: &P) -> anyhow::Result<()> {
+    let creation_code = alloy::hex::decode(TOFU_DECIMALS_CREATION_CODE)?;
+    let deployed = provider
+        .send_transaction(TransactionRequest::default().with_deploy_code(creation_code))
+        .await?
+        .get_receipt()
+        .await?
+        .contract_address
+        .ok_or_else(|| anyhow::anyhow!("TOFU deployment produced no contract address"))?;
+    let runtime = provider.get_code_at(deployed).await?;
+    provider
+        .anvil_set_code(TOFU_TOKEN_DECIMALS, runtime)
+        .await?;
+    Ok(())
+}
 
 sol!(
     #![sol(all_derives = true, rpc)]
@@ -104,7 +166,7 @@ pub enum TakeDirection {
 /// taken by a separate account. Created by `setup_order()`, consumed by
 /// `take_prepared_order()`.
 pub struct PreparedOrder {
-    pub order: IOrderBookV6::OrderV4,
+    pub order: IRaindexV6::OrderV4,
     pub input_vault_id: B256,
     pub output_vault_id: B256,
     pub input_token: Address,
@@ -158,7 +220,7 @@ impl BaseChain<()> {
             .connect(&anvil.endpoint())
             .await?;
 
-        let orderbook = OrderBook::deploy(&provider).await?;
+        let orderbook = RaindexV6::deploy(&provider).await?;
         let orderbook = *orderbook.address();
 
         // Place USDC contract at the canonical USDC_BASE address so vault
@@ -175,31 +237,13 @@ impl BaseChain<()> {
         // shares this Anvil provider (equity e2e tests).
         deploy_usdc_at(&provider, crate::cctp::USDC_ETHEREUM, owner).await?;
 
-        provider
-            .anvil_set_code(
-                address!("F66761F6b5F58202998D6Cd944C81b22Dc6d4f1E"),
-                TOFUTokenDecimals::DEPLOYED_BYTECODE.clone(),
-            )
-            .await?;
+        deploy_tofu_singleton(&provider).await?;
 
-        let interpreter = Interpreter::deploy(&provider).await?;
-        let store = RainStore::deploy(&provider).await?;
-        let parser = Parser::deploy(&provider).await?;
+        etch_rainlang(&provider).await?;
 
-        let interpreter = *interpreter.address();
-        let store = *store.address();
-
-        let deployer = Deployer::deploy(
-            &provider,
-            Deployer::RainterpreterExpressionDeployerConstructionConfigV2 {
-                interpreter,
-                store,
-                parser: *parser.address(),
-            },
-        )
-        .await?;
-
-        let deployer = *deployer.address();
+        let interpreter = RAINLANG_INTERPRETER;
+        let store = RAINLANG_STORE;
+        let deployer = RAINLANG_EXPRESSION_DEPLOYER;
 
         let taker_key = B256::from_slice(&anvil.keys()[1].to_bytes());
         let taker_signer = PrivateKeySigner::from_bytes(&taker_key)?;
@@ -334,7 +378,7 @@ impl<P: Provider + Clone> BaseChain<P> {
     /// Used by USDC rebalancing tests so the bot has a known vault to
     /// withdraw from (BaseToAlpaca) or deposit into (AlpacaToBase).
     pub async fn create_usdc_vault(&self, amount: U256) -> anyhow::Result<B256> {
-        let orderbook = IOrderBookV6::IOrderBookV6Instance::new(self.orderbook, &self.provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook, &self.provider);
         let vault_id = B256::random();
 
         // Over-approve for Rain float precision rounding
@@ -383,7 +427,7 @@ impl<P: Provider + Clone> BaseChain<P> {
         amount: U256,
         decimals: u8,
     ) -> anyhow::Result<()> {
-        let orderbook = IOrderBookV6::IOrderBookV6Instance::new(self.orderbook, &self.provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook, &self.provider);
 
         // Over-approve for Rain float precision rounding
         IERC20::new(token, &self.provider)
@@ -439,7 +483,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .get(symbol)
             .ok_or_else(|| anyhow::anyhow!("Equity token for {symbol} not deployed"))?;
 
-        let orderbook = IOrderBookV6::IOrderBookV6Instance::new(self.orderbook, &self.provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook, &self.provider);
         let deployer_instance = Deployer::DeployerInstance::new(self.deployer, &self.provider);
 
         let is_sell = matches!(direction, TakeDirection::SellEquity);
@@ -484,17 +528,17 @@ impl<P: Provider + Clone> BaseChain<P> {
             usdc_vault_id.unwrap_or_else(B256::random)
         };
 
-        let order_config = IOrderBookV6::OrderConfigV4 {
-            evaluable: IOrderBookV6::EvaluableV4 {
+        let order_config = IRaindexV6::OrderConfigV4 {
+            evaluable: IRaindexV6::EvaluableV4 {
                 interpreter: self.interpreter,
                 store: self.store,
                 bytecode: Bytes::from(parsed_bytecode),
             },
-            validInputs: vec![IOrderBookV6::IOV2 {
+            validInputs: vec![IRaindexV6::IOV2 {
                 token: input_token,
                 vaultId: input_vault_id,
             }],
-            validOutputs: vec![IOrderBookV6::IOV2 {
+            validOutputs: vec![IRaindexV6::IOV2 {
                 token: output_token,
                 vaultId: output_vault_id,
             }],
@@ -514,7 +558,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .inner
             .logs()
             .iter()
-            .find_map(|log| log.log_decode::<IOrderBookV6::AddOrderV3>().ok())
+            .find_map(|log| log.log_decode::<IRaindexV6::AddOrderV3>().ok())
             .ok_or_else(|| anyhow::anyhow!("AddOrderV3 event not found"))?;
         let order = add_event.data().order.clone();
 
@@ -589,8 +633,7 @@ impl<P: Provider + Clone> BaseChain<P> {
         prepared: &PreparedOrder,
         max_amount: Option<Float>,
     ) -> anyhow::Result<TakeOrderResult> {
-        let orderbook =
-            IOrderBookV6::IOrderBookV6Instance::new(self.orderbook, &self.taker_provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook, &self.taker_provider);
 
         // Approve taker's input token payment (taker pays input_token)
         DeployableERC20::new(prepared.input_token, &self.taker_provider)
@@ -615,7 +658,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .get_inner();
         let max_io = max_amount.map_or(default_max, |f| f.get_inner());
 
-        let take_config = IOrderBookV6::TakeOrdersConfigV5 {
+        let take_config = IRaindexV6::TakeOrdersConfigV5 {
             minimumIO: B256::ZERO,
             maximumIO: max_io,
             maximumIORatio: Float::from_fixed_decimal_lossy(U256::from(1_000_000), 0)
@@ -623,7 +666,7 @@ impl<P: Provider + Clone> BaseChain<P> {
                 .0
                 .get_inner(),
             IOIsInput: true,
-            orders: vec![IOrderBookV6::TakeOrderConfigV4 {
+            orders: vec![IRaindexV6::TakeOrderConfigV4 {
                 order: prepared.order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(0),
@@ -701,7 +744,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .get(symbol)
             .ok_or_else(|| anyhow::anyhow!("Equity token for {symbol} not deployed"))?;
 
-        let orderbook = IOrderBookV6::IOrderBookV6Instance::new(self.orderbook, &self.provider);
+        let orderbook = IRaindexV6::IRaindexV6Instance::new(self.orderbook, &self.provider);
         let deployer_instance = Deployer::DeployerInstance::new(self.deployer, &self.provider);
 
         let is_sell = matches!(direction, TakeDirection::SellEquity);
@@ -739,17 +782,17 @@ impl<P: Provider + Clone> BaseChain<P> {
         let input_vault_id = B256::random();
         let output_vault_id = B256::random();
 
-        let order_config = IOrderBookV6::OrderConfigV4 {
-            evaluable: IOrderBookV6::EvaluableV4 {
+        let order_config = IRaindexV6::OrderConfigV4 {
+            evaluable: IRaindexV6::EvaluableV4 {
                 interpreter: self.interpreter,
                 store: self.store,
                 bytecode: Bytes::from(parsed_bytecode),
             },
-            validInputs: vec![IOrderBookV6::IOV2 {
+            validInputs: vec![IRaindexV6::IOV2 {
                 token: input_token,
                 vaultId: input_vault_id,
             }],
-            validOutputs: vec![IOrderBookV6::IOV2 {
+            validOutputs: vec![IRaindexV6::IOV2 {
                 token: output_token,
                 vaultId: output_vault_id,
             }],
@@ -769,7 +812,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .inner
             .logs()
             .iter()
-            .find_map(|log| log.log_decode::<IOrderBookV6::AddOrderV3>().ok())
+            .find_map(|log| log.log_decode::<IRaindexV6::AddOrderV3>().ok())
             .ok_or_else(|| anyhow::anyhow!("AddOrderV3 event not found"))?;
         let order = add_event.data().order.clone();
 
@@ -832,7 +875,7 @@ impl<P: Provider + Clone> BaseChain<P> {
             .call()
             .await?;
 
-        let take_config = IOrderBookV6::TakeOrdersConfigV5 {
+        let take_config = IRaindexV6::TakeOrdersConfigV5 {
             minimumIO: B256::ZERO,
             maximumIO: Float::from_fixed_decimal_lossy(U256::from(1_000_000), 0)
                 .map_err(|err| anyhow::anyhow!("Float conversion: {err:?}"))?
@@ -843,7 +886,7 @@ impl<P: Provider + Clone> BaseChain<P> {
                 .0
                 .get_inner(),
             IOIsInput: true,
-            orders: vec![IOrderBookV6::TakeOrderConfigV4 {
+            orders: vec![IRaindexV6::TakeOrderConfigV4 {
                 order: order.clone(),
                 inputIOIndex: U256::from(0),
                 outputIOIndex: U256::from(0),

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -12,7 +12,7 @@ use st0x_execution::{AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, T
 pub(crate) use st0x_execution::{FractionalShares, Positive, Symbol};
 pub(crate) use st0x_hedge::ExecutionThreshold;
 use st0x_hedge::TradingMode;
-use st0x_hedge::bindings::IOrderBookV6;
+use st0x_hedge::bindings::IRaindexV6;
 pub(crate) use st0x_hedge::{OffchainOrder, Position};
 
 pub(crate) use crate::assert::ExpectedPosition;
@@ -160,7 +160,7 @@ async fn assert_onchain_vaults<P: Provider>(
             .unwrap_or_else(|_| format!("{raw}"))
     };
 
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(orderbook, provider);
+    let orderbook = IRaindexV6::IRaindexV6Instance::new(orderbook, provider);
 
     let output_balance_now = orderbook
         .vaultBalance2(owner, take_result.output_token, take_result.output_vault_id)

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -36,7 +36,7 @@ use st0x_execution::{
 };
 use st0x_finance::{Positive, Usd};
 pub(crate) use st0x_hedge::UsdcRebalancing;
-use st0x_hedge::bindings::IOrderBookV6;
+use st0x_hedge::bindings::IRaindexV6;
 pub(crate) use st0x_hedge::mock_api::REDEMPTION_WALLET;
 use st0x_hedge::mock_api::{AlpacaTokenizationMock, TokenizationStatus};
 pub(crate) use st0x_hedge::mock_api::{RedemptionOutcome, TokenizationRequestType};
@@ -572,7 +572,7 @@ async fn assert_equity_mint_rebalancing<P: Provider>(
         })
         .collect::<anyhow::Result<_>>()?;
 
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(orderbook, provider);
+    let orderbook = IRaindexV6::IRaindexV6Instance::new(orderbook, provider);
     let mut total_refilled_wrapped_shares_delta = U256::ZERO;
     for ((token, vault_id), pre_rebalance_balance) in consumed_output_vaults {
         let post_rebalance_balance = orderbook
@@ -767,7 +767,7 @@ async fn assert_equity_redeem_rebalancing<P: Provider>(
             Ok(((result.input_token, result.input_vault_id), after_take))
         })
         .collect::<anyhow::Result<_>>()?;
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(orderbook, provider);
+    let orderbook = IRaindexV6::IRaindexV6Instance::new(orderbook, provider);
     let mut total_withdrawn_wrapped_shares = U256::ZERO;
     for ((token, vault_id), pre_rebalance_balance) in &redeemed_input_vaults {
         let post_rebalance_balance = orderbook
@@ -1219,7 +1219,7 @@ async fn assert_usdc_rebalancing_onchain_state<P: Provider>(
     event_amounts: &UsdcRebalanceEventAmounts,
     take_results: &[TakeOrderResult],
 ) -> anyhow::Result<()> {
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(orderbook, provider);
+    let orderbook = IRaindexV6::IRaindexV6Instance::new(orderbook, provider);
     let vault_balance = orderbook
         .vaultBalance2(owner, base_chain::USDC_BASE, usdc_vault_id)
         .call()

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -35,7 +35,7 @@ use st0x_finance::{FractionalShares, Positive, Usd};
 use st0x_float_macro::float;
 use st0x_hedge::ImbalanceThreshold;
 use st0x_hedge::OperationMode;
-use st0x_hedge::bindings::IOrderBookV6;
+use st0x_hedge::bindings::IRaindexV6;
 use st0x_hedge::cli::seed_mint_at_tokens_wrapped_for_test;
 
 use self::assertions::*;
@@ -946,7 +946,7 @@ async fn usdc_imbalance_triggers_alpaca_to_base() -> anyhow::Result<()> {
     // flow is long enough (CCTP bridge + attestation) that the vault
     // balance won't change before we snapshot.
     let usdc_vault_balance_before_rebalance =
-        st0x_hedge::bindings::IOrderBookV6::IOrderBookV6Instance::new(
+        st0x_hedge::bindings::IRaindexV6::IRaindexV6Instance::new(
             infra.base_chain.orderbook,
             &infra.base_chain.provider,
         )
@@ -2254,10 +2254,8 @@ async fn wrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<
     let equity_vault_id = prepared.output_vault_id;
     let equity_vault_ids = HashMap::from([("AAPL".to_owned(), equity_vault_id)]);
 
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(
-        infra.base_chain.orderbook,
-        &infra.base_chain.provider,
-    );
+    let orderbook =
+        IRaindexV6::IRaindexV6Instance::new(infra.base_chain.orderbook, &infra.base_chain.provider);
 
     let vault_balance_before_raw = orderbook
         .vaultBalance2(infra.base_chain.owner, wrapped_token, equity_vault_id)
@@ -2412,10 +2410,8 @@ async fn unwrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Resul
     let equity_vault_id = prepared.output_vault_id;
     let equity_vault_ids = HashMap::from([("AAPL".to_owned(), equity_vault_id)]);
 
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(
-        infra.base_chain.orderbook,
-        &infra.base_chain.provider,
-    );
+    let orderbook =
+        IRaindexV6::IRaindexV6Instance::new(infra.base_chain.orderbook, &infra.base_chain.provider);
 
     let vault_balance_before_raw = orderbook
         .vaultBalance2(infra.base_chain.owner, wrapped_token, equity_vault_id)
@@ -2649,10 +2645,8 @@ async fn active_mint_in_tokens_wrapped_recovers_into_raindex_vault() -> anyhow::
     let equity_vault_id = prepared.output_vault_id;
     let equity_vault_ids = HashMap::from([("AAPL".to_owned(), equity_vault_id)]);
 
-    let orderbook = IOrderBookV6::IOrderBookV6Instance::new(
-        infra.base_chain.orderbook,
-        &infra.base_chain.provider,
-    );
+    let orderbook =
+        IRaindexV6::IRaindexV6Instance::new(infra.base_chain.orderbook, &infra.base_chain.provider);
 
     let vault_balance_before = orderbook
         .vaultBalance2(infra.base_chain.owner, wrapped_token, equity_vault_id)


### PR DESCRIPTION
## What

[RAI-700](https://linear.app/makeitrain/issue/RAI-700) (also [RAI-624](https://linear.app/makeitrain/issue/RAI-624) Soldeer vendoring / [RAI-680](https://linear.app/makeitrain/issue/RAI-680) drop submodule path-deps)

Bumps rain.orderbook to RaindexV6: vendors its Solidity dependency closure via Soldeer, drops the git submodules, and renames the generated bindings (`IOrderBookV6` -> `IRaindexV6`, `OrderBook` -> `RaindexV6`).

## Why

Upstream rain.orderbook dropped git submodules in favour of Soldeer and renamed `OrderBookV6` to `RaindexV6`, so the pinned rev, the ABI build, and every binding reference had to move with it. Staying on the old submodule rev blocks pulling in newer orderbook contracts and the matching rain.math.float.

## How

- Bump the `rain-orderbook` flake input to the RaindexV6 rev and drop `submodules = true`; bump `rain-math-float` in lockstep.
- Vendor the Soldeer closure in `nix/rain-orderbook.nix` as a fixed-output derivation that fetches each dependency pinned in `soldeer.lock` (registry URL + zip sha256), so `forge build` runs fully offline.
- Consume rainlang's shipped canonical interpreter/store/parser/deployer artifacts instead of recompiling them -- recompiling under the orderbook's optimizer profile breaks the codegen'd jump tables (runtime `InvalidJump`).
- Repoint the `ST0X_*_ABI` env vars at the RaindexV6 / rainlang artifact paths and rename the `sol!` bindings.
- Pin `wasm-bindgen = "=0.2.122"` to satisfy the newer rain crates' transitive requirement.
- Etch the TOFUTokenDecimals singleton from its canonical creation code (`deploy_tofu_singleton`) and etch the rainlang stack at its deterministic "zoltu" addresses (`etch_rainlang`), matching the hardcoded addresses/codehashes the contracts require.
- `SeedVaultRegistryCtx::from_config` now boxes its `CtxError` to keep the result small after the dependency bump.

## Testing

- Covered by the existing onchain/integration suites, which now deploy against RaindexV6: arbitrage integration tests, raindex deposit/withdraw/vault-balance tests, and the Base-chain e2e flow.
- Vendoring is exercised by the Nix ABI build itself -- `forge build` must resolve the Soldeer closure offline for the ABIs to exist.

## Screenshots

N/A

## Anything else

- Stacks on `refactor/raindex-crate-trait-types`.
- The rainlang interpreter stack is intentionally not rebuilt from source; we rely on upstream's shipped artifacts to preserve the deterministic deploy addresses the expression deployer hardcodes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783140872&installation_id=125569124&pr_number=741&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F741&signature=683aac8c3b3c5050286697886b67fe275872d925dd987d4ae56676d018cf5f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->