### PR TITLE
feat: recover post-burn BridgingFailed via resume (un-fail core)

### DIFF
--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -8436,6 +8436,15 @@ mod tests {
         }
     }
 
+    fn make_usdc_bridging_completion_recovered() -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::BridgingCompletionRecovered {
+            mint_tx_hash: TxHash::random(),
+            amount_received: Usdc::new(float!(99.99)),
+            fee_collected: Usdc::new(float!(0.01)),
+            recovered_at: Utc::now(),
+        }
+    }
+
     fn make_usdc_pre_burn_bridging_failed() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::BridgingFailed {
             burn_tx_hash: None,
@@ -8575,23 +8584,77 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bridged_without_initiated_returns_tracking_error() {
+    async fn recovered_post_burn_bridge_holds_guard_then_clears_on_terminal() {
+        // Recovery lifecycle through the reactor: a post-burn
+        // BridgingFailed is un-failed by BridgingCompletionRecovered (non-terminal
+        // -> guard stays held mid-recovery) and the guard clears only on the
+        // terminal BaseToAlpaca ConversionConfirmed, exactly like the normal
+        // bridge path.
+        let inventory = InventoryView::default().with_usdc(usdc(5000), usdc(5000));
+        let (trigger, _receiver) = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // The guard is armed when the rebalance is initiated.
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        // Initiated sets up tracking so the recovery event has bridged-amount
+        // context; the guard stays held (non-terminal).
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(1000)),
+            )
+            .await
+            .unwrap();
+
+        // The recovery event records the bridged amount and must keep the guard
+        // held (it is not a terminal state).
+        harness
+            .receive::<UsdcRebalance>(id.clone(), make_usdc_bridging_completion_recovered())
+            .await
+            .unwrap();
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "BridgingCompletionRecovered is non-terminal and must hold the guard mid-recovery"
+        );
+
+        // The terminal conversion clears the guard through the normal path.
+        harness
+            .receive::<UsdcRebalance>(
+                id,
+                make_usdc_conversion_confirmed(RebalanceDirection::BaseToAlpaca, usdc(999)),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "terminal ConversionConfirmed must clear the guard after recovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridged_without_initiated_is_tolerated_and_holds_guard() {
+        // A Bridged event with no in-memory tracking is the post-restart-recovery
+        // shape: the guard was reasserted on startup but `usdc_tracking` was not
+        // rebuilt. `track_bridged_amount` warns and returns Ok (consistent with
+        // the other completion helpers) instead of wedging the reactor, and the
+        // non-terminal event leaves the (pre-armed) in-progress guard held.
         let (trigger, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
         let harness = ReactorHarness::new(Arc::clone(&trigger));
         let id = UsdcRebalanceId(Uuid::new_v4());
 
-        let error = harness
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        harness
             .receive::<UsdcRebalance>(id.clone(), make_usdc_bridged())
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(matches!(
-            error,
-            RebalancingServiceError::MissingUsdcTrackingContext {
-                id: error_id,
-                event: usdc::UsdcTrackingEvent::Bridged,
-            } if error_id == id
-        ));
+        assert!(
+            trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "a tolerated non-terminal Bridged event must not clear the guard"
+        );
     }
 
     #[tokio::test]
@@ -9978,6 +10041,11 @@ mod tests {
         ));
         assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
             &make_usdc_bridged()
+        ));
+        // A recovered post-burn bridge re-enters the Bridged stage and must stay
+        // non-terminal so the guard holds until the terminal deposit leg.
+        assert!(!RebalancingService::is_terminal_usdc_rebalance_event(
+            &make_usdc_bridging_completion_recovered()
         ));
     }
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -28,7 +28,6 @@ pub(super) enum UsdcRebalanceOperation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum UsdcTrackingEvent {
     Initiated,
-    Bridged,
     DepositConfirmed,
     ConversionConfirmed,
 }
@@ -37,7 +36,6 @@ impl std::fmt::Display for UsdcTrackingEvent {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Initiated => write!(formatter, "Initiated"),
-            Self::Bridged => write!(formatter, "Bridged"),
             Self::DepositConfirmed => write!(formatter, "DepositConfirmed"),
             Self::ConversionConfirmed => write!(formatter, "ConversionConfirmed"),
         }
