### PR TITLE
refactor: move RaindexService and bindings into st0x-raindex behind rain feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6298,9 +6298,17 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-trait",
+ "proptest",
  "rain-math-float",
+ "serde_json",
  "st0x-evm",
+ "st0x-execution",
+ "st0x-finance",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-test",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ st0x-execution.workspace = true
 st0x-finance.workspace = true
 st0x-float-macro.workspace = true
 st0x-float-serde.workspace = true
-st0x-raindex.workspace = true
+st0x-raindex = { workspace = true, features = ["rain"] }
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/crates/raindex/Cargo.toml
+++ b/crates/raindex/Cargo.toml
@@ -3,12 +3,30 @@ name = "st0x-raindex"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+rain = ["dep:st0x-execution", "dep:st0x-finance", "dep:tokio", "dep:tracing"]
+
 [dependencies]
 alloy.workspace = true
 async-trait.workspace = true
 rain-math-float.workspace = true
 st0x-evm.workspace = true
 thiserror.workspace = true
+
+# Optional deps gated behind the `rain` feature (RaindexService implementation only).
+st0x-execution = { workspace = true, optional = true }
+st0x-finance = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+proptest.workspace = true
+serde_json.workspace = true
+st0x-evm = { workspace = true, features = ["local-signer"] }
+tokio = { workspace = true, features = ["full"] }
+tracing-test.workspace = true
+url.workspace = true
 
 [lints]
 workspace = true

--- a/crates/raindex/src/lib.rs
+++ b/crates/raindex/src/lib.rs
@@ -14,6 +14,11 @@ use async_trait::async_trait;
 
 use st0x_evm::EvmError;
 
+#[cfg(feature = "rain")]
+mod service;
+#[cfg(feature = "rain")]
+pub use service::RaindexService;
+
 /// Base USDC token address.
 pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 

--- a/crates/raindex/src/service.rs
+++ b/crates/raindex/src/service.rs
@@ -1,10 +1,13 @@
 //! Rain OrderBook V6 (Raindex) vault operations on Base.
 //!
-//! This module provides a service layer for depositing and withdrawing tokens to/from
-//! Raindex vaults using the `deposit4` and `withdraw4` contract functions.
+//! [`RaindexService`] implements the [`Raindex`](crate::Raindex) trait for depositing and
+//! withdrawing tokens to/from Raindex vaults using the `deposit4` and `withdraw4`
+//! contract functions. The primary use case is USDC vault management for inventory
+//! rebalancing in the market making system.
 //!
-//! The primary use case is USDC vault management for inventory rebalancing in the
-//! market making system.
+//! This module and its private `IRaindexV6`/`IERC20` bindings are gated behind the
+//! `rain` feature; the [`Raindex`](crate::Raindex) trait and its domain types ship in the
+//! default build.
 //!
 //! ## V6 Float Format
 //!
@@ -14,6 +17,7 @@
 use alloy::primitives::{Address, TxHash, U256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, TransactionReceipt};
+use alloy::sol;
 use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use rain_math_float::Float;
