### PR TITLE
fix: deliver BaseToAlpaca USDC to Alpaca via idempotent deposit send

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2081,9 +2081,12 @@ Base to Alpaca:
 6. Poll Circle attestation service for signature using CCTP nonce (~8 seconds
    for fast transfer)
 7. Submit receiveMessage() tx on Ethereum MessageTransmitter with attestation
+   (mints USDC to the bot's own Ethereum wallet)
 8. Wait for mint tx confirmation (~20 seconds on Ethereum)
-9. Initiate USDC deposit to Alpaca (get transfer_id)
-10. Poll Alpaca API until deposit status is COMPLETE
+9. Send the minted USDC from the bot wallet to Alpaca's deposit address (see
+   "BaseToAlpaca deposit send"; fresh sends directly, resume adopts an existing
+   send)
+10. Poll Alpaca API by the send tx until deposit status is COMPLETE
 11. **Convert USDC to USD**: Place market sell order on USDC/USD pair (sell
     USDC)
 12. Poll Alpaca until conversion order is filled
@@ -3432,3 +3435,39 @@ chat's default topic. When either half (config or secret) is present without the
 other, startup fails fast rather than running with a half-configured alert
 channel. A notification delivery failure is logged but never crashes the
 monitor.
+
+### BaseToAlpaca deposit send
+
+The CCTP mint on the BaseToAlpaca leg sets `mintRecipient` to the bot's own
+market-maker wallet on Ethereum, so the minted USDC lands in the bot wallet --
+NOT at an Alpaca deposit address. Alpaca credits a deposit only when USDC is
+transferred to the per-account deposit address it issues. The deposit leg
+therefore performs an explicit fund-moving send:
+
+1. **Fetch the deposit address.** `get_wallet_address(USDC, ethereum)` returns
+   Alpaca's per-account Ethereum USDC deposit address.
+2. **Send (crash-safe, split fresh vs resume like the CCTP burn).** The fresh
+   path (right after this execution minted) sends the ERC20 transfer of the
+   received amount from the bot wallet to the deposit address DIRECTLY -- no
+   pre-send scan, no finality wait -- since no prior send can exist. The
+   resume-from-`Bridged` path (a crash may have left a prior send) first scans
+   Ethereum for an already-submitted USDC
+   `Transfer(from = bot wallet, to = deposit address, value = amount received)`
+   at or after the mint tx's block (the scan lower bound: the deposit send lands
+   at or after the mint, so no earlier transfer can be this deposit's). If such
+   a transfer exists, it is ADOPTED (no second send); otherwise it sends. A scan
+   failure (an RPC error, or an inconclusive finality-gated scan) returns an
+   error and sends NOTHING -- never a blind re-send -- so a transient fault
+   cannot double-spend.
+3. **Record the send.** The send tx (not the mint tx) is recorded as the deposit
+   reference via `InitiateDeposit`, advancing the aggregate to
+   `DepositInitiated`.
+4. **Poll by the send tx.** Alpaca is polled for the deposit identified by the
+   send tx until it is credited, then `ConfirmDeposit` is emitted and the
+   USDC-to-USD conversion runs.
+
+The resume-path scan is what makes resuming from `Bridged` safe: a crash between
+a fresh direct send and `InitiateDeposit` re-enters the leg from `Bridged`,
+where the scan finds the already-submitted transfer and adopts it instead of
+forwarding the minted USDC twice. Once `InitiateDeposit` is recorded, resume
+re-polls by the recorded send tx without sending again.

--- a/adrs/0006-base-to-alpaca-explicit-alpaca-deposit-send.md
+++ b/adrs/0006-base-to-alpaca-explicit-alpaca-deposit-send.md
@@ -1,0 +1,88 @@
+# ADR 0006: BaseToAlpaca deposit sends USDC to Alpaca explicitly, idempotently
+
+## Status
+
+Accepted
+
+## Context
+
+The automated BaseToAlpaca USDC rebalance bridges USDC from Base to Ethereum via
+CCTP, then must deposit it into Alpaca. The CCTP burn on Base sets the mint's
+`mintRecipient` to the bot's OWN market-maker wallet on Ethereum, so the mint
+credits the bot wallet -- NOT an Alpaca deposit address. Alpaca credits a
+deposit only when USDC is transferred to the per-account deposit address it
+issues from `get_wallet_address(USDC, ethereum)`.
+
+The deposit leg, however, only POLLED Alpaca read-only
+(`poll_deposit_by_tx_hash` on the mint tx) and never SENT the minted USDC
+anywhere. The mint never deposited to Alpaca, so the poll never detected a
+credit and the leg dead-ended at `DepositFailed` (the root cause behind
+RAI-957). The manual `alpaca-deposit` CLI already does the right thing: it
+transfers USDC from the bot wallet to Alpaca's deposit address and polls by the
+SEND tx. The automated leg never folded that send in.
+
+This is a money-moving leg: introducing an explicit send creates a double-spend
+hazard on crash/resume. A crash after a send but before the deposit reference is
+recorded re-enters the leg from `Bridged`, where a blind re-send would forward
+the minted USDC twice.
+
+## Decision
+
+Fold the proven `alpaca-deposit` send into the automated leg, splitting fresh
+from resume exactly like the CCTP burn (`execute_cctp_burn_on_base` burns
+directly; `resume_bridging_submitting` scans first):
+
+1. Fetch Alpaca's USDC deposit address via `get_wallet_address(USDC, ethereum)`.
+2. **Fresh path** (`continue_from_bridged_fresh`, reached right after this
+   execution minted): send the ERC20 transfer of the received amount from the
+   bot wallet to the deposit address DIRECTLY -- no pre-send scan, no finality
+   wait -- because no prior send can exist on first execution. Uses the same
+   `Wallet::submit` path (confirmations, nonce handling) as every other write.
+3. **Resume-from-`Bridged` path** (`continue_from_bridged_resume`): a crash may
+   have left a prior send, so SCAN Ethereum for an already-submitted USDC
+   `Transfer(from = bot wallet, to = deposit address, value = amount received)`
+   at or after the mint tx's block (the scan lower bound is the known
+   `mint_tx_hash`'s block). If found, ADOPT it; otherwise send.
+4. Both paths then record the SEND tx (not the mint tx) as the deposit reference
+   via `InitiateDeposit`, poll Alpaca by the SEND tx, and convert USDC->USD.
+
+A reusable `find_recent_usdc_transfer(from, to, amount, from_block)` helper on
+the CCTP bridge runs the scan with `eth_getLogs` on the USDC `Transfer` topic
+filtered by the indexed `from`/`to` and matching the exact value, mirroring the
+existing `find_recent_mint` / `find_recent_burn` scans.
+
+## Crash-safety argument
+
+The pre-send chain scan is what makes resuming from `Bridged` safe. It is
+bounded below by the mint tx's own block: the deposit send necessarily lands at
+or after the mint, so no earlier transfer can be this deposit's, and the
+single-USDC-rebalance-in-flight invariant plus the exact `(from, to, value)`
+match make an adopted transfer provably this deposit's.
+
+The guarantee is adopt-or-error, never a blind re-send:
+
+- A crash between the send and `InitiateDeposit` re-enters the leg from
+  `Bridged`; the scan finds the already-submitted transfer and adopts it instead
+  of sending again.
+- On scan FAILURE (an RPC error, or a finality-gated scan that cannot yet
+  confirm a true absence on a possibly-lagging load-balanced node), the leg
+  returns an error and sends NOTHING -- mirroring `resume_bridging_submitting` /
+  `find_recent_burn`. A transient fault thus cannot double-spend.
+- Once `InitiateDeposit` is recorded, the `DepositInitiated` resume arm re-polls
+  by the recorded send tx and issues no further send.
+
+## Alternatives considered
+
+- **A dedicated `DepositSendSubmitting` aggregate state** (analogous to
+  `WithdrawalSubmitting` / `BridgingSubmitting`, capturing a `from_block` before
+  the send and resuming through a scan). Rejected as heavier: it adds an event,
+  a state, and a transition for a guarantee the mint-block-bounded scan already
+  provides. The withdrawal/burn submitting states exist because their
+  `from_block` must be captured before an action that has no other durable
+  anchor; here the recorded `mint_tx_hash` is exactly that anchor -- its block
+  bounds the scan precisely, so a separate pre-send state would be redundant
+  bookkeeping.
+- **Scanning from genesis (no block bound).** Rejected: it could adopt an
+  unrelated same-value transfer from the bot wallet to the deposit address from
+  a prior rebalance. Bounding by the mint block excludes everything before this
+  transfer's mint.

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -112,9 +112,11 @@ decision.
 
 ## Index
 
-| #                                                       | Title                                                                            | Status   |
-| ------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
-| [0001](0001-cash-bp-for-equity-hedges.md)               | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
-| [0002](0002-axum-and-tower.md)                          | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |
-| [0003](0003-durable-usdc-rebalance-guard-on-restart.md) | Reconstruct the USDC rebalancing guard from persisted state on startup           | Accepted |
-| [0004](0004-typed-identifiers.md)                       | Model identifiers by what determines them; derive the string form                | Accepted |
+| #                                                           | Title                                                                            | Status   |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
+| [0001](0001-cash-bp-for-equity-hedges.md)                   | Use Alpaca `cash` (not `non_marginable_buying_power`) for equity hedge preflight | Accepted |
+| [0002](0002-axum-and-tower.md)                              | Adopt Axum and lean on Tower for both transport and business logic               | Accepted |
+| [0003](0003-durable-usdc-rebalance-guard-on-restart.md)     | Reconstruct the USDC rebalancing guard from persisted state on startup           | Accepted |
+| [0004](0004-typed-identifiers.md)                           | Model identifiers by what determines them; derive the string form                | Accepted |
+| [0005](0005-max-token-approvals-on-startup.md)              | Grant one-time MAX token approvals to trusted spenders on startup                | Accepted |
+| [0006](0006-base-to-alpaca-explicit-alpaca-deposit-send.md) | BaseToAlpaca deposit sends USDC to Alpaca explicitly, idempotently               | Accepted |

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -275,6 +275,116 @@ impl<W: Wallet> CctpEndpoint<W> {
         Ok(self.wallet.provider().get_block_number().await?)
     }
 
