### PR TITLE
ci: drop redundant matrix entries and rightsize CI runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   nix-source-cache:
     name: nix source cache
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -85,52 +85,19 @@ jobs:
           sort -u "$paths_file" -o "$paths_file"
 
   backend-validation:
-    name: backend ${{ matrix.name }}
+    name: backend test ${{ matrix.partition }} of 4
     needs: nix-source-cache
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
     strategy:
       fail-fast: false
 
       matrix:
-        include:
-          - name: check
-            cache_target: check
-            command: nix develop .#ci-backend -c cargo check --workspace
-
-          - name: test 1 of 4
-            cache_target: test
-            command: >
-              nix develop .#ci-backend -c cargo nextest run --workspace
-              --all-features --profile ci --partition hash:1/4
-
-          - name: test 2 of 4
-            cache_target: test
-            command: >
-              nix develop .#ci-backend -c cargo nextest run --workspace
-              --all-features --profile ci --partition hash:2/4
-
-          - name: test 3 of 4
-            cache_target: test
-            command: >
-              nix develop .#ci-backend -c cargo nextest run --workspace
-              --all-features --profile ci --partition hash:3/4
-
-          - name: test 4 of 4
-            cache_target: test
-            command: >
-              nix develop .#ci-backend -c cargo nextest run --workspace
-              --all-features --profile ci --partition hash:4/4
-
-          - name: clippy
-            cache_target: clippy
-            command: >
-              nix develop .#ci-backend -c cargo clippy --workspace
-              --all-targets --all-features
+        partition: [1, 2, 3, 4]
 
     env:
       CARGO_INCREMENTAL: "0"
-      CARGO_TARGET_DIR: target/${{ matrix.cache_target }}
+      CARGO_TARGET_DIR: target/test
     steps:
       - uses: actions/checkout@v4
 
@@ -179,19 +146,31 @@ jobs:
             ~/.cargo/git/db/
             ~/.cargo/registry/cache/
             ~/.cargo/registry/index/
-            target/${{ matrix.cache_target }}/
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'flake.lock', 'flake.nix', 'rust.nix') }}
+            target/test/
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-test-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'crates/**/Cargo.toml', 'flake.lock', 'flake.nix', 'rust.nix') }}
           restore-keys: |
-            cargo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_target }}-
+            cargo-${{ runner.os }}-${{ runner.arch }}-test-
 
-      - name: ${{ matrix.name }}
-        run: ${{ matrix.command }}
+      # Each partition builds the full test binaries, so clippy reuses the warm
+      # target/test cache instead of compiling the workspace into a separate
+      # dir. It only needs to run once, so it rides on partition 1.
+      - name: test ${{ matrix.partition }} of 4
+        run: |
+          nix develop .#ci-backend -c bash -c '
+            set -euxo pipefail
+            cargo nextest run --workspace --all-features --profile ci \
+              --partition hash:${{ matrix.partition }}/4
+            if [ "${{ matrix.partition }}" = "1" ]; then
+              cargo clippy --workspace --all-targets --all-features
+            fi
+          '
 
   backend:
     name: backend
     needs: backend-validation
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 25
     steps:
       - name: Check backend validation
         run: |
@@ -201,7 +180,8 @@ jobs:
           fi
 
   dashboard:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -236,7 +216,8 @@ jobs:
         run: nix build .#st0x-dashboard
 
   hooks:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What

[RAI-784](https://linear.app/makeitrain/issue/RAI-784) — cut the per-run cost of `.github/workflows/ci.yaml` by collapsing the backend matrix and pinning each job to an explicitly-sized Blacksmith runner. CI-config-only; no Rust source changes.

## Why

`st0x.liquidity` CI dominates a ~$1,800/mo Blacksmith bill (~$1,250/mo from this repo). The cost is driven by stack-restack churn: every branch has a PR, so a push at the bottom of a Graphite stack rewrites every descendant's SHA and fires a full CI matrix on each, and `concurrency` can't dedupe across distinct PRs.

The cost doc's headline lever — switching `on: push` to `on: pull_request` — does **not** help here: `pull_request`'s `synchronize` event fires on the same force-pushes a restack produces, so the run count is unchanged when every branch already has a PR. Likewise `paths-ignore` is not viable, since `backend`/`dashboard`/`hooks` are required status checks on `master`; a docs-only push would produce no check runs and leave those required checks permanently pending. Both are documented as follow-ups. The effective strategy for a stack-heavy, all-PR'd team is to make **each run cheaper** — those savings compound across every redundant restack run.

## How

All changes are in `.github/workflows/ci.yaml`:

- **Drop the redundant `cargo check` matrix entry.** Compilation is already proven by `cargo nextest run` (builds all test binaries) and `cargo clippy --all-targets`, so the dedicated `check` job and its separate `target/check` dir were pure duplication.
- **Collapse the 6-entry `include` matrix into a 4-way `partition: [1, 2, 3, 4]`.** The `backend-validation` job is renamed `backend test ${{ matrix.partition }} of 4`. Each partition runs `cargo nextest run --workspace --all-features --profile ci --partition hash:N/4` inside an inline `nix develop .#ci-backend -c bash -c '...'` block with `set -euxo pipefail`; partition 1 additionally runs `cargo clippy --workspace --all-targets --all-features` via an `if [ "${{ matrix.partition }}" = "1" ]` guard so clippy reuses the warm `target/test` incremental cache rather than compiling the workspace into its own `target/clippy` dir. Clippy strictness is unchanged — warning-denial is enforced by `[workspace.lints]` inherited by every crate, so no `-D warnings` flag is needed. `CARGO_TARGET_DIR`, the cache path, and the cargo cache key all collapse from per-`cache_target` to a single shared `target/test`.
- **Rightsize runners onto explicit Blacksmith labels.** Every job moves off `ubuntu-latest`: `nix source cache`, `hooks`, and the trivial `backend` gate → `blacksmith-2vcpu-ubuntu-2404`; `dashboard` → `blacksmith-4vcpu-ubuntu-2404`; `backend-validation` → `blacksmith-8vcpu-ubuntu-2404`. Timeouts tighten to 25–30 min from the old 30/60 min ceilings.

Net: the backend matrix drops from 6 jobs to 4, one full redundant workspace compile is eliminated, clippy folds onto a warm cache instead of a cold dir, and the lighter jobs run on 2–4 vCPU instead of full-size runners.

## Testing

CI-config-only change; no Rust source is touched, so there is nothing to unit-test. Verified by the actual run on this PR ([run 27100979596](https://github.com/ST0x-Technology/st0x.liquidity/actions/runs/27100979596)), which went fully green: the rightsized `dashboard`/`hooks`/`nix source cache` jobs picked up their new Blacksmith runners (confirming the labels are valid — no indefinite queueing), the backend matrix correctly ran as **4** jobs with partition 1 running clippy after its nextest partition, and the `backend` gate passed.

## Anything else

Deferred to follow-up issues (Phase 2 of the cost doc, not in this PR):
- Cachix migration (`nix-quick-install-action` + `cachix-action` for the shared `rainlanguage` cache + `cache-nix-action`), which needs a `CACHIX_AUTH_TOKEN` org secret with write access from DM.
- `cargo nextest archive` to build test binaries once and run the 4 partitions from the archive.
- Pinning `DeterminateSystems/*@main` and other `@main` action refs to tagged versions.
- Path filters for docs-only changes — needs a companion "skip" workflow (or `dorny/paths-filter`) so the required `backend`/`dashboard`/`hooks` checks still report green, otherwise docs-only PRs are blocked from merging.
