### PR TITLE
feat(position): add CancelOffChainOrder/OffChainOrderCancelled so cancellations aren't logged as failures (L3)

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1210,11 +1210,21 @@ async fn recover_single_orphaned_order(
             }
         }
 
+        // An intentional cancellation clears pending without failure semantics;
+        // a real failure keeps the failure event.
         Some(TerminalPositionFinalization::NoFill) => {
-            info!(%symbol, %order_id, "Orphaned terminal order with no fill -- clearing pending");
-            PositionCommand::FailOffChainOrder {
-                offchain_order_id: order_id,
-                error: "recovered from orphaned terminal state on startup".to_string(),
+            if let OffchainOrder::Cancelled { reason, .. } = &order {
+                info!(%symbol, %order_id, ?reason, "Orphaned cancelled order -- clearing pending");
+                PositionCommand::CancelOffChainOrder {
+                    offchain_order_id: order_id,
+                    reason: *reason,
+                }
+            } else {
+                info!(%symbol, %order_id, "Orphaned terminal order with no fill -- clearing pending");
+                PositionCommand::FailOffChainOrder {
+                    offchain_order_id: order_id,
+                    error: "recovered from orphaned terminal state on startup".to_string(),
+                }
             }
         }
 

--- a/src/position.rs
+++ b/src/position.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use st0x_config::ExecutionThreshold;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Table};
@@ -21,7 +21,7 @@ use st0x_finance::{Usd, Usdc};
 use st0x_float_macro::float;
 use st0x_float_serde::{DebugFloat, DebugOptionFloat};
 
-use crate::offchain::order::OffchainOrderId;
+use crate::offchain::order::{CancellationReason, OffchainOrderId};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Position {
@@ -206,6 +206,20 @@ impl EventSourced for Position {
                     .last_failed_offchain_order_id
                     .or(Some(*offchain_order_id)),
                 last_updated: Some(*failed_at),
+                ..entity.clone()
+            })),
+
+            OffChainOrderCancelled {
+                offchain_order_id, ..
+            } if entity.pending_offchain_order_id != Some(*offchain_order_id) => Ok(None),
+
+            OffChainOrderCancelled { cancelled_at, .. } => Ok(Some(Self {
+                // Intentional cancellation: release the pending slot so the
+                // symbol can re-hedge. Deliberately does NOT set the
+                // failure/idempotency anchor -- the replacement is a fresh
+                // order, not a retry of the cancelled one.
+                pending_offchain_order_id: None,
+                last_updated: Some(*cancelled_at),
                 ..entity.clone()
             })),
 
@@ -414,6 +428,25 @@ impl EventSourced for Position {
                     offchain_order_id,
                     error,
                     failed_at: Utc::now(),
+                }])
+            }
+
+            CancelOffChainOrder {
+                offchain_order_id,
+                reason,
+            } => {
+                self.validate_pending_execution(offchain_order_id)?;
+
+                info!(
+                    target: "hedge",
+                    %offchain_order_id, symbol = %self.symbol, ?reason,
+                    "Offchain order cancelled; clearing pending"
+                );
+
+                Ok(vec![PositionEvent::OffChainOrderCancelled {
+                    offchain_order_id,
+                    reason,
+                    cancelled_at: Utc::now(),
                 }])
             }
 
@@ -736,6 +769,14 @@ pub enum PositionCommand {
         offchain_order_id: OffchainOrderId,
         error: String,
     },
+    /// Clear a pending offchain order that was intentionally cancelled (e.g.
+    /// the extended-hours -> regular cancel-and-replace), distinct from a broker
+    /// failure. Does not set the failure/idempotency anchor: the replacement is
+    /// a fresh order, not a retry under the cancelled key.
+    CancelOffChainOrder {
+        offchain_order_id: OffchainOrderId,
+        reason: CancellationReason,
+    },
     UpdateThreshold {
         threshold: ExecutionThreshold,
     },
@@ -793,6 +834,14 @@ pub enum PositionEvent {
         error: String,
         failed_at: DateTime<Utc>,
     },