+    /// Returns the block in which `tx_hash` was mined on this endpoint's chain.
+    ///
+    /// Used to derive the lower bound for [`find_recent_usdc_transfer`] from the
+    /// known mint tx: the deposit send to Alpaca lands at or after the mint's
+    /// block, so the mint block bounds the transfer scan exactly the way the
+    /// captured head bounds [`find_recent_burn`]. Confirmation-aware: it polls via
+    /// `await_receipt` rather than a single-shot lookup, so a load-balanced node
+    /// that has not yet seen the mint does not yield a spurious "block missing".
+    pub(super) async fn tx_block(&self, tx_hash: TxHash) -> Result<u64, CctpError> {
+        let receipt = self.wallet.await_receipt(tx_hash).await?;
+
+        receipt
+            .block_number
+            .ok_or(CctpError::TxReceiptMissingBlock { tx_hash })
+    }
+
+    /// Sends `amount` of this endpoint's USDC from the wallet to `to`, waiting
+    /// for the configured confirmation depth, and returns the transfer tx hash.
+    ///
+    /// This is the fund-moving leg of a BaseToAlpaca deposit: the CCTP mint
+    /// credits the bot wallet, and this transfer forwards the minted USDC to
+    /// Alpaca's deposit address. Reuses [`Wallet::submit`] so nonce handling and
+    /// confirmation depth match every other write path; a revert is decoded via
+    /// `Registry`.
+    pub(super) async fn send_usdc<Registry: IntoErrorRegistry>(
+        &self,
+        to: Address,
+        amount: U256,
+    ) -> Result<TxHash, CctpError> {
+        let receipt = self
+            .wallet
+            .submit::<Registry, _>(
+                self.usdc_address,
+                IERC20::transferCall { to, amount },
+                "USDC deposit to Alpaca",
+            )
+            .await?;
+
+        Ok(receipt.transaction_hash)
+    }
+
+    /// Scans for a USDC `Transfer(from, to, value == amount)` at or after
+    /// `from_block`, returning the most recent matching transaction hash.
+    ///
+    /// Crash-safe deposit-send recovery: the BaseToAlpaca deposit leg records the
+    /// mint block before sending USDC to Alpaca, so on resume this detects an
+    /// already-submitted send instead of re-sending (which would forward the
+    /// minted USDC twice). The deposit send lands at or after the mint, so the
+    /// match is bounded to `from_block` (the mint's block) onward. Matching on the
+    /// indexed `(from, to)` topics plus the exact `value` -- combined with the
+    /// single-USDC-rebalance-in-flight invariant -- guarantees an adopted transfer
+    /// is this deposit's, not an unrelated same-amount transfer.
+    ///
+    /// Returns `Ok(None)` ONLY when the queried node is confirmations-deep past
+    /// `from_block` and repeated scans agree the transfer is absent; a node that
+    /// may be lagging (the dRPC load-balancing hazard) yields a retryable
+    /// [`CctpError::ScanInconclusive`], so the caller never re-sends off a single
+    /// stale empty `eth_getLogs`.
+    pub(super) async fn find_recent_usdc_transfer(
+        &self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<Option<TxHash>, CctpError> {
+        let from_topic = FixedBytes::<32>::left_padding_from(from.as_slice());
+        let to_topic = FixedBytes::<32>::left_padding_from(to.as_slice());
+        let filter = Filter::new()
+            .from_block(from_block)
+            .address(self.usdc_address)
+            .event_signature(IERC20::Transfer::SIGNATURE_HASH)
+            .topic1(from_topic)
+            .topic2(to_topic);
+
+        for attempt in 1..=SCAN_ATTEMPTS {
+            let logs = self.wallet.provider().get_logs(&filter).await?;
+
+            for log in logs.iter().rev() {
+                let decoded = log.log_decode::<IERC20::Transfer>()?;
+                let event = decoded.data();
+
+                if event.value == amount
+                    && log.block_number.is_some_and(|block| block >= from_block)
+                    && let Some(tx_hash) = log.transaction_hash
+                {
+                    debug!(target: "bridge", %tx_hash, from_block, "Found existing USDC deposit transfer during resume");
+                    return Ok(Some(tx_hash));
+                }
+            }
+
+            // A single empty eth_getLogs from a load-balanced node is not
+            // authoritative (dRPC lag). Only conclude a true absence once the head
+            // is confirmations-deep past from_block AND repeated scans agree; else
+            // retry, and if still inconclusive return a retryable error so the
+            // caller never re-sends off a stale empty result.
+            let head = self.wallet.provider().get_block_number().await?;
+            let caught_up = head >= from_block.saturating_add(SCAN_FINALITY_MARGIN);
+
+            if caught_up && attempt == SCAN_ATTEMPTS {
+                return Ok(None);
+            }
+
+            if attempt < SCAN_ATTEMPTS {
+                tokio::time::sleep(SCAN_RETRY_BACKOFF).await;
+            }
+        }
+
+        Err(CctpError::ScanInconclusive { from_block })
+    }
+
     /// Claims USDC on this chain by submitting the attestation.
     ///
     /// Parses the `MintAndWithdraw` event from the transaction receipt to extract

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -388,6 +388,8 @@ pub enum CctpError {
     MessageSentEventNotFound,
     #[error("MintAndWithdraw event not found in transaction receipt")]
     MintAndWithdrawEventNotFound,
+    #[error("transaction {tx_hash} receipt has no block number")]
+    TxReceiptMissingBlock { tx_hash: TxHash },
     #[error("Message too short for nonce extraction: got {length} bytes, need at least 44")]
     MessageTooShort { length: usize },
     #[error("Message too short for receiveMessage recovery: got {length} bytes, need at least 148")]
@@ -826,6 +828,55 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
     pub async fn base_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
         self.base
             .usdc_balance::<OpenChainErrorRegistry>(holder)
+            .await
+    }
+
+    /// Returns the block in which `tx_hash` was mined on Ethereum, the chain
+    /// where BaseToEthereum mints land.
+    ///
+    /// The BaseToAlpaca deposit leg uses this to bound
+    /// [`find_recent_usdc_transfer`](Self::find_recent_usdc_transfer) from the
+    /// known mint tx: the deposit send to Alpaca lands at or after the mint, so
+    /// the mint's block is the scan lower bound.
+    pub async fn ethereum_tx_block(&self, tx_hash: TxHash) -> Result<u64, CctpError> {
+        self.ethereum.tx_block(tx_hash).await
+    }
+
+    /// Sends `amount` (USDC smallest unit, 6 decimals) of Ethereum USDC from the
+    /// bot wallet to `to`, waiting for confirmation, and returns the tx hash.
+    ///
+    /// Used by the BaseToAlpaca deposit leg to forward minted USDC to Alpaca's
+    /// deposit address. The CCTP mint credits the bot's own wallet, so an explicit
+    /// transfer is required to fund Alpaca -- the mint alone does not deposit.
+    pub async fn send_usdc_on_ethereum(
+        &self,
+        to: Address,
+        amount: U256,
+    ) -> Result<TxHash, CctpError> {
+        self.ethereum
+            .send_usdc::<OpenChainErrorRegistry>(to, amount)
+            .await
+    }
+
+    /// Scans Ethereum for a USDC `Transfer(from, to, value == amount)` at or
+    /// after `from_block`, returning the most recent matching tx hash.
+    ///
+    /// Pre-send idempotency guard for the BaseToAlpaca deposit leg: a crash
+    /// between the deposit send and recording it lands the aggregate back in
+    /// `Bridged`, and this detects the already-submitted send so resume adopts it
+    /// instead of forwarding the minted USDC a second time. Returns a retryable
+    /// [`CctpError::ScanInconclusive`] rather than `Ok(None)` when the queried node
+    /// is not confirmations-deep past `from_block`, so the caller never re-sends
+    /// off a stale empty scan.
+    pub async fn find_recent_usdc_transfer(
+        &self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        from_block: u64,
+    ) -> Result<Option<TxHash>, CctpError> {
+        self.ethereum
+            .find_recent_usdc_transfer(from, to, amount, from_block)
             .await
     }
 }
