### PR TITLE
refactor: convert tokenized equity mint to TransferEquityToMarketMaking apalis job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,37 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "apca"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd6020973dd8af9515252f62c3e4a123f918077832cf96717f88f7bee232549"
-dependencies = [
- "async-compression",
- "async-trait",
- "chrono",
- "futures",
- "http 1.4.0",
- "http-body-util",
- "http-endpoint",
- "hyper 1.9.0",
- "hyper-tls 0.6.0",
- "hyper-util",
- "num-decimal",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "serde_variant",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tracing",
- "tracing-futures",
- "url",
- "uuid",
- "websocket-util",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,7 +1441,6 @@ checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
- "futures-io",
  "pin-project-lite",
  "tokio",
 ]
@@ -3245,15 +3213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-endpoint"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f1452e05dacda1597bf23d0336aa128ee1603cdf1bf539384768c5d9b8a46"
-dependencies = [
- "http 1.4.0",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,7 +3984,6 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5763,15 +5721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_variant"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0068df419f9d9b6488fdded3f1c818522cdea328e02ce9d9f147380265a432"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5860,6 +5809,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -6509,7 +6464,6 @@ dependencies = [
  "alloy",
  "alloy-primitives",
  "anyhow",
- "apca",
  "async-trait",
  "backon",
  "base64 0.22.1",
@@ -7158,11 +7112,9 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
@@ -7401,16 +7353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7579,13 +7521,11 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
- "url",
  "utf-8",
 ]
 
@@ -7804,6 +7744,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -8039,18 +7980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "websocket-util"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725e1a87b5606202cbfabbc44f82a6ae686e2b2555ad3579c3af136243c33d2d"
-dependencies = [
- "futures",
- "tokio",
- "tokio-tungstenite 0.26.2",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ alloy-signer-turnkey = "=1.0.41"
 anyhow = "1.0.102"
 apalis-board = { version = "1.0.0-rc.8", features = ["axum", "ui"] }
 apalis-workflow = "0.1.0-rc.9"
-apca = "0.30.0"
 approx = "0.5.1"
 async-trait = "0.1.81"
 axum = { version = "0.8.9", features = ["ws", "json"] }
@@ -131,7 +130,7 @@ ts-rs = { version = "11.1.0", features = [
 ] }
 url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1"
-uuid = { version = "1.11", features = ["serde", "v4"] }
+uuid = { version = "1.11", features = ["serde", "v4", "v5"] }
 # Pin wasm-bindgen version for compatibility with rain.wasm transitive dependency
 # (bumped in lockstep with the rain.orderbook / rain.math.float bump, whose
 # newer crates require >=0.2.122).

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -15,7 +15,6 @@ aes-gcm.workspace = true
 alloy.workspace = true
 alloy-primitives.workspace = true
 anyhow = { workspace = true, optional = true }
-apca.workspace = true
 async-trait.workspace = true
 backon.workspace = true
 base64.workspace = true
@@ -33,16 +32,17 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
-st0x-dto = { version = "0.1.0", path = "../dto" }
-st0x-finance.workspace = true
-st0x-float-macro.workspace = true
-st0x-float-serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 urlencoding.workspace = true
 uuid.workspace = true
+
+st0x-dto = { version = "0.1.0", path = "../dto" }
+st0x-finance.workspace = true
+st0x-float-macro.workspace = true
+st0x-float-serde.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/src/api.rs
+++ b/src/api.rs
@@ -862,6 +862,7 @@ fn event_payload_inner(step: &str, payload: &str, sequence: i64) -> serde_json::
             .as_object()
             .and_then(|obj| obj.get(step).cloned())
             .unwrap_or(parsed),
+
         Err(error) => {
             warn!(
                 target: "dashboard",
@@ -870,6 +871,7 @@ fn event_payload_inner(step: &str, payload: &str, sequence: i64) -> serde_json::
                 sequence,
                 "Failed to parse event payload for display"
             );
+
             serde_json::json!({
                 "parseError": error.to_string(),
                 "sequence": sequence,
@@ -911,25 +913,31 @@ fn stuck_mint_info(rows: &[(String, String, i64)]) -> Option<StuckTransferInfo> 
                 quantity: requested,
                 ..
             } => quantity = Some(FractionalShares::new(requested).to_string()),
+
             MintAccepted { .. } => accepted = true,
+
             MintAcceptanceFailed { .. } if accepted => {
                 terminal = Some((StuckLocation::Issuer, StuckReason::MintAcceptanceFailed));
             }
+
             WrappingFailed { .. } => {
                 terminal = Some((
                     StuckLocation::BotWalletUnwrapped,
                     StuckReason::WrappingFailed,
                 ));
             }
+
             RaindexDepositFailed { .. } => {
                 terminal = Some((
                     StuckLocation::BotWalletWrapped,
                     StuckReason::RaindexDepositFailed,
                 ));
             }
+
             // Neither strands equity: a rejected mint never left the issuer,
             // and a deposited mint completed successfully.
             MintRejected { .. } | DepositedIntoRaindex { .. } => return None,
+
             // Recovery un-failed the mint and put it back on the success path,
             // so any stuck state observed before it no longer applies; the
             // mint is re-derived from subsequent events (it may fail again).
@@ -972,6 +980,7 @@ fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransfer
                 requested_quantity = requested_quantity
                     .or_else(|| Some(FractionalShares::new(quantity).to_string()));
             }
+
             WithdrawnFromRaindex {
                 quantity,
                 wrapped_amount,
@@ -982,6 +991,7 @@ fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransfer
                     .or_else(|| Some(FractionalShares::new(quantity).to_string()));
                 withdrawn_amount = Some(actual_wrapped_amount.unwrap_or(wrapped_amount));
             }
+
             TokensUnwrapped {
                 quantity,
                 unwrapped_amount,
@@ -995,24 +1005,29 @@ fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransfer
                     .map(|qty| FractionalShares::new(qty).to_string())
                     .or_else(|| shares_from_u256_18_decimal(unwrapped_amount));
             }
+
             TokensSent { .. } => sent = true,
+
             DetectionFailed { .. } if sent => {
                 terminal = Some((
                     StuckLocation::RedemptionWallet,
                     StuckReason::DetectionFailed,
                 ));
             }
+
             RedemptionRejected { .. } if sent => {
                 terminal = Some((
                     StuckLocation::RedemptionWallet,
                     StuckReason::RedemptionRejected,
                 ));
             }
+
             // A terminal success (including recovery, which evolves straight to
             // Completed) means nothing is stranded.
             TransferFailed { .. } | Completed { .. } | ProviderCompletionRecovered { .. } => {
                 return None;
             }
+
             DetectionFailed { .. }
             | RedemptionRejected { .. }
             | UnwrapPending { .. }
@@ -1390,15 +1405,21 @@ async fn recheck_transfer(
 
     let outcome = match kind {
         TransferKind::EquityMint => {
+            let mint_id: IssuerRequestId = id.parse().map_err(|error| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: format!("Invalid mint ID: {error}"),
+                    }),
+                )
+            })?;
+
             handle
                 .transfer
-                .recover_mint(
-                    &IssuerRequestId::new(&id),
-                    &state.pool,
-                    &handle.rebalancing_service,
-                )
+                .recover_mint(&mint_id, &state.pool, &handle.rebalancing_service)
                 .await
         }
+
         TransferKind::EquityRedemption => {
             let redemption_id = id.parse::<RedemptionAggregateId>().map_err(|error| {
                 (
@@ -1408,11 +1429,13 @@ async fn recheck_transfer(
                     }),
                 )
             })?;
+
             handle
                 .transfer
                 .recover_redemption(&redemption_id, &handle.rebalancing_service)
                 .await
         }