+    /// A pending offchain order was intentionally cancelled (not a failure), so
+    /// failure-rate analytics can tell the two apart. Clears the pending
+    /// reference without setting the failure/idempotency anchor.
+    OffChainOrderCancelled {
+        offchain_order_id: OffchainOrderId,
+        reason: CancellationReason,
+        cancelled_at: DateTime<Utc>,
+    },
     ThresholdUpdated {
         old_threshold: ExecutionThreshold,
         new_threshold: ExecutionThreshold,
@@ -823,6 +872,7 @@ impl PositionEvent {
                 broker_timestamp, ..
             } => *broker_timestamp,
             OffChainOrderFailed { failed_at, .. } => *failed_at,
+            OffChainOrderCancelled { cancelled_at, .. } => *cancelled_at,
             ThresholdUpdated { updated_at, .. } => *updated_at,
             ManualPositionAdjusted { adjusted_at, .. } => *adjusted_at,
         }
@@ -838,6 +888,7 @@ impl DomainEvent for PositionEvent {
             OffChainOrderPlaced { .. } => "PositionEvent::OffChainOrderPlaced".to_string(),
             OffChainOrderFilled { .. } => "PositionEvent::OffChainOrderFilled".to_string(),
             OffChainOrderFailed { .. } => "PositionEvent::OffChainOrderFailed".to_string(),
+            OffChainOrderCancelled { .. } => "PositionEvent::OffChainOrderCancelled".to_string(),
             ThresholdUpdated { .. } => "PositionEvent::ThresholdUpdated".to_string(),
             ManualPositionAdjusted { .. } => "PositionEvent::ManualPositionAdjusted".to_string(),
         }
