### PR TITLE
docs: spec extended-hours counter-trading in SPEC.md

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -247,6 +247,66 @@ The bot supports multiple brokers through a unified trait interface:
 - Position querying for inventory management
 - Account balance monitoring for available capital
 
+#### Extended-Hours Counter-Trading
+
+By default, automated counter-trades execute as market orders during regular
+market hours (9:30–16:00 ET). Onchain fills that arrive in pre-market (4:00–9:30
+ET) or after-hours (16:00–20:00 ET) would otherwise leave directional exposure
+unhedged until the next regular open — potentially hours of unmanaged delta.
+When enabled, the bot hedges immediately during extended sessions using limit
+orders, and converges any unfilled extended-hours orders back to market orders
+at the regular open.
+
+This behavior is **opt-in** via the required `extended_hours_counter_trading`
+config flag (committed as `false`). With it disabled, behavior is unchanged:
+market orders during regular hours only.
+
+##### Market session model
+
+Execution decisions are driven by a `MarketSession` classification derived from
+the broker calendar:
+
+- **Regular** — standard hours; counter-trades place market orders.
+- **Extended** — pre-market or after-hours; the broker accepts only limit orders
+  flagged `extended_hours = true`. Counter-trades place a limit order priced
+  from the latest trade price plus a configured slippage buffer
+  (`counter_trade_slippage_bps`). Rounding favors fill probability (buys round
+  up, sells round down) and honors the broker's minimum price variance (penny
+  increments at or above $1.00, sub-penny below).
+- **Closed** — outside all sessions (overnight, weekends, holidays); no order is
+  placed. The exposure is left for the next scan to hedge once the venue
+  reopens, rather than failing a durable job against a multi-hour closure.
+
+The session is re-checked at execution time, immediately before placement, so a
+hedge job that was enqueued in one session but runs after a 9:30/16:00 boundary
+places the order type appropriate to the _current_ session, not the stale
+enqueue-time one.
+
+##### Cancel-and-replace at the regular open
+
+Extended-hours limit orders may not fill before regular hours begin. On the
+first transition into Regular hours, the bot requests cancellation of any
+still-live extended-hours limit order so it is replaced with a market order on
+the subsequent scan. Cancellation is two-phase: the order is reconciled against
+broker state _before_ the cancel is issued (so a fill that landed between the
+last poll and the cancel is recorded, never dropped), then moves to a
+`Cancelling` state and becomes terminal only once the broker confirms. The
+owning position is finalized — applying any partial fill and releasing the
+pending reference so the symbol can resume hedging — once the cancellation
+confirms.
+
+##### Order lifecycle and integrity guarantees
+
+- Orders carry a broker-side `client_order_id` idempotency key so a retry after
+  a lost placement response is deduped by the broker rather than
+  double-submitted.
+- Broker `PartiallyFilled` status is preserved through the executor boundary
+  (cumulative fills are not collapsed into `Submitted`), and broker-confirmed
+  `Cancelled` is represented distinctly from `Failed`.
+- Partial fills are reconciled both by the status-poll loop and immediately
+  before any cancellation, so a fill is never lost when an order transitions to
+  a terminal state.
+
 #### Idempotency Controls
 
 - Event queue table to track all events with unique (transaction_hash,


### PR DESCRIPTION
## What

Adds an "Extended-Hours Counter-Trading" section to `SPEC.md`, documenting the behavior that PR #673 implements: hedging onchain fills that arrive in pre-market / after-hours via limit orders, and converging unfilled extended-hours orders back to market orders at the regular open. This is the spec-first base of the extended-hours stack ([RAI-71](https://linear.app/makeitrain/issue/RAI-71/245-limit-order-support-for-counter-trading-outside-market-hours)).

## Why

Per the repo's planning hierarchy, system behavior is spec'd in `SPEC.md` before implementation. The extended-hours feature was built as one large PR (#673); this carves the spec out as the bottom of the stack so the north-star description lands first and the implementation PRs are downstream from it. Onchain fills arriving outside regular hours would otherwise leave directional exposure unhedged for hours — the spec states the intended remedy.

## How

Documentation only — a new `#### Extended-Hours Counter-Trading` subsection under the broker abstraction in `SPEC.md`. It covers: the opt-in `extended_hours_counter_trading` flag (committed `false`, behavior unchanged when disabled); the `MarketSession` model (Regular places market orders, Extended places limit orders priced from the latest trade plus `counter_trade_slippage_bps` with fill-favoring rounding and broker minimum-price-variance, Closed places nothing); execution-time session re-check so a job that crosses a 9:30/16:00 boundary places the order type for the current session; cancel-and-replace at the regular open with two-phase reconcile-before-cancel; and the order-integrity guarantees (`client_order_id` idempotency, preserved `PartiallyFilled`, distinct `Cancelled` vs `Failed`, partial-fill reconciliation before cancellation).

## Testing

No tests — documentation-only change.

## Anything else

Bottom of the extended-hours stack: the feature implementation is #673, with findings #750–#754 stacked on top.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366387&installation_id=125569124&pr_number=749&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F749&signature=bc5d658f3c9a15971e8502cf2a915034f44ce74fd0d71108b706403c9bd6536a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
