### PR TITLE
refactor(offchain-order): extract shared terminal-order->PositionCommand mapping, unify broker_timestamp to event time (L2)

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -31,7 +31,7 @@ use st0x_event_sorcery::{
 use st0x_evm::Wallet;
 use st0x_execution::{
     ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
-    ExecutionError, Executor, FractionalShares, MarketOrder, MarketSession, Positive, Symbol,
+    ExecutionError, Executor, FractionalShares, MarketOrder, MarketSession, Symbol,
     TryIntoExecutor,
 };
 
@@ -47,7 +47,8 @@ use crate::inventory::{
 use crate::offchain::order::{
     ExecutorOrderPlacer, HandleOrderRejectionJobQueue, OffchainOrder, OffchainOrderCommand,
     OffchainOrderId, OrderPlacer, PollOrderStatus, PollOrderStatusJobQueue,
-    ReconcileOrderFillJobQueue, recover_submitted_offchain_orders,
+    ReconcileOrderFillJobQueue, TerminalPositionFinalization, recover_submitted_offchain_orders,
+    terminal_position_finalization,
 };
 use crate::onchain::OnchainTrade;
 use crate::onchain::USDC_BASE;
@@ -1190,92 +1191,43 @@ async fn recover_single_orphaned_order(
         return Ok(());
     };
 
-    let command = match order {
-        OffchainOrder::Filled {
-            ref executor_order_id,
-            price,
-            filled_at,
-            ..
-        } => {
-            info!(%symbol, %order_id, "Orphaned order already Filled -- recovering");
-            PositionCommand::CompleteOffChainOrder {
-                offchain_order_id: order_id,
-                shares_filled: order.shares(),
-                direction: order.direction(),
-                executor_order_id: executor_order_id.clone(),
-                price,
-                broker_timestamp: filled_at,
-            }
-        }
-
-        OffchainOrder::Failed {
-            shares_filled: Some(shares_filled),
-            avg_price: Some(price),
-            executor_order_id: Some(executor_order_id),
+    let command = match terminal_position_finalization(&order) {
+        Some(TerminalPositionFinalization::Complete {
+            shares_filled,
             direction,
-            ..
-        } if Positive::new(shares_filled).is_ok() => {
-            info!(%symbol, %order_id, "Orphaned order already Failed with partial fill -- recovering");
+            executor_order_id,
+            price,
+            broker_timestamp,
+        }) => {
+            info!(%symbol, %order_id, "Orphaned order terminal with fill -- recovering");
             PositionCommand::CompleteOffChainOrder {
                 offchain_order_id: order_id,
-                shares_filled: Positive::new(shares_filled)?,
+                shares_filled,
                 direction,
                 executor_order_id,
                 price,
-                broker_timestamp: Utc::now(),
+                broker_timestamp,
             }
         }
 
-        OffchainOrder::Failed { .. } => {
-            info!(%symbol, %order_id, "Orphaned order already Failed -- recovering");
+        Some(TerminalPositionFinalization::NoFill) => {
+            info!(%symbol, %order_id, "Orphaned terminal order with no fill -- clearing pending");
             PositionCommand::FailOffChainOrder {
                 offchain_order_id: order_id,
-                error: "recovered from orphaned state on startup".to_string(),
+                error: "recovered from orphaned terminal state on startup".to_string(),
             }
         }
 
-        OffchainOrder::Cancelled {
-            shares_filled,
-            avg_price,
-            direction,
-            executor_order_id,
-            reason,
-            ..
-        } => {
-            info!(%symbol, %order_id, ?reason, "Orphaned order already Cancelled -- recovering");
-
-            if let Ok(positive_filled) = Positive::new(shares_filled) {
-                let Some(price) = avg_price else {
-                    anyhow::bail!(
-                        "cancelled order {order_id} for {symbol} has {shares_filled} shares filled but no average price"
-                    );
-                };
-
-                PositionCommand::CompleteOffChainOrder {
-                    offchain_order_id: order_id,
-                    shares_filled: positive_filled,
-                    direction,
-                    executor_order_id,
-                    price,
-                    broker_timestamp: Utc::now(),
-                }
-            } else {
-                PositionCommand::FailOffChainOrder {
-                    offchain_order_id: order_id,
-                    error: format!("recovered cancelled order: {reason:?}"),
-                }
-            }
+        Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
+            anyhow::bail!(
+                "orphaned order {order_id} for {symbol} has {shares_filled} shares filled but no average price"
+            );
         }
 
-        OffchainOrder::Submitted { .. }
-        | OffchainOrder::PartiallyFilled { .. }
-        | OffchainOrder::Cancelling { .. } => {
+        // Non-terminal: the order is still in progress (Submitted /
+        // PartiallyFilled / Cancelling / Pending) -- nothing to finalize yet.
+        None => {
             debug!(%symbol, %order_id, "Pending offchain order still in progress");
-            return Ok(());
-        }
-
-        OffchainOrder::Pending { .. } => {
-            warn!(%symbol, %order_id, "Offchain order still Pending -- may not have been submitted");
             return Ok(());
         }
     };

--- a/src/offchain/order.rs
+++ b/src/offchain/order.rs
@@ -1052,6 +1052,119 @@ impl OffchainOrder {
     }
 }
 
+/// How a *terminal* [`OffchainOrder`] should finalize its owning `Position`.
+///
+/// Shared by the two finalization sites -- the startup orphan-recovery sweep in
+/// `conductor` and the cancel-and-replace pass in `position_check` -- so the
+/// terminal-state -> position-command mapping lives in one place and cannot
+/// drift between them. `broker_timestamp` is the order's own broker event time
+/// (`filled_at`/`cancelled_at`/`failed_at`), the moment the broker recorded the
+/// outcome -- not the wall-clock time finalization happens to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TerminalPositionFinalization {
+    /// Apply the recorded (priced) fill to the position.
+    Complete {
+        shares_filled: Positive<FractionalShares>,
+        direction: Direction,
+        executor_order_id: ExecutorOrderId,
+        price: Usd,
+        broker_timestamp: DateTime<Utc>,
+    },
+    /// No fill to record -- clear the position's pending reference. The caller
+    /// supplies the reason string it records.
+    NoFill,
+    /// A positive fill quantity with no average price: the fill cannot be
+    /// recorded correctly, so the position must NOT be finalized (the caller
+    /// retries) rather than silently dropping the filled shares.
+    UnpricedFill { shares_filled: FractionalShares },
+}
+
+/// Classifies a terminal [`OffchainOrder`] (`Filled`/`Cancelled`/`Failed`) into
+/// the [`TerminalPositionFinalization`] it implies. Returns `None` for
+/// non-terminal states (the caller leaves the position pending and retries).
+pub(crate) fn terminal_position_finalization(
+    order: &OffchainOrder,
+) -> Option<TerminalPositionFinalization> {
+    match order {
+        OffchainOrder::Filled {
+            shares,
+            direction,
+            executor_order_id,
+            price,
+            filled_at,
+            ..
+        } => Some(TerminalPositionFinalization::Complete {
+            shares_filled: *shares,
+            direction: *direction,
+            executor_order_id: executor_order_id.clone(),
+            price: *price,
+            broker_timestamp: *filled_at,
+        }),
+
+        OffchainOrder::Cancelled {
+            shares_filled,
+            avg_price,
+            direction,
+            executor_order_id,
+            cancelled_at,
+            ..
+        } => Some(classify_terminal_fill(
+            *shares_filled,
+            *avg_price,
+            *direction,
+            executor_order_id.clone(),
+            *cancelled_at,
+        )),
+
+        OffchainOrder::Failed {
+            shares_filled: Some(shares_filled),
+            avg_price,
+            direction,
+            executor_order_id: Some(executor_order_id),
+            failed_at,
+            ..
+        } => Some(classify_terminal_fill(
+            *shares_filled,
+            *avg_price,
+            *direction,
+            executor_order_id.clone(),
+            *failed_at,
+        )),
+
+        // Failed with no recorded fill (or no executor id) -- nothing to apply.
+        OffchainOrder::Failed { .. } => Some(TerminalPositionFinalization::NoFill),
+
+        OffchainOrder::Pending { .. }
+        | OffchainOrder::Submitted { .. }
+        | OffchainOrder::PartiallyFilled { .. }
+        | OffchainOrder::Cancelling { .. } => None,
+    }
+}
+
+/// A priced positive fill -> `Complete`; a positive fill without a price ->
+/// `UnpricedFill` (must not be dropped); zero -> `NoFill`.
+fn classify_terminal_fill(
+    shares_filled: FractionalShares,
+    avg_price: Option<Usd>,
+    direction: Direction,
+    executor_order_id: ExecutorOrderId,
+    broker_timestamp: DateTime<Utc>,
+) -> TerminalPositionFinalization {
+    let Ok(positive) = Positive::new(shares_filled) else {
+        return TerminalPositionFinalization::NoFill;
+    };
+    avg_price.map_or(
+        TerminalPositionFinalization::UnpricedFill { shares_filled },
+        |price| TerminalPositionFinalization::Complete {
+            shares_filled: positive,
+            direction,
+            executor_order_id,
+            price,
+            broker_timestamp,
+        },
+    )
+}
+
 /// Queries the broker for the current state of an order before cancellation
 /// and emits the appropriate partial-fill / fill events so the local
 /// aggregate is reconciled with the broker before the terminal Cancelled

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use apalis::prelude::Status;
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use tracing::{debug, error, info, warn};
@@ -17,7 +16,7 @@ use tracing::{debug, error, info, warn};
 use st0x_config::Ctx;
 use st0x_event_sorcery::{Projection, Store};
 use st0x_execution::{
-    ClientOrderId, CounterTradePreflight, Executor, MarketOrder, MarketSession, Positive, Symbol,
+    ClientOrderId, CounterTradePreflight, Executor, MarketOrder, MarketSession, Symbol,
 };
 
 use crate::conductor::clamp_shares_to_reservation;
@@ -25,6 +24,7 @@ use crate::conductor::job::{Job, JobQueue, Label, QueuePushError};
 use crate::equity_redemption::symbols_with_active_transfers;
 use crate::offchain::order::{
     CancellationReason, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
+    TerminalPositionFinalization, terminal_position_finalization,
 };
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
 use crate::position::{Position, PositionCommand};
@@ -406,156 +406,56 @@ where
         offchain_order_id: OffchainOrderId,
         order: &OffchainOrder,
     ) -> bool {
-        // Try to apply any partial fill first.
-        if let OffchainOrder::Cancelled {
-            shares_filled,
-            avg_price,
-            direction,
-            executor_order_id,
-            ..
-        } = order
-            && let Ok(positive_filled) = Positive::new(*shares_filled)
-        {
-            let Some(avg_price) = avg_price else {
-                warn!(
-                    %symbol, %offchain_order_id,
-                    "Cancelled order has partial fill without avg price; leaving position pending"
-                );
-                return false;
-            };
-
-            if let Err(error) = self
-                .position
-                .send(
-                    symbol,
-                    PositionCommand::CompleteOffChainOrder {
-                        offchain_order_id,
-                        shares_filled: positive_filled,
-                        direction: *direction,
-                        executor_order_id: executor_order_id.clone(),
-                        price: *avg_price,
-                        broker_timestamp: Utc::now(),
-                    },
-                )
-                .await
-            {
-                warn!(
-                    %symbol, %offchain_order_id, %error,
-                    "Failed to apply partial-fill CompleteOffChainOrder after cancel"
-                );
-                return false;
-            }
-            return true;
-        }
-
-        match order {
-            // Filled (short-circuit case): the broker fully filled the
-            // order between our last poll and the cancel. Apply the full
-            // fill to the position.
-            OffchainOrder::Filled {
-                shares,
+        let command = match terminal_position_finalization(order) {
+            Some(TerminalPositionFinalization::Complete {
+                shares_filled,
                 direction,
                 executor_order_id,
                 price,
-                ..
-            } => {
-                if let Err(error) = self
-                    .position
-                    .send(
-                        symbol,
-                        PositionCommand::CompleteOffChainOrder {
-                            offchain_order_id,
-                            shares_filled: *shares,
-                            direction: *direction,
-                            executor_order_id: executor_order_id.clone(),
-                            price: *price,
-                            broker_timestamp: Utc::now(),
-                        },
-                    )
-                    .await
-                {
-                    warn!(
-                        %symbol, %offchain_order_id, %error,
-                        "Failed to apply short-circuit fill after cancel"
-                    );
-                    return false;
-                }
-                true
-            }
-            OffchainOrder::Failed {
-                shares_filled: Some(shares_filled),
-                avg_price: Some(avg_price),
+                broker_timestamp,
+            }) => PositionCommand::CompleteOffChainOrder {
+                offchain_order_id,
+                shares_filled,
                 direction,
-                executor_order_id: Some(executor_order_id),
-                ..
-            } => {
-                let command = Positive::new(*shares_filled).map_or_else(
-                    |_| PositionCommand::FailOffChainOrder {
-                        offchain_order_id,
-                        error: "broker failed order before any fill".to_string(),
-                    },
-                    |positive_filled| PositionCommand::CompleteOffChainOrder {
-                        offchain_order_id,
-                        shares_filled: positive_filled,
-                        direction: *direction,
-                        executor_order_id: executor_order_id.clone(),
-                        price: *avg_price,
-                        broker_timestamp: Utc::now(),
-                    },
-                );
-
-                if let Err(error) = self.position.send(symbol, command).await {
-                    warn!(
-                        %symbol, %offchain_order_id, %error,
-                        "Failed to apply partial-fill CompleteOffChainOrder after broker failure"
-                    );
-                    return false;
-                }
-                true
-            }
-            // Cancelled with no partial fill, or Failed at the broker with
-            // no recorded fill -- nothing to apply to net, just clear pending.
-            OffchainOrder::Cancelled { .. } | OffchainOrder::Failed { .. } => {
-                let error_message = match order {
-                    OffchainOrder::Cancelled { reason, .. } => {
-                        format!("Cancelled: {reason:?}")
-                    }
+                executor_order_id,
+                price,
+                broker_timestamp,
+            },
+            Some(TerminalPositionFinalization::NoFill) => {
+                let error = match order {
+                    OffchainOrder::Cancelled { reason, .. } => format!("Cancelled: {reason:?}"),
                     OffchainOrder::Failed { error, .. } => error.clone(),
-                    _ => unreachable!(),
+                    _ => "terminal order finalized with no fill".to_string(),
                 };
-                if let Err(error) = self
-                    .position
-                    .send(
-                        symbol,
-                        PositionCommand::FailOffChainOrder {
-                            offchain_order_id,
-                            error: error_message,
-                        },
-                    )
-                    .await
-                {
-                    warn!(
-                        %symbol, %offchain_order_id, %error,
-                        "Failed to clear position pending state after cancel"
-                    );
-                    return false;
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id,
+                    error,
                 }
-                true
             }
-            // Live or pre-terminal states should not appear here -- we
-            // just successfully cancelled or the scan retry was triggered.
-            // Log and skip.
-            OffchainOrder::Pending { .. }
-            | OffchainOrder::Submitted { .. }
-            | OffchainOrder::PartiallyFilled { .. }
-            | OffchainOrder::Cancelling { .. } => {
+            Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
+                warn!(
+                    %symbol, %offchain_order_id, ?shares_filled,
+                    "Terminal order has a partial fill without avg price; leaving position pending"
+                );
+                return false;
+            }
+            None => {
                 warn!(
                     %symbol, %offchain_order_id, state = ?order,
-                    "Order in non-terminal state after cancel attempt; skipping position finalize"
+                    "Order in non-terminal state during finalization; skipping"
                 );
-                false
+                return false;
             }
+        };
+
+        if let Err(error) = self.position.send(symbol, command).await {
+            warn!(
+                %symbol, %offchain_order_id, %error,
+                "Failed to finalize position for terminal order"
+            );
+            return false;
         }
+        true
     }
 }
 


### PR DESCRIPTION
## What

Extracts the terminal-`OffchainOrder` → `PositionCommand` mapping into a single shared classifier and unifies the recorded `broker_timestamp` to the order's own broker event time. Review finding L2 on the extended-hours stack ([RAI-71](https://linear.app/makeitrain/issue/RAI-71/245-limit-order-support-for-counter-trading-outside-market-hours)).

## Why

Two finalization sites — the startup orphan-recovery sweep in `conductor::recover_single_orphaned_order` and the cancel-and-replace pass in `position_check::finalize_position_for_terminal_order` — each independently re-implemented the same "given a terminal order, what command finalizes its position" logic. They had drifted: `recover` used the order's `filled_at` for a Filled order but `Utc::now()` for a partial-fill-from-Failed/Cancelled, while `finalize` used `Utc::now()` throughout. Recording wall-clock finalization time instead of the broker event time is a latent inaccuracy in a financial reconciliation path. One shared mapping removes the duplication and forces a single, correct timestamp choice.

## How

`src/offchain/order.rs`: adds a `pub(crate)` `TerminalPositionFinalization` enum with three cases — `Complete { shares_filled, direction, executor_order_id, price, broker_timestamp }` (apply the priced fill), `NoFill` (clear the pending reference), and `UnpricedFill { shares_filled }` (a positive fill with no average price: must NOT finalize, so filled shares are never silently dropped). The `terminal_position_finalization(&OffchainOrder)` function classifies Filled/Cancelled/Failed terminal states and returns `None` for non-terminal states; a `classify_terminal_fill` helper maps a priced positive fill → `Complete`, an unpriced positive fill → `UnpricedFill`, and zero → `NoFill`. Crucially, `broker_timestamp` is taken from the order's own event time (`filled_at` / `cancelled_at` / `failed_at`), not `Utc::now()`. Both call sites in `conductor.rs` and `position_check.rs` now match on the shared enum, collapsing their duplicated arms.

## Testing

Behavior is exercised by the existing orphan-recovery and cancel-and-replace tests in `conductor` and `position_check`, which continue to pass against the shared mapping. The `UnpricedFill` branch preserves the prior "leave position pending, do not drop the fill" behavior at both sites.

## Anything else

`dispatch_post_place_state` is intentionally not folded in — it's a different concern. The timestamp unification is a deliberate behavior change in a reconciliation path (wall-clock → broker event time), made because the broker event time is the semantically correct "when the broker recorded the outcome" value.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366397&installation_id=125569124&pr_number=753&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F753&signature=31c66d8c19f860650907c1dfa3b832418c19293e995b20dd9d95e68905a8d8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
