### PR TITLE
Paginate PnL SQL reads

### DIFF
--- a/dashboard/src/lib/pnl/sql-source.test.ts
+++ b/dashboard/src/lib/pnl/sql-source.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildPnlResponseFromSqlRows,
   buildSqlApiUrl,
+  fetchPnlReportFromSql,
   type SqlPositionEventRow,
   type SqlPositionViewRow,
   type SqlSampleStatsRow
@@ -90,6 +91,22 @@ const offchainBuy = (
   }
 })
 
+const response = (body: unknown): Response =>
+  ({
+    ok: true,
+    json: () => Promise.resolve(body)
+  }) as Response
+
+const fetchInputUrl = (input: RequestInfo | URL): URL => {
+  if (input instanceof URL) return input
+  if (typeof input === 'string') return new URL(input)
+  return new URL(input.url)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 describe('buildSqlApiUrl', () => {
   it('uses the Datasette SQL JSON shape expected by the prod read endpoint', () => {
     const url = buildSqlApiUrl(
@@ -98,7 +115,7 @@ describe('buildSqlApiUrl', () => {
     )
 
     expect(url).toBe(
-      'http://host:8081/st0x-hedge.json?sql=SELECT+symbol%2C+net_position+FROM+position_view&_shape=objects&_size=max'
+      'http://host:8081/st0x-hedge.json?sql=SELECT+*+FROM+%28SELECT+symbol%2C+net_position+FROM+position_view%29+LIMIT+900+OFFSET+0&_shape=objects&_size=max'
     )
   })
 
@@ -112,7 +129,7 @@ describe('buildSqlApiUrl', () => {
       })
 
       expect(buildSqlApiUrl('/__pnl_sql', 'SELECT 1')).toBe(
-        'http://localhost:5174/__pnl_sql?sql=SELECT+1&_shape=objects&_size=max'
+        'http://localhost:5174/__pnl_sql?sql=SELECT+*+FROM+%28SELECT+1%29+LIMIT+900+OFFSET+0&_shape=objects&_size=max'
       )
     } finally {
       Object.defineProperty(globalThis, 'location', {
@@ -121,6 +138,58 @@ describe('buildSqlApiUrl', () => {
         configurable: true
       })
     }
+  })
+})
+
+describe('fetchPnlReportFromSql', () => {
+  it('paginates Datasette SQL reads instead of rendering a capped prefix', async () => {
+    const firstEventPage = Array.from({ length: 900 }, (_, index) => onchainSell(index + 1))
+    const secondEventPage = [
+      onchainSell(901),
+      offchainBuy(902, '2026-05-15T10:01:00Z', '8')
+    ]
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = fetchInputUrl(input)
+      const sql = url.searchParams.get('sql') ?? ''
+
+      if (sql.includes('FROM position_view')) {
+        return Promise.resolve(response({ rows: positionRows, truncated: false }))
+      }
+
+      if (sql.includes('GROUP BY aggregate_id')) {
+        return Promise.resolve(response({ rows: sampleRows, truncated: false }))
+      }
+
+      if (sql.includes('OFFSET 900')) {
+        return Promise.resolve(response({ rows: secondEventPage, truncated: false }))
+      }
+
+      if (sql.includes('OFFSET 0')) {
+        return Promise.resolve(response({ rows: firstEventPage, truncated: false }))
+      }
+
+      return Promise.resolve(response({ rows: [], truncated: false }))
+    })
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const report = await fetchPnlReportFromSql('http://host:8081/st0x-hedge.json', baseQuery)
+    const requestedSql = fetchMock.mock.calls.map(([input]) =>
+      fetchInputUrl(input).searchParams.get('sql')
+    )
+
+    expect(requestedSql.some((sql) => (sql ?? '').includes('OFFSET 900'))).toBe(true)
+    expect(report.summary.counterTradePnlUsd).toBe('2')
+    expect(report.summary.openShortShares).toBe('900')
+    expect(report.entries).toHaveLength(1)
+    expect(report.entries[0]).toEqual(
+      expect.objectContaining({
+        openingRowid: 1,
+        closingRowid: 902,
+        pnlBucket: 'counter_trade',
+        realizedPnlUsd: '2'
+      })
+    )
   })
 })
 

