### PR TITLE
fix: bound log retention to 14 daily files to prevent disk fill

### DIFF
--- a/crates/config/src/telemetry.rs
+++ b/crates/config/src/telemetry.rs
@@ -70,10 +70,30 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::time::Duration;
 use thiserror::Error;
+use tracing_appender::rolling::{InitError, RollingFileAppender, Rotation};
 use tracing_subscriber::layer::{Layer, SubscriberExt};
 use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::LogLevel;
+
+/// Number of daily log files the rolling appender retains. Older files are
+/// pruned automatically as new ones roll, bounding on-disk log growth so a
+/// long-running deployment cannot fill the disk (root cause of the 2026-06-08
+/// SQLITE_FULL incident).
+const LOG_RETENTION_DAYS: usize = 14;
+
+/// Build the daily-rolling file appender used by every file-logging path.
+///
+/// Unlike `tracing_appender::rolling::daily`, the builder form bounds history
+/// via [`LOG_RETENTION_DAYS`] and surfaces directory/file creation failures as
+/// [`InitError`] rather than panicking.
+fn build_log_file_appender(dir: &str) -> Result<RollingFileAppender, InitError> {
+    RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("st0x-hedge.log")
+        .max_log_files(LOG_RETENTION_DAYS)
+        .build(dir)
+}
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -167,8 +187,18 @@ impl TelemetryCtx {
         let fmt_layer = tracing_subscriber::fmt::layer().with_filter(mk_env_filter(log_level));
         let telemetry_layer = telemetry_layer.with_filter(mk_telemetry_filter(log_level));
 
-        let file_guard = if let Some(dir) = log_dir {
-            let file_appender = tracing_appender::rolling::daily(dir, "st0x-hedge.log");
+        let file_appender = log_dir.and_then(|dir| match build_log_file_appender(dir) {
+            Ok(appender) => Some(appender),
+            Err(error) => {
+                // A misconfigured log directory must not take HyperDX export
+                // down with it: keep the OTLP layer alive and continue without
+                // file logging rather than failing the whole telemetry setup.
+                eprintln!("Failed to build rolling file appender, continuing without file logging: {error}");
+                None
+            }
+        });
+
+        let file_guard = if let Some(file_appender) = file_appender {
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
             let file_layer = tracing_subscriber::fmt::layer()
@@ -285,42 +315,61 @@ pub fn setup_tracing(
     let level: tracing::Level = log_level.into();
     let env_filter = mk_env_filter(level);
 
-    if let Some(dir) = log_dir {
-        let file_appender = tracing_appender::rolling::daily(dir, "st0x-hedge.log");
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+    let Some(dir) = log_dir else {
+        install_console_only_subscriber(extra_layer, env_filter);
+        return None;
+    };
 
-        let file_layer = tracing_subscriber::fmt::layer()
-            .json()
-            .with_writer(non_blocking)
-            .with_filter(mk_crate_filter(level));
-
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .compact()
-            .with_filter(env_filter);
-
-        let subscriber = Registry::default()
-            .with(extra_layer)
-            .with(fmt_layer)
-            .with(file_layer);
-
-        if tracing::subscriber::set_global_default(subscriber).is_err() {
-            eprintln!("Failed to set global subscriber (already set)");
+    let file_appender = match build_log_file_appender(dir) {
+        Ok(appender) => appender,
+        Err(error) => {
+            // A misconfigured log directory must not silently disable all
+            // logging: degrade to console-only so the operator still sees
+            // output (and this error) instead of a silent process.
+            eprintln!("Failed to build rolling file appender, using console only: {error}");
+            install_console_only_subscriber(extra_layer, env_filter);
             return None;
         }
+    };
 
-        Some(FileLogGuard { _guard: guard })
-    } else {
-        let fmt_layer = tracing_subscriber::fmt::layer()
-            .compact()
-            .with_filter(env_filter);
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-        let subscriber = Registry::default().with(extra_layer).with(fmt_layer);
+    let file_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_filter(mk_crate_filter(level));
 
-        if tracing::subscriber::set_global_default(subscriber).is_err() {
-            eprintln!("Failed to set global subscriber (already set)");
-        }
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_filter(env_filter);
 
-        None
+    let subscriber = Registry::default()
+        .with(extra_layer)
+        .with(fmt_layer)
+        .with(file_layer);
+
+    if tracing::subscriber::set_global_default(subscriber).is_err() {
+        eprintln!("Failed to set global subscriber (already set)");
+        return None;
+    }
+
+    Some(FileLogGuard { _guard: guard })
+}
+
+/// Install a console-only tracing subscriber as the global default.
+///
+/// Used both when no log directory is configured and as a fallback when the
+/// rolling file appender fails to build, so a missing/unwritable log directory
+/// degrades to console logging rather than disabling logging entirely.
+fn install_console_only_subscriber(extra_layer: Option<ExtraLayer>, env_filter: EnvFilter) {
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_filter(env_filter);
+
+    let subscriber = Registry::default().with(extra_layer).with(fmt_layer);
+
+    if tracing::subscriber::set_global_default(subscriber).is_err() {
+        eprintln!("Failed to set global subscriber (already set)");
     }
 }
 
@@ -378,4 +427,124 @@ fn mk_crate_filter(level: tracing::Level) -> EnvFilter {
         .join(",");
 
     EnvFilter::from(format!("warn,{our_crates},{domain_targets}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use tempfile::{NamedTempFile, tempdir};
+
+    use super::*;
+
+    #[test]
+    fn build_log_file_appender_writes_to_prefixed_file() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_str().unwrap();
+
+        let mut appender = build_log_file_appender(dir_path).unwrap();
+        appender.write_all(b"retention test line\n").unwrap();
+        appender.flush().unwrap();
+
+        let log_files: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with("st0x-hedge.log"))
+            .collect();
+
+        assert_eq!(
+            log_files.len(),
+            1,
+            "expected exactly one log file with the configured prefix, found: {log_files:?}"
+        );
+
+        let contents = std::fs::read_to_string(dir.path().join(&log_files[0])).unwrap();
+        assert!(
+            contents.contains("retention test line"),
+            "log file should contain the written line, got: {contents:?}"
+        );
+    }
+
+    #[test]
+    fn build_log_file_appender_surfaces_directory_creation_error() {
+        // A regular file cannot contain a subdirectory, so directory creation
+        // fails: the fallible builder must surface the error rather than panic.
+        let file = NamedTempFile::new().unwrap();
+        let uncreatable_dir = file.path().join("nested");
+        let dir_path = uncreatable_dir.to_str().unwrap();
+
+        let Err(_) = build_log_file_appender(dir_path) else {
+            panic!("expected appender build to fail when the log directory cannot be created");
+        };
+    }
+
+    #[test]
+    fn setup_tracing_degrades_to_console_only_when_log_dir_is_invalid() {
+        let file = NamedTempFile::new().unwrap();
+        let uncreatable_dir = file.path().join("nested");
+
+        let file_guard = setup_tracing(&LogLevel::Info, uncreatable_dir.to_str(), None);
+
+        assert!(
+            file_guard.is_none(),
+            "an invalid log dir must degrade to console-only logging, not return a file guard"
+        );
+    }
+
+    #[test]
+    fn telemetry_setup_continues_without_file_logging_when_log_dir_is_invalid() {
+        let file = NamedTempFile::new().unwrap();
+        let uncreatable_dir = file.path().join("nested");
+
+        let ctx = TelemetryCtx {
+            api_key: "test-key".to_string(),
+            service_name: "test-service".to_string(),
+        };
+
+        let (file_guard, _telemetry_guard) = ctx
+            .setup(tracing::Level::INFO, uncreatable_dir.to_str(), None)
+            .unwrap();
+
+        assert!(
+            file_guard.is_none(),
+            "an invalid log dir must not produce a file guard nor fail telemetry setup"
+        );
+    }
+
+    #[test]
+    fn build_log_file_appender_prunes_files_beyond_retention_limit() {
+        let dir = tempdir().unwrap();
+
+        // Seed more dated log files than the retention window. tracing-appender
+        // prunes at construction time, so building the appender must delete the
+        // oldest files down to the LOG_RETENTION_DAYS bound. Days are kept in a
+        // valid 01..=N range so the filename date parses on platforms where the
+        // pruner falls back to parsing the date from the filename.
+        let seeded = LOG_RETENTION_DAYS + 6;
+        for day in 1..=seeded {
+            let name = format!("st0x-hedge.log.2026-05-{day:02}");
+            std::fs::File::create(dir.path().join(name)).unwrap();
+        }
+
+        build_log_file_appender(dir.path().to_str().unwrap()).unwrap();
+
+        let remaining = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("st0x-hedge.log")
+            })
+            .count();
+
+        // The pruner deletes seeded files down to max_files - 1 and the
+        // appender then creates the current day's file (dated after the seeded
+        // names, so it never collides), leaving exactly the retention bound.
+        assert_eq!(
+            remaining, LOG_RETENTION_DAYS,
+            "retention should leave exactly {LOG_RETENTION_DAYS} files \
+             (max_files - 1 pruned survivors + today's file), found {remaining}"
+        );
+    }
 }


### PR DESCRIPTION
[RAI-911](https://linear.app/makeitrain/issue/RAI-911/set-max-log-files-retention-on-the-tracing-file-appender-so-old-logs)

## What

- Bound the daily file logger's history: the rolling appender now keeps the last `LOG_RETENTION_DAYS` (14) daily files and prunes older ones, with no external cron/logrotate/tmpfiles dependency.

## Why

- The file logger never deleted old files — `tracing_appender::rolling::daily(...)` writes one `st0x-hedge.log.YYYY-MM-DD` per day and keeps them all forever.
- Root cause of the 2026-06-08 prod incident where unbounded logs filled `/mnt/data` and triggered `SQLITE_FULL`. Freeing disk was the stopgap; this is the in-code fix so it can't recur regardless of disk size.

## How

- Add `build_log_file_appender`, a single helper used by both file-logging sites, building via `RollingFileAppender::builder()` with `Rotation::DAILY`, the existing `st0x-hedge.log` prefix (on-disk names unchanged), and `max_log_files(LOG_RETENTION_DAYS)`. `tracing-appender` prunes oldest files at construction and on each daily roll.
- Builder form is fallible (`Result<_, InitError>`), so both call sites degrade gracefully instead of panicking, each keeping as much observability as possible: `TelemetryCtx::setup` logs the appender error and continues without the file layer, so a bad log dir cannot take HyperDX/OTLP export down with it; `setup_tracing` degrades to console-only via a new `install_console_only_subscriber` helper rather than silently disabling all logging.

## Testing

Five unit tests in `telemetry.rs`: `build_log_file_appender_writes_to_prefixed_file` (writes a line, asserts one prefixed file with the content); `build_log_file_appender_surfaces_directory_creation_error` (uncreatable dir → `Err`, not panic); `build_log_file_appender_prunes_files_beyond_retention_limit` (seeds 20 dated files, asserts exactly `LOG_RETENTION_DAYS` remain — deterministic: the pruner deletes down to `max_files - 1`, then the appender creates today's file); `setup_tracing_degrades_to_console_only_when_log_dir_is_invalid` and `telemetry_setup_continues_without_file_logging_when_log_dir_is_invalid` (both degradation paths return no file guard without failing). `cargo nextest run -p st0x-config --all-features` and `cargo clippy --workspace --all-targets --all-features` pass.

## Anything else

Daily rotation bounds the *number* of historical files (~14 days), not the byte size of a single day's file. The incident was steady-state accumulation of unpruned daily files, which this fixes; byte-rate bounding of one day's log would be a separate change. `LOG_RETENTION_DAYS` is intentionally a compile-time constant, not runtime config — change-and-redeploy is the adjustment path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability with automatic fallback to console-only logging when file appender initialization fails.
  * Enhanced error handling and reporting for logging configuration failures.

* **Tests**
  * Added unit tests for logging functionality, including file retention and error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
