### PR TITLE
ci: pin DeterminateSystems action refs to versioned tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
@@ -106,14 +106,14 @@ jobs:
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
             fallback = true
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
         continue-on-error: true
 
       - name: Restore Nix source cache
@@ -190,7 +190,7 @@ jobs:
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
@@ -226,7 +226,7 @@ jobs:
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -48,14 +48,14 @@ jobs:
             exit 1
           fi
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
             fallback = true
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
         continue-on-error: true
 
       - name: Connect to Tailscale

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -35,14 +35,14 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
             fallback = true
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
         continue-on-error: true
 
       - name: Connect to Tailscale

--- a/.github/workflows/rekey.yaml
+++ b/.github/workflows/rekey.yaml
@@ -19,14 +19,14 @@ jobs:
         with:
           ref: master
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             accept-flake-config = true
             fallback = true
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
         continue-on-error: true
 
       - name: Setup SSH key


### PR DESCRIPTION
## What

[RAI-894](https://linear.app/makeitrain/issue/RAI-894) — Pins the two `DeterminateSystems` GitHub Actions from floating `@main` refs to specific versioned tags across all CI and deploy workflows.

## Why

Pinning actions to `@main` means a breaking upstream change can silently break CI and waste runs, and it introduces supply-chain drift since the same workflow can resolve to different action code on different days. Pinning to versioned tags makes runs reproducible and removes that drift. Part of [RAI-891](https://linear.app/makeitrain/issue/RAI-891) (reduce CI costs, Phase 2 structural).

## How

Replaces `DeterminateSystems/nix-installer-action@main` with `@v22` and `DeterminateSystems/magic-nix-cache-action@main` with `@v14` in every workflow that references them: `.github/workflows/ci.yaml` (4 `nix-installer-action` + 1 `magic-nix-cache-action` occurrence), `.github/workflows/deploy-prod.yaml`, `.github/workflows/deploy-staging.yaml`, and `.github/workflows/rekey.yaml` (each one `nix-installer-action` + one `magic-nix-cache-action`). No other workflow inputs or configuration changed.

## Testing

No standalone verification in the diff — these are CI workflow edits, so correctness is confirmed by the CI runs on this PR succeeding against the pinned tags. The pinned versions (`nix-installer-action@v22`, `magic-nix-cache-action@v14`) are the current latest stable releases of each action.

## Anything else

CI/deploy behavior change: workflows now run against fixed action versions instead of upstream `main`. Future upgrades become explicit, reviewable bumps. Other `@main`-pinned actions (if any) outside the `DeterminateSystems` set are out of scope for this branch.
