### PR TITLE
feat(hedge): enqueue immediate PlaceHedge for extended-hours fills instead of waiting for the scan (M4)

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -110,6 +110,10 @@ pub(crate) struct TradeProcessingCqrs {
     /// hook the order stays `Submitted` forever -- the system has no other
     /// trigger to ask the broker about an in-flight order.
     pub(crate) poll_status_queue: PollOrderStatusJobQueue,
+    /// Used to enqueue an immediate `PlaceHedge` for extended-hours fills, which
+    /// the inline path cannot place itself (it has no `OrderPlacer` for the
+    /// limit-order price lookup). `CheckPositions` is the backstop.
+    pub(crate) hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue,
     pub(crate) extended_hours_counter_trading: bool,
 }
 
@@ -1568,17 +1572,54 @@ where
         return Ok(None);
     };
 
-    // Extended-hours counter-trades are handled by the CheckPositions job
-    // which has access to the OrderPlacer for price lookups. The inline path
-    // can only place market orders.
+    // Extended-hours counter-trades cannot be placed inline (this path has no
+    // OrderPlacer for the limit-order price lookup). Instead of waiting for the
+    // next CheckPositions scan (~1 min), enqueue an immediate PlaceHedge job,
+    // which has the OrderPlacer and submits the limit order. CheckPositions
+    // remains the backstop. Preflight + clamp here, mirroring the scan path, so
+    // we never enqueue a hedge that would exceed buying power.
     if execution.market_session == MarketSession::Extended {
+        let _counter_trade_submission_guard = cqrs.counter_trade_submission_lock.lock().await;
+
+        match preflight_counter_trade_submission(executor, &execution, None).await? {
+            CounterTradeSubmissionCheck::Skipped => return Ok(None),
+            CounterTradeSubmissionCheck::Allowed { reservation } => {
+                clamp_shares_to_reservation(&mut execution, reservation.as_ref());
+            }
+        }
+
+        let offchain_order_id = OffchainOrderId::new();
         info!(
             target: "hedge",
             symbol = %execution.symbol,
             shares = %execution.shares,
             direction = ?execution.direction,
-            "Extended hours: deferring hedge to CheckPositions job (poll-driven, not event-driven)"
+            "Extended hours: enqueueing immediate PlaceHedge (limit order via the job's OrderPlacer)"
         );
+
+        let job = crate::trading::offchain::hedge::PlaceHedge {
+            symbol: execution.symbol.clone(),
+            direction: execution.direction,
+            shares: execution.shares,
+            executor: execution.executor,
+            threshold: cqrs.execution_threshold,
+            offchain_order_id,
+            market_session: execution.market_session,
+        };
+
+        if let Err(error) = cqrs.hedge_queue.clone().push(job).await {
+            error!(
+                target: "hedge",
+                symbol = %execution.symbol,
+                %error,
+                "Failed to enqueue extended-hours hedge; CheckPositions will retry"
+            );
+        }
+
+        // No inline offchain order was placed: the durable PlaceHedge job claims
+        // the position (via PlaceOffChainOrder) when it runs. Returning the job's
+        // not-yet-recorded id would be a synthetic handle the aggregates know
+        // nothing about, so signal "no inline placement" with None.
         return Ok(None);
     }
 
@@ -2898,6 +2939,7 @@ mod tests {
             },
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
             poll_status_queue: PollOrderStatusJobQueue::new(pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(pool),
             extended_hours_counter_trading: false,
         }
     }