@@ -3314,6 +3365,94 @@ mod tests {
                 .unwrap(),
             None,
             "a mint below the scan bound must not be adopted",
+        );
+    }
+
+    #[tokio::test]
+    async fn find_recent_usdc_transfer_matches_on_from_to_value_and_scan_bound() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap();
+
+        let sender = bridge.ethereum.owner();
+        let recipient = address!("0x000000000000000000000000000000000000bEEF");
+        let never_funded = address!("0x000000000000000000000000000000000000dEaD");
+        let amount = U256::from(7_000_000u64); // 7 USDC
+
+        // Capture the head before the send, exactly as the deposit leg captures
+        // the mint's block as the scan lower bound.
+        let from_block = bridge.ethereum.current_block().await.unwrap();
+
+        let send_tx = bridge
+            .ethereum
+            .send_usdc::<NoOpErrorRegistry>(recipient, amount)
+            .await
+            .unwrap();
+
+        // The deposit send (`>= from_block`) lands at `send_block`; the first
+        // block strictly above it is the exclusion bound for the below-bound case.
+        let above_block = bridge.ethereum.current_block().await.unwrap() + 1;
+
+        // The scan is finality-gated: it returns Ok(None) only once the head is
+        // a small margin past the bound. Advance the head with unrelated sends so
+        // the absence assertions resolve to None, not a retryable ScanInconclusive.
+        for _ in 0..4 {
+            bridge
+                .ethereum
+                .send_usdc::<NoOpErrorRegistry>(never_funded, amount)
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            bridge
+                .find_recent_usdc_transfer(sender, recipient, amount, from_block)
+                .await
+                .unwrap(),
+            Some(send_tx),
+            "scan must adopt the exact (from, to, value) transfer at/after the bound",
+        );
+
+        let other_recipient = address!("0x000000000000000000000000000000000000Cafe");
+        assert_eq!(
+            bridge
+                .find_recent_usdc_transfer(sender, other_recipient, amount, from_block)
+                .await
+                .unwrap(),
+            None,
+            "a transfer to a different recipient must not be adopted",
+        );
+
+        assert_eq!(
+            bridge
+                .find_recent_usdc_transfer(sender, recipient, amount + U256::from(1), from_block)
+                .await
+                .unwrap(),
+            None,
+            "a transfer whose value differs must not be adopted",
+        );
+
+        // Scanning from a bound above the send's block excludes it (mirroring the
+        // find_recent_mint below-bound exclusion); the head is already far enough
+        // past `above_block` for the absence to resolve to None.
+        assert_eq!(
+            bridge
+                .find_recent_usdc_transfer(sender, recipient, amount, above_block)
+                .await
+                .unwrap(),
+            None,
+            "a transfer below the scan bound must not be adopted",
         );
     }
 

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -514,20 +514,22 @@ impl AlpacaBrokerMock {
         Ok(())
     }
 
-    /// Starts a background watcher that monitors the Ethereum chain for USDC
-    /// mints to the bot's wallet. When detected, it auto-creates INCOMING
-    /// wallet transfer records in mock state so the bot's deposit polling
-    /// succeeds.
+    /// Starts a background watcher that monitors the Ethereum chain for the USDC
+    /// deposit SEND to Alpaca's deposit address. When detected, it auto-creates
+    /// an INCOMING wallet transfer record (keyed on the send tx) in mock state so
+    /// the bot's deposit polling by the send tx succeeds.
     ///
-    /// In the BaseToAlpaca flow, CCTP mints USDC to `mint_recipient` (the
-    /// bot's Ethereum wallet). The bot then polls Alpaca for a deposit
-    /// matching the mint tx hash. This watcher simulates Alpaca detecting
-    /// the on-chain mint and creating the corresponding transfer record.
+    /// In the BaseToAlpaca flow, CCTP mints USDC to the bot's Ethereum wallet
+    /// (`sender`), and the bot then SENDS that USDC to Alpaca's per-account
+    /// deposit address and polls Alpaca for a deposit matching the SEND tx hash
+    /// (not the mint tx). This watcher detects that on-chain
+    /// `Transfer(sender -> alpaca_deposit_address)` and creates the corresponding
+    /// transfer record, simulating Alpaca crediting the deposit.
     pub async fn start_deposit_watcher<P>(
         &self,
         provider: P,
         usdc_address: Address,
-        mint_recipient: Address,
+        sender: Address,
     ) -> anyhow::Result<JoinHandle<()>>
     where
         P: Provider + Clone + Send + Sync + 'static,
@@ -555,7 +557,7 @@ impl AlpacaBrokerMock {
                     last_block + 1,
                     current,
                     usdc_address,
-                    mint_recipient,
+                    sender,
                 )
                 .await;
 
@@ -567,21 +569,29 @@ impl AlpacaBrokerMock {
     }
 }
 
-/// Scans a single block for USDC Transfer events to `mint_recipient`
-/// and records them as incoming wallet transfers in mock state.
+/// Scans a single block for the USDC deposit SEND
+/// (`Transfer(sender -> alpaca_deposit_address)`) and records it as an incoming
+/// wallet transfer (keyed on the send tx) in mock state.
 /// Returns `true` if the block was fully processed, `false` on RPC error.
 ///
-/// Only records transfers where `from == Address::ZERO` (a mint event),
-/// filtering out regular transfers that happen to target `mint_recipient`.
+/// Matches `from == sender` and `to == alpaca_deposit_address` so the recorded
+/// tx hash is the bot's fund-moving deposit send -- exactly the tx the bot polls
+/// by -- not the upstream CCTP mint (whose `to` is the bot wallet itself).
 async fn scan_block_for_deposits<P: Provider>(
     provider: &P,
     state: &Mutex<MockState>,
     block_num: u64,
     usdc_address: Address,
-    mint_recipient: Address,
+    sender: Address,
 ) -> bool {
     let Ok(Some(block)) = provider.get_block_by_number(block_num.into()).full().await else {
         return false;
+    };
+
+    let Ok(deposit_address) = lock(state).alpaca_deposit_address.parse::<Address>() else {
+        // The deposit address is only set once `register_wallet_endpoints` runs;
+        // until then there is nothing to match, so treat the block as processed.
+        return true;
     };
 
     for tx_hash in block.transactions.hashes() {
@@ -594,9 +604,7 @@ async fn scan_block_for_deposits<P: Provider>(
                 continue;
             };
 
-            if log.address() != usdc_address
-                || event.to != mint_recipient
-                || event.from != Address::ZERO
+            if log.address() != usdc_address || event.from != sender || event.to != deposit_address
             {
                 continue;
             }
@@ -629,7 +637,7 @@ async fn scan_block_for_deposits<P: Provider>(
                 amount,
                 asset: "USDC".to_string(),
                 from_address: event.from,
-                to_address: mint_recipient,
+                to_address: deposit_address,
                 status: TransferStatus::Complete,
                 tx_hash: tx_hash_hex,
                 poll_count: 0,
@@ -641,7 +649,7 @@ async fn scan_block_for_deposits<P: Provider>(
     true
 }
 
-/// Scans a range of blocks for deposits, returning true only if
+/// Scans a range of blocks for the deposit send, returning true only if
 /// every block in the range was fully processed.
 async fn scan_deposit_range<P: Provider>(
     provider: &P,
@@ -649,11 +657,10 @@ async fn scan_deposit_range<P: Provider>(
     from: u64,
     to: u64,
     usdc_address: Address,
-    mint_recipient: Address,
+    sender: Address,
 ) -> bool {
     for block_num in from..=to {
-        if !scan_block_for_deposits(provider, state, block_num, usdc_address, mint_recipient).await
-        {
+        if !scan_block_for_deposits(provider, state, block_num, usdc_address, sender).await {
             return false;
         }
     }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -24,7 +24,7 @@ use st0x_raindex::{Raindex, RaindexService, RaindexVaultId, USDC_BASE};
 
 use super::UsdcTransferError;
 use crate::alpaca_wallet::{
-    AlpacaTransferId, AlpacaWalletService, TokenSymbol, Transfer, TransferStatus,
+    AlpacaTransferId, AlpacaWalletService, Network, TokenSymbol, Transfer, TransferStatus,
 };
 use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
@@ -1291,10 +1291,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     /// 2. Confirm vault withdrawal -> `ConfirmWithdrawal` command
     /// 3. Execute CCTP burn on Base -> `InitiateBridging` command
     /// 4. Poll Circle API for attestation -> `ReceiveAttestation` command
-    /// 5. Execute CCTP mint on Ethereum -> `ConfirmBridging` command
-    /// 6. Initiate Alpaca deposit (mint directly to Alpaca address)
-    ///    -> `InitiateDeposit` command
-    /// 7. Poll Alpaca until deposit credited -> `ConfirmDeposit` command
+    /// 5. Execute CCTP mint on Ethereum (credits the bot wallet)
+    ///    -> `ConfirmBridging` command
+    /// 6. Send the minted USDC from the bot wallet directly to Alpaca's deposit
+    ///    address (fresh path; the resume-from-`Bridged` path scans-or-adopts for
+    ///    idempotency, mirroring the burn) -> `InitiateDeposit` records the send tx
+    /// 7. Poll Alpaca by the send tx until deposit credited -> `ConfirmDeposit`
     ///
     /// On errors, sends appropriate `Fail*` command to transition
     /// aggregate to failed state.
@@ -1446,7 +1448,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, &direction)?;
-                self.continue_from_bridged(id, amount_received, mint_tx_hash)
+                self.continue_from_bridged_resume(id, amount_received, mint_tx_hash)
                     .await
             }
 
@@ -1457,10 +1459,14 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 ..
             }) => {
                 Self::require_base_to_alpaca(id, &direction)?;
-                let TransferRef::OnchainTx(mint_tx) = deposit_ref else {
+                // The recorded `deposit_ref` is the USDC SEND tx (minted USDC
+                // forwarded to Alpaca's deposit address), not the mint tx. The
+                // send already moved funds before `InitiateDeposit` was recorded,
+                // so this resume re-polls Alpaca by it -- no further send occurs.
+                let TransferRef::OnchainTx(send_tx) = deposit_ref else {
                     return Err(UsdcTransferError::DepositRefMustBeOnchain { id: id.clone() });
                 };
-                self.poll_alpaca_deposit_and_confirm(id, mint_tx).await?;
+                self.poll_alpaca_deposit_and_confirm(id, send_tx).await?;
                 self.execute_usdc_to_usd_conversion(id, amount).await?;
                 Ok(())
             }
@@ -1605,7 +1611,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             )
             .await?;
 
-        self.continue_from_bridged(id, amount_received, mint_receipt.tx)
+        self.continue_from_bridged_resume(id, amount_received, mint_receipt.tx)
             .await
     }
 
@@ -1876,7 +1882,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 .await?;
 
             return self
-                .continue_from_bridged(id, amount_received, mint_receipt.tx)
+                .continue_from_bridged_resume(id, amount_received, mint_receipt.tx)
                 .await;
         }
 
