### PR TITLE
ci: skip redundant and docs-only runs via graphite + paths-filter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,67 @@ permissions:
 # which did not share the `rainlanguage` cache that raindex CI populates.
 
 jobs:
+  optimize_ci:
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      # Pinned to the v0.0.9 release commit, not a mutable ref: this action
+      # gates all CI and holds the Graphite token, so the SHA freezes both the
+      # supply chain and the `skip` output contract (set in dist/index.js but
+      # undeclared in the action's action.yml).
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@9bc969adfd43bb790da3b64b543c78c75cef9689  # v0.0.9
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZATION_TOKEN }}
+          # Declared required by the action but unused at the pinned version
+          # (it reads only graphite_token/endpoint/timeout; there is no
+          # run-cancel path). Skipping is enforced solely by the `skip` output
+          # and the job-level if-gates.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Classifies the push: `code == 'true'` when at least one changed file is
+  # NOT a docs file. With `predicate-quantifier: every`, a file matches the
+  # `code` filter only if it matches `**` AND every negated docs glob -- i.e.
+  # it is a non-docs file. A push that mixes code and docs therefore flips
+  # `code` to true and runs full CI (fail-closed); only a confirmed
+  # all-docs push yields `code == 'false'`. If this job errors or is
+  # skipped, `code` is empty/unknown and the gates require the real checks.
+  #
+  # Runs whenever the optimizer did NOT confirm a skip (`skip != 'true'`),
+  # including when `optimize_ci` itself failed (empty skip) -- so a broken
+  # optimizer falls into the run-CI bucket, never the skip bucket.
+  #
+  # NOTE: paths-filter needs the repo checked out for push/workflow_dispatch git
+  # change detection (this workflow is not pull_request-triggered).
+  changes:
+    name: changes
+    needs: optimize_ci
+    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!AGENTS.md'
+              - '!README*'
+
   backend-build:
     name: backend build
