### PR TITLE
refactor: extract wrapper contract handling into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6270,6 +6270,7 @@ dependencies = [
  "st0x-float-serde",
  "st0x-hedge",
  "st0x-raindex",
+ "st0x-wrapper",
  "task-supervisor",
  "temp-env",
  "tempfile",
@@ -6309,6 +6310,22 @@ dependencies = [
  "tracing",
  "tracing-test",
  "url",
+]
+
+[[package]]
+name = "st0x-wrapper"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-primitives",
+ "async-trait",
+ "rain-math-float",
+ "st0x-evm",
+ "st0x-execution",
+ "st0x-float-macro",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/float-macro",
   "crates/float-serde",
   "crates/raindex",
+  "crates/wrapper",
 ]
 resolver = "2"
 exclude = ["lib"]
@@ -104,6 +105,7 @@ st0x-float-macro = { path = "crates/float-macro" }
 st0x-float-serde = { path = "crates/float-serde" }
 st0x-hedge = { path = "." }
 st0x-raindex = { path = "crates/raindex" }
+st0x-wrapper = { path = "crates/wrapper" }
 temp-env = "0.3.6"
 tempfile = "3.24.0"
 test-log = { version = "0.2.19", features = ["trace"] }
@@ -230,6 +232,7 @@ tokio-util.workspace = true
 apalis-workflow.workspace = true
 axum.workspace = true
 apalis-board.workspace = true
+st0x-wrapper = { workspace = true, features = ["erc4626"] }
 
 [dev-dependencies]
 approx.workspace = true
@@ -246,6 +249,7 @@ st0x-event-sorcery = { workspace = true, features = ["test-support"] }
 st0x-evm = { workspace = true, features = ["mock", "test-support"] }
 st0x-execution = { workspace = true, features = ["mock", "test-support"] }
 st0x-hedge = { workspace = true, features = ["test-support", "mock"] }
+st0x-wrapper = { workspace = true, features = ["mock"] }
 temp-env.workspace = true
 tempfile.workspace = true
 test-log.workspace = true

--- a/crates/wrapper/Cargo.toml
+++ b/crates/wrapper/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "st0x-wrapper"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+default = []
+erc4626 = ["dep:tracing"]
+mock = []
+
+[dependencies]
+alloy.workspace = true
+async-trait.workspace = true
+st0x-evm.workspace = true
+st0x-execution.workspace = true
+thiserror.workspace = true
+
+# Optional dep gated behind the `erc4626` feature (WrapperService implementation only).
+tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+alloy-primitives.workspace = true
+rain-math-float.workspace = true
+st0x-float-macro.workspace = true
+tokio = { workspace = true, features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/wrapper/src/lib.rs
+++ b/crates/wrapper/src/lib.rs
@@ -1,10 +1,12 @@
 //! Token wrapping/unwrapping abstractions for ERC-4626 vaults.
-
-mod ratio;
-mod share;
-
-#[cfg(test)]
-pub(crate) mod mock;
+//!
+//! This crate provides the generic [`Wrapper`] trait for wrapping and unwrapping
+//! tokenized equity against ERC-4626 vaults, plus the shared domain types
+//! ([`WrapperError`], [`UnderlyingPerWrapped`], [`RatioError`], [`WrappedEquity`]).
+//!
+//! The default (no-feature) build ships only the trait and domain types. The
+//! ERC-4626 implementation ([`WrapperService`]) is gated behind the `erc4626`
+//! feature, and the test mock (`MockWrapper`) behind the `mock` feature.
 
 use alloy::contract::Error as ContractError;
 use alloy::primitives::{Address, TxHash, U256};
@@ -13,15 +15,39 @@ use async_trait::async_trait;
 use st0x_evm::EvmError;
 use st0x_execution::Symbol;
 
-pub(crate) use ratio::{RatioError, UnderlyingPerWrapped};
-pub(crate) use share::WrapperService;
+mod ratio;
 
-#[cfg(test)]
-pub(crate) use ratio::RATIO_ONE;
+#[cfg(feature = "erc4626")]
+mod service;
+
+#[cfg(feature = "mock")]
+mod mock;
+
+pub use ratio::{RATIO_ONE, RatioError, UnderlyingPerWrapped};
+
+#[cfg(feature = "erc4626")]
+pub use service::WrapperService;
+
+#[cfg(feature = "mock")]
+pub use mock::MockWrapper;
+
+/// The underlying and derivative (ERC-4626 vault) token addresses for a wrappable
+/// equity symbol.
+///
+/// Narrow replacement for the integration crate's view of `EquityAssetConfig`:
+/// `st0x-wrapper` only needs the two token addresses, not the full asset config,
+/// so it stays independent of `st0x-config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WrappedEquity {
+    /// The tokenized equity (underlying) token.
+    pub underlying: Address,
+    /// The tokenized equity derivative (ERC-4626 vault / wrapped) token.
+    pub derivative: Address,
+}
 
 /// Error type for wrapper operations.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum WrapperError {