--- a/dashboard/src/lib/pnl/sql-source.ts
+++ b/dashboard/src/lib/pnl/sql-source.ts
@@ -120,6 +120,7 @@ type PositionReplayDelta = {
 const ATTRIBUTION_METHOD = 'direct_sql_position_fill_replay_fifo'
 const COUNTER_TRADE_THRESHOLD_SECONDS = 300
 const DATASSETTE_DEFAULT_MAX_RETURNED_ROWS = 1000
+const DATASSETTE_SQL_PAGE_SIZE = 900
 const SQL_FETCH_TIMEOUT_MS = 30000
 const SAFE_SQL_SYMBOL = /^[A-Za-z0-9._-]+$/u
 const ZERO = new Decimal(0)
@@ -192,9 +193,14 @@ const globalOrigin = (): string => {
   return 'http://localhost'
 }
 
-export const buildSqlApiUrl = (baseUrl: string, sql: string): string => {
+const stripSqlTerminator = (sql: string): string => sql.trim().replace(/;+\s*$/u, '')
+
+const pagedSql = (sql: string, offset: number): string =>
+  `SELECT * FROM (${stripSqlTerminator(sql)}) LIMIT ${String(DATASSETTE_SQL_PAGE_SIZE)} OFFSET ${String(offset)}`
+
+export const buildSqlApiUrl = (baseUrl: string, sql: string, offset = 0): string => {
   const url = new URL(baseUrl, globalOrigin())
-  url.searchParams.set('sql', sql)
+  url.searchParams.set('sql', pagedSql(sql, offset))
   url.searchParams.set('_shape', 'objects')
   url.searchParams.set('_size', 'max')
   return url.toString()
@@ -205,8 +211,8 @@ type DatasetteRowsResponse = {
   truncated?: boolean
 }
 
-const fetchSqlRows = async <Row>(baseUrl: string, sql: string): Promise<Row[]> => {
-  const response = await fetch(buildSqlApiUrl(baseUrl, sql), {
+const fetchSqlPage = async <Row>(baseUrl: string, sql: string, offset: number): Promise<Row[]> => {
+  const response = await fetch(buildSqlApiUrl(baseUrl, sql, offset), {
     signal: AbortSignal.timeout(SQL_FETCH_TIMEOUT_MS)
   })
 
@@ -220,7 +226,7 @@ const fetchSqlRows = async <Row>(baseUrl: string, sql: string): Promise<Row[]> =
   }
 
   if (body.truncated === true) {
-    throw new Error('SQL endpoint truncated the result set; refusing to render partial PnL')
+    throw new Error('SQL endpoint truncated a paged result set; refusing to render partial PnL')
   }
 
   if (body.truncated === undefined && body.rows.length >= DATASSETTE_DEFAULT_MAX_RETURNED_ROWS) {
@@ -228,6 +234,19 @@ const fetchSqlRows = async <Row>(baseUrl: string, sql: string): Promise<Row[]> =
   }
 
   return body.rows as Row[]
+}
+
+const fetchSqlRows = async <Row>(baseUrl: string, sql: string): Promise<Row[]> => {
+  const rows: Row[] = []
+  let offset = 0
+
+  for (;;) {
+    const page = await fetchSqlPage<Row>(baseUrl, sql, offset)
+    rows.push(...page)
+
+    if (page.length < DATASSETTE_SQL_PAGE_SIZE) return rows
+    offset += DATASSETTE_SQL_PAGE_SIZE
+  }
 }
 
 const positionEventsSql = (symbols: Set<string>): string => `


### PR DESCRIPTION
## What

Fixes the PnL dashboard SQL source so Datasette reads are paginated instead of failing once production fill history exceeds one response page.

## Why

Prod now has enough persisted Position events that a single SQL JSON response is truncated. The dashboard correctly refused to render partial PnL, but it needed to fetch all pages rather than treating any large result set as fatal.

## How

- Wrap dashboard SQL reads with LIMIT/OFFSET paging below Datasette's default max row cap.
- Keep the fail-closed behavior if an individual paged response is still reported as truncated.
- Add regression coverage proving a closing fill on page two is included in replayed PnL.

## Testing

- npm run test:run -- src/lib/pnl/sql-source.test.ts src/lib/pnl/api.test.ts src/lib/env.test.ts
- npx eslint src/lib/pnl/sql-source.ts src/lib/pnl/sql-source.test.ts src/lib/pnl/api.ts src/lib/pnl/api.test.ts src/lib/env.ts src/lib/env.test.ts src/lib/components/pnl-panel.svelte
- env PUBLIC_PNL_SQL_API_URL=/__pnl_sql npm run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783702582&installation_id=125569124&pr_number=776&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F776&signature=320427fb461e74928967ae1d3eb78a5be5130f47f7e19498ae6157da493d05da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of P&L report data retrieval for larger datasets with enhanced error handling and data validation.

* **Tests**
  * Added comprehensive test coverage for P&L report generation with multi-page data fetching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->