### PR TITLE
ci: skip backend CI on docs-only changes via required-check shim

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+# Companion to ci.yaml. Docs/markdown-only pushes are skipped by ci.yaml's
+# `paths-ignore`, but `backend`, `dashboard`, and `hooks` are required status
+# checks on master -- without a reporting workflow those checks stay pending
+# forever and block docs-only PRs from merging. This workflow runs ONLY on
+# docs-only pushes (the inverse `paths:` filter) and reports those three check
+# contexts green. Job names here MUST match the required-check contexts in
+# ci.yaml (`backend`, `dashboard`, `hooks`), and the `paths:` list MUST stay in
+# sync with ci.yaml's `paths-ignore:`.
+#
+# NOTE: a push that touches BOTH docs and code matches both this filter and
+# ci.yaml's, so both workflows run and each emits a `backend`/`dashboard`/`hooks`
+# check. Verify the branch-protection behavior for that mixed case before relying
+# on it (see RAI-895).
+
+on:
+  push:
+    branches-ignore:
+      - 'graphite-base/**'
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'AGENTS.md'
+      - 'README*'
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: backend
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - run: echo "Docs-only change - backend validation not required."
+
+  dashboard:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - run: echo "Docs-only change - dashboard build not required."
+
+  hooks:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - run: echo "Docs-only change - hooks not required."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,15 @@ on:
   push:
     branches-ignore:
       - 'graphite-base/**'
+    # Docs/markdown-only changes skip the real CI. The companion ci-docs.yaml
+    # workflow reports the required backend/dashboard/hooks checks green for
+    # those pushes so docs-only PRs stay mergeable. Keep this list in sync with
+    # the `paths:` filter in ci-docs.yaml.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'AGENTS.md'
+      - 'README*'
 
 concurrency:
   group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || ''}}


### PR DESCRIPTION
## What

[RAI-895](https://linear.app/makeitrain/issue/RAI-895) makes docs/markdown-only pushes skip the real CI matrix while keeping docs-only PRs mergeable. It adds a `paths-ignore` filter to `ci.yaml` and a companion `ci-docs.yaml` workflow that reports the required status checks green for those pushes.

## Why

The expensive `backend`, `dashboard`, and `hooks` jobs in `ci.yaml` don't need to run when a push only touches documentation. But those three are **required status checks** on `master` — if `ci.yaml` simply skips them via `paths-ignore`, the checks never report and stay pending forever, blocking docs-only PRs from ever merging. We need a way to skip the real work without leaving the branch-protection gate stuck.

## How

The mechanism is a **required-check shim**: two workflows with complementary path filters, both named `CI`, that between them always produce the required check contexts. **`ci.yaml`** gains a `paths-ignore:` block (`**/*.md`, `docs/**`, `AGENTS.md`, `README*`) so the real backend/dashboard/hooks jobs do not run on docs-only pushes. **`ci-docs.yaml`** (new) uses the *inverse* `paths:` filter — the exact same glob list — so it runs **only** on docs-only pushes. It defines three trivial jobs (`backend`, `dashboard`, `hooks`) that each just `echo` and exit 0. Because branch protection matches required checks by **context name** (the job name), GitHub sees `backend`/`dashboard`/`hooks` reported green and the PR becomes mergeable — even though no real validation ran. The two path lists are duplicated and **must be kept in sync**: `ci-docs.yaml`'s `paths:` mirrors `ci.yaml`'s `paths-ignore:`, and the job names mirror the required-check contexts; both invariants are documented in the workflow comments. Both workflows share the same `branches-ignore: graphite-base/**` guard.

A known edge case is called out in the `ci-docs.yaml` header comment: a push touching **both** docs and code matches both filters, so both workflows run and each emits `backend`/`dashboard`/`hooks` contexts — the resulting mixed-case branch-protection behavior is flagged for verification under RAI-895 rather than assumed correct.

## Testing

No automated tests — this is CI workflow YAML, which can only be meaningfully exercised by GitHub Actions itself. Correctness depends on the two path filters staying inverse and the shim job names matching the required-check contexts; both are enforced by the in-file comments and observable from real CI runs once merged.

## Anything else

**CI behavior change:** docs-only pushes (`.md`, `docs/`, `AGENTS.md`, `README*`) no longer run the backend/dashboard/hooks matrix; they get instant green shim checks instead. **Follow-up:** verify the mixed docs+code push case behaves correctly under branch protection (noted inline and tracked in RAI-895) — if both workflows reporting the same contexts causes a conflict or a stuck check, the filters may need refining.
