### PR TITLE
feat: redrive manual CLI USDC transfers that time out after the burn

### DIFF
--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -172,8 +172,17 @@ Not covered by `recheck-transfer` yet:
   request id to look up, so this needs a retry/resume-send style CLI.
 - Provider rejections. These remain failed unless an operator performs a
   separate manual reconciliation.
-- USDC rebalancing failures. Those use the USDC/CCTP state machine and need
-  separate recovery commands.
+- USDC rebalancing failures. Those use the USDC/CCTP state machine and have
+  their own recovery command. A manual `transfer-usdc` prints its transfer id
+  and, if interrupted after the burn, is resumed with
+  `stox resume-usdc-transfer --id <id> --direction <to-raindex|to-alpaca>
+  --amount <amount>`.
+  The `--direction` must match the original (a mismatch is rejected to avoid
+  mis-driving) and an unknown id is rejected rather than starting a fresh burn;
+  the `--amount` is required for symmetry with `transfer-usdc` but a resume uses
+  the aggregate's persisted amount. Run it only when the bot is not concurrently
+  driving that same id, since it drives the aggregate directly rather than
+  through the bot's resume lock.
 
 For local dashboard testing, run:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ use sqlx::SqlitePool;
 use std::io::Write;
 use std::sync::Arc;
 use tracing::info;
+use uuid::Uuid;
 
 use st0x_config::{Ctx, Env};
 use st0x_event_sorcery::Projection;
@@ -247,6 +248,26 @@ pub enum Commands {
         #[arg(short = 'd', long = "direction")]
         direction: TransferDirection,
         /// Amount of USDC to transfer
+        #[arg(short = 'a', long = "amount")]
+        amount: Usdc,
+    },
+
+    /// Resume an interrupted USDC transfer by its id (Raindex <-> Alpaca)
+    ///
+    /// Re-drives a transfer whose CLI invocation was interrupted after the burn.
+    /// The id is printed by `transfer-usdc` at start. An unknown id is rejected
+    /// (never starts a fresh burn) and `--direction` must match the original;
+    /// `--amount` is required for symmetry with the printed recovery command but
+    /// is not validated -- the resume uses the aggregate's persisted amount.
+    ResumeUsdcTransfer {
+        /// Id of the transfer to resume (printed by `transfer-usdc`)
+        #[arg(long = "id")]
+        id: Uuid,
+        /// Direction of the original transfer (must match the persisted transfer)
+        #[arg(short = 'd', long = "direction")]
+        direction: TransferDirection,
+        /// Amount printed by `transfer-usdc`; required for symmetry but not
+        /// validated -- the resume uses the persisted amount
         #[arg(short = 'a', long = "amount")]
         amount: Usdc,
     },
@@ -828,6 +849,11 @@ enum ProviderCommand {
         direction: TransferDirection,
         amount: Usdc,
     },