@@ -1903,38 +1909,198 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         let mint_receipt = self
             .execute_cctp_mint_on_ethereum(id, attestation_response)
             .await?;
-        self.continue_from_bridged(id, u256_to_usdc(mint_receipt.amount)?, mint_receipt.tx)
+        self.continue_from_bridged_fresh(id, u256_to_usdc(mint_receipt.amount)?)
             .await
     }
 
-    /// Drives the transfer from `Bridged` through to terminal: re-record the
-    /// Alpaca deposit intent, poll Alpaca for the credit, then convert USDC->USD.
+    /// Drives a FRESH transfer from `Bridged` to terminal: send the minted USDC
+    /// directly to Alpaca's deposit address, record the send, poll Alpaca for the
+    /// credit, then convert USDC->USD.
     ///
-    /// # Crash-safety invariant (load-bearing)
+    /// # Why an explicit send (load-bearing)
     ///
-    /// Unlike the `DepositInitiated` resume arm, this path has no guard
-    /// preventing a re-send of `InitiateDeposit`. It is safe to resume from
-    /// `Bridged` only because the BaseToAlpaca deposit is effected by the CCTP
-    /// mint itself: [`execute_cctp_burn_on_base`](Self::execute_cctp_burn_on_base)
-    /// sets the burn's `mintRecipient` to `self.market_maker_wallet`, so the
-    /// Ethereum-side mint credits USDC directly to the address Alpaca monitors as
-    /// the deposit source. No Alpaca deposit API call moves funds. This function
-    /// therefore only RE-RECORDS intent via `InitiateDeposit` (an idempotent
-    /// aggregate event) and POLLS Alpaca read-only via `poll_deposit_by_tx_hash`
-    /// (a GET). Resuming from `Bridged` issues no new fund-moving call, so
-    /// re-execution cannot double-spend and the missing guard is safe. If the
-    /// mint-deposits-directly assumption ever changes (e.g. an explicit Alpaca
-    /// deposit POST is introduced), this arm must gain a guard or idempotency key.
-    async fn continue_from_bridged(
+    /// The CCTP mint credits the bot's OWN wallet
+    /// ([`execute_cctp_burn_on_base`](Self::execute_cctp_burn_on_base) sets the
+    /// burn's `mintRecipient` to `self.market_maker_wallet`), NOT an Alpaca
+    /// deposit address. Alpaca funds only when USDC is transferred to the
+    /// per-account deposit address from `get_wallet_address`. So this leg fetches
+    /// that address and SENDS the minted USDC there -- a real fund-moving call --
+    /// then polls Alpaca by the SEND tx (not the mint tx). The recorded
+    /// `deposit_ref` is therefore the SEND tx.
+    ///
+    /// # Fresh vs resume (load-bearing)
+    ///
+    /// This is the fresh entry, reached immediately after this execution minted on
+    /// Ethereum (no prior deposit send exists), so it sends DIRECTLY with no
+    /// pre-send chain scan -- mirroring the burn, where the fresh
+    /// [`execute_cctp_burn_on_base`](Self::execute_cctp_burn_on_base) burns
+    /// directly and only the resume path scans. Scanning here would needlessly
+    /// wait for finality on the very first send (and, in tests where the chain head
+    /// sits at the mint block, never conclude).
+    ///
+    /// Crash-safety is preserved by the resume path, not this one: a crash after
+    /// the direct send but before `InitiateDeposit` lands the aggregate back in
+    /// `Bridged`, and the `Bridged` resume arm re-enters via
+    /// [`continue_from_bridged_resume`](Self::continue_from_bridged_resume), whose
+    /// pre-send scan ADOPTS the existing send instead of re-sending -- exactly the
+    /// burn invariant.
+    async fn continue_from_bridged_fresh(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+    ) -> Result<(), UsdcTransferError> {
+        let send_tx = self.send_alpaca_deposit(id, amount_received).await?;
+        self.finish_deposit(id, amount_received, send_tx).await
+    }
+
+    /// Resumes a transfer stalled at `Bridged` (a crash after the mint, possibly
+    /// after a deposit send): scans the chain for an already-submitted send and
+    /// adopts it, otherwise sends, then drives the deposit leg to terminal.
+    ///
+    /// The pre-send scan
+    /// ([`find_recent_usdc_transfer`](st0x_bridge::cctp::CctpBridge::find_recent_usdc_transfer))
+    /// is what makes resume safe: bounded by the mint tx's own block (the send
+    /// lands at or after the mint), it ADOPTS an already-submitted matching
+    /// transfer instead of re-sending. A scan failure (inconclusive or RPC error)
+    /// returns an error WITHOUT sending -- never a blind re-send -- mirroring
+    /// [`resume_bridging_submitting`](Self::resume_bridging_submitting) and
+    /// `find_recent_burn`. The `DepositInitiated` resume arm re-polls by the
+    /// recorded send tx, so once the send is recorded no further send occurs.
+    async fn continue_from_bridged_resume(
         &self,
         id: &UsdcRebalanceId,
         amount_received: Usdc,
         mint_tx: TxHash,
     ) -> Result<(), UsdcTransferError> {
-        self.poll_and_confirm_alpaca_deposit(id, mint_tx).await?;
+        let send_tx = self
+            .send_or_adopt_alpaca_deposit(id, amount_received, mint_tx)
+            .await?;
+        self.finish_deposit(id, amount_received, send_tx).await
+    }
+
+    /// Records the deposit send, polls Alpaca for the credit, then converts
+    /// USDC->USD. Shared tail of the fresh and resume `Bridged` paths -- the only
+    /// difference between them is how `send_tx` is obtained (direct send vs
+    /// scan-or-adopt).
+    async fn finish_deposit(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+        send_tx: TxHash,
+    ) -> Result<(), UsdcTransferError> {
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateDeposit {
+                    deposit: TransferRef::OnchainTx(send_tx),
+                },
+            )
+            .await?;
+
+        self.poll_alpaca_deposit_and_confirm(id, send_tx).await?;
         self.execute_usdc_to_usd_conversion(id, amount_received)
             .await?;
         Ok(())
+    }
+
+    /// Fetches Alpaca's per-account USDC (Ethereum) deposit address.
+    async fn fetch_alpaca_deposit_address(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<Address, UsdcTransferError> {
+        let usdc = TokenSymbol::new("USDC");
+        let ethereum = Network::new("ethereum");
+
+        match self
+            .alpaca_wallet
+            .get_wallet_address(&usdc, &ethereum)
+            .await
+        {
+            Ok(address) => Ok(address),
+            Err(error) => {
+                warn!(target: "rebalance", %id, "Fetching Alpaca deposit address failed: {error}");
+                Err(UsdcTransferError::AlpacaWallet(error))
+            }
+        }
+    }
+
+    /// Sends the minted USDC DIRECTLY to Alpaca's deposit address (no pre-send
+    /// scan). Fresh path only: there is no prior send to adopt because the mint
+    /// just completed in this execution. Crash-safety is provided by the resume
+    /// path's [`send_or_adopt_alpaca_deposit`](Self::send_or_adopt_alpaca_deposit),
+    /// mirroring how the fresh burn path skips the scan that the resume burn path
+    /// performs.
+    #[instrument(target = "rebalance", skip(self), fields(%id, %amount_received), level = tracing::Level::DEBUG)]
+    async fn send_alpaca_deposit(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+    ) -> Result<TxHash, UsdcTransferError> {
+        let deposit_address = self.fetch_alpaca_deposit_address(id).await?;
+        let amount_u256 = usdc_to_u256(amount_received)?;
+
+        let send_tx = self
+            .cctp_bridge
+            .send_usdc_on_ethereum(deposit_address, amount_u256)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
+        info!(target: "rebalance", %id, %send_tx, %deposit_address, %amount_received, "Sent minted USDC to Alpaca deposit address");
+        Ok(send_tx)
+    }
+
+    /// Sends the minted USDC to Alpaca's deposit address, or adopts an
+    /// already-submitted send found on chain (crash-safe resume).
+    ///
+    /// Fetches the per-account USDC deposit address, bounds the scan by the mint
+    /// tx's block, and either adopts a matching existing transfer or submits the
+    /// ERC20 transfer. A scan failure returns an error without sending, so a
+    /// transient RPC/finality hiccup never triggers a blind double-send. Resume
+    /// path only -- the fresh path sends directly via
+    /// [`send_alpaca_deposit`](Self::send_alpaca_deposit).
+    #[instrument(target = "rebalance", skip(self), fields(%id, %amount_received, %mint_tx), level = tracing::Level::DEBUG)]
+    async fn send_or_adopt_alpaca_deposit(
+        &self,
+        id: &UsdcRebalanceId,
+        amount_received: Usdc,
+        mint_tx: TxHash,
+    ) -> Result<TxHash, UsdcTransferError> {
+        let deposit_address = self.fetch_alpaca_deposit_address(id).await?;
+        let amount_u256 = usdc_to_u256(amount_received)?;
+
+        // Bound the idempotency scan by the mint's block: the deposit send lands
+        // at or after the mint, so no earlier transfer can be this deposit's.
+        let from_block = self
+            .cctp_bridge
+            .ethereum_tx_block(mint_tx)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
+        // Fail safe on a scan error: do NOT send. A re-send off an inconclusive or
+        // failed scan could forward the minted USDC twice.
+        if let Some(existing_tx) = self
+            .cctp_bridge
+            .find_recent_usdc_transfer(
+                self.market_maker_wallet,
+                deposit_address,
+                amount_u256,
+                from_block,
+            )
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?
+        {
+            info!(target: "rebalance", %id, %existing_tx, %deposit_address, "Adopting already-submitted USDC deposit transfer to Alpaca on resume");
+            return Ok(existing_tx);
+        }
+
+        let send_tx = self
+            .cctp_bridge
+            .send_usdc_on_ethereum(deposit_address, amount_u256)
+            .await
+            .map_err(|error| UsdcTransferError::Cctp(Box::new(error)))?;
+
+        info!(target: "rebalance", %id, %send_tx, %deposit_address, %amount_received, "Sent minted USDC to Alpaca deposit address");
+        Ok(send_tx)
     }
 
     #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
@@ -2228,44 +2394,19 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         Ok(mint_receipt)
     }
 