@@ -160,7 +158,7 @@ impl UsdcRebalanceStage {
             WithdrawalConfirmed { .. } => Some(Self::WithdrawalConfirmed),
             BridgingInitiated { .. } => Some(Self::BridgingInitiated),
             BridgeAttestationReceived { .. } => Some(Self::BridgeAttestationReceived),
-            Bridged { .. } => Some(Self::Bridged),
+            Bridged { .. } | BridgingCompletionRecovered { .. } => Some(Self::Bridged),
             DepositInitiated { .. } => Some(Self::DepositInitiated),
             DepositConfirmed { .. } => Some(Self::DepositConfirmed),
             // Transient intent markers: immediately superseded by Initiated /
@@ -195,6 +193,9 @@ impl UsdcRebalanceStage {
                 Some(*attested_at)
             }
             (Self::Bridged, Bridged { minted_at, .. }) => Some(*minted_at),
+            (Self::Bridged, BridgingCompletionRecovered { recovered_at, .. }) => {
+                Some(*recovered_at)
+            }
             (
                 Self::DepositInitiated,
                 DepositInitiated {
@@ -670,7 +671,16 @@ impl RebalancingService {
             }
             Bridged {
                 amount_received, ..
+            }
+            | BridgingCompletionRecovered {
+                amount_received, ..
             } => {
+                // `BridgingCompletionRecovered` un-fails a post-burn
+                // `BridgingFailed` back to `Bridged`: the mint is now confirmed,
+                // so record the bridged amount and advance stage progress just
+                // as a first-time `Bridged` would. The in-progress guard stays
+                // held (recovery is mid-flight) and clears on the terminal
+                // deposit, exactly like the normal bridge path.
                 self.track_bridged_amount(id, *amount_received).await?;
                 self.track_usdc_stage_progress(id, event).await;
             }
@@ -865,11 +875,14 @@ impl RebalancingService {
     ) -> Result<(), RebalancingServiceError> {
         let mut tracking = self.usdc_tracking.write().await;
         let Some(existing) = tracking.get_mut(id) else {
-            warn!(target: "rebalance", id = %id, "Bridged event missing USDC tracking context");
-            return Err(RebalancingServiceError::MissingUsdcTrackingContext {
-                id: id.clone(),
-                event: UsdcTrackingEvent::Bridged,
-            });
+            // Resumed after a restart with no rebuilt tracking (e.g. a post-burn
+            // BridgingFailed recovered via RecoverBridging): there is no in-memory
+            // bridged amount to record, and the terminal success event clears the
+            // guard without reconciliation. Warn and return Ok -- consistent with
+            // complete_usdc_rebalance / complete_alpaca_to_base_deposit -- rather
+            // than wedging the reactor on a MissingUsdcTrackingContext error.
+            warn!(target: "rebalance", id = %id, "Bridged event missing USDC tracking context; skipping bridged-amount tracking (resumed after restart)");
+            return Ok(());
         };
 
         existing.bridged_amount_received = Some(amount_received);

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1495,13 +1495,108 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 Ok(())
             }
 
+            // A post-burn BridgingFailed is recoverable: the CCTP burn consumed
+            // the source USDC and the mint may have landed (e.g. a transient
+            // receipt error failed the bridge while receiveMessage succeeded).
+            // Re-check on-chain, un-fail to Bridged, and finish the deposit.
+            Some(UsdcRebalance::BridgingFailed {
+                direction,
+                burn_tx_hash,
+                ..
+            }) => {
+                Self::require_base_to_alpaca(id, &direction)?;
+                self.recover_from_bridging_failed(id, burn_tx_hash).await
+            }
+
             Some(
                 UsdcRebalance::WithdrawalFailed { .. }
-                | UsdcRebalance::BridgingFailed { .. }
                 | UsdcRebalance::DepositFailed { .. }
                 | UsdcRebalance::ConversionFailed { .. },
             ) => Err(UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() }),
         }
+    }
+
+    /// Recover a post-burn `BridgingFailed` whose CCTP mint may have landed:
+    /// re-poll the attestation, idempotently mint (a consumed nonce returns the
+    /// existing receipt rather than re-minting), un-fail to `Bridged` via
+    /// `RecoverBridging`, then drive the deposit leg to terminal so the
+    /// in-progress guard clears through the normal path. A pre-burn failure (no
+    /// burn tx) has no mint to adopt and is left for manual reconciliation.
+    ///
+    /// BaseToAlpaca only (mint lands on Ethereum); an `AlpacaToBase`
+    /// `BridgingFailed` is still surfaced for manual reconciliation.
+    async fn recover_from_bridging_failed(
+        &self,
+        id: &UsdcRebalanceId,
+        burn_tx_hash: Option<TxHash>,
+    ) -> Result<(), UsdcTransferError> {
+        let Some(burn_tx_hash) = burn_tx_hash else {
+            warn!(
+                target: "rebalance",
+                %id,
+                "Pre-burn BridgingFailed has no mint to recover; leaving for \
+                 manual reconciliation"
+            );
+            return Err(UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() });
+        };
+
+        info!(
+            target: "rebalance",
+            %id,
+            %burn_tx_hash,
+            "Recovering post-burn BridgingFailed: re-checking the CCTP mint on-chain"
+        );
+
+        // Poll the bridge directly (not `poll_cctp_attestation`, which fails the
+        // bridge on error) because the aggregate is already terminally failed --
+        // a transient poll/mint error must leave it recoverable for the next
+        // redrive, not re-fail it.
+        let attestation = match self
+            .cctp_bridge
+            .poll_attestation(BridgeDirection::BaseToEthereum, burn_tx_hash)
+            .await
+        {
+            Ok(attestation) => attestation,
+            // Circle has not signed yet. Surface the dedicated timeout error so
+            // the job reschedules on the attestation redrive cadence rather than
+            // the generic backoff, mirroring `poll_cctp_attestation` -- without
+            // failing the (already-terminal) aggregate.
+            Err(CctpError::AttestationTimeout { attempts, source }) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    attempts,
+                    ?source,
+                    "Attestation not yet available during bridge recovery; rescheduling redrive"
+                );
+                return Err(UsdcTransferError::AttestationTimedOut { id: id.clone() });
+            }
+            Err(error) => return Err(UsdcTransferError::Cctp(Box::new(error))),
+        };
+
+        // Idempotent: if the nonce was already consumed, `mint` returns the
+        // existing receipt via `recover_already_minted` instead of re-minting.
+        let mint_receipt = self
+            .cctp_bridge
+            .mint(BridgeDirection::BaseToEthereum, &attestation)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
+        let amount_received = u256_to_usdc(mint_receipt.amount)?;
+
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::RecoverBridging {
+                    mint_tx: mint_receipt.tx,
+                    amount_received,
+                    fee_collected: u256_to_usdc(mint_receipt.fee)?,
+                },
+            )
+            .await?;
+
+        self.continue_from_bridged(id, amount_received, mint_receipt.tx)
+            .await
     }
 
     fn require_base_to_alpaca(
@@ -2076,10 +2171,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         //   returns `MintAndWithdrawEventNotFound` with no `usedNonces()` probe,
         //   and there the nonce may already be consumed.
         //
-        // No path is auto-recovered today: a mint that lands (or already landed)
-        // but is unconfirmed here stays a terminal `BridgingFailed` for manual
-        // operator reconciliation. Do not re-probe -- a synchronous re-check
-        // cannot observe a mint that confirms after this decision.
+        // Do not re-probe synchronously here -- a re-check cannot observe a mint
+        // that confirms after this decision, and recovery is deferred, not lost:
+        // a post-burn `BridgingFailed` (carries `burn_tx_hash`) is later un-failed
+        // by `recover_from_bridging_failed` on a resume/redrive, which re-polls the
+        // attestation, idempotently adopts the landed mint, and drives the deposit
+        // leg to terminal. That resume is operator-triggered today (CLI/apalis
+        // redrive); a pre-burn failure has no mint to adopt and stays terminal.
         let mint_receipt = match self
             .cctp_bridge
             .mint(BridgeDirection::BaseToEthereum, &attestation_response)
@@ -4696,21 +4794,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_base_to_alpaca_from_terminal_failure_returns_previously_failed_error() {
+    async fn resume_base_to_alpaca_from_pre_burn_failure_returns_previously_failed_error() {
         let server = MockServer::start();
         let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc("100");
 
-        let burn_tx =
+        let withdraw_tx =
             fixed_bytes!("0xcccc000000000000000000000000000000000000000000000000000000000002");
         cqrs.send(
             &id,
             UsdcRebalanceCommand::Initiate {
                 direction: RebalanceDirection::BaseToAlpaca,
                 amount,
-                withdrawal: TransferRef::OnchainTx(burn_tx),
+                withdrawal: TransferRef::OnchainTx(withdraw_tx),
             },
         )
         .await
@@ -4718,9 +4816,11 @@ mod tests {
         cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
             .await
             .unwrap();
-        cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
-            .await
-            .unwrap();
+        // Fail BEFORE the burn (no `InitiateBridging`), so the resulting
+        // `BridgingFailed` carries `burn_tx_hash: None`. A pre-burn failure has
+        // no mint to adopt, so resume must still reject it as terminal -- it is
+        // NOT recoverable. (A post-burn `BridgingFailed` IS now recovered, see
+        // `resume_base_to_alpaca_from_bridging_failed_recovers_to_terminal`.)
         cqrs.send(
             &id,
             UsdcRebalanceCommand::FailBridging {
@@ -5532,6 +5632,172 @@ mod tests {
         assert!(
             matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
             "Expected ConversionComplete after adopting the existing mint on resume, \
+             got: {final_state:?}"
+        );
+    }
+
+    /// The un-fail core: a post-burn `BridgingFailed` whose mint actually landed
+    /// is un-failed and driven to terminal on resume. We mint for real, then fail
+    /// the aggregate post-burn, then resume. `recover_from_bridging_failed`
+    /// re-polls, mints idempotently (the consumed nonce returns the existing
+    /// receipt rather than reverting), emits `RecoverBridging`, and finishes the
+    /// deposit leg. Reaching `ConversionComplete` proves the un-fail + adoption +
+    /// terminal drive all happened -- a re-mint would revert on the used nonce and
+    /// re-latch `BridgingFailed`.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridging_failed_recovers_to_terminal() {
+        let chains = deploy_dual_chain_cctp().await;
+
+        let attestation = CctpAttestationMock::start().await;
+        let _watcher = attestation
+            .start_watcher(
+                ProviderBuilder::new()
+                    .connect(&chains.ethereum_endpoint)
+                    .await
+                    .unwrap(),
+                ProviderBuilder::new()
+                    .connect(&chains.base_endpoint)
+                    .await
+                    .unwrap(),
+                chains.attester_key,
+            )
+            .await
+            .unwrap();
+
+        let cctp_bridge = Arc::new(
+            CctpBridge::try_from_ctx(CctpCtx {
+                usdc_ethereum: USDC_ADDRESS,
+                usdc_base: USDC_ADDRESS,
+                ethereum_wallet: create_test_wallet(&chains.ethereum_endpoint, &chains.bot_key),
+                base_wallet: create_test_wallet(&chains.base_endpoint, &chains.bot_key),
+                circle_api_base: attestation.base_url(),
+                token_messenger: chains.token_messenger,
+                message_transmitter: chains.message_transmitter,
+            })
+            .unwrap(),
+        );
+
+        // Produce a real on-chain mint so the nonce is already consumed before
+        // recovery runs -- recovery must adopt it, not re-mint.
+        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        let amount = usdc("100");
+        let amount_u256 = usdc_to_u256(amount).unwrap();
+        let burn_receipt = cctp_bridge
+            .burn(
+                BridgeDirection::BaseToEthereum,
+                amount_u256,
+                market_maker_wallet,
+            )
+            .await
+            .unwrap();
+        let attestation_response = cctp_bridge
+            .poll_attestation(BridgeDirection::BaseToEthereum, burn_receipt.tx)
+            .await
+            .unwrap();
+        let mint_receipt = cctp_bridge
+            .mint(BridgeDirection::BaseToEthereum, &attestation_response)
+            .await
+            .unwrap();
+
+        let server = MockServer::start();
+        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let pool = crate::test_utils::setup_test_db().await;
+        let (_vault_registry_store, vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool)
+                .build(())
+                .await
+                .unwrap();
+        let vault_service = RaindexService::new(
+            create_test_wallet(&chains.base_endpoint, &chains.bot_key),
+            ORDERBOOK_ADDRESS,
+            vault_registry_projection,
+            chains.bot_address,
+        );
+        let cqrs = create_test_store_instance().await;
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::clone(&cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
+        );
+
+        // Drive to a POST-burn BridgingFailed: InitiateBridging records the burn
+        // tx, then FailBridging preserves it (a transient receipt error failing
+        // the bridge while the mint had in fact landed -- the incident this
+        // recovery path exists to repair).
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_receipt.tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateBridging {
+                burn_tx: burn_receipt.tx,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::FailBridging {
+                reason: "transient receipt error while the mint actually landed".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Downstream Alpaca legs after the un-fail: deposit detection (by the
+        // adopted mint tx) then the USDC->USD conversion.
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{:#x}", mint_receipt.tx),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "100");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "100",
+        );
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
+            "Expected ConversionComplete after recovering a post-burn BridgingFailed, \
              got: {final_state:?}"
         );
     }

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -33,7 +33,8 @@
 //!
 //! Terminal states:
 //! - WithdrawalFailed
-//! - BridgingFailed
+//! - BridgingFailed (terminal EXCEPT a post-burn failure carrying a burn tx,
+//!   which RecoverBridging un-fails back to Bridged once the mint is confirmed)
 //! - DepositFailed
 //! - DepositConfirmed for AlpacaToBase
 //! - ConversionConfirmed for BaseToAlpaca
@@ -64,7 +65,10 @@
 //! - `BridgingFailed`: Preserves `burn_tx_hash` and `cctp_nonce` when available
 //! - `DepositFailed`: Preserves `deposit_ref` for tracking the failed deposit
 //!
-//! Terminal states reject all commands to prevent invalid state transitions.
+//! Terminal states reject all commands to prevent invalid state transitions,
+//! with one exception: a post-burn `BridgingFailed` (carrying a burn tx) accepts
+//! `RecoverBridging`, which un-fails it back to `Bridged` once the mint that
+//! actually landed is confirmed on-chain.
 //!
 //! [`AlpacaWalletService`]: crate::alpaca_wallet::AlpacaWalletService
 
@@ -267,6 +271,17 @@ pub(crate) enum UsdcRebalanceCommand {
     FailWithdrawal { reason: String },
     /// Record bridging failure. Valid from `Bridging` or `Attested` states.
     FailBridging { reason: String },
+    /// Recover a post-burn `BridgingFailed` whose CCTP mint actually landed
+    /// on-chain (a transient receipt error failed the bridge while the
+    /// `receiveMessage` in fact succeeded). Transitions back to `Bridged` so the
+    /// deposit leg completes and the in-progress guard clears via the normal
+    /// terminal path. Valid ONLY from a `BridgingFailed` carrying a burn tx
+    /// (post-burn). Driven by a resume/recheck of the failed transfer.
+    RecoverBridging {
+        mint_tx: TxHash,
+        amount_received: Usdc,
+        fee_collected: Usdc,
+    },
     /// Record deposit failure. Valid only from `DepositInitiated` state.
     FailDeposit { reason: String },
 }
@@ -377,6 +392,15 @@ pub(crate) enum UsdcRebalanceEvent {
         reason: String,
         failed_at: DateTime<Utc>,
     },
+    /// A post-burn `BridgingFailed` whose CCTP mint was confirmed on-chain after
+    /// the fact. Un-fails the aggregate back to `Bridged` so the deposit leg can
+    /// finish. Mirrors equities' `ProviderCompletionRecovered`.
+    BridgingCompletionRecovered {
+        mint_tx_hash: TxHash,
+        amount_received: Usdc,
+        fee_collected: Usdc,
+        recovered_at: DateTime<Utc>,
+    },
     /// Deposit to destination initiated.
     DepositInitiated {
         deposit_ref: TransferRef,
@@ -414,6 +438,9 @@ impl DomainEvent for UsdcRebalanceEvent {
             Self::AttestationTimedOut { .. } => "UsdcRebalanceEvent::AttestationTimedOut",
             Self::Bridged { .. } => "UsdcRebalanceEvent::Bridged",
             Self::BridgingFailed { .. } => "UsdcRebalanceEvent::BridgingFailed",
+            Self::BridgingCompletionRecovered { .. } => {
+                "UsdcRebalanceEvent::BridgingCompletionRecovered"
+            }
             Self::DepositInitiated { .. } => "UsdcRebalanceEvent::DepositInitiated",
             Self::DepositConfirmed { .. } => "UsdcRebalanceEvent::DepositConfirmed",
             Self::DepositFailed { .. } => "UsdcRebalanceEvent::DepositFailed",
@@ -977,6 +1004,7 @@ pub(crate) async fn interrupted_usdc_rebalance_ids(
                'UsdcRebalanceEvent::AttestationTimedOut', \
                'UsdcRebalanceEvent::Bridged', \
                'UsdcRebalanceEvent::BridgingFailed', \
+               'UsdcRebalanceEvent::BridgingCompletionRecovered', \
                'UsdcRebalanceEvent::DepositInitiated', \
                'UsdcRebalanceEvent::DepositConfirmed', \
                'UsdcRebalanceEvent::DepositFailed' \
@@ -1335,6 +1363,35 @@ impl EventSourced for UsdcRebalance {
                 minted_at: *minted_at,
             },
 
+            // Un-fail a post-burn `BridgingFailed` whose mint landed on-chain.
+            // Only matches when the failed state carries a burn tx (post-burn);
+            // a pre-burn `BridgingFailed` (burn_tx_hash None) has no mint to
+            // adopt and falls through to an invalid transition.
+            (
+                BridgingCompletionRecovered {
+                    mint_tx_hash,
+                    amount_received,
+                    fee_collected,
+                    recovered_at,
+                },
+                Self::BridgingFailed {
+                    direction,
+                    amount,
+                    burn_tx_hash: Some(burn_tx_hash),
+                    initiated_at,
+                    ..
+                },
+            ) => Self::Bridged {
+                direction: direction.clone(),
+                amount: *amount,
+                amount_received: *amount_received,
+                fee_collected: *fee_collected,
+                burn_tx_hash: *burn_tx_hash,
+                mint_tx_hash: *mint_tx_hash,
+                initiated_at: *initiated_at,
+                minted_at: *recovered_at,
+            },
+
             (
                 BridgingFailed {
                     burn_tx_hash,
@@ -1535,6 +1592,8 @@ impl EventSourced for UsdcRebalance {
 
             ConfirmBridging { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
 
+            RecoverBridging { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
+
             InitiateDeposit { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
 
             ConfirmDeposit | FailDeposit { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
@@ -1590,6 +1649,11 @@ impl EventSourced for UsdcRebalance {
                 fee_collected,
             } => self.transition_confirm_bridging(mint_tx, amount_received, fee_collected),
             FailBridging { reason } => self.transition_fail_bridging(reason),
+            RecoverBridging {
+                mint_tx,
+                amount_received,
+                fee_collected,
+            } => self.transition_recover_bridging(mint_tx, amount_received, fee_collected),
             InitiateDeposit { deposit } => self.transition_initiate_deposit(deposit),
             ConfirmDeposit => self.transition_confirm_deposit(),
             FailDeposit { reason } => self.transition_fail_deposit(reason),
@@ -2025,6 +2089,44 @@ impl UsdcRebalance {
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
             | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+        }
+    }
+
+    /// Un-fail a post-burn `BridgingFailed` whose CCTP mint is confirmed
+    /// on-chain, transitioning back to `Bridged` so the deposit leg completes.
+    /// Valid only from a `BridgingFailed` carrying a burn tx: a pre-burn failure
+    /// has no mint to adopt and must be re-initiated rather than recovered.
+    fn transition_recover_bridging(
+        &self,
+        mint_tx: TxHash,
+        amount_received: Usdc,
+        fee_collected: Usdc,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        use UsdcRebalanceEvent::*;
+        match self {
+            Self::BridgingFailed {
+                burn_tx_hash: Some(_),
+                ..
+            } => Ok(vec![BridgingCompletionRecovered {
+                mint_tx_hash: mint_tx,
+                amount_received,
+                fee_collected,
+                recovered_at: Utc::now(),
+            }]),
+            Self::BridgingFailed {
+                burn_tx_hash: None, ..
+            } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "RecoverBridging".to_string(),
+                state: "BridgingFailed (pre-burn: no mint to recover)".to_string(),
+            }),
+            // Recovery only makes sense for a terminally-failed post-burn
+            // bridge; from any other state there is nothing to un-fail.
+            _ => Err(UsdcRebalanceError::InvalidCommand {
+                command: "RecoverBridging".to_string(),
+                state: "non-failed (RecoverBridging is only valid from a \
+                        post-burn BridgingFailed)"
+                    .to_string(),
+            }),
         }
     }
 
@@ -4522,6 +4624,170 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recover_bridging_unfails_post_burn_failed_to_bridged() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let nonce =
+            fixed_bytes!("0x00000000000000000000000000000000000000000000000000000000000000aa");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        // A post-burn BridgingFailed (carries a burn tx) whose mint in fact
+        // landed: RecoverBridging un-fails it back to Bridged.
+        let history = vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: burn_tx,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingFailed {
+                burn_tx_hash: Some(burn_tx),
+                cctp_nonce: Some(nonce),
+                reason: "dropped from mempool".to_string(),
+                failed_at: Utc::now(),
+            },
+        ];
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(history.clone())
+            .when(UsdcRebalanceCommand::RecoverBridging {
+                mint_tx,
+                amount_received: Usdc::new(float!(99.99)),
+                fee_collected: Usdc::new(float!(0.01)),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingCompletionRecovered {
+            mint_tx_hash,
+            amount_received,
+            fee_collected,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BridgingCompletionRecovered, got {:?}", events[0]);
+        };
+        assert_eq!(*mint_tx_hash, mint_tx);
+        assert_eq!(*amount_received, Usdc::new(float!(99.99)));
+        assert_eq!(*fee_collected, Usdc::new(float!(0.01)));
+
+        // Applying the event must un-fail the aggregate back to Bridged with the
+        // recovered mint adopted -- the apply arm, not just the command handler.
+        let state = replay::<UsdcRebalance>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize aggregate state");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Bridged {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    burn_tx_hash: state_burn_tx,
+                    mint_tx_hash: state_mint_tx,
+                    amount_received: state_received,
+                    fee_collected: state_fee,
+                    ..
+                } if state_burn_tx == burn_tx
+                    && state_mint_tx == mint_tx
+                    && state_received == Usdc::new(float!(99.99))
+                    && state_fee == Usdc::new(float!(0.01))
+            ),
+            "recovered aggregate should be Bridged with the adopted mint, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_bridging_rejects_pre_burn_failed() {
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        // A pre-burn BridgingFailed (no burn tx) has no mint to adopt; recovery
+        // must be rejected -- the transfer should be re-initiated, not un-failed.
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(100.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingFailed {
+                    burn_tx_hash: None,
+                    cctp_nonce: None,
+                    reason: "pre-burn failure".to_string(),
+                    failed_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::RecoverBridging {
+                mint_tx,
+                amount_received: Usdc::new(float!(99.99)),
+                fee_collected: Usdc::new(float!(0.01)),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn recover_bridging_rejects_non_failed_state() {
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        // RecoverBridging is only valid from a post-burn BridgingFailed. From a
+        // non-failed state (here mid-bridge, after the burn) it must be rejected
+        // as an invalid command, never silently adopting a second mint.
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(100.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    )),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: fixed_bytes!(
+                        "0x0000000000000000000000000000000000000000000000000000000000000001"
+                    ),
+                    burned_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::RecoverBridging {
+                mint_tx,
+                amount_received: Usdc::new(float!(99.99)),
+                fee_collected: Usdc::new(float!(0.01)),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
     async fn test_deposit_failed_rejects_confirm_deposit() {
         let burn_tx =
             fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
@@ -6087,6 +6353,55 @@ mod tests {
             .await
             .unwrap();
 
+        // Recovered post-burn bridge (latest event BridgingCompletionRecovered,
+        // state Bridged) -- mid-flight after un-fail, holds the guard, must be
+        // included so a crash before the deposit leg reasserts usdc_in_progress.
+        let recovered = UsdcRebalanceId(Uuid::new_v4());
+        store
+            .send(
+                &recovered,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount,
+                    withdrawal: TransferRef::OnchainTx(BURN_TX),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&recovered, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(
+                &recovered,
+                UsdcRebalanceCommand::InitiateBridging { burn_tx: BURN_TX },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &recovered,
+                UsdcRebalanceCommand::FailBridging {
+                    reason: "transient receipt error".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &recovered,
+                UsdcRebalanceCommand::RecoverBridging {
+                    mint_tx: fixed_bytes!(
+                        "0x2222222222222222222222222222222222222222222222222222222222222222"
+                    ),
+                    amount_received: Usdc::new(float!(399.99)),
+                    fee_collected: Usdc::new(float!(0.01)),
+                },
+            )
+            .await
+            .unwrap();
+
         // In-progress (mid-withdrawal) -- must be included.
         let withdrawing = UsdcRebalanceId(Uuid::new_v4());
         store
@@ -6106,7 +6421,7 @@ mod tests {
 
         assert_eq!(
             got,
-            HashSet::from([bridge_failed, awaiting_attestation, withdrawing])
+            HashSet::from([bridge_failed, awaiting_attestation, recovered, withdrawing])
         );
         assert!(
             interrupted.unparseable.is_empty(),


### PR DESCRIPTION
## What

- Makes a **post-burn `BridgingFailed` recoverable**: re-check the CCTP mint on-chain, un-fail the aggregate back to `Bridged`, and finish the deposit leg so the `usdc_in_progress` guard clears through the normal terminal path.
- This is the shared "un-fail core" the epic's recovery work (RAI-906 worker, future recheck endpoint) builds on.

## Why

- [RAI-909](https://linear.app/makeitrain/issue/RAI-909): a terminal post-burn `BridgingFailed` (the RAI-903 incident — a CCTP mint falsely reported dropped while it actually landed) is a dead end.
- RAI-836's startup re-arm covers only the non-terminal post-burn states (`Bridging`/`AwaitingAttestation`/`Attested`); a `BridgingFailed` is rejected by resume with `PreviouslyFailedAggregate`, so the burned USDC stays stranded and the guard stays latched.
- Recoverable today through **existing** resume entrypoints — RAI-835's `resume-usdc-transfer` CLI and RAI-836's apalis re-arm — so no new operator surface is required to recover `bd5cb533`.

## How

- **Aggregate (`src/usdc_rebalance.rs`)**: new `UsdcRebalanceCommand::RecoverBridging` + `UsdcRebalanceEvent::BridgingCompletionRecovered`, with an `evolve` arm `BridgingFailed { burn_tx_hash: Some(_) } -> Bridged` (mirrors equities' `ProviderCompletionRecovered`). `transition_recover_bridging` accepts the command only from a post-burn `BridgingFailed`; a pre-burn failure (no burn tx) is rejected — there is no mint to adopt.
- **Manager (`src/rebalancing/usdc/manager.rs`)**: `resume_base_to_alpaca` routes a `BridgingFailed` to `recover_from_bridging_failed`, which re-polls the attestation, idempotently mints (a consumed nonce returns the existing receipt via `recover_already_minted` — RAI-905), emits `RecoverBridging`, then drives `continue_from_bridged` to terminal. It polls the bridge directly (not `poll_cctp_attestation`, which fails the bridge on error) so a transient error leaves the aggregate recoverable for the next redrive instead of re-failing it.
- **Trigger (`src/rebalancing/trigger/usdc.rs`)**: `BridgingCompletionRecovered` is treated as the `Bridged` stage — guard stays held mid-recovery and clears on the terminal deposit, exactly like the normal bridge path (RAI-907).

## Testing

`cargo nextest run -p st0x-hedge recover_bridging` — both green:
- `recover_bridging_unfails_post_burn_failed_to_bridged`
- `recover_bridging_rejects_pre_burn_failed`

`cargo check -p st0x-hedge` clean; `cargo fmt` clean.

## Anything else

- **BaseToAlpaca only** (the incident direction; mint lands on Ethereum). An `AlpacaToBase` `BridgingFailed` is still surfaced for manual reconciliation — follow-up.
- Explicit `recheck-transfer --type usdc` endpoint + CLI flag + dashboard surfacing remain a thin follow-up on top of this core.
- Automatic inventory-poll recovery worker is RAI-906 (builds on this core).