+    ResumeUsdcTransfer {
+        id: Uuid,
+        direction: TransferDirection,
+        amount: Usdc,
+    },
     CctpBridge {
         amount: Option<Usdc>,
         all: bool,
@@ -946,6 +972,15 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::TransferUsdc { direction, amount } => {
             Err(ProviderCommand::TransferUsdc { direction, amount })
         }
+        Commands::ResumeUsdcTransfer {
+            id,
+            direction,
+            amount,
+        } => Err(ProviderCommand::ResumeUsdcTransfer {
+            id,
+            direction,
+            amount,
+        }),
         Commands::VaultDeposit {
             amount,
             token,
@@ -1328,6 +1363,14 @@ async fn run_provider_command<W: Write>(
         ProviderCommand::TransferUsdc { direction, amount } => {
             rebalancing::transfer_usdc_command(stdout, direction, amount, ctx, pool).await
         }
+        ProviderCommand::ResumeUsdcTransfer {
+            id,
+            direction,
+            amount,
+        } => {
+            rebalancing::resume_usdc_transfer_command(stdout, id, direction, amount, ctx, pool)
+                .await
+        }
         ProviderCommand::CctpBridge { amount, all, from } => {
             cctp::cctp_bridge_command::<OpenChainErrorRegistry, _>(stdout, amount, all, from, ctx)
                 .await
@@ -1522,6 +1565,7 @@ mod tests {
             Err(
                 ProviderCommand::ProcessTx { .. }
                 | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::ResumeUsdcTransfer { .. }
                 | ProviderCommand::CctpBridge { .. }
                 | ProviderCommand::CctpRecover { .. }
                 | ProviderCommand::ResetAllowance { .. }
@@ -1542,6 +1586,7 @@ mod tests {
             Err(ProviderCommand::ProcessTx { .. }) => {}
             Err(
                 ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::ResumeUsdcTransfer { .. }
                 | ProviderCommand::CctpBridge { .. }
                 | ProviderCommand::CctpRecover { .. }
                 | ProviderCommand::ResetAllowance { .. }
@@ -1575,6 +1620,38 @@ mod tests {
     }
 
     #[test]
+    fn resume_usdc_transfer_command_parses_id_direction_and_amount() {
+        let id = Uuid::from_u128(42);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "resume-usdc-transfer",
+            "--id",
+            &id.to_string(),
+            "--direction",
+            "to-raindex",
+            "--amount",
+            "100",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::ResumeUsdcTransfer {
+                id: parsed_id,
+                direction,
+                amount,
+            } => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(direction, TransferDirection::ToRaindex));
+                assert_eq!(
+                    amount,
+                    Usdc::new(rain_math_float::Float::parse("100".to_string()).unwrap())
+                );
+            }
+            other => panic!("expected resume-usdc-transfer command, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn classify_recheck_transfer_command_as_simple() {
         // The recheck-transfer command must route without an RPC provider:
         // it delegates to the running bot's REST API rather than touching chain.
@@ -1592,6 +1669,7 @@ mod tests {
             Err(
                 ProviderCommand::ProcessTx { .. }
                 | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::ResumeUsdcTransfer { .. }
                 | ProviderCommand::CctpBridge { .. }
                 | ProviderCommand::CctpRecover { .. }
                 | ProviderCommand::ResetAllowance { .. }
@@ -1816,6 +1894,7 @@ mod tests {
             Err(
                 ProviderCommand::ProcessTx { .. }
                 | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::ResumeUsdcTransfer { .. }
                 | ProviderCommand::CctpBridge { .. }
                 | ProviderCommand::CctpRecover { .. }
                 | ProviderCommand::ResetAllowance { .. }

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -3,8 +3,11 @@
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
 use sqlx::SqlitePool;
+use std::future::Future;
 use std::io::{self, Write};
 use std::sync::Arc;
+use std::time::Duration;
+use tracing::warn;
 use uuid::Uuid;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
@@ -25,13 +28,14 @@ use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use crate::rebalancing::usdc::CrossVenueCashTransfer;
+use crate::rebalancing::usdc::UsdcTransferError;
 use crate::tokenization::{
     AlpacaTokenizationService, TokenizationRequest, TokenizationRequestStatus, Tokenizer,
 };
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand,
 };
-use crate::usdc_rebalance::{UsdcRebalance, UsdcRebalanceId};
+use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
 use crate::vault_registry::VaultRegistry;
 use crate::wrapper::{Wrapper, WrapperService};
 use st0x_config::{BrokerCtx, Ctx};
@@ -171,10 +175,124 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
     Ok(())
 }
 
+/// Per-retry delay for the manual CLI redrive loop when Circle's attestation is
+/// not yet ready. Mirrors the apalis job's redrive cadence.
+const CLI_ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
+
+/// Drives a manual USDC transfer to a terminal outcome, redriving on attestation
+/// timeouts so a single CLI invocation cannot strand after the burn.
+///
+/// `resume` is re-invoked with the same `UsdcRebalanceId` on every attempt, so a
+/// timeout resumes the already-burned transfer instead of starting a second
+/// fund-moving one. Any non-timeout error -- including
+/// `AttestationRetryDeadlineElapsed` and a previously-failed aggregate -- is
+/// terminal and returned to the caller.
+async fn redrive_transfer_until_settled<Resume, Fut>(
+    redrive_delay: Duration,
+    mut resume: Resume,
+) -> Result<(), UsdcTransferError>
+where
+    Resume: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), UsdcTransferError>>,
+{
+    loop {
+        match resume().await {
+            Ok(()) => return Ok(()),
+            Err(UsdcTransferError::AttestationTimedOut { id }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    ?redrive_delay,
+                    "Circle attestation not ready for manual USDC transfer; retrying after delay"
+                );
+                tokio::time::sleep(redrive_delay).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Starts a fresh manual USDC transfer. Surfaces the generated id up front so an
+/// operator can resume it (via `resume-usdc-transfer`) if the process is
+/// interrupted, then drives it to terminal with attestation-timeout redrive.
+/// Whether a USDC transfer command may start a fresh transfer or must resume an
+/// existing one. Drives the `None`-state policy in [`run_usdc_transfer`]: a
+/// freshly generated id is expected to have no state (first run), but an
+/// operator-supplied resume id that loads to `None` is a wrong/typoed id and
+/// must be rejected -- never burned into a brand-new transfer.
+#[derive(Clone, Copy)]
+enum UsdcTransferStartMode {
+    Fresh,
+    Resume,
+}
+
 pub(super) async fn transfer_usdc_command<Writer: Write>(
     stdout: &mut Writer,
     direction: TransferDirection,
     amount: Usdc,
+    ctx: &Ctx,
+    pool: &SqlitePool,
+) -> anyhow::Result<()> {
+    let id = UsdcRebalanceId(Uuid::new_v4());
+    let dir_flag = match direction {
+        TransferDirection::ToRaindex => "to-raindex",
+        TransferDirection::ToAlpaca => "to-alpaca",
+    };
+    writeln!(
+        stdout,
+        "USDC transfer id: {id}\n   If this is interrupted after the burn, resume with:\n   \
+         resume-usdc-transfer --id {id} --direction {dir_flag} --amount {amount}"
+    )?;
+    // Flush the recovery id to durable output BEFORE the burn: the resume safety
+    // story depends on the operator still having this id if the process is killed
+    // after burning, and buffered/redirected stdout could otherwise lose it.
+    stdout.flush()?;
+    run_usdc_transfer(
+        stdout,
+        direction,
+        amount,
+        id,
+        UsdcTransferStartMode::Fresh,
+        ctx,
+        pool,
+    )
+    .await
+}
+
+/// Resumes an interrupted manual USDC transfer by its id, driving it to terminal
+/// with the same attestation-timeout redrive as a fresh transfer. Refuses to run
+/// if the id has no persisted transfer (a wrong/typoed id would otherwise start a
+/// brand-new burn) or if `--direction` disagrees with the persisted transfer. The
+/// `--amount` is required for symmetry with the `transfer-usdc` recovery hint but
+/// is not validated -- a resume uses the aggregate's persisted amount.
+pub(super) async fn resume_usdc_transfer_command<Writer: Write>(
+    stdout: &mut Writer,
+    id: Uuid,
+    direction: TransferDirection,
+    amount: Usdc,
+    ctx: &Ctx,
+    pool: &SqlitePool,
+) -> anyhow::Result<()> {
+    let id = UsdcRebalanceId(id);
+    writeln!(stdout, "Resuming USDC transfer id: {id}")?;
+    run_usdc_transfer(
+        stdout,
+        direction,
+        amount,
+        id,
+        UsdcTransferStartMode::Resume,
+        ctx,
+        pool,
+    )
+    .await
+}
+
+async fn run_usdc_transfer<Writer: Write>(
+    stdout: &mut Writer,
+    direction: TransferDirection,
+    amount: Usdc,
+    id: UsdcRebalanceId,
+    mode: UsdcTransferStartMode,
     ctx: &Ctx,
     pool: &SqlitePool,
 ) -> anyhow::Result<()> {
@@ -183,6 +301,43 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         TransferDirection::ToAlpaca => "Raindex -> Alpaca",
     };
     writeln!(stdout, "Transferring USDC: {dir}, Amount: {amount} USDC")?;
+
+    let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+        .build(())
+        .await?;
+
+    // A resume must target an existing transfer, checked up front before any
+    // broker/bridge setup. The manager's `resume_*` path treats a `None`-state id
+    // as a first run and burns a brand-new transfer -- correct for a freshly
+    // generated `transfer-usdc` id, but a fund-moving foot-gun for an
+    // operator-supplied resume id that is mistyped or points at the wrong
+    // database. Reject `None`, and reject a `--direction` that disagrees with the
+    // persisted transfer (driving the opposite-direction resume path would
+    // mis-drive the aggregate). The `--amount` is NOT validated: it stays in the
+    // recovery command for symmetry with `transfer-usdc`, but a resume uses the
+    // aggregate's persisted amount, and the persisted state amount is the
+    // post-conversion/post-fee effective amount, not the original requested one.
+    if matches!(mode, UsdcTransferStartMode::Resume) {
+        let Some(state) = usdc_store.load(&id).await? else {
+            anyhow::bail!(
+                "resume-usdc-transfer: no transfer found for id {id}. Refusing to start a new \
+                 burn -- check the id and that you are pointed at the right database."
+            );
+        };
+
+        let expected_direction = match direction {
+            TransferDirection::ToRaindex => RebalanceDirection::AlpacaToBase,
+            TransferDirection::ToAlpaca => RebalanceDirection::BaseToAlpaca,
+        };
+
+        if state.direction() != expected_direction {
+            anyhow::bail!(
+                "resume-usdc-transfer: --direction does not match the persisted transfer for id \
+                 {id} (persisted {:?}). Refusing to mis-drive the transfer.",
+                state.direction()
+            );
+        }
+    }
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
         anyhow::bail!("transfer-usdc requires Alpaca Broker API configuration");
@@ -261,10 +416,6 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
         owner,
     ));
 
-    let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
-        .build(())
-        .await?;
-
     let attestation_retry_deadline = ctx.rebalancing_ctx()?.attestation_retry_deadline;
 
     let rebalance_manager = CrossVenueCashTransfer::new(
@@ -280,22 +431,28 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
 
     writeln!(stdout, "   Transfer may take several minutes...")?;
 
-    let id = UsdcRebalanceId(Uuid::new_v4());
+    // Drive through `resume_*` (not `execute_*`): a fresh id with no prior state
+    // takes the execute path inside `resume_*`, and an attestation timeout
+    // re-enters from the persisted state on the same id -- so this single
+    // invocation covers both the first run and every redrive without ever
+    // minting a second `UsdcRebalanceId` against the already-burned funds.
+    redrive_transfer_until_settled(CLI_ATTESTATION_REDRIVE_DELAY, || async {
+        match direction {
+            TransferDirection::ToRaindex => {
+                rebalance_manager.resume_alpaca_to_base(&id, amount).await
+            }
+            TransferDirection::ToAlpaca => {
+                rebalance_manager.resume_base_to_alpaca(&id, amount).await
+            }
+        }
+    })
+    .await?;
 
-    match direction {
-        TransferDirection::ToRaindex => {
-            rebalance_manager
-                .execute_alpaca_to_base(&id, amount)
-                .await?;
-            writeln!(stdout, "USDC transfer to Raindex completed successfully")?;
-        }
-        TransferDirection::ToAlpaca => {
-            rebalance_manager
-                .execute_base_to_alpaca(&id, amount)
-                .await?;
-            writeln!(stdout, "USDC transfer to Alpaca completed successfully")?;
-        }
-    }
+    let completion = match direction {
+        TransferDirection::ToRaindex => "USDC transfer to Raindex completed successfully",
+        TransferDirection::ToAlpaca => "USDC transfer to Alpaca completed successfully",
+    };
+    writeln!(stdout, "{completion}")?;
 
     Ok(())
 }
@@ -747,12 +904,70 @@ mod tests {
     use super::*;
     use crate::inventory::ImbalanceThreshold;
     use crate::test_utils::setup_test_db;
+    use crate::usdc_rebalance::{TransferRef, UsdcRebalanceCommand};
     use st0x_config::EvmCtx;
     use st0x_config::ExecutionThreshold;
     use st0x_config::RebalancingCtx;
     use st0x_config::{
         AssetsConfig, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode, TradingMode,
     };
+
+    /// RAI-835: the manual redrive loop must re-invoke `resume` on the same id
+    /// after an attestation timeout and drive through to success -- so a single
+    /// CLI invocation cannot strand a burned transfer.
+    #[tokio::test]
+    async fn redrive_loop_retries_attestation_timeout_then_succeeds() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let result = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            let attempt = calls.get() + 1;
+            calls.set(attempt);
+            async move {
+                if attempt == 1 {
+                    Err(UsdcTransferError::AttestationTimedOut {
+                        id: UsdcRebalanceId(Uuid::from_u128(7)),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        result.expect("redrive must succeed once the attestation arrives");
+        assert_eq!(
+            calls.get(),
+            2,
+            "the loop must retry exactly once after the timeout, then succeed",
+        );
+    }
+
+    /// RAI-835: a non-timeout terminal outcome (deadline elapsed) must end the
+    /// loop immediately, not spin forever.
+    #[tokio::test]
+    async fn redrive_loop_returns_terminal_error_without_looping() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let result = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            calls.set(calls.get() + 1);
+            async move {
+                Err(UsdcTransferError::AttestationRetryDeadlineElapsed {
+                    id: UsdcRebalanceId(Uuid::from_u128(7)),
+                })
+            }
+        })
+        .await;
+
+        let error = result.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::AttestationRetryDeadlineElapsed { .. }
+            ),
+            "a deadline-elapsed outcome must surface, not be retried; got {error:?}",
+        );
+        assert_eq!(calls.get(), 1, "a terminal error must not be retried");
+    }
 
     fn create_ctx_without_rebalancing() -> Ctx {
         Ctx {
@@ -933,6 +1148,139 @@ mod tests {
         assert!(
             err_msg.contains("requires Alpaca Broker API configuration"),
             "Expected Alpaca Broker API error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_usdc_transfer_rejects_unknown_id_without_burning() {
+        // The core safety contract of `resume-usdc-transfer`: an id that has no
+        // persisted transfer (a typo, or the wrong database) MUST be rejected up
+        // front rather than falling through to the manager's `None` -> fresh-burn
+        // path. The existence check runs before any broker/bridge setup, so a bare
+        // ctx and an empty pool reach it directly.
+        let ctx = create_ctx_without_rebalancing();
+        let pool = setup_test_db().await;
+        let amount = Usdc::new(Float::parse("100".to_string()).unwrap());
+        let unknown_id = Uuid::from_u128(0xDEAD_BEEF);
+
+        let mut stdout = Vec::new();
+        let result = resume_usdc_transfer_command(
+            &mut stdout,
+            unknown_id,
+            TransferDirection::ToRaindex,
+            amount,
+            &ctx,
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("no transfer found for id"),
+            "resume of an unknown id must refuse, not start a new burn; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_usdc_transfer_rejects_direction_mismatch() {
+        // Seed an AlpacaToBase transfer, then resume with the opposite direction
+        // (`--direction to-alpaca` => BaseToAlpaca). The guard must reject it
+        // rather than driving the aggregate through the wrong-direction resume
+        // path. The check runs before broker setup, so a bare ctx reaches it.
+        let ctx = create_ctx_without_rebalancing();
+        let pool = setup_test_db().await;
+        let amount = Usdc::new(Float::parse("100".to_string()).unwrap());
+        let id = Uuid::from_u128(99);
+
+        let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        store
+            .send(
+                &UsdcRebalanceId(id),
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(b256!(
+                        "0x00000000000000000000000000000000000000000000000000000000000000a1"
+                    )),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut stdout = Vec::new();
+        let result = resume_usdc_transfer_command(
+            &mut stdout,
+            id,
+            TransferDirection::ToAlpaca,
+            amount,
+            &ctx,
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("does not match the persisted transfer"),
+            "resume with the wrong direction must be rejected, not mis-drive; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_usdc_transfer_accepts_amount_differing_from_persisted() {
+        // Regression guard: a resume with the CORRECT direction but a `--amount`
+        // different from the persisted state amount must NOT be rejected. The
+        // persisted amount is the post-slippage/post-fee effective amount, not the
+        // original requested one the operator types, so validating against it
+        // would wrongly reject legitimate resumes (the iter2 bug). The preflight
+        // guard must let it through -- here it then fails at broker setup, proving
+        // the guard accepted it.
+        let ctx = create_ctx_without_rebalancing();
+        let pool = setup_test_db().await;
+        let seeded_amount = Usdc::new(Float::parse("100".to_string()).unwrap());
+        let different_amount = Usdc::new(Float::parse("250".to_string()).unwrap());
+        let id = Uuid::from_u128(123);
+
+        let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        store
+            .send(
+                &UsdcRebalanceId(id),
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: seeded_amount,
+                    withdrawal: TransferRef::OnchainTx(b256!(
+                        "0x00000000000000000000000000000000000000000000000000000000000000a2"
+                    )),
+                },
+            )
+            .await
+            .unwrap();
+
+        // ToRaindex maps to AlpacaToBase -- the correct direction for the seed.
+        let mut stdout = Vec::new();
+        let result = resume_usdc_transfer_command(
+            &mut stdout,
+            id,
+            TransferDirection::ToRaindex,
+            different_amount,
+            &ctx,
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            !err_msg.contains("does not match"),
+            "a differing --amount must pass the guard (resume uses persisted amount); got: {err_msg}"
+        );
+        assert!(
+            err_msg.contains("requires Alpaca Broker API configuration"),
+            "past the guard, the bare ctx must fail at broker setup; got: {err_msg}"
         );
     }
 

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -889,6 +889,38 @@ impl UsdcRebalance {
             _ => None,
         }
     }
+
+    /// The rebalance direction, present in every non-initial state and invariant
+    /// across the whole lifecycle. Used by the CLI `resume-usdc-transfer` command
+    /// to validate the operator-supplied `--direction` against the persisted
+    /// transfer, so a wrong flag is rejected rather than mis-driving the aggregate
+    /// through the opposite-direction resume path.
+    ///
+    /// Deliberately does NOT expose the amount: a state's `amount` field is
+    /// reassigned to the conversion `filled_amount` (and later the post-fee
+    /// `amount_received`), so it is not the original requested amount the CLI
+    /// prints -- validating `--amount` against it would reject legitimate resumes
+    /// whenever slippage or CCTP fees move the effective amount.
+    pub(crate) fn direction(&self) -> RebalanceDirection {
+        match self {
+            Self::Converting { direction, .. }
+            | Self::ConversionComplete { direction, .. }
+            | Self::ConversionFailed { direction, .. }
+            | Self::WithdrawalSubmitting { direction, .. }
+            | Self::Withdrawing { direction, .. }
+            | Self::WithdrawalComplete { direction, .. }
+            | Self::WithdrawalFailed { direction, .. }
+            | Self::BridgingSubmitting { direction, .. }
+            | Self::Bridging { direction, .. }
+            | Self::AwaitingAttestation { direction, .. }
+            | Self::Attested { direction, .. }
+            | Self::Bridged { direction, .. }
+            | Self::BridgingFailed { direction, .. }
+            | Self::DepositInitiated { direction, .. }
+            | Self::DepositConfirmed { direction, .. }
+            | Self::DepositFailed { direction, .. } => direction.clone(),
+        }
+    }
 }
 
 /// Candidate `UsdcRebalance` aggregates whose latest event leaves them
@@ -3185,6 +3217,54 @@ mod tests {
             None,
             "BridgingSubmitting is pre-burn and must NOT be re-armed (double-burn risk)",
         );
+    }
+
+    // `direction` backs the CLI resume guard's `--direction` validation, so a
+    // wrong destructure in its 16-arm match would mis-classify a transfer's
+    // direction and either reject a valid resume or mis-drive the aggregate.
+    // Spot-check states spread across the or-pattern in both directions.
+    #[test]
+    fn direction_reads_persisted_direction() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000002");
+        let now = Utc::now();
+        let amount = Usdc::new(float!(321));
+
+        let bridged = UsdcRebalance::Bridged {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount,
+            amount_received: Usdc::new(float!(320)),
+            fee_collected: Usdc::new(float!(1)),
+            burn_tx_hash: burn_tx,
+            mint_tx_hash: burn_tx,
+            initiated_at: now,
+            minted_at: now,
+        };
+        assert_eq!(bridged.direction(), RebalanceDirection::AlpacaToBase);
+
+        let conversion_complete = UsdcRebalance::ConversionComplete {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount,
+            filled_amount: Usdc::new(float!(999)),
+            initiated_at: now,
+            converted_at: now,
+        };
+        assert_eq!(
+            conversion_complete.direction(),
+            RebalanceDirection::BaseToAlpaca,
+        );
+
+        let deposit_failed = UsdcRebalance::DepositFailed {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount,
+            burn_tx_hash: burn_tx,
+            mint_tx_hash: burn_tx,
+            deposit_ref: None,
+            reason: "boom".to_string(),
+            initiated_at: now,
+            failed_at: now,
+        };
+        assert_eq!(deposit_failed.direction(), RebalanceDirection::AlpacaToBase);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

[RAI-835](https://linear.app/makeitrain/issue/RAI-835) — Make the manual `transfer-usdc` CLI drive a transfer to a terminal outcome instead of exiting on the first attestation timeout, surface the transfer id up front, and add a `resume-usdc-transfer` command to safely re-drive an interrupted transfer on its existing id.

## Why

`transfer-usdc` called `execute_*` directly and exited on `AttestationTimedOut`. After the retryable-timeout work those paths persist a non-terminal `AwaitingAttestation` state, but only the apalis job handlers catch `AttestationTimedOut` and enqueue the redrive — a manual transfer could therefore burn USDC, persist a retryable state, and stop with nobody retrying it. Re-running the CLI minted a fresh `UsdcRebalanceId` with no link to the burned funds, risking a **second** fund-moving transfer rather than resuming the first.

## How

**`src/cli/rebalancing.rs`** — `transfer_usdc_command` and the new `resume_usdc_transfer_command` both funnel into a shared `run_usdc_transfer`, parameterized by a `UsdcTransferStartMode` enum (`Fresh` / `Resume`). The core loop is `redrive_transfer_until_settled`, a small generic over a `resume` closure that re-invokes it on `AttestationTimedOut` after `CLI_ATTESTATION_REDRIVE_DELAY` (60s, mirroring the apalis cadence) and returns on success or any other terminal error (including `AttestationRetryDeadlineElapsed` and a previously-failed aggregate). Deadline bounding comes for free because the manager commits `TimeoutAttestation` on the first timeout.

The driver now calls `resume_alpaca_to_base` / `resume_base_to_alpaca` (not `execute_*`): a fresh id with no prior state takes the execute path inside `resume_*`, and a timeout re-enters from persisted state on the same id — so one invocation covers both first run and every redrive without minting a second id. `transfer_usdc_command` generates the id, prints it together with the exact `resume-usdc-transfer` recovery command, and **flushes stdout before the burn** so the id survives a process kill.

`Resume` mode runs a preflight guard before any broker/bridge setup: it loads the aggregate and `bail!`s if the id has no persisted state (a typo/wrong-DB id would otherwise fall through to a brand-new burn), and `bail!`s if `--direction` disagrees with the persisted transfer. `--amount` is intentionally **not** validated — a resume uses the aggregate's persisted (post-conversion/post-fee) amount, so validating against the operator-typed original would reject legitimate resumes.

**`src/usdc_rebalance.rs`** — adds `UsdcRebalance::direction()`, reading the direction out of all 16 non-initial states for the guard. Its docstring documents why amount is deliberately not exposed (the `amount` field is reassigned to the filled/received amount over the lifecycle).

**`src/cli/mod.rs`** — adds the `ResumeUsdcTransfer { id, direction, amount }` clap command and `ProviderCommand` variant, routed through `classify_command` / `run_provider_command` as a provider command.

**`docs/cli-ops.md`** — documents the printed id, the `resume-usdc-transfer` recovery flow, the direction-match and unknown-id rejections, and the caveat that it drives the aggregate directly (run only when the bot is not concurrently driving the same id).

## Testing

- `redrive_loop_retries_attestation_timeout_then_succeeds` / `redrive_loop_returns_terminal_error_without_looping` — the loop retries exactly once on a timeout then succeeds, and surfaces an `AttestationRetryDeadlineElapsed` terminal error after a single call without spinning. Pure closure tests, no onchain/broker wiring.
- `resume_usdc_transfer_rejects_unknown_id_without_burning` — a resume of an id with no persisted state is refused before any setup.
- `resume_usdc_transfer_rejects_direction_mismatch` — seeds an `AlpacaToBase` transfer, resumes with `to-alpaca`, asserts the guard rejects it.
- `resume_usdc_transfer_accepts_amount_differing_from_persisted` — regression guard: a correct-direction resume with a differing `--amount` passes the preflight (then fails later at broker setup), proving amount is not validated.
- `resume_usdc_transfer_command_parses_id_direction_and_amount` — clap wiring for the new command.
- `direction_reads_persisted_direction` — spot-checks `UsdcRebalance::direction()` across states from both directions to catch a wrong destructure in the 16-arm match.

## Anything else

Final PR (4 of 4) of the [RAI-833](https://linear.app/makeitrain/issue/RAI-833) attestation-retry follow-ups, stacked on `rai-836-rearm-resumable-transfers-on-recovery`. The deadline-bounded redrive depends on the manager committing `TimeoutAttestation` in `continue_from_bridging`, preserved by RAI-836's startup re-arm choice. No migrations, config, or feature flags. `resume-usdc-transfer` drives the aggregate directly rather than through the bot's resume lock, so it must not be run concurrently with the bot operating on the same id.