-    #[instrument(target = "rebalance", skip(self), fields(%id, %mint_tx), level = tracing::Level::DEBUG)]
-    async fn poll_and_confirm_alpaca_deposit(
-        &self,
-        id: &UsdcRebalanceId,
-        mint_tx: TxHash,
-    ) -> Result<(), UsdcTransferError> {
-        // Record the deposit initiation with the mint tx. This is a pure
-        // intent record, never a fund-moving call: the CCTP mint already
-        // deposited the USDC directly to the Alpaca-controlled address, so the
-        // "deposit" IS the on-chain mint tx. That invariant is what makes
-        // resume from `Bridged` safe -- re-sending `InitiateDeposit` here just
-        // re-records the same mint tx, it does not move funds again. The only
-        // Alpaca interaction (below) is a read-only poll to detect the deposit.
-        self.cqrs
-            .send(
-                id,
-                UsdcRebalanceCommand::InitiateDeposit {
-                    deposit: TransferRef::OnchainTx(mint_tx),
-                },
-            )
-            .await?;
-
-        self.poll_alpaca_deposit_and_confirm(id, mint_tx).await
-    }
-
-    /// Polls Alpaca for the deposit identified by `mint_tx`, then sends
-    /// `ConfirmDeposit`. Assumes the aggregate is already in
-    /// `DepositInitiated` (caller has sent `InitiateDeposit`, or we are
-    /// resuming from that state).
-    #[instrument(target = "rebalance", skip(self), fields(%id, %mint_tx), level = tracing::Level::DEBUG)]
+    /// Polls Alpaca for the deposit identified by the USDC `send_tx` (the
+    /// transfer of minted USDC to Alpaca's deposit address), then sends
+    /// `ConfirmDeposit`. Assumes the aggregate is already in `DepositInitiated`
+    /// (caller has sent `InitiateDeposit`, or we are resuming from that state).
+    #[instrument(target = "rebalance", skip(self), fields(%id, %send_tx), level = tracing::Level::DEBUG)]
     async fn poll_alpaca_deposit_and_confirm(
         &self,
         id: &UsdcRebalanceId,
-        mint_tx: TxHash,
+        send_tx: TxHash,
     ) -> Result<(), UsdcTransferError> {
-        info!(target: "rebalance", %mint_tx, "Polling Alpaca for deposit detection");
+        info!(target: "rebalance", %send_tx, "Polling Alpaca for deposit detection");
 
-        let transfer = match self.alpaca_wallet.poll_deposit_by_tx_hash(&mint_tx).await {
+        let transfer = match self.alpaca_wallet.poll_deposit_by_tx_hash(&send_tx).await {
             Ok(transfer) => transfer,
             Err(error) => {
                 warn!(target: "rebalance", "Alpaca deposit polling failed: {error}");
@@ -2319,9 +2460,10 @@ pub(crate) fn u256_to_usdc(amount: U256) -> Result<Usdc, UsdcTransferError> {
 mod tests {
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::{B256, address, b256, fixed_bytes};
-    use alloy::providers::ProviderBuilder;
     use alloy::providers::ext::AnvilApi as _;
+    use alloy::providers::{Provider, ProviderBuilder};
     use alloy::signers::local::PrivateKeySigner;
+    use alloy::sol_types::SolEvent;
     use httpmock::prelude::*;
     use reqwest::StatusCode;
     use serde_json::json;
@@ -2342,12 +2484,15 @@ mod tests {
         link_chains, mint_usdc, set_max_burn_amount,
     };
     use st0x_event_sorcery::{AggregateError, LifecycleError, test_store};
-    use st0x_evm::Wallet;
     use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_evm::{Evm, NoOpErrorRegistry, Wallet};
     use st0x_raindex::RaindexService;
 
     use super::*;
-    use crate::alpaca_wallet::{AlpacaTransferId, AlpacaWalletClient, AlpacaWalletError};
+    use crate::alpaca_wallet::{
+        AlpacaTransferId, AlpacaWalletClient, AlpacaWalletError, PollingConfig,
+    };
+    use crate::bindings::IERC20;
     use crate::usdc_rebalance::{RebalanceDirection, TransferRef, UsdcRebalanceError};
     use st0x_finance::UsdcConversionError;
 
@@ -5160,21 +5305,44 @@ mod tests {
         );
     }
 
+    /// Resume from `Bridged` must NOT re-burn or re-mint: the bridge step is
+    /// already done. With no CCTP contracts deployed, a re-burn/re-mint attempt
+    /// would hit un-deployed contracts and fail loud. Driving to
+    /// `ConversionComplete` via the deposit-send (adopting an already-submitted
+    /// transfer) proves the resume touches only the deposit + conversion legs.
     #[tokio::test]
     async fn resume_base_to_alpaca_from_bridged_skips_burn_and_mint() {
+        let chain = deploy_ethereum_usdc_chain().await;
         let server = MockServer::start();
-        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+        let _address_mock = mock_alpaca_deposit_address(&server);
+
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let cqrs = create_test_store_instance().await;
+        let manager = build_deposit_manager(&chain, &server, alpaca_wallet, cqrs.clone()).await;
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc("100");
         let amount_received = usdc("99.99");
-        let (_burn_tx, mint_tx) =
-            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        let amount_u256 = usdc_to_u256(amount_received).unwrap();
+        stage_bridged_with_mint_tx(&cqrs, &id, amount, amount_received, chain.mint_tx).await;
 
-        // Mock Alpaca deposit poll for the mint tx and the subsequent
-        // USDC->USD conversion. No CCTP mocks are configured — a resume from
-        // Bridged that tried to re-burn or re-mint would attempt to hit the
-        // (un-deployed) CCTP contracts via anvil and fail the test loud.
+        // Pre-submit the deposit transfer so resume adopts it (no second send),
+        // then drives the deposit + conversion to terminal. No CCTP mocks: a
+        // re-burn/re-mint would hit the un-deployed CCTP contracts and fail loud.
+        let bridge_wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
+        let existing_send = bridge_wallet
+            .submit::<NoOpErrorRegistry, _>(
+                USDC_ADDRESS,
+                IERC20::transferCall {
+                    to: ALPACA_DEPOSIT_ADDRESS,
+                    amount: amount_u256,
+                },
+                "pre-existing deposit send",
+            )
+            .await
+            .unwrap()
+            .transaction_hash;
+
         let _transfers_mock = server.mock(|when, then| {
             when.method(GET)
                 .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
@@ -5187,10 +5355,10 @@ mod tests {
                     "usd_value": "99.99",
                     "chain": "ethereum",
                     "asset": "USDC",
-                    "from_address": "0x0000000000000000000000000000000000000001",
-                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "from_address": format!("{:#x}", chain.bot_address),
+                    "to_address": format!("{ALPACA_DEPOSIT_ADDRESS:#x}"),
                     "status": "COMPLETE",
-                    "tx_hash": format!("{mint_tx:#x}"),
+                    "tx_hash": format!("{existing_send:#x}"),
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0.5",
                     "fees": "0"
@@ -5493,8 +5661,10 @@ mod tests {
             .unwrap(),
         );
 
-        // Produce a real on-chain mint to the market maker wallet.
-        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        // Mint to the bot wallet (the Ethereum signer): in production
+        // `market_maker_wallet` IS the bot wallet, and the BaseToAlpaca deposit
+        // leg sends the minted USDC from it to Alpaca's deposit address.
+        let market_maker_wallet = chains.bot_address;
         let amount = usdc("100");
         let amount_u256 = usdc_to_u256(amount).unwrap();
         let burn_receipt = cctp_bridge
@@ -5578,8 +5748,16 @@ mod tests {
         .await
         .unwrap();
 
-        // Downstream Alpaca legs after adoption: deposit detection (by the mint
-        // tx) then the USDC->USD conversion.
+        // After mint adoption, the deposit leg fetches Alpaca's address and sends
+        // the minted USDC there. Pre-submit that transfer so the deposit scan
+        // adopts it (the crash-before-record window) and the transfers poll can
+        // match its known tx hash.
+        let _address_mock = mock_alpaca_deposit_address(&server);
+        let deposit_send = cctp_bridge
+            .send_usdc_on_ethereum(ALPACA_DEPOSIT_ADDRESS, mint_receipt.amount)
+            .await
+            .unwrap();
+
         let _transfers_mock = server.mock(|when, then| {
             when.method(GET)
                 .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
@@ -5592,10 +5770,10 @@ mod tests {
                     "usd_value": "100",
                     "chain": "ethereum",
                     "asset": "USDC",
-                    "from_address": "0x0000000000000000000000000000000000000001",
-                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "from_address": format!("{:#x}", chains.bot_address),
+                    "to_address": format!("{ALPACA_DEPOSIT_ADDRESS:#x}"),
                     "status": "COMPLETE",
-                    "tx_hash": format!("{:#x}", mint_receipt.tx),
+                    "tx_hash": format!("{deposit_send:#x}"),
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0",
                     "fees": "0"
@@ -5664,8 +5842,10 @@ mod tests {
         );
 
         // Produce a real on-chain mint so the nonce is already consumed before
-        // recovery runs -- recovery must adopt it, not re-mint.
-        let market_maker_wallet = address!("0x1111111111111111111111111111111111111111");
+        // recovery runs -- recovery must adopt it, not re-mint. Mint to the bot
+        // wallet (the Ethereum signer): in production `market_maker_wallet` IS the
+        // bot wallet, and the deposit leg sends the minted USDC from it to Alpaca.
+        let market_maker_wallet = chains.bot_address;
         let amount = usdc("100");
         let amount_u256 = usdc_to_u256(amount).unwrap();
         let burn_receipt = cctp_bridge
@@ -5747,8 +5927,15 @@ mod tests {
             "expected BridgingFailed before recovery, got: {failed_state:?}"
         );
 
-        // Downstream Alpaca legs after the un-fail: deposit detection (by the
-        // adopted mint tx) then the USDC->USD conversion.
+        // After the un-fail, the deposit leg fetches Alpaca's address and sends
+        // the minted USDC there. Pre-submit that transfer so the deposit scan
+        // adopts it and the transfers poll can match its known tx hash.
+        let _address_mock = mock_alpaca_deposit_address(&server);
+        let deposit_send = cctp_bridge
+            .send_usdc_on_ethereum(ALPACA_DEPOSIT_ADDRESS, mint_receipt.amount)
+            .await
+            .unwrap();
+
         let _transfers_mock = server.mock(|when, then| {
             when.method(GET)
                 .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
@@ -5761,10 +5948,10 @@ mod tests {
                     "usd_value": "100",
                     "chain": "ethereum",
                     "asset": "USDC",
-                    "from_address": "0x0000000000000000000000000000000000000001",
-                    "to_address": "0x1111111111111111111111111111111111111111",
+                    "from_address": format!("{:#x}", chains.bot_address),
+                    "to_address": format!("{ALPACA_DEPOSIT_ADDRESS:#x}"),
                     "status": "COMPLETE",
-                    "tx_hash": format!("{:#x}", mint_receipt.tx),
+                    "tx_hash": format!("{deposit_send:#x}"),
                     "created_at": "2024-01-01T00:00:00Z",
                     "network_fee": "0",
                     "fees": "0"
@@ -5863,85 +6050,60 @@ mod tests {
         );
     }
 
+    /// Resume from `Bridged` MUST move funds: the CCTP mint credits the bot's own
+    /// wallet, not Alpaca, so the deposit leg fetches Alpaca's deposit address and
+    /// SENDS the minted USDC there. This is the root-cause fix -- the old poll-only
+    /// leg never sent, so the deposit dead-ended. Asserts the address lookup ran
+    /// and the on-chain USDC moved bot -> Alpaca address by the deposit amount.
     #[tokio::test]
-    async fn resume_base_to_alpaca_from_bridged_makes_no_fund_moving_deposit_call() {
+    async fn resume_base_to_alpaca_from_bridged_sends_fund_moving_deposit() {
+        let chain = deploy_ethereum_usdc_chain().await;
         let server = MockServer::start();
-        let (manager, cqrs, _anvil) = make_resume_test_manager(&server).await;
+        let address_mock = mock_alpaca_deposit_address(&server);
+
+        let alpaca_wallet = Arc::new(create_short_poll_wallet_service(&server));
+        let cqrs = create_test_store_instance().await;
+        let manager = build_deposit_manager(&chain, &server, alpaca_wallet, cqrs.clone()).await;
 
         let id = UsdcRebalanceId(Uuid::new_v4());
         let amount = usdc("100");
         let amount_received = usdc("99.99");
-        let (_burn_tx, mint_tx) =
-            advance_to_bridged_base_to_alpaca(&cqrs, &id, amount, amount_received).await;
+        stage_bridged_with_mint_tx(&cqrs, &id, amount, amount_received, chain.mint_tx).await;
 
-        // The CCTP mint already credited the Alpaca-monitored address, so resume
-        // only OBSERVES the deposit via this GET poll, never re-issues a transfer.
-        let deposit_poll_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([{
-                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
-                    "direction": "INCOMING",
-                    "amount": "99.99",
-                    "usd_value": "99.99",
-                    "chain": "ethereum",
-                    "asset": "USDC",
-                    "from_address": "0x0000000000000000000000000000000000000001",
-                    "to_address": "0x1111111111111111111111111111111111111111",
-                    "status": "COMPLETE",
-                    "tx_hash": format!("{mint_tx:#x}"),
-                    "created_at": "2024-01-01T00:00:00Z",
-                    "network_fee": "0.5",
-                    "fees": "0"
-                }]));
-        });
-        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
-        let _get_order_mock = create_get_order_mock(
-            &server,
-            "61e7b016-9c91-4a97-b912-615c9d365c9d",
-            "filled",
-            "99.99",
-        );
+        let alpaca_before = usdc_balance_of(&chain, ALPACA_DEPOSIT_ADDRESS).await;
+        assert_eq!(alpaca_before, U256::ZERO, "Alpaca address starts unfunded");
 
-        // A fund-moving Alpaca transfer is a POST to /wallets/transfers, and the
-        // withdrawal path GETs /wallets/whitelists. Resume from Bridged must do
-        // NEITHER -- the deposit was effected by the mint, not an Alpaca API call.
-        let transfers_post_mock = server.mock(|when, then| {
-            when.method(POST)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!({}));
-        });
-        let whitelist_mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/whitelists");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(json!([]));
-        });
-
-        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
-
-        deposit_poll_mock.assert();
-        assert_eq!(
-            transfers_post_mock.calls(),
-            0,
-            "resume from Bridged must NOT POST a fund-moving Alpaca transfer; the CCTP \
-             mint already deposited directly to the Alpaca address",
-        );
-        assert_eq!(
-            whitelist_mock.calls(),
-            0,
-            "resume from Bridged must NOT touch the withdrawal whitelist path",
-        );
-
-        let final_state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        // No deposit transfer is mocked, so the leg sends, then fails at the poll
+        // (short timeout). The send is what we assert on.
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
         assert!(
-            matches!(final_state, UsdcRebalance::ConversionComplete { .. }),
-            "Expected ConversionComplete after resume from Bridged, got: {final_state:?}",
+            matches!(error, UsdcTransferError::AlpacaWallet(_)),
+            "with no deposit detected the leg fails at the Alpaca poll, got: {error:?}",
+        );
+
+        address_mock.assert();
+        let amount_u256 = usdc_to_u256(amount_received).unwrap();
+        assert_eq!(
+            usdc_balance_of(&chain, ALPACA_DEPOSIT_ADDRESS).await,
+            amount_u256,
+            "resume from Bridged MUST send the minted USDC to Alpaca's deposit address",
+        );
+
+        // The recorded deposit_ref is the SEND tx (not the mint tx), and that tx
+        // transfers USDC to the Alpaca deposit address.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        let recorded = deposit_ref_tx(&state);
+        assert_ne!(
+            recorded, chain.mint_tx,
+            "the recorded deposit_ref must be the SEND tx, not the mint tx",
+        );
+        assert_eq!(
+            usdc_transfer_recipient(&chain, recorded).await,
+            ALPACA_DEPOSIT_ADDRESS,
+            "the recorded send tx must transfer USDC to the Alpaca deposit address",
         );
     }
 
@@ -6223,5 +6385,462 @@ mod tests {
             "a transient destination head lookup failure must leave the aggregate in \
              `Bridging` for retry, not latch a terminal `BridgingFailed`, got: {state:?}",
         );
+    }
+
+    /// On-chain harness for the BaseToAlpaca deposit-send leg: a single Ethereum
+    /// anvil with `TestMintBurnToken` at the canonical USDC address and the bot
+    /// wallet funded, plus a real funding tx whose hash/block stand in for the
+    /// CCTP mint that the deposit scan is bounded by.
+    struct EthereumUsdcChain {
+        endpoint: String,
+        bot_key: B256,
+        bot_address: Address,
+        mint_tx: TxHash,
+        _anvil: AnvilInstance,
+    }
+
+    /// Deploys USDC on a fresh Ethereum anvil, funds the bot wallet, and records
+    /// a real on-chain tx (the USDC mint to the bot) usable as the deposit scan's
+    /// `mint_tx` bound. The bot is both the CCTP mint recipient and the deposit
+    /// sender, mirroring production where `market_maker_wallet` is the bot wallet.
+    async fn deploy_ethereum_usdc_chain() -> EthereumUsdcChain {
+        let anvil = Anvil::new().chain_id(1u64).spawn();
+        let endpoint = anvil.endpoint();
+        let bot_key = B256::from_slice(&anvil.keys()[0].to_bytes());
+        let bot_address = PrivateKeySigner::from_bytes(&bot_key).unwrap().address();
+
+        let provider = ProviderBuilder::new().connect(&endpoint).await.unwrap();
+        provider
+            .anvil_set_code(USDC_ADDRESS, TestMintBurnToken::DEPLOYED_BYTECODE.clone())
+            .await
+            .unwrap();
+
+        // A real USDC mint to the bot: funds the send and gives the resume scan a
+        // genuine mint tx whose block bounds the transfer scan.
+        let signer = PrivateKeySigner::from_bytes(&bot_key).unwrap();
+        let bot_provider = ProviderBuilder::new()
+            .wallet(alloy::network::EthereumWallet::from(signer))
+            .connect(&endpoint)
+            .await
+            .unwrap();
+        let token = TestMintBurnToken::new(USDC_ADDRESS, &bot_provider);
+        let mint_receipt = token
+            .mint(bot_address, U256::from(1_000_000_000_000u64))
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        // Advance the head a few blocks past the mint so the finality-gated
+        // deposit scan can conclude a true absence (Ok(None)) rather than a
+        // retryable ScanInconclusive, letting a fresh resume proceed to the send.
+        provider.anvil_mine(Some(5), None).await.unwrap();
+
+        EthereumUsdcChain {
+            endpoint,
+            bot_key,
+            bot_address,
+            mint_tx: mint_receipt.transaction_hash,
+            _anvil: anvil,
+        }
+    }
+
+    /// Builds a manager whose CCTP bridge and vault both run against
+    /// `chain` (Ethereum), with `market_maker_wallet` set to the bot wallet so
+    /// the minted USDC is held by the address that signs the deposit send.
+    /// `wallet_polling` overrides the Alpaca deposit poll cadence (a short timeout
+    /// lets a no-match poll fail fast instead of hanging 30 minutes).
+    async fn build_deposit_manager(
+        chain: &EthereumUsdcChain,
+        server: &MockServer,
+        alpaca_wallet: Arc<AlpacaWalletService>,
+        cqrs: Arc<Store<UsdcRebalance>>,
+    ) -> CrossVenueCashTransfer<RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>>
+    {
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let bridge_wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(bridge_wallet);
+
+        CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs,
+            chain.bot_address,
+            TEST_VAULT_ID,
+            TEST_ATTESTATION_RETRY_DEADLINE,
+        )
+    }
+
+    /// Builds an Alpaca wallet service against `server` with a short deposit poll
+    /// timeout so a no-match poll resolves quickly in tests.
+    fn create_short_poll_wallet_service(server: &MockServer) -> AlpacaWalletService {
+        let client = AlpacaWalletClient::new(
+            server.base_url(),
+            TEST_ACCOUNT_ID,
+            "test_key".to_string(),
+            "test_secret".to_string(),
+        );
+        let polling = PollingConfig {
+            interval: Duration::from_millis(10),
+            timeout: Duration::from_millis(200),
+            max_retries: 1,
+            min_retry_delay: Duration::from_millis(5),
+            max_retry_delay: Duration::from_millis(20),
+        };
+
+        AlpacaWalletService::new_with_client(client, Some(polling))
+    }
+
+    const ALPACA_DEPOSIT_ADDRESS: Address = address!("0x000000000000000000000000000000000000A1BC");
+
+    /// Mocks the Alpaca `GET /wallets?asset=USDC&network=ethereum` deposit-address
+    /// lookup the deposit-send leg calls before transferring.
+    fn mock_alpaca_deposit_address(server: &MockServer) -> httpmock::Mock<'_> {
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets")
+                .query_param("asset", "USDC")
+                .query_param("network", "ethereum");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "asset_id": "5d0de74f-827b-41a7-9f74-9c07c08fe55f",
+                    "address": format!("{ALPACA_DEPOSIT_ADDRESS:#x}"),
+                    "created_at": "2025-08-07T08:52:40.656166Z"
+                }));
+        })
+    }
+
+    /// Reads `holder`'s USDC balance on `chain` for asserting the deposit send
+    /// actually credited the Alpaca address (and debited the bot).
+    async fn usdc_balance_of(chain: &EthereumUsdcChain, holder: Address) -> U256 {
+        let wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
+        wallet
+            .call::<NoOpErrorRegistry, _>(USDC_ADDRESS, IERC20::balanceOfCall { account: holder })
+            .await
+            .unwrap()
+    }
+
+    /// Reads the on-chain `deposit_ref` (the deposit send tx) recorded by
+    /// `InitiateDeposit` and preserved into the failed state.
+    fn deposit_ref_tx(state: &UsdcRebalance) -> TxHash {
+        match state {
+            UsdcRebalance::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(tx),
+                ..
+            }
+            | UsdcRebalance::DepositFailed {
+                deposit_ref: Some(TransferRef::OnchainTx(tx)),
+                ..
+            } => *tx,
+            other => {
+                panic!("expected a deposit state with an on-chain deposit_ref, got: {other:?}")
+            }
+        }
+    }
+
+    /// Idempotent resume: when a matching USDC transfer already exists on chain
+    /// since the mint block, the leg ADOPTS it and does NOT send a second
+    /// transfer (the bot's nonce is unchanged), then polls + confirms + converts
+    /// to terminal.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_adopts_existing_send() {
+        let chain = deploy_ethereum_usdc_chain().await;
+        let server = MockServer::start();
+        let address_mock = mock_alpaca_deposit_address(&server);
+
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let cqrs = create_test_store_instance().await;
+        let manager = build_deposit_manager(&chain, &server, alpaca_wallet, cqrs.clone()).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        let amount_u256 = usdc_to_u256(amount_received).unwrap();
+        stage_bridged_with_mint_tx(&cqrs, &id, amount, amount_received, chain.mint_tx).await;
+
+        // Pre-submit the deposit transfer on chain (the crash-before-record
+        // window): resume must adopt THIS tx instead of sending a second time.
+        let bridge_wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
+        let existing_send = bridge_wallet
+            .submit::<NoOpErrorRegistry, _>(
+                USDC_ADDRESS,
+                IERC20::transferCall {
+                    to: ALPACA_DEPOSIT_ADDRESS,
+                    amount: amount_u256,
+                },
+                "pre-existing deposit send",
+            )
+            .await
+            .unwrap()
+            .transaction_hash;
+        let nonce_after_send = bridge_wallet
+            .provider()
+            .get_transaction_count(chain.bot_address)
+            .await
+            .unwrap();
+
+        // Deposit detection (by the adopted send tx) + USDC->USD conversion.
+        let _transfers_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": "61e7b016-9c91-4a97-b912-615c9d365c9d",
+                    "direction": "INCOMING",
+                    "amount": "99.99",
+                    "usd_value": "99.99",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": format!("{:#x}", chain.bot_address),
+                    "to_address": format!("{ALPACA_DEPOSIT_ADDRESS:#x}"),
+                    "status": "COMPLETE",
+                    "tx_hash": format!("{existing_send:#x}"),
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }]));
+        });
+        let _conversion_mock = create_conversion_order_mock(&server, "99.99");
+        let _get_order_mock = create_get_order_mock(
+            &server,
+            "61e7b016-9c91-4a97-b912-615c9d365c9d",
+            "filled",
+            "99.99",
+        );
+
+        manager.resume_base_to_alpaca(&id, amount).await.unwrap();
+
+        address_mock.assert();
+        assert_eq!(
+            bridge_wallet
+                .provider()
+                .get_transaction_count(chain.bot_address)
+                .await
+                .unwrap(),
+            nonce_after_send,
+            "adopting the existing send must NOT submit a second transfer (nonce unchanged)",
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(state, UsdcRebalance::ConversionComplete { .. }),
+            "adopting the existing send must drive the deposit + conversion to terminal, got: {state:?}",
+        );
+    }
+
+    /// Scan failure -> error, no send: when the pre-send chain scan cannot be run
+    /// (the chain is unreachable), the leg returns an error and submits NO
+    /// transfer, so a transient RPC fault never double-spends.
+    #[tokio::test]
+    async fn resume_base_to_alpaca_from_bridged_scan_failure_does_not_send() {
+        let chain = deploy_ethereum_usdc_chain().await;
+        let server = MockServer::start();
+        let _address_mock = mock_alpaca_deposit_address(&server);
+
+        let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
+        let cqrs = create_test_store_instance().await;
+        let manager = build_deposit_manager(&chain, &server, alpaca_wallet, cqrs.clone()).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        stage_bridged_with_mint_tx(&cqrs, &id, amount, amount_received, chain.mint_tx).await;
+
+        let bot_before = usdc_balance_of(&chain, chain.bot_address).await;
+        assert_eq!(
+            bot_before,
+            U256::from(1_000_000_000_000u64),
+            "the bot holds the full minted balance before the resume attempt",
+        );
+
+        // Kill the chain so the mint-block lookup / transfer scan fails. Dropping
+        // the whole chain drops its anvil instance. The leg must surface a Cctp
+        // error from the failed scan -- which happens strictly BEFORE the send --
+        // so no transfer is ever submitted.
+        drop(chain);
+
+        let error = manager
+            .resume_base_to_alpaca(&id, amount)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, UsdcTransferError::Cctp(_)),
+            "a scan/chain failure before the send must surface a Cctp error, got: {error:?}",
+        );
+    }
+
+    /// The FRESH `Bridged` entry (immediately after this execution minted) MUST
+    /// send the deposit DIRECTLY with no pre-send chain scan -- mirroring the
+    /// fresh burn path. The scan is finality-gated (head must be
+    /// `SCAN_FINALITY_MARGIN` past the mint block) and would otherwise wedge with
+    /// a retryable `ScanInconclusive` whenever the chain head sits at the mint
+    /// block, exactly the e2e-anvil condition. This test keeps the head AT the
+    /// mint block and asserts the fresh leg still sends and records the send tx.
+    #[tokio::test]
+    async fn continue_from_bridged_fresh_sends_directly_without_scan() {
+        let chain = deploy_ethereum_usdc_chain_head_at_mint().await;
+        let server = MockServer::start();
+        let address_mock = mock_alpaca_deposit_address(&server);
+
+        let alpaca_wallet = Arc::new(create_short_poll_wallet_service(&server));
+        let cqrs = create_test_store_instance().await;
+        let manager = build_deposit_manager(&chain, &server, alpaca_wallet, cqrs.clone()).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("100");
+        let amount_received = usdc("99.99");
+        stage_bridged_with_mint_tx(&cqrs, &id, amount, amount_received, chain.mint_tx).await;
+
+        let alpaca_before = usdc_balance_of(&chain, ALPACA_DEPOSIT_ADDRESS).await;
+        assert_eq!(alpaca_before, U256::ZERO, "Alpaca address starts unfunded");
+
+        // No deposit transfer is mocked, so the fresh leg sends, then fails at the
+        // poll (short timeout). The DIRECT send (no scan, no finality wait) is the
+        // behavior under test.
+        let error = manager
+            .continue_from_bridged_fresh(&id, amount_received)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, UsdcTransferError::AlpacaWallet(_)),
+            "with no deposit detected the leg fails at the Alpaca poll, got: {error:?}",
+        );
+
+        address_mock.assert();
+        let amount_u256 = usdc_to_u256(amount_received).unwrap();
+        assert_eq!(
+            usdc_balance_of(&chain, ALPACA_DEPOSIT_ADDRESS).await,
+            amount_u256,
+            "the fresh leg MUST send the minted USDC to Alpaca's deposit address even with the \
+             head at the mint block (no finality-gated scan)",
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        let recorded = deposit_ref_tx(&state);
+        assert_eq!(
+            usdc_transfer_recipient(&chain, recorded).await,
+            ALPACA_DEPOSIT_ADDRESS,
+            "the recorded send tx must transfer USDC to the Alpaca deposit address",
+        );
+    }
+
+    /// Like [`deploy_ethereum_usdc_chain`] but leaves the chain head AT the mint
+    /// block (no extra blocks mined). The finality-gated deposit scan cannot
+    /// conclude here, so this isolates the fresh path's no-scan direct send.
+    async fn deploy_ethereum_usdc_chain_head_at_mint() -> EthereumUsdcChain {
+        let anvil = Anvil::new().chain_id(1u64).spawn();
+        let endpoint = anvil.endpoint();
+        let bot_key = B256::from_slice(&anvil.keys()[0].to_bytes());
+        let bot_address = PrivateKeySigner::from_bytes(&bot_key).unwrap().address();
+
+        let provider = ProviderBuilder::new().connect(&endpoint).await.unwrap();
+        provider
+            .anvil_set_code(USDC_ADDRESS, TestMintBurnToken::DEPLOYED_BYTECODE.clone())
+            .await
+            .unwrap();
+
+        let signer = PrivateKeySigner::from_bytes(&bot_key).unwrap();
+        let bot_provider = ProviderBuilder::new()
+            .wallet(alloy::network::EthereumWallet::from(signer))
+            .connect(&endpoint)
+            .await
+            .unwrap();
+        let token = TestMintBurnToken::new(USDC_ADDRESS, &bot_provider);
+        let mint_receipt = token
+            .mint(bot_address, U256::from(1_000_000_000_000u64))
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        EthereumUsdcChain {
+            endpoint,
+            bot_key,
+            bot_address,
+            mint_tx: mint_receipt.transaction_hash,
+            _anvil: anvil,
+        }
+    }
+
+    /// Reads the `to` of the USDC `Transfer` event emitted by `tx` on `chain`.
+    async fn usdc_transfer_recipient(chain: &EthereumUsdcChain, tx: TxHash) -> Address {
+        let provider = ProviderBuilder::new()
+            .connect(&chain.endpoint)
+            .await
+            .unwrap();
+        let receipt = provider
+            .get_transaction_receipt(tx)
+            .await
+            .unwrap()
+            .expect("send tx receipt exists");
+        receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                IERC20::Transfer::decode_log(log.as_ref())
+                    .ok()
+                    .map(|event| event.to)
+            })
+            .expect("a USDC Transfer event is present in the send tx")
+    }
+
+    /// Drives the aggregate to `Bridged` recording `mint_tx` as the mint tx hash,
+    /// so resume from `Bridged` re-enters `continue_from_bridged_resume` with a
+    /// real on-chain mint tx to bound the deposit scan.
+    async fn stage_bridged_with_mint_tx(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+        amount_received: Usdc,
+        mint_tx: TxHash,
+    ) {
+        let burn_tx =
+            fixed_bytes!("0xaaaa000000000000000000000000000000000000000000000000000000000099");
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount,
+                withdrawal: TransferRef::OnchainTx(burn_tx),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .await
+            .unwrap();
+        cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ReceiveAttestation {
+                attestation: vec![0x01],
+                cctp_nonce: B256::left_padding_from(&99_999u64.to_be_bytes()),
+                message: valid_cctp_message(),
+                mint_scan_from_block: 0,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmBridging {
+                mint_tx,
+                amount_received,
+                fee_collected: usdc("0.01"),
+            },
+        )
+        .await
+        .unwrap();
     }
 }

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -1302,13 +1302,21 @@ async fn assert_usdc_rebalancing_onchain_state<P: Provider>(
             // mid-flight state, not baseline.
             U256::ZERO
         }
