### PR TITLE
feat: register unwrapped equity recovery worker

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -71,6 +71,10 @@ use crate::tokenization::alpaca::AlpacaTokenizationService;
 use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{DexTradeAccountingJobQueue, TradeAccountingError};
+use crate::unwrapped_equity_recovery::{
+    UnwrappedEquityRecovery, UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJobQueue,
+    UnwrappedEquityRecoveryServices,
+};
 use crate::vault_registry::{
     SeedVaultRegistry, SeedVaultRegistryCtx, SeedVaultRegistryJobQueue, VaultRegistry,
     VaultRegistryCommand, VaultRegistryId,
@@ -167,6 +171,32 @@ where
     Ok(())
 }
 
+/// Resets recovery queue rows that were left in-flight by a previous process.
+/// Recovery jobs are durable and crash-resumable, but only if the apalis row is
+/// made runnable again before the deterministic worker id starts heartbeating.
+async fn requeue_recovery_orphans<Task>(
+    queue: &job::JobQueue<Task>,
+    recovery_label: &str,
+) -> anyhow::Result<()>
+where
+    Task: serde::Serialize + serde::de::DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    let count = queue.requeue_orphaned().await.with_context(|| {
+        format!("failed to re-queue orphaned {recovery_label} recovery jobs at startup")
+    })?;
+
+    if count > 0 {
+        info!(
+            target: "rebalance",
+            count,
+            recovery = recovery_label,
+            "Re-queued orphaned recovery job(s) for crash-safe resume",
+        );
+    }
+
+    Ok(())
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -245,6 +275,7 @@ impl Conductor {
             service: rebalancing_service,
             recovery_transfer,
             wrapped_equity_recovery_store,
+            unwrapped_equity_recovery_store,
             mint_store,
             redemption_store,
             transfer_usdc_to_hedging_ctx,
@@ -332,12 +363,13 @@ impl Conductor {
         let rejection_queue = HandleOrderRejectionJobQueue::new(&pool);
 
         let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&pool);
+        let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&pool);
 
         let wrapped_equity_recovery_ctx = match (
             wrapped_equity_recovery_store,
             rebalancing_service.clone(),
-            mint_store,
-            redemption_store,
+            mint_store.clone(),
+            redemption_store.clone(),
         ) {
             (Some(store), Some(service), Some(mint_store), Some(redemption_store)) => {
                 Some(Arc::new(WrappedEquityRecoveryCtx {
@@ -350,6 +382,23 @@ impl Conductor {
             }
             _ => None,
         };
+
+        let unwrapped_equity_recovery_ctx = build_unwrapped_equity_recovery_ctx(
+            unwrapped_equity_recovery_store,
+            rebalancing_service.clone(),
+            mint_store,
+            redemption_store,
+            inventory.clone(),
+            unwrapped_equity_recovery_queue.clone(),
+            Duration::from_secs(ctx.inventory_poll_interval),
+        );
+
+        if wrapped_equity_recovery_ctx.is_some() {
+            requeue_recovery_orphans(&wrapped_equity_recovery_queue, "wrapped equity").await?;
+        }
+        if unwrapped_equity_recovery_ctx.is_some() {
+            requeue_recovery_orphans(&unwrapped_equity_recovery_queue, "unwrapped equity").await?;
+        }
 
         let check_positions_queue = CheckPositionsJobQueue::new(&pool);
 
@@ -397,6 +446,8 @@ impl Conductor {
             .check_positions_queue(check_positions_queue)
             .wrapped_equity_recovery_queue(wrapped_equity_recovery_queue)
             .maybe_wrapped_equity_recovery_ctx(wrapped_equity_recovery_ctx)
+            .unwrapped_equity_recovery_queue(unwrapped_equity_recovery_queue)
+            .maybe_unwrapped_equity_recovery_ctx(unwrapped_equity_recovery_ctx)
             .equity_check_scheduler(schedulers.equity)
             .usdc_check_scheduler(schedulers.usdc)
             .transfer_usdc_to_hedging_queue(schedulers.transfer_usdc_to_hedging)
@@ -516,6 +567,34 @@ impl Conductor {
         }
         self.job_cleanup.abort();
     }
+}
+
+/// Builds the [`UnwrappedEquityRecoveryCtx`] when every dependency the recovery
+/// job needs is present; returns `None` (recovery wiring absent) if any is not.
+fn build_unwrapped_equity_recovery_ctx(
+    store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
+    service: Option<Arc<RebalancingService>>,
+    mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
+    redemption_store: Option<Arc<Store<EquityRedemption>>>,
+    inventory: Arc<BroadcastingInventory>,
+    queue: UnwrappedEquityRecoveryJobQueue,
+    reschedule_interval: Duration,
+) -> Option<Arc<UnwrappedEquityRecoveryCtx>> {
+    let (Some(store), Some(service), Some(mint_store), Some(redemption_store)) =
+        (store, service, mint_store, redemption_store)
+    else {
+        return None;
+    };
+
+    Some(Arc::new(UnwrappedEquityRecoveryCtx {
+        inventory,
+        store,
+        mint_store,
+        redemption_store,
+        equity_in_progress: service.equity_in_progress.clone(),
+        queue,
+        reschedule_interval,
+    }))
 }
 
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
@@ -691,6 +770,7 @@ struct RebalancingInfrastructure {
     service: Arc<RebalancingService>,
     recovery_transfer: Arc<CrossVenueEquityTransfer>,
     wrapped_equity_recovery_store: Arc<Store<WrappedEquityRecovery>>,
+    unwrapped_equity_recovery_store: Arc<Store<UnwrappedEquityRecovery>>,
     mint_store: Arc<Store<TokenizedEquityMint>>,
     redemption_store: Arc<Store<EquityRedemption>>,
     transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
@@ -724,6 +804,7 @@ struct PositionAndRebalancing {
     service: Option<Arc<RebalancingService>>,
     recovery_transfer: Option<Arc<CrossVenueEquityTransfer>>,
     wrapped_equity_recovery_store: Option<Arc<Store<WrappedEquityRecovery>>>,
+    unwrapped_equity_recovery_store: Option<Arc<Store<UnwrappedEquityRecovery>>>,
     mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
@@ -781,6 +862,7 @@ impl PositionAndRebalancing {
                 service: Some(infra.service),
                 recovery_transfer: Some(infra.recovery_transfer),
                 wrapped_equity_recovery_store: Some(infra.wrapped_equity_recovery_store),
+                unwrapped_equity_recovery_store: Some(infra.unwrapped_equity_recovery_store),
                 mint_store: Some(infra.mint_store),
                 redemption_store: Some(infra.redemption_store),
                 transfer_usdc_to_hedging_ctx: Some(infra.transfer_usdc_to_hedging_ctx),
@@ -809,6 +891,7 @@ impl PositionAndRebalancing {
                 service: None,
                 recovery_transfer: None,
                 wrapped_equity_recovery_store: None,
+                unwrapped_equity_recovery_store: None,
                 mint_store: None,
                 redemption_store: None,
                 transfer_usdc_to_hedging_ctx: None,
@@ -937,6 +1020,16 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
                 })
                 .await?;
 
+        let unwrapped_equity_recovery_store =
+            StoreBuilder::<UnwrappedEquityRecovery>::new(deps.pool.clone())
+                .build(UnwrappedEquityRecoveryServices {
+                    raindex: raindex_service.clone(),
+                    wrapper: wrapper.clone(),
+                    transfer: recovery_transfer.clone(),
+                    wallet: base_wallet.address(),
+                })
+                .await?;
+
         recover_interrupted_tokenization_aggregates(
             &deps.pool,
             &rebalancing_service,
@@ -1016,6 +1109,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             service: rebalancing_service,
             recovery_transfer,
             wrapped_equity_recovery_store,
+            unwrapped_equity_recovery_store,
             mint_store,
             redemption_store,
             transfer_usdc_to_hedging_ctx,
@@ -2149,6 +2243,8 @@ mod tests {
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService, TriggeredOperation};
     use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
     use crate::trading::onchain::inclusion::EmittedOnChain;
+    use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
+    use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
     use crate::wrapper::mock::MockWrapper;
     use crate::wrapper::{RATIO_ONE, UnderlyingPerWrapped};
 
@@ -2188,6 +2284,42 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn requeue_recovery_orphans_resets_unwrapped_recovery_rows() {
+        let pool = setup_test_db().await;
+        setup_apalis_tables(&pool).await.unwrap();
+        let mut queue = UnwrappedEquityRecoveryJobQueue::new(&pool);
+        let job_type = std::any::type_name::<UnwrappedEquityRecoveryJob>();
+
+        queue
+            .push(UnwrappedEquityRecoveryJob {
+                symbol: Symbol::new("AAPL").unwrap(),
+                recovery_id: UnwrappedEquityRecoveryId(uuid::Uuid::new_v4()),
+            })
+            .await
+            .unwrap();
+
+        sqlx::query("UPDATE Jobs SET status = ?, lock_at = 1 WHERE job_type = ?")
+            .bind(Status::Running.to_string())
+            .bind(job_type)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        requeue_recovery_orphans(&queue, "unwrapped equity")
+            .await
+            .unwrap();
+
+        let (status, lock_by): (String, Option<String>) =
+            sqlx::query_as("SELECT status, lock_by FROM Jobs WHERE job_type = ?")
+                .bind(job_type)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, Status::Pending.to_string());
+        assert_eq!(lock_by, None);
     }
 
     async fn job_count(pool: &SqlitePool) -> i64 {

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -55,6 +55,9 @@ use crate::trading::offchain::hedge::{HedgeCtx, HedgeJobQueue, PlaceHedge};
 use crate::trading::onchain::trade_accountant::{
     AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
 };
+use crate::unwrapped_equity_recovery::{
+    UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJob, UnwrappedEquityRecoveryJobQueue,
+};
 use crate::vault_registry::{
     SeedVaultRegistry, SeedVaultRegistryCtx, SeedVaultRegistryJobQueue, VaultRegistry,
 };
@@ -102,6 +105,8 @@ pub(crate) fn spawn<Prov, Exec>(
     check_positions_queue: CheckPositionsJobQueue,
     wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
+    unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
+    unwrapped_equity_recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
@@ -304,6 +309,8 @@ where
         check_positions_queue,
         wrapped_equity_recovery_queue,
         wrapped_equity_recovery_ctx,
+        unwrapped_equity_recovery_queue,
+        unwrapped_equity_recovery_ctx,
         equity_check_scheduler,
         usdc_check_scheduler,
         transfer_usdc_to_hedging_queue,
@@ -356,6 +363,8 @@ where
     check_positions_queue: CheckPositionsJobQueue,
     wrapped_equity_recovery_queue: WrappedEquityRecoveryJobQueue,
     wrapped_equity_recovery_ctx: Option<Arc<WrappedEquityRecoveryCtx>>,
+    unwrapped_equity_recovery_queue: UnwrappedEquityRecoveryJobQueue,
+    unwrapped_equity_recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
     equity_check_scheduler: EquityRebalancingCheckScheduler,
     usdc_check_scheduler: UsdcRebalancingCheckScheduler,
     transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
@@ -395,6 +404,8 @@ where
             check_positions_queue,
             wrapped_equity_recovery_queue,
             wrapped_equity_recovery_ctx,
+            unwrapped_equity_recovery_queue,
+            unwrapped_equity_recovery_ctx,
             equity_check_scheduler,
             usdc_check_scheduler,
             transfer_usdc_to_hedging_queue,
@@ -426,6 +437,8 @@ where
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_wrapped_equity_recovery = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_unwrapped_equity_recovery = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_check_positions = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_usdc_to_hedging = failure_injector.clone();
@@ -441,6 +454,7 @@ where
         let failure_notify_for_usdc_rebalancing_check = failure_notify.clone();
         let failure_notify_for_seed_vault_registry = failure_notify.clone();
         let failure_notify_for_wrapped_equity_recovery = failure_notify.clone();
+        let failure_notify_for_unwrapped_equity_recovery = failure_notify.clone();
         let failure_notify_for_check_positions = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
@@ -458,6 +472,7 @@ where
         let fail_stop_for_usdc_rebalancing_check = fail_stop.clone();
         let fail_stop_for_seed_vault_registry = fail_stop.clone();
         let fail_stop_for_wrapped_equity_recovery = fail_stop.clone();
+        let fail_stop_for_unwrapped_equity_recovery = fail_stop.clone();
         let fail_stop_for_check_positions = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
@@ -608,6 +623,16 @@ where
                 failure_injector_for_wrapped_equity_recovery,
             );
 
+            let apalis_monitor = register_unwrapped_equity_recovery_worker(
+                apalis_monitor,
+                unwrapped_equity_recovery_ctx,
+                unwrapped_equity_recovery_queue,
+                fail_stop_for_unwrapped_equity_recovery,
+                failure_notify_for_unwrapped_equity_recovery,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_unwrapped_equity_recovery,
+            );
+
             let apalis_monitor = register_transfer_usdc_to_hedging_worker(
                 apalis_monitor,
                 transfer_usdc_to_hedging_ctx,
@@ -689,6 +714,38 @@ fn register_wrapped_equity_recovery_worker(
     monitor.register(move |index| {
         build_supervised_worker!(
             ::<WrappedEquityRecoveryCtx, WrappedEquityRecoveryJob>,
+            index,
+            recovery_queue.clone(),
+            recovery_ctx.clone(),
+            fail_stop.clone(),
+            failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Conditionally registers the unwrapped-equity recovery worker. Same
+/// pattern as `register_wrapped_equity_recovery_worker`.
+fn register_unwrapped_equity_recovery_worker(
+    monitor: Monitor,
+    recovery_ctx: Option<Arc<UnwrappedEquityRecoveryCtx>>,
+    recovery_queue: UnwrappedEquityRecoveryJobQueue,
+    fail_stop: CircuitBreakerConfig,
+    failure_notify: Arc<tokio::sync::Notify>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(recovery_ctx) = recovery_ctx else {
+        debug!(
+            "Unwrapped-equity recovery worker not registered: rebalancing disabled \
+             (no recovery ctx). Detected tSTOCK on the bot wallet will not be recovered."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_supervised_worker!(
+            ::<UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJob>,
             index,
             recovery_queue.clone(),
             recovery_ctx.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ mod trading;
 #[cfg(feature = "mock")]
 pub use tokenization::mock_api;
 mod tokenized_equity_mint;
-#[cfg(test)]
 mod unwrapped_equity_recovery;
 mod usdc_rebalance;
 mod vault_registry;

--- a/src/unwrapped_equity_recovery/mod.rs
+++ b/src/unwrapped_equity_recovery/mod.rs
@@ -9,3 +9,8 @@
 
 pub(crate) mod aggregate;
 mod job;
+
+pub(crate) use aggregate::{UnwrappedEquityRecovery, UnwrappedEquityRecoveryServices};
+pub(crate) use job::{
+    UnwrappedEquityRecoveryCtx, UnwrappedEquityRecoveryJob, UnwrappedEquityRecoveryJobQueue,
+};


### PR DESCRIPTION
## What

Wires the `UnwrappedEquityRecovery` job into the conductor's production execution path. Previously the module was only compiled under `#[cfg(test)]`; it is now a fully registered apalis worker alongside the existing wrapped-equity recovery worker.

## Why

Unwrapped equity (tSTOCK held directly on the bot wallet) detected after a crash or interrupted flow was silently ignored in production. The recovery logic existed but was never connected to the live worker registry, meaning stranded tSTOCK positions would not be automatically recovered.

## How

- `UnwrappedEquityRecoveryStore` is built inside `spawn_rebalancing_infrastructure` using `UnwrappedEquityRecoveryServices` (raindex, wrapper, transfer, wallet address) and threaded through `RebalancingInfrastructure` and `PositionAndRebalancing`.
- `build_unwrapped_equity_recovery_ctx` constructs the `UnwrappedEquityRecoveryCtx` (including inventory, queue, and reschedule interval) when all required dependencies are present, mirroring the existing wrapped-equity pattern.
- `register_unwrapped_equity_recovery_worker` conditionally registers the apalis worker; if the ctx is absent (rebalancing disabled), it logs a debug message and skips registration gracefully.
- A shared `requeue_recovery_orphans` helper resets any `Running`-state apalis rows left behind by a previous process crash, making recovery jobs crash-resumable. It is called at startup for both wrapped and unwrapped equity queues when their respective contexts are present.
- The `#[cfg(test)]` gate on the `unwrapped_equity_recovery` module is removed so it is compiled unconditionally.

## Testing

A new integration test `requeue_recovery_orphans_resets_unwrapped_recovery_rows` pushes a job, manually forces it into `Running` state with a lock, calls `requeue_recovery_orphans`, and asserts the row is reset to `Pending` with no `lock_by` value.

## Screenshots

N/A

## Anything else

The `mint_store` and `redemption_store` `Arc`s are now cloned before being consumed by the wrapped-equity context so they can also be forwarded to the unwrapped-equity context builder.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783646326&installation_id=125569124&pr_number=774&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F774&signature=1595053848a87b5ac3bd369b16f003d0d39b4b6ed2c1c5c73408b7f0e9142a99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>