### PR TITLE
test: e2e post-burn BridgingFailed recovery to terminal

### DIFF
--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -5761,6 +5761,13 @@ mod tests {
         .await
         .unwrap();
 
+        // Sanity: the aggregate is terminally failed before recovery.
+        let failed_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(failed_state, UsdcRebalance::BridgingFailed { .. }),
+            "expected BridgingFailed before recovery, got: {failed_state:?}"
+        );
+
         // Downstream Alpaca legs after the un-fail: deposit detection (by the
         // adopted mint tx) then the USDC->USD conversion.
         let _transfers_mock = server.mock(|when, then| {
@@ -5792,6 +5799,7 @@ mod tests {
             "100",
         );
 
+        // Resume the terminally-failed transfer: it must recover, not stay failed.
         manager.resume_base_to_alpaca(&id, amount).await.unwrap();
 
         let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");


### PR DESCRIPTION
## What

- Dual-chain CCTP integration test `resume_base_to_alpaca_from_bridging_failed_recovers_to_terminal` (`src/rebalancing/usdc/manager.rs`) proving the recovery path end-to-end.
- It burns + mints a real CCTP transfer on dual anvil chains (mint genuinely lands — the incident), drives the aggregate to a post-burn `BridgingFailed` via `Initiate -> ConfirmWithdrawal -> InitiateBridging -> FailBridging` (reason `"dropped from mempool (not found after 4s)"`), then calls `resume_base_to_alpaca` and asserts it reaches `ConversionComplete`.

## Why

- [RAI-908](https://linear.app/makeitrain/issue/RAI-908): the RAI-903 epic needs an end-to-end test proving the full recovery path — a transfer that falsely failed after the CCTP burn (mint landed, transient receipt error latched `BridgingFailed`) is recovered and driven to terminal.
- Per-issue unit tests already cover the pieces (904 receipt debounce, 905 idempotency, 909 un-fail transition, 906 re-arm classifier); this wires them together.

## How

- Mirrors the existing `resume_base_to_alpaca_from_attested_adopts_existing_mint` harness (real `CctpBridge` over `deploy_dual_chain_cctp`, Alpaca mocked), exercising the production resume path against real on-chain CCTP state rather than a mock.
- The test asserts the aggregate reaches `ConversionComplete`, which proves the recovery chain: re-poll attestation -> idempotent mint adopts the already-used nonce (`recover_already_minted`) -> `RecoverBridging` un-fails to `Bridged` -> deposit + USDC->USD conversion to terminal. `ConversionComplete` is a clearable-terminal state, so the `usdc_in_progress` guard would release on this path (the test asserts the terminal state, not the guard flag directly).

## Testing

`cargo nextest run -p st0x-hedge resume_base_to_alpaca_from_bridging_failed_recovers_to_terminal` — green (6.9s). Runs under the `ci-backend` foundry shell in CI.