-        UsdcRebalanceType::BaseToAlpaca => ethereum_usdc_balance_before_rebalance
-            .checked_add(event_amounts.bridged_amount_received)
-            .ok_or_else(|| anyhow::anyhow!("Ethereum USDC overflow on BaseToAlpaca mint"))?,
+        UsdcRebalanceType::BaseToAlpaca => {
+            // The CCTP mint credits `bridged_amount_received` to the bot's
+            // Ethereum wallet, then the deposit-send leg forwards exactly that
+            // same amount on to Alpaca's deposit address -- a net-zero change --
+            // so the wallet ends at the pre-rebalance reading. (Before this send
+            // leg the minted USDC stayed in the wallet; the leg now moves it to
+            // Alpaca.) The BaseToAlpaca mint lands after the on-chain
+            // withdraw/burn, so `before` is captured pre-mint at baseline.
+            ethereum_usdc_balance_before_rebalance
+        }
     };
     assert_eq!(
         ethereum_usdc_balance_after_rebalance, expected_ethereum_post_units,
-        "Ethereum USDC balance should reconcile exactly with CCTP transfer amount"
+        "Ethereum USDC balance should reconcile exactly: the CCTP mint credits \
+         the wallet and the deposit-send forwards it to Alpaca, returning to zero"
     );
 
     Ok(())


