### PR TITLE
docs: ADR 0003 model identifiers by what determines them; pad ADR 0001

### DIFF
--- a/adrs/0001-cash-bp-for-equity-hedges.md
+++ b/adrs/0001-cash-bp-for-equity-hedges.md
@@ -1,4 +1,4 @@
-# ADR 1: Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight
+# ADR 0001: Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight
 
 ## Status
 

--- a/adrs/0004-typed-identifiers.md
+++ b/adrs/0004-typed-identifiers.md
@@ -1,0 +1,88 @@
+# ADR 0004: Model identifiers by what determines them; derive the string form
+
+- Status: Accepted
+- Date: 2026-06-04
+
+## Context
+
+Identifiers we exchange with external systems were frequently represented as
+`String`, or as a newtype that merely wraps `String`. The old
+`ClientOrderId(String)` in `crates/execution/src/order/mod.rs` was the
+motivating example: it is the idempotency key forwarded to Alpaca, and it was
+built three ways —
+
+- `from_uuid(Uuid)` — the string is a single `Uuid`.
+- `from_prefixed_uuid(prefix: &'static str, Uuid)` — the string is a fixed
+  prefix drawn from a closed set (`"preflight-"`, `"cli-"`) concatenated with a
+  `Uuid`.
+- `new(impl Into<String>)` — an arbitrary, length-validated string.
+
+Every constructor collapses structured inputs into an opaque `String` and
+discards the structure. Nothing can recover the prefix or the `Uuid` from a
+stored value; the prefix set is enforced only by whichever `&'static str`
+literals callers happen to pass; and `new` admits any string. The newtype gives
+the appearance of a domain type while remaining stringly-typed — the invariants
+that actually determine a valid value (which prefixes exist, that the body is a
+`Uuid`) live nowhere in the type.
+
+## Decision
+
+A value whose string form is _determined by other values_ is modeled as those
+values, and the string is **derived** from them via a conversion. The string is
+never the stored source of truth.
+
+1. **A string built from N inputs is a struct of N typed fields.** The rendered
+   string comes from a `Display`/`From` conversion over the struct. The struct —
+   not the string — is what we store and pass around.
+2. **A value drawn from a fixed, finite set of literals is an enum** (a single
+   constant is a unit variant). Static prefixes like `"preflight-"` and `"cli-"`
+   become variants of a closed enum, not `&'static str` arguments.
+3. **A `String` newtype is acceptable only when the string is genuinely opaque**
+   — it arrives fully formed from outside our control (a broker order id we read
+   back) and we never construct or destructure it ourselves. Even then it owns a
+   parser/validator, not a bare wrapper.
+
+For `ClientOrderId` this is now an enum over its real shapes — a bare `Uuid`, or
+the CLI-prefixed `Uuid` variant — with `Display` producing the wire string and
+`FromStr`/serde preserving the wire-compatible string form. The broker request
+field stays a `String`, but only as the _output_ of converting a well-typed
+`ClientOrderId` at the SDK boundary, never as an internal carrier.
+
+## Consequences
+
+### Positive
+
+- Invalid identifiers become unrepresentable: an unknown prefix cannot be
+  constructed and the body is always a real `Uuid`.
+- The prefix set is closed and exhaustively matchable — adding a kind is a
+  compiler-enforced change, not a grep for string literals.
+- Components can be recovered where it matters, because they were never
+  discarded.
+- The `String` lives only at the boundary, matching the standing rule to convert
+  domain newtypes to SDK primitives inside the callee.
+
+### Negative / costs
+
+- More types and a little conversion code per identifier.
+- A migration cost for existing call sites and for any persisted/serialized form
+  (serde must (de)serialize via the rendered string to keep wire compatibility).
+
+### Neutral
+
+- The wire format is unchanged; only the in-memory representation gains
+  structure.
+
+## Alternatives considered
+
+- **Keep the `String` newtype, add validation in `new`.** Rejected: validating
+  in a constructor does not capture _what determines_ the value, leaves the
+  prefix set open, and still discards structure.
+- **Separate newtypes per shape with no shared type.** Rejected: a caller
+  holding "some client order id" would need an ad-hoc enum anyway; model the sum
+  type directly.
+
+## Follow-ups
+
+- Audit other `*(String)` identifier newtypes (broker order ids, correlation
+  ids) with the same test: is the string determined by values we already hold?
+  If so, model the values.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -58,12 +58,6 @@ adrs/
 - The kebab name should be terse and decision-shaped (e.g.
   `0002-axum-and-tower.md`, not `0002-web-framework.md`).
 
-  ADRs written before this convention landed (e.g.
-  `1-cash-bp-for-equity-hedges.md`) keep their original filenames — the README
-  rule is "indices are never reused, even if an ADR is superseded," and that
-  applies to filenames too. That earlier ADR sits at index `1`; the first ADR
-  written under this convention is ADR `0002`.
-
 ## ADR template
 
 ```markdown
@@ -120,6 +114,7 @@ decision.
 
 | #                                                       | Title                                                                            | Status   |
 | ------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
-| [1](1-cash-bp-for-equity-hedges.md)                     | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
+| [0001](0001-cash-bp-for-equity-hedges.md)               | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
 | [0002](0002-axum-and-tower.md)                          | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |
 | [0003](0003-durable-usdc-rebalance-guard-on-restart.md) | Reconstruct the USDC rebalancing guard from persisted state on startup           | Accepted |
+| [0004](0004-typed-identifiers.md)                       | Model identifiers by what determines them; derive the string form                | Accepted |


### PR DESCRIPTION
## What

[RAI-858](https://linear.app/makeitrain/issue/RAI-858)

Add ADR 0003 (model identifiers by what determines them; derive the string form from the typed values) and pad ADR 0001's filename to the zero-padded `NNNN` convention.

## Why

`String` newtype identifiers like `ClientOrderId(String)` discard the structure that actually determines a valid value (closed prefix set, `Uuid` body), so invalid identifiers stay representable and components can't be recovered. ADR 0003 records the standing decision to model that structure instead. Renaming ADR 0001 brings the one pre-convention filename in line with the zero-padded `NNNN` scheme so every ADR follows one rule.

## How

- Add `adrs/0003-typed-identifiers.md`: model an identifier as the typed values that determine it, derive the string via `Display`/`From`, reserve `String` newtypes for genuinely opaque external ids.
- Use `ClientOrderId` as the motivating example: an enum over a bare `Uuid` or a typed prefix-kind plus `Uuid`, with the wire `String` produced only at the SDK boundary.
- Rename `adrs/1-cash-bp-for-equity-hedges.md` to `adrs/0001-cash-bp-for-equity-hedges.md` and update its heading to `ADR 0001`.
- Update `adrs/README.md`: drop the now-obsolete pre-convention exemption note and re-pad the index table to `0001`/`0003`.

## Testing

Docs only.

## Screenshots

N/A

## Anything else

- The ADR is Proposed; the `ClientOrderId` remodel and the audit of other `*(String)` identifier newtypes are listed as follow-ups, not done here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783192425&installation_id=125569124&pr_number=742&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F742&signature=9b962ae5bbb6eefbea6c3775ffcee7fd66eb74fd210359b997216f108b9e4651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Architecture Decision Records (ADR) numbering convention to use zero-padded four-digit indices for consistency.
  * Added new ADR guidance on modeling structured identifiers with type safety, including derived string representations.
  * Revised ADR index and file layout documentation to reflect updated conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->