@@ -22,9 +26,18 @@ use tracing::{debug, info};
 use st0x_evm::{Evm, IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
 use st0x_execution::FractionalShares;
 use st0x_finance::Usdc;
-pub(crate) use st0x_raindex::{Raindex, RaindexError, RaindexVaultId, USDC_BASE};
 
-use crate::bindings::{IERC20, IRaindexV6};
+use crate::{Raindex, RaindexError, RaindexVaultId, USDC_BASE};
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    IRaindexV6, env!("ST0X_IORDERBOOK_V6_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    IERC20, env!("ST0X_IERC20_ABI")
+);
 
 const USDC_DECIMALS: u8 = 6;
 
@@ -56,14 +69,14 @@ const SCAN_FINALITY_MARGIN: u64 = 2;
 /// let deposit_tx = service.submit_deposit_usdc(vault_id, amount).await?;
 /// service.confirm_tx(deposit_tx).await?;
 /// ```
-pub(crate) struct RaindexService<E: Evm> {
+pub struct RaindexService<E: Evm> {
     orderbook_address: Address,
     evm: E,
     owner: Address,
 }
 
 impl<E: Evm> RaindexService<E> {
-    pub(crate) fn new(evm: E, orderbook: Address, owner: Address) -> Self {
+    pub fn new(evm: E, orderbook: Address, owner: Address) -> Self {
         Self {
             orderbook_address: orderbook,
             evm,
@@ -88,7 +101,7 @@ impl<W: Wallet> RaindexService<W> {
     /// Returns `RaindexError::ZeroAmount` if amount is zero.
     /// Returns `RaindexError::Float` if amount cannot be converted to float format.
     /// Returns `RaindexError::Evm` for transaction errors.
-    pub(crate) async fn deposit<Registry: IntoErrorRegistry>(
+    pub async fn deposit<Registry: IntoErrorRegistry>(
         &self,
         token: Address,
         vault_id: RaindexVaultId,
@@ -207,7 +220,7 @@ impl<W: Wallet> RaindexService<W> {
     /// `InitiateDeposit` before confirmation, so a crash during the confirmation
     /// wait resumes from `DepositInitiated` (re-verifying the recorded tx via
     /// `confirm_tx`) instead of re-submitting a second deposit.
-    pub(crate) async fn submit_deposit_usdc(
+    pub async fn submit_deposit_usdc(
         &self,
         vault_id: RaindexVaultId,
         amount: U256,
@@ -227,7 +240,7 @@ impl<W: Wallet> RaindexService<W> {
     ///
     /// * `vault_id` - Source vault identifier
     /// * `target_amount` - Target amount of USDC to withdraw (in USDC's base units, 6 decimals)
-    pub(crate) async fn withdraw_usdc(
+    pub async fn withdraw_usdc(
         &self,
         vault_id: RaindexVaultId,
         target_amount: U256,
@@ -239,7 +252,7 @@ impl<W: Wallet> RaindexService<W> {
 
 /// Read operations that only need chain access (no signing).
 impl<E: Evm> RaindexService<E> {
-    pub(crate) async fn get_equity_balance<Registry: IntoErrorRegistry>(
+    pub async fn get_equity_balance<Registry: IntoErrorRegistry>(
         &self,
         owner: Address,
         token: Address,
@@ -252,7 +265,7 @@ impl<E: Evm> RaindexService<E> {
     }
 
     /// Gets the USDC balance of a vault on Base.
-    pub(crate) async fn get_usdc_balance<Registry: IntoErrorRegistry>(
+    pub async fn get_usdc_balance<Registry: IntoErrorRegistry>(
         &self,
         owner: Address,
         vault_id: RaindexVaultId,
@@ -283,7 +296,7 @@ impl<E: Evm> RaindexService<E> {
     /// be lagging (the dRPC load-balancing hazard AGENTS.md warns about) yields a
     /// retryable [`RaindexError::ScanInconclusive`] instead, so the caller never
     /// re-executes the irreversible withdraw off a single stale empty `eth_getLogs`.
-    pub(crate) async fn find_recent_withdrawal(
+    pub async fn find_recent_withdrawal(
         &self,
         token: Address,
         vault_id: RaindexVaultId,
@@ -340,7 +353,7 @@ impl<E: Evm> RaindexService<E> {
     /// Returns the current chain head. Captured before submitting an on-chain
     /// action so a later [`find_recent_withdrawal`](Self::find_recent_withdrawal)
     /// scan can bound its search to blocks at or after the action.
-    pub(crate) async fn current_block(&self) -> Result<u64, RaindexError> {
+    pub async fn current_block(&self) -> Result<u64, RaindexError> {
         Ok(self.evm.provider().get_block_number().await?)
     }
 
@@ -461,32 +474,72 @@ impl<W: Wallet> Raindex for RaindexService<W> {
 
 #[cfg(test)]
 mod tests {
-    use alloy::network::Ethereum;
+    use alloy::network::{Ethereum, TransactionBuilder};
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::Log as PrimitiveLog;
     use alloy::primitives::{B256, address, b256};
-    use alloy::providers::Provider;
+    use alloy::providers::ext::AnvilApi as _;
     use alloy::providers::fillers::{
         BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
     };
-    use alloy::providers::{Identity, ProviderBuilder, RootProvider};
-    use alloy::rpc::types::Log;
+    use alloy::providers::mock::Asserter;
+    use alloy::providers::{Identity, Provider, ProviderBuilder, RootProvider};
+    use alloy::rpc::types::{Log, TransactionRequest};
+    use alloy::sol;
     use alloy::transports::{RpcError, TransportErrorKind};
     use proptest::prelude::*;
+    use serde_json::json;
     use tracing_test::traced_test;
 
-    use alloy::providers::mock::Asserter;
-    use serde_json::json;
-
-    use st0x_evm::EvmError;
-    use st0x_evm::NoOpErrorRegistry;
-    use st0x_evm::ReadOnlyEvm;
-    use st0x_evm::Wallet;
     use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_evm::{EvmError, NoOpErrorRegistry, ReadOnlyEvm, Wallet};
 
     use super::*;
-    use crate::bindings::{IRaindexV6, RaindexV6, TestERC20};
-    use crate::test_utils::deploy_tofu_singleton;
+
+    sol!(
+        #![sol(all_derives = true, rpc)]
+        RaindexV6, env!("ST0X_ORDERBOOK_ABI")
+    );
+
+    sol!(
+        #![sol(all_derives = true, rpc)]
+        TestERC20, env!("ST0X_TEST_ERC20_ABI")
+    );
+
+    /// Deterministic singleton address of the TOFUTokenDecimals contract. The
+    /// orderbook's `LibTOFUTokenDecimals.ensureDeployed` hardcodes this address and
+    /// checks the codehash, so any test exercising deposits, withdrawals, or order
+    /// takes must place the canonical runtime here.
+    const TOFU_TOKEN_DECIMALS: Address = address!("0x200e12D10bb0c5E4a17e7018f0F1161919bb9389");
+
+    /// Canonical TOFUTokenDecimals init bytecode, copied from
+    /// rain-tofu-erc20-decimals' `LibTOFUTokenDecimals.TOFU_DECIMALS_EXPECTED_CREATION_CODE`.
+    /// Deploying this and etching the resulting runtime at `TOFU_TOKEN_DECIMALS` yields the
+    /// codehash `ensureDeployed` requires; rain.orderbook's own recompile of TOFUTokenDecimals.sol
+    /// does not match that hash, so its artifact bytecode cannot be used directly.
+    const TOFU_DECIMALS_CREATION_CODE: &str = "0x6080604052348015600e575f80fd5b5061044b8061001c5f395ff3fe608060405234801561000f575f80fd5b506004361061004a575f3560e01c80630782d7e11461004e57806354636d2b14610078578063b7bad1b11461009d578063f5c36eaf146100b0575b5f80fd5b61006161005c366004610363565b6100c3565b60405161006f929190610403565b60405180910390f35b61008b610086366004610363565b6100d8565b60405160ff909116815260200161006f565b6100616100ab366004610363565b6100e9565b61008b6100be366004610363565b6100f5565b5f806100cf5f84610100565b91509150915091565b5f6100e35f836101f0565b92915050565b5f806100cf5f84610281565b5f6100e35f83610356565b73ffffffffffffffffffffffffffffffffffffffff81165f9081526020838152604080832081518083019092525460ff8082161515835261010090910416818301527f313ce56700000000000000000000000000000000000000000000000000000000808452839283908190816004818a5afa915060203d1015610182575f91505b811561019857505f5160ff811115610198575f91505b816101af57505050602001516003925090506101e9565b83516101c3575f955093506101e992505050565b836020015160ff1681146101d85760026101db565b60015b846020015195509550505050505b9250929050565b5f805f6101fd8585610281565b909250905060018260038111156102165761021661039d565b1415801561023557505f8260038111156102325761023261039d565b14155b156102795783826040517fee07877f000000000000000000000000000000000000000000000000000000008152600401610270929190610421565b60405180910390fd5b949350505050565b5f805f8061028f8686610100565b90925090505f8260038111156102a7576102a761039d565b0361034b576040805180820182526001815260ff838116602080840191825273ffffffffffffffffffffffffffffffffffffffff8a165f908152908b9052939093209151825493517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00009094169015157fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff161761010093909116929092029190911790555b909590945092505050565b5f805f6101fd8585610100565b5f60208284031215610373575f80fd5b813573ffffffffffffffffffffffffffffffffffffffff81168114610396575f80fd5b9392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b600481106103ff577f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b9052565b6040810161041182856103ca565b60ff831660208301529392505050565b73ffffffffffffffffffffffffffffffffffffffff831681526040810161039660208301846103ca56";
+
+    /// Deploys the canonical TOFUTokenDecimals init bytecode and etches the resulting
+    /// runtime at [`TOFU_TOKEN_DECIMALS`]. The orderbook checks both the address and
+    /// the codehash, so the runtime must come from executing the canonical creation
+    /// code rather than from a recompiled artifact.
+    async fn deploy_tofu_singleton<P: Provider>(provider: &P) {
+        let creation_code = alloy::hex::decode(TOFU_DECIMALS_CREATION_CODE).unwrap();
+        let deployed = provider
+            .send_transaction(TransactionRequest::default().with_deploy_code(creation_code))
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap()
+            .contract_address
+            .unwrap();
+        let runtime = provider.get_code_at(deployed).await.unwrap();
+        provider
+            .anvil_set_code(TOFU_TOKEN_DECIMALS, runtime)
+            .await
+            .unwrap();
+    }
 
     type BaseProvider = FillProvider<
         JoinFill<

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -18,12 +18,12 @@ use st0x_execution::{
     TimeInForce,
 };
 use st0x_finance::Usdc;
+use st0x_raindex::{RaindexService, RaindexVaultId};
 
 use super::{TransferDirection, TransferType};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::bindings::IERC20;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
-use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -10,10 +10,10 @@ use st0x_config::Ctx;
 use st0x_evm::{Evm, OpenChainErrorRegistry};
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
+use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
 
 use crate::bindings::IERC20;
 use crate::onchain::USDC_BASE;
-use crate::onchain::raindex::{Raindex, RaindexService, RaindexVaultId};
 
 pub(super) struct Deposit {
     pub(super) amount: Float,

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -33,6 +33,7 @@ use st0x_execution::{
     ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
     ExecutionError, Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
 };
+use st0x_raindex::{RaindexService, RaindexVaultId};
 
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
@@ -54,7 +55,6 @@ use crate::onchain::USDC_BASE;
 use crate::onchain::accumulator::check_all_positions;
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
 use crate::onchain::backfill::BackfillJobQueue;
-use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -16,6 +16,7 @@ use st0x_event_sorcery::{Projection, Store};
 use st0x_evm::ReadOnlyEvm;
 use st0x_execution::Executor;
 use st0x_finance::{HasZero, Positive, Usd};
+use st0x_raindex::RaindexService;
 
 use super::Conductor;
 use super::exit::MonitorTaskError;
@@ -37,7 +38,6 @@ use crate::offchain::order::{
 };
 use crate::onchain::backfill::{BackfillJobQueue, BackfillRange};
 use crate::onchain::pyth::FeedIdCache;
-use crate::onchain::raindex::RaindexService;
 use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -2211,14 +2211,14 @@ mod tests {
     use alloy::rpc::types::Log;
     use st0x_dto::EquityRedemptionStatus;
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
+    use st0x_float_macro::float;
+    use st0x_raindex::RaindexVaultId;
 
     use super::*;
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::RaindexVaultId;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
     use crate::wrapper::mock::MockWrapper;
-    use st0x_float_macro::float;
 
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -32,6 +32,7 @@ use st0x_execution::{
 };
 use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
+use st0x_raindex::{Raindex, RaindexVaultId};
 
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
@@ -39,7 +40,6 @@ use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, Redemp
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
-use crate::onchain::raindex::{Raindex, RaindexVaultId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
@@ -456,7 +456,7 @@ async fn build_imbalanced_inventory(imbalance: Imbalance<'_>) {
 
 fn build_equity_transfer_with_wrapper(
     pool: &SqlitePool,
-    raindex: Arc<dyn crate::onchain::raindex::Raindex>,
+    raindex: Arc<dyn Raindex>,
     vault_lookup: Arc<dyn VaultLookup>,
     tokenizer: Arc<dyn Tokenizer>,
     mock_wrapper: MockWrapper,
@@ -495,7 +495,7 @@ fn build_equity_transfer_with_wrapper(
 /// lifecycle events flow through the trigger and update inflight state.
 async fn build_equity_transfer_with_service(
     pool: &SqlitePool,
-    raindex: Arc<dyn crate::onchain::raindex::Raindex>,
+    raindex: Arc<dyn Raindex>,
     vault_lookup: Arc<dyn VaultLookup>,
     tokenizer: Arc<dyn Tokenizer>,
     mock_wrapper: MockWrapper,
@@ -1234,10 +1234,10 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     use st0x_evm::ReadOnlyEvm;
     use st0x_execution::{Inventory as ExecutorInventory, MockExecutor};
     use st0x_finance::Usd;
+    use st0x_raindex::RaindexService;
 
     use crate::inventory::InventoryPollingService;
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
-    use crate::onchain::raindex::RaindexService;
 
     let pool = setup_test_db().await;
 

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -20,12 +20,12 @@ use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
 use st0x_execution::{Executor, FractionalShares, InventoryResult, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, UsdToCentsError};
+use st0x_raindex::{RaindexError, RaindexService, RaindexVaultId};
 
 use crate::bindings::IERC20;
 use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
 };
-use crate::onchain::raindex::{RaindexError, RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
 use crate::tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use std::sync::Mutex;
 
 use st0x_evm::EvmError;
+use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
 
-use super::raindex::{Raindex, RaindexError, RaindexVaultId};
 use crate::bindings::IERC20;
 
 /// Whether `submit_deposit` should succeed, fail generically, or fail

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -24,7 +24,6 @@ pub(crate) mod io;
 #[cfg(test)]
 pub(crate) mod mock;
 pub(crate) mod pyth;
-pub(crate) mod raindex;
 mod take_order;
 pub(crate) mod trade;
 

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
+use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
 
 use super::RebalancingService;
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
@@ -32,7 +33,6 @@ use super::trigger::RecoveryClaim;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
-use crate::onchain::raindex::{Raindex, RaindexError, RaindexVaultId};
 use crate::tokenization::{
     AlpacaTokenizationError, MintVerificationError, TokenizationRequest, TokenizationRequestStatus,
     Tokenizer, TokenizerError,

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -16,13 +16,13 @@ use st0x_evm::Wallet;
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, EmptySymbolError, Executor, Symbol,
 };
+use st0x_raindex::{RaindexService, RaindexVaultId};
 
 use super::equity::CrossVenueEquityTransfer;
 use super::usdc::{CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca};
 use super::{Rebalancer, TriggeredOperation};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::equity_redemption::EquityRedemption;
-use crate::onchain::raindex::{RaindexService, RaindexVaultId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -20,12 +20,12 @@ use st0x_execution::{
     AlpacaBrokerApi, ClientOrderId, ConversionDirection, CryptoOrderOutcome, Positive,
 };
 use st0x_finance::Usdc;
+use st0x_raindex::{Raindex, RaindexService, RaindexVaultId, USDC_BASE};
 
 use super::UsdcTransferError;
 use crate::alpaca_wallet::{
     AlpacaTransferId, AlpacaWalletService, TokenSymbol, Transfer, TransferStatus,
 };
-use crate::onchain::raindex::{Raindex, RaindexService, RaindexVaultId, USDC_BASE};
 use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
 };
@@ -2334,10 +2334,10 @@ mod tests {
     use st0x_event_sorcery::{AggregateError, LifecycleError, test_store};
     use st0x_evm::Wallet;
     use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_raindex::RaindexService;
 
     use super::*;
     use crate::alpaca_wallet::{AlpacaTransferId, AlpacaWalletClient, AlpacaWalletError};
-    use crate::onchain::raindex::RaindexService;
     use crate::usdc_rebalance::{RebalanceDirection, TransferRef, UsdcRebalanceError};
     use st0x_finance::UsdcConversionError;
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -24,9 +24,9 @@ use st0x_bridge::cctp::CctpError;
 use st0x_event_sorcery::SendError;
 use st0x_execution::{AlpacaBrokerApiError, ClientOrderId, InvalidSharesError, NotPositive};
 use st0x_finance::{Usdc, UsdcConversionError};
+use st0x_raindex::RaindexError;
 
 use crate::alpaca_wallet::AlpacaWalletError;
-use crate::onchain::raindex::RaindexError;
 use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
 
 #[derive(Debug, Error)]

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -1968,15 +1968,15 @@ mod tests {
     use std::sync::Arc;
 
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore};
+    use st0x_float_macro::float;
+    use st0x_raindex::RaindexVaultId;
 
     use super::*;
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::RaindexVaultId;
     use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockMintPollOutcome, MockMintRequestOutcome, MockTokenizer};
     use crate::vault_lookup::MockVaultLookup;
     use crate::wrapper::mock::MockWrapper;
-    use st0x_float_macro::float;
 
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -46,9 +46,9 @@ use uuid::Uuid;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
+use st0x_raindex::Raindex;
 
 use crate::equity_redemption::RedemptionAggregateId;
-use crate::onchain::raindex::Raindex;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
 use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
 use crate::vault_lookup::VaultLookup;
@@ -818,9 +818,9 @@ mod tests {
 
     use st0x_event_sorcery::EventSourced;
     use st0x_execution::{FractionalShares, Symbol};
+    use st0x_raindex::RaindexVaultId;
 
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::RaindexVaultId;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -674,11 +674,11 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_event_sorcery::test_store;
+    use st0x_raindex::{Raindex, RaindexVaultId};
 
     use crate::conductor::setup_apalis_tables;
     use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand};
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::{Raindex, RaindexVaultId};
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};

--- a/src/vault_lookup.rs
+++ b/src/vault_lookup.rs
@@ -1,9 +1,10 @@
 //! Vault resolution over the [`VaultRegistry`] projection.
 //!
-//! Separates "which vault holds this token/symbol" (a registry read) from Rain
-//! OrderBook chain operations. Upstack routing moves registry-backed lookups
-//! here first; later branches can make the chain layer take explicit vault IDs
-//! without knowing about the [`VaultRegistry`] projection.
+//! Separates "which vault holds this token/symbol" (a registry read) from the
+//! Rain OrderBook chain operations in [`st0x_raindex`]. The chain
+//! layer takes an explicit vault id; this module resolves that id from the
+//! [`VaultRegistry`] aggregate so the chain layer never needs the projection
+//! and can live in a standalone crate independent of `st0x-config`.
 
 use alloy::primitives::Address;
 use async_trait::async_trait;
@@ -13,8 +14,8 @@ use std::sync::Arc;
 
 use st0x_event_sorcery::ProjectionError;
 use st0x_execution::Symbol;
+use st0x_raindex::RaindexVaultId;
 
-use crate::onchain::raindex::RaindexVaultId;
 use crate::vault_registry::{VaultRegistry, VaultRegistryId, VaultRegistryProjection};
 
 /// Resolves Raindex vault ids from the [`VaultRegistry`] projection.

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -41,9 +41,9 @@ use uuid::Uuid;
 
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
+use st0x_raindex::Raindex;
 
 use crate::equity_redemption::RedemptionAggregateId;
-use crate::onchain::raindex::Raindex;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
 use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
 use crate::vault_lookup::VaultLookup;
@@ -580,9 +580,9 @@ mod tests {
 
     use st0x_event_sorcery::EventSourced;
     use st0x_execution::{FractionalShares, Symbol};
+    use st0x_raindex::RaindexVaultId;
 
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::RaindexVaultId;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -452,6 +452,7 @@ mod tests {
     use uuid::Uuid;
 
     use st0x_event_sorcery::test_store;
+    use st0x_raindex::Raindex;
 
     use super::super::aggregate::WrappedEquityRecoveryServices;
     use super::*;
@@ -459,7 +460,6 @@ mod tests {
     use crate::inventory::BroadcastingInventory;
     use crate::inventory::view::InventoryView;
     use crate::onchain::mock::MockRaindex;
-    use crate::onchain::raindex::Raindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};


### PR DESCRIPTION
## What

Moves `RaindexService` and its private `IOrderBookV6`/`IERC20` `sol!` bindings out of the `st0x-hedge` main crate into the `st0x-raindex` crate, behind a new `rain` feature. Closes RAI-832 and completes the RAI-48 epic.

## Why

`st0x-raindex` already owned the `Raindex` trait and domain types (`RaindexVaultId`, `RaindexError`, `USDC_BASE`), but the `RaindexService` implementation and its contract bindings still lived in the main crate — an incomplete crate boundary. Gating the implementation behind a feature mirrors `st0x-bridge`'s `cctp` feature and lets the default build ship only the trait + types.

## How

- Added a `rain` feature to `st0x-raindex`, pulling impl-only deps (`st0x-execution`, `st0x-finance`, `tokio`, `tracing`) as optional. `st0x-evm` and `rain-math-float` stay non-optional because the default-build `RaindexError` references them via `#[from]` (a deliberate divergence from `st0x-bridge`).
- Moved `RaindexService` + its `sol!` bindings into `crates/raindex/src/service.rs`, gated by `#[cfg(feature = "rain")]`. The bindings stay private — no binding-generated type crosses the `Raindex` trait boundary.
- The main crate keeps its own `IOrderBookV6` bindings (`src/bindings.rs`) for event decoding; the crate regenerates its own copies from the same `ST0X_*_ABI` env vars.
- Re-pointed all consumers from `crate::onchain::raindex::*` to `st0x_raindex::*` and deleted the old module.
- Widened `RaindexService::new` + the inherent methods consumers call directly (`deposit`, `deposit_usdc`, `withdraw_usdc`, `current_block`, `find_recent_withdrawal`, `get_equity_balance`, `get_usdc_balance`) to `pub` for cross-crate access; internal helpers stay private.
- Relocated the anvil/integration test suite into the crate with its own `deploy_tofu_singleton` fixture and deployable `RaindexV6`/`TestERC20` bindings.

## Testing

- `cargo check --workspace --all-targets --all-features` — clean.
- `cargo nextest run -p st0x-raindex --features rain` in the `ci-backend` (anvil) shell — 17/17 pass.
- `cargo clippy --workspace --all-targets --all-features` — clean.
- `cargo fmt` — clean.

## Screenshots

N/A

## Anything else

Final PR of the `st0x-raindex` extraction stack (RAI-48), stacked on `docs/adr-typed-identifiers`. The mock seam (`MockRaindex`) is unchanged — it implements the trait and lives in the main crate's test tree, so no `mock` feature was needed on `st0x-raindex`.
