### PR TITLE
docs: fix stale references in README, conductor, and domain docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Current broker support is limited to `alpaca-broker-api` and `dry-run`.
 
 ```bash
 cargo run --bin server -- --config path/to/config.toml --secrets path/to/secrets.toml
-cargo run --bin reporter -- --config path/to/config.toml
 ```
 
 Manual wrap of tokenized equity into wrapped vault shares (requires rebalancing
@@ -282,12 +281,6 @@ the bot cycles liquidity back through hedging and rebalancing.
 
 Open `http://localhost:5173` to watch the dashboard. Press `Ctrl-C` to stop.
 
-## P&L Tracking
-
-The P&L reporter (`cargo run --bin reporter`) calculates realized profit/loss
-using FIFO accounting and writes metrics to the `metrics_pnl` table for Grafana
-visualization. This subsystem is currently being reworked.
-
 ## Project Structure
 
 ### Cargo Workspace
@@ -295,19 +288,29 @@ visualization. This subsystem is currently being reworked.
 Workspace crates:
 
 - **`st0x-hedge`** (root) - Main arbitrage bot: event loop, CQRS/ES aggregates,
-  conductor, reporter, dashboard backend, and CLI
+  conductor, dashboard backend, and CLI
+- **`st0x-config`** (`crates/config/`) - TOML/secrets loading, `Ctx`/`BrokerCtx`/`Env`
+  assembly, and tracing setup. Only `st0x-hedge` binaries may depend on this.
 - **`st0x-dto`** (`crates/dto/`) - Dashboard DTOs and TypeScript binding
   generation
-- **`st0x-event-sorcery`** (`crates/event-sorcery/`) - CQRS/event-sourcing
-  helpers, snapshot-backed loading, compactable observational event streams, and
-  testing utilities
 - **`st0x-execution`** (`crates/execution/`) - Standalone `Executor` trait
   abstraction with Alpaca Broker API and mock implementations
+- **`st0x-finance`** (`crates/finance/`) - Leaf crate with zero workspace
+  dependencies providing shared financial primitives: `Symbol`, `FractionalShares`,
+  `Usdc`, `Usd`, `Positive`, `NonNegative`, `HasZero`, and `Id<Tag>`
 - **`st0x-bridge`** (`crates/bridge/`) - Cross-chain bridge abstractions and
   CCTP implementation
 - **`st0x-evm`** (`crates/evm/`) - EVM wallet, provider, and test-chain support
+- **`st0x-float-macro`** (`crates/float-macro/`) - Procedural macro crate
+  providing the `float!` literal macro
 - **`st0x-float-serde`** (`crates/float-serde/`) - Shared Rain Float formatting
   and serde helpers for workspace wire formats
+
+External dependency (not a local workspace member):
+
+- **`st0x-event-sorcery`** (git: `ST0x-Technology/event-sorcery`) - CQRS/event-sourcing
+  helpers, snapshot-backed loading, compactable observational event streams, and
+  testing utilities
 
 ### Infrastructure
 

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -47,15 +47,19 @@ SupervisorBuilder::default()
 
 ### OrderFillMonitor
 
-Defined in `src/conductor/order_fill_monitor.rs`. Subscribes to
+Defined in `src/conductor/monitor/order_fills.rs`. Subscribes to
 ClearV3/TakeOrderV3 WebSocket streams and pushes each event into the
-`DexTradeAccountingJobQueue` as an `AccountForDexTrade` job.
+`DexTradeAccountingJobQueue` as an `AccountForDexTrade` job. On every
+(re)connect it also enqueues a `BackfillRange` job covering the gap between
+the last persisted checkpoint and the current confirmation boundary, so events
+missed during a disconnect are recovered without relying on the live stream.
 
 ```rust
 struct OrderFillMonitor {
-    ws_url: Url,
-    orderbook: Address,
+    evm_ctx: EvmCtx,
     job_queue: DexTradeAccountingJobQueue,
+    backfill_queue: BackfillJobQueue,
+    pool: SqlitePool,
 }
 ```
 

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -164,8 +164,7 @@ Both operations are tracked as CQRS event-sourced aggregates
 
 ### Reporter
 
-A standalone service (separate binary) that computes P&L metrics from trade
-history. It uses FIFO inventory accounting to calculate realized P&L, cumulative
-P&L, and net position for each symbol. Runs on a polling interval against the
-same SQLite database as the server, but requires no secrets (only a plaintext
-config with the database path).
+P&L reporting has been removed. Historical realized P&L, cumulative P&L, and
+per-symbol net position were previously provided by a separate `reporter` binary
+that read from the shared SQLite database; that subsystem no longer exists in the
+codebase.


### PR DESCRIPTION
## What

Fixes three documentation files that contained stale or incorrect information discovered by auditing docs against the current codebase.

## Why

Stale docs mislead contributors: commands that don't work, file paths that don't exist, and crate lists that are incomplete cause confusion and wasted time.

## How

**README.md:**
- Removed `cargo run --bin reporter` from the Configuration section — the `reporter` binary no longer exists in `src/bin/`
- Removed the P&L Tracking section which described the removed reporter subsystem
- Updated the Cargo Workspace crate list:
  - Added `st0x-config` (`crates/config/`), `st0x-finance` (`crates/finance/`), and `st0x-float-macro` (`crates/float-macro/`) which are workspace members missing from the list
  - Moved `st0x-event-sorcery` to an "External dependency" note — it is a git dependency pointing to `ST0x-Technology/event-sorcery`, not a local `crates/` directory
  - Removed "reporter" from the `st0x-hedge` crate description

**docs/conductor.md:**
- Fixed `OrderFillMonitor` source file path: was `src/conductor/order_fill_monitor.rs`, is `src/conductor/monitor/order_fills.rs`
- Updated the struct definition to match the current code (`evm_ctx`, `backfill_queue`, `pool` instead of the old `ws_url`, `orderbook`)
- Added a note that each reconnect enqueues a `BackfillRange` job to recover events missed during the disconnect window

**docs/domain.md:**
- Updated the Reporter section to state the subsystem has been removed rather than describing it as an active standalone binary

## Testing

Verified against current source:
- `src/bin/` contains `server.rs`, `cli.rs`, `decode-floats.rs`, `validate-config.rs` — no `reporter.rs`
- `src/conductor/monitor/order_fills.rs` exists with the struct fields shown
- `Cargo.toml` workspace members confirmed: `crates/config`, `crates/finance`, `crates/float-macro` are present; `event-sorcery` is a `git` dependency not a path dep

## Anything else

There is an older `docs/fix-stale-references` branch on the remote that made similar fixes against an older master. That branch has since diverged from master and is not in a mergeable state; this PR supersedes it with the same fixes applied cleanly on top of the current master.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNSWuG2fsaMh7tRvtW16Ee)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783394281&installation_id=125569124&pr_number=755&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F755&signature=9fbb3b4b647e86bb2708039e8d11e1da310b534045609baf441167e34416f227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started instructions with current server setup steps.
  * Revised project structure documentation with expanded workspace overview.
  * Enhanced order monitoring documentation with improved event recovery during reconnection.
  * Updated documentation to reflect removal of the historical P&L reporting subsystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->