### PR TITLE
fix(execution): make OrderPlacer::get_order_status fail loudly instead of fabricating Submitted (L1)

### DIFF
--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -1313,17 +1313,22 @@ pub trait OrderPlacer: Send + Sync {
     }
 
     /// Queries the broker for the current state of an order. Used by the
-    /// `CancelOrder` handler to reconcile any fills that landed between
-    /// the last poll and the cancel. The default returns `Submitted` so
-    /// implementations without status-query support don't break the
-    /// reconciliation flow -- they just skip it.
+    /// `CancelOrder` handler's `reconcile_pre_cancel` to apply any fill that
+    /// landed between the last poll and the cancel.
+    ///
+    /// The default deliberately FAILS rather than fabricating a `Submitted`
+    /// state: a fabricated-`Submitted` default would make an implementer that
+    /// forgot to query the broker silently skip reconciliation and drop a fill
+    /// -- the exact partial-fill loss `reconcile_pre_cancel` exists to prevent.
+    /// `reconcile_pre_cancel` maps this error to `PreCancelStatusFetchFailed`,
+    /// which keeps the order in its prior state and retries instead of
+    /// cancelling blind. Real implementations (`ExecutorOrderPlacer`) override
+    /// this to delegate to the executor.
     async fn get_order_status(
         &self,
-        executor_order_id: &ExecutorOrderId,
+        _executor_order_id: &ExecutorOrderId,
     ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(st0x_execution::OrderState::Submitted {
-            order_id: executor_order_id.as_ref().to_string(),
-        })
+        Err("get_order_status not implemented for this OrderPlacer".into())
     }
 }
 
@@ -1420,6 +1425,17 @@ pub(crate) fn noop_order_placer() -> Arc<dyn OrderPlacer> {
             _executor_order_id: &ExecutorOrderId,
         ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             Ok(())
+        }
+
+        async fn get_order_status(
+            &self,
+            executor_order_id: &ExecutorOrderId,
+        ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>> {
+            // No-op placer reports the order still live, so pre-cancel
+            // reconciliation finds nothing to apply (matches the prior default).
+            Ok(st0x_execution::OrderState::Submitted {
+                order_id: executor_order_id.as_ref().to_string(),
+            })
         }
     }
 
@@ -2317,6 +2333,18 @@ mod tests {
                     _executor_order_id: &ExecutorOrderId,
                 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     Err("simulated broker DELETE failure".into())
+                }
+
+                async fn get_order_status(
+                    &self,
+                    executor_order_id: &ExecutorOrderId,
+                ) -> Result<st0x_execution::OrderState, Box<dyn std::error::Error + Send + Sync>>
+                {
+                    // Order still live -> pre-cancel reconciliation is a no-op,
+                    // so the flow reaches the failing DELETE under test.
+                    Ok(st0x_execution::OrderState::Submitted {
+                        order_id: executor_order_id.as_ref().to_string(),
+                    })
                 }
             }
 


### PR DESCRIPTION
## What

Changes the default implementation of `OrderPlacer::get_order_status` in `src/offchain/order.rs` to fail loudly instead of fabricating an `OrderState::Submitted`. Review finding L1 on the extended-hours stack ([RAI-71](https://linear.app/makeitrain/issue/RAI-71/245-limit-order-support-for-counter-trading-outside-market-hours)).

## Why

`get_order_status` exists so the `CancelOrder` handler's `reconcile_pre_cancel` can apply any fill that landed between the last poll and the cancel. The previous default returned a synthetic `Submitted` state, which meant an `OrderPlacer` implementer who forgot to query the broker would silently skip reconciliation and drop a fill — exactly the partial-fill loss that `reconcile_pre_cancel` exists to prevent. A fabricated default turns a missing implementation into silent financial data loss rather than a visible error.

## How

The trait default now returns `Err("get_order_status not implemented for this OrderPlacer")`. `reconcile_pre_cancel` maps that error to `PreCancelStatusFetchFailed`, which keeps the order in its prior state and retries rather than cancelling blind. The real production implementation (`ExecutorOrderPlacer`) already overrides this to delegate to the executor, so production behavior is unchanged. Two test stubs that relied on the old default to reach the code under test — `Noop` (the `noop_order_placer`) and `CancelFailing` — get explicit `get_order_status` overrides returning `Submitted` (order still live, so pre-cancel reconciliation finds nothing to apply), preserving their existing test semantics.

## Testing

Covered by the existing offchain-order suite: the cancel/reconcile tests exercise both stub overrides, and the full lib suite passes. No behavior change for the production placer.

## Anything else

Stacked on the feature monolith #673. Behavior-preserving for all real placers; the change only affects implementations that never overrode the method (of which there are none in production).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366393&installation_id=125569124&pr_number=750&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F750&signature=593a61616fcdc089793535897b0e0695ea786a341733f4ffadd9f1472e83439c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
