### PR TITLE
feat: reconcile USDC rebalances stuck in terminal DepositFailed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1647,6 +1647,16 @@ enum TransferRef {
     AlpacaId(AlpacaTransferId),
     OnchainTx(TxHash),
 }
+
+// Typed (not opaque-string) reason an operator reconciled a stranded post-burn
+// rebalance, recorded on `OperatorReconciled` / `Reconciled` for the audit trail.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+enum ReconcileReason {
+    // The minted USDC was moved to its destination manually.
+    FundsMovedManually,
+    // The deposit was credited at the destination outside the bot's view.
+    DepositCreditedOffline,
+}
 ```
 
 **States**:
@@ -1778,6 +1788,18 @@ enum UsdcRebalance {
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
+
+    // Guard-clearing terminal: an operator reconciled a stranded post-burn
+    // failure out-of-band. Retains `amount` and `initiated_at` so the
+    // projection still reports the real transfer rather than a zero-value one
+    // starting at `reconciled_at`.
+    Reconciled {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        reason: ReconcileReason,
+        initiated_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
+    },
 }
 ```
 
@@ -1838,6 +1860,11 @@ enum UsdcRebalanceCommand {
     InitiateDeposit { deposit: TransferRef },
     ConfirmDeposit,
     FailDeposit { reason: String },
+
+    // Reconcile a stranded post-burn failure to the terminal `Reconciled`
+    // state, clearing the rebalancing guard rather than re-driving the failed
+    // leg. Valid only from a post-burn terminal failure (see Business Rules).
+    ReconcileStuckRebalance { reason: ReconcileReason },
 }
 ```
 
@@ -1909,6 +1936,18 @@ enum UsdcRebalanceEvent {
         deposit_ref: Option<TransferRef>,
         failed_tx_hash: Option<TxHash>,
         failed_at: DateTime<Utc>,
+    },
+    // Operator reconciled a stranded post-burn failure. Carries `direction` so
+    // the reactor derives the source venue without in-memory tracking (which
+    // may be absent after a restart), plus `amount` and `initiated_at` so the
+    // projection preserves the real post-burn transfer instead of a zero-value
+    // one starting at reconciliation time.
+    OperatorReconciled {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        reason: ReconcileReason,
+        initiated_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
     },
 }
 
@@ -1989,6 +2028,18 @@ enum BridgeStage { Burn, Attestation, Mint }
   AlpacaToBase) or before post-deposit conversion (for BaseToAlpaca)
 - Can mark failed from any non-terminal state
 - Each rebalancing has unique UUID allowing multiple parallel operations
+- **Operator reconciliation** (`ReconcileStuckRebalance` -> `OperatorReconciled`
+  -> `Reconciled`): valid ONLY from a post-burn terminal failure that strands
+  the rebalancing guard with no other exit -- `DepositFailed`, a post-burn
+  `BridgingFailed` (a `burn_tx_hash` or `cctp_nonce` is recorded), or a
+  `BaseToAlpaca` `ConversionFailed` (the post-deposit USDC->USD leg). Every
+  other state is rejected: an in-progress transfer must be resumed, and a
+  pre-burn failure already reconciles to source on its own. `Reconciled` is a
+  clearing terminal -- it carries **post-burn semantics**, meaning the reactor
+  zeroes source-venue inflight WITHOUT crediting `available` (the USDC was
+  already burned via CCTP, so the funds genuinely left the source venue; this is
+  NOT a cancel, which would wrongly credit `available`). See "Operator
+  reconciliation of a stranded post-burn failure" under Failure Handling.
 
 ##### Integration Points
 
@@ -2723,6 +2774,25 @@ state (success, or a pre-burn failure that reconciles to source) re-asserts the
 guard at boot and blocks new USDC rebalancing until it settles or an operator
 recovers it. USDC bridges are not auto-resumed on restart, so the guard is held
 until manual recovery.
+
+**Operator reconciliation of a stranded post-burn failure**: A USDC rebalance
+that fails after the CCTP burn holds the rebalancing guard, blocking further
+USDC rebalancing. Because the burned/minted USDC was handled out-of-band, this
+is reconciled rather than re-driven: the `reconcile-usdc-transfer` CLI command
+sends `ReconcileStuckRebalance`, which emits `OperatorReconciled` and drives the
+aggregate to a new clearing terminal state, `Reconciled`. The reactor then
+clears the in-progress guard, removes tracking, and reconciles source-venue
+inflight with **post-burn semantics** -- it zeroes the source-venue inflight
+WITHOUT crediting `available`, because the funds already left the source venue
+(it is NOT a cancel, which would wrongly credit available). The command is valid
+ONLY from a post-burn terminal failure that strands the guard: `DepositFailed`
+(the CCTP mint landed but the destination deposit failed), a post-burn
+`BridgingFailed` (a `burn_tx_hash` or `cctp_nonce` is recorded), or a
+`BaseToAlpaca` `ConversionFailed` (the post-deposit USDC->USD leg). Every other
+state is rejected -- an in-progress transfer must be resumed, and a pre-burn
+failure already reconciles to source on its own. Because `Reconciled` is a
+clearable terminal, a restart does not re-latch the guard, and automatic USDC
+rebalancing resumes.
 
 ##### Manual Reconciliation Required
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -58,6 +58,27 @@ pub enum TransferType {
     Redemption,
 }
 
+/// Why an operator is reconciling a stuck post-burn USDC transfer.
+///
+/// CLI-facing mirror of [`crate::usdc_rebalance::ReconcileReason`]; mapped to
+/// the domain enum in the command handler so clap stays out of the aggregate.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ReconcileReasonArg {
+    /// The minted USDC was moved to its destination manually.
+    FundsMovedManually,
+    /// The deposit was credited at the destination outside the bot's view.
+    DepositCreditedOffline,
+}
+
+impl From<ReconcileReasonArg> for crate::usdc_rebalance::ReconcileReason {
+    fn from(reason: ReconcileReasonArg) -> Self {
+        match reason {
+            ReconcileReasonArg::FundsMovedManually => Self::FundsMovedManually,
+            ReconcileReasonArg::DepositCreditedOffline => Self::DepositCreditedOffline,
+        }
+    }
+}
+
 /// Aggregate types that have materialized views.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AggregateView {
@@ -270,6 +291,22 @@ pub enum Commands {
         /// validated -- the resume uses the persisted amount
         #[arg(short = 'a', long = "amount")]
         amount: Usdc,
+    },
+
+    /// Reconcile a USDC transfer stuck in the post-burn DepositFailed state
+    ///
+    /// Drives a post-burn `DepositFailed` USDC rebalance to the clearing
+    /// terminal `Reconciled` state: the minted USDC was handled out-of-band, so
+    /// this resolves the transfer (clearing the in-progress guard and
+    /// reconciling source-venue inflight) rather than re-driving the deposit.
+    /// Rejects an unknown id or an aggregate not in `DepositFailed`.
+    ReconcileUsdcTransfer {
+        /// Id of the stuck transfer to reconcile
+        #[arg(long = "id")]
+        id: Uuid,
+        /// Why the transfer is being reconciled
+        #[arg(short = 'r', long = "reason", default_value = "funds-moved-manually")]
+        reason: ReconcileReasonArg,
     },
 
     /// Deposit USDC directly to Alpaca from Ethereum (bypasses vault/CCTP)
@@ -734,6 +771,10 @@ enum SimpleCommand {
         transfer_type: TransferType,
         id: String,
     },
+    ReconcileUsdcTransfer {
+        id: Uuid,
+        reason: ReconcileReasonArg,
+    },
 }
 
 #[cfg(feature = "test-support")]
@@ -1051,6 +1092,9 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::RecheckTransfer { transfer_type, id } => {
             Ok(SimpleCommand::RecheckTransfer { transfer_type, id })
         }
+        Commands::ReconcileUsdcTransfer { id, reason } => {
+            Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason })
+        }
     }
 }
 
@@ -1213,6 +1257,9 @@ async fn run_simple_command<W: Write>(
         } => rebalancing::fail_transfer_command(stdout, pool, transfer_type, &id, &reason).await,
         SimpleCommand::RecheckTransfer { transfer_type, id } => {
             rebalancing::recheck_transfer_command(stdout, transfer_type, &id, ctx).await
+        }
+        SimpleCommand::ReconcileUsdcTransfer { id, reason } => {
+            rebalancing::reconcile_usdc_transfer_command(stdout, id, reason.into(), pool).await
         }
     }
 }
@@ -1648,6 +1695,78 @@ mod tests {
                 );
             }
             other => panic!("expected resume-usdc-transfer command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_usdc_transfer_command_parses_id_and_reason() {
+        let id = Uuid::from_u128(77);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "reconcile-usdc-transfer",
+            "--id",
+            &id.to_string(),
+            "--reason",
+            "deposit-credited-offline",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::ReconcileUsdcTransfer {
+                id: parsed_id,
+                reason,
+            } => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(reason, ReconcileReasonArg::DepositCreditedOffline));
+            }
+            other => panic!("expected reconcile-usdc-transfer command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconcile_usdc_transfer_command_defaults_reason_to_funds_moved_manually() {
+        let id = Uuid::from_u128(78);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "reconcile-usdc-transfer",
+            "--id",
+            &id.to_string(),
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::ReconcileUsdcTransfer { reason, .. } => {
+                assert!(matches!(reason, ReconcileReasonArg::FundsMovedManually));
+            }
+            other => panic!("expected reconcile-usdc-transfer command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_reconcile_usdc_transfer_command_as_simple() {
+        // reconcile-usdc-transfer only loads + sends to the event store, so it
+        // must route without an RPC provider.
+        let command = Commands::ReconcileUsdcTransfer {
+            id: Uuid::from_u128(42),
+            reason: ReconcileReasonArg::FundsMovedManually,
+        };
+
+        match classify_command(command) {
+            Ok(SimpleCommand::ReconcileUsdcTransfer { reason, .. }) => {
+                assert!(matches!(reason, ReconcileReasonArg::FundsMovedManually));
+            }
+            Ok(_) => panic!("expected reconcile-usdc-transfer simple command"),
+            Err(
+                ProviderCommand::ProcessTx { .. }
+                | ProviderCommand::TransferUsdc { .. }
+                | ProviderCommand::ResumeUsdcTransfer { .. }
+                | ProviderCommand::CctpBridge { .. }
+                | ProviderCommand::CctpRecover { .. }
+                | ProviderCommand::ResetAllowance { .. }
+                | ProviderCommand::AlpacaTokenize { .. }
+                | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::AlpacaTokenizationRequests,
+            ) => panic!("expected simple command classification, got provider command"),
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -37,7 +37,9 @@ use crate::tokenization::{
 use crate::tokenized_equity_mint::{
     IssuerRequestId, TokenizedEquityMint, TokenizedEquityMintCommand,
 };
-use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalance, UsdcRebalanceId};
+use crate::usdc_rebalance::{
+    RebalanceDirection, ReconcileReason, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
+};
 use crate::vault_lookup::{VaultLookup, VaultRegistryLookup};
 use crate::vault_registry::VaultRegistry;
 use st0x_config::{BrokerCtx, Ctx};
@@ -452,6 +454,82 @@ async fn run_usdc_transfer<Writer: Write>(
         TransferDirection::ToAlpaca => "USDC transfer to Alpaca completed successfully",
     };
     writeln!(stdout, "{completion}")?;
+
+    Ok(())
+}
+
+/// Reconciles a USDC transfer stranded in a post-burn terminal failure to the
+/// clearing terminal `Reconciled` state, releasing the in-progress guard.
+///
+/// The burned/minted USDC was handled out-of-band, so this resolves the
+/// transfer (clearing the in-progress guard and reconciling source-venue
+/// inflight via the reactor) rather than re-driving the failed leg. Builds a
+/// standalone `UsdcRebalance` store and sends `ReconcileStuckRebalance`
+/// directly -- no broker/bridge/vault is needed because reconciliation only
+/// loads and sends. Rejects an unknown id (refusing to act on the wrong
+/// transfer/database) and an aggregate that is not a guard-stranding post-burn
+/// failure (the command itself rejects the latter, but the preflight gives a
+/// clearer operator-facing error first).
+pub(super) async fn reconcile_usdc_transfer_command<Writer: Write>(
+    stdout: &mut Writer,
+    id: Uuid,
+    reason: ReconcileReason,
+    pool: &SqlitePool,
+) -> anyhow::Result<()> {
+    let id = UsdcRebalanceId(id);
+    writeln!(stdout, "Reconciling stuck USDC transfer id: {id}")?;
+
+    let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+        .build(())
+        .await?;
+
+    let Some(state) = usdc_store.load(&id).await? else {
+        anyhow::bail!(
+            "reconcile-usdc-transfer: no transfer found for id {id}. Refusing to act -- check \
+             the id and that you are pointed at the right database."
+        );
+    };
+
+    // Authoritative gate is the aggregate command; this preflight mirrors its
+    // accepted set (DepositFailed, post-burn BridgingFailed, BaseToAlpaca
+    // ConversionFailed) only to give the operator a clearer error first.
+    let is_post_burn_failure = matches!(
+        state,
+        UsdcRebalance::DepositFailed { .. }
+            | UsdcRebalance::BridgingFailed {
+                burn_tx_hash: Some(_),
+                ..
+            }
+            | UsdcRebalance::BridgingFailed {
+                cctp_nonce: Some(_),
+                ..
+            }
+            | UsdcRebalance::ConversionFailed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            }
+    );
+
+    if !is_post_burn_failure {
+        anyhow::bail!(
+            "reconcile-usdc-transfer: transfer {id} is in state {state:?}, not a post-burn \
+             terminal failure that strands the in-progress guard (DepositFailed, post-burn \
+             BridgingFailed, or a BaseToAlpaca ConversionFailed). Refusing to act."
+        );
+    }
+
+    usdc_store
+        .send(
+            &id,
+            UsdcRebalanceCommand::ReconcileStuckRebalance { reason },
+        )
+        .await?;
+
+    writeln!(
+        stdout,
+        "Reconciled USDC transfer {id} (reason: {reason:?}); the in-progress guard will clear \
+         and USDC rebalancing resumes."
+    )?;
 
     Ok(())
 }
@@ -903,7 +981,7 @@ mod tests {
     use super::*;
     use crate::inventory::ImbalanceThreshold;
     use crate::test_utils::setup_test_db;
-    use crate::usdc_rebalance::{TransferRef, UsdcRebalanceCommand};
+    use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
     use st0x_config::EvmCtx;
     use st0x_config::ExecutionThreshold;
     use st0x_config::RebalancingCtx;
@@ -1177,6 +1255,69 @@ mod tests {
         assert!(
             err_msg.contains("no transfer found for id"),
             "resume of an unknown id must refuse, not start a new burn; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_usdc_transfer_rejects_unknown_id() {
+        let pool = setup_test_db().await;
+        let unknown_id = Uuid::from_u128(0xFEED_FACE);
+
+        let mut stdout = Vec::new();
+        let result = reconcile_usdc_transfer_command(
+            &mut stdout,
+            unknown_id,
+            ReconcileReason::FundsMovedManually,
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("no transfer found for id"),
+            "reconcile of an unknown id must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_usdc_transfer_rejects_in_progress_aggregate() {
+        // An Initiated (in-progress, pre-burn) aggregate is not a guard-stranding
+        // post-burn failure, so the preflight must reject it before sending the
+        // reconcile command.
+        let pool = setup_test_db().await;
+        let id = Uuid::from_u128(7777);
+
+        let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        store
+            .send(
+                &UsdcRebalanceId(id),
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(Float::parse("100".to_string()).unwrap()),
+                    withdrawal: TransferRef::OnchainTx(b256!(
+                        "0x00000000000000000000000000000000000000000000000000000000000000b1"
+                    )),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut stdout = Vec::new();
+        let result = reconcile_usdc_transfer_command(
+            &mut stdout,
+            id,
+            ReconcileReason::FundsMovedManually,
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not a post-burn terminal failure that strands the in-progress guard"),
+            "reconcile of an in-progress aggregate must refuse; got: {err_msg}"
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -3589,6 +3589,7 @@ impl RebalancingService {
                 | BridgingFailed { .. }
                 | DepositFailed { .. }
                 | ConversionFailed { .. }
+                | OperatorReconciled { .. }
                 | ConversionConfirmed {
                     direction: RebalanceDirection::BaseToAlpaca,
                     ..
@@ -8217,6 +8218,290 @@ mod tests {
         );
     }
 
+    /// An operator reconciling a post-burn `DepositFailed` must clear the guard,
+    /// remove tracking, and zero the source-venue (MarketMaking for BaseToAlpaca)
+    /// inflight WITHOUT crediting available -- post-burn semantics, because the
+    /// minted USDC physically left the source.
+    #[tokio::test]
+    async fn operator_reconcile_clears_guard_and_zeroes_source_inflight_post_burn() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+
+        for event in [
+            make_usdc_initiated(RebalanceDirection::BaseToAlpaca, usdc(400)),
+            make_usdc_withdrawal_confirmed(),
+            make_usdc_bridging_initiated(),
+            make_usdc_bridge_attestation_received(),
+            make_usdc_bridged(),
+            make_usdc_deposit_initiated(),
+            make_usdc_deposit_failed(),
+        ] {
+            harness
+                .receive::<UsdcRebalance>(id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        // Sanity: the burn moved 400 from MarketMaking available to inflight, and
+        // the post-burn deposit failure preserved it.
+        assert_usdc_inventory_balances(&trigger, usdc(500), usdc(400), usdc(100), Usdc::ZERO).await;
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_operator_reconciled(RebalanceDirection::BaseToAlpaca),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "operator reconcile must remove tracking"
+        );
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "operator reconcile must clear the USDC guard"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "operator reconcile must clear the active rebalance ID"
+        );
+        // Available unchanged (500), inflight zeroed -- funds left the source.
+        assert_usdc_inventory_balances(&trigger, usdc(500), Usdc::ZERO, usdc(100), Usdc::ZERO)
+            .await;
+    }
+
+    /// Post-restart the reactor has no in-memory tracking, yet an operator
+    /// reconcile must still clear the guard and zero the source inflight derived
+    /// from the event's `direction` -- never panic on absent tracking.
+    #[tokio::test]
+    async fn operator_reconcile_works_when_tracking_absent() {
+        let inventory = InventoryView::default().with_usdc(usdc(900), usdc(100));
+        let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // Seed the source (MarketMaking) inflight to mimic a post-restart state
+        // where the burn already moved 400 into inflight, but in-memory tracking
+        // was not rebuilt and the guard was merely re-asserted. Also carry a
+        // stale active rebalance id so the test proves the Clear terminal action
+        // drops it.
+        {
+            let mut inventory = trigger.inventory.write().await;
+            *inventory = inventory
+                .clone()
+                .update_usdc(
+                    Inventory::transfer(Venue::MarketMaking, TransferOp::Start, usdc(400)),
+                    Utc::now(),
+                )
+                .unwrap()
+                .set_active_usdc_rebalance(id.clone());
+        }
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        assert!(!trigger.usdc_tracking.read().await.contains_key(&id));
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            Some(&id)
+        );
+        // Sanity: 400 moved from MarketMaking available to inflight.
+        assert_usdc_inventory_balances(&trigger, usdc(500), usdc(400), usdc(100), Usdc::ZERO).await;
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_operator_reconciled(RebalanceDirection::BaseToAlpaca),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "operator reconcile must clear the guard even with tracking absent"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "operator reconcile must not resurrect in-memory tracking"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "operator reconcile must clear the stale active rebalance id"
+        );
+        // Available unchanged (500), inflight zeroed via the event's direction.
+        assert_usdc_inventory_balances(&trigger, usdc(500), Usdc::ZERO, usdc(100), Usdc::ZERO)
+            .await;
+    }
+
+    /// Mirror of `operator_reconcile_works_when_tracking_absent` for the other
+    /// direction: `AlpacaToBase` must zero the Hedging (source) inflight derived
+    /// from the event's `direction` -- not MarketMaking -- and still clear the
+    /// guard and the stale active id with tracking absent post-restart.
+    #[tokio::test]
+    async fn operator_reconcile_alpaca_to_base_clears_hedging_source_when_tracking_absent() {
+        // Hedging is the offchain venue (second arg), so seed it with enough to
+        // move 400 into inflight.
+        let inventory = InventoryView::default().with_usdc(usdc(100), usdc(900));
+        let (reactor, _receiver) = make_trigger_with_inventory(inventory).await;
+        let trigger = reactor.clone();
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // Burn already moved 400 from the Hedging venue into inflight; tracking
+        // was not rebuilt and a stale active id lingers.
+        {
+            let mut inventory = trigger.inventory.write().await;
+            *inventory = inventory
+                .clone()
+                .update_usdc(
+                    Inventory::transfer(Venue::Hedging, TransferOp::Start, usdc(400)),
+                    Utc::now(),
+                )
+                .unwrap()
+                .set_active_usdc_rebalance(id.clone());
+        }
+        trigger.usdc_in_progress.store(true, Ordering::SeqCst);
+        assert!(!trigger.usdc_tracking.read().await.contains_key(&id));
+        // Sanity: 400 moved from Hedging available (900 -> 500) to inflight.
+        assert_usdc_inventory_balances(&trigger, usdc(100), Usdc::ZERO, usdc(500), usdc(400)).await;
+
+        harness
+            .receive::<UsdcRebalance>(
+                id.clone(),
+                make_usdc_operator_reconciled(RebalanceDirection::AlpacaToBase),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            !trigger.usdc_in_progress.load(Ordering::SeqCst),
+            "operator reconcile must clear the guard even with tracking absent"
+        );
+        assert!(
+            !trigger.usdc_tracking.read().await.contains_key(&id),
+            "operator reconcile must not resurrect in-memory tracking"
+        );
+        assert_eq!(
+            trigger.inventory.read().await.active_usdc_rebalance(),
+            None,
+            "operator reconcile must clear the stale active rebalance id"
+        );
+        // Hedging inflight zeroed via the event's direction; MarketMaking and
+        // Hedging available are both untouched (post-burn: no credit).
+        assert_usdc_inventory_balances(&trigger, usdc(100), Usdc::ZERO, usdc(500), Usdc::ZERO)
+            .await;
+    }
+
+    /// A `Reconciled` aggregate is a clearing terminal: startup guard recovery
+    /// must NOT re-latch the guard for it (the opposite of a post-burn failure).
+    #[tokio::test]
+    async fn recover_usdc_guard_does_not_relatch_for_reconciled() {
+        let pool = crate::test_utils::setup_test_db().await;
+        let store = test_store::<UsdcRebalance>(pool.clone(), ());
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        // Drive a BaseToAlpaca aggregate to DepositFailed, then reconcile it.
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::Initiate {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: usdc(400),
+                    withdrawal: TransferRef::OnchainTx(burn_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        store
+            .send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::ReceiveAttestation {
+                    attestation: vec![0x01],
+                    cctp_nonce: B256::left_padding_from(&42u64.to_be_bytes()),
+                    message: valid_cctp_message(),
+                    mint_scan_from_block: 100,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmBridging {
+                    mint_tx,
+                    amount_received: usdc(399),
+                    fee_collected: usdc(1),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::InitiateDeposit {
+                    deposit: TransferRef::OnchainTx(mint_tx),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::FailDeposit {
+                    reason: "deposit rejected".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &id,
+                UsdcRebalanceCommand::ReconcileStuckRebalance {
+                    reason: crate::usdc_rebalance::ReconcileReason::FundsMovedManually,
+                },
+            )
+            .await
+            .unwrap();
+
+        let (service, _receiver) = make_trigger_with_inventory(InventoryView::default()).await;
+        service.recover_usdc_guard(&pool, &store).await.unwrap();
+
+        assert!(
+            !service.usdc_in_progress.load(Ordering::SeqCst),
+            "a Reconciled aggregate must not re-latch the USDC guard on startup"
+        );
+        // A Reconciled aggregate is a terminal no-op: startup recovery must not
+        // enqueue any fresh transfer work in either direction.
+        assert_eq!(
+            count_pending_transfer_usdc_to_hedging_jobs(&service).await,
+            0,
+            "a Reconciled aggregate must not enqueue a USDC->Hedging transfer on startup"
+        );
+        assert_eq!(
+            count_pending_transfer_usdc_to_market_making_jobs(&service).await,
+            0,
+            "a Reconciled aggregate must not enqueue a USDC->MarketMaking transfer on startup"
+        );
+    }
+
     /// For BaseToAlpaca the conversion is the post-deposit USDC->USD leg, so a
     /// `ConversionFailed` there is post-mint: it must preserve inflight + the
     /// guard, even though `ConversionInitiated` resets the tracked stage to a
@@ -8770,6 +9055,16 @@ mod tests {
             deposit_ref: Some(TransferRef::OnchainTx(TxHash::random())),
             reason: "Deposit rejected".to_string(),
             failed_at: Utc::now(),
+        }
+    }
+
+    fn make_usdc_operator_reconciled(direction: RebalanceDirection) -> UsdcRebalanceEvent {
+        UsdcRebalanceEvent::OperatorReconciled {
+            direction,
+            amount: usdc(400),
+            reason: crate::usdc_rebalance::ReconcileReason::FundsMovedManually,
+            initiated_at: Utc::now(),
+            reconciled_at: Utc::now(),
         }
     }
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -51,12 +51,20 @@ pub(super) struct UsdcRebalanceTracking {
     pub(super) last_progress_at: DateTime<Utc>,
 }
 
+/// Single source of truth for the direction -> source-venue mapping: the venue
+/// the USDC physically leaves. Both `UsdcRebalanceTracking::source_venue` and the
+/// restart-safe operator-reconciliation path (which has no tracking instance to
+/// call the method on) derive from this, so the two cannot drift.
+fn source_venue(direction: &RebalanceDirection) -> Venue {
+    match direction {
+        RebalanceDirection::AlpacaToBase => Venue::Hedging,
+        RebalanceDirection::BaseToAlpaca => Venue::MarketMaking,
+    }
+}
+
 impl UsdcRebalanceTracking {
     pub(super) fn source_venue(&self) -> Venue {
-        match self.direction {
-            RebalanceDirection::AlpacaToBase => Venue::Hedging,
-            RebalanceDirection::BaseToAlpaca => Venue::MarketMaking,
-        }
+        source_venue(&self.direction)
     }
 
     fn source_transfer_started(&self) -> bool {
@@ -170,7 +178,8 @@ impl UsdcRebalanceStage {
             | ConversionFailed { .. }
             | WithdrawalFailed { .. }
             | BridgingFailed { .. }
-            | DepositFailed { .. } => None,
+            | DepositFailed { .. }
+            | OperatorReconciled { .. } => None,
         }
     }
 
@@ -727,7 +736,38 @@ impl RebalancingService {
                     self.cancel_tracked_usdc_rebalance(id).await?;
                 }
             }
+            // Operator reconciliation of a post-burn `DepositFailed`: the minted
+            // USDC left the source venue, so reconcile inflight with post-burn
+            // semantics -- zero the source-venue inflight WITHOUT crediting
+            // available -- never a `Cancel` (which would wrongly credit
+            // available). Derives the source venue from `direction`, so it works
+            // with tracking absent (post-restart). The caller's Clear terminal
+            // action removes tracking and clears the guard.
+            OperatorReconciled { direction, .. } => {
+                self.reconcile_operator_resolved(direction, Utc::now())
+                    .await?;
+            }
         }
+
+        Ok(())
+    }
+
+    /// Reconciles source-venue USDC inflight for an operator-reconciled,
+    /// post-burn rebalance: zeroes the source-venue inflight while leaving
+    /// `available` unchanged, because the funds physically left the source.
+    /// Derives the source venue from `direction` via the shared `source_venue`
+    /// mapping so it does not depend on in-memory tracking, which may be absent
+    /// after a restart.
+    async fn reconcile_operator_resolved(
+        &self,
+        direction: &RebalanceDirection,
+        now: DateTime<Utc>,
+    ) -> Result<(), RebalancingServiceError> {
+        let mut inventory = self.inventory.write().await;
+        *inventory = inventory
+            .clone()
+            .clear_usdc_inflight(source_venue(direction), now)?;
+        drop(inventory);
 
         Ok(())
     }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -718,10 +718,16 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 }
             }
 
-            Some(DepositConfirmed {
-                direction: AlpacaToBase,
-                ..
-            }) => Ok(()),
+            // Terminal-success no-ops: an AlpacaToBase deposit already
+            // confirmed, or an operator-reconciled transfer resolved
+            // out-of-band -- both have nothing left to drive.
+            Some(
+                DepositConfirmed {
+                    direction: AlpacaToBase,
+                    ..
+                }
+                | Reconciled { .. },
+            ) => Ok(()),
 
             Some(
                 Converting {
@@ -1513,6 +1519,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 | UsdcRebalance::DepositFailed { .. }
                 | UsdcRebalance::ConversionFailed { .. },
             ) => Err(UsdcTransferError::PreviouslyFailedAggregate { id: id.clone() }),
+
+            // Operator-reconciled is a clearing terminal: the transfer was
+            // resolved out-of-band, so a resume has nothing to drive.
+            Some(UsdcRebalance::Reconciled { .. }) => Ok(()),
         }
     }
 

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -121,6 +121,17 @@ pub(crate) enum RebalanceDirection {
     BaseToAlpaca,
 }
 
+/// Why an operator reconciled a USDC rebalance stranded in the post-burn
+/// terminal `DepositFailed` state. The funds were handled out-of-band, so the
+/// reconcile records the reason rather than re-driving the failed deposit.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum ReconcileReason {
+    /// The minted USDC was moved to its destination manually.
+    FundsMovedManually,
+    /// The deposit was credited at the destination outside the bot's view.
+    DepositCreditedOffline,
+}
+
 /// Errors that can occur during USDC rebalance operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum UsdcRebalanceError {
@@ -284,6 +295,13 @@ pub(crate) enum UsdcRebalanceCommand {
     },
     /// Record deposit failure. Valid only from `DepositInitiated` state.
     FailDeposit { reason: String },
+    /// Reconcile a USDC rebalance stranded in the post-burn terminal
+    /// `DepositFailed` state to a guard-clearing terminal `Reconciled` state.
+    /// The minted USDC was handled out-of-band, so this resolves the transfer
+    /// (clearing the in-progress guard and reconciling source-venue inflight)
+    /// rather than re-driving the Alpaca deposit. Valid ONLY from
+    /// `DepositFailed`.
+    ReconcileStuckRebalance { reason: ReconcileReason },
 }
 
 /// Events emitted by the USDC rebalance aggregate.
@@ -418,6 +436,19 @@ pub(crate) enum UsdcRebalanceEvent {
         reason: String,
         failed_at: DateTime<Utc>,
     },
+    /// An operator reconciled a post-burn `DepositFailed` rebalance to the
+    /// guard-clearing terminal `Reconciled` state. Carries `direction` so the
+    /// reactor derives the source venue without in-memory tracking (which may
+    /// be absent after a restart), plus `amount` and `initiated_at` so the
+    /// projection preserves the real post-burn transfer instead of defaulting
+    /// it to a zero-value transfer starting at reconciliation time.
+    OperatorReconciled {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        reason: ReconcileReason,
+        initiated_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
+    },
 }
 
 impl DomainEvent for UsdcRebalanceEvent {
@@ -444,6 +475,7 @@ impl DomainEvent for UsdcRebalanceEvent {
             Self::DepositInitiated { .. } => "UsdcRebalanceEvent::DepositInitiated",
             Self::DepositConfirmed { .. } => "UsdcRebalanceEvent::DepositConfirmed",
             Self::DepositFailed { .. } => "UsdcRebalanceEvent::DepositFailed",
+            Self::OperatorReconciled { .. } => "UsdcRebalanceEvent::OperatorReconciled",
         }
         .to_string()
     }
@@ -619,9 +651,25 @@ pub(crate) enum UsdcRebalance {
         initiated_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
+    /// An operator reconciled a post-burn `DepositFailed` rebalance
+    /// out-of-band (clearable terminal state). The in-progress guard clears and
+    /// source-venue inflight is reconciled with post-burn semantics. Retains
+    /// `amount` and `initiated_at` so the projection still reports the real
+    /// transfer rather than a zero-value one starting at `reconciled_at`.
+    Reconciled {
+        direction: RebalanceDirection,
+        amount: Usdc,
+        reason: ReconcileReason,
+        initiated_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
+    },
 }
 
 impl UsdcRebalance {
+    // A single state-dispatch match mapping each state to its DTO tuple, one
+    // trivial arm per state. Splitting it would scatter the mapping across
+    // pointless helpers; per the project guidance, suppress the length lint.
+    #[expect(clippy::too_many_lines)]
     pub(crate) fn to_dto(&self, id: &UsdcRebalanceId) -> TransferOperation {
         let (direction, amount, status, started_at, updated_at) = match self {
             Self::Converting {
@@ -818,6 +866,22 @@ impl UsdcRebalance {
                     *deposit_confirmed_at,
                 )
             }
+
+            Self::Reconciled {
+                direction,
+                amount,
+                initiated_at,
+                reconciled_at,
+                ..
+            } => (
+                direction,
+                *amount,
+                UsdcBridgeStatus::Completed {
+                    completed_at: *reconciled_at,
+                },
+                *initiated_at,
+                *reconciled_at,
+            ),
         };
 
         TransferOperation::UsdcBridge(UsdcBridgeOperation {
@@ -895,8 +959,11 @@ impl UsdcRebalance {
                     RebalanceDirection::AlpacaToBase => false,
                 }
             }
-            // Withdrawal failure is always pre-burn: reconcile to source and clear.
-            Self::WithdrawalFailed { .. } => false,
+            // Withdrawal failure is always pre-burn: reconcile to source and
+            // clear. Operator reconciliation is the explicit clearing terminal
+            // for a post-burn `DepositFailed`, so the guard must not re-latch on
+            // startup for it either.
+            Self::WithdrawalFailed { .. } | Self::Reconciled { .. } => false,
         }
     }
 
@@ -970,7 +1037,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { direction, .. }
             | Self::DepositInitiated { direction, .. }
             | Self::DepositConfirmed { direction, .. }
-            | Self::DepositFailed { direction, .. } => direction.clone(),
+            | Self::DepositFailed { direction, .. }
+            | Self::Reconciled { direction, .. } => direction.clone(),
         }
     }
 }
@@ -1085,7 +1153,10 @@ impl EventSourced for UsdcRebalance {
     // v2/v3) to clear stale snapshots and rebuild from events, so any persisted
     // `Attested` snapshot is regenerated under the current schema rather than
     // relying on serde's missing-Option-as-None leniency.
-    const SCHEMA_VERSION: u64 = 4;
+    // v5: added the terminal `Reconciled` state (and `OperatorReconciled` event)
+    // for operator reconciliation of a post-burn `DepositFailed`. Bumped to
+    // clear stale snapshots so they rebuild from events under the new schema.
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use UsdcRebalanceEvent::*;
@@ -1534,6 +1605,37 @@ impl EventSourced for UsdcRebalance {
                 failed_at: *failed_at,
             },
 
+            (
+                OperatorReconciled {
+                    direction,
+                    amount,
+                    reason,
+                    initiated_at,
+                    reconciled_at,
+                },
+                // Mirrors the states `transition_reconcile_stuck_rebalance`
+                // accepts: a post-burn terminal failure that strands the guard.
+                Self::DepositFailed { .. }
+                | Self::BridgingFailed {
+                    burn_tx_hash: Some(_),
+                    ..
+                }
+                | Self::BridgingFailed {
+                    cctp_nonce: Some(_),
+                    ..
+                }
+                | Self::ConversionFailed {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    ..
+                },
+            ) => Self::Reconciled {
+                direction: direction.clone(),
+                amount: *amount,
+                reason: *reason,
+                initiated_at: *initiated_at,
+                reconciled_at: *reconciled_at,
+            },
+
             _ => return Ok(None),
         };
 
@@ -1622,6 +1724,11 @@ impl EventSourced for UsdcRebalance {
             InitiateDeposit { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
 
             ConfirmDeposit | FailDeposit { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
+
+            ReconcileStuckRebalance { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "ReconcileStuckRebalance".to_string(),
+                state: "Uninitialized".to_string(),
+            }),
         }
     }
 
@@ -1682,6 +1789,7 @@ impl EventSourced for UsdcRebalance {
             InitiateDeposit { deposit } => self.transition_initiate_deposit(deposit),
             ConfirmDeposit => self.transition_confirm_deposit(),
             FailDeposit { reason } => self.transition_fail_deposit(reason),
+            ReconcileStuckRebalance { reason } => self.transition_reconcile_stuck_rebalance(reason),
         }
     }
 }
@@ -1920,7 +2028,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::InvalidCommand {
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::InvalidCommand {
                 command: "BeginBridging".to_string(),
                 state: "bridging already started".to_string(),
             }),
@@ -1956,7 +2065,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::InvalidCommand {
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::InvalidCommand {
                 command: "InitiateBridging".to_string(),
                 state: "Bridging".to_string(),
             }),
@@ -1997,7 +2107,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
         }
     }
 
@@ -2032,7 +2143,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
         }
     }
 
@@ -2064,7 +2176,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
         }
     }
 
@@ -2113,7 +2226,8 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::BridgingAlreadyCompleted),
         }
     }
 
@@ -2179,7 +2293,8 @@ impl UsdcRebalance {
             }]),
             Self::DepositInitiated { .. }
             | Self::DepositConfirmed { .. }
-            | Self::DepositFailed { .. } => Err(UsdcRebalanceError::InvalidCommand {
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::InvalidCommand {
                 command: "InitiateDeposit".to_string(),
                 state: format!("{self:?}"),
             }),
@@ -2206,12 +2321,12 @@ impl UsdcRebalance {
                 direction: direction.clone(),
                 deposit_confirmed_at: Utc::now(),
             }]),
-            Self::DepositConfirmed { .. } | Self::DepositFailed { .. } => {
-                Err(UsdcRebalanceError::InvalidCommand {
-                    command: "ConfirmDeposit".to_string(),
-                    state: format!("{self:?}"),
-                })
-            }
+            Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "ConfirmDeposit".to_string(),
+                state: format!("{self:?}"),
+            }),
         }
     }
 
@@ -2239,13 +2354,81 @@ impl UsdcRebalance {
                 reason,
                 failed_at: Utc::now(),
             }]),
-            Self::DepositConfirmed { .. } | Self::DepositFailed { .. } => {
-                Err(UsdcRebalanceError::InvalidCommand {
-                    command: "FailDeposit".to_string(),
-                    state: format!("{self:?}"),
-                })
-            }
+            Self::DepositConfirmed { .. }
+            | Self::DepositFailed { .. }
+            | Self::Reconciled { .. } => Err(UsdcRebalanceError::InvalidCommand {
+                command: "FailDeposit".to_string(),
+                state: format!("{self:?}"),
+            }),
         }
+    }
+
+    /// Reconciles a stuck post-burn rebalance to the guard-clearing terminal
+    /// `Reconciled` state. The CCTP burn/mint already moved the funds off the
+    /// source venue, so the operator settles them out-of-band and this clears
+    /// the `usdc_in_progress` guard rather than re-driving the failed leg.
+    ///
+    /// Valid only from a post-burn terminal failure that strands the guard with
+    /// no other exit:
+    ///
+    /// - `DepositFailed` -- only reachable from `DepositInitiated`, hence always
+    ///   post-mint.
+    /// - `BridgingFailed` with a recorded `burn_tx_hash` or `cctp_nonce` -- both
+    ///   are only ever populated after the burn reaches CCTP, so either proves
+    ///   the failure is post-burn (mirrors the reactor's post-burn classifier).
+    ///   A pre-burn `BridgingFailed` (both `None`) carries no burned funds and
+    ///   already reconciles to source on its own.
+    /// - A `BaseToAlpaca` `ConversionFailed` -- that conversion is the
+    ///   post-deposit USDC->USD leg, so it is post-mint. The `AlpacaToBase`
+    ///   `ConversionFailed` is the pre-withdrawal leg (pre-burn) and reconciles
+    ///   to source on its own.
+    ///
+    /// Every other state is rejected: an in-progress transfer is still being
+    /// driven (resume it instead), a pre-burn failure already reconciles to
+    /// source, and a terminal success or `Reconciled` has nothing to reconcile.
+    fn transition_reconcile_stuck_rebalance(
+        &self,
+        reason: ReconcileReason,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+        use UsdcRebalanceEvent::*;
+        let (direction, amount, initiated_at) = match self {
+            Self::DepositFailed {
+                direction,
+                amount,
+                initiated_at,
+                ..
+            }
+            | Self::ConversionFailed {
+                direction: direction @ RebalanceDirection::BaseToAlpaca,
+                amount,
+                initiated_at,
+                ..
+            } => (direction.clone(), *amount, *initiated_at),
+            Self::BridgingFailed {
+                direction,
+                amount,
+                burn_tx_hash,
+                cctp_nonce,
+                initiated_at,
+                ..
+            } if burn_tx_hash.is_some() || cctp_nonce.is_some() => {
+                (direction.clone(), *amount, *initiated_at)
+            }
+            _ => {
+                return Err(UsdcRebalanceError::InvalidCommand {
+                    command: "ReconcileStuckRebalance".to_string(),
+                    state: format!("{self:?}"),
+                });
+            }
+        };
+
+        Ok(vec![OperatorReconciled {
+            direction,
+            amount,
+            reason,
+            initiated_at,
+            reconciled_at: Utc::now(),
+        }])
     }
 }
 
@@ -4862,6 +5045,530 @@ mod tests {
         ));
     }
 
+    /// Event history that lands a BaseToAlpaca aggregate in the post-burn
+    /// terminal `DepositFailed` state, for the operator-reconcile tests.
+    fn deposit_failed_history() -> Vec<UsdcRebalanceEvent> {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: burn_tx,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![0x01],
+                cctp_nonce: TEST_CCTP_NONCE,
+                message: None,
+                mint_scan_from_block: Some(100),
+                attested_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::Bridged {
+                mint_tx_hash: mint_tx,
+                amount_received: Usdc::new(float!(99.99)),
+                fee_collected: Usdc::new(float!(0.01)),
+                minted_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                deposit_initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::DepositFailed {
+                deposit_ref: Some(TransferRef::OnchainTx(mint_tx)),
+                reason: "deposit rejected".to_string(),
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
+    /// Event history that lands a BaseToAlpaca aggregate in a post-burn terminal
+    /// `BridgingFailed` state (a burn tx is recorded but the bridge never
+    /// completed), for the operator-reconcile tests.
+    fn post_burn_bridging_failed_history() -> Vec<UsdcRebalanceEvent> {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: burn_tx,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingFailed {
+                burn_tx_hash: Some(burn_tx),
+                cctp_nonce: None,
+                reason: "attestation never arrived".to_string(),
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
+    /// Event history that lands a BaseToAlpaca aggregate in the post-deposit
+    /// (post-mint) terminal `ConversionFailed` state -- the USDC->USD leg failed
+    /// after the deposit confirmed -- for the operator-reconcile tests.
+    fn base_to_alpaca_conversion_failed_history() -> Vec<UsdcRebalanceEvent> {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: burn_tx,
+                burned_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![0x01],
+                cctp_nonce: TEST_CCTP_NONCE,
+                message: None,
+                mint_scan_from_block: Some(100),
+                attested_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::Bridged {
+                mint_tx_hash: mint_tx,
+                amount_received: Usdc::new(float!(99.99)),
+                fee_collected: Usdc::new(float!(0.01)),
+                minted_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                deposit_initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                deposit_confirmed_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(99.99)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::ConversionFailed {
+                reason: "USDC->USD conversion rejected".to_string(),
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
+    /// Drives `ReconcileStuckRebalance` against a history that ends in a
+    /// guard-stranding post-burn failure and asserts it emits a single
+    /// `OperatorReconciled` preserving the source amount and initiation
+    /// timestamp, then materializes the clearing terminal `Reconciled`.
+    async fn assert_reconcile_emits_operator_reconciled(
+        history: Vec<UsdcRebalanceEvent>,
+        expected_direction: RebalanceDirection,
+    ) {
+        // The source failure carries the real post-burn amount and original
+        // initiation timestamp; reconciliation must preserve both so the
+        // projection does not collapse the transfer to a zero-value one.
+        let (source_amount, source_initiated_at) = match replay::<UsdcRebalance>(history.clone())
+            .expect("history should replay")
+            .expect("history should materialize a failure state")
+        {
+            UsdcRebalance::DepositFailed {
+                amount,
+                initiated_at,
+                ..
+            }
+            | UsdcRebalance::BridgingFailed {
+                amount,
+                initiated_at,
+                ..
+            }
+            | UsdcRebalance::ConversionFailed {
+                amount,
+                initiated_at,
+                ..
+            } => (amount, initiated_at),
+            other => panic!("fixture should end in a post-burn failure, got {other:?}"),
+        };
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(history.clone())
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::OperatorReconciled {
+            direction,
+            amount,
+            reason,
+            initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected OperatorReconciled, got {:?}", events[0]);
+        };
+        assert_eq!(*direction, expected_direction);
+        assert_eq!(*amount, source_amount);
+        assert_eq!(*reason, ReconcileReason::FundsMovedManually);
+        assert_eq!(*initiated_at, source_initiated_at);
+
+        // Applying the event must drive the aggregate to the clearing terminal
+        // Reconciled state -- the evolve arm, not just the command handler.
+        let state = replay::<UsdcRebalance>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize aggregate state");
+        assert!(
+            matches!(state, UsdcRebalance::Reconciled { .. }),
+            "reconciled aggregate should be Reconciled, got {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_from_post_burn_bridging_failed_emits_operator_reconciled() {
+        assert_reconcile_emits_operator_reconciled(
+            post_burn_bridging_failed_history(),
+            RebalanceDirection::BaseToAlpaca,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_from_base_to_alpaca_conversion_failed_emits_reconciled() {
+        assert_reconcile_emits_operator_reconciled(
+            base_to_alpaca_conversion_failed_history(),
+            RebalanceDirection::BaseToAlpaca,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_from_deposit_failed_emits_operator_reconciled() {
+        let history = deposit_failed_history();
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(history.clone())
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .events();
+
+        // The DepositFailed source state carries the real post-burn amount and
+        // original initiation timestamp; reconciliation must preserve both so
+        // the projection does not collapse the transfer to a zero-value one.
+        let UsdcRebalance::DepositFailed {
+            amount: failed_amount,
+            initiated_at: failed_initiated_at,
+            ..
+        } = replay::<UsdcRebalance>(history.clone())
+            .expect("history should replay")
+            .expect("history should materialize DepositFailed")
+        else {
+            panic!("fixture should end in DepositFailed");
+        };
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::OperatorReconciled {
+            direction,
+            amount,
+            reason,
+            initiated_at,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected OperatorReconciled, got {:?}", events[0]);
+        };
+        assert_eq!(*direction, RebalanceDirection::BaseToAlpaca);
+        assert_eq!(*amount, failed_amount);
+        assert_eq!(*reason, ReconcileReason::FundsMovedManually);
+        assert_eq!(*initiated_at, failed_initiated_at);
+
+        // Applying the event must drive the aggregate to the clearing terminal
+        // Reconciled state -- the evolve arm, not just the command handler.
+        let state = replay::<UsdcRebalance>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize aggregate state");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::Reconciled {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    reason: ReconcileReason::FundsMovedManually,
+                    ..
+                }
+            ),
+            "reconciled aggregate should be Reconciled, got {state:?}"
+        );
+    }
+
+    #[test]
+    fn reconciled_does_not_hold_rebalance_guard() {
+        let reconciled = UsdcRebalance::Reconciled {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100.00)),
+            reason: ReconcileReason::FundsMovedManually,
+            initiated_at: Utc::now(),
+            reconciled_at: Utc::now(),
+        };
+        assert!(
+            !reconciled.holds_rebalance_guard(),
+            "operator-reconciled terminal must clear the guard"
+        );
+    }
+
+    #[test]
+    fn reconciled_direction_reads_persisted_direction() {
+        let reconciled = UsdcRebalance::Reconciled {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(100.00)),
+            reason: ReconcileReason::DepositCreditedOffline,
+            initiated_at: Utc::now(),
+            reconciled_at: Utc::now(),
+        };
+        assert_eq!(reconciled.direction(), RebalanceDirection::AlpacaToBase);
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_bridged() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(100.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: mint_tx,
+                    amount_received: Usdc::new(float!(99.99)),
+                    fee_collected: Usdc::new(float!(0.01)),
+                    minted_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_deposit_initiated() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+        let mint_tx =
+            fixed_bytes!("0x1111111111111111111111111111111111111111111111111111111111111111");
+
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(100.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingInitiated {
+                    burn_tx_hash: burn_tx,
+                    burned_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![0x01],
+                    cctp_nonce: TEST_CCTP_NONCE,
+                    message: None,
+                    mint_scan_from_block: Some(100),
+                    attested_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: mint_tx,
+                    amount_received: Usdc::new(float!(99.99)),
+                    fee_collected: Usdc::new(float!(0.01)),
+                    minted_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::DepositInitiated {
+                    deposit_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+                    deposit_initiated_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_initiated() {
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::OnchainTx(fixed_bytes!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )),
+                initiated_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_already_reconciled() {
+        let mut history = deposit_failed_history();
+        history.push(UsdcRebalanceEvent::OperatorReconciled {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(100.00)),
+            reason: ReconcileReason::FundsMovedManually,
+            initiated_at: Utc::now(),
+            reconciled_at: Utc::now(),
+        });
+
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(history)
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::DepositCreditedOffline,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_pre_burn_bridging_failed() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000001");
+
+        // A pre-burn BridgingFailed (no burn tx, no CCTP nonce) carries no
+        // burned funds: the failure already reconciles to source, so reconcile
+        // must reject it rather than zero source inflight without crediting
+        // available (which would lose the never-burned funds).
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: Usdc::new(float!(100.00)),
+                    withdrawal_ref: TransferRef::OnchainTx(burn_tx),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::BridgingFailed {
+                    burn_tx_hash: None,
+                    cctp_nonce: None,
+                    reason: "burn reverted before broadcast".to_string(),
+                    failed_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_stuck_rebalance_rejected_from_alpaca_to_base_conversion_failed() {
+        // AlpacaToBase ConversionFailed is the pre-withdrawal (pre-burn)
+        // USD->USDC leg: no funds left the source, so reconcile must reject it.
+        // It reconciles to source on its own via the normal failure path.
+        let error = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::ConversionInitiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(100.00)),
+                    order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::ConversionFailed {
+                    reason: "USD->USDC conversion rejected".to_string(),
+                    failed_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::ReconcileStuckRebalance {
+                reason: ReconcileReason::FundsMovedManually,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(UsdcRebalanceError::InvalidCommand { .. })
+        ));
+    }
+
     #[tokio::test]
     async fn test_deposit_failed_rejects_confirm_deposit() {
         let burn_tx =
@@ -5934,6 +6641,36 @@ mod tests {
         ));
         assert_eq!(bridge.started_at, initiated_at);
         assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_reconciled_preserves_amount_and_original_initiated_at() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let reconciled_at = initiated_at + chrono::Duration::seconds(120);
+        let state = UsdcRebalance::Reconciled {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(750)),
+            reason: ReconcileReason::FundsMovedManually,
+            initiated_at,
+            reconciled_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // The funds genuinely left the source venue via CCTP burn, so the
+        // projection must report the real transfer amount and its original
+        // start time -- not a zero-value transfer beginning at reconciliation.
+        assert_eq!(bridge.amount, Usdc::new(float!(750)));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, reconciled_at);
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Completed { completed_at } if completed_at == reconciled_at
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

- Add operator CLI `reconcile-usdc-transfer --id <id> [--reason funds-moved-manually|deposit-credited-offline]` that drives a USDC rebalance stuck in terminal `DepositFailed` to a new clearing terminal state `Reconciled`, releasing the `usdc_in_progress` guard.
- New aggregate command `ReconcileStuckRebalance`, event `OperatorReconciled`, and terminal state `Reconciled` (`src/usdc_rebalance.rs`).
- Reactor reconciles source-venue USDC inflight when the reconcile lands (`src/rebalancing/trigger/{mod,usdc}.rs`).

## Why

- A post-burn `DepositFailed` permanently blocks **all** USDC rebalancing: `holds_rebalance_guard()` is true for it, so `recover_usdc_guard` re-latches the guard every startup and the timeout sweep preserves it every cycle (`Skipped USDC trigger: already in progress` forever).
- Nothing transitions out of `DepositFailed` (`InitiateDeposit`/`ConfirmDeposit`/`FailDeposit` all reject it); `RecoverBridging` only applies to `BridgingFailed`; `resume-usdc-transfer` just returns the prior failure.
- Closes [RAI-957](https://linear.app/makeitrain/issue/RAI-957).

## How

- `ReconcileStuckRebalance { reason }` is valid only from `DepositFailed` (else `InvalidCommand`) and emits `OperatorReconciled { direction, reason, reconciled_at }`, evolving to terminal `Reconciled`, for which `holds_rebalance_guard()` returns false.
- The reactor classifies `OperatorReconciled` as a Clear terminal: it removes tracking, clears the guard, and zeroes source-venue USDC inflight via `clear_usdc_inflight` — **post-burn semantics: it does not credit `available`**, because the minted funds physically left source. The venue is derived from the event `direction`, so it works with in-memory tracking absent after a restart.
- `reason` is a typed `ReconcileReason` enum (no opaque String). `SCHEMA_VERSION` bumps 4→5; the aggregate uses the default `Retain` policy so existing events replay (no `CompactedSnapshotClear`).
- The CLI builds a standalone `UsdcRebalance` store (mirrors `resume-usdc-transfer`) and rejects an unknown id or a non-`DepositFailed` aggregate before sending.
- `resume-usdc-transfer` now treats a `Reconciled` aggregate as a terminal no-op (`Ok(())`) instead of erroring.

## Testing

- 15 new tests: aggregate (emit from `DepositFailed`; reject from `Bridged`/`DepositInitiated`/`Initiated`/already-`Reconciled`; evolve; `holds_rebalance_guard==false`; `direction`); reactor (clears guard + removes tracking + zeroes source inflight **without** changing `available`; works with tracking absent; `recover_usdc_guard` does not re-latch for `Reconciled`); CLI (rejects unknown/non-`DepositFailed`, parses `--id`/`--reason`).

## Anything else

- Schema bump verified deploy-safe (`Retain` policy → full event replay). Operator runbook after deploy: `reconcile-usdc-transfer --id bd5cb533-bdb2-4825-a21c-a3dc48667f1f --reason funds-moved-manually`.
