### PR TITLE
ci: build test binaries once via cargo nextest archive

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,17 +84,11 @@ jobs:
           xargs nix path-info -r < "$abi_outputs" >> "$paths_file"
           sort -u "$paths_file" -o "$paths_file"
 
-  backend-validation:
-    name: backend test ${{ matrix.partition }} of 4
+  backend-build:
+    name: backend build
     needs: nix-source-cache
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-
-      matrix:
-        partition: [1, 2, 3, 4]
-
     env:
       CARGO_INCREMENTAL: "0"
       CARGO_TARGET_DIR: target/test
@@ -151,30 +145,103 @@ jobs:
           restore-keys: |
             cargo-${{ runner.os }}-${{ runner.arch }}-test-
 
-      # Each partition builds the full test binaries, so clippy reuses the warm
-      # target/test cache instead of compiling the workspace into a separate
-      # dir. It only needs to run once, so it rides on partition 1.
+      # Build the test binaries once into a nextest archive shared by all four
+      # partitions, and run clippy here since this is the single full compile.
+      - name: Build nextest archive and run clippy
+        run: |
+          nix develop .#ci-backend -c bash -c '
+            set -euxo pipefail
+            cargo nextest archive --workspace --all-features --profile ci \
+              --archive-file "$RUNNER_TEMP/nextest-archive.tar.zst"
+            cargo clippy --workspace --all-targets --all-features
+            # compile_fail_tests (trybuild) shells out to cargo at run time, so
+            # run it here where the workspace build cache is warm. The archive
+            # partitions only carry prebuilt binaries and would compile it cold.
+            cargo nextest run --workspace --all-features --profile ci \
+              -E "test(compile_fail_tests)"
+          '
+
+      - name: Upload nextest archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive
+          path: ${{ runner.temp }}/nextest-archive.tar.zst
+          retention-days: 1
+          if-no-files-found: error
+
+  backend-test:
+    name: backend test ${{ matrix.partition }} of 4
+    needs: backend-build
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+
+      matrix:
+        partition: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Git fetch fail-fast
+        run: |
+          git config --global http.lowSpeedLimit 524288
+          git config --global http.lowSpeedTime 60
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        continue-on-error: true
+
+      - name: Restore Nix source cache
+        id: nix-source-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .tmp/nix-ci-cache
+            .tmp/nix-ci-cache-paths.txt
+          key: nix-source-abi-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', 'flake.nix', 'nix/*.nix') }}
+          fail-on-cache-miss: false
+
+      - name: Import Nix source cache
+        if: steps.nix-source-cache.outputs.cache-hit == 'true'
+        run: |
+          nix copy \
+            --from "file://$GITHUB_WORKSPACE/.tmp/nix-ci-cache" \
+            --no-check-sigs \
+            --stdin < "$GITHUB_WORKSPACE/.tmp/nix-ci-cache-paths.txt"
+
+      - name: Download nextest archive
+        uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
+          path: ${{ runner.temp }}
+
+      # Test binaries come from the archive built in backend-build; no recompile.
       - name: test ${{ matrix.partition }} of 4
         run: |
           nix develop .#ci-backend -c bash -c '
             set -euxo pipefail
-            cargo nextest run --workspace --all-features --profile ci \
+            cargo nextest run --archive-file "$RUNNER_TEMP/nextest-archive.tar.zst" \
+              --workspace-remap . --profile ci \
+              -E "not test(compile_fail_tests)" \
               --partition hash:${{ matrix.partition }}/4
-            if [ "${{ matrix.partition }}" = "1" ]; then
-              cargo clippy --workspace --all-targets --all-features
-            fi
           '
 
   backend:
     name: backend
-    needs: backend-validation
+    needs: [backend-build, backend-test]
     if: always()
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
       - name: Check backend validation
         run: |
-          if [ "${{ needs.backend-validation.result }}" != "success" ]; then
+          if [ "${{ needs.backend-build.result }}" != "success" ] || [ "${{ needs.backend-test.result }}" != "success" ]; then
             echo "backend validation failed"
             exit 1
           fi


### PR DESCRIPTION
## What

[RAI-893](https://linear.app/makeitrain/issue/RAI-893): Split the backend CI job into a single `backend-build` job that compiles the workspace into a `cargo nextest archive` and a downstream `backend-test` job whose four partitions run prebuilt binaries from that archive instead of each recompiling the full workspace.

## Why

Previously every one of the four `backend-validation` matrix partitions built the entire test binary set independently, so the workspace was compiled four times per CI run. Building once and distributing the archive eliminates the redundant compiles, cutting total CI compute and wall time.

## How

In `.github/workflows/ci.yaml`: the old `backend-validation` matrix job is replaced by two jobs. **`backend-build`** runs `cargo nextest archive --workspace --all-features --profile ci` into `$RUNNER_TEMP/nextest-archive.tar.zst`, runs `cargo clippy` here (the single full compile, so the warm cache is reused), and uploads the archive via `actions/upload-artifact@v4` (`retention-days: 1`, `if-no-files-found: error`). `compile_fail_tests` (trybuild) is run in this job too via `-E "test(compile_fail_tests)"` because trybuild shells out to `cargo` at run time and needs the warm workspace build cache — the archive partitions only carry prebuilt binaries and would compile it cold. **`backend-test`** (`needs: backend-build`) keeps the `partition: [1,2,3,4]` matrix, re-does the checkout / nix-installer / magic-nix-cache / Nix source cache restore steps, downloads the archive via `actions/download-artifact@v4`, then runs `cargo nextest run --archive-file ... --workspace-remap . --profile ci -E "not test(compile_fail_tests)" --partition hash:N/4` with no recompile. The aggregate **`backend`** gate now depends on `[backend-build, backend-test]` and checks both results.

## Testing

No unit/integration tests — this is a CI workflow change. Verification is the CI run on this PR itself: backend-build must produce and upload the archive, and all four backend-test partitions must succeed consuming it.

## Anything else

The nextest archive artifact is retained for only 1 day (`retention-days: 1`) since it is consumed within the same run. `backend-test` partitions must repeat the Nix install and source-cache restore because they run on fresh runners that don't share `backend-build`'s environment; only the prebuilt test binaries travel via the artifact.