@@ -1131,6 +1182,14 @@ impl std::fmt::Debug for PositionCommand {
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
                 .finish(),
+            Self::CancelOffChainOrder {
+                offchain_order_id,
+                reason,
+            } => f
+                .debug_struct("CancelOffChainOrder")
+                .field("offchain_order_id", offchain_order_id)
+                .field("reason", reason)
+                .finish(),
             Self::UpdateThreshold { threshold } => f
                 .debug_struct("UpdateThreshold")
                 .field("threshold", threshold)
@@ -1227,6 +1286,16 @@ impl std::fmt::Debug for PositionEvent {
                 .field("offchain_order_id", offchain_order_id)
                 .field("error", error)
                 .field("failed_at", failed_at)
+                .finish(),
+            Self::OffChainOrderCancelled {
+                offchain_order_id,
+                reason,
+                cancelled_at,
+            } => f
+                .debug_struct("OffChainOrderCancelled")
+                .field("offchain_order_id", offchain_order_id)
+                .field("reason", reason)
+                .field("cancelled_at", cancelled_at)
                 .finish(),
             Self::ThresholdUpdated {
                 old_threshold,
@@ -1579,6 +1648,64 @@ mod tests {
             .events();
 
         assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_offchain_order_emits_cancelled_not_failed() {
+        let threshold = one_share_threshold();
+        let offchain_order_id = OffchainOrderId::new();
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    threshold,
+                    initialized_at: Utc::now(),
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: FractionalShares::new(float!(1.5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: Utc::now(),
+                    seen_at: Utc::now(),
+                },
+                PositionEvent::OffChainOrderPlaced {
+                    offchain_order_id,
+                    shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+                    direction: Direction::Sell,
+                    executor: SupportedExecutor::DryRun,
+                    trigger_reason: TriggerReason::SharesThreshold {
+                        net_position_shares: float!(1.5),
+                        threshold_shares: float!(1),
+                    },
+                    placed_at: Utc::now(),
+                },
+            ])
+            .when(PositionCommand::CancelOffChainOrder {
+                offchain_order_id,
+                reason: CancellationReason::MarketOpenReplacement,
+            })
+            .await
+            .events();
+
+        // An intentional cancellation must emit OffChainOrderCancelled, NOT
+        // OffChainOrderFailed -- otherwise it pollutes failure-rate analytics.
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(
+                events.first(),
+                Some(PositionEvent::OffChainOrderCancelled {
+                    reason: CancellationReason::MarketOpenReplacement,
+                    ..
+                })
+            ),
+            "expected OffChainOrderCancelled, got: {:?}",
+            events.first()
+        );
     }
 
     #[tokio::test]

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -421,17 +421,22 @@ where
                 price,
                 broker_timestamp,
             },
-            Some(TerminalPositionFinalization::NoFill) => {
-                let error = match order {
-                    OffchainOrder::Cancelled { reason, .. } => format!("Cancelled: {reason:?}"),
-                    OffchainOrder::Failed { error, .. } => error.clone(),
-                    _ => "terminal order finalized with no fill".to_string(),
-                };
-                PositionCommand::FailOffChainOrder {
+            Some(TerminalPositionFinalization::NoFill) => match order {
+                // An intentional cancellation clears the pending slot without
+                // the failure semantics (keeps failure-rate analytics clean).
+                OffchainOrder::Cancelled { reason, .. } => PositionCommand::CancelOffChainOrder {
                     offchain_order_id,
-                    error,
-                }
-            }
+                    reason: *reason,
+                },
+                OffchainOrder::Failed { error, .. } => PositionCommand::FailOffChainOrder {
+                    offchain_order_id,
+                    error: error.clone(),
+                },
+                _ => PositionCommand::FailOffChainOrder {
+                    offchain_order_id,
+                    error: "terminal order finalized with no fill".to_string(),
+                },
+            },
             Some(TerminalPositionFinalization::UnpricedFill { shares_filled }) => {
                 warn!(
                     %symbol, %offchain_order_id, ?shares_filled,

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1540,7 +1540,10 @@ impl Reactor for RebalancingService {
                             .insert(symbol);
                         return Ok(());
                     }
-                    OffChainOrderFailed { .. } => {
+                    OffChainOrderFailed { .. } | OffChainOrderCancelled { .. } => {
+                        // A failure or an intentional cancellation both release
+                        // the symbol's pending-offchain-order gate; nudge an
+                        // immediate equity check rather than waiting a poll cycle.
                         self.pending_offchain_order_symbols
                             .write()
                             .await


### PR DESCRIPTION
## What

Adds a `PositionCommand::CancelOffChainOrder` → `PositionEvent::OffChainOrderCancelled` pair to the event-sourced `Position` aggregate so an intentional cancellation is recorded distinctly from a broker failure. Review finding L3 on the extended-hours stack ([RAI-71](https://linear.app/makeitrain/issue/RAI-71/245-limit-order-support-for-counter-trading-outside-market-hours)).

## Why

The extended-hours → regular cancel-and-replace cancels a still-live limit order so it can be re-placed as a market order. Previously this was recorded as `OffChainOrderFailed`, which pollutes failure-rate analytics (an intentional cancel is not a failure) and, more importantly, set the failure/idempotency anchor — but a cancel-and-replace gets a fresh market order, not a retry under the cancelled key. The two outcomes need distinct events.

## How

`src/position.rs`: new `PositionCommand::CancelOffChainOrder { offchain_order_id, reason: CancellationReason }` and `PositionEvent::OffChainOrderCancelled { offchain_order_id, reason, cancelled_at }`. The command handler validates the pending execution and emits the cancelled event. The apply path releases the pending slot (`pending_offchain_order_id = None`) so the symbol can re-hedge, but deliberately does NOT set the failure/idempotency anchor — the replacement is a fresh order. Stale events (id ≠ current pending) are ignored. Manual `Debug` arms, `event_type`, and `event_timestamp` are extended for the new event. `src/position_check.rs` and `src/conductor.rs` now route the `NoFill` terminal case through `CancelOffChainOrder` for `OffchainOrder::Cancelled` (and keep `FailOffChainOrder` for genuine failures). `src/rebalancing/trigger/mod.rs` groups `OffChainOrderCancelled` with `OffChainOrderFailed` since both release the symbol's pending-order gate and should nudge an immediate equity check.

## Testing

New unit test `cancel_offchain_order_emits_cancelled_not_failed`: given an initialized position with a placed offchain order, `CancelOffChainOrder` must emit exactly one `OffChainOrderCancelled` (with the supplied `CancellationReason::MarketOpenReplacement`), never `OffChainOrderFailed`. The existing position-aggregate and finalization tests continue to pass.

## Anything else

Tip of the extended-hours stack. The key semantic decision — cancel clears pending without setting the idempotency anchor — is what makes the replacement a fresh order rather than a deduped retry of the cancelled one.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366399&installation_id=125569124&pr_number=754&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F754&signature=fe89d334adfab47024d94ad3d088af80501c70b99e952c242bf3f410bc09e1a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
