### PR TITLE
fix: preflight maxRedeem before unwrap to avoid on-chain revert

### DIFF
--- a/crates/wrapper/src/lib.rs
+++ b/crates/wrapper/src/lib.rs
@@ -54,6 +54,22 @@ pub enum WrapperError {
     MissingDepositEvent,
     #[error("Missing Withdraw event in transaction receipt")]
     MissingWithdrawEvent,
+    /// Preflight rejected an unwrap because the requested shares exceed the vault's
+    /// `maxRedeem(owner)`. This signals inventory/balance drift: the bot believes it
+    /// holds more wrapped shares than the wallet actually owns. We fail fast here
+    /// rather than clamp the amount (clamping would silently mask the drift and
+    /// violate the financial-integrity rule that range violations must error, not
+    /// cap). Reconciling the underlying inventory drift — and any non-1:1
+    /// wrapped-ratio handling — is out of scope and tracked separately.
+    #[error(
+        "Redeem of {requested} wrapped shares exceeds vault {wrapped_token} \
+         maxRedeem of {max_redeem} for owner"
+    )]
+    RedeemExceedsMax {
+        wrapped_token: Address,
+        requested: U256,
+        max_redeem: U256,
+    },
     #[error("Contract call error: {0}")]
     Evm(#[from] EvmError),
     #[error("Contract view error: {0}")]
@@ -125,7 +141,15 @@ pub trait Wrapper: Send + Sync {
 
     /// Submit an ERC-4626 redeem without waiting for confirmation.
     ///
-    /// Returns the tx hash immediately. Use
+    /// Preflights the vault's `maxRedeem(owner)` before submitting any
+    /// transaction: if `wrapped_amount` exceeds `maxRedeem`, returns
+    /// [`WrapperError::RedeemExceedsMax`] without sending a tx (no on-chain
+    /// revert, no wasted gas). Exceeding `maxRedeem` signals inventory/balance
+    /// drift — the bot believes it holds more wrapped shares than the wallet
+    /// actually owns — so we fail fast here rather than clamp the amount, per
+    /// the financial-integrity rule that range violations must error, not cap.
+    ///
+    /// On success, returns the tx hash immediately. Use
     /// [`confirm_unwrap`](Wrapper::confirm_unwrap) to wait for
     /// confirmation and extract the actual underlying amount received.
     async fn submit_unwrap(

--- a/crates/wrapper/src/service.rs
+++ b/crates/wrapper/src/service.rs
@@ -223,6 +223,13 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         receiver: Address,
         owner: Address,
     ) -> Result<TxHash, WrapperError> {
+        let max_redeem: U256 = self
+            .wallet
+            .call::<OpenChainErrorRegistry, _>(wrapped_token, IERC4626::maxRedeemCall { owner })
+            .await?;
+
+        check_redeem_within_max(wrapped_token, wrapped_amount, max_redeem)?;
+
         info!(target: "orderbook", %wrapped_token, %wrapped_amount, "Sending ERC4626 redeem");
         let tx_hash = self
             .wallet
@@ -270,6 +277,31 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
     fn owner(&self) -> Address {
         self.wallet.address()
     }
+}
+
+/// Preflight check that a requested redeem does not exceed the vault's
+/// `maxRedeem(owner)`.
+///
+/// Returns [`WrapperError::RedeemExceedsMax`] when `requested > max_redeem`, so
+/// the caller can fail fast before submitting any transaction. We deliberately do
+/// not clamp `requested` down to `max_redeem`: a request that exceeds `maxRedeem`
+/// signals inventory/balance drift (the bot believes it holds more wrapped shares
+/// than the wallet actually owns), and the financial-integrity rule requires range
+/// violations to error rather than be silently capped.
+fn check_redeem_within_max(
+    wrapped_token: Address,
+    requested: U256,
+    max_redeem: U256,
+) -> Result<(), WrapperError> {
+    if requested > max_redeem {
+        return Err(WrapperError::RedeemExceedsMax {
+            wrapped_token,
+            requested,
+            max_redeem,
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -447,6 +479,56 @@ mod tests {
                     if symbol.to_string() == "XYZ"
             ),
             "expected SymbolNotConfigured for XYZ, got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn check_redeem_within_max_allows_requested_below_max() {
+        let wrapped_token = Address::random();
+        let requested = U256::from(50u64);
+        let max_redeem = U256::from(100u64);
+
+        check_redeem_within_max(wrapped_token, requested, max_redeem)
+            .expect("redeem within max must be allowed");
+    }
+
+    #[test]
+    fn check_redeem_within_max_allows_requested_equal_to_max() {
+        let wrapped_token = Address::random();
+        let amount = U256::from(100u64);
+
+        check_redeem_within_max(wrapped_token, amount, amount)
+            .expect("redeem equal to max must be allowed");
+    }
+
+    #[test]
+    fn check_redeem_within_max_allows_zero_against_zero_max() {
+        let wrapped_token = Address::random();
+
+        check_redeem_within_max(wrapped_token, U256::ZERO, U256::ZERO)
+            .expect("zero redeem against zero max must be allowed");
+    }
+
+    #[test]
+    fn check_redeem_within_max_rejects_requested_above_max() {
+        let wrapped_token = Address::random();
+        // Mirrors the observed MSTR drift: requested 5.4336 vs maxRedeem 5.0989
+        // (scaled to 18 decimals).
+        let requested = U256::from(5_433_600_000_000_000_000u128);
+        let max_redeem = U256::from(5_098_900_000_000_000_000u128);
+
+        let error = check_redeem_within_max(wrapped_token, requested, max_redeem).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                WrapperError::RedeemExceedsMax {
+                    wrapped_token: token,
+                    requested: req,
+                    max_redeem: max,
+                } if token == wrapped_token && req == requested && max == max_redeem
+            ),
+            "expected RedeemExceedsMax carrying the requested/max amounts, got: {error:?}"
         );
     }
 }


### PR DESCRIPTION
## What

- Preflight wrapped-equity unwrap against the vault's `maxRedeem(owner)` and fail fast with a typed error before submitting, instead of letting the redeem revert on-chain.

## Why

- `submit_unwrap` issued ERC4626 `redeem(shares)` with no `maxRedeem` check, so an inventory overestimate (observed MSTR: 5.4336 requested vs 5.0989 owned) reverted on-chain with `ERC4626ExceededMaxRedeem` — wasted gas, opaque `UnwrapFailed`.
- Closes [RAI-960](https://linear.app/makeitrain/issue/RAI-960).

## How

- `submit_unwrap` (`crates/wrapper/src/service.rs`) reads `maxRedeem(owner)` and runs a pure `check_redeem_within_max` preflight; submits only when `requested <= max_redeem`, else returns `WrapperError::RedeemExceedsMax { wrapped_token, requested, max_redeem }` with no transaction sent.
- Does **not** clamp the amount — per the repo financial-integrity rule (range violations error, not clamp); clamping would mask the inventory/balance drift. The deeper drift reconciliation is out of scope (noted in the error doc).

## Testing

- 4 unit tests on the pure preflight helper: below / equal / zero / exceeds (asserting the exact `RedeemExceedsMax` variant with the MSTR drift values).
- No anvil error-path test: the toolchain ships an interface-only ERC4626 ABI with no deployable vault bytecode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced ERC-4626 unwrap operation handling with preflight validation that verifies requests against vault-specific redemption limits.
  * New error variant introduced when a requested unwrap amount exceeds the vault's maximum allowed redemption limit.
  * Detailed error responses now include vault token address, requested unwrap amount, and the vault's maximum redemption limit for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->