### PR TITLE
fix: correct agenix secret path broken by os.nix restructure

### DIFF
--- a/nix/tailscale.nix
+++ b/nix/tailscale.nix
@@ -40,7 +40,7 @@ in
   };
 
   age.secrets."tailscale-authkey-${environment}" = {
-    file = ./secret/tailscale-authkey-${environment}.age;
+    file = ../secret/tailscale-authkey-${environment}.age;
     mode = "0400";
   };
 


### PR DESCRIPTION
## What

- [RAI-937](https://linear.app/makeitrain/issue/RAI-937/fix-agenix-secret-path-broken-by-osnix-restructure)

Fixes the agenix secret path in `nix/tailscale.nix` so production deploys can evaluate again. The `age.secrets."tailscale-authkey-${environment}"` declaration referenced `./secret/...`, which now resolves to a nonexistent `nix/secret/` directory; this changes it to `../secret/...` so it points at the repo-root `secret/` directory where the encrypted auth keys actually live.

## Why

Every "Deploy to Production" run has been failing at the deploy-rs evaluation step with `error: Path 'nix/secret/tailscale-authkey-prod.age' does not exist in Git repository`. The "Deploy" job never gets past evaluation, so nothing reaches the host. (The `HTTP error 418` / Magic Nix Cache throttling lines in the same logs are unrelated noise.)

The break was introduced by #697 ("chore: restructure os.nix into focused modules"). That PR lifted the `age.secrets` block verbatim out of the repo-root `os.nix` — where `./secret/` correctly resolved to `secret/` — into `nix/tailscale.nix`. Nix path literals resolve relative to the file they appear in, so from `nix/tailscale.nix` the unchanged `./secret/` started pointing at `nix/secret/`, which does not exist. Because the regression landed on master, every production deploy since has failed.

## How

One-line change on `nix/tailscale.nix:43`: `./secret/...` -> `../secret/...`. `../secret/` from the `nix/` directory resolves to the root-level `secret/` directory, matching the sibling module `nix/upgradeable-services.nix:22`, which already uses `../services.nix` for root-level references.

The other deployed secret, `st0x-hedge.toml.age`, is unaffected: it is decrypted by deploy.nix's own `rage` path (via `infra/default.nix`), not through an agenix `file =` path literal, so it never depended on the `nix/`-relative resolution.

## Testing

No automated tests — this is a Nix deployment config path fix not covered by the Rust test suite. Verified by confirming `secret/tailscale-authkey-prod.age` and `secret/tailscale-authkey-staging.age` exist at the repo root (so `../secret/` resolves) and that no other `age.secrets` `file =` literal in the `nix/` modules has the same relative-path defect. End-to-end validation is the next "Deploy to Production" run reaching the activation steps.

## Anything else

Deploy-only change; no application code, schema, or dependency changes. The fix should be merged and a production deploy re-triggered to confirm evaluation now succeeds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783527565&installation_id=125569124&pr_number=761&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F761&signature=b5489b18c8a673b432ad649082d54e6e8c39bcc98433f0873b0962c8f828ee72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file path reference for Tailscale authentication key resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
