### PR TITLE
feat: persist CCTP message envelope so Attested resume mints offline

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1720,8 +1720,12 @@ enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: TxHash,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
         attestation: Vec<u8>,
+        // Full CCTP message envelope, persisted so a resume reconstructs the
+        // AttestationResponse and mints without re-polling Circle. None for
+        // transfers whose BridgeAttestationReceived predates this field.
+        message: Option<Vec<u8>>,
         mint_scan_from_block: u64,
         initiated_at: DateTime<Utc>,
         attested_at: DateTime<Utc>,
@@ -1740,7 +1744,7 @@ enum UsdcRebalance {
         direction: RebalanceDirection,
         amount: Usdc,
         burn_tx_hash: Option<TxHash>,
-        cctp_nonce: Option<u64>,
+        cctp_nonce: Option<B256>,
         reason: String,
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
@@ -1826,7 +1830,7 @@ enum UsdcRebalanceCommand {
     // Records that attestation polling timed out, moving Bridging ->
     // AwaitingAttestation with the deadline beyond which retries stop.
     TimeoutAttestation { retry_deadline_at: DateTime<Utc> },
-    ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: u64, mint_scan_from_block: u64 },
+    ReceiveAttestation { attestation: Vec<u8>, cctp_nonce: B256, message: Vec<u8>, mint_scan_from_block: u64 },
     ConfirmBridging { mint_tx: TxHash, amount_received: Usdc, fee_collected: Usdc },
     FailBridging { reason: String },
 
@@ -1872,7 +1876,12 @@ enum UsdcRebalanceEvent {
     },
     BridgeAttestationReceived {
         attestation: Vec<u8>,
-        cctp_nonce: u64,
+        cctp_nonce: B256,
+        // Full CCTP message envelope, persisted so an Attested resume
+        // reconstructs the AttestationResponse and mints without re-polling
+        // Circle. Option: None for events serialized before this field existed
+        // (those resume via the legacy re-poll fallback).
+        message: Option<Vec<u8>>,
         mint_scan_from_block: u64,
         attested_at: DateTime<Utc>,
     },
@@ -1884,7 +1893,7 @@ enum UsdcRebalanceEvent {
     },
     BridgingFailed {
         burn_tx_hash: Option<TxHash>,
-        cctp_nonce: Option<u64>,
+        cctp_nonce: Option<B256>,
         stage: BridgeStage,
         failed_tx_hash: Option<TxHash>,
         failed_at: DateTime<Utc>,
@@ -1952,12 +1961,18 @@ enum BridgeStage { Burn, Attestation, Mint }
   surface as the same retryable timeout -- so a malformed response is bounded by
   the deadline rather than failing fast. (Failing fast on a definitively
   malformed `complete` response is a tracked follow-up.)
-- **Post-attestation re-poll retries until success (no deadline)**: once
-  `BridgeAttestationReceived` is recorded (`Attested`), the attestation is
-  permanently retrievable from Circle. The mint needs the full message envelope,
-  which the aggregate does not persist, so resuming from `Attested` re-polls
-  Circle; a timeout there retries until success rather than failing, because the
-  USDC is already burned and bounding it would strand recoverable funds. The
+- **Attested resume reconstructs the mint offline (no Circle re-poll)**: the
+  mint needs the full CCTP message envelope, which `BridgeAttestationReceived`
+  persists (the `message` field) alongside the attestation. Resuming from
+  `Attested` reconstructs the `AttestationResponse` from the stored envelope and
+  attestation -- re-deriving and cross-checking the nonce against the recorded
+  `cctp_nonce` -- and mints with no Circle call. A reconstruction failure
+  (corrupt envelope, placeholder nonce, or nonce mismatch) marks
+  `BridgingFailed` for operator reconciliation, since the USDC is already
+  burned. Transfers whose `BridgeAttestationReceived` predates the `message`
+  field carry `None` and fall back to re-polling Circle: the attestation is
+  permanently retrievable, so a timeout there retries until success rather than
+  failing (bounding it would strand recoverable funds). The
   `attestation_retry_deadline` bounds only the `AwaitingAttestation` wait (where
   the attestation may never arrive).
 - Bridge mint transaction requires valid attestation

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -191,6 +191,45 @@ impl crate::Attestation for AttestationResponse {
     fn as_bytes(&self) -> &[u8] {
         &self.attestation
     }
+
+    fn message_bytes(&self) -> &[u8] {
+        &self.message
+    }
+}
+
+impl AttestationResponse {
+    /// Reconstructs a response from a persisted message envelope and signature,
+    /// re-deriving the nonce from the message so a stored attestation is
+    /// self-validating (an all-zero placeholder nonce is rejected, mirroring a
+    /// fresh poll).
+    ///
+    /// Validates that the message reaches the CCTP body offset
+    /// (`MESSAGE_BODY_INDEX`) -- the same bound [`parse_received_message`] uses --
+    /// not merely enough to extract a nonce. A truncated envelope that still
+    /// carried a non-zero nonce would otherwise construct and then revert in
+    /// `receiveMessage` on-chain instead of failing here, where the caller routes
+    /// it to operator reconciliation. This is the shared constructor for both a
+    /// fresh poll and a persisted-envelope resume, so both enforce identical
+    /// rules. (It does not guarantee a mintable body, only a complete header.)
+    ///
+    /// Module-private: external callers reconstruct via
+    /// [`crate::Bridge::reconstruct_attestation`] so they never depend on this
+    /// concrete representation.
+    fn from_parts(message: Bytes, attestation: Bytes) -> Result<Self, CctpError> {
+        if message.len() < MESSAGE_BODY_INDEX {
+            return Err(CctpError::MessageTooShortForRecovery {
+                length: message.len(),
+            });
+        }
+
+        let nonce = extract_nonce_from_message(&message)?;
+
+        Ok(Self {
+            message,
+            attestation,
+            nonce,
+        })
+    }
 }
 
 // CCTP V2 message layout (see Circle's evm-cctp-contracts: src/messages/v2/MessageV2.sol):
@@ -611,17 +650,12 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
                 source: err,
             })?;
 
-        // `extract_nonce_from_message` rejects the all-zero placeholder nonce
-        // (`PlaceholderNonce`), so a "complete" attestation that leaked the
-        // bytes32(0) from the MessageSent event fails fast here rather than
-        // threading an invalid nonce through the bridge as if it were real.
-        let nonce = extract_nonce_from_message(&message)?;
-
-        Ok(AttestationResponse {
-            message,
-            attestation,
-            nonce,
-        })
+        // Validate through the same constructor a persisted-envelope resume uses,
+        // so a fresh poll and a reconstruction enforce identical rules: a
+        // truncated envelope or an all-zero placeholder nonce (the bytes32(0) the
+        // MessageSent event leaks) fails fast here rather than being recorded and
+        // then rejected on a later resume.
+        AttestationResponse::from_parts(message, attestation)
     }
 
     /// Burns USDC on the source chain for the given bridge direction.
@@ -775,6 +809,14 @@ where
         })
     }
 
+    fn reconstruct_attestation(
+        &self,
+        message: Vec<u8>,
+        attestation: Vec<u8>,
+    ) -> Result<Self::Attestation, Self::Error> {
+        AttestationResponse::from_parts(Bytes::from(message), Bytes::from(attestation))
+    }
+
     /// Scans the burn source chain for an already-submitted burn matching
     /// `(amount, destinationDomain, recipient)` at or after `from_block`, for
     /// crash-safe resume. Delegates to the source endpoint for the given