### PR DESCRIPTION
## What

- Make the automated BaseToAlpaca USDC rebalance actually deliver funds to Alpaca: it now sends the minted USDC from the bot wallet to Alpaca's deposit address and polls by that send tx, instead of only polling read-only.
- Idempotent, crash-safe: fresh path sends directly; resume scans-and-adopts an existing send. ADR 0006.

## Why

- The CCTP burn sets `mintRecipient = market_maker_wallet` (the bot's own Ethereum wallet), so the mint credits the bot wallet — not an Alpaca deposit address. The old leg only polled, so BaseToAlpaca dead-ended at `DepositFailed`. This is the root cause behind RAI-957.
- Closes [RAI-962](https://linear.app/makeitrain/issue/RAI-962).

## How

- `continue_from_bridged` is split (mirroring the CCTP burn pattern, fresh=direct / resume=scan-or-adopt): `continue_from_bridged_fresh` sends directly via `send_alpaca_deposit` (no scan); `continue_from_bridged_resume` uses `send_or_adopt_alpaca_deposit` (finality-gated scan, adopt-or-send); both share `finish_deposit` (`InitiateDeposit{send_tx}` → poll → confirm → USDC→USD convert).
- New bridge helpers (`crates/bridge/src/cctp/{evm,mod}.rs`): `ethereum_tx_block`, `send_usdc_on_ethereum`, and a finality-gated `find_recent_usdc_transfer` (exact from/to/value match, bounded by the mint block). new `CctpError::TxReceiptMissingBlock` (reuses the existing `ScanInconclusive`).
- Crash-safety: a crash after a fresh send (before `InitiateDeposit`) lands in `Bridged`; the resume scan adopts the existing send (no double-send). Adoption is provably correct via exact `(from, to, value)` match + the mint-block lower bound + the single-USDC-rebalance-in-flight invariant. On scan failure it sends nothing.
- E2E Alpaca mock (`crates/execution/.../mock_api.rs`) updated to detect the deposit by the **send** tx (not the mint).

## Testing

- Manager unit/anvil (`usdc::manager`, 61 pass): fresh sends directly to the Alpaca address with the head at the mint block; resume adopts an existing send (nonce unchanged); scan failure does not send.
- Bridge: `find_recent_usdc_transfer` from/to/value/scan-bound matching.
- E2E `usdc_imbalance_triggers_base_to_alpaca` + `interrupted_usdc_base_to_alpaca_resumes_after_restart` pass; the BaseToAlpaca Ethereum-balance assertion updated for the new net-zero (mint in, forward out) behavior.

## Anything else

- Money-moving change — review carefully. To confirm: Alpaca credits the deposit by the **send** tx (the manual `alpaca-deposit` CLI relies on the same), and the address wiring (Alpaca lookup uses `Network::new("ethereum")`; the transfer uses the bridge's configured Ethereum USDC address).
