### PR TITLE
feat: grant one-time max token approvals on startup

### DIFF
--- a/adrs/0005-max-token-approvals-on-startup.md
+++ b/adrs/0005-max-token-approvals-on-startup.md
@@ -1,0 +1,114 @@
+# ADR 0005: Grant one-time MAX token approvals to trusted spenders on startup
+
+## Status
+
+Accepted
+
+## Context
+
+The market maker repeatedly performs two on-chain actions that move ERC20 tokens
+via a spender's `transferFrom`:
+
+- **Wrapping**: depositing the underlying tokenized equity (tToken) into its
+  ERC-4626 wrapper vault (wtToken) to receive wrapped shares.
+- **Vault deposits**: depositing wrapped equity (wtToken) and USDC into the
+  Raindex orderbook via `deposit4`.
+
+Each of these previously approved exactly the operation amount immediately
+before the action: `WrapperService::submit_wrap` approved `(tToken -> wtToken)`
+and `RaindexService::approve_for_orderbook` approved `(token -> orderbook)`.
+
+That per-operation pattern is gas-coupled and race-prone:
+
+- The approve is a separate transaction that must land before the wrap/deposit.
+  On low gas it can fail to mine, so the subsequent `transferFrom` reverts with
+  `ERC20InsufficientAllowance`.
+- The skip-if-sufficient check reads `allowance(owner, spender)` first. Behind a
+  load-balanced RPC (the dRPC hazard AGENTS.md warns about), a stale node can
+  return an allowance that omits a just-issued approve, so the code skips the
+  approve it actually needed -- and again the transfer reverts.
+
+These reverts surfaced in production and, critically, wedged the COIN
+unwrapped-equity recovery path: recovery wraps then deposits, so an
+allowance-coupled revert there leaves operational equity stranded.
+
+## Decision
+
+Grant a single idempotent `U256::MAX` approval per `(token, spender)` pair at
+startup, to the **trusted spenders only**:
+
+1. `approve(underlying tToken -> wtToken vault, MAX)` -- enables wrapping.
+2. `approve(wtToken -> orderbook, MAX)` -- enables depositing wrapped equity.
+3. `approve(USDC -> orderbook, MAX)` -- enables USDC vault deposits.
+
+Targets 1 and 2 are built for every configured equity symbol that has trading or
+rebalancing enabled; the symbol -> address mapping is resolved through the
+`Wrapper` trait (`lookup_underlying` / `lookup_derivative`). The orderbook comes
+from the EVM config, USDC from the shared `USDC_BASE` constant, and the owner is
+the base bot wallet.
+
+The grant runs inline during conductor startup, after the RPC probe and vault
+registry seeding but **before any worker or rebalancer spawns**, so allowances
+are durably on chain before the first wrap/deposit. It submits through the same
+`Wallet::submit` path every other on-chain write uses, so confirmation depth and
+nonce handling are consistent. A failure to grant fails startup fast with a
+typed error (`StartupApprovalError`): the bot must not come up looking healthy
+while wrap/deposit would revert.
+
+## Idempotency and re-arm
+
+For each pair the routine reads `allowance(owner, spender)` and applies a pure
+decision: if the allowance is already at or above a high watermark
+(`U256::MAX / 2`) it skips, otherwise it submits `approve(spender, MAX)`. The
+watermark cleanly separates an already-granted MAX approval (possibly partially
+consumed by transfers) from a bounded per-operation allowance that still needs
+upgrading. A restart therefore submits no redundant approves once MAX is in
+place, and a newly configured symbol or a wallet whose allowance was reset is
+re-armed automatically on the next startup.
+
+## Security trade-off
+
+An infinite approval is only as safe as its spender. Here the spenders are our
+own ERC-4626 wrapper vaults and the audited Raindex orderbook -- contracts the
+bot already entrusts with its operating balances every cycle. The wallet holds
+only operational balances (not a treasury), so the marginal risk of an unlimited
+versus per-operation allowance to these specific, bot-controlled protocol
+contracts is acceptable, and it removes a whole class of liveness failures.
+
+## Revocation and incident response
+
+- Trigger immediate revocation if a trusted spender is compromised, replaced, or
+  exhibits abnormal behavior (unexpected wrapper-vault or orderbook upgrade,
+  anomalous outgoing transfers, monitoring or audit alerts).
+- Stop the bot first so no worker re-arms allowances or keeps moving funds while
+  the spender is suspect.
+- Revoke by setting the allowance to `0` for each affected `(token, spender)`
+  pair from the bot wallet, e.g.
+  `cast send <token> "approve(address,uint256)" <spender> 0`.
+- Do not restart the bot until the spender is validated: startup re-grants MAX
+  to every configured target, so bringing the bot up re-arms the allowance the
+  revocation just removed. The startup fail-fast stays the safety net only for
+  spenders that are trusted again.
+
+## Consequences
+
+- Wrap and vault-deposit no longer depend on a per-operation approve landing, so
+  the `ERC20InsufficientAllowance` revert class -- and the recovery wedge it
+  caused -- is eliminated for the trusted spenders.
+- The per-operation approvals in `WrapperService::submit_wrap` and
+  `RaindexService::approve_for_orderbook` remain in place as a defensive
+  fallback. Once the startup MAX grant lands they short-circuit to a no-op (the
+  allowance already exceeds any operation amount), so they cost nothing but
+  still cover any spender not pre-approved at startup.
+- A standalone bot with no `[wallet]` configured skips the grant entirely: it
+  never wraps or deposits, so it has no allowances to grant.
+
+## Alternatives considered
+
+- **Keep per-operation approvals, just retry harder.** Rejected: it does not
+  remove the gas coupling or the stale-allowance race; it only narrows the
+  window. The failure recurred in production despite the skip-if-sufficient
+  guard.
+- **Approve exactly the operation amount but as a separate confirmed step with
+  its own recovery.** Rejected: more moving parts and persisted state for a
+  problem a one-time MAX grant removes outright.

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -55,6 +55,7 @@ use crate::onchain::USDC_BASE;
 #[cfg(test)]
 use crate::onchain::accumulator::check_all_positions;
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
+use crate::onchain::approvals::{build_approval_targets, grant_startup_approvals};
 use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