@@ -854,7 +896,7 @@ mod tests {
     use st0x_evm::local::RawPrivateKeyWallet;
 
     use super::*;
-    use crate::Bridge;
+    use crate::{Attestation, Bridge};
 
     const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
     const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
@@ -1025,7 +1067,9 @@ mod tests {
         // Complete attestation whose message carries the placeholder bytes32(0) nonce that
         // CCTP V2 emits in the MessageSent event. Circle should never return this on a complete
         // attestation; the bridge must fail fast rather than thread it through as a real nonce.
-        let zero_nonce_message = build_nonce_message(&[0u8; NONCE_INDEX], [0u8; 32], &[0u8; 56]);
+        // Full-length so it reaches the nonce check rather than the envelope-length guard.
+        let zero_nonce_message =
+            build_nonce_message(&[0u8; NONCE_INDEX], [0u8; 32], &[0u8; MESSAGE_BODY_INDEX]);
 
         let mock = server.mock(|when, then| {
             when.method(GET)
@@ -1071,7 +1115,11 @@ mod tests {
         let server = MockServer::start();
 
         let expected_nonce = [0xABu8; 32];
-        let message = build_nonce_message(&[0u8; NONCE_INDEX], expected_nonce, &[0u8; 56]);
+        let message = build_nonce_message(
+            &[0u8; NONCE_INDEX],
+            expected_nonce,
+            &[0u8; MESSAGE_BODY_INDEX],
+        );
 
         let mock = server.mock(|when, then| {
             when.method(GET)
@@ -2516,6 +2564,98 @@ mod tests {
         let message = build_nonce_message(&[0xCD; NONCE_INDEX], [0u8; 32], &[0xEF; 56]);
 
         let err = extract_nonce_from_message(&message).unwrap_err();
+
+        assert!(
+            matches!(err, CctpError::PlaceholderNonce),
+            "Expected PlaceholderNonce, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_parts_reconstructs_response_with_message_derived_nonce() {
+        // A persisted envelope resumes a mint offline: `from_parts` must rebuild
+        // the response with the nonce re-derived from the message (not trusting a
+        // separately-stored copy) and preserve the attestation signature verbatim.
+        let expected_nonce: [u8; 32] = core::array::from_fn(|index| {
+            u8::try_from(index + 1).expect("index 0..31 + 1 always fits in u8")
+        });
+        // A full CCTP envelope: header + nonce + body, length >= MESSAGE_BODY_INDEX.
+        let body = vec![0xCD; MESSAGE_BODY_INDEX];
+        let message = build_nonce_message(&[0u8; NONCE_INDEX], expected_nonce, &body);
+        let attestation = vec![0xAB; 65];
+
+        let response = AttestationResponse::from_parts(
+            Bytes::from(message.clone()),
+            Bytes::from(attestation.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(response.nonce(), B256::from(expected_nonce));
+        assert_eq!(response.as_bytes(), attestation.as_slice());
+        assert_eq!(response.message_bytes(), message.as_slice());
+    }
+
+    #[test]
+    fn from_parts_accepts_message_at_body_index_boundary() {
+        // A message of exactly MESSAGE_BODY_INDEX bytes is the shortest envelope
+        // `from_parts` accepts: one byte shorter is rejected (see
+        // from_parts_rejects_truncated_envelope_with_valid_nonce). This pins the
+        // boundary to MESSAGE_BODY_INDEX, not MIN_MESSAGE_LENGTH.
+        let expected_nonce: [u8; 32] = core::array::from_fn(|index| {
+            u8::try_from(index + 1).expect("index 0..31 + 1 always fits in u8")
+        });
+        let trailer_len = MESSAGE_BODY_INDEX - MIN_MESSAGE_LENGTH;
+        let message =
+            build_nonce_message(&[0u8; NONCE_INDEX], expected_nonce, &vec![0u8; trailer_len]);
+        assert_eq!(message.len(), MESSAGE_BODY_INDEX);
+
+        let response = AttestationResponse::from_parts(
+            Bytes::from(message.clone()),
+            Bytes::from(vec![0xAB; 65]),
+        )
+        .unwrap();
+
+        assert_eq!(response.nonce(), B256::from(expected_nonce));
+        assert_eq!(response.message_bytes(), message.as_slice());
+    }
+
+    #[test]
+    fn from_parts_rejects_truncated_envelope_with_valid_nonce() {
+        // A nonce-bearing but truncated envelope (long enough to extract a nonce,
+        // too short to be a full CCTP message) is corrupt persisted data. It must
+        // be rejected at reconstruction rather than reconstructing and reverting
+        // in `receiveMessage` on-chain.
+        let expected_nonce: [u8; 32] = core::array::from_fn(|index| {
+            u8::try_from(index + 1).expect("index 0..31 + 1 always fits in u8")
+        });
+        let truncated_len = MESSAGE_BODY_INDEX - 1;
+        let body_len = truncated_len - MIN_MESSAGE_LENGTH;
+        let message =
+            build_nonce_message(&[0u8; NONCE_INDEX], expected_nonce, &vec![0u8; body_len]);
+        assert_eq!(message.len(), truncated_len);
+
+        let err =
+            AttestationResponse::from_parts(Bytes::from(message), Bytes::from(vec![0xAB; 65]))
+                .unwrap_err();
+
+        assert!(
+            matches!(err, CctpError::MessageTooShortForRecovery { length } if length == truncated_len),
+            "Expected MessageTooShortForRecovery, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_parts_rejects_placeholder_nonce() {
+        // An all-zero nonce means the attested message was never filled in by
+        // Circle; reconstructing from it must fail rather than mint with a bogus
+        // nonce, mirroring a fresh poll. The envelope is full-length so it reaches
+        // the nonce check rather than the length check.
+        let message =
+            build_nonce_message(&[0xCD; NONCE_INDEX], [0u8; 32], &[0xEF; MESSAGE_BODY_INDEX]);
+
+        let err =
+            AttestationResponse::from_parts(Bytes::from(message), Bytes::from(vec![0xAB; 65]))
+                .unwrap_err();
 
         assert!(
             matches!(err, CctpError::PlaceholderNonce),

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -46,8 +46,14 @@ pub trait Attestation: Send + Sync {
     /// Returns the 32-byte CCTP V2 nonce for this attestation.
     fn nonce(&self) -> B256;
 
-    /// Returns the raw attestation bytes.
+    /// Returns the raw attestation signature bytes.
     fn as_bytes(&self) -> &[u8];
+
+    /// Returns the full message envelope bytes. Minting needs the whole
+    /// envelope (not just the signature), so a caller persisting an attestation
+    /// for an offline resume stores these alongside [`Attestation::as_bytes`]
+    /// and later rebuilds via [`Bridge::reconstruct_attestation`].
+    fn message_bytes(&self) -> &[u8];
 }
 
 /// Generic bridge trait for cross-chain USDC transfers.
@@ -82,6 +88,18 @@ pub trait Bridge: Send + Sync + 'static {
         direction: BridgeDirection,
         attestation: &Self::Attestation,
     ) -> Result<MintReceipt, Self::Error>;
+
+    /// Rebuilds an attestation from a persisted message envelope and signature,
+    /// so an `Attested` resume mints offline without re-polling the attestation
+    /// service. The implementation re-derives and validates any embedded nonce,
+    /// so a corrupt or truncated envelope fails here rather than on-chain. This
+    /// keeps reconstruction behind the trait, so callers never depend on a
+    /// concrete attestation representation.
+    fn reconstruct_attestation(
+        &self,
+        message: Vec<u8>,
+        attestation: Vec<u8>,
+    ) -> Result<Self::Attestation, Self::Error>;
 
     /// Scans the burn source chain for an already-submitted burn matching
     /// `(amount, destinationDomain, recipient)` at or after `from_block`, for

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -8261,9 +8261,20 @@ mod tests {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![1, 2, 3, 4],
             cctp_nonce: B256::left_padding_from(&42u64.to_be_bytes()),
+            message: None,
             mint_scan_from_block: Some(100),
             attested_at: Utc::now(),
         }
+    }
+
+    /// A full-length CCTP message envelope (>= MESSAGE_BODY_INDEX = 148 bytes,
+    /// non-zero nonce in bytes 12..44), matching the manager-test helper so a
+    /// `ReceiveAttestation` fixture lands a stored envelope that
+    /// `AttestationResponse::from_parts` would accept.
+    fn valid_cctp_message() -> Vec<u8> {
+        let mut message = vec![0u8; 200];
+        message[43] = 1;
+        message
     }
 
     fn make_usdc_bridged() -> UsdcRebalanceEvent {
@@ -9769,6 +9780,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
+                    message: valid_cctp_message(),
                     mint_scan_from_block: 100,
                 },
             )
@@ -9856,6 +9868,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&67890u64.to_be_bytes()),
+                    message: valid_cctp_message(),
                     mint_scan_from_block: 100,
                 },
             )
@@ -10154,6 +10167,7 @@ mod tests {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: vec![1, 2, 3],
                     cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
+                    message: valid_cctp_message(),
                     mint_scan_from_block: 100,
                 },
             )

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -1708,6 +1708,7 @@ mod tests {
         UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: vec![],
             cctp_nonce: B256::ZERO,
+            message: None,
             mint_scan_from_block: Some(100),
             attested_at: ts(105),
         }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -4,7 +4,7 @@
 //! `CctpBridge`, `RaindexService`, and the `UsdcRebalance` aggregate to
 //! execute USDC transfers between Alpaca and Base.
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::primitives::{Address, B256, TxHash, U256};
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
 use std::sync::Arc;
@@ -232,6 +232,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 UsdcRebalanceCommand::ReceiveAttestation {
                     attestation: response.as_bytes().to_vec(),
                     cctp_nonce: response.nonce(),
+                    message: response.message_bytes().to_vec(),
                     mint_scan_from_block,
                 },
             )
@@ -239,6 +240,100 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         info!(target: "rebalance", "Circle attestation received");
         Ok(())
+    }
+
+    /// Obtains the [`AttestationResponse`] for an `Attested` resume.
+    ///
+    /// When the full CCTP message envelope was persisted with the attestation
+    /// (the common case since envelope persistence landed), the response is
+    /// reconstructed from stored data and no Circle call is made -- making the
+    /// `Attested` resume deterministic and offline-capable. Transfers whose
+    /// `BridgeAttestationReceived` predates the envelope field carry no message,
+    /// so they fall back to re-polling Circle (idempotent for a completed
+    /// attestation).
+    async fn attested_attestation_response(
+        &self,
+        id: &UsdcRebalanceId,
+        mint_direction: BridgeDirection,
+        burn_tx: TxHash,
+        attestation: Vec<u8>,
+        cctp_nonce: B256,
+        message: Option<Vec<u8>>,
+    ) -> Result<AttestationResponse, UsdcTransferError> {
+        let Some(message) = message else {
+            warn!(
+                target: "rebalance",
+                %id,
+                "Attested transfer predates envelope persistence; re-polling Circle for the attestation"
+            );
+            return match self
+                .poll_cctp_attestation(id, mint_direction, burn_tx)
+                .await?
+            {
+                AttestationPollOutcome::Received(response) => Ok(response),
+                AttestationPollOutcome::TimedOut => {
+                    Err(UsdcTransferError::AttestationTimedOut { id: id.clone() })
+                }
+            };
+        };
+
+        info!(
+            target: "rebalance",
+            %id,
+            "Reconstructing attestation from the persisted message envelope; no Circle re-poll needed"
+        );
+
+        // A reconstruction failure means the persisted envelope is unusable
+        // (corrupt bytes, placeholder nonce). The USDC is already burned, so move
+        // the aggregate to `BridgingFailed` for operator reconciliation rather
+        // than wedging it in `Attested` while the worker exhausts retries --
+        // mirroring the hard-error arm of `poll_cctp_attestation`.
+        let response = match self
+            .cctp_bridge
+            .reconstruct_attestation(message, attestation)
+        {
+            Ok(response) => response,
+            Err(error) => {
+                warn!(target: "rebalance", %id, ?error, "Reconstructing attestation from the persisted envelope failed");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailBridging {
+                            reason: format!("attestation reconstruction failed: {error}"),
+                        },
+                    )
+                    .await?;
+                return Err(UsdcTransferError::Cctp(Box::new(error)));
+            }
+        };
+
+        // The nonce is persisted twice: standalone (`cctp_nonce`) and embedded in
+        // the envelope. Both originate from the same attestation, so a mismatch
+        // means the persisted record is internally inconsistent (storage
+        // corruption or manual repair). Refuse to mint against an unverifiable
+        // nonce; the burn is durable, so surface a terminal failure for operator
+        // reconciliation.
+        let reconstructed = response.nonce();
+        if reconstructed != cctp_nonce {
+            warn!(target: "rebalance", %id, %reconstructed, recorded = %cctp_nonce, "Reconstructed attestation nonce does not match the recorded cctp_nonce");
+            self.cqrs
+                .send(
+                    id,
+                    UsdcRebalanceCommand::FailBridging {
+                        reason: format!(
+                            "attestation nonce mismatch: reconstructed {reconstructed}, recorded {cctp_nonce}"
+                        ),
+                    },
+                )
+                .await?;
+            return Err(UsdcTransferError::AttestationNonceMismatch {
+                id: id.clone(),
+                recorded: cctp_nonce,
+                reconstructed,
+            });
+        }
+
+        Ok(response)
     }
 
     /// Converts USD buying power to USDC in the crypto wallet.
@@ -441,6 +536,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     ///
     /// On errors, sends appropriate `Fail*` command to transition
     /// aggregate to failed state.
+    // A single state-dispatch match with one trivial arm per aggregate state.
+    // Splitting it would scatter the resume routing across pointless helpers; per
+    // the project guidance, suppress the length lint instead.
+    #[allow(clippy::too_many_lines)]
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
     pub(crate) async fn resume_alpaca_to_base(
         &self,
@@ -544,15 +643,19 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             // re-recording it -- then go straight to mint + vault deposit.
             Some(Attested {
                 direction: AlpacaToBase,
-                amount,
                 burn_tx_hash,
+                cctp_nonce,
+                attestation,
+                message,
                 mint_scan_from_block,
                 ..
             }) => {
                 self.continue_alpaca_to_base_from_attested(
                     id,
-                    amount,
                     burn_tx_hash,
+                    attestation,
+                    cctp_nonce,
+                    message,
                     mint_scan_from_block,
                 )
                 .await
@@ -816,13 +919,16 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// scans the Base chain (bounded by `mint_scan_from_block`) for an
     /// already-submitted mint to the market-maker wallet and adopts it via
     /// `ConfirmBridging` -- re-minting would revert on the already-used CCTP
-    /// nonce. Only if no mint is found does it re-poll Circle (idempotent) and
-    /// mint afresh.
+    /// nonce. Only if no mint is found does it reconstruct the attestation from
+    /// the persisted message envelope (or re-poll Circle for transfers predating
+    /// envelope persistence) and mint afresh.
     async fn continue_alpaca_to_base_from_attested(
         &self,
         id: &UsdcRebalanceId,
-        amount: Usdc,
         burn_tx_hash: TxHash,
+        attestation: Vec<u8>,
+        cctp_nonce: B256,
+        message: Option<Vec<u8>>,
         mint_scan_from_block: Option<u64>,
     ) -> Result<(), UsdcTransferError> {
         // Events persisted before crash-safe resume carry no scan bound. Scanning
@@ -863,23 +969,21 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 .await;
         }
 
-        // No mint landed yet: re-poll Circle for the attestation (idempotent for a
-        // completed attestation) WITHOUT re-emitting `ReceiveAttestation`, then
-        // mint on Base. `execute_cctp_mint` emits `ConfirmBridging`, advancing the
-        // aggregate to `Bridged`.
-        let burn_receipt = BurnReceipt {
-            tx: burn_tx_hash,
-            amount: usdc_to_u256(amount)?,
-        };
-        let attestation_response = match self
-            .poll_cctp_attestation(id, BridgeDirection::EthereumToBase, burn_receipt.tx)
-            .await?
-        {
-            AttestationPollOutcome::Received(response) => response,
-            AttestationPollOutcome::TimedOut => {
-                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
-            }
-        };
+        // No mint landed yet: reconstruct the attestation from persisted data
+        // (or re-poll Circle for transfers predating envelope persistence)
+        // WITHOUT re-emitting `ReceiveAttestation`, then mint on Base.
+        // `execute_cctp_mint` emits `ConfirmBridging`, advancing the aggregate to
+        // `Bridged`.
+        let attestation_response = self
+            .attested_attestation_response(
+                id,
+                BridgeDirection::EthereumToBase,
+                burn_tx_hash,
+                attestation,
+                cctp_nonce,
+                message,
+            )
+            .await?;
         let mint_receipt = self.execute_cctp_mint(id, attestation_response).await?;
 
         self.continue_alpaca_to_base_from_bridged(id, u256_to_usdc(mint_receipt.amount)?)
@@ -1212,10 +1316,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     }
 
     /// Non-obvious points the match body below cannot express on its own:
-    /// - `Attested` re-polls rather than reconstructing an `AttestationResponse`
-    ///   because the aggregate stores attestation bytes + nonce but not the
-    ///   full message envelope [`Bridge::mint`] needs; Circle's API is
-    ///   idempotent for completed attestations so the cost is negligible.
+    /// - `Attested` reconstructs the `AttestationResponse` from the persisted
+    ///   message envelope and mints with no Circle call. Transfers whose
+    ///   attestation predates envelope persistence carry no message and fall
+    ///   back to re-polling Circle (idempotent for a completed attestation).
     /// - `Converting` is unrecoverable: the aggregate persists the correlation
     ///   UUID but not the broker order ID, so a polling-based resume cannot
     ///   identify the order. Operator reconciles manually.
@@ -1309,8 +1413,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
             Some(UsdcRebalance::Attested {
                 direction,
-                amount,
                 burn_tx_hash,
+                cctp_nonce,
+                attestation,
+                message,
                 mint_scan_from_block,
                 ..
             }) => {
@@ -1318,8 +1424,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 self.continue_from_attested(
                     id,
                     direction,
-                    amount,
                     burn_tx_hash,
+                    attestation,
+                    cctp_nonce,
+                    message,
                     mint_scan_from_block,
                 )
                 .await
@@ -1599,23 +1707,26 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// already-submitted mint to the market maker wallet and adopts it via
     /// `ConfirmBridging` -- re-minting would revert on the already-used CCTP
     /// nonce and fail a transfer whose USDC was in fact minted. When no mint is
-    /// found, it re-polls Circle for a fresh [`AttestationResponse`] (the
-    /// aggregate stores the attestation bytes and nonce but not the full message
-    /// envelope [`Bridge::mint`] needs) and mints, WITHOUT re-emitting
+    /// found, it reconstructs the [`AttestationResponse`] from the persisted
+    /// message envelope and mints with no Circle call, WITHOUT re-emitting
     /// `ReceiveAttestation` -- which the aggregate rejects from `Attested`.
+    /// Transfers whose attestation predates envelope persistence carry no
+    /// message and fall back to re-polling Circle.
     ///
-    /// A re-poll timeout here retries until success (no deadline) by design:
-    /// reaching `Attested` means Circle already issued an attestation once, so a
-    /// re-poll timeout is transient and bounding it would strand already-burned
-    /// USDC. The `attestation_retry_deadline` bounds only the
+    /// A re-poll timeout in the fallback path retries until success (no deadline)
+    /// by design: reaching `Attested` means Circle already issued an attestation
+    /// once, so a re-poll timeout is transient and bounding it would strand
+    /// already-burned USDC. The `attestation_retry_deadline` bounds only the
     /// `AwaitingAttestation` wait. A hard (non-timeout) poll error still fails
     /// the bridge -- see [`Self::poll_cctp_attestation`].
     async fn continue_from_attested(
         &self,
         id: &UsdcRebalanceId,
         direction: RebalanceDirection,
-        amount: Usdc,
         burn_tx_hash: TxHash,
+        attestation: Vec<u8>,
+        cctp_nonce: B256,
+        message: Option<Vec<u8>>,
         mint_scan_from_block: Option<u64>,
     ) -> Result<(), UsdcTransferError> {
         // Events persisted before crash-safe resume carry no scan bound. Scanning
@@ -1664,19 +1775,16 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 .await;
         }
 
-        let burn_receipt = BurnReceipt {
-            tx: burn_tx_hash,
-            amount: usdc_to_u256(amount)?,
-        };
-        let attestation_response = match self
-            .poll_cctp_attestation(id, BridgeDirection::BaseToEthereum, burn_receipt.tx)
-            .await?
-        {
-            AttestationPollOutcome::Received(response) => response,
-            AttestationPollOutcome::TimedOut => {
-                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
-            }
-        };
+        let attestation_response = self
+            .attested_attestation_response(
+                id,
+                mint_direction,
+                burn_tx_hash,
+                attestation,
+                cctp_nonce,
+                message,
+            )
+            .await?;
         self.mint_and_continue(id, attestation_response).await
     }
 
@@ -2171,6 +2279,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&99999u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 mint_scan_from_block: 100,
             },
         )
@@ -2260,6 +2369,7 @@ mod tests {
             ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 mint_scan_from_block: 100,
             },
         )
@@ -2347,7 +2457,11 @@ mod tests {
             id,
             ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
+                // Must equal the nonce embedded in `valid_cctp_message()` (byte 43 = 1):
+                // an `Attested` resume cross-checks the re-derived envelope nonce against
+                // this recorded value and fails on a mismatch.
+                cctp_nonce: B256::left_padding_from(&1u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 // Scan from genesis: the fresh test chain sits below 100, so a 0
                 // bound makes the find_recent_mint scan a valid range that
                 // genuinely finds no mint, letting resume proceed to the mint.
@@ -3184,6 +3298,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&12345u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 mint_scan_from_block: 100,
             },
         )
@@ -3869,7 +3984,11 @@ mod tests {
             id,
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
-                cctp_nonce: B256::left_padding_from(&99_999u64.to_be_bytes()),
+                // Must equal the nonce embedded in `valid_cctp_message()` (byte 43 = 1):
+                // an `Attested` resume cross-checks the re-derived envelope nonce against
+                // this recorded value and fails on a mismatch.
+                cctp_nonce: B256::left_padding_from(&1u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 // Scan from genesis, not the sibling helpers' `100`: the resume test
                 // built on this helper actually scans from this block for an
                 // already-submitted mint, and the fresh test chain (advanced only via
@@ -4037,12 +4156,27 @@ mod tests {
         );
     }
 
+    /// A CCTP message envelope valid for nonce extraction: >= MIN_MESSAGE_LENGTH
+    /// (44 bytes) with a non-zero nonce in bytes 12..44 (byte 43 set), so
+    /// `AttestationResponse::from_parts` reconstructs it without rejecting a
+    /// placeholder nonce. Used as the persisted `message` in `ReceiveAttestation`
+    /// fixtures so an `Attested` resume reconstructs rather than re-polling.
+    fn valid_cctp_message() -> Vec<u8> {
+        // A full CCTP envelope (>= MESSAGE_BODY_INDEX bytes): `from_parts` rejects
+        // anything shorter as a truncated/corrupt envelope. Byte 43 (last byte of
+        // the nonce at bytes 12..44) is set to 1 so the extracted nonce is 1.
+        let mut message = vec![0u8; 200];
+        message[43] = 1;
+        message
+    }
+
     /// Mocks Circle's `/v2/messages/` lookup to return a `complete` attestation
     /// immediately, so a re-poll from `AwaitingAttestation` resolves without the
-    /// 5-minute real-API retry. The message just needs to be >=
-    /// MIN_MESSAGE_LENGTH (44 bytes) for nonce extraction.
+    /// 5-minute real-API retry. The message is a full-length CCTP envelope (>=
+    /// MESSAGE_BODY_INDEX) so it passes the shared `from_parts` validation the
+    /// poll path now enforces, with byte 43 = 1 giving an extracted nonce of 1.
     fn mock_complete_attestation(server: &MockServer) -> httpmock::Mock<'_> {
-        let mut message = vec![0u8; 100];
+        let mut message = vec![0u8; 200];
         message[43] = 1;
         let message_hex = format!("0x{}", alloy::hex::encode(&message));
         let attestation_hex = format!("0x{}", "ab".repeat(65));
@@ -4183,6 +4317,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: B256::left_padding_from(&99_999u64.to_be_bytes()),
+                message: valid_cctp_message(),
                 mint_scan_from_block: 100,
             },
         )