+
         TransferKind::UsdcBridge => {
             return Err((
                 StatusCode::BAD_REQUEST,
@@ -1444,20 +1467,20 @@ async fn recheck_transfer(
 /// references aggregate/request ids; internal failures stay generic so they do
 /// not leak internals (the full error is logged at the call site).
 fn recheck_error_response(error: &RecheckError) -> (StatusCode, String) {
+    use RecheckError::{
+        Database, MalformedWallet, Mint, MissingTxHash, NoAcceptedRequest, Rebalancing, Redemption,
+        Tokenizer,
+    };
+
     match error {
-        RecheckError::NoAcceptedRequest(_)
-        | RecheckError::MissingTxHash(_)
-        | RecheckError::MalformedWallet { .. } => {
+        NoAcceptedRequest(_) | MissingTxHash(_) | MalformedWallet { .. } => {
             (StatusCode::UNPROCESSABLE_ENTITY, error.to_string())
         }
-        RecheckError::Tokenizer(_) => (
+        Tokenizer(_) => (
             StatusCode::BAD_GATEWAY,
             "Tokenization provider unavailable; retry later".to_string(),
         ),
-        RecheckError::Mint(_)
-        | RecheckError::Redemption(_)
-        | RecheckError::Rebalancing(_)
-        | RecheckError::Database(_) => (
+        Mint(_) | Redemption(_) | Rebalancing(_) | Database(_) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Failed to recheck transfer".to_string(),
         ),
@@ -1498,6 +1521,7 @@ mod tests {
     use super::*;
     use crate::dashboard;
     use crate::inventory::{self, BroadcastingInventory};
+    use crate::tokenized_equity_mint::issuer_request_id;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
         let (sender, _) = broadcast::channel(16);
@@ -1520,6 +1544,11 @@ mod tests {
 
     #[test]
     fn stuck_mint_info_reports_accepted_provider_failure() {
+        let mint_id = issuer_request_id("mint-1");
+        let mint_accepted_payload = format!(
+            r#"{{"MintAccepted":{{"issuer_request_id":"{mint_id}","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}}}"#
+        );
+
         let rows = vec![
             event_row(
                 "TokenizedEquityMintEvent::MintRequested",
@@ -1528,7 +1557,7 @@ mod tests {
             ),
             event_row(
                 "TokenizedEquityMintEvent::MintAccepted",
-                r#"{"MintAccepted":{"issuer_request_id":"mint-1","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+                &mint_accepted_payload,
                 1,
             ),
             event_row(
@@ -2403,17 +2432,17 @@ mod tests {
     #[test]
     fn recheck_error_response_distinguishes_recoverability() {
         use crate::tokenization::{MintVerificationError, TokenizerError};
-        use crate::tokenized_equity_mint::TokenizationRequestId;
+        use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
 
         // Not-recoverable: the persisted aggregate state forbids recovery, so
         // retrying will not help -> 422 carrying the typed reason.
-        let (status, message) = recheck_error_response(&RecheckError::NoAcceptedRequest(
-            IssuerRequestId::new("mint-1"),
-        ));
+        let mint_id = issuer_request_id("mint-1");
+        let (status, message) =
+            recheck_error_response(&RecheckError::NoAcceptedRequest(mint_id.clone()));
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(
             message,
-            "mint mint-1 has no accepted provider request to re-check"
+            format!("mint {mint_id} has no accepted provider request to re-check")
         );
 
         let (status, _) = recheck_error_response(&RecheckError::MissingTxHash(
@@ -2423,7 +2452,7 @@ mod tests {
 
         let parse_error = "not-an-address".parse::<Address>().unwrap_err();
         let (status, _) = recheck_error_response(&RecheckError::MalformedWallet {
-            id: IssuerRequestId::new("mint-1"),
+            id: mint_id,
             source: parse_error,
         });
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -235,6 +235,9 @@ pub enum Commands {
         /// Number of shares to transfer (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
+        /// Issuer request id for mint resume (printed by a fresh to-raindex run)
+        #[arg(long = "issuer-request-id")]
+        issuer_request_id: Option<Uuid>,
         /// Alpaca redemption wallet (overrides [tokenization] config)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
@@ -696,6 +699,7 @@ enum SimpleCommand {
         direction: TransferDirection,
         symbol: Symbol,
         quantity: FractionalShares,
+        issuer_request_id: Option<Uuid>,
         redemption_wallet: Option<Address>,
     },
     WrapEquity {
@@ -826,7 +830,7 @@ pub async fn seed_mint_at_tokens_wrapped_for_test(
     };
 
     let symbol = Symbol::new(symbol_str.to_string())?;
-    let mint_id = IssuerRequestId::new(mint_id_str);
+    let mint_id: IssuerRequestId = mint_id_str.parse()?;
     let now = Utc::now();
 
     let events = [
@@ -869,7 +873,7 @@ pub async fn seed_mint_at_tokens_wrapped_for_test(
              (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
              VALUES ('TokenizedEquityMint', ?, ?, ?, ?, ?, '{}')",
         )
-        .bind(raw_id)
+        .bind(raw_id.to_string())
         .bind(sequence)
         .bind(event.event_type())
         .bind(event.event_version())
@@ -972,11 +976,13 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
             direction,
             symbol,
             quantity,
+            issuer_request_id,
             redemption_wallet,
         } => Ok(SimpleCommand::TransferEquity {
             direction,
             symbol,
             quantity,
+            issuer_request_id,
             redemption_wallet,
         }),
         Commands::WrapEquity { symbol, quantity } => {
@@ -1151,6 +1157,7 @@ async fn run_simple_command<W: Write>(
             direction,
             symbol,
             quantity,
+            issuer_request_id,
             redemption_wallet,
         } => {
             rebalancing::transfer_equity_command(
@@ -1158,6 +1165,7 @@ async fn run_simple_command<W: Write>(
                 direction,
                 &symbol,
                 quantity,
+                issuer_request_id,
                 redemption_wallet,
                 ctx,
                 pool,

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -129,6 +129,7 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
     direction: TransferDirection,
     symbol: &Symbol,
     quantity: FractionalShares,
+    issuer_request_id: Option<Uuid>,
     redemption_wallet_flag: Option<Address>,
     ctx: &Ctx,
     pool: &SqlitePool,
@@ -150,14 +151,25 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
             writeln!(stdout, "   Creating mint request...")?;
             writeln!(stdout, "   Receiving Wallet: {}", cli_services.wallet)?;
 
-            CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-                &equity_transfer,
-                Equity {
-                    symbol: symbol.clone(),
-                    quantity,
-                },
-            )
-            .await?;
+            let (issuer_request_id, fresh_mint) = issuer_request_id.map_or_else(
+                || (IssuerRequestId::generate(), true),
+                |uuid| (IssuerRequestId(uuid), false),
+            );
+
+            if fresh_mint {
+                writeln!(stdout, "Equity mint issuer_request_id: {issuer_request_id}")?;
+                writeln!(
+                    stdout,
+                    "   If this is interrupted, resume with:\n   \
+                     transfer-equity --direction to-raindex --symbol {symbol} \
+                     --quantity {quantity} --issuer-request-id {issuer_request_id}"
+                )?;
+                stdout.flush()?;
+            }
+
+            equity_transfer
+                .resume_equity_to_market_making(&issuer_request_id, symbol, quantity)
+                .await?;
 
             writeln!(stdout, "✅ Mint completed successfully")?;
         }
@@ -617,7 +629,7 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
 
     writeln!(stdout, "   Sending mint request to Alpaca...")?;
 
-    let issuer_request_id = IssuerRequestId::new(Uuid::new_v4().to_string());
+    let issuer_request_id = IssuerRequestId::generate();
     let request = tokenization_service
         .request_mint(
             symbol.clone(),
@@ -859,7 +871,9 @@ pub(crate) async fn fail_transfer_command<W: Write>(
 
     match transfer_type {
         TransferType::Mint => {
-            let mint_id = IssuerRequestId::new(id);
+            let mint_id: IssuerRequestId = id
+                .parse()
+                .map_err(|error| anyhow::anyhow!("Invalid mint id {id:?}: {error}"))?;
 
             let entity = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(pool, &mint_id)
                 .await?
@@ -1233,6 +1247,7 @@ mod tests {
             &symbol,
             quantity,
             None,
+            None,
             &ctx,
             &pool,
         )
@@ -1258,6 +1273,7 @@ mod tests {
             TransferDirection::ToRaindex,
             &symbol,
             quantity,
+            None,
             None,
             &ctx,
             &pool,

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -62,7 +62,9 @@ use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vau
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
-use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
+use crate::rebalancing::equity::{
+    CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToMarketMakingCtx,
+};
 use crate::rebalancing::usdc::{
     TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
 };
@@ -178,6 +180,58 @@ pub(crate) struct Conductor {
 /// in-flight, so a wedged row would silently suppress every future transfer in
 /// that direction. Fails fast on a reset error -- the bot must not come up
 /// looking healthy with crash-safe recovery disabled.
+///
+/// A previous process may have died mid-transfer, leaving an apalis `Running`
+/// row that no live worker owns. Resets orphaned rows for every transfer
+/// queue whose worker is wired (its ctx is present, i.e. rebalancing is
+/// enabled) before the monitor spawns, so any `Running` row is orphaned by
+/// definition. The USDC queues are wedge-prone symmetrically: Base->Alpaca
+/// via the enqueue dedup, Alpaca->Base because `rearm_stranded_transfers`
+/// treats a `Running` row as in-flight and skips it. The equity mint queue
+/// is wedge-prone via its per-symbol enqueue dedup.
+async fn requeue_wired_transfer_orphans(
+    schedulers: &RebalancingSchedulers,
+    usdc_to_hedging_ctx: Option<&Arc<TransferUsdcToHedgingCtx>>,
+    usdc_to_market_making_ctx: Option<&Arc<TransferUsdcToMarketMakingCtx>>,
+    equity_to_market_making_ctx: Option<&Arc<TransferEquityToMarketMakingCtx>>,
+) -> anyhow::Result<()> {
+    if usdc_to_hedging_ctx.is_some() {
+        requeue_transfer_orphans(&schedulers.transfer_usdc_to_hedging, "Base->Alpaca").await?;
+    }
+
+    if usdc_to_market_making_ctx.is_some() {
+        requeue_transfer_orphans(&schedulers.transfer_usdc_to_market_making, "Alpaca->Base")
+            .await?;
+    }
+
+    if equity_to_market_making_ctx.is_some() {
+        requeue_transfer_orphans(
+            &schedulers.transfer_equity_to_market_making,
+            "equity hedging->market-making",
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn requeue_startup_orphans(
+    schedulers: &RebalancingSchedulers,
+    backfill_queue: &BackfillJobQueue,
+    usdc_to_hedging_ctx: Option<&Arc<TransferUsdcToHedgingCtx>>,
+    usdc_to_market_making_ctx: Option<&Arc<TransferUsdcToMarketMakingCtx>>,
+    equity_to_market_making_ctx: Option<&Arc<TransferEquityToMarketMakingCtx>>,
+) -> anyhow::Result<()> {
+    requeue_wired_transfer_orphans(
+        schedulers,
+        usdc_to_hedging_ctx,
+        usdc_to_market_making_ctx,
+        equity_to_market_making_ctx,
+    )
+    .await?;
+    requeue_backfill_orphans(backfill_queue).await
+}
+
 async fn requeue_transfer_orphans<Task>(
     queue: &job::JobQueue<Task>,
     direction_label: &str,
@@ -241,6 +295,21 @@ async fn requeue_backfill_orphans(backfill_queue: &BackfillJobQueue) -> anyhow::
         );
     }
 
+    Ok(())
+}
+
+async fn requeue_equity_recovery_orphans(
+    wrapped_ctx: Option<&Arc<WrappedEquityRecoveryCtx>>,
+    unwrapped_ctx: Option<&Arc<UnwrappedEquityRecoveryCtx>>,
+    wrapped_queue: &WrappedEquityRecoveryJobQueue,
+    unwrapped_queue: &UnwrappedEquityRecoveryJobQueue,
+) -> anyhow::Result<()> {
+    if wrapped_ctx.is_some() {
+        requeue_recovery_orphans(wrapped_queue, "wrapped equity").await?;
+    }
+    if unwrapped_ctx.is_some() {
+        requeue_recovery_orphans(unwrapped_queue, "unwrapped equity").await?;
+    }
     Ok(())
 }
 
@@ -338,6 +407,7 @@ impl Conductor {
             redemption_store,
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_ctx,
+            transfer_equity_to_market_making_ctx,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -350,23 +420,14 @@ impl Conductor {
         )
         .await?;
 
-        // A previous process may have died mid-transfer, leaving an apalis
-        // `Running` row that no live worker owns. Reset orphaned rows for both
-        // transfer directions before the monitor spawns (so any `Running` row is
-        // orphaned by definition). The two queues are wedge-prone symmetrically:
-        // Base->Alpaca via the enqueue dedup, Alpaca->Base because
-        // `rearm_stranded_transfers` treats a `Running` row as in-flight and
-        // skips it. Only meaningful when the transfer worker is wired, i.e.
-        // rebalancing is enabled (both ctxs are set together).
-        if transfer_usdc_to_hedging_ctx.is_some() {
-            requeue_transfer_orphans(&schedulers.transfer_usdc_to_hedging, "Base->Alpaca").await?;
-        }
-        if transfer_usdc_to_market_making_ctx.is_some() {
-            requeue_transfer_orphans(&schedulers.transfer_usdc_to_market_making, "Alpaca->Base")
-                .await?;
-        }
-
-        requeue_backfill_orphans(&backfill_queue).await?;
+        requeue_startup_orphans(
+            &schedulers,
+            &backfill_queue,
+            transfer_usdc_to_hedging_ctx.as_ref(),
+            transfer_usdc_to_market_making_ctx.as_ref(),
+            transfer_equity_to_market_making_ctx.as_ref(),
+        )
+        .await?;
 
         // Hydrate the in-memory InventoryView from persisted snapshot
         // state so the runtime projection has the same data as the
@@ -406,25 +467,15 @@ impl Conductor {
         let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&apalis_pool);
         let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
 
-        let wrapped_equity_recovery_ctx = match (
+        let wrapped_equity_recovery_ctx = build_wrapped_equity_recovery_ctx(
             wrapped_equity_recovery_store,
             rebalancing_service.clone(),
             mint_store.clone(),
             redemption_store.clone(),
-        ) {
-            (Some(store), Some(service), Some(mint_store), Some(redemption_store)) => {
-                Some(Arc::new(WrappedEquityRecoveryCtx {
-                    inventory: inventory.clone(),
-                    store,
-                    mint_store,
-                    redemption_store,
-                    equity_in_progress: service.equity_in_progress.clone(),
-                    queue: wrapped_equity_recovery_queue.clone(),
-                    reschedule_interval: Duration::from_secs(ctx.inventory_poll_interval),
-                }))
-            }
-            _ => None,
-        };
+            inventory.clone(),
+            wrapped_equity_recovery_queue.clone(),
+            Duration::from_secs(ctx.inventory_poll_interval),
+        );
 
         let unwrapped_equity_recovery_ctx = build_unwrapped_equity_recovery_ctx(
             unwrapped_equity_recovery_store,
@@ -436,12 +487,13 @@ impl Conductor {
             Duration::from_secs(ctx.inventory_poll_interval),
         );
 
-        if wrapped_equity_recovery_ctx.is_some() {
-            requeue_recovery_orphans(&wrapped_equity_recovery_queue, "wrapped equity").await?;
-        }
-        if unwrapped_equity_recovery_ctx.is_some() {
-            requeue_recovery_orphans(&unwrapped_equity_recovery_queue, "unwrapped equity").await?;
-        }
+        requeue_equity_recovery_orphans(
+            wrapped_equity_recovery_ctx.as_ref(),
+            unwrapped_equity_recovery_ctx.as_ref(),
+            &wrapped_equity_recovery_queue,
+            &unwrapped_equity_recovery_queue,
+        )
+        .await?;
 
         let check_positions_queue = CheckPositionsJobQueue::new(&apalis_pool);
 
@@ -498,6 +550,8 @@ impl Conductor {
             .maybe_transfer_usdc_to_hedging_ctx(transfer_usdc_to_hedging_ctx)
             .transfer_usdc_to_market_making_queue(schedulers.transfer_usdc_to_market_making)
             .maybe_transfer_usdc_to_market_making_ctx(transfer_usdc_to_market_making_ctx)
+            .transfer_equity_to_market_making_queue(schedulers.transfer_equity_to_market_making)
+            .maybe_transfer_equity_to_market_making_ctx(transfer_equity_to_market_making_ctx)
             .maybe_rebalancing_service(rebalancing_service)
             .seed_vault_registry_queue(seed_vault_registry_queue)
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
@@ -611,6 +665,34 @@ impl Conductor {
         }
         self.job_cleanup.abort();
     }
+}
+
+/// Builds the [`WrappedEquityRecoveryCtx`] when every dependency the recovery
+/// job needs is present; returns `None` (recovery wiring absent) if any is not.
+fn build_wrapped_equity_recovery_ctx(
+    store: Option<Arc<Store<WrappedEquityRecovery>>>,
+    service: Option<Arc<RebalancingService>>,
+    mint_store: Option<Arc<Store<TokenizedEquityMint>>>,
+    redemption_store: Option<Arc<Store<EquityRedemption>>>,
+    inventory: Arc<BroadcastingInventory>,
+    queue: WrappedEquityRecoveryJobQueue,
+    reschedule_interval: Duration,
+) -> Option<Arc<WrappedEquityRecoveryCtx>> {
+    let (Some(store), Some(service), Some(mint_store), Some(redemption_store)) =
+        (store, service, mint_store, redemption_store)
+    else {
+        return None;
+    };
+
+    Some(Arc::new(WrappedEquityRecoveryCtx {
+        inventory,
+        store,
+        mint_store,
+        redemption_store,
+        equity_in_progress: service.equity_in_progress.clone(),
+        queue,
+        reschedule_interval,
+    }))
 }
 
 /// Builds the [`UnwrappedEquityRecoveryCtx`] when every dependency the recovery
@@ -856,6 +938,7 @@ struct RebalancingInfrastructure {
     redemption_store: Arc<Store<EquityRedemption>>,
     transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
     transfer_usdc_to_market_making_ctx: Arc<TransferUsdcToMarketMakingCtx>,
+    transfer_equity_to_market_making_ctx: Arc<TransferEquityToMarketMakingCtx>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -890,6 +973,7 @@ struct PositionAndRebalancing {
     redemption_store: Option<Arc<Store<EquityRedemption>>>,
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
+    transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
 }
 
 impl PositionAndRebalancing {
@@ -948,6 +1032,9 @@ impl PositionAndRebalancing {
                 redemption_store: Some(infra.redemption_store),
                 transfer_usdc_to_hedging_ctx: Some(infra.transfer_usdc_to_hedging_ctx),
                 transfer_usdc_to_market_making_ctx: Some(infra.transfer_usdc_to_market_making_ctx),
+                transfer_equity_to_market_making_ctx: Some(
+                    infra.transfer_equity_to_market_making_ctx,
+                ),
             })
         } else {
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -977,6 +1064,7 @@ impl PositionAndRebalancing {
                 redemption_store: None,
                 transfer_usdc_to_hedging_ctx: None,
                 transfer_usdc_to_market_making_ctx: None,
+                transfer_equity_to_market_making_ctx: None,
             })
         }
     }
@@ -1203,6 +1291,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             job_queue: transfer_usdc_to_market_making_queue,
         });
 
+        let transfer_equity_to_market_making_ctx = Arc::new(TransferEquityToMarketMakingCtx {
+            transfer: recovery_transfer.clone(),
+        });
+
         Ok(RebalancingInfrastructure {
             position: built.position,
             position_projection: built.position_projection,
@@ -1218,6 +1310,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             redemption_store,
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_ctx,
+            transfer_equity_to_market_making_ctx,
         })
     })
 }
@@ -2345,6 +2438,7 @@ mod tests {
     use crate::inventory::{ImbalanceThreshold, Inventory, InventoryView, Venue};
     use crate::offchain::order::OrderPlacementResult;
     use crate::onchain::trade::OnchainTrade;
+    use crate::rebalancing::equity::TransferEquityToMarketMaking;
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService, TriggeredOperation};
     use crate::test_utils::{
         OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db, setup_test_pools,
@@ -3812,7 +3906,11 @@ mod tests {
         );
     }
 
-    /// Builds an `InventoryView` with an equity imbalance: 20% onchain, 80% offchain.
+    /// Builds an `InventoryView` one onchain share below the 20/80 imbalance used
+    /// in mint assertions: the position fill in
+    /// `position_events_reach_rebalancing_service` adds one onchain share before
+    /// the trigger enqueues the mint job.
+    ///
     /// With a 50% target +/- 20% deviation, 20% < 30% lower bound -> TooMuchOffchain.
     fn imbalanced_inventory(symbol: &Symbol) -> InventoryView {
         InventoryView::default()
@@ -3827,7 +3925,7 @@ mod tests {
                 Inventory::available(
                     Venue::MarketMaking,
                     Operator::Add,
-                    FractionalShares::new(float!(20)),
+                    FractionalShares::new(float!(19)),
                 ),
                 chrono::Utc::now(),
             )
@@ -3937,10 +4035,34 @@ mod tests {
             .await
             .unwrap();
 
-        let triggered = operation_receiver.try_recv();
+        let job_payload: Vec<u8> = sqlx::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ? LIMIT 1",
+        )
+        .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+        .fetch_one(&pool)
+        .await
+        .expect("Expected a TransferEquityToMarketMaking job enqueued by the trigger");
+
+        let job: TransferEquityToMarketMaking =
+            serde_json::from_slice(&job_payload).expect("deserialize enqueued mint job");
+
+        assert_eq!(job.symbol, symbol);
+        assert_eq!(
+            job.quantity,
+            FractionalShares::new(float!(30)),
+            "20 onchain / 80 offchain imbalance should mint 30 shares to reach target"
+        );
         assert!(
-            matches!(triggered, Ok(TriggeredOperation::Mint { .. })),
-            "Expected Mint operation from trigger on position event, got {triggered:?}"
+            !job.issuer_request_id.0.is_nil(),
+            "enqueue must assign a fresh issuer_request_id"
+        );
+
+        assert!(
+            matches!(
+                operation_receiver.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            ),
+            "Mints must not be dispatched over the mpsc channel"
         );
     }
 

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -43,6 +43,10 @@ use crate::onchain::pyth::PythFeedIds;
 use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
+use crate::rebalancing::equity::{
+    TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
+    TransferEquityToMarketMakingJobQueue,
+};
 use crate::rebalancing::usdc::{
     TransferUsdcToHedging, TransferUsdcToHedgingCtx, TransferUsdcToHedgingJobQueue,
     TransferUsdcToMarketMaking, TransferUsdcToMarketMakingCtx, TransferUsdcToMarketMakingJobQueue,
@@ -114,6 +118,8 @@ pub(crate) fn spawn<Prov, Exec>(
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
+    transfer_equity_to_market_making_queue: TransferEquityToMarketMakingJobQueue,
+    transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     rebalancing_service: Option<Arc<RebalancingService>>,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
@@ -344,6 +350,8 @@ where
         transfer_usdc_to_hedging_ctx,
         transfer_usdc_to_market_making_queue,
         transfer_usdc_to_market_making_ctx,
+        transfer_equity_to_market_making_queue,
+        transfer_equity_to_market_making_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
@@ -398,6 +406,8 @@ where
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
+    transfer_equity_to_market_making_queue: TransferEquityToMarketMakingJobQueue,
+    transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
@@ -439,6 +449,8 @@ where
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_queue,
             transfer_usdc_to_market_making_ctx,
+            transfer_equity_to_market_making_queue,
+            transfer_equity_to_market_making_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
@@ -471,6 +483,8 @@ where
         let failure_injector_for_transfer_usdc_to_hedging = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_usdc_to_market_making = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_transfer_equity_to_market_making = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -485,6 +499,7 @@ where
         let failure_notify_for_check_positions = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
+        let failure_notify_for_transfer_equity_to_market_making = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -503,6 +518,7 @@ where
         let fail_stop_for_check_positions = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
+        let fail_stop_for_transfer_equity_to_market_making = fail_stop.clone();
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -678,6 +694,16 @@ where
                 failure_notify_for_transfer_usdc_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_usdc_to_market_making,
+            );
+
+            let apalis_monitor = register_transfer_equity_to_market_making_worker(
+                apalis_monitor,
+                transfer_equity_to_market_making_ctx,
+                transfer_equity_to_market_making_queue,
+                fail_stop_for_transfer_equity_to_market_making,
+                failure_notify_for_transfer_equity_to_market_making,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_transfer_equity_to_market_making,
             );
 
             let is_draining = apalis_shutdown_token.clone();
@@ -873,6 +899,39 @@ fn register_transfer_usdc_to_market_making_worker(
     monitor.register(move |index| {
         build_supervised_worker!(
             ::<TransferUsdcToMarketMakingCtx, TransferUsdcToMarketMaking>,
+            index,
+            transfer_queue.clone(),
+            transfer_ctx.clone(),
+            fail_stop.clone(),
+            failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Conditionally registers the `TransferEquityToMarketMaking` worker. Same
+/// pattern as the USDC transfer workers: the ctx is `None` when rebalancing
+/// is disabled, in which case the queue exists but no worker consumes it.
+fn register_transfer_equity_to_market_making_worker(
+    monitor: Monitor,
+    transfer_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
+    transfer_queue: TransferEquityToMarketMakingJobQueue,
+    fail_stop: CircuitBreakerConfig,
+    failure_notify: Arc<tokio::sync::Notify>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(transfer_ctx) = transfer_ctx else {
+        warn!(
+            "TransferEquityToMarketMaking worker not registered: rebalancing disabled \
+             (no transfer ctx). Equity mints will not be processed."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_supervised_worker!(
+            ::<TransferEquityToMarketMakingCtx, TransferEquityToMarketMaking>,
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -366,6 +366,7 @@ pub enum JobKind {
     CheckPositions,
     TransferUsdcToHedging,
     TransferUsdcToMarketMaking,
+    TransferEquityToMarketMaking,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -404,6 +405,7 @@ pub struct FailureInjector {
     check_positions: Arc<Mutex<InjectionState>>,
     transfer_usdc_to_hedging: Arc<Mutex<InjectionState>>,
     transfer_usdc_to_market_making: Arc<Mutex<InjectionState>>,
+    transfer_equity_to_market_making: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -440,6 +442,7 @@ impl FailureInjector {
             check_positions: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_usdc_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_usdc_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
+            transfer_equity_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -488,6 +491,7 @@ impl FailureInjector {
             JobKind::CheckPositions => &self.check_positions,
             JobKind::TransferUsdcToHedging => &self.transfer_usdc_to_hedging,
             JobKind::TransferUsdcToMarketMaking => &self.transfer_usdc_to_market_making,
+            JobKind::TransferEquityToMarketMaking => &self.transfer_equity_to_market_making,
         };
 
         match mutex.lock() {

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -139,9 +139,9 @@ mod tests {
     };
     use crate::onchain::mock::MockRaindex;
     use crate::position::{PositionCommand, TradeId};
+    use crate::rebalancing::equity::TransferEquityToMarketMaking;
     use crate::rebalancing::{
-        RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, TriggeredOperation,
-        drain_pending_jobs,
+        RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, drain_pending_jobs,
     };
     use crate::test_utils::setup_test_pools;
     use crate::tokenization::mock::MockTokenizer;
@@ -360,7 +360,7 @@ mod tests {
             tokenizer: Arc::new(MockTokenizer::new()),
             wrapper: Arc::new(MockWrapper::new()),
         };
-        let built = manifest.build(pool, services).await.unwrap();
+        let built = manifest.build(pool.clone(), services).await.unwrap();
 
         built
             .position
@@ -413,10 +413,24 @@ mod tests {
         }
 
         drain_pending_jobs(&rebalancing_service).await.unwrap();
-        let triggered = operation_receiver.try_recv();
+        let pending_mint_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            pending_mint_jobs, 1,
+            "expected the rebalancing subscriber to enqueue a mint job on the position event"
+        );
+
         assert!(
-            matches!(triggered, Ok(TriggeredOperation::Mint { .. })),
-            "expected rebalancing subscriber to receive position event, got {triggered:?}"
+            matches!(
+                operation_receiver.try_recv(),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            ),
+            "mints must not be dispatched over the mpsc channel"
         );
     }
 }

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -357,7 +357,9 @@ mod tests {
 
     use super::*;
     use crate::equity_redemption::EquityRedemptionEvent;
-    use crate::tokenized_equity_mint::TokenizedEquityMintEvent;
+    use crate::tokenized_equity_mint::{
+        IssuerRequestId, TokenizedEquityMintEvent, issuer_request_id,
+    };
     use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent};
 
     fn mint_transfer(status: EquityMintStatus) -> TransferOperation {
@@ -451,19 +453,27 @@ mod tests {
         .unwrap();
     }
 
+    struct SeededTransferIds {
+        active_mint: IssuerRequestId,
+        failed_mint: IssuerRequestId,
+        usdc: Uuid,
+    }
+
     /// Seeds the database with transfer events spanning all three aggregate
     /// types and covering active, recent-terminal, and old-terminal cases.
-    /// Returns the UUID used for the USDC rebalance aggregate.
-    async fn seed_transfer_events(pool: &SqlitePool) -> Uuid {
+    async fn seed_transfer_events(pool: &SqlitePool) -> SeededTransferIds {
         let now = Utc::now();
         let one_hour_ago = now - Duration::hours(1);
         let two_days_ago = now - Duration::hours(48);
+
+        let active_mint_id = issuer_request_id("active-mint-1");
+        let failed_mint_id = issuer_request_id("failed-mint-1");
 
         // 1. Active mint (non-terminal: only MintRequested)
         insert_event(
             pool,
             "TokenizedEquityMint",
-            "active-mint-1",
+            &active_mint_id.to_string(),
             1,
             "TokenizedEquityMintEvent::MintRequested",
             serde_json::to_value(TokenizedEquityMintEvent::MintRequested {
@@ -480,7 +490,7 @@ mod tests {
         insert_event(
             pool,
             "TokenizedEquityMint",
-            "failed-mint-1",
+            &failed_mint_id.to_string(),
             1,
             "TokenizedEquityMintEvent::MintRequested",
             serde_json::to_value(TokenizedEquityMintEvent::MintRequested {
@@ -496,7 +506,7 @@ mod tests {
         insert_event(
             pool,
             "TokenizedEquityMint",
-            "failed-mint-1",
+            &failed_mint_id.to_string(),
             2,
             "TokenizedEquityMintEvent::MintRejected",
             serde_json::to_value(TokenizedEquityMintEvent::MintRejected {
@@ -595,7 +605,11 @@ mod tests {
         )
         .await;
 
-        usdc_id
+        SeededTransferIds {
+            active_mint: active_mint_id,
+            failed_mint: failed_mint_id,
+            usdc: usdc_id,
+        }
     }
 
     #[tokio::test]
@@ -603,7 +617,7 @@ mod tests {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
 
-        let usdc_id = seed_transfer_events(&pool).await;
+        let seeded = seed_transfer_events(&pool).await;
         let loaded = load_transfers(&pool).await;
 
         // Active should contain the in-progress mint and in-progress redemption
@@ -631,7 +645,10 @@ mod tests {
             .find(|transfer| matches!(transfer, TransferOperation::EquityMint(_)))
             .unwrap();
         if let TransferOperation::EquityMint(op) = active_mint {
-            assert_eq!(op.id, Id::<EquityMintTag>::new("active-mint-1".to_string()));
+            assert_eq!(
+                op.id,
+                Id::<EquityMintTag>::new(seeded.active_mint.to_string())
+            );
         }
 
         let has_active_redemption = loaded.active.iter().any(|transfer| {
@@ -722,7 +739,7 @@ mod tests {
         {
             assert_eq!(
                 usdc_op.id,
-                Id::<UsdcBridgeTag>::new(usdc_id.to_string()),
+                Id::<UsdcBridgeTag>::new(seeded.usdc.to_string()),
                 "USDC bridge ID should match the aggregate_id"
             );
         }
@@ -735,7 +752,7 @@ mod tests {
         {
             assert_eq!(
                 mint_op.id,
-                Id::<EquityMintTag>::new("failed-mint-1".to_string()),
+                Id::<EquityMintTag>::new(seeded.failed_mint.to_string()),
                 "failed mint ID should match the aggregate_id"
             );
         }
@@ -784,10 +801,12 @@ mod tests {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
 
+        let bad_mint_id = issuer_request_id("bad-mint-1");
+
         insert_event(
             &pool,
             "TokenizedEquityMint",
-            "bad-mint-1",
+            &bad_mint_id.to_string(),
             1,
             "TokenizedEquityMintEvent::MintRequested",
             serde_json::json!({"malformed": true}),
@@ -800,7 +819,7 @@ mod tests {
         assert_eq!(result.warnings.len(), 1, "expected one warning");
         match result.warnings.as_slice() {
             [TransferWarning::MintReplayFailed { id }] => {
-                assert_eq!(id, &Id::<EquityMintTag>::new("bad-mint-1".to_string()));
+                assert_eq!(id, &Id::<EquityMintTag>::new(bad_mint_id.to_string()));
             }
             other => panic!("expected MintReplayFailed, got: {other:?}"),
         }
@@ -835,12 +854,14 @@ mod tests {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
 
+        let bad_mint_id = issuer_request_id("bad-mint-1");
+
         // Insert an event with a payload that can't be deserialized as a
         // TokenizedEquityMintEvent — this triggers a MintReplayFailed warning.
         insert_event(
             &pool,
             "TokenizedEquityMint",
-            "bad-mint-1",
+            &bad_mint_id.to_string(),
             1,
             "TokenizedEquityMintEvent::MintRequested",
             serde_json::json!({"malformed": true}),
@@ -854,7 +875,7 @@ mod tests {
         assert_eq!(loaded.warnings.len(), 1, "expected one replay warning");
         match loaded.warnings.as_slice() {
             [TransferWarning::MintReplayFailed { id }] => {
-                assert_eq!(id, &Id::<EquityMintTag>::new("bad-mint-1".to_string()));
+                assert_eq!(id, &Id::<EquityMintTag>::new(bad_mint_id.to_string()));
             }
             other => panic!("expected MintReplayFailed, got: {other:?}"),
         }

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -37,14 +37,17 @@ use st0x_wrapper::MockWrapper;
 
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
+use crate::conductor::job::Job;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
 use crate::position::{Position, PositionCommand, TradeId};
-use crate::rebalancing::equity::mock::MockCrossVenueEquityTransfer;
-use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
-use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
+use crate::rebalancing::equity::{
+    CrossVenueEquityTransfer, EquityTransferServices, MintTransferError,
+    TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
+    TransferEquityToMarketMakingJobError,
+};
 use crate::rebalancing::usdc::{TransferUsdcToHedging, TransferUsdcToMarketMaking};
 use crate::rebalancing::{
     Rebalancer, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
@@ -57,7 +60,7 @@ use crate::tokenization::alpaca::tests::{
     tokenization_requests_path,
 };
 use crate::tokenization::mock::MockTokenizer;
-use crate::tokenized_equity_mint::TokenizedEquityMint;
+use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMint};
 use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 use crate::vault_registry::{VaultRegistry, VaultRegistryCommand, VaultRegistryId};
 
@@ -84,6 +87,27 @@ async fn seed_vault_registry(pool: &SqlitePool, symbol: &Symbol, token: Address)
     )
     .await
     .unwrap();
+}
+
+/// Fetches the single pending `TransferEquityToMarketMaking` job payload from
+/// the apalis Jobs table, as the registered worker would receive it.
+async fn fetch_pending_equity_mint_job(pool: &SqlitePool) -> TransferEquityToMarketMaking {
+    let payload: Vec<u8> =
+        sqlx::query_scalar("SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+            .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+            .fetch_one(pool)
+            .await
+            .expect("expected exactly one pending TransferEquityToMarketMaking job");
+
+    serde_json::from_slice(&payload).expect("deserialize TransferEquityToMarketMaking payload")
+}
+
+async fn pending_equity_mint_job_count(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
+        .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+        .fetch_one(pool)
+        .await
+        .unwrap()
 }
 
 fn mock_vault_lookup_for_symbol(symbol: &Symbol, token: Address) -> Arc<dyn VaultLookup> {
@@ -283,9 +307,12 @@ fn setup_redemption_mocks(server: &MockServer, expected_tx_hash: TxHash) -> (Moc
     (detection_mock, completion_mock)
 }
 
-fn sample_pending_response(id: &str) -> serde_json::Value {
+fn sample_pending_response(
+    tokenization_request_id: &str,
+    issuer_request_id: &IssuerRequestId,
+) -> serde_json::Value {
     json!({
-        "tokenization_request_id": id,
+        "tokenization_request_id": tokenization_request_id,
         "type": "mint",
         "status": "pending",
         "underlying_symbol": "AAPL",
@@ -294,14 +321,18 @@ fn sample_pending_response(id: &str) -> serde_json::Value {
         "issuer": "st0x",
         "network": "base",
         "wallet_address": "0x0000000000000000000000000000000000000000",
-        "issuer_request_id": "issuer_123",
+        "issuer_request_id": issuer_request_id.to_string(),
         "created_at": "2024-01-15T10:30:00Z"
     })
 }
 
-fn sample_completed_response(id: &str, tx_hash: TxHash) -> serde_json::Value {
+fn sample_completed_response(
+    tokenization_request_id: &str,
+    issuer_request_id: &IssuerRequestId,
+    tx_hash: TxHash,
+) -> serde_json::Value {
     json!({
-        "tokenization_request_id": id,
+        "tokenization_request_id": tokenization_request_id,
         "type": "mint",
         "status": "completed",
         "underlying_symbol": "AAPL",
@@ -310,7 +341,7 @@ fn sample_completed_response(id: &str, tx_hash: TxHash) -> serde_json::Value {
         "issuer": "st0x",
         "network": "base",
         "wallet_address": "0x0000000000000000000000000000000000000000",
-        "issuer_request_id": "issuer_123",
+        "issuer_request_id": issuer_request_id.to_string(),
         "tx_hash": tx_hash,
         "created_at": "2024-01-15T10:30:00Z"
     })
@@ -539,10 +570,10 @@ async fn build_equity_transfer_with_service(
 
 /// Verifies the full equity mint rebalancing pipeline: position CQRS commands
 /// flow through the RebalancingService (registered as a Query processor),
-/// update the InventoryView, detect an equity imbalance, and dispatch a Mint
-/// operation through the Rebalancer to the CrossVenueEquityTransfer which
-/// drives the TokenizedEquityMint aggregate to completion via the Alpaca
-/// tokenization API.
+/// update the InventoryView, detect an equity imbalance, and enqueue a
+/// `TransferEquityToMarketMaking` apalis job whose `perform` drives the
+/// TokenizedEquityMint aggregate to completion on the real
+/// CrossVenueEquityTransfer via the Alpaca tokenization API.
 #[tokio::test]
 #[allow(clippy::too_many_lines)]
 async fn equity_offchain_imbalance_triggers_mint() {
@@ -553,7 +584,7 @@ async fn equity_offchain_imbalance_triggers_mint() {
         service,
         inventory: _,
         position_cqrs,
-        receiver,
+        receiver: _receiver,
     } = setup_equity_trigger().await;
 
     // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain.
@@ -620,45 +651,6 @@ async fn equity_offchain_imbalance_triggers_mint() {
 
     let wallet_hex = format!("{:#x}", signer.address());
 
-    // json_body_partial acts as an implicit assertion: the mock only matches if
-    // the request contains these exact fields. mint_mock.assert() below then
-    // verifies the mock was called, confirming the correct qty was sent.
-    let mint_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path(tokenization_mint_path())
-            .json_body_includes(
-                json!({
-                    "underlying_symbol": "AAPL",
-                    "qty": "30.5",
-                    "wallet_address": wallet_hex,
-                })
-                .to_string(),
-            );
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(sample_pending_response("mint_int_test"));
-    });
-
-    let poll_mock = server.mock(|when, then| {
-        when.method(GET).path(tokenization_requests_path());
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!([sample_completed_response(
-                "mint_int_test",
-                mint_tx_hash
-            )]));
-    });
-
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
-
-    let rebalancer = Rebalancer::new(
-        equity_transfer as _,
-        mock_equity as _,
-        receiver,
-        Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
     // One more onchain sell triggers the CQRS -> trigger -> Mint flow now that
     // VaultRegistry is seeded. Inventory: 19 onchain, 80 offchain = 19.2%.
     position_cqrs
@@ -681,13 +673,47 @@ async fn equity_offchain_imbalance_triggers_mint() {
         .unwrap();
     drain_pending_jobs(&service).await.unwrap();
 
-    // Both trigger and position_cqrs hold Arc<RebalancingService> which owns the
-    // mpsc sender. Both must be dropped to close the channel so rebalancer.run()
-    // can exit after processing all queued operations.
-    drop(service);
-    drop(position_cqrs);
+    // The trigger enqueues the mint as an apalis job; run its perform against
+    // the real equity transfer, exactly as the registered worker would.
+    let job = fetch_pending_equity_mint_job(&pool).await;
 
-    rebalancer.run().await;
+    // json_body_partial acts as an implicit assertion: the mock only matches if
+    // the request contains these exact fields. mint_mock.assert() below then
+    // verifies the mock was called, confirming the correct qty was sent.
+    let mint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path(tokenization_mint_path())
+            .json_body_includes(
+                json!({
+                    "underlying_symbol": "AAPL",
+                    "qty": "30.5",
+                    "wallet_address": wallet_hex,
+                })
+                .to_string(),
+            );
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(sample_pending_response(
+                "mint_int_test",
+                &job.issuer_request_id,
+            ));
+    });
+
+    let poll_mock = server.mock(|when, then| {
+        when.method(GET).path(tokenization_requests_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([sample_completed_response(
+                "mint_int_test",
+                &job.issuer_request_id,
+                mint_tx_hash
+            )]));
+    });
+
+    let ctx = TransferEquityToMarketMakingCtx {
+        transfer: equity_transfer,
+    };
+    Job::perform(&job, &ctx).await.unwrap();
 
     mint_mock.assert();
     poll_mock.assert();
@@ -868,9 +894,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
     .await;
     seed_vault_registry(&pool, &symbol, token_address).await;
 
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
     let rebalancer = Rebalancer::new(
-        Arc::clone(&mock_equity) as _,
         equity_transfer as _,
         receiver,
         Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
@@ -1038,9 +1062,9 @@ async fn equity_onchain_imbalance_triggers_redemption() {
         "Detected should capture the request ID from the API response"
     );
     assert_eq!(
-        mock_equity.mint_calls(),
+        pending_equity_mint_job_count(&pool).await,
         0,
-        "Mint should not have been called"
+        "No mint job should have been enqueued"
     );
 }
 
@@ -1542,8 +1566,8 @@ async fn usdc_none_disables_usdc_rebalancing() {
 
 /// Tests that when the Alpaca mint API returns an HTTP error, the
 /// `TokenizedEquityMint` aggregate returns an error without emitting any
-/// events. The rebalancer swallows the error, so no mint events appear
-/// in the event store.
+/// events. The job's perform propagates the pre-receipt failure (so apalis
+/// retries it), and no mint events appear in the event store.
 #[tokio::test]
 async fn mint_api_failure_produces_rejected_event() {
     let EquityTriggerFixture {
@@ -1553,7 +1577,7 @@ async fn mint_api_failure_produces_rejected_event() {
         service,
         inventory: _,
         position_cqrs,
-        receiver,
+        receiver: _receiver,
     } = setup_equity_trigger().await;
 
     // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain
@@ -1588,16 +1612,6 @@ async fn mint_api_failure_produces_rejected_event() {
         then.status(500).body("Internal Server Error");
     });
 
-    let mock_equity = Arc::new(MockCrossVenueEquityTransfer::new());
-
-    let rebalancer = Rebalancer::new(
-        equity_transfer as _,
-        mock_equity as _,
-        receiver,
-        Arc::new(std::sync::RwLock::new(std::collections::HashSet::new())),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
     // One more sell triggers the CQRS -> trigger -> Mint flow
     position_cqrs
         .send(
@@ -1619,10 +1633,19 @@ async fn mint_api_failure_produces_rejected_event() {
         .unwrap();
     drain_pending_jobs(&service).await.unwrap();
 
-    drop(service);
-    drop(position_cqrs);
-
-    rebalancer.run().await;
+    let job = fetch_pending_equity_mint_job(&pool).await;
+    let ctx = TransferEquityToMarketMakingCtx {
+        transfer: equity_transfer,
+    };
+    let error = Job::perform(&job, &ctx).await.unwrap_err();
+    assert!(
+        matches!(
+            error,
+            TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PreReceipt(_))
+        ),
+        "an Alpaca API failure before tokens exist must propagate as a \
+         pre-receipt transfer error so apalis retries the job, got {error:?}"
+    );
 
     mint_mock.assert();
 
@@ -2056,7 +2079,7 @@ async fn mint_accepted_sets_offchain_inflight() {
         service,
         inventory,
         position_cqrs,
-        mut receiver,
+        receiver: _receiver,
     } = setup_equity_trigger().await;
 
     // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain
@@ -2119,22 +2142,6 @@ async fn mint_accepted_sets_offchain_inflight() {
     )
     .await;
 
-    // Mock the mint API to accept but never complete (stays pending forever)
-    server.mock(|when, then| {
-        when.method(POST).path(tokenization_mint_path());
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(sample_pending_response("inflight_test"));
-    });
-
-    // Mock the poll endpoint to keep returning pending
-    server.mock(|when, then| {
-        when.method(GET).path(tokenization_requests_path());
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!([sample_pending_response("inflight_test")]));
-    });
-
     // Trigger the imbalance via a position command to dispatch the Mint
     position_cqrs
         .send(
@@ -2156,36 +2163,45 @@ async fn mint_accepted_sets_offchain_inflight() {
         .unwrap();
     drain_pending_jobs(&service).await.unwrap();
 
-    // Receive the dispatched Mint operation and get the quantity
-    let operation = receiver
-        .try_recv()
-        .expect("Trigger should dispatch a Mint operation for the imbalance");
-    let TriggeredOperation::Mint {
-        symbol: mint_symbol,
-        quantity: mint_quantity,
-    } = operation
-    else {
-        panic!("Expected Mint operation, got {operation:?}");
-    };
-    assert_eq!(mint_symbol, symbol);
+    // Fetch the enqueued mint job and get the quantity
+    let job = fetch_pending_equity_mint_job(&pool).await;
+    assert_eq!(job.symbol, symbol);
+    let mint_quantity = job.quantity;
 
-    // Execute the mint transfer. This calls the Alpaca API, gets MintAccepted,
+    // Mock the mint API to accept but never complete (stays pending forever)
+    server.mock(|when, then| {
+        when.method(POST).path(tokenization_mint_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(sample_pending_response(
+                "inflight_test",
+                &job.issuer_request_id,
+            ));
+    });
+
+    // Mock the poll endpoint to keep returning pending
+    server.mock(|when, then| {
+        when.method(GET).path(tokenization_requests_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([sample_pending_response(
+                "inflight_test",
+                &job.issuer_request_id
+            )]));
+    });
+
+    // Execute the mint job. This calls the Alpaca API, gets MintAccepted,
     // which triggers on_mint -> Inventory::transfer(Hedging, Start, qty).
     // The poll will return pending, so the mint aggregate will time out or loop,
     // but MintAccepted has already fired by then. We spawn and cancel to
     // get just the MintAccepted event through.
     let transfer_handle = tokio::spawn({
         let equity_transfer = Arc::clone(&equity_transfer);
-        let mint_symbol = mint_symbol.clone();
         async move {
-            let _ = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-                equity_transfer.as_ref(),
-                Equity {
-                    symbol: mint_symbol,
-                    quantity: mint_quantity,
-                },
-            )
-            .await;
+            let ctx = TransferEquityToMarketMakingCtx {
+                transfer: equity_transfer,
+            };
+            let _ = Job::perform(&job, &ctx).await;
         }
     });
 
@@ -2256,7 +2272,7 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
         service,
         inventory,
         position_cqrs,
-        mut receiver,
+        receiver: _receiver,
     } = setup_equity_trigger().await;
 
     // Build inventory: 20 onchain, 80 offchain = 20% ratio -> TooMuchOffchain
@@ -2317,32 +2333,6 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
 
     let wallet_hex = format!("{:#x}", signer.address());
 
-    let mint_mock = server.mock(|when, then| {
-        when.method(POST)
-            .path(tokenization_mint_path())
-            .json_body_includes(
-                json!({
-                    "underlying_symbol": "AAPL",
-                    "qty": "30.5",
-                    "wallet_address": wallet_hex,
-                })
-                .to_string(),
-            );
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(sample_pending_response("completed_mint_test"));
-    });
-
-    let poll_mock = server.mock(|when, then| {
-        when.method(GET).path(tokenization_requests_path());
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!([sample_completed_response(
-                "completed_mint_test",
-                mint_tx_hash
-            )]));
-    });
-
     // Trigger the mint via a position command
     position_cqrs
         .send(
@@ -2364,17 +2354,40 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
         .unwrap();
     drain_pending_jobs(&service).await.unwrap();
 
-    // Receive the dispatched Mint operation
-    let operation = receiver
-        .try_recv()
-        .expect("Trigger should dispatch a Mint operation");
-    let TriggeredOperation::Mint {
-        symbol: mint_symbol,
-        quantity: mint_quantity,
-    } = operation
-    else {
-        panic!("Expected Mint operation, got {operation:?}");
-    };
+    // Fetch the enqueued mint job
+    let job = fetch_pending_equity_mint_job(&pool).await;
+    assert_eq!(job.symbol, symbol);
+    let mint_quantity = job.quantity;
+
+    let mint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path(tokenization_mint_path())
+            .json_body_includes(
+                json!({
+                    "underlying_symbol": "AAPL",
+                    "qty": "30.5",
+                    "wallet_address": wallet_hex,
+                })
+                .to_string(),
+            );
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(sample_pending_response(
+                "completed_mint_test",
+                &job.issuer_request_id,
+            ));
+    });
+
+    let poll_mock = server.mock(|when, then| {
+        when.method(GET).path(tokenization_requests_path());
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!([sample_completed_response(
+                "completed_mint_test",
+                &job.issuer_request_id,
+                mint_tx_hash
+            )]));
+    });
 
     // Record initial onchain available before the mint executes
     let initial_onchain_available = {
@@ -2382,16 +2395,11 @@ async fn completed_mint_clears_inflight_and_updates_inventory() {
         inv.equity_available(&symbol, Venue::MarketMaking).unwrap()
     };
 
-    // Execute the full mint lifecycle through CrossVenueTransfer
-    CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-        equity_transfer.as_ref(),
-        Equity {
-            symbol: mint_symbol,
-            quantity: mint_quantity,
-        },
-    )
-    .await
-    .unwrap();
+    // Execute the full mint lifecycle through the job's perform
+    let ctx = TransferEquityToMarketMakingCtx {
+        transfer: Arc::clone(&equity_transfer) as _,
+    };
+    Job::perform(&job, &ctx).await.unwrap();
 
     mint_mock.assert();
     poll_mock.assert();

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -979,6 +979,7 @@ mod tests {
     use super::*;
     use crate::inventory::snapshot::InventorySnapshotEvent;
     use crate::test_utils::setup_test_db;
+    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::vault_registry::{VaultRegistry, VaultRegistryCommand};
 
     #[derive(Clone, Default)]
@@ -1001,7 +1002,7 @@ mod tests {
             PendingRequestOwnershipSnapshot {
                 mint_issuers: mint_issuer_request_ids
                     .into_iter()
-                    .map(IssuerRequestId::new)
+                    .map(issuer_request_id)
                     .collect(),
                 mint_tokenizations: mint_tokenization_request_ids
                     .into_iter()
@@ -3406,11 +3407,11 @@ mod tests {
         request_type: crate::tokenization::TokenizationRequestType,
         symbol: &str,
         quantity: i64,
-        issuer_request_id: &str,
+        issuer_id_label: &str,
         wallet: Option<Address>,
     ) -> crate::tokenization::TokenizationRequest {
         crate::tokenization::TokenizationRequest {
-            issuer_request_id: Some(IssuerRequestId::new(issuer_request_id)),
+            issuer_request_id: Some(issuer_request_id(issuer_id_label)),
             ..mock_pending_request_with_wallet(request_type, symbol, quantity, wallet)
         }
     }

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -1,0 +1,224 @@
+//! Apalis job that drives tokenized equity mints (hedging -> market-making)
+//! through the `TokenizedEquityMint` lifecycle.
+//!
+//! The job is keyed by an `IssuerRequestId` chosen at enqueue time, so apalis
+//! retries (and bot restarts that re-pick the row from the Jobs table) hit
+//! the same aggregate. The worker calls the trait-erased resume entry point
+//! on the equity transfer, which loads the aggregate via `Store::load` and
+//! dispatches on its current state: an absent aggregate starts a fresh mint,
+//! an in-flight one resumes from its persisted step, and a terminal one is a
+//! no-op. New transfers and mid-flight resumes share the same entry point --
+//! that uniformity is what makes recovery dispatch fall out of the standard
+//! transfer lifecycle.
+//!
+//! The per-symbol `equity_in_progress` guard is cleared event-driven when the
+//! aggregate reaches a terminal state (success or a recorded failure), not by
+//! this worker. A transient failure that only schedules a retry keeps the
+//! guard latched so automation does not re-arm a fresh mint on top of a
+//! partial one.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use st0x_execution::{FractionalShares, Symbol};
+
+use super::{CrossVenueEquityTransfer, MintTransferError};
+use crate::conductor::job::{Job, JobQueue, Label};
+use crate::tokenized_equity_mint::IssuerRequestId;
+
+/// Apalis queue type for [`TransferEquityToMarketMaking`].
+pub(crate) type TransferEquityToMarketMakingJobQueue = JobQueue<TransferEquityToMarketMaking>;
+
+/// Trait-erased entry point for the hedging->market-making equity apalis
+/// job. [`CrossVenueEquityTransfer`] is concrete, but the indirection gives
+/// the job a mock seam, mirroring the USDC transfer jobs.
+#[async_trait]
+pub(crate) trait ResumeEquityToMarketMaking: Send + Sync + 'static {
+    async fn resume_equity_to_market_making(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), MintTransferError>;
+}
+
+#[async_trait]
+impl ResumeEquityToMarketMaking for CrossVenueEquityTransfer {
+    async fn resume_equity_to_market_making(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), MintTransferError> {
+        Self::resume_equity_to_market_making(self, issuer_request_id, symbol, quantity).await
+    }
+}
+
+/// Dependencies the job needs to drive the mint.
+pub(crate) struct TransferEquityToMarketMakingCtx {
+    pub(crate) transfer: Arc<dyn ResumeEquityToMarketMaking>,
+}
+
+/// Errors emitted by [`TransferEquityToMarketMaking::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum TransferEquityToMarketMakingJobError {
+    #[error(transparent)]
+    Transfer(#[from] MintTransferError),
+}
+
+/// Apalis job payload. The `issuer_request_id` is generated at enqueue time
+/// so retries resume the same aggregate (and Alpaca deduplicates the mint
+/// request by the same id).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TransferEquityToMarketMaking {
+    pub(crate) issuer_request_id: IssuerRequestId,
+    pub(crate) symbol: Symbol,
+    pub(crate) quantity: FractionalShares,
+}
+
+impl Job<TransferEquityToMarketMakingCtx> for TransferEquityToMarketMaking {
+    type Output = ();
+    type Error = TransferEquityToMarketMakingJobError;
+
+    const WORKER_NAME: &'static str = "transfer-equity-to-market-making-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::TransferEquityToMarketMaking;
+
+    fn label(&self) -> Label {
+        Label::new(format!(
+            "TransferEquityToMarketMaking:{}",
+            self.issuer_request_id
+        ))
+    }
+
+    async fn perform(
+        &self,
+        ctx: &TransferEquityToMarketMakingCtx,
+    ) -> Result<Self::Output, Self::Error> {
+        ctx.transfer
+            .resume_equity_to_market_making(&self.issuer_request_id, &self.symbol, self.quantity)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use serde_json::json;
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::rebalancing::equity::MintError;
+    use crate::tokenized_equity_mint::issuer_request_id;
+
+    /// Records the resume call and returns a configurable outcome, so the
+    /// job's `perform` can be tested without broker/onchain setup.
+    struct RecordingResume {
+        fail: bool,
+        captured: Mutex<Option<(IssuerRequestId, Symbol, FractionalShares)>>,
+    }
+
+    #[async_trait]
+    impl ResumeEquityToMarketMaking for RecordingResume {
+        async fn resume_equity_to_market_making(
+            &self,
+            issuer_request_id: &IssuerRequestId,
+            symbol: &Symbol,
+            quantity: FractionalShares,
+        ) -> Result<(), MintTransferError> {
+            *self.captured.lock().unwrap() =
+                Some((issuer_request_id.clone(), symbol.clone(), quantity));
+
+            if self.fail {
+                Err(MintTransferError::PreReceipt(MintError::EntityNotFound {
+                    issuer_request_id: issuer_request_id.clone(),
+                    expected_state: "test-induced",
+                }))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn perform_forwards_id_symbol_and_quantity_to_resume() {
+        let stub = Arc::new(RecordingResume {
+            fail: false,
+            captured: Mutex::new(None),
+        });
+        let ctx = TransferEquityToMarketMakingCtx {
+            transfer: stub.clone(),
+        };
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_request_id("mint-forward"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        let captured = stub.captured.lock().unwrap().take();
+        let (issuer_request_id, symbol, quantity) =
+            captured.expect("perform must call resume_equity_to_market_making");
+        assert_eq!(issuer_request_id, job.issuer_request_id);
+        assert_eq!(symbol, job.symbol);
+        assert_eq!(quantity, job.quantity);
+    }
+
+    #[tokio::test]
+    async fn perform_propagates_resume_failure() {
+        let ctx = TransferEquityToMarketMakingCtx {
+            transfer: Arc::new(RecordingResume {
+                fail: true,
+                captured: Mutex::new(None),
+            }),
+        };
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_request_id("mint-fail"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        // The failure must propagate (not be swallowed) so apalis retries and
+        // the event-driven `equity_in_progress` guard stays latched until the
+        // aggregate reaches a terminal state -- swallowing it would free the
+        // guard and let a fresh mint arm on top of a partial one.
+        assert!(matches!(
+            error,
+            TransferEquityToMarketMakingJobError::Transfer(MintTransferError::PreReceipt(_))
+        ));
+    }
+
+    #[test]
+    fn payload_roundtrips_through_json() {
+        let job = TransferEquityToMarketMaking {
+            issuer_request_id: issuer_request_id("mint-roundtrip"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(2.5)),
+        };
+
+        let expected = json!({
+            "issuer_request_id": issuer_request_id("mint-roundtrip").to_string(),
+            "symbol": "AAPL",
+            "quantity": "2.5",
+        });
+
+        assert_eq!(serde_json::to_value(&job).unwrap(), expected);
+
+        let roundtripped: TransferEquityToMarketMaking = serde_json::from_value(expected).unwrap();
+
+        assert_eq!(roundtripped.issuer_request_id, job.issuer_request_id);
+        assert_eq!(roundtripped.symbol, job.symbol);
+        assert_eq!(roundtripped.quantity, job.quantity);
+    }
+}

--- a/src/rebalancing/equity/mock.rs
+++ b/src/rebalancing/equity/mock.rs
@@ -6,15 +6,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use st0x_execution::{FractionalShares, Symbol};
 
-use super::{Equity, MintTransferError, RedemptionError};
+use super::{Equity, RedemptionError};
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
-
-/// Parameters captured from a hedging-to-market-making (mint) call.
-#[derive(Debug, Clone)]
-pub(crate) struct MintCall {
-    pub(crate) symbol: Symbol,
-    pub(crate) quantity: FractionalShares,
-}
 
 /// Parameters captured from a market-making-to-hedging (redemption) call.
 #[derive(Debug, Clone)]
@@ -23,58 +16,31 @@ pub(crate) struct RedemptionCall {
     pub(crate) quantity: FractionalShares,
 }
 
-/// Mock equity cross-venue transfer for testing.
+/// Mock equity cross-venue transfer for testing the redemption direction.
 ///
-/// Tracks call counts and captures parameters for verification.
+/// Tracks call counts and captures parameters for verification. The mint
+/// direction (hedging -> market-making) is driven by the
+/// `TransferEquityToMarketMaking` apalis job, not this trait, so the mock
+/// only implements redemption.
 pub(crate) struct MockCrossVenueEquityTransfer {
-    mint_count: AtomicUsize,
     redeem_count: AtomicUsize,
-    last_mint: Mutex<Option<MintCall>>,
     last_redeem: Mutex<Option<RedemptionCall>>,
 }
 
 impl MockCrossVenueEquityTransfer {
     pub(crate) fn new() -> Self {
         Self {
-            mint_count: AtomicUsize::new(0),
             redeem_count: AtomicUsize::new(0),
-            last_mint: Mutex::new(None),
             last_redeem: Mutex::new(None),
         }
-    }
-
-    pub(crate) fn mint_calls(&self) -> usize {
-        self.mint_count.load(Ordering::SeqCst)
     }
 
     pub(crate) fn redeem_calls(&self) -> usize {
         self.redeem_count.load(Ordering::SeqCst)
     }
 
-    pub(crate) fn last_mint_call(&self) -> Option<MintCall> {
-        self.last_mint.lock().unwrap().clone()
-    }
-
     pub(crate) fn last_redeem_call(&self) -> Option<RedemptionCall> {
         self.last_redeem.lock().unwrap().clone()
-    }
-}
-
-/// Hedging -> Market-Making (mint direction).
-#[async_trait]
-impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for MockCrossVenueEquityTransfer {
-    type Asset = Equity;
-    type Error = MintTransferError;
-
-    async fn transfer(&self, asset: Self::Asset) -> Result<(), Self::Error> {
-        self.mint_count.fetch_add(1, Ordering::SeqCst);
-
-        *self.last_mint.lock().unwrap() = Some(MintCall {
-            symbol: asset.symbol,
-            quantity: asset.quantity,
-        });
-
-        Ok(())
     }
 }
 
@@ -104,74 +70,12 @@ mod tests {
     #[test]
     fn new_mock_starts_with_zero_counts() {
         let mock = MockCrossVenueEquityTransfer::new();
-        assert_eq!(mock.mint_calls(), 0);
         assert_eq!(mock.redeem_calls(), 0);
-    }
-
-    #[test]
-    fn new_mock_has_no_last_calls() {
-        let mock = MockCrossVenueEquityTransfer::new();
-        assert!(mock.last_mint_call().is_none());
         assert!(mock.last_redeem_call().is_none());
     }
 
     #[tokio::test]
-    async fn mint_increments_count() {
-        let mock = MockCrossVenueEquityTransfer::new();
-
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &mock,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100)),
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(mock.mint_calls(), 1);
-        assert_eq!(mock.redeem_calls(), 0);
-    }
-
-    #[tokio::test]
-    async fn redeem_increments_count() {
-        let mock = MockCrossVenueEquityTransfer::new();
-
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(
-            &mock,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(50)),
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(mock.mint_calls(), 0);
-        assert_eq!(mock.redeem_calls(), 1);
-    }
-
-    #[tokio::test]
-    async fn mint_captures_parameters() {
-        let mock = MockCrossVenueEquityTransfer::new();
-
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &mock,
-            Equity {
-                symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(float!(42.5)),
-            },
-        )
-        .await
-        .unwrap();
-
-        let call = mock.last_mint_call().unwrap();
-        assert_eq!(call.symbol, Symbol::new("TSLA").unwrap());
-        assert_eq!(call.quantity, FractionalShares::new(float!(42.5)));
-    }
-
-    #[tokio::test]
-    async fn redeem_captures_parameters() {
+    async fn redeem_increments_count_and_captures_parameters() {
         let mock = MockCrossVenueEquityTransfer::new();
 
         CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(
@@ -184,42 +88,10 @@ mod tests {
         .await
         .unwrap();
 
+        assert_eq!(mock.redeem_calls(), 1);
+
         let call = mock.last_redeem_call().unwrap();
         assert_eq!(call.symbol, Symbol::new("GOOG").unwrap());
         assert_eq!(call.quantity, FractionalShares::new(float!(7.25)));
-    }
-
-    #[tokio::test]
-    async fn operations_are_independent() {
-        let mock = MockCrossVenueEquityTransfer::new();
-
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &mock,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(10)),
-            },
-        )
-        .await
-        .unwrap();
-
-        CrossVenueTransfer::<MarketMakingVenue, HedgingVenue>::transfer(
-            &mock,
-            Equity {
-                symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(float!(20)),
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(mock.mint_calls(), 1);
-        assert_eq!(mock.redeem_calls(), 1);
-
-        let mint = mock.last_mint_call().unwrap();
-        let redeem = mock.last_redeem_call().unwrap();
-
-        assert_eq!(mint.symbol, Symbol::new("AAPL").unwrap());
-        assert_eq!(redeem.symbol, Symbol::new("TSLA").unwrap());
     }
 }

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -8,8 +8,16 @@
 //! - **Market-Making -> Hedging** (redemption): withdraws tokenized equity
 //!   from a Raindex vault and sends it to Alpaca for redemption.
 
+mod job;
 #[cfg(test)]
 pub(crate) mod mock;
+
+#[cfg(test)]
+pub(crate) use job::TransferEquityToMarketMakingJobError;
+pub(crate) use job::{
+    TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
+    TransferEquityToMarketMakingJobQueue,
+};
 
 use alloy::hex::FromHexError;
 use alloy::primitives::{Address, TxHash, U256};
@@ -154,7 +162,7 @@ async fn load_mint_recheck_context(
          ORDER BY accepted.sequence DESC \
          LIMIT 1",
     )
-    .bind(raw_id)
+    .bind(raw_id.to_string())
     .fetch_optional(pool)
     .await?;
 
@@ -473,6 +481,27 @@ pub(crate) enum MintTransferError {
     /// Tokens exist in the wallet; guard must stay set for recovery.
     #[error(transparent)]
     PostReceipt(MintError),
+}
+
+fn mint_reached_post_receipt(entity: &TokenizedEquityMint) -> bool {
+    matches!(
+        entity,
+        TokenizedEquityMint::TokensReceived { .. }
+            | TokenizedEquityMint::WrapSubmitted { .. }
+            | TokenizedEquityMint::TokensWrapped { .. }
+            | TokenizedEquityMint::VaultDepositSubmitted { .. }
+            | TokenizedEquityMint::DepositedIntoRaindex { .. }
+    )
+}
+
+fn classify_mint_resume_error(
+    reached: Result<TokenizedEquityMint, MintError>,
+    error: MintError,
+) -> MintTransferError {
+    match reached {
+        Ok(entity) if mint_reached_post_receipt(&entity) => MintTransferError::PostReceipt(error),
+        Ok(_) | Err(_) => MintTransferError::PreReceipt(error),
+    }
 }
 
 #[derive(Debug, Error)]
@@ -1458,24 +1487,60 @@ impl CrossVenueEquityTransfer {
     }
 }
 
-/// Hedging -> Market-Making: tokenize equity on Alpaca and deposit into
-/// Raindex vault.
-#[async_trait]
-impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTransfer {
-    type Asset = Equity;
-    type Error = MintTransferError;
+impl CrossVenueEquityTransfer {
+    /// Hedging -> Market-Making: drives the mint lifecycle (tokenize equity
+    /// on Alpaca, wrap, deposit into the Raindex vault) for the given
+    /// `issuer_request_id`, whether fresh or interrupted.
+    ///
+    /// The id is chosen by the caller at enqueue time so apalis retries (and
+    /// bot restarts that re-pick the job row) re-enter the same aggregate: an
+    /// absent aggregate starts a new mint, an in-flight one resumes from its
+    /// persisted state, and a terminal one is a no-op.
+    #[instrument(target = "rebalance", skip_all, fields(%issuer_request_id, %symbol, %quantity))]
+    pub(crate) async fn resume_equity_to_market_making(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), MintTransferError> {
+        let existing = self
+            .mint_store
+            .load(issuer_request_id)
+            .await
+            .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
-    #[instrument(target = "rebalance", skip_all, fields(symbol = %asset.symbol, quantity = %asset.quantity))]
-    async fn transfer(&self, asset: Self::Asset) -> Result<(), Self::Error> {
-        let Equity { symbol, quantity } = asset;
-        let issuer_request_id = IssuerRequestId::new(Uuid::new_v4().to_string());
+        match existing {
+            None => self.start_mint(issuer_request_id, symbol, quantity).await,
+            Some(
+                TokenizedEquityMint::MintRequested { .. }
+                | TokenizedEquityMint::MintAccepted { .. },
+            ) => {
+                if let Err(error) = self.resume_mint(issuer_request_id).await {
+                    let reached = self.load_mint_entity(issuer_request_id).await;
+                    return Err(classify_mint_resume_error(reached, error));
+                }
 
+                Ok(())
+            }
+            Some(_) => self
+                .resume_mint(issuer_request_id)
+                .await
+                .map_err(MintTransferError::PostReceipt),
+        }
+    }
+
+    async fn start_mint(
+        &self,
+        issuer_request_id: &IssuerRequestId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), MintTransferError> {
         debug!(target: "rebalance", %issuer_request_id, wallet = %self.wallet, "Requesting mint");
 
         // Pre-receipt: no tokens exist yet, safe to retry on failure.
         self.mint_store
             .send(
-                &issuer_request_id,
+                issuer_request_id,
                 TokenizedEquityMintCommand::RequestMint {
                     issuer_request_id: issuer_request_id.clone(),
                     symbol: symbol.clone(),
@@ -1489,17 +1554,17 @@ impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for CrossVenueEquityTra
         info!(target: "rebalance", "Mint request accepted, polling for completion");
 
         self.mint_store
-            .send(&issuer_request_id, TokenizedEquityMintCommand::Poll)
+            .send(issuer_request_id, TokenizedEquityMintCommand::Poll)
             .await
             .map_err(|error| MintTransferError::PreReceipt(error.into()))?;
 
         // Post-receipt: tokens exist in wallet from this point on.
         let tokens_received = self
-            .load_tokens_received(&issuer_request_id)
+            .load_tokens_received(issuer_request_id)
             .await
             .map_err(MintTransferError::PostReceipt)?;
 
-        self.finalize_received_mint(&issuer_request_id, tokens_received)
+        self.finalize_received_mint(issuer_request_id, tokens_received)
             .await
             .map_err(MintTransferError::PostReceipt)
     }
@@ -1567,6 +1632,7 @@ mod tests {
     use crate::tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
     };
+    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::usdc_rebalance::UsdcRebalance;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistry;
@@ -1600,13 +1666,25 @@ mod tests {
              (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
              VALUES ('TokenizedEquityMint', ?, ?, ?, '1.0', ?, '{}')",
         )
-        .bind(raw)
+        .bind(raw.to_string())
         .bind(sequence)
         .bind(event_type)
         .bind(payload)
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    fn mint_accepted_payload(id: &IssuerRequestId) -> String {
+        format!(
+            r#"{{"MintAccepted":{{"issuer_request_id":"{id}","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}}}"#
+        )
+    }
+
+    fn provider_completion_recovered_payload(id: &IssuerRequestId) -> String {
+        format!(
+            r#"{{"ProviderCompletionRecovered":{{"issuer_request_id":"{id}","wallet":"0x0000000000000000000000000000000000000001","tokenization_request_id":"tok-1","tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111","shares_minted":"10000000000000000000","fees":null,"recovered_at":"2026-01-01T00:02:00Z"}}}}"#
+        )
     }
 
     #[tokio::test]
@@ -1617,7 +1695,7 @@ mod tests {
         // (which would re-wrap already-moved tokens), so received_tokens must be
         // true even though no TokensReceived event exists.
         let pool = crate::test_utils::setup_test_db().await;
-        let id = IssuerRequestId::new("mint-rerecover");
+        let id = issuer_request_id("mint-rerecover");
 
         insert_mint_event(
             &pool,
@@ -1632,7 +1710,7 @@ mod tests {
             &id,
             1,
             "TokenizedEquityMintEvent::MintAccepted",
-            r#"{"MintAccepted":{"issuer_request_id":"mint-rerecover","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+            &mint_accepted_payload(&id),
         )
         .await;
         insert_mint_event(
@@ -1640,7 +1718,7 @@ mod tests {
             &id,
             2,
             "TokenizedEquityMintEvent::ProviderCompletionRecovered",
-            r#"{"ProviderCompletionRecovered":{"issuer_request_id":"mint-rerecover","wallet":"0x0000000000000000000000000000000000000001","tokenization_request_id":"tok-1","tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111","shares_minted":"10000000000000000000","fees":null,"recovered_at":"2026-01-01T00:02:00Z"}}"#,
+            &provider_completion_recovered_payload(&id),
         )
         .await;
 
@@ -1662,7 +1740,7 @@ mod tests {
     async fn recover_mint_clears_hedging_inflight() {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let id = IssuerRequestId::new("mint-recover-inflight");
+        let id = issuer_request_id("mint-recover-inflight");
 
         // Reactor-less failure injection: the live reactor never observes these
         // events, so its inventory holds the full Hedging balance with nothing
@@ -1680,7 +1758,7 @@ mod tests {
             &id,
             2,
             "TokenizedEquityMintEvent::MintAccepted",
-            r#"{"MintAccepted":{"issuer_request_id":"mint-recover-inflight","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+            &mint_accepted_payload(&id),
         )
         .await;
         insert_mint_event(
@@ -1804,7 +1882,7 @@ mod tests {
     async fn recover_mint_does_not_double_count_existing_inflight() {
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let id = IssuerRequestId::new("mint-double-count");
+        let id = issuer_request_id("mint-double-count");
 
         insert_mint_event(
             &pool,
@@ -1819,7 +1897,7 @@ mod tests {
             &id,
             2,
             "TokenizedEquityMintEvent::MintAccepted",
-            r#"{"MintAccepted":{"issuer_request_id":"mint-double-count","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+            &mint_accepted_payload(&id),
         )
         .await;
         insert_mint_event(
@@ -1966,15 +2044,14 @@ mod tests {
         )
         .await;
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap();
+        transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -1986,7 +2063,7 @@ mod tests {
         )
         .await;
 
-        let id = IssuerRequestId::new("ISS-RESUME");
+        let id = issuer_request_id("ISS-RESUME");
         transfer
             .mint_store
             .send(
@@ -2008,6 +2085,84 @@ mod tests {
             matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
             "Expected deposited mint after resume, got: {entity:?}"
         );
+    }
+
+    /// Re-running the job entry point with an id whose aggregate already
+    /// exists must resume from the persisted state (the crash-recovery path)
+    /// rather than re-requesting the mint from Alpaca.
+    #[tokio::test]
+    async fn resume_equity_to_market_making_resumes_existing_aggregate() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-CRASH-RESUME");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        // First attempt crashes after the mint request was accepted: the
+        // aggregate is persisted in MintAccepted.
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: symbol.clone(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        // The re-enqueued job runs the same entry point with the same id; a
+        // fresh RequestMint here would fail with AlreadyInProgress, so
+        // completing proves the resume path was taken.
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10)))
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "Expected deposited mint after job re-run, got: {entity:?}"
+        );
+    }
+
+    /// A terminal aggregate is a no-op for the job entry point: apalis
+    /// retries after a partial failure must not error once the aggregate
+    /// has already completed.
+    #[tokio::test]
+    async fn resume_equity_to_market_making_is_noop_on_completed_mint() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-DONE");
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10)))
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::DepositedIntoRaindex { .. }),
+            "Expected deposited mint, got: {entity:?}"
+        );
+
+        transfer
+            .resume_equity_to_market_making(&id, &symbol, FractionalShares::new(float!(10)))
+            .await
+            .expect("a completed mint must be a clean no-op for the job retry");
     }
 
     #[tokio::test]
@@ -2198,15 +2353,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(error, MintTransferError::PostReceipt(MintError::Wrapper(_))),
@@ -2223,15 +2377,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(error, MintTransferError::PostReceipt(MintError::Raindex(_))),
@@ -2248,15 +2401,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2278,15 +2430,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2321,15 +2472,14 @@ mod tests {
         )
         .await;
 
-        CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100)),
-            },
-        )
-        .await
-        .unwrap();
+        transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100)),
+            )
+            .await
+            .unwrap();
 
         let deposited = raindex.last_deposited_token().expect("deposit was called");
         assert_eq!(
@@ -2354,15 +2504,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2387,15 +2536,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2420,15 +2568,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2453,15 +2600,14 @@ mod tests {
         )
         .await;
 
-        let error = CrossVenueTransfer::<HedgingVenue, MarketMakingVenue>::transfer(
-            &transfer,
-            Equity {
-                symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(100.0)),
-            },
-        )
-        .await
-        .unwrap_err();
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-TEST"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(100.0)),
+            )
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(
@@ -2483,7 +2629,7 @@ mod tests {
         )
         .await;
 
-        let id = IssuerRequestId::new("ISS-REVERT-RECOVERY");
+        let id = issuer_request_id("ISS-REVERT-RECOVERY");
 
         // Advance the aggregate to TokensWrapped state manually:
         // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted
@@ -2575,7 +2721,7 @@ mod tests {
         )
         .await;
 
-        let id = IssuerRequestId::new("ISS-WRAP-SUBMITTED-RECOVERY");
+        let id = issuer_request_id("ISS-WRAP-SUBMITTED-RECOVERY");
 
         // Advance aggregate to WrapSubmitted state:
         // RequestMint -> MintAccepted -> TokensReceived -> WrapSubmitted

--- a/src/rebalancing/rebalancer.rs
+++ b/src/rebalancing/rebalancer.rs
@@ -9,22 +9,18 @@ use tracing::{error, info, warn};
 
 use st0x_execution::{FractionalShares, Symbol};
 
-use super::equity::{Equity, MintTransferError, RedemptionError};
+use super::equity::{Equity, RedemptionError};
 use super::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
 use super::trigger::TriggeredOperation;
-
-/// Type-erased equity transfer (hedging -> market-making).
-type EquityToMarketMaking = dyn CrossVenueTransfer<HedgingVenue, MarketMakingVenue, Asset = Equity, Error = MintTransferError>;
 
 /// Type-erased equity transfer (market-making -> hedging).
 type EquityToHedging = dyn CrossVenueTransfer<MarketMakingVenue, HedgingVenue, Asset = Equity, Error = RedemptionError>;
 
-/// Receives triggered equity rebalancing operations and routes them to the
-/// appropriate cross-venue transfer implementation. USDC rebalances no
+/// Receives triggered equity redemption operations and routes them to the
+/// cross-venue transfer implementation. USDC rebalances and equity mints no
 /// longer flow through this channel — they're enqueued as apalis jobs
 /// directly from the trigger.
 pub(crate) struct Rebalancer {
-    equity_to_mm: Arc<EquityToMarketMaking>,
     equity_to_hedging: Arc<EquityToHedging>,
     receiver: mpsc::Receiver<TriggeredOperation>,
     equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
@@ -33,14 +29,12 @@ pub(crate) struct Rebalancer {
 
 impl Rebalancer {
     pub(crate) fn new(
-        equity_to_mm: Arc<EquityToMarketMaking>,
         equity_to_hedging: Arc<EquityToHedging>,
         receiver: mpsc::Receiver<TriggeredOperation>,
         equity_in_progress: Arc<std::sync::RwLock<HashSet<Symbol>>>,
         shutdown_token: CancellationToken,
     ) -> Self {
         Self {
-            equity_to_mm,
             equity_to_hedging,
             receiver,
             equity_in_progress,
@@ -80,36 +74,20 @@ impl Rebalancer {
     async fn execute(&self, operation: TriggeredOperation) {
         match operation {
             TriggeredOperation::Mint { symbol, quantity } => {
-                self.execute_mint(symbol, quantity).await;
+                error!(
+                    target: "rebalance",
+                    %symbol,
+                    %quantity,
+                    "Mint operation received over the mpsc channel; mints are \
+                     driven by TransferEquityToMarketMaking apalis jobs and \
+                     must not be dispatched here"
+                );
             }
 
             TriggeredOperation::Redemption {
                 symbol, quantity, ..
             } => {
                 self.execute_redemption(symbol, quantity).await;
-            }
-        }
-    }
-
-    async fn execute_mint(&self, symbol: Symbol, quantity: FractionalShares) {
-        let log_symbol = symbol.clone();
-
-        if let Err(error) = self
-            .equity_to_mm
-            .transfer(Equity { symbol, quantity })
-            .await
-        {
-            match &error {
-                MintTransferError::PreReceipt(_) => {
-                    error!(target: "rebalance", ?error, symbol = %log_symbol, %quantity,
-                        "Mint failed before tokens received; clearing guard for retry");
-                    self.clear_equity_in_progress(&log_symbol);
-                }
-
-                MintTransferError::PostReceipt(_) => {
-                    error!(target: "rebalance", ?error, symbol = %log_symbol, %quantity,
-                        "Mint failed after tokens received; keeping guard set for recovery");
-                }
             }
         }
     }
@@ -148,6 +126,7 @@ impl Rebalancer {
 mod tests {
     use alloy::primitives::address;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use st0x_execution::{FractionalShares, Symbol};
 
@@ -160,7 +139,6 @@ mod tests {
         let (sender, receiver) = mpsc::channel(10);
 
         let rebalancer = Rebalancer::new(
-            Arc::clone(&equity) as Arc<EquityToMarketMaking>,
             Arc::clone(&equity) as Arc<EquityToHedging>,
             receiver,
             Arc::new(std::sync::RwLock::new(HashSet::new())),
@@ -178,18 +156,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_mint_calls_equity_to_market_making() {
-        let equity = execute(vec![TriggeredOperation::Mint {
-            symbol: Symbol::new("AAPL").unwrap(),
-            quantity: FractionalShares::new(float!(10)),
-        }])
-        .await;
-
-        assert_eq!(equity.mint_calls(), 1);
-        assert_eq!(equity.redeem_calls(), 0);
-    }
-
-    #[tokio::test]
     async fn execute_redemption_calls_equity_to_hedging() {
         let equity = execute(vec![TriggeredOperation::Redemption {
             symbol: Symbol::new("AAPL").unwrap(),
@@ -199,143 +165,47 @@ mod tests {
         }])
         .await;
 
-        assert_eq!(equity.mint_calls(), 0);
         assert_eq!(equity.redeem_calls(), 1);
     }
 
     #[tokio::test]
     async fn run_processes_multiple_operations() {
         let equity = execute(vec![
-            TriggeredOperation::Mint {
+            TriggeredOperation::Redemption {
                 symbol: Symbol::new("AAPL").unwrap(),
-                quantity: FractionalShares::new(float!(10)),
-            },
-            TriggeredOperation::Mint {
-                symbol: Symbol::new("TSLA").unwrap(),
-                quantity: FractionalShares::new(float!(20)),
+                quantity: FractionalShares::new(float!(5)),
+                wrapped_token: address!("0x1234567890123456789012345678901234567890"),
+                unwrapped_token: address!("0xabcdef0123456789abcdef0123456789abcdef01"),
             },
             TriggeredOperation::Redemption {
                 symbol: Symbol::new("GOOG").unwrap(),
-                quantity: FractionalShares::new(float!(5)),
+                quantity: FractionalShares::new(float!(7)),
                 wrapped_token: address!("0x1234567890123456789012345678901234567890"),
                 unwrapped_token: address!("0xabcdef0123456789abcdef0123456789abcdef01"),
             },
         ])
         .await;
 
-        assert_eq!(equity.mint_calls(), 2);
-        assert_eq!(equity.redeem_calls(), 1);
+        assert_eq!(equity.redeem_calls(), 2);
+    }
+
+    /// A mint arriving over the channel is a wiring bug (mints are apalis
+    /// jobs); the rebalancer must log and skip it, not execute a transfer.
+    #[tokio::test]
+    async fn mint_over_channel_is_ignored() {
+        let equity = execute(vec![TriggeredOperation::Mint {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+        }])
+        .await;
+
+        assert_eq!(equity.redeem_calls(), 0);
     }
 
     #[tokio::test]
     async fn run_terminates_when_channel_closes() {
-        execute(vec![]).await;
-    }
-
-    /// Mint transfer that always returns the configured error.
-    struct FailingMintTransfer {
-        error: std::sync::Mutex<Option<MintTransferError>>,
-    }
-
-    #[async_trait::async_trait]
-    impl CrossVenueTransfer<HedgingVenue, MarketMakingVenue> for FailingMintTransfer {
-        type Asset = Equity;
-        type Error = MintTransferError;
-
-        async fn transfer(&self, _asset: Self::Asset) -> Result<(), Self::Error> {
-            Err(self.error.lock().unwrap().take().unwrap())
-        }
-    }
-
-    fn make_pre_receipt_error() -> MintTransferError {
-        use crate::rebalancing::equity::MintError;
-        use crate::tokenized_equity_mint::IssuerRequestId;
-
-        MintTransferError::PreReceipt(MintError::EntityNotFound {
-            issuer_request_id: IssuerRequestId::new("test-pre".to_string()),
-            expected_state: "test",
-        })
-    }
-
-    fn make_post_receipt_error() -> MintTransferError {
-        use crate::rebalancing::equity::MintError;
-        use crate::tokenized_equity_mint::IssuerRequestId;
-
-        MintTransferError::PostReceipt(MintError::EntityNotFound {
-            issuer_request_id: IssuerRequestId::new("test-post".to_string()),
-            expected_state: "test",
-        })
-    }
-
-    #[tokio::test]
-    async fn pre_receipt_mint_failure_clears_guard() {
-        let symbol = Symbol::new("AAPL").unwrap();
-        let equity_in_progress = Arc::new(std::sync::RwLock::new(HashSet::from([symbol.clone()])));
-        let (sender, receiver) = mpsc::channel(10);
-
-        let failing_mint = Arc::new(FailingMintTransfer {
-            error: std::sync::Mutex::new(Some(make_pre_receipt_error())),
-        });
-        let equity = Arc::new(MockCrossVenueEquityTransfer::new());
-
-        let rebalancer = Rebalancer::new(
-            failing_mint,
-            Arc::clone(&equity) as Arc<EquityToHedging>,
-            receiver,
-            Arc::clone(&equity_in_progress),
-            CancellationToken::new(),
-        );
-
-        sender
-            .send(TriggeredOperation::Mint {
-                symbol: symbol.clone(),
-                quantity: FractionalShares::new(float!(10)),
-            })
+        tokio::time::timeout(Duration::from_secs(1), execute(vec![]))
             .await
-            .unwrap();
-        drop(sender);
-
-        rebalancer.run().await;
-
-        assert!(
-            !equity_in_progress.read().unwrap().contains(&symbol),
-            "guard should be cleared after pre-receipt failure"
-        );
-    }
-
-    #[tokio::test]
-    async fn post_receipt_mint_failure_keeps_guard() {
-        let symbol = Symbol::new("AAPL").unwrap();
-        let equity_in_progress = Arc::new(std::sync::RwLock::new(HashSet::from([symbol.clone()])));
-        let (sender, receiver) = mpsc::channel(10);
-
-        let failing_mint = Arc::new(FailingMintTransfer {
-            error: std::sync::Mutex::new(Some(make_post_receipt_error())),
-        });
-        let equity = Arc::new(MockCrossVenueEquityTransfer::new());
-
-        let rebalancer = Rebalancer::new(
-            failing_mint,
-            Arc::clone(&equity) as Arc<EquityToHedging>,
-            receiver,
-            Arc::clone(&equity_in_progress),
-            CancellationToken::new(),
-        );
-
-        sender
-            .send(TriggeredOperation::Mint {
-                symbol: symbol.clone(),
-                quantity: FractionalShares::new(float!(10)),
-            })
-            .await
-            .unwrap();
-        drop(sender);
-
-        rebalancer.run().await;
-
-        assert!(
-            equity_in_progress.read().unwrap().contains(&symbol),
-            "guard should remain set after post-receipt failure"
-        );
+            .expect("timed out waiting for execute");
     }
 }

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -183,7 +183,6 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         let shutdown_token = CancellationToken::new();
 
         let rebalancer = Rebalancer::new(
-            Arc::clone(&equity) as _,
             equity as _,
             operation_receiver,
             equity_in_progress,

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -37,6 +37,9 @@ use crate::inventory::{
     Operator, PendingRequestOwnership, PendingRequestOwnershipSnapshot, TransferOp, Venue,
 };
 use crate::position::{Position, PositionEvent};
+use crate::rebalancing::equity::{
+    TransferEquityToMarketMaking, TransferEquityToMarketMakingJobQueue,
+};
 use crate::rebalancing::usdc::{
     TransferUsdcToHedging, TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking,
     TransferUsdcToMarketMakingJobQueue,
@@ -69,6 +72,7 @@ pub(crate) struct RebalancingSchedulers {
     pub(crate) unwrapped_equity_recovery: UnwrappedEquityRecoveryJobQueue,
     pub(crate) transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue,
     pub(crate) transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue,
+    pub(crate) transfer_equity_to_market_making: TransferEquityToMarketMakingJobQueue,
 }
 
 impl RebalancingSchedulers {
@@ -80,6 +84,7 @@ impl RebalancingSchedulers {
             unwrapped_equity_recovery: UnwrappedEquityRecoveryJobQueue::new(pool),
             transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue::new(pool),
             transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue::new(pool),
+            transfer_equity_to_market_making: TransferEquityToMarketMakingJobQueue::new(pool),
         }
     }
 }
@@ -463,6 +468,11 @@ pub(crate) struct RebalancingService {
     /// directly rather than dispatching through the `Rebalancer` mpsc channel.
     pub(super) transfer_usdc_to_hedging_queue: TransferUsdcToHedgingJobQueue,
     pub(super) transfer_usdc_to_market_making_queue: TransferUsdcToMarketMakingJobQueue,
+    /// Queue for the equity mint apalis job (hedging -> market-making).
+    /// `check_and_trigger_equity` enqueues into this directly for the mint
+    /// direction rather than dispatching through the `Rebalancer` mpsc
+    /// channel.
+    pub(super) transfer_equity_to_market_making_queue: TransferEquityToMarketMakingJobQueue,
     /// Tracks symbol/quantity for in-flight mints. The initial `MintRequested`
     /// event carries this data; follow-up events don't.
     mint_tracking: Arc<RwLock<HashMap<IssuerRequestId, MintTracking>>>,
@@ -546,6 +556,7 @@ impl RebalancingService {
             wrapped_equity_recovery: wrapped_equity_recovery_queue,
             unwrapped_equity_recovery: unwrapped_equity_recovery_queue,
             transfer_usdc_to_hedging: transfer_usdc_to_hedging_queue,
+            transfer_equity_to_market_making: transfer_equity_to_market_making_queue,
             transfer_usdc_to_market_making: transfer_usdc_to_market_making_queue,
         } = schedulers;
         Self {
@@ -565,6 +576,7 @@ impl RebalancingService {
             unwrapped_equity_recovery_queue,
             transfer_usdc_to_hedging_queue,
             transfer_usdc_to_market_making_queue,
+            transfer_equity_to_market_making_queue,
             mint_tracking: Arc::new(RwLock::new(HashMap::new())),
             redemption_tracking: Arc::new(RwLock::new(HashMap::new())),
             usdc_tracking: Arc::new(RwLock::new(HashMap::new())),
@@ -2396,13 +2408,13 @@ impl RebalancingService {
 
         // Re-check immediately before dispatch: an OffChainOrderPlaced for this
         // symbol may have landed during the awaits in build_equity_operation.
-        // try_send_operation is synchronous, so no await intervenes between this
-        // check and the send, keeping the race window as tight as possible.
         // This narrows but cannot fully close the gap: the in-memory set is a
         // reactor-lagged projection of the position aggregate's
         // pending_offchain_order_id, so a just-committed OffChainOrderPlaced
-        // not yet seen by the reactor is invisible here. Closing that fully
-        // needs a source-side reservation, not a reactor-lagged projection.
+        // not yet seen by the reactor is invisible here (and the mint path
+        // awaits its Jobs-table dedupe query between this check and the
+        // push). Closing that fully needs a source-side reservation, not a
+        // reactor-lagged projection.
         if self.has_pending_offchain_order(symbol).await {
             debug!(
                 target: "rebalance",
@@ -2412,11 +2424,21 @@ impl RebalancingService {
             return Ok(());
         }
 
-        if !self.try_send_operation(&operation, "equity") {
+        let dispatched = match operation {
+            TriggeredOperation::Mint { symbol, quantity } => {
+                self.enqueue_transfer_equity_to_market_making(symbol, quantity)
+                    .await
+            }
+            operation @ TriggeredOperation::Redemption { .. } => {
+                self.try_send_operation(&operation, "equity")
+            }
+        };
+
+        if !dispatched {
             return Ok(());
         }
 
-        debug!(target: "rebalance", %symbol, ?operation, "Triggered equity rebalancing");
+        debug!(target: "rebalance", %symbol, "Triggered equity rebalancing");
         guard.defuse();
         Ok(())
     }
@@ -2510,7 +2532,8 @@ impl RebalancingService {
             "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
              FROM Jobs \
              WHERE job_type IN (?, ?) \
-             AND status IN ('Pending', 'Queued', 'Running') \
+             AND (status IN ('Pending', 'Queued', 'Running') \
+                  OR (status = 'Failed' AND attempts < max_attempts)) \
              ORDER BY run_at ASC \
              LIMIT 1",
         )
@@ -2672,6 +2695,127 @@ impl RebalancingService {
                     %error,
                     %amount,
                     "Failed to enqueue TransferUsdcToMarketMaking job",
+                );
+                false
+            }
+        }
+    }
+
+    /// Returns the oldest non-terminal equity mint job for this symbol (the
+    /// row id and its age in seconds), if any.
+    ///
+    /// The in-memory `equity_in_progress` guard resets on restart, so without
+    /// this check a crash between `queue.push` and the first persisted
+    /// `TokenizedEquityMint` event would let the next imbalance check enqueue
+    /// a second mint for the same imbalance. The payload is a `serde_json`
+    /// BLOB (apalis `JsonCodec`), so the symbol is filtered via
+    /// `json_extract`.
+    async fn in_flight_equity_mint(
+        pool: &apalis_sqlite::SqlitePool,
+        symbol: &Symbol,
+    ) -> Result<Option<(String, i64)>, sqlx_apalis::Error> {
+        sqlx_apalis::query_as(
+            "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
+             FROM Jobs \
+             WHERE job_type = ? \
+             AND json_extract(job, '$.symbol') = ? \
+             AND (status IN ('Pending', 'Queued', 'Running') \
+                  OR (status = 'Failed' AND attempts < max_attempts)) \
+             ORDER BY run_at ASC \
+             LIMIT 1",
+        )
+        .bind(std::any::type_name::<TransferEquityToMarketMaking>())
+        .bind(symbol.to_string())
+        .fetch_optional(pool)
+        .await
+    }
+
+    /// Enqueues a [`TransferEquityToMarketMaking`] apalis job for a
+    /// hedging->market-making equity mint. Generates a fresh
+    /// `IssuerRequestId` at push time so apalis retries (and bot restarts
+    /// that re-pick the job row) hit the same aggregate. Returns `true` on
+    /// successful enqueue.
+    async fn enqueue_transfer_equity_to_market_making(
+        &self,
+        symbol: Symbol,
+        quantity: FractionalShares,
+    ) -> bool {
+        // A non-terminal row in flight longer than this is treated as likely
+        // stuck: the suppression is logged at warn (with the row id and age)
+        // so it is actionable rather than silently freezing the symbol.
+        const STUCK_TRANSFER_WARN_AFTER_SECS: i64 = 15 * 60;
+
+        let mut queue = self.transfer_equity_to_market_making_queue.clone();
+
+        match Self::in_flight_equity_mint(queue.pool(), &symbol).await {
+            Ok(Some((row_id, age_secs))) if age_secs >= STUCK_TRANSFER_WARN_AFTER_SECS => {
+                warn!(
+                    target: "rebalance",
+                    %row_id,
+                    age_secs,
+                    threshold_secs = STUCK_TRANSFER_WARN_AFTER_SECS,
+                    %symbol,
+                    %quantity,
+                    "Skipped equity mint enqueue: an in-flight mint for this symbol looks \
+                     stuck and is suppressing new rebalances; investigate before it \
+                     starves market making",
+                );
+                return false;
+            }
+            Ok(Some((row_id, age_secs))) => {
+                debug!(
+                    target: "rebalance",
+                    %row_id,
+                    age_secs,
+                    %symbol,
+                    %quantity,
+                    "Skipped equity mint enqueue: a non-terminal mint for this symbol \
+                     already exists; apalis will resume it",
+                );
+                return false;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    %symbol,
+                    "Failed to query for in-flight equity mints; \
+                     skipping enqueue to avoid double-pushing",
+                );
+                return false;
+            }
+        }
+
+        let issuer_request_id = IssuerRequestId::generate();
+
+        let push = queue
+            .push(TransferEquityToMarketMaking {
+                issuer_request_id: issuer_request_id.clone(),
+                symbol: symbol.clone(),
+                quantity,
+            })
+            .await;
+
+        match push {
+            Ok(()) => {
+                debug!(
+                    target: "rebalance",
+                    %issuer_request_id,
+                    %symbol,
+                    %quantity,
+                    "Enqueued TransferEquityToMarketMaking job for equity mint",
+                );
+                true
+            }
+
+            Err(QueuePushError(error)) => {
+                warn!(
+                    target: "rebalance",
+                    %error,
+                    %symbol,
+                    %quantity,
+                    "Failed to enqueue TransferEquityToMarketMaking job",
                 );
                 false
             }
@@ -3850,7 +3994,7 @@ mod tests {
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
-    use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
+    use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
     use crate::usdc_rebalance::{
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
@@ -3970,7 +4114,7 @@ mod tests {
     async fn recover_mint_state_restores_tracking_and_inflight() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-recovery");
+        let mint_id = issuer_request_id("mint-recovery");
         let accepted_at = Utc::now();
 
         trigger
@@ -4082,7 +4226,7 @@ mod tests {
     async fn recovery_after_explicit_mint_failure_moves_equity_to_market_making() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-explicit-recovery");
+        let mint_id = issuer_request_id("mint-explicit-recovery");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         // An explicit MintAcceptanceFailed cancelled the in-flight back to
@@ -4135,7 +4279,7 @@ mod tests {
     async fn recovery_after_timeout_mint_failure_clears_tombstone_and_moves_equity() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-timeout-recovery");
+        let mint_id = issuer_request_id("mint-timeout-recovery");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         // A timeout cleared the in-flight without crediting available (Hedging
@@ -4316,7 +4460,7 @@ mod tests {
     async fn abandon_mint_recovery_guard_clears_active_mint() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-resume-failure");
+        let mint_id = issuer_request_id("mint-resume-failure");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         *trigger.inventory.write().await =
@@ -4374,8 +4518,8 @@ mod tests {
     async fn mint_recovery_claim_refuses_a_different_mint_without_mutating() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let recovering = IssuerRequestId::new("recovering-mint");
-        let other = IssuerRequestId::new("other-mint");
+        let recovering = issuer_request_id("recovering-mint");
+        let other = issuer_request_id("other-mint");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         // Explicit-failure shape (available 100, in-flight 0) but a *different*
@@ -4415,7 +4559,7 @@ mod tests {
     async fn mint_recovery_claim_succeeds_for_self_owned_slot() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let recovering = IssuerRequestId::new("recovering-mint");
+        let recovering = issuer_request_id("recovering-mint");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         // The slot is still owned by the recovering mint itself (e.g. a
@@ -4558,8 +4702,8 @@ mod tests {
     async fn abandon_mint_recovery_guard_keeps_active_mint_owned_by_other_id() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let recovering_id = IssuerRequestId::new("recovering-mint");
-        let other_id = IssuerRequestId::new("other-active-mint");
+        let recovering_id = issuer_request_id("recovering-mint");
+        let other_id = issuer_request_id("other-active-mint");
 
         // A different aggregate owns the symbol's active-mint slot (e.g. a
         // concurrent mint). Abandoning the recovering mint's guard must NOT clear
@@ -4583,7 +4727,7 @@ mod tests {
     async fn rollback_after_explicit_mint_dispatch_failure_restores_available() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-explicit-rollback");
+        let mint_id = issuer_request_id("mint-explicit-rollback");
         let tok = TokenizationRequestId("TOK-1".to_string());
 
         // Explicit failure cancelled the in-flight back to available: 100/0.
@@ -4646,7 +4790,7 @@ mod tests {
     async fn rollback_after_timeout_mint_dispatch_failure_restores_tombstone() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("mint-timeout-rollback");
+        let mint_id = issuer_request_id("mint-timeout-rollback");
         let tok = TokenizationRequestId("TOK-1".to_string());
         let tombstone_at = Utc::now();
 
@@ -4980,7 +5124,7 @@ mod tests {
     async fn pending_request_ownership_exposes_active_mint_ids() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("owned-mint");
+        let mint_id = issuer_request_id("owned-mint");
         let tokenization_request_id = TokenizationRequestId("owned-tokenization".to_string());
 
         *trigger.inventory.write().await =
@@ -5038,7 +5182,7 @@ mod tests {
                 .contains(&tokenization_request_id)
         );
 
-        let success_mint_id = IssuerRequestId::new("owned-success-mint");
+        let success_mint_id = issuer_request_id("owned-success-mint");
         let success_tokenization_request_id =
             TokenizationRequestId("owned-success-tokenization".to_string());
 
@@ -5654,6 +5798,60 @@ mod tests {
         .expect("count pending TransferUsdcToMarketMaking jobs")
     }
 
+    /// Counts pending `TransferEquityToMarketMaking` rows in the apalis Jobs
+    /// table backing this service. Used by trigger tests that previously
+    /// asserted on the mpsc receiver for mints and now must assert on the
+    /// queue.
+    async fn count_pending_equity_mint_jobs(service: &RebalancingService) -> i64 {
+        let job_type = std::any::type_name::<TransferEquityToMarketMaking>();
+        sqlx_apalis::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(job_type)
+        .fetch_one(service.transfer_equity_to_market_making_queue.pool())
+        .await
+        .expect("count pending TransferEquityToMarketMaking jobs")
+    }
+
+    /// Drains every pending equity mint row from the service's Jobs table and
+    /// returns the parsed payloads. Marking rows `Done` lets repeated trigger
+    /// cycles in the same test see fresh state.
+    async fn take_pending_equity_mint_jobs(
+        service: &RebalancingService,
+    ) -> Vec<TransferEquityToMarketMaking> {
+        let pool = service
+            .transfer_equity_to_market_making_queue
+            .pool()
+            .clone();
+        let job_type = std::any::type_name::<TransferEquityToMarketMaking>();
+
+        let rows: Vec<(String, Vec<u8>)> = sqlx_apalis::query_as(
+            "SELECT id, job FROM Jobs \
+             WHERE status = 'Pending' AND job_type = ? \
+             ORDER BY run_at",
+        )
+        .bind(job_type)
+        .fetch_all(&pool)
+        .await
+        .expect("query pending TransferEquityToMarketMaking jobs");
+
+        let mut jobs = Vec::with_capacity(rows.len());
+        for (row_id, payload) in rows {
+            let job: TransferEquityToMarketMaking =
+                serde_json::from_slice(&payload).expect("deserialize TransferEquityToMarketMaking");
+
+            sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+                .bind(&row_id)
+                .execute(&pool)
+                .await
+                .expect("mark equity mint job row Done");
+
+            jobs.push(job);
+        }
+
+        jobs
+    }
+
     /// Drains every pending USDC transfer row (both directions) from the
     /// service's Jobs table and returns them parsed as
     /// [`UsdcRebalanceOperation`]. Marking rows `Done` lets repeated trigger
@@ -5793,7 +5991,7 @@ mod tests {
         // handle it (either by auto-registering or by decoupling the
         // inventory update failure from the rebalancing check).
         let symbol = Symbol::new("AAPL").unwrap();
-        let (sender, mut receiver) = mpsc::channel(10);
+        let (sender, _receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default().with_usdc(usdc(1_000_000), usdc(1_000_000)),
@@ -5840,7 +6038,7 @@ mod tests {
         }
 
         // Drain any intermediate triggers and do a final check.
-        while receiver.try_recv().is_ok() {}
+        take_pending_equity_mint_jobs(&trigger).await;
         trigger.clear_equity_in_progress(&symbol);
 
         // One more event to trigger the check after the imbalance is built up.
@@ -5851,11 +6049,13 @@ mod tests {
             .unwrap();
         drain_pending_jobs(&trigger).await.unwrap();
 
-        let triggered = receiver.try_recv();
-        assert!(
-            matches!(triggered, Ok(TriggeredOperation::Mint { .. })),
-            "Expected Mint for imbalanced inventory starting from empty, got {triggered:?}"
+        let jobs = take_pending_equity_mint_jobs(&trigger).await;
+        assert_eq!(
+            jobs.len(),
+            1,
+            "Expected a mint job enqueued for imbalanced inventory starting from empty"
         );
+        assert_eq!(jobs[0].symbol, symbol);
     }
 
     #[tokio::test]
@@ -6256,7 +6456,7 @@ mod tests {
             )
             .unwrap();
 
-        let (trigger, mut receiver) =
+        let (trigger, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let harness = ReactorHarness::new(trigger.clone());
 
@@ -6268,12 +6468,10 @@ mod tests {
             .unwrap();
         drain_pending_jobs(&trigger).await.unwrap();
 
-        // Mint should be triggered because too much offchain.
-        let triggered = receiver.try_recv();
-        assert!(
-            matches!(triggered, Ok(TriggeredOperation::Mint { .. })),
-            "Expected Mint operation, got {triggered:?}"
-        );
+        // A mint job should be enqueued because too much offchain.
+        let jobs = take_pending_equity_mint_jobs(&trigger).await;
+        assert_eq!(jobs.len(), 1, "Expected a mint job for the imbalance");
+        assert_eq!(jobs[0].symbol, symbol);
     }
 
     #[tokio::test]
@@ -6326,7 +6524,7 @@ mod tests {
 
     fn make_mint_accepted() -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::MintAccepted {
-            issuer_request_id: IssuerRequestId::new("ISS123"),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             accepted_at: Utc::now(),
         }
@@ -6408,16 +6606,17 @@ mod tests {
             )
             .unwrap();
 
-        let (reactor, mut receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
 
         // Initially, trigger should detect imbalance (too much offchain).
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        let initial_check = receiver.try_recv();
-        assert!(
-            matches!(initial_check, Ok(TriggeredOperation::Mint { .. })),
-            "Expected initial imbalance to trigger Mint, got {initial_check:?}"
+        let initial_jobs = take_pending_equity_mint_jobs(&trigger).await;
+        assert_eq!(
+            initial_jobs.len(),
+            1,
+            "Expected initial imbalance to enqueue a mint job"
         );
 
         // Clear in-progress so we can test again.
@@ -6439,12 +6638,10 @@ mod tests {
 
         // With inflight, imbalance detection should not trigger anything.
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(
-                receiver.try_recv().unwrap_err(),
-                mpsc::error::TryRecvError::Empty
-            ),
-            "Expected no operation due to inflight"
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "Expected no mint job due to inflight"
         );
     }
 
@@ -6544,7 +6741,7 @@ mod tests {
         }
 
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = IssuerRequestId::new("mint-1");
+        let id = issuer_request_id("mint-1");
 
         harness
             .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, float!(10)))
@@ -6621,17 +6818,18 @@ mod tests {
             )
             .unwrap();
 
-        let (reactor, mut receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = IssuerRequestId::new("mint-blocks");
+        let id = issuer_request_id("mint-blocks");
 
         // Verify imbalance triggers before reactor events
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(receiver.try_recv(), Ok(TriggeredOperation::Mint { .. })),
-            "Should trigger Mint before reactor events"
+        assert_eq!(
+            take_pending_equity_mint_jobs(&trigger).await.len(),
+            1,
+            "Should enqueue a mint job before reactor events"
         );
         trigger.clear_equity_in_progress(&symbol);
 
@@ -6648,8 +6846,9 @@ mod tests {
 
         // Now check: inflight should block imbalance detection
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
             "Inflight from MintAccepted should block imbalance detection"
         );
     }
@@ -6677,7 +6876,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = IssuerRequestId::new("mint-transfer");
+        let id = issuer_request_id("mint-transfer");
 
         // Full mint flow: MintRequested -> MintAccepted -> TokensReceived
         harness
@@ -6724,11 +6923,11 @@ mod tests {
             )
             .unwrap();
 
-        let (reactor, mut receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = IssuerRequestId::new("mint-fail");
+        let id = issuer_request_id("mint-fail");
 
         // MintRequested -> MintAccepted -> MintAcceptanceFailed
         harness
@@ -6748,9 +6947,10 @@ mod tests {
 
         // After cancellation, inflight is cleared, imbalance should trigger again
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(receiver.try_recv(), Ok(TriggeredOperation::Mint { .. })),
-            "Imbalance should re-trigger after MintAcceptanceFailed cancels inflight"
+        assert_eq!(
+            take_pending_equity_mint_jobs(&trigger).await.len(),
+            1,
+            "Imbalance should re-enqueue a mint job after MintAcceptanceFailed cancels inflight"
         );
     }
 
@@ -6784,7 +6984,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = IssuerRequestId::new("mint-deposit");
+        let id = issuer_request_id("mint-deposit");
 
         // Full happy-path: MintRequested -> MintAccepted -> TokensReceived -> DepositedIntoRaindex
         harness
@@ -6841,7 +7041,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = IssuerRequestId::new("mint-wrapping-fail");
+        let id = issuer_request_id("mint-wrapping-fail");
 
         harness
             .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, float!(30)))
@@ -6887,7 +7087,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = IssuerRequestId::new("mint-deposit-fail");
+        let id = issuer_request_id("mint-deposit-fail");
 
         harness
             .receive::<TokenizedEquityMint>(id.clone(), make_mint_requested(&symbol, float!(30)))
@@ -7328,7 +7528,7 @@ mod tests {
             )
             .unwrap();
 
-        let (reactor, mut receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let id = InventorySnapshotId {
@@ -7338,9 +7538,10 @@ mod tests {
 
         // Verify initial imbalance triggers
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(receiver.try_recv(), Ok(TriggeredOperation::Mint { .. })),
-            "20% ratio should trigger Mint"
+        assert_eq!(
+            take_pending_equity_mint_jobs(&trigger).await.len(),
+            1,
+            "20% ratio should enqueue a mint job"
         );
         trigger.clear_equity_in_progress(&symbol);
 
@@ -7361,8 +7562,9 @@ mod tests {
 
         // After snapshot: 20 onchain, 20 offchain = balanced
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
-        assert!(
-            matches!(receiver.try_recv(), Err(TryRecvError::Empty)),
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
             "50% ratio should be balanced after offchain equity snapshot"
         );
     }
@@ -14188,7 +14390,7 @@ mod tests {
             owner: TEST_ORDER_OWNER,
         };
 
-        let mint_id = IssuerRequestId::new("mint-stale-regression");
+        let mint_id = issuer_request_id("mint-stale-regression");
 
         // MintRequested starts inflight at Hedging venue
         harness
@@ -14574,7 +14776,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("timed-out-mint-recheck");
+        let id = issuer_request_id("timed-out-mint-recheck");
 
         trigger.mint_tracking.write().await.insert(
             id.clone(),
@@ -14640,7 +14842,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("timed-out-mint-late-request");
+        let id = issuer_request_id("timed-out-mint-late-request");
 
         trigger.mint_tracking.write().await.insert(
             id.clone(),
@@ -14700,7 +14902,7 @@ mod tests {
     async fn timed_out_mint_cleanup_clears_active_mint_id() {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
-        let id = IssuerRequestId::new("timed-out-mint-active-id");
+        let id = issuer_request_id("timed-out-mint-active-id");
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(50), shares(50))
             .update_equity(
@@ -14750,7 +14952,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("mint-sync-gate-tombstone");
+        let id = issuer_request_id("mint-sync-gate-tombstone");
         let sync_guard = trigger.mint_event_sync.lock().await;
         let trigger_for_task = Arc::clone(&trigger);
         let task_symbol = symbol.clone();
@@ -15191,7 +15393,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("recovery-timeout-sweep");
+        let id = issuer_request_id("recovery-timeout-sweep");
 
         trigger.mint_tracking.write().await.insert(
             id.clone(),
@@ -15254,7 +15456,7 @@ mod tests {
         let stale_time = Utc::now()
             - ChronoDuration::from_std(TIMEOUT_TOMBSTONE_RETENTION).unwrap()
             - ChronoDuration::seconds(1);
-        let mint_id = IssuerRequestId::new("stale-mint");
+        let mint_id = issuer_request_id("stale-mint");
         let redemption_id = RedemptionAggregateId::new("stale-redemption");
         let usdc_id = UsdcRebalanceId(Uuid::new_v4());
 
@@ -15324,7 +15526,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("mint-active-id");
+        let id = issuer_request_id("mint-active-id");
 
         trigger
             .on_mint(id.clone(), make_mint_requested(&symbol, float!(10)))
@@ -15358,7 +15560,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = IssuerRequestId::new("mint-clear-id");
+        let id = issuer_request_id("mint-clear-id");
 
         trigger
             .on_mint(id.clone(), make_mint_requested(&symbol, float!(10)))
@@ -15548,7 +15750,7 @@ mod tests {
             .with_equity(symbol.clone(), shares(20), shares(80))
             .with_usdc(usdc(1_000_000), usdc(1_000_000));
 
-        let (reactor, mut receiver) =
+        let (reactor, _receiver) =
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
 
@@ -15559,11 +15761,61 @@ mod tests {
         .await
         .unwrap();
 
-        let dispatched = receiver.try_recv().unwrap();
-        let TriggeredOperation::Mint { symbol: minted, .. } = dispatched else {
-            panic!("Expected Mint, got {dispatched:?}");
+        let dispatched = take_pending_equity_mint_jobs(&trigger).await;
+        let [job] = dispatched.as_slice() else {
+            panic!("Expected exactly one mint job, got {dispatched:?}");
         };
-        assert_eq!(minted, symbol);
+        assert_eq!(job.symbol, symbol);
+    }
+
+    /// A crash between `queue.push` and the first persisted mint event leaves
+    /// a pending job row while the in-memory guard resets. The Jobs-table
+    /// dedupe must suppress a second enqueue for the same symbol while
+    /// leaving other symbols free to enqueue.
+    #[tokio::test]
+    async fn equity_mint_enqueue_dedupes_per_symbol_against_jobs_table() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(20), shares(80))
+            .with_usdc(usdc(1_000_000), usdc(1_000_000));
+
+        let (reactor, _receiver) =
+            make_trigger_with_inventory_and_registry(inventory, &symbol).await;
+        let trigger = reactor.clone();
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+        assert_eq!(count_pending_equity_mint_jobs(&trigger).await, 1);
+
+        // Simulate a restart: the in-memory guard resets while the job row
+        // is still pending.
+        trigger.clear_equity_in_progress(&symbol);
+
+        EquityRebalancingCheck {
+            symbol: symbol.clone(),
+        }
+        .perform(&trigger)
+        .await
+        .unwrap();
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            1,
+            "a pending mint row for the symbol must suppress a duplicate enqueue"
+        );
+
+        // A different symbol is not suppressed by AAPL's pending row.
+        let enqueued = trigger
+            .enqueue_transfer_equity_to_market_making(Symbol::new("TSLA").unwrap(), shares(30))
+            .await;
+        assert!(
+            enqueued,
+            "a pending mint row for one symbol must not block other symbols"
+        );
+        assert_eq!(count_pending_equity_mint_jobs(&trigger).await, 2);
     }
 
     #[tokio::test]
@@ -15637,6 +15889,11 @@ mod tests {
         assert!(
             matches!(actual, Err(TryRecvError::Empty)),
             "Balanced inventory should not dispatch a TriggeredOperation, got {actual:?}"
+        );
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "Balanced inventory should not enqueue a mint job"
         );
     }
 

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -1008,6 +1008,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::bindings::TestERC20;
+    use crate::tokenized_equity_mint::issuer_request_id;
     use st0x_float_macro::float;
 
     pub(crate) const TEST_REDEMPTION_WALLET: Address =
@@ -1085,7 +1086,7 @@ pub(crate) mod tests {
             issuer: Issuer::new("st0x"),
             network: Network::new("base"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            issuer_request_id: IssuerRequestId::new("test-issuer-request-id"),
+            issuer_request_id: issuer_request_id("test-issuer-request-id"),
         }
     }
 
@@ -1095,6 +1096,9 @@ pub(crate) mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, key) = setup_anvil();
         let client = create_test_client(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
+
+        let request = create_mint_request();
+        let issuer_id = request.issuer_request_id.to_string();
 
         let mint_mock = server.mock(|when, then| {
             when.method(POST)
@@ -1107,7 +1111,7 @@ pub(crate) mod tests {
                     "issuer": "st0x",
                     "network": "base",
                     "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "issuer_request_id": "test-issuer-request-id"
+                    "issuer_request_id": issuer_id,
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -1121,12 +1125,12 @@ pub(crate) mod tests {
                     "issuer": "st0x",
                     "network": "base",
                     "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "issuer_request_id": "iss_req_456",
+                    "issuer_request_id": issuer_id,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         });
 
-        let request = create_mint_request();
+        let expected_issuer_id = request.issuer_request_id.clone();
         let result = client.request_mint(request).await.unwrap();
 
         assert_eq!(result.id, TokenizationRequestId("tok_req_123".to_string()));
@@ -1138,10 +1142,7 @@ pub(crate) mod tests {
             Some("tAAPL".to_string())
         );
         assert_eq!(result.quantity, FractionalShares::new(float!(100.5)));
-        assert_eq!(
-            result.issuer_request_id,
-            Some(IssuerRequestId("iss_req_456".to_string()))
-        );
+        assert_eq!(result.issuer_request_id, Some(expected_issuer_id));
         assert!(logs_contain(
             "Alpaca tokenization mint response body received"
         ));
@@ -1923,7 +1924,7 @@ pub(crate) mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let mint_result = service
-            .request_mint(symbol, quantity, wallet, IssuerRequestId::new("test-id"))
+            .request_mint(symbol, quantity, wallet, issuer_request_id("test-id"))
             .await
             .unwrap();
 
@@ -2017,7 +2018,8 @@ pub(crate) mod tests {
         let service =
             create_test_service_from_mock(&server, &endpoint, &key, TEST_REDEMPTION_WALLET).await;
 
-        let issuer_request_id = IssuerRequestId::new("our-tracking-id-123");
+        let expected_id = issuer_request_id("our-tracking-id-123");
+        let expected_id_str = expected_id.to_string();
 
         let mint_mock = server.mock(|when, then| {
             when.method(POST)
@@ -2028,7 +2030,7 @@ pub(crate) mod tests {
                     "issuer": "st0x",
                     "network": "base",
                     "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "issuer_request_id": "our-tracking-id-123"
+                    "issuer_request_id": expected_id_str,
                 }));
             then.status(200)
                 .header("content-type", "application/json")
@@ -2042,7 +2044,7 @@ pub(crate) mod tests {
                     "issuer": "st0x",
                     "network": "base",
                     "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "issuer_request_id": "our-tracking-id-123",
+                    "issuer_request_id": expected_id_str,
                     "created_at": "2024-01-15T10:30:00Z"
                 }));
         });
@@ -2052,13 +2054,13 @@ pub(crate) mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let result = service
-            .request_mint(symbol, quantity, wallet, issuer_request_id.clone())
+            .request_mint(symbol, quantity, wallet, expected_id.clone())
             .await
             .unwrap();
 
         assert_eq!(
             result.issuer_request_id,
-            Some(issuer_request_id),
+            Some(expected_id),
             "Alpaca should return the same issuer_request_id we sent"
         );
 

--- a/src/tokenization/mock_api.rs
+++ b/src/tokenization/mock_api.rs
@@ -315,7 +315,7 @@ impl AlpacaTokenizationMock {
 
         state.requests.push(MockTokenizationRequest {
             tokenization_request_id: Uuid::new_v4().to_string(),
-            issuer_request_id: String::new(),
+            issuer_request_id: Uuid::new_v4().to_string(),
             underlying_symbol: symbol.to_string(),
             quantity,
             wallet_address: wallet,
@@ -507,7 +507,7 @@ async fn scan_block_for_redemptions<P: Provider>(
 
             guard.requests.push(MockTokenizationRequest {
                 tokenization_request_id: Uuid::new_v4().to_string(),
-                issuer_request_id: String::new(),
+                issuer_request_id: Uuid::new_v4().to_string(),
                 underlying_symbol: symbol.clone(),
                 quantity,
                 // Use the bot's wallet (order_owner), matching real Alpaca
@@ -611,7 +611,7 @@ fn register_mint_endpoint(server: &MockServer, state: &Arc<Mutex<TokenizationSta
             };
             let issuer_request_id = body["issuer_request_id"]
                 .as_str()
-                .map_or_else(String::new, ToString::to_string);
+                .map_or_else(|| Uuid::new_v4().to_string(), ToString::to_string);
 
             let tokenization_request_id = Uuid::new_v4().to_string();
 

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -44,8 +44,10 @@ use chrono::{DateTime, Utc};
 use rain_math_float::{Float, FloatError};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
+use std::fmt::Display;
 use std::str::FromStr;
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use st0x_dto::{EquityMintOperation, EquityMintStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
@@ -55,28 +57,38 @@ use st0x_finance::Id;
 use crate::rebalancing::equity::EquityTransferServices;
 use crate::tokenization::TokenizationRequestStatus;
 
-/// Alpaca issuer request identifier returned when a tokenization request is accepted.
+/// Our internal tracking id for a tokenized equity mint, chosen at enqueue time.
+///
+/// Mirrors [`crate::usdc_rebalance::UsdcRebalanceId`]: a UUID so invalid ids are
+/// unrepresentable and apalis/CLI retries always target the same aggregate.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub(crate) struct IssuerRequestId(pub(crate) String);
+pub(crate) struct IssuerRequestId(pub(crate) Uuid);
 
 impl IssuerRequestId {
-    pub(crate) fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    pub(crate) fn generate() -> Self {
+        Self(Uuid::new_v4())
     }
 }
 
-impl std::fmt::Display for IssuerRequestId {
+impl Display for IssuerRequestId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 impl FromStr for IssuerRequestId {
-    type Err = std::convert::Infallible;
+    type Err = uuid::Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(value.to_string()))
+        Ok(Self(Uuid::parse_str(value)?))
     }
+}
+
+/// Deterministic issuer request id for tests. Maps a human-readable label to a
+/// UUID v5 so test aggregate ids stay valid [`IssuerRequestId`] values.
+#[cfg(test)]
+pub(crate) fn issuer_request_id(label: &str) -> IssuerRequestId {
+    IssuerRequestId(Uuid::new_v5(&Uuid::NAMESPACE_OID, label.as_bytes()))
 }
 
 /// Alpaca tokenization request identifier used to track the mint operation through their API.
@@ -1084,7 +1096,7 @@ impl TokenizedEquityMint {
                 requested_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Minting,
@@ -1099,7 +1111,7 @@ impl TokenizedEquityMint {
                 accepted_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Minting,
@@ -1121,7 +1133,7 @@ impl TokenizedEquityMint {
                 received_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Wrapping,
@@ -1143,7 +1155,7 @@ impl TokenizedEquityMint {
                 wrapped_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Depositing,
@@ -1158,7 +1170,7 @@ impl TokenizedEquityMint {
                 deposited_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Completed {
@@ -1175,7 +1187,7 @@ impl TokenizedEquityMint {
                 failed_at,
                 ..
             } => TransferOperation::EquityMint(EquityMintOperation {
-                id: Id::new(issuer_request_id.clone()),
+                id: Id::new(issuer_request_id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: Failed {
@@ -1219,7 +1231,12 @@ pub(crate) async fn interrupted_mint_ids(
     .fetch_all(pool)
     .await?;
 
-    Ok(rows.into_iter().map(IssuerRequestId::new).collect())
+    rows.into_iter()
+        .map(|row| {
+            row.parse()
+                .map_err(|error| sqlx::Error::Decode(Box::new(error)))
+        })
+        .collect::<Result<Vec<_>, _>>()
 }
 
 /// Our tokenized equity tokens use 18 decimals.
@@ -1993,7 +2010,7 @@ mod tests {
 
     fn mint_command() -> TokenizedEquityMintCommand {
         TokenizedEquityMintCommand::RequestMint {
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(10),
             wallet: Address::ZERO,
@@ -2011,7 +2028,7 @@ mod tests {
 
     fn mint_accepted_event() -> TokenizedEquityMintEvent {
         TokenizedEquityMintEvent::MintAccepted {
-            issuer_request_id: IssuerRequestId("ISS123".to_string()),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             accepted_at: Utc::now(),
         }
@@ -2069,6 +2086,12 @@ mod tests {
         )
     }
 
+    fn mint_accepted_payload(id: &IssuerRequestId) -> String {
+        format!(
+            r#"{{"MintAccepted":{{"issuer_request_id":"{id}","tokenization_request_id":"TOK001","accepted_at":"2026-01-01T00:00:00Z"}}}}"#
+        )
+    }
+
     #[tokio::test]
     async fn initialize_emits_requested_and_accepted() {
         let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
@@ -2087,7 +2110,7 @@ mod tests {
             matches!(
                 &events[1],
                 TokenizedEquityMintEvent::MintAccepted { issuer_request_id, .. }
-                    if *issuer_request_id == IssuerRequestId::new("ISS001")
+                    if *issuer_request_id == super::issuer_request_id("ISS001")
             ),
             "Expected MintAccepted with ISS001, got: {:?}",
             events[1]
@@ -2098,7 +2121,7 @@ mod tests {
     async fn poll_after_acceptance_emits_tokens_received() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
 
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
         store
             .send(&id, TokenizedEquityMintCommand::Poll)
@@ -2118,7 +2141,7 @@ mod tests {
         let tokenizer = MockTokenizer::new().with_fees(expected_fees);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
 
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
         store.send(&id, mint_command()).await.unwrap();
         store
             .send(&id, TokenizedEquityMintCommand::Poll)
@@ -2143,7 +2166,7 @@ mod tests {
     async fn poll_completed_with_wrong_token_symbol_errors() {
         let tokenizer = MockTokenizer::new().with_token_symbol_override("tGME");
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         let error = store
@@ -2176,7 +2199,7 @@ mod tests {
     async fn poll_completed_with_missing_token_symbol_errors() {
         let tokenizer = MockTokenizer::new().with_no_token_symbol();
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         let error = store
@@ -2207,7 +2230,7 @@ mod tests {
     async fn poll_rejected_emits_acceptance_failed() {
         let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Rejected);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -2227,7 +2250,7 @@ mod tests {
         let deposited = TokenizedEquityMint::DepositedIntoRaindex {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(100.5),
-            issuer_request_id: IssuerRequestId("ISS123".to_string()),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             token_tx_hash: TxHash::random(),
             wrap_tx_hash: TxHash::random(),
@@ -2237,7 +2260,7 @@ mod tests {
         };
 
         let event = TokenizedEquityMintEvent::MintAccepted {
-            issuer_request_id: IssuerRequestId("ISS999".to_string()),
+            issuer_request_id: issuer_request_id("ISS999"),
             tokenization_request_id: TokenizationRequestId("TOK999".to_string()),
             accepted_at: Utc::now(),
         };
@@ -2272,7 +2295,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(100.5),
             wallet: Address::random(),
-            issuer_request_id: IssuerRequestId("ISS123".to_string()),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
@@ -2331,7 +2354,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(100.5),
             wallet: Address::random(),
-            issuer_request_id: IssuerRequestId("ISS123".to_string()),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
@@ -2380,7 +2403,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(100.5),
             wallet: Address::random(),
-            issuer_request_id: IssuerRequestId("ISS123".to_string()),
+            issuer_request_id: issuer_request_id("ISS123"),
             tokenization_request_id: TokenizationRequestId("TOK456".to_string()),
             requested_at: Utc::now(),
             accepted_at: Utc::now(),
@@ -2401,7 +2424,7 @@ mod tests {
         let tokenizer =
             MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::Rejected);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
 
@@ -2417,7 +2440,7 @@ mod tests {
         let tokenizer =
             MockTokenizer::new().with_mint_request_outcome(MockMintRequestOutcome::ApiError);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         let error = store.send(&id, mint_command()).await.unwrap_err();
         assert!(
@@ -2435,7 +2458,7 @@ mod tests {
     async fn poll_pending_emits_acceptance_failed() {
         let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::Pending);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -2454,7 +2477,7 @@ mod tests {
     async fn poll_error_emits_acceptance_failed() {
         let tokenizer = MockTokenizer::new().with_mint_poll_outcome(MockMintPollOutcome::PollError);
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(tokenizer));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -2478,12 +2501,12 @@ mod tests {
             vault_lookup: Arc::new(mock_vault_lookup()),
             wrapper: Arc::new(MockWrapper::new()),
         });
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
 
         let recorded_id = tokenizer.last_issuer_request_id().unwrap();
-        assert_eq!(recorded_id, IssuerRequestId::new("ISS001"));
+        assert_eq!(recorded_id, issuer_request_id("ISS001"));
     }
 
     #[test]
@@ -2515,7 +2538,7 @@ mod tests {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(10),
             wallet: Address::random(),
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             tokenization_request_id: TokenizationRequestId("REQ001".to_string()),
             tx_hash: TxHash::random(),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
@@ -2544,7 +2567,7 @@ mod tests {
     #[tokio::test]
     async fn wrap_tokens_is_pure_state_transition() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -2572,7 +2595,7 @@ mod tests {
     #[tokio::test]
     async fn deposit_to_vault_is_pure_state_transition() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -2610,9 +2633,12 @@ mod tests {
     async fn interrupted_mint_ids_returns_only_non_terminal_mints() {
         let pool = crate::test_utils::setup_test_db().await;
 
+        let mint_accepted_id = issuer_request_id("mint-accepted");
+        let mint_deposited_id = issuer_request_id("mint-deposited");
+
         insert_event(
             &pool,
-            "mint-accepted",
+            &mint_accepted_id.to_string(),
             0,
             "TokenizedEquityMintEvent::MintRequested",
             &mint_requested_payload("AAPL"),
@@ -2620,16 +2646,16 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "mint-accepted",
+            &mint_accepted_id.to_string(),
             1,
             "TokenizedEquityMintEvent::MintAccepted",
-            r#"{"MintAccepted":{"issuer_request_id":"ISS001","tokenization_request_id":"TOK001","accepted_at":"2026-01-01T00:00:00Z"}}"#,
+            &mint_accepted_payload(&mint_accepted_id),
         )
         .await;
 
         insert_event(
             &pool,
-            "mint-deposited",
+            &mint_deposited_id.to_string(),
             0,
             "TokenizedEquityMintEvent::MintRequested",
             &mint_requested_payload("TSLA"),
@@ -2637,7 +2663,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "mint-deposited",
+            &mint_deposited_id.to_string(),
             1,
             "TokenizedEquityMintEvent::DepositedIntoRaindex",
             r#"{"DepositedIntoRaindex":{"vault_deposit_tx_hash":"0x0000000000000000000000000000000000000000000000000000000000000002","deposited_at":"2026-01-01T00:00:00Z"}}"#,
@@ -2645,7 +2671,7 @@ mod tests {
         .await;
 
         let result = interrupted_mint_ids(&pool).await.unwrap();
-        assert_eq!(result, vec![IssuerRequestId::new("mint-accepted")]);
+        assert_eq!(result, vec![mint_accepted_id]);
     }
 
     #[test]
@@ -2678,7 +2704,7 @@ mod tests {
 
     #[test]
     fn to_dto_maps_in_progress_variants() {
-        let id = IssuerRequestId::new("MINT-001");
+        let id = issuer_request_id("MINT-001");
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
         let later = now + chrono::Duration::seconds(60);
@@ -2693,7 +2719,7 @@ mod tests {
         let TransferOperation::EquityMint(op) = dto else {
             panic!("Expected EquityMint, got: {dto:?}");
         };
-        assert_eq!(op.id, Id::new("MINT-001"));
+        assert_eq!(op.id, Id::new(id.to_string()));
         assert_eq!(op.symbol, symbol);
         assert_eq!(op.quantity, FractionalShares::new(float!(10)));
         assert!(
@@ -2708,7 +2734,7 @@ mod tests {
             symbol: symbol.clone(),
             quantity: float!(10),
             wallet: Address::ZERO,
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             requested_at: now,
             accepted_at: later,
@@ -2728,7 +2754,7 @@ mod tests {
             symbol: symbol.clone(),
             quantity: float!(10),
             wallet: Address::ZERO,
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::random(),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
@@ -2752,7 +2778,7 @@ mod tests {
             symbol,
             quantity: float!(10),
             wallet: Address::ZERO,
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::random(),
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
@@ -2777,7 +2803,7 @@ mod tests {
 
     #[test]
     fn to_dto_maps_terminal_variants() {
-        let id = IssuerRequestId::new("MINT-001");
+        let id = issuer_request_id("MINT-001");
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
         let later = now + chrono::Duration::seconds(60);
@@ -2785,7 +2811,7 @@ mod tests {
         let deposited = TokenizedEquityMint::DepositedIntoRaindex {
             symbol: symbol.clone(),
             quantity: float!(10),
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             token_tx_hash: TxHash::random(),
             wrap_tx_hash: TxHash::random(),
@@ -2839,7 +2865,7 @@ mod tests {
         };
 
         let recovered = TokenizedEquityMintEvent::ProviderCompletionRecovered {
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             wallet: Address::ZERO,
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::ZERO,
@@ -2876,7 +2902,7 @@ mod tests {
         // table. Assert the decimal-string form (independent of the type under
         // test) and a clean round-trip.
         let event = TokenizedEquityMintEvent::ProviderCompletionRecovered {
-            issuer_request_id: IssuerRequestId::new("ISS001"),
+            issuer_request_id: issuer_request_id("ISS001"),
             wallet: Address::ZERO,
             tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
             tx_hash: TxHash::ZERO,
@@ -2904,7 +2930,7 @@ mod tests {
         let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
             .given(vec![mint_requested_event()])
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
-                issuer_request_id: IssuerRequestId::new("ISS001"),
+                issuer_request_id: issuer_request_id("ISS001"),
                 wallet: Address::ZERO,
                 tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
                 tx_hash: TxHash::ZERO,
@@ -2933,7 +2959,7 @@ mod tests {
                 vault_deposited_event(),
             ])
             .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
-                issuer_request_id: IssuerRequestId::new("ISS001"),
+                issuer_request_id: issuer_request_id("ISS001"),
                 wallet: Address::ZERO,
                 tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
                 tx_hash: TxHash::ZERO,
@@ -2954,7 +2980,7 @@ mod tests {
     #[tokio::test]
     async fn fail_acceptance_from_accepted_transitions_to_failed() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
 
@@ -2978,7 +3004,7 @@ mod tests {
     #[tokio::test]
     async fn fail_wrapping_from_tokens_received_transitions_to_failed() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -3006,7 +3032,7 @@ mod tests {
     #[tokio::test]
     async fn fail_raindex_deposit_from_tokens_wrapped_transitions_to_failed() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store
@@ -3044,7 +3070,7 @@ mod tests {
     #[tokio::test]
     async fn fail_wrapping_rejected_from_wrong_state() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         // MintAccepted state -- FailWrapping requires TokensReceived
         store.send(&id, mint_command()).await.unwrap();
@@ -3067,7 +3093,7 @@ mod tests {
     #[tokio::test]
     async fn fail_acceptance_rejected_from_terminal_state() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
-        let id = IssuerRequestId::new("ISS001");
+        let id = issuer_request_id("ISS001");
 
         store.send(&id, mint_command()).await.unwrap();
         store

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -819,6 +819,7 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
+    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::vault_lookup::{MockVaultLookup, VaultLookup};
 
     use super::*;
@@ -1490,7 +1491,7 @@ mod tests {
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::DispatchToMint {
-                    mint_id: IssuerRequestId::new("ISS-NONEXISTENT"),
+                    mint_id: issuer_request_id("ISS-NONEXISTENT"),
                 },
                 &services,
             )

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -682,7 +682,9 @@ mod tests {
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::tokenization::Tokenizer;
     use crate::tokenization::mock::{MockCompletionOutcome, MockDetectionOutcome, MockTokenizer};
-    use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintCommand};
+    use crate::tokenized_equity_mint::{
+        TokenizedEquityMint, TokenizedEquityMintCommand, issuer_request_id,
+    };
     use crate::vault_lookup::MockVaultLookup;
 
     use super::super::aggregate::UnwrappedEquityRecoveryServices;
@@ -860,7 +862,7 @@ mod tests {
     #[tokio::test]
     async fn resume_from_detected_validates_active_aggregate_quantity() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("missing-mint");
+        let mint_id = issuer_request_id("missing-mint");
 
         let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
@@ -1006,7 +1008,7 @@ mod tests {
     #[test]
     fn decide_dispatch_resolves_all_four_paths() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("ISS001");
+        let mint_id = issuer_request_id("ISS001");
         let redemption_id = RedemptionAggregateId("RED001".to_string());
 
         assert!(
@@ -1117,7 +1119,7 @@ mod tests {
     #[tokio::test]
     async fn validate_active_mint_quantity_accepts_exact_match() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("ISS001");
+        let mint_id = issuer_request_id("ISS001");
         let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
 
         ctx.mint_store
@@ -1145,7 +1147,7 @@ mod tests {
     #[tokio::test]
     async fn validate_active_mint_quantity_rejects_mismatch() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("ISS001");
+        let mint_id = issuer_request_id("ISS001");
         let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
 
         ctx.mint_store
@@ -1229,7 +1231,7 @@ mod tests {
     #[tokio::test]
     async fn perform_fresh_active_validation_failure_is_retryable_error() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("missing-mint");
+        let mint_id = issuer_request_id("missing-mint");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id);
         let ctx = test_ctx(view, HashSet::new()).await;
@@ -1332,7 +1334,7 @@ mod tests {
     #[tokio::test]
     async fn perform_conflict_fails_recovery_without_retrying() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("ISS001");
+        let mint_id = issuer_request_id("ISS001");
         let redemption_id = RedemptionAggregateId("RED001".to_string());
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id.clone())
@@ -1480,7 +1482,7 @@ mod tests {
     #[tokio::test]
     async fn perform_drives_active_mint_path_to_dispatched_to_mint() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let mint_id = IssuerRequestId::new("ISS001");
+        let mint_id = issuer_request_id("ISS001");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id.clone());
         let ctx = test_ctx(view, HashSet::new()).await;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -586,6 +586,7 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
+    use crate::tokenized_equity_mint::issuer_request_id;
     use crate::vault_lookup::MockVaultLookup;
 
     use super::*;
@@ -757,7 +758,7 @@ mod tests {
     async fn dispatch_to_mint_records_failure_when_resume_mint_fails() {
         let services = test_services().await;
         let detected = detected_state();
-        let mint_id = IssuerRequestId::new("ISS-NONEXISTENT");
+        let mint_id = issuer_request_id("ISS-NONEXISTENT");
 
         let events = detected
             .transition(

--- a/tests/e2e/rebalancing/mod.rs
+++ b/tests/e2e/rebalancing/mod.rs
@@ -41,6 +41,10 @@ use st0x_hedge::cli::seed_mint_at_tokens_wrapped_for_test;
 use self::assertions::*;
 use crate::assert::{StoredEvent, assert_single_clean_aggregate};
 
+fn issuer_request_id(label: &str) -> String {
+    uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, label.as_bytes()).to_string()
+}
+
 fn aggregate_id_for_event(events: &[crate::assert::StoredEvent], event_type: &str) -> String {
     events
         .iter()
@@ -2627,9 +2631,11 @@ async fn active_mint_in_tokens_wrapped_recovers_into_raindex_vault() -> anyhow::
 
     sqlx::migrate!("./migrations").run(&pool).await?;
 
+    let recovery_mint_id = issuer_request_id("ISS-RECOVERY-E2E");
+
     seed_mint_at_tokens_wrapped_for_test(
         &pool,
-        "ISS-RECOVERY-E2E",
+        &recovery_mint_id,
         "AAPL",
         infra.base_chain.owner,
         TxHash::random(),
@@ -2717,7 +2723,7 @@ async fn active_mint_in_tokens_wrapped_recovers_into_raindex_vault() -> anyhow::
 
     let seeded_mint_events: Vec<StoredEvent> = mint_events
         .into_iter()
-        .filter(|event| event.aggregate_id == "ISS-RECOVERY-E2E")
+        .filter(|event| event.aggregate_id == recovery_mint_id)
         .collect();
 
     assert_event_subsequence(


### PR DESCRIPTION
## What

Closes RAI-391. Converts the tokenized equity mint (hedging -> market-making) from a one-off `tokio::spawn` driven by the `Rebalancer` mpsc channel into a persisted, retryable `TransferEquityToMarketMaking` apalis job.

## Why

The `TokenizedEquityMint` aggregate already persists step-by-step state and `resume_mint` exists, but resumption only fired at startup recovery. A bot running continuously through mint failures had no way to resume them until the next restart, and a crash between trigger and transfer orphaned the operation entirely.

## How

- New `TransferEquityToMarketMaking` job (`src/rebalancing/equity/job.rs`), keyed by an `IssuerRequestId` generated at enqueue time so apalis retries and restarts re-enter the same aggregate (and Alpaca deduplicates by the same id).
- `CrossVenueEquityTransfer::resume_equity_to_market_making` is the single entry point: absent aggregate starts a fresh mint, in-flight one resumes from its persisted state, terminal one is a no-op — mirroring the USDC transfer jobs.
- `check_and_trigger_equity` enqueues the job directly instead of sending `TriggeredOperation::Mint` over the mpsc channel, with a per-symbol Jobs-table dedupe gate (the in-memory guard resets on restart).
- Conductor registers the worker (rebalancing-gated, like the USDC transfer workers) and re-queues orphaned rows at startup.
- The `CrossVenueTransfer<HedgingVenue, MarketMakingVenue>` impl and `Rebalancer::execute_mint` routing are removed; redemption still flows through the channel until RAI-392.

## Testing

- Job unit tests: perform forwards payload to the transfer, propagates failures for apalis retry, payload JSON roundtrip.
- Dispatch tests: fresh id runs the full mint flow; existing aggregate resumes (crash simulation); completed aggregate is a clean no-op.
- Trigger tests: imbalance enqueues the job (not mpsc), per-symbol Jobs-table dedupe with cross-symbol independence, inflight/balanced suppression.
- Integration tests reworked to drive the enqueued job through `perform` against the real transfer (full lifecycle on Anvil + httpmock).
- `cargo nextest run -p st0x-hedge --lib`: 1547 passed. Clippy and fmt clean.

## Anything else

RAI-392 (redemption conversion) stacks on this; once it lands, the `Rebalancer`, the mpsc channel, and the `CrossVenueTransfer` trait can be removed entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CLI flag to supply a mint request id for equity transfers.

* **Refactor**
  * Equity mint transfers now flow through a dedicated asynchronous job queue (with enqueue dedupe and crash-safe recovery) instead of immediate channel dispatch, improving resilience, restart recovery, and visibility into pending jobs.

* **Bug Fixes**
  * Prevent duplicate mint enqueues across restarts and improve mint-recovery handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->