@@ -274,6 +275,14 @@ impl Conductor {
         // below as an apalis worker so the queue retries on failure if
         // seeding is re-triggered later (e.g. from a recovery flow).
         crate::conductor::job::Job::perform(&SeedVaultRegistry, &seed_vault_registry_ctx).await?;
+
+        // Grant one-time idempotent MAX approvals to the trusted spenders (our
+        // ERC-4626 wrapper vaults and the Raindex orderbook) before any worker
+        // or rebalancer runs, so wrap/deposit never reverts with
+        // ERC20InsufficientAllowance. Fails fast -- the bot must not come up
+        // healthy with these missing. Only runs when a wallet is configured;
+        // without one the bot cannot submit on-chain transactions at all.
+        grant_startup_token_approvals(&ctx).await?;
 
         let rebalancing = match ctx.rebalancing_ctx() {
             Ok(ctx) => Some(ctx.clone()),
@@ -617,6 +626,54 @@ fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Addr
         .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
         .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
         .collect()
+}
+
+/// Grants one-time idempotent MAX ERC20 approvals to the trusted spenders at
+/// startup: each configured equity's underlying -> wrapper vault and wrapped ->
+/// orderbook, plus USDC -> orderbook. Resolves token addresses through a
+/// [`WrapperService`] built from the equity config, and submits through the
+/// base wallet so confirmations and nonce handling match every other on-chain
+/// write.
+///
+/// Skips entirely when no wallet is configured -- a standalone bot without a
+/// wallet never wraps or deposits, so it has no allowances to grant.
+async fn grant_startup_token_approvals(ctx: &Ctx) -> anyhow::Result<()> {
+    let base_wallet = match ctx.wallet() {
+        Ok(wallet_ctx) => wallet_ctx.base_wallet().clone(),
+        Err(CtxError::WalletNotConfigured) => {
+            info!(
+                target: "orderbook",
+                "No wallet configured -- skipping startup token approvals"
+            );
+            return Ok(());
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    let wrapper = WrapperService::new(
+        base_wallet.clone(),
+        to_wrapped_equities(&ctx.assets.equities.symbols),
+    );
+
+    let symbols = ctx
+        .assets
+        .equities
+        .symbols
+        .keys()
+        .filter(|symbol| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .cloned();
+
+    let targets = build_approval_targets(&wrapper, symbols, ctx.evm.orderbook, USDC_BASE)?;
+
+    grant_startup_approvals(&base_wallet, &targets).await?;
+
+    info!(
+        target: "orderbook",
+        target_count = targets.len(),
+        "Startup token approvals ensured"
+    );
+
+    Ok(())
 }
 
 /// Context for vault discovery operations during trade processing.

--- a/src/onchain/approvals.rs
+++ b/src/onchain/approvals.rs
@@ -1,0 +1,646 @@
+//! One-time idempotent MAX ERC20 approvals granted on startup.
+//!
+//! The market maker repeatedly wraps tokenized equity into its ERC-4626 vault
+//! and deposits both wrapped equity and USDC into the Raindex orderbook. The
+//! per-operation approve transactions that previously preceded each of those
+//! actions were gas-coupled and race-prone: an approve that could not land on
+//! low gas, or a stale allowance read served by a lagging load-balanced RPC
+//! node, left the subsequent `transferFrom` to revert with
+//! `ERC20InsufficientAllowance` -- which in turn wedged unwrapped-equity
+//! recovery.
+//!
+//! This module grants a single `U256::MAX` allowance per `(token, spender)`
+//! pair at startup, to the trusted spenders only: our own ERC-4626 wrapper
+//! vaults and the Raindex orderbook. The grant is idempotent -- an allowance
+//! already at or near max is left untouched -- so restarts do not re-submit
+//! redundant approves. The per-operation approvals remain in place as a
+//! defensive fallback; once the startup grant lands they short-circuit to a
+//! no-op because the allowance already exceeds any operation amount.
+
+use alloy::primitives::{Address, U256};
+
+use st0x_evm::{OpenChainErrorRegistry, Wallet};
+use st0x_execution::Symbol;
+use st0x_wrapper::{Wrapper, WrapperError};
+
+use crate::bindings::IERC20;
+
+/// High watermark above which an existing allowance is treated as "already
+/// effectively unlimited", so the startup grant skips it. A genuine MAX
+/// approval sits at `U256::MAX`; normal per-operation approvals are many orders
+/// of magnitude below `U256::MAX / 2`, so this cleanly distinguishes an
+/// already-granted MAX approval (possibly partially consumed by transfers) from
+/// a bounded per-operation allowance that still needs the startup grant.
+const MAX_APPROVAL_WATERMARK: U256 = U256::from_limbs([
+    0xffff_ffff_ffff_ffff,
+    0xffff_ffff_ffff_ffff,
+    0xffff_ffff_ffff_ffff,
+    0x7fff_ffff_ffff_ffff,
+]);
+
+/// Whether a startup approval needs to be submitted for a `(token, spender)`
+/// pair, given the allowance currently on chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApprovalDecision {
+    /// The existing allowance is at or above [`MAX_APPROVAL_WATERMARK`]; no
+    /// approve transaction is submitted.
+    AlreadySufficient,
+    /// The allowance is below the watermark; submit `approve(spender, MAX)`.
+    GrantMax,
+}
+
+/// Pure idempotency decision: skip when the on-chain allowance is already at or
+/// above the max watermark, otherwise grant a fresh MAX approval.
+pub(crate) fn approval_decision(current_allowance: U256) -> ApprovalDecision {
+    if current_allowance >= MAX_APPROVAL_WATERMARK {
+        ApprovalDecision::AlreadySufficient
+    } else {
+        ApprovalDecision::GrantMax
+    }
+}
+
+/// A single `(token, spender)` approval the startup routine must guarantee,
+/// carrying the symbol context (or `None` for cash) for logging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ApprovalTarget {
+    /// ERC20 token whose allowance is being granted.
+    pub(crate) token: Address,
+    /// Trusted spender receiving the MAX allowance.
+    pub(crate) spender: Address,
+    /// Equity symbol this approval enables, or `None` for the USDC/cash grant.
+    pub(crate) symbol: Option<Symbol>,
+    /// Human-readable role of this approval, for logs and the submit note.
+    pub(crate) purpose: ApprovalPurpose,
+}
+
+/// What an [`ApprovalTarget`] enables, used purely for log/note context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApprovalPurpose {
+    /// `approve(underlying tToken -> wtToken vault)` -- enables wrapping.
+    WrapUnderlying,
+    /// `approve(wtToken -> orderbook)` -- enables depositing wrapped equity.
+    DepositWrappedEquity,
+    /// `approve(USDC -> orderbook)` -- enables USDC vault deposits.
+    DepositUsdc,
+}
+
+impl ApprovalPurpose {
+    /// Stable note string passed to `Wallet::submit` for tracing.
+    const fn note(self) -> &'static str {
+        match self {
+            Self::WrapUnderlying => "startup MAX approve: underlying -> wrapper vault",
+            Self::DepositWrappedEquity => "startup MAX approve: wrapped equity -> orderbook",
+            Self::DepositUsdc => "startup MAX approve: USDC -> orderbook",
+        }
+    }
+}
+
+/// Errors that abort startup when the bot cannot guarantee its operating
+/// allowances. These are fail-fast: the bot must not come up looking healthy
+/// while wrap/deposit would revert with `ERC20InsufficientAllowance`.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StartupApprovalError {
+    #[error("failed to resolve token addresses for symbol {symbol}")]
+    SymbolResolution {
+        symbol: Symbol,
+        #[source]
+        source: Box<WrapperError>,
+    },
+    #[error(
+        "failed to read allowance for token {token} spender {spender} \
+         (symbol {symbol:?})"
+    )]
+    AllowanceRead {
+        token: Address,
+        spender: Address,
+        symbol: Option<Symbol>,
+        #[source]
+        source: Box<st0x_evm::EvmError>,
+    },
+    #[error(
+        "failed to submit MAX approve for token {token} spender {spender} \
+         (symbol {symbol:?})"
+    )]
+    ApproveSubmit {
+        token: Address,
+        spender: Address,
+        symbol: Option<Symbol>,
+        #[source]
+        source: Box<st0x_evm::EvmError>,
+    },
+}
+
+/// Builds the full list of startup approval targets: for every configured
+/// equity symbol, the two wrap/deposit grants, plus the single USDC grant.
+///
+/// Token addresses are resolved through the [`Wrapper`] trait so the symbol ->
+/// address mapping is owned in one place; the orderbook and USDC addresses come
+/// from the caller (EVM config / raindex constant).
+pub(crate) fn build_approval_targets(
+    wrapper: &dyn Wrapper,
+    symbols: impl IntoIterator<Item = Symbol>,
+    orderbook: Address,
+    usdc: Address,
+) -> Result<Vec<ApprovalTarget>, StartupApprovalError> {
+    let mut targets = Vec::new();
+
+    for symbol in symbols {
+        let underlying = wrapper.lookup_underlying(&symbol).map_err(|source| {
+            StartupApprovalError::SymbolResolution {
+                symbol: symbol.clone(),
+                source: Box::new(source),
+            }
+        })?;
+
+        let derivative = wrapper.lookup_derivative(&symbol).map_err(|source| {
+            StartupApprovalError::SymbolResolution {
+                symbol: symbol.clone(),
+                source: Box::new(source),
+            }
+        })?;
+
+        targets.push(ApprovalTarget {
+            token: underlying,
+            spender: derivative,
+            symbol: Some(symbol.clone()),
+            purpose: ApprovalPurpose::WrapUnderlying,
+        });
+
+        targets.push(ApprovalTarget {
+            token: derivative,
+            spender: orderbook,
+            symbol: Some(symbol),
+            purpose: ApprovalPurpose::DepositWrappedEquity,
+        });
+    }
+
+    targets.push(ApprovalTarget {
+        token: usdc,
+        spender: orderbook,
+        symbol: None,
+        purpose: ApprovalPurpose::DepositUsdc,
+    });
+
+    Ok(targets)
+}
+
+/// Grants idempotent MAX approvals for every target, reading each current
+/// allowance first and submitting `approve(spender, MAX)` only when below the
+/// watermark. Each submitted approve waits for the wallet's configured
+/// confirmation depth (baked into `Wallet::submit`), so allowances are durably
+/// on chain before the routine returns.
+///
+/// Fails fast on the first allowance read or approve submission error -- these
+/// approvals are required for wrap/deposit to function.
+pub(crate) async fn grant_startup_approvals<W: Wallet>(
+    wallet: &W,
+    targets: &[ApprovalTarget],
+) -> Result<(), StartupApprovalError> {
+    let owner = wallet.address();
+
+    for target in targets {
+        let ApprovalTarget {
+            token,
+            spender,
+            symbol,
+            purpose,
+        } = target;
+
+        let current_allowance: U256 = wallet
+            .call::<OpenChainErrorRegistry, _>(
+                *token,
+                IERC20::allowanceCall {
+                    owner,
+                    spender: *spender,
+                },
+            )
+            .await
+            .map_err(|source| StartupApprovalError::AllowanceRead {
+                token: *token,
+                spender: *spender,
+                symbol: symbol.clone(),
+                source: Box::new(source),
+            })?;
+
+        match approval_decision(current_allowance) {
+            ApprovalDecision::AlreadySufficient => {
+                tracing::info!(
+                    target: "startup",
+                    %token,
+                    %spender,
+                    ?symbol,
+                    purpose = ?purpose,
+                    %current_allowance,
+                    "Startup approval already sufficient, skipping"
+                );
+            }
+
+            ApprovalDecision::GrantMax => {
+                tracing::info!(
+                    target: "startup",
+                    %token,
+                    %spender,
+                    ?symbol,
+                    purpose = ?purpose,
+                    %current_allowance,
+                    "Granting MAX approval on startup"
+                );
+
+                wallet
+                    .submit::<OpenChainErrorRegistry, _>(
+                        *token,
+                        IERC20::approveCall {
+                            spender: *spender,
+                            amount: U256::MAX,
+                        },
+                        purpose.note(),
+                    )
+                    .await
+                    .map_err(|source| StartupApprovalError::ApproveSubmit {
+                        token: *token,
+                        spender: *spender,
+                        symbol: symbol.clone(),
+                        source: Box::new(source),
+                    })?;
+
+                tracing::info!(
+                    target: "startup",
+                    %token,
+                    %spender,
+                    ?symbol,
+                    purpose = ?purpose,
+                    "MAX approval granted"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::node_bindings::{Anvil, AnvilInstance};
+    use alloy::primitives::{B256, TxHash, U256};
+    use alloy::providers::{Provider, ProviderBuilder};
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+
+    use st0x_evm::Evm;
+    use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_wrapper::{UnderlyingPerWrapped, WrappedEquity};
+
+    use super::*;
+    use crate::bindings::TestERC20;
+
+    /// Per-symbol wrapper stub: resolves underlying/derivative addresses from a
+    /// configured map and errors on an unconfigured symbol, so the
+    /// target-building path can be exercised with real address resolution.
+    /// `MockWrapper` returns fixed addresses regardless of symbol and has no
+    /// unconfigured-symbol path, so it cannot drive these tests.
+    struct StubWrapper {
+        equities: HashMap<Symbol, WrappedEquity>,
+    }
+
+    impl StubWrapper {
+        fn lookup(&self, symbol: &Symbol) -> Result<&WrappedEquity, WrapperError> {
+            self.equities
+                .get(symbol)
+                .ok_or_else(|| WrapperError::SymbolNotConfigured(symbol.clone()))
+        }
+    }
+
+    #[async_trait]
+    impl Wrapper for StubWrapper {
+        async fn get_ratio_for_symbol(
+            &self,
+            _symbol: &Symbol,
+        ) -> Result<UnderlyingPerWrapped, WrapperError> {
+            unimplemented!("ratio not used by approval target building")
+        }
+
+        fn lookup_underlying(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
+            Ok(self.lookup(symbol)?.underlying)
+        }
+
+        fn lookup_derivative(&self, symbol: &Symbol) -> Result<Address, WrapperError> {
+            Ok(self.lookup(symbol)?.derivative)
+        }
+
+        async fn to_wrapped(
+            &self,
+            _wrapped_token: Address,
+            _underlying_amount: U256,
+            _receiver: Address,
+        ) -> Result<(TxHash, U256), WrapperError> {
+            unimplemented!("wrap not used by approval target building")
+        }
+
+        async fn to_underlying(
+            &self,
+            _wrapped_token: Address,
+            _wrapped_amount: U256,
+            _receiver: Address,
+            _owner: Address,
+        ) -> Result<(TxHash, U256), WrapperError> {
+            unimplemented!("unwrap not used by approval target building")
+        }
+
+        async fn submit_wrap(
+            &self,
+            _wrapped_token: Address,
+            _underlying_amount: U256,
+            _receiver: Address,
+        ) -> Result<TxHash, WrapperError> {
+            unimplemented!("submit_wrap not used by approval target building")
+        }
+
+        async fn confirm_wrap(
+            &self,
+            _wrapped_token: Address,
+            _tx_hash: TxHash,
+        ) -> Result<U256, WrapperError> {
+            unimplemented!("confirm_wrap not used by approval target building")
+        }
+
+        async fn submit_unwrap(
+            &self,
+            _wrapped_token: Address,
+            _wrapped_amount: U256,
+            _receiver: Address,
+            _owner: Address,
+        ) -> Result<TxHash, WrapperError> {
+            unimplemented!("submit_unwrap not used by approval target building")
+        }
+
+        async fn confirm_unwrap(
+            &self,
+            _wrapped_token: Address,
+            _tx_hash: TxHash,
+        ) -> Result<U256, WrapperError> {
+            unimplemented!("confirm_unwrap not used by approval target building")
+        }
+
+        fn owner(&self) -> Address {
+            Address::ZERO
+        }
+    }
+
+    /// Watermark sits exactly at `U256::MAX / 2`, the midpoint between a bounded
+    /// per-operation allowance and an already-granted MAX approval.
+    #[test]
+    fn watermark_is_half_of_max() {
+        assert_eq!(MAX_APPROVAL_WATERMARK, U256::MAX / U256::from(2));
+    }
+
+    #[test]
+    fn approval_decision_grants_when_zero() {
+        assert_eq!(approval_decision(U256::ZERO), ApprovalDecision::GrantMax);
+    }
+
+    #[test]
+    fn approval_decision_grants_for_bounded_per_op_allowance() {
+        // A typical per-operation allowance (1000 tokens, 18 decimals) is far
+        // below the watermark and must be upgraded to MAX.
+        let per_op = U256::from(1000u64) * U256::from(10u64).pow(U256::from(18u64));
+        assert_eq!(approval_decision(per_op), ApprovalDecision::GrantMax);
+    }
+
+    #[test]
+    fn approval_decision_grants_just_below_watermark() {
+        assert_eq!(
+            approval_decision(MAX_APPROVAL_WATERMARK - U256::from(1)),
+            ApprovalDecision::GrantMax
+        );
+    }
+
+    #[test]
+    fn approval_decision_skips_at_watermark() {
+        assert_eq!(
+            approval_decision(MAX_APPROVAL_WATERMARK),
+            ApprovalDecision::AlreadySufficient
+        );
+    }
+
+    #[test]
+    fn approval_decision_skips_at_max() {
+        assert_eq!(
+            approval_decision(U256::MAX),
+            ApprovalDecision::AlreadySufficient
+        );
+    }
+
+    fn wrapper_with(symbol: &str, equity: WrappedEquity) -> StubWrapper {
+        let mut equities = HashMap::new();
+        equities.insert(symbol.parse::<Symbol>().unwrap(), equity);
+        StubWrapper { equities }
+    }
+
+    #[test]
+    fn build_targets_emits_two_per_symbol_plus_usdc() {
+        let underlying = Address::random();
+        let derivative = Address::random();
+        let orderbook = Address::random();
+        let usdc = Address::random();
+
+        let wrapper = wrapper_with(
+            "AAPL",
+            WrappedEquity {
+                underlying,
+                derivative,
+            },
+        );
+
+        let symbols = vec!["AAPL".parse::<Symbol>().unwrap()];
+        let targets = build_approval_targets(&wrapper, symbols, orderbook, usdc).unwrap();
+
+        assert_eq!(
+            targets,
+            vec![
+                ApprovalTarget {
+                    token: underlying,
+                    spender: derivative,
+                    symbol: Some("AAPL".parse().unwrap()),
+                    purpose: ApprovalPurpose::WrapUnderlying,
+                },
+                ApprovalTarget {
+                    token: derivative,
+                    spender: orderbook,
+                    symbol: Some("AAPL".parse().unwrap()),
+                    purpose: ApprovalPurpose::DepositWrappedEquity,
+                },
+                ApprovalTarget {
+                    token: usdc,
+                    spender: orderbook,
+                    symbol: None,
+                    purpose: ApprovalPurpose::DepositUsdc,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn build_targets_errors_on_unconfigured_symbol() {
+        let wrapper = wrapper_with(
+            "AAPL",
+            WrappedEquity {
+                underlying: Address::random(),
+                derivative: Address::random(),
+            },
+        );
+
+        let symbols = vec!["TSLA".parse::<Symbol>().unwrap()];
+        let error = build_approval_targets(&wrapper, symbols, Address::random(), Address::random())
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                StartupApprovalError::SymbolResolution { ref symbol, .. }
+                    if symbol.to_string() == "TSLA"
+            ),
+            "expected SymbolResolution for TSLA, got: {error:?}"
+        );
+    }
+
+    /// Spawns anvil, builds a wallet from key[0], and deploys `count`
+    /// `TestERC20` tokens. Returns the wallet plus deployed token addresses.
+    async fn setup_anvil(
+        count: usize,
+    ) -> (
+        AnvilInstance,
+        RawPrivateKeyWallet<impl Provider + Clone + use<>>,
+        Vec<Address>,
+    ) {
+        let anvil = Anvil::new().spawn();
+        let private_key = B256::from_slice(&anvil.keys()[0].to_bytes());
+        let provider = ProviderBuilder::new().connect_http(anvil.endpoint().parse().unwrap());
+        let wallet = RawPrivateKeyWallet::new(&private_key, provider.clone(), 1).unwrap();
+
+        let mut tokens = Vec::with_capacity(count);
+        for _ in 0..count {
+            // Deploy via the wallet's signing provider so the deploy tx is
+            // signed (the bare read provider has no `from` for the nonce
+            // manager).
+            let token = TestERC20::deploy(wallet.signing_provider()).await.unwrap();
+            tokens.push(*token.address());
+        }
+
+        (anvil, wallet, tokens)
+    }
+
+    async fn read_allowance<W: Wallet>(
+        wallet: &W,
+        token: Address,
+        owner: Address,
+        spender: Address,
+    ) -> U256 {
+        wallet
+            .call::<OpenChainErrorRegistry, _>(token, IERC20::allowanceCall { owner, spender })
+            .await
+            .unwrap()
+    }
+
+    fn usdc_targets(tokens: &[Address], spender: Address) -> Vec<ApprovalTarget> {
+        tokens
+            .iter()
+            .map(|token| ApprovalTarget {
+                token: *token,
+                spender,
+                symbol: None,
+                purpose: ApprovalPurpose::DepositUsdc,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn grants_max_allowance_for_every_target() {
+        let (_anvil, wallet, tokens) = setup_anvil(3).await;
+        let owner = wallet.address();
+        let spender = Address::random();
+
+        let targets = usdc_targets(&tokens, spender);
+
+        grant_startup_approvals(&wallet, &targets).await.unwrap();
+
+        for token in &tokens {
+            assert_eq!(
+                read_allowance(&wallet, *token, owner, spender).await,
+                U256::MAX,
+                "every target must end at MAX allowance",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn second_run_submits_no_redundant_approve() {
+        let (_anvil, wallet, tokens) = setup_anvil(2).await;
+        let owner = wallet.address();
+        let spender = Address::random();
+
+        let targets = usdc_targets(&tokens, spender);
+
+        grant_startup_approvals(&wallet, &targets).await.unwrap();
+
+        // The wallet's nonce after the first grant: one approve tx per token.
+        let nonce_after_first = wallet
+            .provider()
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        // Re-run: every allowance is already MAX, so the idempotency check must
+        // skip all of them and submit zero further transactions.
+        grant_startup_approvals(&wallet, &targets).await.unwrap();
+
+        let nonce_after_second = wallet
+            .provider()
+            .get_transaction_count(owner)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            nonce_after_second, nonce_after_first,
+            "the second idempotent run must submit no approve transactions",
+        );
+
+        for token in &tokens {
+            assert_eq!(
+                read_allowance(&wallet, *token, owner, spender).await,
+                U256::MAX,
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn allowance_read_failure_surfaces_typed_startup_error() {
+        let (_anvil, wallet, _tokens) = setup_anvil(0).await;
+
+        // A token address with no deployed code: the `allowance` view call
+        // returns empty data, which fails to ABI-decode -- the routine must
+        // surface this as a typed AllowanceRead error and fail startup, not
+        // proceed as if the allowance were known.
+        let bogus_token = Address::random();
+        let spender = Address::random();
+
+        let targets = vec![ApprovalTarget {
+            token: bogus_token,
+            spender,
+            symbol: None,
+            purpose: ApprovalPurpose::DepositUsdc,
+        }];
+
+        let error = grant_startup_approvals(&wallet, &targets)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                StartupApprovalError::AllowanceRead { token, spender: spent, .. }
+                    if token == bogus_token && spent == spender
+            ),
+            "expected AllowanceRead error for non-contract token, got: {error:?}",
+        );
+    }
+}

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -18,6 +18,7 @@ use st0x_execution::{
 use crate::position::{Position, PositionError};
 
 pub(crate) mod accumulator;
+pub(crate) mod approvals;
 pub(crate) mod backfill;
 mod clear;
 pub(crate) mod io;


### PR DESCRIPTION
## What

- Grant one-time idempotent `U256::MAX` approvals on startup to the trusted spenders, replacing fragile per-operation approvals before wrap / vault-deposit.
- New `src/onchain/approvals.rs` runner wired into `Conductor::run`; ADR 0005.

## Why

- Per-op, exact-amount approvals are gas-coupled and race-prone: the approve tx must land before the deposit (it fails on low gas), and a stale load-balanced-RPC allowance read can skip the approve, reverting the deposit with `ERC20InsufficientAllowance`.
- This blocked the unwrapped-equity recovery (stuck COIN) and SPYM/COIN mints.
- Closes [RAI-963](https://linear.app/makeitrain/issue/RAI-963).

## How

- `grant_startup_approvals` ensures, per configured equity symbol with trading or rebalancing enabled: `approve(tToken → wtToken vault, MAX)` and `approve(wtToken → orderbook, MAX)`; once `approve(USDC → orderbook, MAX)`. Symbols/addresses resolve via the `Wrapper` trait + `evm.orderbook` + `USDC_BASE`.
- Idempotent: pure `approval_decision` grants MAX unless the current allowance is already `>= U256::MAX/2`, else skips. Submission goes through `Wallet::submit` (required confirmations); typed `StartupApprovalError`.
- Runs after vault-registry seeding, before workers spawn; fails startup fast on error. No `[wallet]` configured → logged skip.
- The existing per-op approvals remain as a defensive no-op fallback (they skip once MAX is set).

## Testing

- 11 tests: idempotency-decision table + target builder (unit); anvil integration (grants MAX for every target; second run submits no redundant approve — nonce unchanged; allowance-read failure surfaces the typed startup error).

## Anything else

- ADR 0005 records the decision and the security trade-off (infinite approval only to our own ERC-4626 wrappers + the Raindex orderbook; the wallet holds only operational balances).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now grants one-time maximum token approvals during startup to improve operation reliability and prevent approval-related failures.

* **Documentation**
  * Added architecture decision record documenting the token approval strategy and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->