### PR TITLE
chore: set prod cash reserve to 0 in checked-in config

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -72,8 +72,8 @@ vault_id = "0xfab4"
 rebalancing = "enabled"
 # Maximum USDC moved per rebalance operation.
 operational_limit = 1000
-# USD cash kept offchain and unavailable for rebalancing.
-reserved = 25000
+# No cash reserve: all offchain USDC is available for rebalancing.
+# (Omitted because `reserved` is typed Positive<Usd> and rejects 0.)
 
 # Per-equity asset configuration.
 # - trading: whether the bot hedges fills for this asset.


### PR DESCRIPTION
## What

- Remove `reserved = 25000` from the checked-in prod config (`config/prod/st0x-hedge.toml`) so prod holds back **0** USD — all offchain USDC is available for rebalancing.
- [RAI-902](https://linear.app/makeitrain/issue/RAI-902/set-prod-cash-reserve-to-0-in-checked-in-config)

## Why

- A live ops hotfix already set the reserve to 0 on prod, but that edit lives in tmpfs (`/run/st0x/st0x-hedge.config`) and is wiped on each deploy.
- The next deploy reinstalls `config/prod/st0x-hedge.toml`, reverting it to `reserved = 25000`. This change makes the 0 reserve permanent.

## How

- `reserved` is typed `Option<Positive<Usd>>` and the loader intentionally rejects `0`, so "reserve = 0" is expressed by **omitting** the field (`None` → no subtraction → full offchain balance available).
- Drop the field and update the comment to record that the omission is deliberate.
- No type loosening — the `Positive` invariant is left intact.

## Testing

No logic changed. Existing config-validity tests (`server_config_toml_is_valid`, `all_repo_config_tomls_are_valid` in `crates/config/src/loader.rs`) parse the prod config and pass.

## Anything else

Config-only change; no code paths modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit offchain cash reserve value from production configuration and added clarifying notes that no offchain cash reserve is specified due to validation constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->