+    needs: [optimize_ci, changes]
+    if: ${{ needs.optimize_ci.outputs.skip != 'true' && needs.changes.outputs.code == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
@@ -94,7 +153,8 @@ jobs:
 
   backend-test:
     name: backend test ${{ matrix.partition }} of 4
-    needs: backend-build
+    needs: [optimize_ci, changes, backend-build]
+    if: ${{ needs.optimize_ci.outputs.skip != 'true' && needs.changes.outputs.code == 'true' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
@@ -156,30 +216,56 @@ jobs:
 
   backend:
     name: backend
-    needs: [backend-build, backend-test]
-    if: always()
+    needs: [optimize_ci, changes, backend-build, backend-test]
+    # Runs unless the optimizer CONFIRMED a skip (skip == 'true'). A failed or
+    # empty optimizer (skip == '') falls through here and runs the gate, so a
+    # broken optimizer can never silently satisfy this required check.
+    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
       - name: Check backend validation
         run: |
+          # Skip backend validation ONLY for a confirmed docs-only push: the
+          # changes job succeeded AND found no code files (code == 'false').
+          # Any other state -- changes failed/skipped, or code present -- falls
+          # through and requires the real jobs (which were skipped on a
+          # non-code path), so this gate fails closed rather than
+          # green-lighting untested code.
+          if [ "${{ needs.changes.result }}" = "success" ] && [ "${{ needs.changes.outputs.code }}" = "false" ]; then
+            echo "Docs-only change - backend validation not required."
+            exit 0
+          fi
           if [ "${{ needs.backend-build.result }}" != "success" ] || [ "${{ needs.backend-test.result }}" != "success" ]; then
-            echo "backend validation failed"
+            echo "backend validation failed (build=${{ needs.backend-build.result }}, test=${{ needs.backend-test.result }})"
             exit 1
           fi
 
+  # Required check. Always runs when not graphite-skipped; the real build
+  # steps are skipped only on a confirmed docs-only push (changes succeeded
+  # AND code == 'false'), so a docs-only push reports this check green
+  # without spinning up the dashboard toolchain.
   dashboard:
+    needs: [optimize_ci, changes]
+    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
+      - name: Docs-only change - dashboard build not required
+        if: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'false' }}
+        run: echo "Docs-only change; skipping dashboard build."
+
       - uses: actions/checkout@v4
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
 
       - name: Configure Git fetch fail-fast
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: |
           git config --global http.lowSpeedLimit 524288
           git config --global http.lowSpeedTime 60
 
       - uses: nixbuild/nix-quick-install-action@v34
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         with:
           # Nix 2.24-2.28 fail to resolve rainix's overridden `foundry` input
           # (`cannot find flake 'flake:foundry'`); the fix landed in 2.30. v30
@@ -194,6 +280,7 @@ jobs:
             keep-outputs = true
 
       - uses: cachix/cachix-action@v15
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         continue-on-error: true
         with:
           name: rainlanguage
@@ -201,30 +288,42 @@ jobs:
           useDaemon: false
 
       - uses: nix-community/cache-nix-action@v7
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 8G
 
       - name: Check bun.nix is up to date
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: |
           nix run .#genBunNix
           nix fmt -- dashboard/bun.nix
           git diff --exit-code dashboard/bun.nix
 
       - name: Generate dashboard API bindings
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: nix run .#st0x-dto -- dashboard/src/lib/api
 
       - name: Dashboard lint
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         working-directory: dashboard
         run: |
           nix develop "$GITHUB_WORKSPACE#ci-dashboard" -c bun install --frozen-lockfile
           nix develop "$GITHUB_WORKSPACE#ci-dashboard" -c bun run lint
 
       - name: Dashboard
+        if: ${{ !(needs.changes.result == 'success' && needs.changes.outputs.code == 'false') }}
         run: nix build .#st0x-dashboard
 
+  # Required check. Runs fully whenever not graphite-skipped -- including on
+  # docs-only pushes -- because pre-commit is the only check that validates
+  # docs files (deno fmt covers markdown). Short-circuiting it on docs-only
+  # pushes would let unformatted docs merge green and then break
+  # `pre-commit run --all-files` for every subsequent push on any branch.
   hooks:
+    needs: optimize_ci
+    if: ${{ always() && needs.optimize_ci.outputs.skip != 'true' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## What

- Add an `optimize_ci` job (`withgraphite/graphite-ci-action`) that sets a `skip` output to short-circuit the whole workflow on redundant stacked-branch runs; every other job is gated on `skip == 'false'`.
- Add a `changes` job (`dorny/paths-filter`, runs only when not graphite-skipped) that classifies the push as code-touching or docs-only via a `code` output.
- Gate the heavy jobs (`nix-source-cache`, `backend-build`, `backend-test`) on `code == 'true'` so docs-only pushes skip the Nix/Rust toolchain entirely.
- Keep the required gate jobs (`backend`, `dashboard`, `hooks`) reporting green on docs-only pushes — their real steps are individually gated on `code == 'true'`, so the checks resolve without a separate workflow.

## Why

- Cut CI cost and queue time: stacked-branch re-runs and docs-only changes shouldn't pay for full backend builds, partitioned tests, and the dashboard toolchain.
- Branch-protection required checks (`backend`, `dashboard`, `hooks`) must still report on every push, so they short-circuit to green instead of being filtered out.

## How

- `code` filter matches everything except docs globs (`**/*.md`, `docs/**`, `AGENTS.md`, `README*`); any non-docs file flips it true. Indeterminate diffs fail toward running CI.
- `backend` gate fails closed: it skips validation only when `needs.changes.result == 'success'` AND `code != 'true'`; if `changes` errored it falls through and requires the real (skipped) jobs, failing rather than green-lighting untested code.

## Testing

No new tests — CI workflow change only. Exercised by the workflow itself on this PR and on subsequent docs-only/stacked pushes.

## Anything else

- New dependencies: `withgraphite/graphite-ci-action@main` (requires `GRAPHITE_CI_OPTIMIZATION_TOKEN` secret) and `dorny/paths-filter@v3`.
- No application code, schema, or migration changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783608380&installation_id=125569124&pr_number=772&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F772&signature=e8fb455c2c88953dff6fd3abc7318c9a78d975f4bc87c85cf6edce75ff4f6290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow adds an optimization step and change-classification to gate downstream jobs.
  * Backend build, test, and validation are now conditionally executed based on optimization/change classification to skip unnecessary runs.
  * Dashboard and hooks jobs have finer-grained conditional execution so heavy steps are skipped for docs-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Supersedes #759 (RAI-895).
