### PR TITLE
fix: restart datasette in db-reset path

### DIFF
--- a/infra/default.nix
+++ b/infra/default.nix
@@ -297,6 +297,14 @@ let
               echo "Ensuring st0x-hedge is restarted on ${env}..." >&2
               ssh_remote "mkdir -p /run/st0x && touch /run/st0x/st0x-hedge.ready && systemctl start st0x-hedge" || true
             fi
+            # datasette holds the pre-reset DB inode open; recreating the DB
+            # leaves it serving the deleted file forever. Reopen the live inode
+            # on every exit path, even under --stopped. The marker must be
+            # touched first: datasette's ConditionPathExists gates the start, so
+            # a bare restart with an absent marker silently stops it (exit 0).
+            echo "Restarting datasette on ${env}..." >&2
+            ssh_remote "mkdir -p /run/st0x && touch /run/st0x/datasette.ready && systemctl restart datasette" \
+              || echo "WARNING: datasette restart failed on ${env}; it may still serve the deleted inode" >&2
             _cleanup_identity
           }
           trap _restart_service EXIT


### PR DESCRIPTION
## What

- Make `<env>-db-reset` restart the `datasette` service after recreating the hedge DB, so the read-only `:8081` explorer reopens the live DB file instead of serving a deleted inode.
- [RAI-901](https://linear.app/makeitrain/issue/RAI-901/db-reset-strands-datasette-on-a-deleted-db-inode-stale-endpoint)

## Why

- `db-reset` recreates the DB as a **new inode** (`rm -f` + recreate); the long-running `datasette` process keeps its old fd open and serves the now-**deleted** inode forever — its endpoint freezes at the pre-reset snapshot until someone manually restarts it.
- Hit on prod: datasette's fds pointed at `/mnt/data/st0x-hedge.db (deleted)` and the quant's trade/latency queries were stuck ~5 days behind live, while the bot itself traded normally.
- `db-reset` previously only ever touched `st0x-hedge`, never `datasette`.

## How

- Restart datasette inside the `_restart_service` EXIT trap **unconditionally** (outside the `--stopped` guard), so it reopens the live inode on success, under `--stopped`, and on any early-exit path.
- Touch the unit marker (`/run/st0x/datasette.ready`) before `systemctl restart`: datasette is gated by `ConditionPathExists`, so a bare restart with an absent marker stops the unit and silently skips the start (exit 0). Mirrors the `st0x-hedge` line directly above and the `deploy.nix` activation pattern.
- A restart failure logs a stderr warning rather than being swallowed by `|| true`, without masking the script's exit code or skipping identity cleanup.

## Testing

No automated harness exists for these Nix deploy scripts — they are validated at build time by `writeShellApplication` (shellcheck) plus `nixfmt`/`statix` in CI. Manual verification on the next real reset: confirm datasette's open fds point at the live inode (no `(deleted)`) and a `:8081` fill query matches `sqlite3 /mnt/data/st0x-hedge.db`. Prod was already manually unstuck during diagnosis (`systemctl restart datasette`); this prevents recurrence.

## Anything else

The `st0x-hedge` start in the same trap still uses a silent `|| true` — left as-is since its failure is independently surfaced by the `systemctl is-active` check on the non-trap path. Out of scope here.