@@ -3064,6 +3106,81 @@ mod tests {
                 .unwrap()
                 .is_empty(),
             "Skipped counter trades must not create offchain orders"
+        );
+    }
+
+    #[tokio::test]
+    async fn extended_hours_trade_enqueues_immediate_hedge_job() {
+        // With extended-hours counter-trading enabled and the broker in an
+        // Extended session, an onchain fill must enqueue an immediate PlaceHedge
+        // job (which has the OrderPlacer for the limit order) rather than place
+        // inline or wait for the next CheckPositions scan.
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = TradeProcessingCqrs {
+            onchain_trade: frameworks.onchain_trade.clone(),
+            position: frameworks.position.clone(),
+            position_projection: frameworks.position_projection.clone(),
+            offchain_order: frameworks.offchain_order.clone(),
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: AssetsConfig {
+                equities: EquitiesConfig::default(),
+                cash: None,
+            },
+            counter_trade_submission_lock: Arc::new(Mutex::new(())),
+            poll_status_queue: PollOrderStatusJobQueue::new(&pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&pool),
+            extended_hours_counter_trading: true,
+        };
+
+        let trade_event = make_trade_event(77);
+        let trade = test_trade_with_amount_and_direction(float!(5.0), 77, Direction::Buy);
+
+        let executor = MockExecutor::new()
+            .with_market_session(MarketSession::Extended)
+            .with_inventory(ExecutionInventory {
+                positions: vec![EquityPosition {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: FractionalShares::new(float!(10.0)),
+                    market_value: None,
+                }],
+                usd_balance_cents: 1_000_000,
+                cash_buying_power_cents: Some(1_000_000),
+                alpaca_usdc: None,
+                cash_withdrawable_cents: None,
+            });
+
+        let result = process_queued_trade(&executor, &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "no inline offchain order is placed for extended hours; the PlaceHedge \
+             job claims the position when it runs"
+        );
+
+        assert!(
+            offchain_order_projection
+                .load_all()
+                .await
+                .unwrap()
+                .is_empty(),
+            "extended-hours hedge must be deferred to a PlaceHedge job, not placed inline"
+        );
+
+        let hedge_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<
+                crate::trading::offchain::hedge::PlaceHedge,
+            >())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            hedge_jobs, 1,
+            "exactly one immediate PlaceHedge job should be enqueued for the extended-hours fill"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -253,6 +253,7 @@ where
         assets: context.ctx.assets.clone(),
         counter_trade_submission_lock,
         poll_status_queue: poll_status_queue.clone(),
+        hedge_queue: hedge_queue.clone(),
         extended_hours_counter_trading: context.ctx.extended_hours_counter_trading,
     };
 

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -702,6 +702,7 @@ async fn create_test_cqrs_with_assets(
         assets,
         counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
         poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(pool),
+        hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(pool),
         extended_hours_counter_trading: false,
     };
 

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -344,6 +344,7 @@ mod tests {
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
             poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&pool),
             extended_hours_counter_trading: false,
         };
 
@@ -472,6 +473,7 @@ mod tests {
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
             poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&pool),
+            hedge_queue: crate::trading::offchain::hedge::HedgeJobQueue::new(&pool),
             extended_hours_counter_trading: false,
         };
 


### PR DESCRIPTION
## What

When an onchain fill arrives during an Extended market session, the inline trade-processing path now enqueues an immediate `PlaceHedge` job instead of deferring entirely to the next `CheckPositions` scan. Review finding M4 on the extended-hours stack ([RAI-71](https://linear.app/makeitrain/issue/RAI-71/245-limit-order-support-for-counter-trading-outside-market-hours)).

## Why

The inline path cannot place an extended-hours limit order itself — it has no `OrderPlacer` for the limit-order price lookup. Previously it logged "deferring hedge to CheckPositions" and waited for the next scan (~1 minute), leaving directional exposure unhedged for up to a poll cycle. Enqueueing an immediate `PlaceHedge` (which does have the `OrderPlacer`) hedges right away while keeping `CheckPositions` as the backstop.

## How

`src/conductor.rs`: `TradeProcessingCqrs` gains a `hedge_queue: HedgeJobQueue`. In the `MarketSession::Extended` branch of the inline path, the code takes the `counter_trade_submission_lock`, runs `preflight_counter_trade_submission` + `clamp_shares_to_reservation` (mirroring the scan path so it never enqueues a hedge exceeding buying power), then pushes a `PlaceHedge` job carrying the symbol, direction, clamped shares, executor, threshold, a fresh `OffchainOrderId`, and the `market_session`. An enqueue failure is logged (`CheckPositions` retries). The function returns `Ok(None)`: no inline offchain order was placed, and the durable `PlaceHedge` job claims the position via `PlaceOffChainOrder` when it runs — returning the job's not-yet-recorded id would be a synthetic handle the aggregates know nothing about. `src/conductor/builder.rs` wires `hedge_queue` through; three test constructors (`integration_tests/arbitrage.rs`, `trading/onchain/trade_accountant.rs`) get the new field.

## Testing

New unit test `extended_hours_trade_enqueues_immediate_hedge_job` (in `conductor.rs`): with extended-hours counter-trading enabled and the mock broker in an Extended session, an onchain fill must (1) return `None` from `process_queued_trade`, (2) place no inline offchain order (projection stays empty), and (3) enqueue exactly one `PlaceHedge` job in the `Jobs` table. The production caller already ignores the return value and no prior test asserted the old deferral, so the contract change is safe.

## Anything else

The buying-power preflight runs at enqueue time, not at job-submission time — a pre-existing property shared with the `CheckPositions` scan path (#673 explicitly deferred perform-time preflight). Not introduced here.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366395&installation_id=125569124&pr_number=751&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F751&signature=400e25503db7c0ce75c433da19c285f3dd20ca756f14297163a77841e0528dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