+pub enum WrapperError {
     #[error("Symbol not configured: {0}")]
     SymbolNotConfigured(Symbol),
     #[error("Missing Deposit event in transaction receipt")]
@@ -38,7 +64,7 @@ pub(crate) enum WrapperError {
 
 /// Trait for wrapping and unwrapping tokens via ERC-4626 vaults.
 #[async_trait]
-pub(crate) trait Wrapper: Send + Sync {
+pub trait Wrapper: Send + Sync {
     /// Gets the underlying-per-wrapped ratio for a symbol.
     async fn get_ratio_for_symbol(
         &self,

--- a/crates/wrapper/src/mock.rs
+++ b/crates/wrapper/src/mock.rs
@@ -4,12 +4,12 @@ use alloy::primitives::{Address, TxHash, U256};
 use alloy::transports::RpcError;
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, PoisonError};
 
 use st0x_evm::EvmError;
 use st0x_execution::Symbol;
 
-use super::{RATIO_ONE, UnderlyingPerWrapped, Wrapper, WrapperError};
+use crate::{RATIO_ONE, UnderlyingPerWrapped, Wrapper, WrapperError};
 
 /// Which operation the mock should simulate failing.
 #[derive(Default, PartialEq, Eq)]
@@ -25,7 +25,7 @@ enum MockFailure {
 }
 
 /// Mock wrapper for testing that returns predictable values.
-pub(crate) struct MockWrapper {
+pub struct MockWrapper {
     owner: Address,
     unwrap_tx: TxHash,
     tokenized_shares: Address,
@@ -37,7 +37,7 @@ pub(crate) struct MockWrapper {
 }
 
 impl MockWrapper {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             owner: Address::ZERO,
             unwrap_tx: TxHash::random(),
@@ -50,7 +50,7 @@ impl MockWrapper {
     }
 
     /// Creates a mock wrapper with a custom ratio.
-    pub(crate) fn with_ratio(ratio: U256) -> Self {
+    pub fn with_ratio(ratio: U256) -> Self {
         Self {
             owner: Address::ZERO,
             unwrap_tx: TxHash::random(),
@@ -63,34 +63,36 @@ impl MockWrapper {
     }
 
     /// Sets the tokenized shares address returned by `lookup_underlying`.
-    pub(crate) fn with_tokenized_shares(mut self, token: Address) -> Self {
+    #[must_use]
+    pub fn with_tokenized_shares(mut self, token: Address) -> Self {
         self.tokenized_shares = token;
         self
     }
 
     /// Sets the wrapped (derivative) token address returned by
     /// `lookup_derivative`.
-    pub(crate) fn with_wrapped_token(mut self, token: Address) -> Self {
+    #[must_use]
+    pub fn with_wrapped_token(mut self, token: Address) -> Self {
         self.wrapped_token = token;
         self
     }
 
     /// Creates a mock wrapper that fails on wrap operations.
-    pub(crate) fn failing() -> Self {
+    pub fn failing() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::Wrap;
         mock
     }
 
     /// Creates a mock wrapper that fails on unwrap operations.
-    pub(crate) fn failing_unwrap() -> Self {
+    pub fn failing_unwrap() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::Unwrap;
         mock
     }
 
     /// Creates a mock wrapper that fails on underlying token lookup.
-    pub(crate) fn failing_lookup() -> Self {
+    pub fn failing_lookup() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::Lookup;
         mock
@@ -99,7 +101,7 @@ impl MockWrapper {
     /// Creates a mock wrapper that submits wraps successfully but fails on
     /// `confirm_wrap`, simulating a receipt that never surfaces the deposit
     /// event.
-    pub(crate) fn failing_confirm_wrap() -> Self {
+    pub fn failing_confirm_wrap() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::ConfirmWrap;
         mock
@@ -107,7 +109,7 @@ impl MockWrapper {
 
     /// Creates a mock wrapper that fails `confirm_wrap` with a retryable RPC
     /// error rather than a confirmed missing-event receipt.
-    pub(crate) fn retryable_confirm_wrap() -> Self {
+    pub fn retryable_confirm_wrap() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::RetryableConfirmWrap;
         mock
@@ -115,7 +117,7 @@ impl MockWrapper {
 
     /// Creates a mock wrapper that succeeds on underlying token lookup but
     /// fails on derivative token lookup.
-    pub(crate) fn failing_derivative_lookup() -> Self {
+    pub fn failing_derivative_lookup() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::DerivativeLookup;
         mock
@@ -124,11 +126,17 @@ impl MockWrapper {
     /// Pre-seeds a tx hash into `submitted_amounts` so that `confirm_wrap`
     /// recognises it. Used by tests that manually advance the aggregate to
     /// `WrapSubmitted` without going through `submit_wrap`.
-    pub(crate) fn seed_submitted_amount(&self, tx_hash: TxHash, amount: U256) {
+    pub fn seed_submitted_amount(&self, tx_hash: TxHash, amount: U256) {
         self.submitted_amounts
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(tx_hash, amount);
+    }
+}
+
+impl Default for MockWrapper {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -138,7 +146,7 @@ impl Wrapper for MockWrapper {
         &self,
         _symbol: &Symbol,
     ) -> Result<UnderlyingPerWrapped, WrapperError> {
-        Ok(UnderlyingPerWrapped::new(self.ratio).expect("ratio is non-zero"))
+        Ok(UnderlyingPerWrapped::new(self.ratio)?)
     }
 
     fn lookup_underlying(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
@@ -194,7 +202,7 @@ impl Wrapper for MockWrapper {
         let tx_hash = TxHash::random();
         self.submitted_amounts
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(tx_hash, underlying_amount);
         Ok(tx_hash)
     }
@@ -218,13 +226,11 @@ impl Wrapper for MockWrapper {
         }
 
         // 1:1 ratio — return the amount that was submitted for this tx
-        let amount = self
-            .submitted_amounts
+        self.submitted_amounts
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .remove(&tx_hash)
-            .expect("confirm called with tx hash that was never submitted");
-        Ok(amount)
+            .ok_or(WrapperError::MissingDepositEvent)
     }
 
     async fn submit_unwrap(
@@ -239,7 +245,7 @@ impl Wrapper for MockWrapper {
         }
         self.submitted_amounts
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .insert(self.unwrap_tx, wrapped_amount);
         Ok(self.unwrap_tx)
     }
@@ -250,13 +256,11 @@ impl Wrapper for MockWrapper {
         tx_hash: TxHash,
     ) -> Result<U256, WrapperError> {
         // 1:1 ratio — return the amount that was submitted for this tx
-        let amount = self
-            .submitted_amounts
+        self.submitted_amounts
             .lock()
-            .unwrap()
+            .unwrap_or_else(PoisonError::into_inner)
             .remove(&tx_hash)
-            .expect("confirm called with tx hash that was never submitted");
-        Ok(amount)
+            .ok_or(WrapperError::MissingWithdrawEvent)
     }
 
     fn owner(&self) -> Address {

--- a/crates/wrapper/src/ratio.rs
+++ b/crates/wrapper/src/ratio.rs
@@ -6,10 +6,10 @@
 
 use alloy::primitives::U256;
 
-use crate::shares::{FractionalShares, SharesConversionError};
+use st0x_execution::{FractionalShares, SharesConversionError};
 
 /// One unit in ratio representation (10^18).
-pub(crate) const RATIO_ONE: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+pub const RATIO_ONE: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
 /// Ratio of underlying tokens per wrapped token.
 ///
@@ -18,14 +18,14 @@ pub(crate) const RATIO_ONE: U256 = U256::from_limbs([1_000_000_000_000_000_000, 
 /// A ratio of 1.0 means 1 wrapped token = 1 underlying token.
 /// A ratio of 1.05 means 1 wrapped token = 1.05 underlying tokens (5% appreciation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct UnderlyingPerWrapped {
+pub struct UnderlyingPerWrapped {
     /// Underlying tokens per wrapped share with 18 decimals precision.
     /// Obtained from vault's `convertToAssets(10^18)`.
     ratio: U256,
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum RatioError {
+pub enum RatioError {
     #[error("Division by zero: ratio is zero")]
     DivisionByZero,
     #[error("Arithmetic overflow during conversion")]
@@ -41,7 +41,7 @@ impl UnderlyingPerWrapped {
     ///
     /// * `ratio` - The number of underlying tokens per wrapped share,
     ///   with 18 decimals of precision (e.g., 1_000_000_000_000_000_000 = 1.0).
-    pub(crate) fn new(ratio: U256) -> Result<Self, RatioError> {
+    pub fn new(ratio: U256) -> Result<Self, RatioError> {
         if ratio.is_zero() {
             return Err(RatioError::DivisionByZero);
         }
@@ -52,7 +52,7 @@ impl UnderlyingPerWrapped {
     /// Converts wrapped token amount to underlying amount.
     ///
     /// Formula: underlying = wrapped * ratio / 10^18
-    pub(crate) fn to_underlying(self, wrapped: U256) -> Result<U256, RatioError> {
+    pub fn to_underlying(self, wrapped: U256) -> Result<U256, RatioError> {
         let numerator = wrapped
             .checked_mul(self.ratio)
             .ok_or(RatioError::Overflow)?;
@@ -63,7 +63,7 @@ impl UnderlyingPerWrapped {
     /// Converts wrapped FractionalShares to underlying FractionalShares.
     ///
     /// Handles the conversion chain: FractionalShares -> U256 -> apply ratio -> FractionalShares.
-    pub(crate) fn to_underlying_fractional(
+    pub fn to_underlying_fractional(
         self,
         wrapped: FractionalShares,
     ) -> Result<FractionalShares, RatioError> {

--- a/crates/wrapper/src/service.rs
+++ b/crates/wrapper/src/service.rs
@@ -1,17 +1,30 @@
 //! WrapperService implementation for ERC-4626 token wrapping/unwrapping.
+//!
+//! This module and its private `IERC20`/`IERC4626` bindings are gated behind the
+//! `erc4626` feature; the [`Wrapper`](crate::Wrapper) trait and its domain types ship
+//! in the default build.
 
 use alloy::primitives::{Address, TxHash, U256};
+use alloy::sol;
 use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use tracing::info;
 
-use st0x_config::EquityAssetConfig;
 use st0x_evm::{IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
 use st0x_execution::Symbol;
 
-use super::{UnderlyingPerWrapped, Wrapper, WrapperError};
-use crate::bindings::{IERC20, IERC4626};
+use crate::{UnderlyingPerWrapped, WrappedEquity, Wrapper, WrapperError};
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    IERC20, env!("ST0X_IERC20_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    IERC4626, env!("ST0X_IERC4626_ABI")
+);
 
 /// One unit with 18 decimals for ratio queries.
 const RATIO_QUERY_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
@@ -20,13 +33,13 @@ const RATIO_QUERY_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0,
 ///
 /// Uses the wallet's embedded provider for read-only view calls (ratio
 /// queries) and the wallet itself for write transactions (deposit/redeem).
-pub(crate) struct WrapperService<W: Wallet> {
+pub struct WrapperService<W: Wallet> {
     wallet: W,
-    config: HashMap<Symbol, EquityAssetConfig>,
+    config: HashMap<Symbol, WrappedEquity>,
 }
 
 impl<W: Wallet> WrapperService<W> {
-    pub(crate) fn new(wallet: W, config: HashMap<Symbol, EquityAssetConfig>) -> Self {
+    pub fn new(wallet: W, config: HashMap<Symbol, WrappedEquity>) -> Self {
         Self { wallet, config }
     }
 
@@ -48,8 +61,8 @@ impl<W: Wallet> WrapperService<W> {
         Ok(UnderlyingPerWrapped::new(assets_per_share)?)
     }
 
-    /// Gets the asset config for a symbol.
-    pub(crate) fn lookup_equity(&self, symbol: &Symbol) -> Option<&EquityAssetConfig> {
+    /// Gets the configured token pair for a symbol.
+    fn lookup_equity(&self, symbol: &Symbol) -> Option<&WrappedEquity> {
         self.config.get(symbol)
     }
 }
@@ -64,7 +77,7 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             .lookup_equity(symbol)
             .ok_or_else(|| WrapperError::SymbolNotConfigured(symbol.clone()))?;
 
-        self.get_ratio::<OpenChainErrorRegistry>(asset.tokenized_equity_derivative)
+        self.get_ratio::<OpenChainErrorRegistry>(asset.derivative)
             .await
     }
 
@@ -73,7 +86,7 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             .lookup_equity(symbol)
             .ok_or_else(|| WrapperError::SymbolNotConfigured(symbol.clone()))?;
 
-        Ok(asset.tokenized_equity)
+        Ok(asset.underlying)
     }
 
     fn lookup_derivative(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
@@ -81,7 +94,7 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             .lookup_equity(symbol)
             .ok_or_else(|| WrapperError::SymbolNotConfigured(symbol.clone()))?;
 
-        Ok(asset.tokenized_equity_derivative)
+        Ok(asset.derivative)
     }
 
     async fn to_wrapped(
@@ -261,51 +274,108 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Address;
-    use std::collections::HashMap;
+    use alloy::primitives::Bytes;
+    use alloy::providers::RootProvider;
+    use alloy::rpc::client::RpcClient;
+    use alloy::rpc::types::TransactionReceipt;
+    use std::sync::Arc;
 
-    use st0x_execution::Symbol;
+    use st0x_evm::{Evm, EvmError};
 
     use super::*;
-    use crate::test_utils::StubWallet;
-    use st0x_config::{EquityAssetConfig, OperationMode};
 
-    fn test_asset_config() -> EquityAssetConfig {
-        EquityAssetConfig {
-            tokenized_equity: Address::random(),
-            tokenized_equity_derivative: Address::random(),
-            vault_ids: Vec::new(),
-            trading: OperationMode::Enabled,
-            rebalancing: OperationMode::Disabled,
-            wrapped_equity_recovery: OperationMode::Disabled,
-            operational_limit: None,
+    /// Panicking wallet stub for tests that only exercise config lookups and
+    /// error paths (no real chain connectivity). Provider type matches
+    /// production (`RootProvider`).
+    struct StubWallet {
+        address: Address,
+        provider: RootProvider,
+    }
+
+    impl StubWallet {
+        fn stub(address: Address) -> Arc<dyn Wallet<Provider = RootProvider>> {
+            Arc::new(Self {
+                address,
+                provider: RootProvider::new(
+                    RpcClient::builder().http("http://stub.invalid".parse().unwrap()),
+                ),
+            })
         }
     }
 
-    fn service_with_symbol(symbol: &str, config: EquityAssetConfig) -> WrapperService<impl Wallet> {
+    #[async_trait]
+    impl Evm for StubWallet {
+        type Provider = RootProvider;
+
+        fn provider(&self) -> &RootProvider {
+            &self.provider
+        }
+    }
+
+    #[async_trait]
+    impl Wallet for StubWallet {
+        fn address(&self) -> Address {
+            self.address
+        }
+
+        async fn send_pending(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TxHash, EvmError> {
+            panic!(
+                "StubWallet::send_pending called - use a real wallet in tests that need transactions"
+            )
+        }
+
+        async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            panic!(
+                "StubWallet::await_receipt called - use a real wallet in tests that need transactions"
+            )
+        }
+
+        async fn send(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TransactionReceipt, EvmError> {
+            panic!("StubWallet::send called - use a real wallet in tests that need transactions")
+        }
+    }
+
+    fn test_equity() -> WrappedEquity {
+        WrappedEquity {
+            underlying: Address::random(),
+            derivative: Address::random(),
+        }
+    }
+
+    fn service_with_symbol(symbol: &str, equity: WrappedEquity) -> WrapperService<impl Wallet> {
         let wallet = StubWallet::stub(Address::random());
         let mut equities = HashMap::new();
-        equities.insert(symbol.parse::<Symbol>().unwrap(), config);
+        equities.insert(symbol.parse::<Symbol>().unwrap(), equity);
         WrapperService::new(wallet, equities)
     }
 
     #[test]
     fn lookup_equity_returns_configured_symbol() {
-        let config = test_asset_config();
-        let expected_tokenized = config.tokenized_equity;
-        let expected_trd = config.tokenized_equity_derivative;
-        let service = service_with_symbol("AAPL", config);
+        let equity = test_equity();
+        let expected_underlying = equity.underlying;
+        let expected_derivative = equity.derivative;
+        let service = service_with_symbol("AAPL", equity);
 
         let result = service.lookup_equity(&"AAPL".parse().unwrap());
 
         assert!(result.is_some());
-        assert_eq!(result.unwrap().tokenized_equity_derivative, expected_trd);
-        assert_eq!(result.unwrap().tokenized_equity, expected_tokenized);
+        assert_eq!(result.unwrap().derivative, expected_derivative);
+        assert_eq!(result.unwrap().underlying, expected_underlying);
     }
 
     #[test]
     fn lookup_equity_returns_none_for_unconfigured() {
-        let service = service_with_symbol("AAPL", test_asset_config());
+        let service = service_with_symbol("AAPL", test_equity());
 
         let result = service.lookup_equity(&"TSLA".parse().unwrap());
 
@@ -314,9 +384,9 @@ mod tests {
 
     #[test]
     fn lookup_derivative_returns_vault_address() {
-        let config = test_asset_config();
-        let expected = config.tokenized_equity_derivative;
-        let service = service_with_symbol("AAPL", config);
+        let equity = test_equity();
+        let expected = equity.derivative;
+        let service = service_with_symbol("AAPL", equity);
 
         let result = service.lookup_derivative(&"AAPL".parse().unwrap()).unwrap();
 
@@ -325,9 +395,9 @@ mod tests {
 
     #[test]
     fn lookup_underlying_returns_underlying_address() {
-        let config = test_asset_config();
-        let expected = config.tokenized_equity;
-        let service = service_with_symbol("AAPL", config);
+        let equity = test_equity();
+        let expected = equity.underlying;
+        let service = service_with_symbol("AAPL", equity);
 
         let result = service.lookup_underlying(&"AAPL".parse().unwrap()).unwrap();
 
@@ -336,7 +406,7 @@ mod tests {
 
     #[test]
     fn lookup_derivative_errors_on_unconfigured_symbol() {
-        let service = service_with_symbol("AAPL", test_asset_config());
+        let service = service_with_symbol("AAPL", test_equity());
 
         let error = service
             .lookup_derivative(&"MSFT".parse().unwrap())
@@ -363,7 +433,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_ratio_for_symbol_errors_on_unconfigured() {
-        let service = service_with_symbol("AAPL", test_asset_config());
+        let service = service_with_symbol("AAPL", test_equity());
 
         let error = service
             .get_ratio_for_symbol(&"XYZ".parse().unwrap())

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -19,6 +19,7 @@ use st0x_execution::{
 };
 use st0x_finance::Usdc;
 use st0x_raindex::{RaindexService, RaindexVaultId};
+use st0x_wrapper::{Wrapper, WrapperService};
 
 use super::{TransferDirection, TransferType};
 use crate::alpaca_wallet::AlpacaWalletService;
@@ -26,6 +27,7 @@ use crate::bindings::IERC20;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
+use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::rebalancing::usdc::CrossVenueCashTransfer;
 use crate::rebalancing::usdc::UsdcTransferError;
@@ -38,7 +40,6 @@ use crate::tokenized_equity_mint::{
 use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
 use crate::vault_lookup::{VaultLookup, VaultRegistryLookup};
 use crate::vault_registry::VaultRegistry;
-use crate::wrapper::{Wrapper, WrapperService};
 use st0x_config::{BrokerCtx, Ctx};
 
 struct EquityTransferCliServices {
@@ -83,7 +84,7 @@ async fn build_equity_transfer_services(
 
     let wrapper: Arc<dyn Wrapper> = Arc::new(WrapperService::new(
         base_caller.clone(),
-        ctx.assets.equities.symbols.clone(),
+        to_wrapped_equities(&ctx.assets.equities.symbols),
     ));
 
     let vault_lookup: Arc<dyn VaultLookup> = Arc::new(VaultRegistryLookup::new(

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -5,8 +5,9 @@ use std::io::Write;
 
 use st0x_config::Ctx;
 use st0x_execution::{FractionalShares, Positive, Symbol};
+use st0x_wrapper::{Wrapper, WrapperService};
 
-use crate::wrapper::{Wrapper, WrapperService};
+use crate::rebalancing::to_wrapped_equities;
 
 pub(super) async fn wrap_equity_command<Writer: Write>(
     stdout: &mut Writer,
@@ -17,7 +18,10 @@ pub(super) async fn wrap_equity_command<Writer: Write>(
     let wallet_ctx = ctx.wallet()?;
     let base_wallet = wallet_ctx.base_wallet().clone();
     let owner = base_wallet.address();
-    let wrapper = WrapperService::new(base_wallet, ctx.assets.equities.symbols.clone());
+    let wrapper = WrapperService::new(
+        base_wallet,
+        to_wrapped_equities(&ctx.assets.equities.symbols),
+    );
 
     wrap_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
 }
@@ -78,7 +82,10 @@ pub(super) async fn unwrap_equity_command<Writer: Write>(
     let wallet_ctx = ctx.wallet()?;
     let base_wallet = wallet_ctx.base_wallet().clone();
     let owner = base_wallet.address();
-    let wrapper = WrapperService::new(base_wallet, ctx.assets.equities.symbols.clone());
+    let wrapper = WrapperService::new(
+        base_wallet,
+        to_wrapped_equities(&ctx.assets.equities.symbols),
+    );
 
     unwrap_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
 }
@@ -130,13 +137,13 @@ mod tests {
     use url::Url;
 
     use st0x_execution::Symbol;
+    use st0x_wrapper::MockWrapper;
 
     use super::{
         unwrap_equity_command, unwrap_equity_with_wrapper, wrap_equity_command,
         wrap_equity_with_wrapper,
     };
     use crate::test_utils::positive_shares;
-    use crate::wrapper::mock::MockWrapper;
     use st0x_config::EvmCtx;
     use st0x_config::ExecutionThreshold;
     use st0x_config::{AssetsConfig, BrokerCtx, Ctx, EquitiesConfig, LogLevel, TradingMode};

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -34,6 +34,7 @@ use st0x_execution::{
     ExecutionError, Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
 };
 use st0x_raindex::{RaindexService, RaindexVaultId};
+use st0x_wrapper::WrapperService;
 
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
@@ -63,7 +64,7 @@ use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferService
 use crate::rebalancing::usdc::{TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx};
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
-    RebalancingServiceConfig,
+    RebalancingServiceConfig, to_wrapped_equities,
 };
 use crate::symbol::cache::SymbolCache;
 use crate::tokenization::Tokenizer;
@@ -84,7 +85,6 @@ use crate::wrapped_equity_recovery::{
     WrappedEquityRecovery, WrappedEquityRecoveryCtx, WrappedEquityRecoveryJobQueue,
     WrappedEquityRecoveryServices,
 };
-use crate::wrapper::WrapperService;
 
 pub(crate) use builder::CqrsFrameworks;
 use manifest::QueryManifest;
@@ -949,7 +949,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let wrapper = Arc::new(WrapperService::new(
             base_wallet.clone(),
-            deps.ctx.assets.equities.symbols.clone(),
+            to_wrapped_equities(&deps.ctx.assets.equities.symbols),
         ));
 
         let equity_transfer_services = EquityTransferServices {
@@ -2242,6 +2242,7 @@ mod tests {
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
+    use st0x_wrapper::{MockWrapper, RATIO_ONE, UnderlyingPerWrapped};
 
     use super::*;
     use crate::bindings::IRaindexV6::{
@@ -2257,8 +2258,6 @@ mod tests {
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
-    use crate::wrapper::mock::MockWrapper;
-    use crate::wrapper::{RATIO_ONE, UnderlyingPerWrapped};
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {
         UnderlyingPerWrapped::new(RATIO_ONE).unwrap()

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -130,6 +130,7 @@ mod tests {
     use st0x_execution::{Direction, FractionalShares, Symbol};
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
@@ -146,7 +147,6 @@ mod tests {
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
-    use crate::wrapper::mock::MockWrapper;
     use st0x_config::{AssetsConfig, EquitiesConfig, ExecutionThreshold};
 
     fn test_trigger_config() -> RebalancingServiceConfig {

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -2213,12 +2213,12 @@ mod tests {
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
     use st0x_float_macro::float;
     use st0x_raindex::RaindexVaultId;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::onchain::mock::MockRaindex;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
-    use crate::wrapper::mock::MockWrapper;
 
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -33,6 +33,7 @@ use st0x_execution::{
 use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 use st0x_raindex::{Raindex, RaindexVaultId};
+use st0x_wrapper::MockWrapper;
 
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
@@ -59,7 +60,6 @@ use crate::tokenization::mock::MockTokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
-use crate::wrapper::mock::MockWrapper;
 
 const TEST_ORDERBOOK: Address = address!("0x0000000000000000000000000000000000000001");
 const TEST_ORDER_OWNER: Address = address!("0x0000000000000000000000000000000000000002");
@@ -462,7 +462,7 @@ fn build_equity_transfer_with_wrapper(
     mock_wrapper: MockWrapper,
     wallet: Address,
 ) -> Arc<CrossVenueEquityTransfer> {
-    let wrapper: Arc<dyn crate::wrapper::Wrapper> = Arc::new(mock_wrapper);
+    let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(mock_wrapper);
 
     let equity_services = EquityTransferServices {
         raindex: Arc::clone(&raindex),
@@ -502,7 +502,7 @@ async fn build_equity_transfer_with_service(
     wallet: Address,
     service: &Arc<RebalancingService>,
 ) -> Arc<CrossVenueEquityTransfer> {
-    let wrapper: Arc<dyn crate::wrapper::Wrapper> = Arc::new(mock_wrapper);
+    let wrapper: Arc<dyn st0x_wrapper::Wrapper> = Arc::new(mock_wrapper);
 
     let equity_services = EquityTransferServices {
         raindex: Arc::clone(&raindex),

--- a/src/inventory/view.rs
+++ b/src/inventory/view.rs
@@ -14,13 +14,13 @@ use st0x_config::ImbalanceThreshold;
 use st0x_dto::{InFlightCash, InFlightEquity, SymbolInventory, UsdcInventory};
 use st0x_execution::{Direction, FractionalShares, HasZero, Symbol};
 use st0x_finance::{Usd, Usdc};
+use st0x_wrapper::{RatioError, UnderlyingPerWrapped};
 
 use super::snapshot::InventorySnapshotEvent;
 use super::venue_balance::{InventoryError, VenueBalance};
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::tokenized_equity_mint::IssuerRequestId;
 use crate::usdc_rebalance::UsdcRebalanceId;
-use crate::wrapper::{RatioError, UnderlyingPerWrapped};
 
 /// Error type for inventory view operations.
 #[derive(Debug, thiserror::Error)]
@@ -1803,9 +1803,9 @@ mod tests {
     use rain_math_float::Float;
 
     use st0x_finance::Usdc;
+    use st0x_wrapper::RATIO_ONE;
 
     use super::*;
-    use crate::wrapper::RATIO_ONE;
     use st0x_float_macro::float;
 
     fn shares(amount: i64) -> FractionalShares {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ mod onchain_trade;
 mod position;
 mod position_check;
 mod rebalancing;
-mod shares;
 mod symbol;
 mod tokenization;
 mod trading;
@@ -64,7 +63,6 @@ mod usdc_rebalance;
 mod vault_lookup;
 mod vault_registry;
 mod wrapped_equity_recovery;
-mod wrapper;
 
 pub use st0x_config::{
     ExtraLayer, FileLogGuard, TelemetryError, TelemetryGuard, mk_env_filter, setup_tracing,

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -26,6 +26,7 @@ use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
 use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
+use st0x_wrapper::{UnderlyingPerWrapped, Wrapper, WrapperError};
 
 use super::RebalancingService;
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
@@ -42,7 +43,6 @@ use crate::tokenized_equity_mint::{
     TokenizedEquityMintCommand,
 };
 use crate::vault_lookup::{VaultLookup, VaultLookupError};
-use crate::wrapper::{UnderlyingPerWrapped, Wrapper, WrapperError};
 
 /// A quantity of equity in a specific symbol.
 #[derive(Debug)]
@@ -1556,6 +1556,7 @@ mod tests {
     use st0x_float_macro::float;
 
     use st0x_config::{AssetsConfig, EquitiesConfig};
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::inventory::{
@@ -1568,7 +1569,6 @@ mod tests {
     };
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistry;
-    use crate::wrapper::mock::MockWrapper;
 
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new()

--- a/src/rebalancing/mod.rs
+++ b/src/rebalancing/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod trigger;
 pub(crate) mod usdc;
 
 pub(crate) use rebalancer::Rebalancer;
-pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks};
+pub(crate) use spawn::{RebalancerServices, RebalancingCqrsFrameworks, to_wrapped_equities};
 #[cfg(test)]
 pub(crate) use trigger::drain_pending_jobs;
 pub(crate) use trigger::{

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -17,6 +17,7 @@ use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, EmptySymbolError, Executor, Symbol,
 };
 use st0x_raindex::{RaindexService, RaindexVaultId};
+use st0x_wrapper::{WrappedEquity, WrapperService};
 
 use super::equity::CrossVenueEquityTransfer;
 use super::usdc::{CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca};
@@ -28,7 +29,6 @@ use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizedEquityMint;
 use crate::usdc_rebalance::UsdcRebalance;
 use crate::vault_lookup::VaultLookup;
-use crate::wrapper::WrapperService;
 
 /// Errors that can occur when spawning the rebalancer.
 #[derive(Debug, thiserror::Error)]
@@ -39,6 +39,25 @@ pub(crate) enum SpawnRebalancerError {
     Cctp(#[from] Box<CctpError>),
     #[error("failed to create wrapper service: {0}")]
     Wrapper(#[from] EmptySymbolError),
+}
+
+/// Adapts the config-layer equity asset map to the narrow per-symbol token pairs
+/// [`WrapperService`] needs, keeping `st0x-wrapper` independent of `st0x-config`.
+pub(crate) fn to_wrapped_equities(
+    equities: &HashMap<Symbol, EquityAssetConfig>,
+) -> HashMap<Symbol, WrappedEquity> {
+    equities
+        .iter()
+        .map(|(symbol, asset)| {
+            (
+                symbol.clone(),
+                WrappedEquity {
+                    underlying: asset.tokenized_equity,
+                    derivative: asset.tokenized_equity_derivative,
+                },
+            )
+        })
+        .collect()
 }
 
 pub(crate) struct RebalancingCqrsFrameworks {
@@ -107,7 +126,10 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             .map_err(|error| SpawnRebalancerError::Cctp(Box::new(error)))?,
         );
 
-        let wrapper = Arc::new(WrapperService::new(base_wallet, equities));
+        let wrapper = Arc::new(WrapperService::new(
+            base_wallet,
+            to_wrapped_equities(&equities),
+        ));
 
         Ok(Self {
             broker,
@@ -214,9 +236,40 @@ mod tests {
     use crate::tokenization::alpaca::AlpacaTokenizationService;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
-    use crate::wrapper::mock::MockWrapper;
-    use st0x_config::{AssetsConfig, EquitiesConfig};
+    use st0x_config::{AssetsConfig, EquitiesConfig, OperationMode};
     use st0x_float_macro::float;
+    use st0x_wrapper::{MockWrapper, WrappedEquity};
+
+    #[test]
+    fn to_wrapped_equities_maps_underlying_and_derivative() {
+        let underlying = Address::random();
+        let derivative = Address::random();
+        let symbol: Symbol = "AAPL".parse().unwrap();
+
+        let mut config = HashMap::new();
+        config.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: underlying,
+                tokenized_equity_derivative: derivative,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let wrapped = to_wrapped_equities(&config);
+
+        assert_eq!(
+            wrapped.get(&symbol),
+            Some(&WrappedEquity {
+                underlying,
+                derivative,
+            }),
+        );
+    }
 
     type BaseProvider = FillProvider<
         JoinFill<

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -9,13 +9,13 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 
 use st0x_execution::{FractionalShares, Positive, Symbol};
+use st0x_wrapper::{UnderlyingPerWrapped, WrapperError};
 
 use super::{RebalancingService, TokenAddressError, TriggeredOperation};
 use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::inventory::{
     BroadcastingInventory, EquityImbalanceError, Imbalance, ImbalanceThreshold,
 };
-use crate::wrapper::{UnderlyingPerWrapped, WrapperError};
 
 /// Maximum decimal places for Alpaca tokenization API quantities.
 const ALPACA_QUANTITY_MAX_DECIMAL_PLACES: u8 = 9;
@@ -318,11 +318,11 @@ mod tests {
 
     use st0x_dto::Statement;
     use st0x_execution::FractionalShares;
+    use st0x_wrapper::RATIO_ONE;
 
     use super::*;
     use crate::inventory::view::Operator;
     use crate::inventory::{Inventory, InventoryView, TransferOp, Venue};
-    use crate::wrapper::RATIO_ONE;
     use st0x_float_macro::float;
 
     fn one_to_one_ratio() -> UnderlyingPerWrapped {

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -22,6 +22,7 @@ use st0x_event_sorcery::{
 };
 use st0x_execution::{FractionalShares, Positive, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, Usdc};
+use st0x_wrapper::{Wrapper, WrapperError};
 
 use self::usdc::UsdcRebalanceOperation;
 use crate::conductor::job::QueuePushError;
@@ -54,7 +55,6 @@ use crate::usdc_rebalance::{
 use crate::vault_registry::{VaultRegistry, VaultRegistryId};
 use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
 use crate::wrapped_equity_recovery::{WrappedEquityRecoveryJob, WrappedEquityRecoveryJobQueue};
-use crate::wrapper::{Wrapper, WrapperError};
 
 pub(crate) use equity::{EquityRebalancingCheck, EquityRebalancingCheckScheduler};
 pub(crate) use usdc::{UsdcRebalancingCheck, UsdcRebalancingCheckScheduler};
@@ -3648,6 +3648,7 @@ mod tests {
     };
     use st0x_finance::{Usd, Usdc};
     use st0x_float_macro::float;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::alpaca_wallet::AlpacaTransferId;
@@ -3665,7 +3666,6 @@ mod tests {
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
     use crate::vault_registry::VaultRegistryCommand;
-    use crate::wrapper::mock::MockWrapper;
 
     fn test_config() -> RebalancingServiceConfig {
         RebalancingServiceConfig {

--- a/src/shares.rs
+++ b/src/shares.rs
@@ -1,3 +1,0 @@
-//! Re-exports from the execution crate for share types and utilities.
-
-pub use st0x_execution::{FractionalShares, SharesConversionError};

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,18 +2,14 @@
 //! and builders for onchain trades and offchain executions.
 
 use alloy::network::TransactionBuilder;
-use alloy::primitives::{Address, B256, Bytes, LogData, TxHash, address, bytes, fixed_bytes};
+use alloy::primitives::{Address, B256, LogData, address, bytes, fixed_bytes};
+use alloy::providers::Provider;
 use alloy::providers::ext::AnvilApi as _;
-use alloy::providers::{Provider, RootProvider};
-use alloy::rpc::client::RpcClient;
-use alloy::rpc::types::{Log, TransactionReceipt, TransactionRequest};
-use async_trait::async_trait;
+use alloy::rpc::types::{Log, TransactionRequest};
 use chrono::Utc;
 use rain_math_float::Float;
 use sqlx::SqlitePool;
-use std::sync::Arc;
 
-use st0x_evm::{Evm, EvmError, Wallet};
 use st0x_execution::{Direction, FractionalShares, Positive};
 
 use crate::bindings::IRaindexV6::{EvaluableV4, IOV2, OrderV4};
@@ -54,68 +50,6 @@ pub(crate) async fn deploy_tofu_singleton<P: Provider>(provider: &P) {
         .anvil_set_code(TOFU_TOKEN_DECIMALS, runtime)
         .await
         .unwrap();
-}
-
-/// Panicking wallet stub for tests that construct `RebalancingCtx`
-/// without needing real chain connectivity. Provider type matches
-/// production (`RootProvider`) so it fits `Arc<dyn Wallet<Provider =
-/// RootProvider>>`.
-pub(crate) struct StubWallet {
-    address: Address,
-    provider: RootProvider,
-}
-
-impl StubWallet {
-    pub(crate) fn stub(address: Address) -> Arc<dyn Wallet<Provider = RootProvider>> {
-        Arc::new(Self {
-            address,
-            provider: RootProvider::new(
-                RpcClient::builder().http("http://stub.invalid".parse().unwrap()),
-            ),
-        })
-    }
-}
-
-#[async_trait]
-impl Evm for StubWallet {
-    type Provider = RootProvider;
-
-    fn provider(&self) -> &RootProvider {
-        &self.provider
-    }
-}
-
-#[async_trait]
-impl Wallet for StubWallet {
-    fn address(&self) -> Address {
-        self.address
-    }
-
-    async fn send_pending(
-        &self,
-        _contract: Address,
-        _calldata: Bytes,
-        _note: &str,
-    ) -> Result<TxHash, EvmError> {
-        panic!(
-            "StubWallet::send_pending called - use a real wallet in tests that need transactions"
-        )
-    }
-
-    async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
-        panic!(
-            "StubWallet::await_receipt called - use a real wallet in tests that need transactions"
-        )
-    }
-
-    async fn send(
-        &self,
-        _contract: Address,
-        _calldata: Bytes,
-        _note: &str,
-    ) -> Result<TransactionReceipt, EvmError> {
-        panic!("StubWallet::send called - use a real wallet in tests that need transactions")
-    }
 }
 
 /// Returns a test `OrderV4` instance that is shared across multiple

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -1970,13 +1970,13 @@ mod tests {
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore};
     use st0x_float_macro::float;
     use st0x_raindex::RaindexVaultId;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
     use crate::onchain::mock::MockRaindex;
     use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockMintPollOutcome, MockMintRequestOutcome, MockTokenizer};
     use crate::vault_lookup::MockVaultLookup;
-    use crate::wrapper::mock::MockWrapper;
 
     fn mock_vault_lookup() -> MockVaultLookup {
         MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO))

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -47,12 +47,12 @@ use uuid::Uuid;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
+use st0x_wrapper::{Wrapper, WrapperError};
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
 use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
 use crate::vault_lookup::VaultLookup;
-use crate::wrapper::Wrapper;
 
 /// Aggregate identifier. Each detection creates a fresh UUID; multiple
 /// recoveries for the same symbol are independent aggregates.
@@ -698,18 +698,13 @@ async fn confirm_orphan_wrap_or_fail(
         Err(error) => {
             warn!(target: "rebalance", %symbol, %wrap_tx_hash, ?error, "Unwrapped equity recovery: confirm_wrap failed");
             match error {
-                crate::wrapper::WrapperError::MissingDepositEvent => {
+                WrapperError::MissingDepositEvent
+                | WrapperError::Evm(st0x_evm::EvmError::TransactionDropped { .. }) => {
                     Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
                         reason: format!("wrapper.confirm_wrap failed: {error}"),
                         failed_at: Utc::now(),
                     }])
                 }
-                crate::wrapper::WrapperError::Evm(st0x_evm::EvmError::TransactionDropped {
-                    ..
-                }) => Ok(vec![UnwrappedEquityRecoveryEvent::RecoveryFailed {
-                    reason: format!("wrapper.confirm_wrap failed: {error}"),
-                    failed_at: Utc::now(),
-                }]),
                 _ => Err(UnwrappedEquityRecoveryError::RetryableWrapConfirmation { wrap_tx_hash }),
             }
         }
@@ -819,12 +814,12 @@ mod tests {
     use st0x_event_sorcery::EventSourced;
     use st0x_execution::{FractionalShares, Symbol};
     use st0x_raindex::RaindexVaultId;
+    use st0x_wrapper::MockWrapper;
 
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
-    use crate::wrapper::mock::MockWrapper;
 
     use super::*;
 

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -675,6 +675,7 @@ mod tests {
 
     use st0x_event_sorcery::test_store;
     use st0x_raindex::{Raindex, RaindexVaultId};
+    use st0x_wrapper::{MockWrapper, Wrapper};
 
     use crate::conductor::setup_apalis_tables;
     use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand};
@@ -684,8 +685,6 @@ mod tests {
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
     use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
     use crate::vault_lookup::MockVaultLookup;
-    use crate::wrapper::Wrapper;
-    use crate::wrapper::mock::MockWrapper;
 
     use super::super::aggregate::UnwrappedEquityRecoveryServices;
     use super::*;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -42,12 +42,12 @@ use uuid::Uuid;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
+use st0x_wrapper::Wrapper;
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
 use crate::tokenized_equity_mint::{IssuerRequestId, TOKENIZED_EQUITY_DECIMALS};
 use crate::vault_lookup::VaultLookup;
-use crate::wrapper::Wrapper;
 
 /// Aggregate identifier. Each detection creates a fresh UUID; multiple
 /// recoveries for the same symbol are independent aggregates.
@@ -581,12 +581,12 @@ mod tests {
     use st0x_event_sorcery::EventSourced;
     use st0x_execution::{FractionalShares, Symbol};
     use st0x_raindex::RaindexVaultId;
+    use st0x_wrapper::MockWrapper;
 
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
-    use crate::wrapper::mock::MockWrapper;
 
     use super::*;
 

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -453,6 +453,7 @@ mod tests {
 
     use st0x_event_sorcery::test_store;
     use st0x_raindex::Raindex;
+    use st0x_wrapper::{MockWrapper, Wrapper};
 
     use super::super::aggregate::WrappedEquityRecoveryServices;
     use super::*;
@@ -463,8 +464,6 @@ mod tests {
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
-    use crate::wrapper::Wrapper;
-    use crate::wrapper::mock::MockWrapper;
 
     #[tokio::test]
     async fn guard_contention_reschedules_without_dropping_the_recovery() {


### PR DESCRIPTION
## What

Extracts wrapper-contract handling out of the `st0x-hedge` main crate into a new
standalone `st0x-wrapper` crate (`crates/wrapper`), behind a `Wrapper` trait.
Closes RAI-747.

## Why

Continues the workspace crate-extraction effort (sibling to the `st0x-raindex`
extraction): the wrapper / unwrap-ratio and share logic should live behind a
crate boundary with a generic trait so the main crate depends on it rather than
owning it. Tightens domain boundaries and shrinks `st0x-hedge`.

## How

- New `crates/wrapper` workspace member exposing a `Wrapper` trait (`src/lib.rs`),
  its service implementation (`service.rs`, from the former `wrapper/share.rs`),
  `ratio.rs`, and a `mock.rs` test seam.
- Re-points all consumers (rebalancing, conductor, inventory, CLI, the
  wrapped/unwrapped equity recovery aggregates, and `test_utils`) at the crate.

## Testing

- Wrapper unit tests move with the crate; the workspace build and existing
  rebalancing / recovery tests cover the re-pointed consumers.

## Screenshots

N/A

## Anything else

This sits after the `st0x-raindex` extraction in the stack and follows the same boundary pattern: shared trait/types live in the crate, while the hedge crate only wires concrete services where it owns runtime configuration.