@@ -4292,12 +4427,14 @@ mod tests {
 
     #[cfg(feature = "test-support")]
     #[tokio::test]
-    async fn resume_base_to_alpaca_from_attested_does_not_re_emit_receive_attestation() {
+    async fn resume_base_to_alpaca_from_attested_reconstructs_without_repolling_circle() {
         let server = MockServer::start();
 
-        // Return a `complete` attestation immediately so poll_cctp_attestation
-        // resolves without the 5-minute real-API retry.
-        let _attestation_mock = mock_complete_attestation(&server);
+        // A `complete` attestation is mocked, but the resume must NOT call it:
+        // the persisted message envelope lets it reconstruct the attestation
+        // offline. The mock exists only to prove (via 0 hits) that no re-poll
+        // happens.
+        let attestation_mock = mock_complete_attestation(&server);
 
         let (manager, cqrs, _anvil) =
             make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
@@ -4318,9 +4455,9 @@ mod tests {
 
         // The OLD (buggy) behavior re-sent ReceiveAttestation from Attested, which
         // the aggregate rejects -> UsdcTransferError::Aggregate(InvalidCommand).
-        // The fix routes Attested through continue_from_attested (poll -> mint, no
-        // ReceiveAttestation), so resume gets PAST the Attested gate and instead
-        // fails at the mint on the undeployed contract -> Cctp.
+        // The fix routes Attested through continue_from_attested (reconstruct ->
+        // mint, no ReceiveAttestation), so resume gets PAST the Attested gate and
+        // instead fails at the mint on the undeployed contract -> Cctp.
         assert!(
             !matches!(&error, UsdcTransferError::Aggregate(_)),
             "resume from Attested must NOT re-emit ReceiveAttestation (the aggregate \
@@ -4330,6 +4467,146 @@ mod tests {
             matches!(error, UsdcTransferError::Cctp(_)),
             "resume from Attested should proceed to mint and fail with a Cctp contract \
              error; got: {error:?}",
+        );
+        assert_eq!(
+            attestation_mock.calls(),
+            0,
+            "resume from Attested must reconstruct the attestation from the persisted \
+             message envelope, not re-poll Circle",
+        );
+    }
+
+    fn valid_message_nonce() -> B256 {
+        // `valid_cctp_message()` sets byte 43 = 1, so the nonce extracted from it
+        // is 1. The staging helpers record this as `cctp_nonce`.
+        B256::left_padding_from(&1u64.to_be_bytes())
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn attested_attestation_response_without_message_repolls_circle() {
+        let server = MockServer::start();
+        let attestation_mock = mock_complete_attestation(&server);
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let burn_tx = advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        // A transfer whose `BridgeAttestationReceived` predates envelope
+        // persistence carries `message: None`, so the response must be re-fetched
+        // from Circle (the backward-compatible fallback).
+        let response = manager
+            .attested_attestation_response(
+                &id,
+                BridgeDirection::BaseToEthereum,
+                burn_tx,
+                vec![0x01],
+                valid_message_nonce(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.nonce(), valid_message_nonce());
+        assert_eq!(
+            attestation_mock.calls(),
+            1,
+            "a legacy None-envelope resume must re-poll Circle exactly once",
+        );
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn attested_attestation_response_with_corrupt_envelope_fails_bridging() {
+        let server = MockServer::start();
+        let attestation_mock = mock_complete_attestation(&server);
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let burn_tx = advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        // A persisted envelope too short to extract a nonce is unusable. The USDC
+        // is already burned, so the aggregate must move to `BridgingFailed` for
+        // operator reconciliation rather than wedge in `Attested`.
+        let error = manager
+            .attested_attestation_response(
+                &id,
+                BridgeDirection::BaseToEthereum,
+                burn_tx,
+                vec![0x01],
+                valid_message_nonce(),
+                Some(vec![0u8; 10]),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "a corrupt envelope must surface a Cctp error, got: {error:?}",
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::BridgingFailed { .. }),
+            "a reconstruction failure must fail the bridge, got: {state:?}",
+        );
+        assert_eq!(
+            attestation_mock.calls(),
+            0,
+            "a reconstruction failure must not re-poll Circle",
+        );
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn attested_attestation_response_with_mismatched_nonce_fails_bridging() {
+        let server = MockServer::start();
+        let attestation_mock = mock_complete_attestation(&server);
+
+        let (manager, cqrs, _anvil) =
+            make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let burn_tx = advance_to_attested_base_to_alpaca(&cqrs, &id, amount).await;
+
+        // `valid_cctp_message()` embeds nonce 1; recording a different cctp_nonce
+        // makes the persisted record internally inconsistent. Minting against an
+        // unverifiable nonce is refused -> `BridgingFailed`.
+        let recorded = B256::left_padding_from(&999u64.to_be_bytes());
+        let error = manager
+            .attested_attestation_response(
+                &id,
+                BridgeDirection::BaseToEthereum,
+                burn_tx,
+                vec![0x01],
+                recorded,
+                Some(valid_cctp_message()),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::AttestationNonceMismatch { recorded: error_recorded, reconstructed, .. }
+                    if error_recorded == recorded && reconstructed == valid_message_nonce()
+            ),
+            "a nonce mismatch must surface AttestationNonceMismatch, got: {error:?}",
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::BridgingFailed { .. }),
+            "a nonce mismatch must fail the bridge, got: {state:?}",
+        );
+        assert_eq!(
+            attestation_mock.calls(),
+            0,
+            "a nonce mismatch must not re-poll Circle",
         );
     }
 
@@ -5123,6 +5400,7 @@ mod tests {
             UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: attestation_response.as_bytes().to_vec(),
                 cctp_nonce: attestation_response.nonce(),
+                message: attestation_response.message_bytes().to_vec(),
                 mint_scan_from_block,
             },
         )
@@ -5170,6 +5448,80 @@ mod tests {
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected ConversionComplete after adopting the existing mint on resume, \
              got: {final_state:?}"
+        );
+    }
+
+    /// A persisted envelope must actually mint, not merely reconstruct. Rebuild
+    /// the `AttestationResponse` from the stored message + attestation bytes
+    /// (exactly as an `Attested` resume does via `from_parts`) and mint it
+    /// on-chain over dual-chain CCTP with no Circle re-poll. A successful mint
+    /// receipt for the burned amount proves the stored envelope alone is
+    /// sufficient to call `receiveMessage` -- guarding against persisting an
+    /// envelope shape that round-trips but cannot mint.
+    #[tokio::test]
+    async fn persisted_envelope_reconstructs_into_a_mintable_response() {
+        let chains = deploy_dual_chain_cctp().await;
+
+        let attestation = CctpAttestationMock::start().await;
+        let _watcher = attestation
+            .start_watcher(
+                ProviderBuilder::new()
+                    .connect(&chains.ethereum_endpoint)
+                    .await
+                    .unwrap(),
+                ProviderBuilder::new()
+                    .connect(&chains.base_endpoint)
+                    .await
+                    .unwrap(),
+                chains.attester_key,
+            )
+            .await
+            .unwrap();
+
+        let cctp_bridge = CctpBridge::try_from_ctx(CctpCtx {
+            usdc_ethereum: USDC_ADDRESS,
+            usdc_base: USDC_ADDRESS,
+            ethereum_wallet: create_test_wallet(&chains.ethereum_endpoint, &chains.bot_key),
+            base_wallet: create_test_wallet(&chains.base_endpoint, &chains.bot_key),
+            circle_api_base: attestation.base_url(),
+            token_messenger: chains.token_messenger,
+            message_transmitter: chains.message_transmitter,
+        })
+        .unwrap();
+
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let amount_u256 = usdc_to_u256(usdc("100")).unwrap();
+        let burn_receipt = cctp_bridge
+            .burn(
+                BridgeDirection::BaseToEthereum,
+                amount_u256,
+                market_maker_wallet,
+            )
+            .await
+            .unwrap();
+        let response = cctp_bridge
+            .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .await
+            .unwrap();
+
+        // Persist then reconstruct exactly as the `Attested` resume path does:
+        // store only the envelope + attestation bytes, then rebuild with no
+        // Circle call.
+        let reconstructed = cctp_bridge
+            .reconstruct_attestation(
+                response.message_bytes().to_vec(),
+                response.as_bytes().to_vec(),
+            )
+            .unwrap();
+
+        let mint_receipt = cctp_bridge
+            .mint(BridgeDirection::BaseToEthereum, &reconstructed)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mint_receipt.amount, amount_u256,
+            "the reconstructed envelope must mint the full burned amount",
         );
     }
 
@@ -5364,28 +5716,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_alpaca_to_base_from_attested_does_not_re_emit_receive_attestation() {
+    async fn resume_alpaca_to_base_from_attested_reconstructs_without_repolling_circle() {
         let server = MockServer::start();
 
-        // Return a `complete` attestation for any /v2/messages request so the
-        // attestation re-poll resolves immediately (same shape as the
-        // Base->Alpaca sibling test).
-        let mut message = vec![0u8; 100];
-        message[43] = 1;
-        let message_hex = format!("0x{}", alloy::hex::encode(&message));
-        let attestation_hex = format!("0x{}", "ab".repeat(65));
-        let _attestation_mock = server.mock(|when, then| {
-            when.method(GET).path_includes("/v2/messages/");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({
-                    "messages": [{
-                        "status": "complete",
-                        "message": message_hex,
-                        "attestation": attestation_hex,
-                    }]
-                }));
-        });
+        // A `complete` attestation is mocked, but the resume must NOT call it:
+        // the persisted message envelope lets it reconstruct the attestation
+        // offline. The mock exists only to prove (via 0 hits) that no re-poll
+        // happens. (Same shape as the Base->Alpaca sibling test.)
+        let attestation_mock = mock_complete_attestation(&server);
 
         let (manager, cqrs, _anvil) =
             make_resume_test_manager_with_circle_api(&server, server.base_url()).await;
@@ -5420,6 +5758,12 @@ mod tests {
             matches!(error, UsdcTransferError::Cctp(_)),
             "resume from Attested should proceed past the gate to the CCTP mint and \
              fail with a Cctp error; got: {error:?}",
+        );
+        assert_eq!(
+            attestation_mock.calls(),
+            0,
+            "resume from Attested must reconstruct the attestation from the persisted \
+             message envelope, not re-poll Circle",
         );
     }
 

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -88,6 +88,16 @@ pub(crate) enum UsdcTransferError {
         id: UsdcRebalanceId,
         retry_deadline: Duration,
     },
+    #[error(
+        "USDC rebalance {id} recorded cctp_nonce {recorded} does not match nonce \
+         {reconstructed} re-derived from the persisted message envelope; failed for \
+         operator reconciliation rather than minting against an unverifiable nonce"
+    )]
+    AttestationNonceMismatch {
+        id: UsdcRebalanceId,
+        recorded: alloy::primitives::B256,
+        reconstructed: alloy::primitives::B256,
+    },
     #[error("USDC rebalance {id} cannot resume: aggregate is in terminal failure state")]
     PreviouslyFailedAggregate { id: UsdcRebalanceId },
     #[error(

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -241,6 +241,10 @@ pub(crate) enum UsdcRebalanceCommand {
     ReceiveAttestation {
         attestation: Vec<u8>,
         cctp_nonce: B256,
+        /// Full CCTP message envelope from the attestation, persisted on the
+        /// `BridgeAttestationReceived` event so an `Attested` resume mints
+        /// without re-polling Circle.
+        message: Vec<u8>,
         mint_scan_from_block: u64,
     },
     /// Record that Circle attestation polling timed out while the burn remains
@@ -340,6 +344,11 @@ pub(crate) enum UsdcRebalanceEvent {
     BridgeAttestationReceived {
         attestation: Vec<u8>,
         cctp_nonce: B256,
+        /// Full CCTP message envelope, persisted so an `Attested` resume mints
+        /// without re-polling Circle. `None` for events serialized before this
+        /// field existed: such a resume re-polls Circle as a fallback.
+        #[serde(default)]
+        message: Option<Vec<u8>>,
         #[serde(default)]
         mint_scan_from_block: Option<u64>,
         attested_at: DateTime<Utc>,
@@ -517,6 +526,11 @@ pub(crate) enum UsdcRebalance {
         burn_tx_hash: TxHash,
         cctp_nonce: B256,
         attestation: Vec<u8>,
+        /// Full CCTP message envelope from the attestation, persisted so a resume
+        /// can reconstruct the `AttestationResponse` and mint without re-polling
+        /// Circle. `None` for transfers whose `BridgeAttestationReceived` predates
+        /// this field: such a resume falls back to re-polling Circle.
+        message: Option<Vec<u8>>,
         /// Destination chain head captured before the mint, bounding the
         /// crash-safe resume scan that adopts an already-submitted mint. `None`
         /// for transfers whose `BridgeAttestationReceived` predates this field.
@@ -952,7 +966,15 @@ impl EventSourced for UsdcRebalance {
     // attestation), which deserializes unchanged into Option<B256>.
     // v3: added the non-terminal AwaitingAttestation state so attestation
     // timeouts replay as retryable instead of terminal bridge failures.
-    const SCHEMA_VERSION: u64 = 3;
+    // v4: added the `message` envelope field to the Attested state and the
+    // BridgeAttestationReceived event. The field is `Option<Vec<u8>>`, so serde
+    // deserializes both a stale snapshot and a pre-field event with a missing
+    // `message` as `None` -- legacy `Attested` transfers stay loadable and
+    // resume via the re-poll fallback either way. Bumped (defensively, matching
+    // v2/v3) to clear stale snapshots and rebuild from events, so any persisted
+    // `Attested` snapshot is regenerated under the current schema rather than
+    // relying on serde's missing-Option-as-None leniency.
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1178,6 +1200,7 @@ impl EventSourced for UsdcRebalance {
                 BridgeAttestationReceived {
                     attestation,
                     cctp_nonce,
+                    message,
                     mint_scan_from_block,
                     attested_at,
                 },
@@ -1201,6 +1224,7 @@ impl EventSourced for UsdcRebalance {
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
                 attestation: attestation.clone(),
+                message: message.clone(),
                 mint_scan_from_block: *mint_scan_from_block,
                 initiated_at: *initiated_at,
                 attested_at: *attested_at,
@@ -1491,8 +1515,14 @@ impl EventSourced for UsdcRebalance {
             ReceiveAttestation {
                 attestation,
                 cctp_nonce,
+                message,
                 mint_scan_from_block,
-            } => self.transition_receive_attestation(attestation, cctp_nonce, mint_scan_from_block),
+            } => self.transition_receive_attestation(
+                attestation,
+                cctp_nonce,
+                message,
+                mint_scan_from_block,
+            ),
             TimeoutAttestation { retry_deadline_at } => {
                 self.transition_timeout_attestation(retry_deadline_at)
             }
@@ -1790,6 +1820,7 @@ impl UsdcRebalance {
         &self,
         attestation: Vec<u8>,
         cctp_nonce: B256,
+        message: Vec<u8>,
         mint_scan_from_block: u64,
     ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
@@ -1806,6 +1837,7 @@ impl UsdcRebalance {
                 Ok(vec![BridgeAttestationReceived {
                     attestation,
                     cctp_nonce,
+                    message: Some(message),
                     mint_scan_from_block: Some(mint_scan_from_block),
                     attested_at: Utc::now(),
                 }])
@@ -2035,7 +2067,7 @@ impl UsdcRebalance {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::fixed_bytes;
-    use serde_json::{from_value, json};
+    use serde_json::{from_value, json, to_value};
     use std::collections::HashSet;
     use uuid::Uuid;
 
@@ -2077,6 +2109,113 @@ mod tests {
         };
 
         assert_eq!(mint_scan_from_block, None);
+    }
+
+    // An event persisted before the `message` envelope field existed must still
+    // deserialize on replay -- to `None`, not a hard error -- so an `Attested`
+    // resume of an older aggregate falls back to re-polling Circle rather than
+    // failing to rebuild (the `#[serde(default)]`).
+    #[test]
+    fn bridge_attestation_received_without_message_deserializes_to_none() {
+        let old_event = json!({
+            "BridgeAttestationReceived": {
+                "attestation": [1, 2, 3],
+                "cctp_nonce": "0xa01ca42d9082e926a81dc287d973a8f072dfa1b20a4fbf7b20f3abda1b376278",
+                "mint_scan_from_block": 100,
+                "attested_at": "2026-01-01T00:00:00Z"
+            }
+        });
+
+        let event: UsdcRebalanceEvent =
+            from_value(old_event).expect("pre-field event must still deserialize");
+
+        let UsdcRebalanceEvent::BridgeAttestationReceived { message, .. } = event else {
+            panic!("expected BridgeAttestationReceived");
+        };
+
+        assert_eq!(message, None);
+    }
+
+    // The `message` envelope must survive replay into the `Attested` state so an
+    // `Attested` resume can reconstruct the attestation without re-polling Circle.
+    #[test]
+    fn bridge_attestation_received_carries_message_into_attested() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let envelope = vec![0xDE, 0xAD, 0xBE, 0xEF];
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100)),
+                withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: burn_tx,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![0x01],
+                cctp_nonce: TEST_CCTP_NONCE,
+                message: Some(envelope.clone()),
+                mint_scan_from_block: Some(100),
+                attested_at: Utc::now(),
+            },
+        ])
+        .expect("event stream should replay into Attested");
+
+        let Some(UsdcRebalance::Attested { message, .. }) = state else {
+            panic!("expected Attested, got {state:?}");
+        };
+
+        assert_eq!(message, Some(envelope));
+    }
+
+    // A snapshot persisted before the `message` field existed must still load
+    // under the current schema: `message` is `Option<Vec<u8>>`, and serde
+    // deserializes a missing key for an `Option` field as `None` (no
+    // `#[serde(default)]` required). So a stale `Attested` snapshot remains
+    // loadable and resumes via the legacy re-poll fallback -- the state-level
+    // mirror of `bridge_attestation_received_without_message_deserializes_to_none`.
+    // This guards the backward-compat boundary: switching `message` to a
+    // non-optional type, or adding `deny_unknown_fields`, would strand in-flight
+    // pre-`message` transfers held in an `Attested` snapshot.
+    #[test]
+    fn attested_snapshot_without_message_deserializes_to_none() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mut snapshot = to_value(UsdcRebalance::Attested {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100)),
+            burn_tx_hash: burn_tx,
+            cctp_nonce: TEST_CCTP_NONCE,
+            attestation: vec![0x01, 0x02, 0x03],
+            message: Some(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+            mint_scan_from_block: Some(100),
+            initiated_at: Utc::now(),
+            attested_at: Utc::now(),
+        })
+        .expect("Attested state serializes");
+
+        // Simulate a snapshot persisted before the `message` field existed.
+        snapshot
+            .get_mut("Attested")
+            .and_then(|attested| attested.as_object_mut())
+            .expect("externally-tagged Attested object")
+            .remove("message");
+
+        let state =
+            from_value::<UsdcRebalance>(snapshot).expect("pre-message snapshot must still load");
+
+        let UsdcRebalance::Attested { message, .. } = state else {
+            panic!("expected Attested, got {state:?}");
+        };
+
+        assert_eq!(message, None);
     }
 
     #[tokio::test]
@@ -2698,6 +2837,7 @@ mod tests {
             UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: None,
                 mint_scan_from_block: Some(100),
                 attested_at,
             },
@@ -2834,6 +2974,7 @@ mod tests {
         let burn_tx_hash =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
         let attestation = vec![0x01, 0x02, 0x03, 0x04];
+        let message = vec![0x05, 0x06, 0x07, 0x08];
 
         let events = TestHarness::<UsdcRebalance>::with(())
             .given(vec![
@@ -2854,6 +2995,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: attestation.clone(),
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: message.clone(),
                 mint_scan_from_block: 8_675_309,
             })
             .await
@@ -2863,6 +3005,7 @@ mod tests {
         let UsdcRebalanceEvent::BridgeAttestationReceived {
             attestation: event_attestation,
             cctp_nonce: event_nonce,
+            message: event_message,
             mint_scan_from_block,
             ..
         } = &events[0]
@@ -2871,6 +3014,11 @@ mod tests {
         };
 
         assert_eq!(*event_attestation, attestation);
+        assert_eq!(
+            *event_message,
+            Some(message),
+            "ReceiveAttestation must persist the full CCTP message envelope into the event",
+        );
         assert_eq!(
             *mint_scan_from_block,
             Some(8_675_309),
@@ -2899,6 +3047,7 @@ mod tests {
             &UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: None,
                 mint_scan_from_block: Some(8_675_309),
                 attested_at: Utc::now(),
             },
@@ -2928,6 +3077,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -2953,6 +3103,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -2983,6 +3134,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -3014,6 +3166,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01, 0x02],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -3049,6 +3202,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3056,6 +3210,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x03, 0x04],
                 cctp_nonce: OTHER_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -3093,6 +3248,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02, 0x03, 0x04],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3316,6 +3472,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3416,6 +3573,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3468,6 +3626,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3559,6 +3718,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3617,6 +3777,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3670,6 +3831,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3715,6 +3877,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3767,6 +3930,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3816,6 +3980,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3880,6 +4045,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01, 0x02],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3940,6 +4106,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0xAB, 0xCD, 0xEF],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -3993,6 +4160,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x11, 0x22, 0x33, 0x44],
                     cctp_nonce: OTHER_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4101,6 +4269,7 @@ mod tests {
             .when(UsdcRebalanceCommand::ReceiveAttestation {
                 attestation: vec![0x01],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: vec![],
                 mint_scan_from_block: 100,
             })
             .await
@@ -4180,6 +4349,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4234,6 +4404,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4291,6 +4462,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4609,6 +4781,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4676,6 +4849,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4749,6 +4923,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4811,6 +4986,7 @@ mod tests {
                 UsdcRebalanceEvent::BridgeAttestationReceived {
                     attestation: vec![0x01],
                     cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
                     mint_scan_from_block: Some(100),
                     attested_at: Utc::now(),
                 },
@@ -4879,6 +5055,7 @@ mod tests {
             UsdcRebalanceEvent::BridgeAttestationReceived {
                 attestation: vec![0x01],
                 cctp_nonce: TEST_CCTP_NONCE,
+                message: None,
                 mint_scan_from_block: Some(100),
                 attested_at: withdrawal_confirmed_at + chrono::Duration::seconds(15),
             },
@@ -5283,6 +5460,7 @@ mod tests {
             burn_tx_hash: burn_tx,
             cctp_nonce: TEST_CCTP_NONCE,
             attestation: vec![0xAA, 0xBB],
+            message: None,
             mint_scan_from_block: Some(100),
             initiated_at,
             attested_at,
@@ -5443,6 +5621,7 @@ mod tests {
                 burn_tx_hash: BURN_TX,
                 cctp_nonce: TEST_CCTP_NONCE,
                 attestation: vec![],
+                message: None,
                 mint_scan_from_block: Some(100),
                 initiated_at: now,
                 attested_at: now,


### PR DESCRIPTION
## What

Resolves [RAI-834](https://linear.app/makeitrain/issue/RAI-834). Persists the full CCTP message envelope alongside the attestation on `BridgeAttestationReceived`, so a USDC bridge resuming from the `Attested` state reconstructs the `AttestationResponse` from stored data and mints with **no Circle call** -- instead of re-polling Circle to rebuild the envelope that `Bridge::mint` requires.

## Why

Resuming from `Attested` previously re-polled Circle to reconstruct the `AttestationResponse`, because the aggregate stored only the attestation bytes plus nonce, not the full message envelope. That made `Attested` recovery depend on an external API for data we had already received once, and was the root cause behind the `Attested` re-poll loop flagged in review of the attestation-retry work. The envelope is durable data we already hold; reconstructing offline removes the external dependency and makes the resume deterministic.

## How

- **`st0x-bridge` trait surface (`crates/bridge/src/lib.rs`)**: add `Attestation::message_bytes()` (the full envelope, distinct from the signature `as_bytes()`) and `Bridge::reconstruct_attestation(message, attestation)`, keeping reconstruction behind the trait so callers never touch a concrete attestation type.
- **CCTP impl (`crates/bridge/src/cctp/mod.rs`)**: add the private `AttestationResponse::from_parts(message, attestation)`, which re-derives the nonce from the message via the existing `extract_nonce_from_message` (so a stored envelope is self-validating -- an all-zero placeholder nonce is rejected) and guards that the message reaches `MESSAGE_BODY_INDEX` (rejecting a truncated envelope that would otherwise revert in `receiveMessage` on-chain). The fresh `poll_attestation` path is refactored to go through this same constructor, so a fresh poll and a persisted-envelope resume enforce identical rules. `reconstruct_attestation` delegates to `from_parts`.
- **Aggregate (`src/usdc_rebalance.rs`)**: carry `message` on the `ReceiveAttestation` command, the `BridgeAttestationReceived` event (`Option<Vec<u8>>`, `#[serde(default)]`), and the `Attested` state -- mirroring the existing backward-compat pattern for `mint_scan_from_block`. `SCHEMA_VERSION` bumps `3 -> 4` (defensively, matching v2/v3) so stale snapshots rebuild from events. `transition_receive_attestation` threads the envelope into the event as `Some(message)`.
- **Manager (`src/rebalancing/usdc/manager.rs`)**: new `attested_attestation_response` centralizes the resume sourcing -- reconstructs via `reconstruct_attestation` when the envelope is present (no Circle call), and cross-checks the re-derived nonce against the recorded `cctp_nonce`. A reconstruction failure (corrupt/truncated envelope, placeholder nonce) or a nonce mismatch sends `FailBridging` for operator reconciliation, since the USDC is already burned. Transfers whose `BridgeAttestationReceived` predates the field carry `None` and fall back to re-polling Circle. Both `continue_from_attested` and `continue_alpaca_to_base_from_attested` route through it (and now take `attestation`/`cctp_nonce`/`message` instead of `amount`).
- **Error type (`src/rebalancing/usdc/mod.rs`)**: add `UsdcTransferError::AttestationNonceMismatch { id, recorded, reconstructed }` (typed `B256`s, no opaque strings) for the cross-check failure.
- **SPEC.md**: rewrite the post-attestation resume section to describe offline reconstruction with the legacy re-poll fallback, and sync the `cctp_nonce` type (`u64 -> B256`) and the new `message` field on the command/event/state.

## Testing

- **Manager, anvil (`manager.rs`)**: `resume_{base_to_alpaca,alpaca_to_base}_from_attested_reconstructs_without_repolling_circle` assert the Circle mock gets **0 hits** on an `Attested` resume; `attested_attestation_response_without_message_repolls_circle` asserts the legacy `None` path re-polls exactly once; `attested_attestation_response_with_corrupt_envelope_fails_bridging` and `..._with_mismatched_nonce_fails_bridging` assert the aggregate lands in `BridgingFailed` with no re-poll; `persisted_envelope_reconstructs_into_a_mintable_response` burns over dual-chain CCTP, reconstructs from stored bytes alone, and mints the full amount on-chain -- proving the persisted shape is genuinely mintable, not just round-trippable.
- **CCTP (`cctp/mod.rs`)**: `from_parts_reconstructs_response_with_message_derived_nonce`, `from_parts_accepts_message_at_body_index_boundary`, `from_parts_rejects_truncated_envelope_with_valid_nonce`, and `from_parts_rejects_placeholder_nonce` pin the reconstruction contract at the `MESSAGE_BODY_INDEX` boundary.
- **Aggregate (`usdc_rebalance.rs`)**: `bridge_attestation_received_without_message_deserializes_to_none` and `attested_snapshot_without_message_deserializes_to_none` guard the backward-compat boundary; `bridge_attestation_received_carries_message_into_attested` confirms the envelope survives replay; the `ReceiveAttestation` round-trip test now also asserts the envelope persists into the event.

## Anything else

- **Backward compatible**: events and snapshots persisted before this field deserialize the envelope as `None` (`#[serde(default)]` / missing-Option leniency) and resume via the unchanged re-poll fallback; in-flight pre-`message` `Attested` transfers stay loadable.
- **No DB migration**: the change is confined to event/snapshot JSON payloads; the `SCHEMA_VERSION` bump to 4 clears stale snapshots so they rebuild from events.
- **Stack context**: first of a 4-PR stack for [RAI-833](https://linear.app/makeitrain/issue/RAI-833) (USDC attestation-retry follow-ups): RAI-834 -> RAI-837 -> RAI-836 -> RAI-835.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * USDC rebalance transfers can now resume from persisted attestation data without re-querying Circle, reducing recovery time after network interruptions.
  * Added nonce validation for reconstructed attestations to detect and report mismatches.

* **Bug Fixes**
  * Improved validation of attestation message integrity to prevent processing of corrupted or incomplete payloads.
  * Enhanced error reporting for attestation reconstruction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->