### PR TITLE
refactor: convert tokenized equity redemption to TransferEquityToHedging apalis job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,9 +346,15 @@ convention -- new generated paths should not extend that list.
   you want to understand CLI commands or configuration options, read the code.
   If you want to test functionality, write proper tests. There is never a reason
   to run the application speculatively.
-- When handling clippy errors about function lengths or cognitive complexity,
-  don't split up the functions more than necessary to get below the limit.
-  Instead ask the user if we can add a clippy allow for that error.
+- When clippy flags function length (`too_many_lines`) or cognitive complexity,
+  treat suppression as the LAST resort and work the options in order first: (1)
+  extract a genuine logical chunk -- a cohesive multi-step unit, never a
+  one-liner helper; (2) if a repeated pattern is driving the blowout, factor the
+  repetition out; (3) if it is irreducible boilerplate, consider a custom macro.
+  Only when none of these can bring the function under the threshold without
+  making the code worse may an allow be considered -- and adding any
+  `#[allow(...)]` requires EXPLICIT user permission first (per the Quality
+  Control Policy). Precedent elsewhere in the codebase is NOT permission.
 
 ### Push policy
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -63,7 +63,8 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{
-    CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToMarketMakingCtx,
+    CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToHedgingCtx,
+    TransferEquityToMarketMakingCtx,
 };
 use crate::rebalancing::usdc::{
     TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
@@ -194,6 +195,7 @@ async fn requeue_wired_transfer_orphans(
     usdc_to_hedging_ctx: Option<&Arc<TransferUsdcToHedgingCtx>>,
     usdc_to_market_making_ctx: Option<&Arc<TransferUsdcToMarketMakingCtx>>,
     equity_to_market_making_ctx: Option<&Arc<TransferEquityToMarketMakingCtx>>,
+    equity_to_hedging_ctx: Option<&Arc<TransferEquityToHedgingCtx>>,
 ) -> anyhow::Result<()> {
     if usdc_to_hedging_ctx.is_some() {
         requeue_transfer_orphans(&schedulers.transfer_usdc_to_hedging, "Base->Alpaca").await?;
@@ -208,6 +210,14 @@ async fn requeue_wired_transfer_orphans(
         requeue_transfer_orphans(
             &schedulers.transfer_equity_to_market_making,
             "equity hedging->market-making",
+        )
+        .await?;
+    }
+
+    if equity_to_hedging_ctx.is_some() {
+        requeue_transfer_orphans(
+            &schedulers.transfer_equity_to_hedging,
+            "equity market-making->hedging",
         )
         .await?;
     }
@@ -408,6 +418,7 @@ impl Conductor {
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_ctx,
+            transfer_equity_to_hedging_ctx,
         } = PositionAndRebalancing::setup(
             rebalancing,
             &ctx,
@@ -426,6 +437,7 @@ impl Conductor {
             transfer_usdc_to_hedging_ctx.as_ref(),
             transfer_usdc_to_market_making_ctx.as_ref(),
             transfer_equity_to_market_making_ctx.as_ref(),
+            transfer_equity_to_hedging_ctx.as_ref(),
         )
         .await?;
 
@@ -552,6 +564,8 @@ impl Conductor {
             .maybe_transfer_usdc_to_market_making_ctx(transfer_usdc_to_market_making_ctx)
             .transfer_equity_to_market_making_queue(schedulers.transfer_equity_to_market_making)
             .maybe_transfer_equity_to_market_making_ctx(transfer_equity_to_market_making_ctx)
+            .transfer_equity_to_hedging_queue(schedulers.transfer_equity_to_hedging)
+            .maybe_transfer_equity_to_hedging_ctx(transfer_equity_to_hedging_ctx)
             .maybe_rebalancing_service(rebalancing_service)
             .seed_vault_registry_queue(seed_vault_registry_queue)
             .seed_vault_registry_ctx(seed_vault_registry_ctx)
@@ -939,6 +953,7 @@ struct RebalancingInfrastructure {
     transfer_usdc_to_hedging_ctx: Arc<TransferUsdcToHedgingCtx>,
     transfer_usdc_to_market_making_ctx: Arc<TransferUsdcToMarketMakingCtx>,
     transfer_equity_to_market_making_ctx: Arc<TransferEquityToMarketMakingCtx>,
+    transfer_equity_to_hedging_ctx: Arc<TransferEquityToHedgingCtx>,
 }
 
 /// Shared infrastructure dependencies needed to spawn rebalancing.
@@ -974,6 +989,7 @@ struct PositionAndRebalancing {
     transfer_usdc_to_hedging_ctx: Option<Arc<TransferUsdcToHedgingCtx>>,
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
+    transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
 }
 
 impl PositionAndRebalancing {
@@ -1035,6 +1051,7 @@ impl PositionAndRebalancing {
                 transfer_equity_to_market_making_ctx: Some(
                     infra.transfer_equity_to_market_making_ctx,
                 ),
+                transfer_equity_to_hedging_ctx: Some(infra.transfer_equity_to_hedging_ctx),
             })
         } else {
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -1065,6 +1082,7 @@ impl PositionAndRebalancing {
                 transfer_usdc_to_hedging_ctx: None,
                 transfer_usdc_to_market_making_ctx: None,
                 transfer_equity_to_market_making_ctx: None,
+                transfer_equity_to_hedging_ctx: None,
             })
         }
     }
@@ -1295,6 +1313,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer: recovery_transfer.clone(),
         });
 
+        let transfer_equity_to_hedging_ctx = Arc::new(TransferEquityToHedgingCtx {
+            transfer: recovery_transfer.clone(),
+        });
+
         Ok(RebalancingInfrastructure {
             position: built.position,
             position_projection: built.position_projection,
@@ -1311,6 +1333,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer_usdc_to_hedging_ctx,
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_ctx,
+            transfer_equity_to_hedging_ctx,
         })
     })
 }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -231,12 +231,14 @@ async fn requeue_startup_orphans(
     usdc_to_hedging_ctx: Option<&Arc<TransferUsdcToHedgingCtx>>,
     usdc_to_market_making_ctx: Option<&Arc<TransferUsdcToMarketMakingCtx>>,
     equity_to_market_making_ctx: Option<&Arc<TransferEquityToMarketMakingCtx>>,
+    equity_to_hedging_ctx: Option<&Arc<TransferEquityToHedgingCtx>>,
 ) -> anyhow::Result<()> {
     requeue_wired_transfer_orphans(
         schedulers,
         usdc_to_hedging_ctx,
         usdc_to_market_making_ctx,
         equity_to_market_making_ctx,
+        equity_to_hedging_ctx,
     )
     .await?;
     requeue_backfill_orphans(backfill_queue).await
@@ -1209,26 +1211,16 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         // Built outside `QueryManifest` because the recovery aggregate's
         // services include `recovery_transfer`, which depends on the
         // mint/redemption stores produced by the manifest above.
-        let wrapped_equity_recovery_store =
-            StoreBuilder::<WrappedEquityRecovery>::new(deps.pool.clone())
-                .build(WrappedEquityRecoveryServices {
-                    raindex: raindex_service.clone(),
-                    vault_lookup: vault_lookup.clone(),
-                    wrapper: wrapper.clone(),
-                    transfer: recovery_transfer.clone(),
-                })
-                .await?;
-
-        let unwrapped_equity_recovery_store =
-            StoreBuilder::<UnwrappedEquityRecovery>::new(deps.pool.clone())
-                .build(UnwrappedEquityRecoveryServices {
-                    raindex: raindex_service.clone(),
-                    vault_lookup: vault_lookup.clone(),
-                    wrapper: wrapper.clone(),
-                    transfer: recovery_transfer.clone(),
-                    wallet: base_wallet.address(),
-                })
-                .await?;
+        let (wrapped_equity_recovery_store, unwrapped_equity_recovery_store) =
+            build_equity_recovery_stores(
+                &deps.pool,
+                raindex_service.clone(),
+                vault_lookup.clone(),
+                wrapper.clone(),
+                recovery_transfer.clone(),
+                base_wallet.address(),
+            )
+            .await?;
 
         recover_interrupted_tokenization_aggregates(
             &deps.pool,
@@ -1336,6 +1328,45 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             transfer_equity_to_hedging_ctx,
         })
     })
+}
+
+/// Builds the wrapped and unwrapped equity-recovery aggregate stores.
+///
+/// Both share the recovery `transfer` and the raindex/vault/wrapper
+/// dependencies; the unwrapped store additionally needs the base `wallet`
+/// address to settle unwraps. Kept together because they are the recovery
+/// counterpart built from the same `recovery_transfer`.
+async fn build_equity_recovery_stores<Chain: Wallet + Clone>(
+    pool: &SqlitePool,
+    raindex: Arc<RaindexService<Chain>>,
+    vault_lookup: Arc<dyn VaultLookup>,
+    wrapper: Arc<WrapperService<Chain>>,
+    transfer: Arc<CrossVenueEquityTransfer>,
+    wallet: Address,
+) -> anyhow::Result<(
+    Arc<Store<WrappedEquityRecovery>>,
+    Arc<Store<UnwrappedEquityRecovery>>,
+)> {
+    let wrapped_store = StoreBuilder::<WrappedEquityRecovery>::new(pool.clone())
+        .build(WrappedEquityRecoveryServices {
+            raindex: raindex.clone(),
+            vault_lookup: vault_lookup.clone(),
+            wrapper: wrapper.clone(),
+            transfer: transfer.clone(),
+        })
+        .await?;
+
+    let unwrapped_store = StoreBuilder::<UnwrappedEquityRecovery>::new(pool.clone())
+        .build(UnwrappedEquityRecoveryServices {
+            raindex,
+            vault_lookup,
+            wrapper,
+            transfer,
+            wallet,
+        })
+        .await?;
+
+    Ok((wrapped_store, unwrapped_store))
 }
 
 /// Recovers inflight state from event history at startup.

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -44,6 +44,7 @@ use crate::onchain_trade::OnChainTrade;
 use crate::position::Position;
 use crate::position_check::{CheckPositions, CheckPositionsCtx, CheckPositionsJobQueue};
 use crate::rebalancing::equity::{
+    TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobQueue,
 };
@@ -120,6 +121,8 @@ pub(crate) fn spawn<Prov, Exec>(
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_equity_to_market_making_queue: TransferEquityToMarketMakingJobQueue,
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
+    transfer_equity_to_hedging_queue: TransferEquityToHedgingJobQueue,
+    transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     rebalancing_service: Option<Arc<RebalancingService>>,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     seed_vault_registry_ctx: Arc<SeedVaultRegistryCtx>,
@@ -352,6 +355,8 @@ where
         transfer_usdc_to_market_making_ctx,
         transfer_equity_to_market_making_queue,
         transfer_equity_to_market_making_ctx,
+        transfer_equity_to_hedging_queue,
+        transfer_equity_to_hedging_ctx,
         apalis_shutdown_token,
         seed_vault_registry_queue,
         #[cfg(any(test, feature = "test-support"))]
@@ -408,6 +413,8 @@ where
     transfer_usdc_to_market_making_ctx: Option<Arc<TransferUsdcToMarketMakingCtx>>,
     transfer_equity_to_market_making_queue: TransferEquityToMarketMakingJobQueue,
     transfer_equity_to_market_making_ctx: Option<Arc<TransferEquityToMarketMakingCtx>>,
+    transfer_equity_to_hedging_queue: TransferEquityToHedgingJobQueue,
+    transfer_equity_to_hedging_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
     apalis_shutdown_token: CancellationToken,
     seed_vault_registry_queue: SeedVaultRegistryJobQueue,
     #[cfg(any(test, feature = "test-support"))]
@@ -451,6 +458,8 @@ where
             transfer_usdc_to_market_making_ctx,
             transfer_equity_to_market_making_queue,
             transfer_equity_to_market_making_ctx,
+            transfer_equity_to_hedging_queue,
+            transfer_equity_to_hedging_ctx,
             apalis_shutdown_token,
             seed_vault_registry_queue,
             #[cfg(any(test, feature = "test-support"))]
@@ -485,6 +494,8 @@ where
         let failure_injector_for_transfer_usdc_to_market_making = failure_injector.clone();
         #[cfg(any(test, feature = "test-support"))]
         let failure_injector_for_transfer_equity_to_market_making = failure_injector.clone();
+        #[cfg(any(test, feature = "test-support"))]
+        let failure_injector_for_transfer_equity_to_hedging = failure_injector.clone();
         let failure_notify = Arc::new(tokio::sync::Notify::new());
         let failure_notify_for_hedge = failure_notify.clone();
         let failure_notify_for_backfill = failure_notify.clone();
@@ -500,6 +511,7 @@ where
         let failure_notify_for_transfer_usdc_to_hedging = failure_notify.clone();
         let failure_notify_for_transfer_usdc_to_market_making = failure_notify.clone();
         let failure_notify_for_transfer_equity_to_market_making = failure_notify.clone();
+        let failure_notify_for_transfer_equity_to_hedging = failure_notify.clone();
         let failure_notify_for_select = failure_notify.clone();
 
         let fail_stop = CircuitBreakerConfig::default()
@@ -519,6 +531,7 @@ where
         let fail_stop_for_transfer_usdc_to_hedging = fail_stop.clone();
         let fail_stop_for_transfer_usdc_to_market_making = fail_stop.clone();
         let fail_stop_for_transfer_equity_to_market_making = fail_stop.clone();
+        let fail_stop_for_transfer_equity_to_hedging = fail_stop.clone();
 
         let accountant_ctx_for_backfill = accountant_ctx.clone();
 
@@ -704,6 +717,16 @@ where
                 failure_notify_for_transfer_equity_to_market_making,
                 #[cfg(any(test, feature = "test-support"))]
                 failure_injector_for_transfer_equity_to_market_making,
+            );
+
+            let apalis_monitor = register_transfer_equity_to_hedging_worker(
+                apalis_monitor,
+                transfer_equity_to_hedging_ctx,
+                transfer_equity_to_hedging_queue,
+                fail_stop_for_transfer_equity_to_hedging,
+                failure_notify_for_transfer_equity_to_hedging,
+                #[cfg(any(test, feature = "test-support"))]
+                failure_injector_for_transfer_equity_to_hedging,
             );
 
             let is_draining = apalis_shutdown_token.clone();
@@ -932,6 +955,38 @@ fn register_transfer_equity_to_market_making_worker(
     monitor.register(move |index| {
         build_supervised_worker!(
             ::<TransferEquityToMarketMakingCtx, TransferEquityToMarketMaking>,
+            index,
+            transfer_queue.clone(),
+            transfer_ctx.clone(),
+            fail_stop.clone(),
+            failure_notify.clone(),
+            #[cfg(any(test, feature = "test-support"))]
+            failure_injector.clone(),
+        )
+    })
+}
+
+/// Sibling of [`register_transfer_equity_to_market_making_worker`] for the
+/// redemption (market-making -> hedging) direction.
+fn register_transfer_equity_to_hedging_worker(
+    monitor: Monitor,
+    transfer_ctx: Option<Arc<TransferEquityToHedgingCtx>>,
+    transfer_queue: TransferEquityToHedgingJobQueue,
+    fail_stop: CircuitBreakerConfig,
+    failure_notify: Arc<tokio::sync::Notify>,
+    #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
+) -> Monitor {
+    let Some(transfer_ctx) = transfer_ctx else {
+        warn!(
+            "TransferEquityToHedging worker not registered: rebalancing disabled \
+             (no transfer ctx). Equity redemptions will not be processed."
+        );
+        return monitor;
+    };
+
+    monitor.register(move |index| {
+        build_supervised_worker!(
+            ::<TransferEquityToHedgingCtx, TransferEquityToHedging>,
             index,
             transfer_queue.clone(),
             transfer_ctx.clone(),

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -367,6 +367,7 @@ pub enum JobKind {
     TransferUsdcToHedging,
     TransferUsdcToMarketMaking,
     TransferEquityToMarketMaking,
+    TransferEquityToHedging,
 }
 
 /// Job execution error. Wraps the concrete `Job::Error` type at
@@ -406,6 +407,7 @@ pub struct FailureInjector {
     transfer_usdc_to_hedging: Arc<Mutex<InjectionState>>,
     transfer_usdc_to_market_making: Arc<Mutex<InjectionState>>,
     transfer_equity_to_market_making: Arc<Mutex<InjectionState>>,
+    transfer_equity_to_hedging: Arc<Mutex<InjectionState>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -443,6 +445,7 @@ impl FailureInjector {
             transfer_usdc_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_usdc_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
             transfer_equity_to_market_making: Arc::new(Mutex::new(InjectionState::Idle)),
+            transfer_equity_to_hedging: Arc::new(Mutex::new(InjectionState::Idle)),
         }
     }
 
@@ -492,6 +495,7 @@ impl FailureInjector {
             JobKind::TransferUsdcToHedging => &self.transfer_usdc_to_hedging,
             JobKind::TransferUsdcToMarketMaking => &self.transfer_usdc_to_market_making,
             JobKind::TransferEquityToMarketMaking => &self.transfer_equity_to_market_making,
+            JobKind::TransferEquityToHedging => &self.transfer_equity_to_hedging,
         };
 
         match mutex.lock() {

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -356,7 +356,9 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::equity_redemption::EquityRedemptionEvent;
+    use crate::equity_redemption::{
+        EquityRedemptionEvent, RedemptionAggregateId, redemption_aggregate_id,
+    };
     use crate::tokenized_equity_mint::{
         IssuerRequestId, TokenizedEquityMintEvent, issuer_request_id,
     };
@@ -456,6 +458,7 @@ mod tests {
     struct SeededTransferIds {
         active_mint: IssuerRequestId,
         failed_mint: IssuerRequestId,
+        active_redemption: RedemptionAggregateId,
         usdc: Uuid,
     }
 
@@ -517,11 +520,14 @@ mod tests {
         )
         .await;
 
+        let old_redemption_id = redemption_aggregate_id("old-redemption-1");
+        let active_redemption_id = redemption_aggregate_id("active-redemption-1");
+
         // 3. Old failed redemption (terminal, >24h ago -- should NOT appear)
         insert_event(
             pool,
             "EquityRedemption",
-            "old-redemption-1",
+            &old_redemption_id.to_string(),
             1,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             serde_json::to_value(EquityRedemptionEvent::WithdrawnFromRaindex {
@@ -540,7 +546,7 @@ mod tests {
         insert_event(
             pool,
             "EquityRedemption",
-            "old-redemption-1",
+            &old_redemption_id.to_string(),
             2,
             "EquityRedemptionEvent::TransferFailed",
             serde_json::to_value(EquityRedemptionEvent::TransferFailed {
@@ -556,7 +562,7 @@ mod tests {
         insert_event(
             pool,
             "EquityRedemption",
-            "active-redemption-1",
+            &active_redemption_id.to_string(),
             1,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             serde_json::to_value(EquityRedemptionEvent::WithdrawnFromRaindex {
@@ -608,6 +614,7 @@ mod tests {
         SeededTransferIds {
             active_mint: active_mint_id,
             failed_mint: failed_mint_id,
+            active_redemption: active_redemption_id,
             usdc: usdc_id,
         }
     }
@@ -673,7 +680,7 @@ mod tests {
         if let TransferOperation::EquityRedemption(op) = active_redemption {
             assert_eq!(
                 op.id,
-                Id::<EquityRedemptionTag>::new("active-redemption-1".to_string())
+                Id::<EquityRedemptionTag>::new(seeded.active_redemption.to_string())
             );
         }
 

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -64,8 +64,10 @@ use rain_math_float::Float;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use st0x_dto::{EquityRedemptionOperation, EquityRedemptionStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
@@ -81,27 +83,39 @@ use crate::tokenized_equity_mint::TokenizationRequestId;
 const TOKENIZED_EQUITY_DECIMALS: u8 = 18;
 
 /// Unique identifier for a redemption aggregate instance.
+///
+/// Mirrors [`crate::tokenized_equity_mint::IssuerRequestId`]: a UUID chosen at
+/// enqueue time so apalis retries and bot restarts always target the same
+/// aggregate.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub(crate) struct RedemptionAggregateId(pub(crate) String);
+pub(crate) struct RedemptionAggregateId(pub(crate) Uuid);
 
 impl RedemptionAggregateId {
-    pub(crate) fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
+    pub(crate) fn generate() -> Self {
+        Self(Uuid::new_v4())
     }
 }
 
-impl std::fmt::Display for RedemptionAggregateId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl Display for RedemptionAggregateId {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
     }
 }
 
 impl FromStr for RedemptionAggregateId {
-    type Err = std::convert::Infallible;
+    type Err = uuid::Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self(value.to_string()))
+        Ok(Self(Uuid::parse_str(value)?))
     }
+}
+
+/// Deterministic redemption aggregate id for tests. Maps a human-readable label
+/// to a UUID v5 so test aggregate ids stay valid [`RedemptionAggregateId`]
+/// values.
+#[cfg(test)]
+pub(crate) fn redemption_aggregate_id(label: &str) -> RedemptionAggregateId {
+    RedemptionAggregateId(Uuid::new_v5(&Uuid::NAMESPACE_OID, label.as_bytes()))
 }
 
 /// Errors that can occur during equity redemption operations.
@@ -856,7 +870,7 @@ impl EquityRedemption {
                 pending_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Withdrawing,
@@ -870,7 +884,7 @@ impl EquityRedemption {
                 submitted_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Withdrawing,
@@ -884,7 +898,7 @@ impl EquityRedemption {
                 withdrawn_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Withdrawing,
@@ -904,7 +918,7 @@ impl EquityRedemption {
                 withdrawn_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Unwrapping,
@@ -926,7 +940,7 @@ impl EquityRedemption {
                 unwrapped_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Unwrapping,
@@ -940,7 +954,7 @@ impl EquityRedemption {
                 sent_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Sending,
@@ -955,7 +969,7 @@ impl EquityRedemption {
                 detected_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::PendingConfirmation,
@@ -970,7 +984,7 @@ impl EquityRedemption {
                 completed_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Completed {
@@ -987,7 +1001,7 @@ impl EquityRedemption {
                 failed_at,
                 ..
             } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
-                id: Id::new(id.0.clone()),
+                id: Id::new(id.to_string()),
                 symbol: symbol.clone(),
                 quantity: FractionalShares::new(*quantity),
                 status: EquityRedemptionStatus::Failed {
@@ -1987,16 +2001,20 @@ pub(crate) async fn symbols_with_stuck_redemptions(
 
     let mut result: HashMap<Symbol, FractionalShares> = HashMap::new();
 
-    for (aggregate_id, raw_symbol, raw_quantity, raw_wrapped_amount) in rows {
-        let Some(symbol) = parse_stuck_symbol(&aggregate_id, raw_symbol) else {
+    for (raw_aggregate_id, raw_symbol, raw_quantity, raw_wrapped_amount) in rows {
+        let Ok(aggregate_id) = RedemptionAggregateId::from_str(&raw_aggregate_id) else {
+            warn!(target: "rebalance",
+                %raw_aggregate_id,
+                "Stuck redemption has invalid aggregate id, skipping"
+            );
             continue;
         };
 
-        let Some(quantity) = parse_stuck_quantity(
-            RedemptionAggregateId::new(&aggregate_id),
-            raw_quantity,
-            raw_wrapped_amount,
-        )?
+        let Some(symbol) = parse_stuck_symbol(&raw_aggregate_id, raw_symbol) else {
+            continue;
+        };
+
+        let Some(quantity) = parse_stuck_quantity(aggregate_id, raw_quantity, raw_wrapped_amount)?
         else {
             continue;
         };
@@ -2007,7 +2025,7 @@ pub(crate) async fn symbols_with_stuck_redemptions(
             Err(error) => {
                 warn!(target: "rebalance",
                     %error,
-                    %aggregate_id,
+                    %raw_aggregate_id,
                     "Float overflow summing stuck redemption quantities, \
                      keeping accumulated value"
                 );
@@ -2134,7 +2152,21 @@ pub(crate) async fn interrupted_redemption_ids(
     .fetch_all(pool)
     .await?;
 
-    Ok(rows.into_iter().map(RedemptionAggregateId::new).collect())
+    Ok(rows
+        .into_iter()
+        .filter_map(|aggregate_id| {
+            aggregate_id
+                .parse::<RedemptionAggregateId>()
+                .inspect_err(|error| {
+                    warn!(target: "rebalance",
+                        %error,
+                        %aggregate_id,
+                        "Interrupted redemption has invalid aggregate id, skipping"
+                    );
+                })
+                .ok()
+        })
+        .collect())
 }
 
 fn parse_stuck_symbol(aggregate_id: &str, raw: Option<String>) -> Option<Symbol> {
@@ -2400,7 +2432,7 @@ mod tests {
     #[tokio::test]
     async fn complete_redemption_flow_end_to_end() {
         let store = TestStore::<EquityRedemption>::new(mock_services());
-        let id = RedemptionAggregateId::new("end-to-end");
+        let id = redemption_aggregate_id("end-to-end");
 
         store
             .send(
@@ -2482,7 +2514,7 @@ mod tests {
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("underlying-token-fix");
+        let id = redemption_aggregate_id("underlying-token-fix");
 
         store
             .send(
@@ -2555,7 +2587,7 @@ mod tests {
             wrapper: Arc::new(MockWrapper::new()),
         };
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("partial-withdraw");
+        let id = redemption_aggregate_id("partial-withdraw");
 
         store
             .send(
@@ -2603,7 +2635,7 @@ mod tests {
             wrapper: Arc::new(MockWrapper::new()),
         };
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("unwrap-partial-withdraw");
+        let id = redemption_aggregate_id("unwrap-partial-withdraw");
 
         store
             .send(
@@ -2662,7 +2694,7 @@ mod tests {
             wrapper: Arc::new(MockWrapper::new()),
         };
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("missing-withdraw-transfer");
+        let id = redemption_aggregate_id("missing-withdraw-transfer");
 
         store
             .send(
@@ -3036,7 +3068,7 @@ mod tests {
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("send-fail");
+        let id = redemption_aggregate_id("send-fail");
 
         store
             .send(
@@ -3103,7 +3135,7 @@ mod tests {
         };
 
         let store = TestStore::<EquityRedemption>::new(services);
-        let id = RedemptionAggregateId::new("no-wallet");
+        let id = redemption_aggregate_id("no-wallet");
 
         store
             .send(
@@ -3218,7 +3250,7 @@ mod tests {
     #[tokio::test]
     async fn redeem_when_already_started_returns_already_started() {
         let store = TestStore::<EquityRedemption>::new(mock_services());
-        let id = RedemptionAggregateId::new("redemption-1");
+        let id = redemption_aggregate_id("redemption-1");
 
         store
             .send(
@@ -3255,7 +3287,7 @@ mod tests {
     #[tokio::test]
     async fn redeem_when_pending_returns_already_started() {
         let store = TestStore::<EquityRedemption>::new(mock_services());
-        let id = RedemptionAggregateId::new("redemption-1");
+        let id = redemption_aggregate_id("redemption-1");
 
         store
             .send(
@@ -3337,7 +3369,7 @@ mod tests {
     /// Insert a minimal event row into the events table.
     async fn insert_event(
         pool: &SqlitePool,
-        aggregate_id: &str,
+        aggregate_id: &RedemptionAggregateId,
         sequence: i64,
         event_type: &str,
         payload: &str,
@@ -3348,7 +3380,7 @@ mod tests {
               event_version, payload, metadata) \
              VALUES ('EquityRedemption', ?1, ?2, ?3, '1', ?4, '{}')",
         )
-        .bind(aggregate_id)
+        .bind(aggregate_id.to_string())
         .bind(sequence)
         .bind(event_type)
         .bind(payload)
@@ -3376,7 +3408,7 @@ mod tests {
         // AAPL: WithdrawnFromRaindex -> DetectionFailed (stuck)
         insert_event(
             &pool,
-            "redemption-1",
+            &redemption_aggregate_id("redemption-1"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3384,7 +3416,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-1",
+            &redemption_aggregate_id("redemption-1"),
             1,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3408,7 +3440,7 @@ mod tests {
 
         insert_event(
             &pool,
-            "partial-redemption",
+            &redemption_aggregate_id("partial-redemption"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("COIN"),
@@ -3416,7 +3448,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "partial-redemption",
+            &redemption_aggregate_id("partial-redemption"),
             1,
             "EquityRedemptionEvent::TokensUnwrapped",
             &tokens_unwrapped_payload("7.5", "7500000000000000000"),
@@ -3424,7 +3456,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "partial-redemption",
+            &redemption_aggregate_id("partial-redemption"),
             2,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3447,7 +3479,7 @@ mod tests {
 
         insert_event(
             &pool,
-            "invalid-actual",
+            &redemption_aggregate_id("invalid-actual"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("COIN"),
@@ -3455,7 +3487,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "invalid-actual",
+            &redemption_aggregate_id("invalid-actual"),
             1,
             "EquityRedemptionEvent::TokensUnwrapped",
             &tokens_unwrapped_payload("invalid", "invalid"),
@@ -3463,7 +3495,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "invalid-actual",
+            &redemption_aggregate_id("invalid-actual"),
             2,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3485,7 +3517,7 @@ mod tests {
         // TSLA: WithdrawnFromRaindex -> RedemptionRejected (stuck)
         insert_event(
             &pool,
-            "redemption-2",
+            &redemption_aggregate_id("redemption-2"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("TSLA"),
@@ -3493,7 +3525,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-2",
+            &redemption_aggregate_id("redemption-2"),
             1,
             "EquityRedemptionEvent::RedemptionRejected",
             r#"{"RedemptionRejected":{"reason":"test","rejected_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3518,7 +3550,7 @@ mod tests {
         // AAPL: DetectionFailed (stuck)
         insert_event(
             &pool,
-            "stuck",
+            &redemption_aggregate_id("stuck"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3526,7 +3558,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "stuck",
+            &redemption_aggregate_id("stuck"),
             1,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3536,7 +3568,7 @@ mod tests {
         // MSFT: Completed (not stuck)
         insert_event(
             &pool,
-            "completed",
+            &redemption_aggregate_id("completed"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("MSFT"),
@@ -3544,7 +3576,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "completed",
+            &redemption_aggregate_id("completed"),
             1,
             "EquityRedemptionEvent::Completed",
             r#"{"Completed":{"completed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3554,7 +3586,7 @@ mod tests {
         // GOOG: TransferFailed (not stuck — tokens still in our wallet)
         insert_event(
             &pool,
-            "transfer-failed",
+            &redemption_aggregate_id("transfer-failed"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("GOOG"),
@@ -3562,7 +3594,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "transfer-failed",
+            &redemption_aggregate_id("transfer-failed"),
             1,
             "EquityRedemptionEvent::TransferFailed",
             r#"{"TransferFailed":{"tx_hash":null,"failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3586,7 +3618,7 @@ mod tests {
 
         insert_event(
             &pool,
-            "resume-me",
+            &redemption_aggregate_id("resume-me"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3594,7 +3626,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "resume-me",
+            &redemption_aggregate_id("resume-me"),
             1,
             "EquityRedemptionEvent::TokensSent",
             r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000001","redemption_tx":"0x0000000000000000000000000000000000000000000000000000000000000002","sent_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3603,7 +3635,7 @@ mod tests {
 
         insert_event(
             &pool,
-            "completed",
+            &redemption_aggregate_id("completed"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("TSLA"),
@@ -3611,7 +3643,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "completed",
+            &redemption_aggregate_id("completed"),
             1,
             "EquityRedemptionEvent::Completed",
             r#"{"Completed":{"completed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3619,7 +3651,7 @@ mod tests {
         .await;
 
         let result = interrupted_redemption_ids(&pool).await.unwrap();
-        assert_eq!(result, vec![RedemptionAggregateId::new("resume-me")]);
+        assert_eq!(result, vec![redemption_aggregate_id("resume-me")]);
     }
 
     #[tokio::test]
@@ -3637,7 +3669,7 @@ mod tests {
         // AAPL: valid stuck redemption (DetectionFailed)
         insert_event(
             &pool,
-            "valid-stuck",
+            &redemption_aggregate_id("valid-stuck"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3645,7 +3677,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "valid-stuck",
+            &redemption_aggregate_id("valid-stuck"),
             1,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3655,7 +3687,7 @@ mod tests {
         // NULL symbol: malformed WithdrawnFromRaindex payload missing symbol
         insert_event(
             &pool,
-            "null-symbol",
+            &redemption_aggregate_id("null-symbol"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             r#"{"WithdrawnFromRaindex":{"quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","raindex_withdraw_tx":"0x0000000000000000000000000000000000000000000000000000000000000001","withdrawn_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3663,7 +3695,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "null-symbol",
+            &redemption_aggregate_id("null-symbol"),
             1,
             "EquityRedemptionEvent::RedemptionRejected",
             r#"{"RedemptionRejected":{"reason":"test","rejected_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3673,7 +3705,7 @@ mod tests {
         // Invalid symbol: symbol fails Symbol::new validation
         insert_event(
             &pool,
-            "invalid-symbol",
+            &redemption_aggregate_id("invalid-symbol"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload(""),
@@ -3681,7 +3713,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "invalid-symbol",
+            &redemption_aggregate_id("invalid-symbol"),
             1,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3707,7 +3739,7 @@ mod tests {
 
     #[test]
     fn to_dto_maps_in_progress_variants() {
-        let id = RedemptionAggregateId::new("REDEEM-001");
+        let id = redemption_aggregate_id("REDEEM-001");
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
         let later = now + chrono::Duration::seconds(60);
@@ -3726,7 +3758,7 @@ mod tests {
                 withdrawn.to_dto(&id)
             );
         };
-        assert_eq!(op.id, Id::new("REDEEM-001"));
+        assert_eq!(op.id, Id::new(id.to_string()));
         assert_eq!(op.symbol, symbol);
         assert_eq!(op.quantity, FractionalShares::new(float!(50.25)));
         assert!(
@@ -3807,7 +3839,7 @@ mod tests {
         // AAPL: latest event is WithdrawnFromRaindex (active)
         insert_event(
             &pool,
-            "redemption-active-1",
+            &redemption_aggregate_id("redemption-active-1"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3817,7 +3849,7 @@ mod tests {
         // TSLA: latest event is Detected (active)
         insert_event(
             &pool,
-            "redemption-active-2",
+            &redemption_aggregate_id("redemption-active-2"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("TSLA"),
@@ -3825,7 +3857,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-active-2",
+            &redemption_aggregate_id("redemption-active-2"),
             1,
             "EquityRedemptionEvent::TokensSent",
             r#"{"TokensSent":{"sent_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3833,7 +3865,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-active-2",
+            &redemption_aggregate_id("redemption-active-2"),
             2,
             "EquityRedemptionEvent::Detected",
             r#"{"Detected":{"tokenization_request_id":"TOK001","detected_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3853,7 +3885,7 @@ mod tests {
         // AAPL: completed (terminal) — should be excluded
         insert_event(
             &pool,
-            "redemption-terminal-1",
+            &redemption_aggregate_id("redemption-terminal-1"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3861,7 +3893,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-terminal-1",
+            &redemption_aggregate_id("redemption-terminal-1"),
             1,
             "EquityRedemptionEvent::Completed",
             r#"{"Completed":{"redemption_tx":"0x0000000000000000000000000000000000000000000000000000000000000001","tokenization_request_id":"TOK001","completed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3871,7 +3903,7 @@ mod tests {
         // TSLA: detection failed (terminal) — should be excluded
         insert_event(
             &pool,
-            "redemption-terminal-2",
+            &redemption_aggregate_id("redemption-terminal-2"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("TSLA"),
@@ -3879,7 +3911,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-terminal-2",
+            &redemption_aggregate_id("redemption-terminal-2"),
             1,
             "EquityRedemptionEvent::DetectionFailed",
             r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
@@ -3900,7 +3932,7 @@ mod tests {
         // Two active redemptions for the same symbol
         insert_event(
             &pool,
-            "redemption-dup-1",
+            &redemption_aggregate_id("redemption-dup-1"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3908,7 +3940,7 @@ mod tests {
         .await;
         insert_event(
             &pool,
-            "redemption-dup-2",
+            &redemption_aggregate_id("redemption-dup-2"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("AAPL"),
@@ -3927,7 +3959,7 @@ mod tests {
         // Row with NULL symbol in payload (corrupt data)
         insert_event(
             &pool,
-            "redemption-null",
+            &redemption_aggregate_id("redemption-null"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             r#"{"WithdrawnFromRaindex":{}}"#,
@@ -3937,7 +3969,7 @@ mod tests {
         // Valid row alongside the corrupt one
         insert_event(
             &pool,
-            "redemption-valid",
+            &redemption_aggregate_id("redemption-valid"),
             0,
             "EquityRedemptionEvent::WithdrawnFromRaindex",
             &withdrawn_payload("NVDA"),
@@ -3951,7 +3983,7 @@ mod tests {
 
     #[test]
     fn to_dto_maps_terminal_variants() {
-        let id = RedemptionAggregateId::new("REDEEM-001");
+        let id = redemption_aggregate_id("REDEEM-001");
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
         let later = now + chrono::Duration::seconds(60);

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -38,7 +38,9 @@ use st0x_wrapper::MockWrapper;
 use super::{ExpectedEvent, assert_events, fetch_events};
 use crate::bindings::{IERC20, TestERC20};
 use crate::conductor::job::Job;
-use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
+use crate::equity_redemption::{
+    EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
+};
 use crate::inventory::{BroadcastingInventory, ImbalanceThreshold, InventoryView, Venue};
 use crate::offchain::order::OffchainOrderId;
 use crate::onchain::mock::MockRaindex;
@@ -2474,7 +2476,7 @@ async fn transfer_failed_cancels_redemption_inflight() {
         .await
         .unwrap();
 
-    let redemption_id = RedemptionAggregateId::new("redemption-transfer-failed");
+    let redemption_id = redemption_aggregate_id("redemption-transfer-failed");
 
     // Redeem: creates VaultWithdrawPending
     redemption_store

--- a/src/rebalancing/equity/job.rs
+++ b/src/rebalancing/equity/job.rs
@@ -1,20 +1,22 @@
-//! Apalis job that drives tokenized equity mints (hedging -> market-making)
-//! through the `TokenizedEquityMint` lifecycle.
+//! Apalis jobs that drive tokenized equity transfers through their
+//! lifecycles, one per direction: [`TransferEquityToMarketMaking`] for mints
+//! (`TokenizedEquityMint`) and [`TransferEquityToHedging`] for redemptions
+//! (`EquityRedemption`).
 //!
-//! The job is keyed by an `IssuerRequestId` chosen at enqueue time, so apalis
+//! Each job is keyed by an aggregate id chosen at enqueue time, so apalis
 //! retries (and bot restarts that re-pick the row from the Jobs table) hit
 //! the same aggregate. The worker calls the trait-erased resume entry point
 //! on the equity transfer, which loads the aggregate via `Store::load` and
-//! dispatches on its current state: an absent aggregate starts a fresh mint,
-//! an in-flight one resumes from its persisted step, and a terminal one is a
-//! no-op. New transfers and mid-flight resumes share the same entry point --
-//! that uniformity is what makes recovery dispatch fall out of the standard
-//! transfer lifecycle.
+//! dispatches on its current state: an absent aggregate starts a fresh
+//! transfer, an in-flight one resumes from its persisted step, and a terminal
+//! one is a no-op. New transfers and mid-flight resumes share the same entry
+//! point -- that uniformity is what makes recovery dispatch fall out of the
+//! standard transfer lifecycle.
 //!
 //! The per-symbol `equity_in_progress` guard is cleared event-driven when the
 //! aggregate reaches a terminal state (success or a recorded failure), not by
-//! this worker. A transient failure that only schedules a retry keeps the
-//! guard latched so automation does not re-arm a fresh mint on top of a
+//! these workers. A transient failure that only schedules a retry keeps the
+//! guard latched so automation does not re-arm a fresh transfer on top of a
 //! partial one.
 
 use std::sync::Arc;
@@ -25,8 +27,9 @@ use thiserror::Error;
 
 use st0x_execution::{FractionalShares, Symbol};
 
-use super::{CrossVenueEquityTransfer, MintTransferError};
+use super::{CrossVenueEquityTransfer, MintTransferError, RedemptionError};
 use crate::conductor::job::{Job, JobQueue, Label};
+use crate::equity_redemption::RedemptionAggregateId;
 use crate::tokenized_equity_mint::IssuerRequestId;
 
 /// Apalis queue type for [`TransferEquityToMarketMaking`].
@@ -108,6 +111,78 @@ impl Job<TransferEquityToMarketMakingCtx> for TransferEquityToMarketMaking {
     }
 }
 
+/// Apalis queue type for [`TransferEquityToHedging`].
+pub(crate) type TransferEquityToHedgingJobQueue = JobQueue<TransferEquityToHedging>;
+
+/// Trait-erased entry point for the market-making->hedging equity apalis
+/// job. Sibling of [`ResumeEquityToMarketMaking`]; same mock-seam rationale.
+#[async_trait]
+pub(crate) trait ResumeEquityToHedging: Send + Sync + 'static {
+    async fn resume_equity_to_hedging(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), RedemptionError>;
+}
+
+#[async_trait]
+impl ResumeEquityToHedging for CrossVenueEquityTransfer {
+    async fn resume_equity_to_hedging(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), RedemptionError> {
+        Self::resume_equity_to_hedging(self, aggregate_id, symbol, quantity).await
+    }
+}
+
+/// Dependencies the redemption job needs. Symmetric to
+/// [`TransferEquityToMarketMakingCtx`].
+pub(crate) struct TransferEquityToHedgingCtx {
+    pub(crate) transfer: Arc<dyn ResumeEquityToHedging>,
+}
+
+/// Errors emitted by [`TransferEquityToHedging::perform`].
+#[derive(Debug, Error)]
+pub(crate) enum TransferEquityToHedgingJobError {
+    #[error(transparent)]
+    Transfer(#[from] RedemptionError),
+}
+
+/// Apalis job payload for the redemption direction. The `aggregate_id` is
+/// generated at enqueue time so retries resume the same aggregate.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct TransferEquityToHedging {
+    pub(crate) aggregate_id: RedemptionAggregateId,
+    pub(crate) symbol: Symbol,
+    pub(crate) quantity: FractionalShares,
+}
+
+impl Job<TransferEquityToHedgingCtx> for TransferEquityToHedging {
+    type Output = ();
+    type Error = TransferEquityToHedgingJobError;
+
+    const WORKER_NAME: &'static str = "transfer-equity-to-hedging-worker";
+
+    #[cfg(any(test, feature = "test-support"))]
+    const JOB_KIND: crate::conductor::job::JobKind =
+        crate::conductor::job::JobKind::TransferEquityToHedging;
+
+    fn label(&self) -> Label {
+        Label::new(format!("TransferEquityToHedging:{}", self.aggregate_id))
+    }
+
+    async fn perform(&self, ctx: &TransferEquityToHedgingCtx) -> Result<Self::Output, Self::Error> {
+        ctx.transfer
+            .resume_equity_to_hedging(&self.aggregate_id, &self.symbol, self.quantity)
+            .await?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -116,6 +191,7 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
+    use crate::equity_redemption::redemption_aggregate_id;
     use crate::rebalancing::equity::MintError;
     use crate::tokenized_equity_mint::issuer_request_id;
 
@@ -220,5 +296,97 @@ mod tests {
         assert_eq!(roundtripped.issuer_request_id, job.issuer_request_id);
         assert_eq!(roundtripped.symbol, job.symbol);
         assert_eq!(roundtripped.quantity, job.quantity);
+    }
+
+    /// Records the redemption resume call and returns a configurable outcome.
+    struct RecordingRedemptionResume {
+        fail: bool,
+        captured: Mutex<Option<(RedemptionAggregateId, Symbol, FractionalShares)>>,
+    }
+
+    #[async_trait]
+    impl ResumeEquityToHedging for RecordingRedemptionResume {
+        async fn resume_equity_to_hedging(
+            &self,
+            aggregate_id: &RedemptionAggregateId,
+            symbol: &Symbol,
+            quantity: FractionalShares,
+        ) -> Result<(), RedemptionError> {
+            *self.captured.lock().unwrap() = Some((aggregate_id.clone(), symbol.clone(), quantity));
+
+            if self.fail {
+                Err(RedemptionError::EntityNotFound {
+                    aggregate_id: aggregate_id.clone(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn redemption_perform_forwards_id_symbol_and_quantity_to_resume() {
+        let stub = Arc::new(RecordingRedemptionResume {
+            fail: false,
+            captured: Mutex::new(None),
+        });
+        let ctx = TransferEquityToHedgingCtx {
+            transfer: stub.clone(),
+        };
+        let job = TransferEquityToHedging {
+            aggregate_id: redemption_aggregate_id("redeem-forward"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+        };
+
+        Job::perform(&job, &ctx).await.unwrap();
+
+        let captured = stub.captured.lock().unwrap().take();
+        let (aggregate_id, symbol, quantity) =
+            captured.expect("perform must call resume_equity_to_hedging");
+        assert_eq!(aggregate_id, job.aggregate_id);
+        assert_eq!(symbol, job.symbol);
+        assert_eq!(quantity, job.quantity);
+    }
+
+    #[tokio::test]
+    async fn redemption_perform_propagates_resume_failure() {
+        let ctx = TransferEquityToHedgingCtx {
+            transfer: Arc::new(RecordingRedemptionResume {
+                fail: true,
+                captured: Mutex::new(None),
+            }),
+        };
+        let job = TransferEquityToHedging {
+            aggregate_id: redemption_aggregate_id("redeem-fail"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(10)),
+        };
+
+        let error = Job::perform(&job, &ctx).await.unwrap_err();
+
+        // The failure must propagate (not be swallowed) so apalis retries and
+        // the event-driven `equity_in_progress` guard stays latched until the
+        // aggregate reaches a terminal state.
+        assert!(matches!(
+            error,
+            TransferEquityToHedgingJobError::Transfer(RedemptionError::EntityNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn redemption_payload_roundtrips_through_json() {
+        let job = TransferEquityToHedging {
+            aggregate_id: redemption_aggregate_id("redeem-roundtrip"),
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: FractionalShares::new(float!(2.5)),
+        };
+
+        let serialized = serde_json::to_vec(&job).unwrap();
+        let deserialized: TransferEquityToHedging = serde_json::from_slice(&serialized).unwrap();
+
+        assert_eq!(deserialized.aggregate_id, job.aggregate_id);
+        assert_eq!(deserialized.symbol, job.symbol);
+        assert_eq!(deserialized.quantity, job.quantity);
     }
 }

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod mock;
 #[cfg(test)]
 pub(crate) use job::TransferEquityToMarketMakingJobError;
 pub(crate) use job::{
+    TransferEquityToHedging, TransferEquityToHedgingCtx, TransferEquityToHedgingJobQueue,
     TransferEquityToMarketMaking, TransferEquityToMarketMakingCtx,
     TransferEquityToMarketMakingJobQueue,
 };
@@ -28,7 +29,6 @@ use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, warn};
-use uuid::Uuid;
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
@@ -1570,38 +1570,76 @@ impl CrossVenueEquityTransfer {
     }
 }
 
+impl CrossVenueEquityTransfer {
+    /// Market-Making -> Hedging: drives the redemption lifecycle (withdraw
+    /// tokenized equity from the Raindex vault, unwrap, send to Alpaca for
+    /// redemption) for the given `aggregate_id`, whether fresh or
+    /// interrupted.
+    ///
+    /// The id is chosen by the caller at enqueue time so apalis retries (and
+    /// bot restarts that re-pick the job row) re-enter the same aggregate: an
+    /// absent aggregate starts a new redemption, an in-flight one resumes
+    /// from its persisted state, and a terminal one is a no-op.
+    #[instrument(target = "rebalance", skip_all, fields(%aggregate_id, %symbol, %quantity))]
+    pub(crate) async fn resume_equity_to_hedging(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), RedemptionError> {
+        let existing = self.redemption_store.load(aggregate_id).await?;
+
+        match existing {
+            None => self.start_redemption(aggregate_id, symbol, quantity).await,
+            Some(_) => self.resume_redemption(aggregate_id).await,
+        }
+    }
+
+    async fn start_redemption(
+        &self,
+        aggregate_id: &RedemptionAggregateId,
+        symbol: &Symbol,
+        quantity: FractionalShares,
+    ) -> Result<(), RedemptionError> {
+        let token = self.vault_lookup.vault_token_for_symbol(symbol).await?;
+        let amount = quantity.to_u256_18_decimals()?;
+
+        info!(target: "rebalance", %token, %amount, %aggregate_id, "Starting equity transfer to hedging venue");
+
+        self.withdraw_from_raindex(aggregate_id, symbol, quantity, token, amount)
+            .await?;
+
+        info!(target: "rebalance", "Withdrawn from Raindex, unwrapping and sending to Alpaca");
+
+        let redemption_tx = self.unwrap_and_send(aggregate_id).await?;
+
+        info!(target: "rebalance", %redemption_tx, "Tokens sent, polling for detection");
+        let request_id = self.poll_detection(aggregate_id, &redemption_tx).await?;
+
+        info!(target: "rebalance", %request_id, "Redemption detected, awaiting completion");
+        self.poll_completion(aggregate_id, &request_id).await?;
+
+        info!(target: "rebalance", "Equity transfer to hedging venue completed successfully");
+        Ok(())
+    }
+}
+
 /// Market-Making -> Hedging: withdraw tokenized equity from Raindex vault
-/// and send to Alpaca for redemption.
+/// and send to Alpaca for redemption. Thin delegation kept while the
+/// `Rebalancer` mpsc channel still routes redemptions; the channel and this
+/// impl go away once the trigger enqueues [`TransferEquityToHedging`]
+/// directly.
 #[async_trait]
 impl CrossVenueTransfer<MarketMakingVenue, HedgingVenue> for CrossVenueEquityTransfer {
     type Asset = Equity;
     type Error = RedemptionError;
 
-    #[instrument(target = "rebalance", skip_all, fields(symbol = %asset.symbol, quantity = %asset.quantity))]
     async fn transfer(&self, asset: Self::Asset) -> Result<(), Self::Error> {
         let Equity { symbol, quantity } = asset;
+        let aggregate_id = RedemptionAggregateId::generate();
 
-        let token = self.vault_lookup.vault_token_for_symbol(&symbol).await?;
-        let amount = quantity.to_u256_18_decimals()?;
-        let aggregate_id = RedemptionAggregateId::new(Uuid::new_v4().to_string());
-
-        info!(target: "rebalance", %token, %amount, %aggregate_id, "Starting equity transfer to hedging venue");
-
-        self.withdraw_from_raindex(&aggregate_id, &symbol, quantity, token, amount)
-            .await?;
-
-        info!(target: "rebalance", "Withdrawn from Raindex, unwrapping and sending to Alpaca");
-
-        let redemption_tx = self.unwrap_and_send(&aggregate_id).await?;
-
-        info!(target: "rebalance", %redemption_tx, "Tokens sent, polling for detection");
-        let request_id = self.poll_detection(&aggregate_id, &redemption_tx).await?;
-
-        info!(target: "rebalance", %request_id, "Redemption detected, awaiting completion");
-        self.poll_completion(&aggregate_id, &request_id).await?;
-
-        info!(target: "rebalance", "Equity transfer to hedging venue completed successfully");
-        Ok(())
+        self.start_redemption(&aggregate_id, &symbol, quantity)
+            .await
     }
 }
 
@@ -1624,6 +1662,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::equity_redemption::redemption_aggregate_id;
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
     };
@@ -2179,7 +2218,7 @@ mod tests {
         )
         .await;
 
-        let id = RedemptionAggregateId::new("redemption-resume");
+        let id = redemption_aggregate_id("redemption-resume");
         let symbol = Symbol::new("TEST").unwrap();
         let token = transfer
             .vault_lookup
@@ -2209,6 +2248,119 @@ mod tests {
             matches!(entity, EquityRedemption::Completed { .. }),
             "Expected completed redemption after resume, got: {entity:?}"
         );
+    }
+
+    /// A fresh id runs the full redemption flow through the job entry point.
+    #[tokio::test]
+    async fn resume_equity_to_hedging_starts_fresh_redemption() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-fresh");
+        transfer
+            .resume_equity_to_hedging(
+                &id,
+                &Symbol::new("TEST").unwrap(),
+                FractionalShares::new(float!(50)),
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "Expected completed redemption, got: {entity:?}"
+        );
+    }
+
+    /// Re-running the job entry point with an id whose aggregate already
+    /// exists must resume from the persisted state (the crash-recovery path)
+    /// rather than re-running the vault withdrawal from scratch.
+    #[tokio::test]
+    async fn resume_equity_to_hedging_resumes_existing_aggregate() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-crash-resume");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = quantity.to_u256_18_decimals().unwrap();
+
+        // First attempt crashes after the withdrawal: the aggregate is
+        // persisted mid-flight.
+        transfer
+            .withdraw_from_raindex(&id, &symbol, quantity, token, amount)
+            .await
+            .unwrap();
+
+        // The re-enqueued job runs the same entry point with the same id; a
+        // fresh Redeem command here would fail on the already-initialized
+        // aggregate, so completing proves the resume path was taken.
+        transfer
+            .resume_equity_to_hedging(&id, &symbol, quantity)
+            .await
+            .unwrap();
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Completed { .. }),
+            "Expected completed redemption after job re-run, got: {entity:?}"
+        );
+    }
+
+    /// A terminal aggregate is a no-op for the job entry point: apalis
+    /// retries after a partial failure must not error once the aggregate has
+    /// already completed.
+    #[tokio::test]
+    async fn resume_equity_to_hedging_is_noop_on_completed_redemption() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(
+            MockTokenizer::new()
+                .with_detection_outcome(MockDetectionOutcome::Detected)
+                .with_completion_outcome(MockCompletionOutcome::Completed),
+        );
+        let transfer = create_equity_transfer(
+            tokenizer,
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-done");
+        let symbol = Symbol::new("TEST").unwrap();
+        let quantity = FractionalShares::new(float!(50));
+
+        transfer
+            .resume_equity_to_hedging(&id, &symbol, quantity)
+            .await
+            .unwrap();
+
+        transfer
+            .resume_equity_to_hedging(&id, &symbol, quantity)
+            .await
+            .expect("a completed redemption must be a clean no-op for the job retry");
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -38,7 +38,8 @@ use crate::inventory::{
 };
 use crate::position::{Position, PositionEvent};
 use crate::rebalancing::equity::{
-    TransferEquityToMarketMaking, TransferEquityToMarketMakingJobQueue,
+    TransferEquityToHedgingJobQueue, TransferEquityToMarketMaking,
+    TransferEquityToMarketMakingJobQueue,
 };
 use crate::rebalancing::usdc::{
     TransferUsdcToHedging, TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking,
@@ -73,6 +74,7 @@ pub(crate) struct RebalancingSchedulers {
     pub(crate) transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue,
     pub(crate) transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue,
     pub(crate) transfer_equity_to_market_making: TransferEquityToMarketMakingJobQueue,
+    pub(crate) transfer_equity_to_hedging: TransferEquityToHedgingJobQueue,
 }
 
 impl RebalancingSchedulers {
@@ -85,6 +87,7 @@ impl RebalancingSchedulers {
             transfer_usdc_to_hedging: TransferUsdcToHedgingJobQueue::new(pool),
             transfer_usdc_to_market_making: TransferUsdcToMarketMakingJobQueue::new(pool),
             transfer_equity_to_market_making: TransferEquityToMarketMakingJobQueue::new(pool),
+            transfer_equity_to_hedging: TransferEquityToHedgingJobQueue::new(pool),
         }
     }
 }
@@ -557,6 +560,9 @@ impl RebalancingService {
             unwrapped_equity_recovery: unwrapped_equity_recovery_queue,
             transfer_usdc_to_hedging: transfer_usdc_to_hedging_queue,
             transfer_equity_to_market_making: transfer_equity_to_market_making_queue,
+            // Consumed by the conductor's worker wiring only until the
+            // trigger enqueues redemptions directly.
+            transfer_equity_to_hedging: _,
             transfer_usdc_to_market_making: transfer_usdc_to_market_making_queue,
         } = schedulers;
         Self {
@@ -3986,7 +3992,7 @@ mod tests {
     use super::*;
     use crate::alpaca_wallet::AlpacaTransferId;
     use crate::conductor::job::Job;
-    use crate::equity_redemption::DetectionFailure;
+    use crate::equity_redemption::{DetectionFailure, redemption_aggregate_id};
     use crate::inventory::snapshot::{
         InventorySnapshot, InventorySnapshotEvent, InventorySnapshotId,
     };
@@ -4170,7 +4176,7 @@ mod tests {
     async fn recover_redemption_state_restores_tracking_and_inflight() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-recovery");
+        let redemption_id = redemption_aggregate_id("redemption-recovery");
         let detected_at = Utc::now();
         let redemption_tx = TxHash::random();
 
@@ -4342,7 +4348,7 @@ mod tests {
     async fn recovery_after_explicit_redemption_failure_moves_equity_to_hedging() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-explicit-recovery");
+        let redemption_id = redemption_aggregate_id("redemption-explicit-recovery");
 
         // An explicit DetectionFailed/RedemptionRejected does not touch
         // inventory, so the in-flight is still held at MarketMaking (onchain):
@@ -4398,7 +4404,7 @@ mod tests {
     async fn recovery_after_timeout_redemption_failure_clears_tombstone_and_moves_equity() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-timeout-recovery");
+        let redemption_id = redemption_aggregate_id("redemption-timeout-recovery");
 
         // A timeout cleared the MarketMaking in-flight and tombstoned the
         // aggregate; available stays debited at 90.
@@ -4597,8 +4603,8 @@ mod tests {
     async fn redemption_recovery_claim_refuses_a_different_redemption_without_mutating() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let recovering = RedemptionAggregateId::new("recovering-redemption");
-        let other = RedemptionAggregateId::new("other-redemption");
+        let recovering = redemption_aggregate_id("recovering-redemption");
+        let other = redemption_aggregate_id("other-redemption");
         let tombstone_at = Utc::now();
 
         // Timeout shape with a *different* redemption owning the slot. The claim
@@ -4659,7 +4665,7 @@ mod tests {
     async fn redemption_recovery_claim_succeeds_for_self_owned_slot() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let recovering = RedemptionAggregateId::new("recovering-redemption");
+        let recovering = redemption_aggregate_id("recovering-redemption");
         let tombstone_at = Utc::now();
 
         *trigger.inventory.write().await = InventoryView::default()
@@ -4874,7 +4880,7 @@ mod tests {
     async fn rollback_after_timeout_redemption_dispatch_failure_restores_tombstone() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-timeout-rollback");
+        let redemption_id = redemption_aggregate_id("redemption-timeout-rollback");
         let tombstone_at = Utc::now();
 
         // Timeout cleared the MarketMaking in-flight and tombstoned; 90/0.
@@ -4961,7 +4967,7 @@ mod tests {
     async fn rollback_after_explicit_redemption_dispatch_failure_keeps_inflight() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-explicit-rollback");
+        let redemption_id = redemption_aggregate_id("redemption-explicit-rollback");
 
         // An explicit failure left the MarketMaking in-flight in place: 90
         // available, 10 in-flight. Rebuild does not touch inventory here.
@@ -5020,7 +5026,7 @@ mod tests {
     async fn rollback_redemption_clears_self_owned_active_redemption() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-self-owned");
+        let redemption_id = redemption_aggregate_id("redemption-self-owned");
 
         // Explicit-failure shape with the slot still self-owned (a reactor-less
         // failure the live process never observed -- the claim treats this as
@@ -5069,8 +5075,8 @@ mod tests {
     async fn rollback_redemption_keeps_active_redemption_owned_by_other_id() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("redemption-rollback");
-        let other_id = RedemptionAggregateId::new("other-redemption");
+        let redemption_id = redemption_aggregate_id("redemption-rollback");
+        let other_id = redemption_aggregate_id("other-redemption");
 
         // No owner at claim time -> claim succeeds.
         *trigger.inventory.write().await = InventoryView::default()
@@ -5233,7 +5239,7 @@ mod tests {
     async fn pending_request_ownership_exposes_active_redemption_request_id() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId::new("owned-redemption");
+        let redemption_id = redemption_aggregate_id("owned-redemption");
         let tokenization_request_id = TokenizationRequestId("owned-redemption-request".to_string());
         let redemption_tx = TxHash::random();
 
@@ -5332,7 +5338,7 @@ mod tests {
         for terminal_event in terminal_events {
             let (trigger, _receiver) = make_trigger().await;
             let symbol = Symbol::new("AAPL").unwrap();
-            let redemption_id = RedemptionAggregateId::new("failing-redemption");
+            let redemption_id = redemption_aggregate_id("failing-redemption");
             let tokenization_request_id =
                 TokenizationRequestId("failing-redemption-request".to_string());
             let redemption_tx = TxHash::random();
@@ -5406,7 +5412,7 @@ mod tests {
     async fn recover_redemption_state_keeps_requested_quantity_until_unwrap_confirms() {
         let (trigger, _receiver) = make_trigger().await;
         let symbol = Symbol::new("COIN").unwrap();
-        let redemption_id = RedemptionAggregateId::new("partial-redemption-recovery");
+        let redemption_id = redemption_aggregate_id("partial-redemption-recovery");
         let requested_quantity = float!(37.143292455);
         let actual_wrapped_amount = U256::from(33_681_456_848_531_939_569_u128);
         let requested_fractional = FractionalShares::new(requested_quantity);
@@ -6778,7 +6784,7 @@ mod tests {
         }
 
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-1");
+        let id = redemption_aggregate_id("redemption-1");
 
         harness
             .receive::<EquityRedemption>(
@@ -7127,7 +7133,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = RedemptionAggregateId::new("redemption-transfer-fail");
+        let id = redemption_aggregate_id("redemption-transfer-fail");
 
         harness
             .receive::<EquityRedemption>(
@@ -7170,7 +7176,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = RedemptionAggregateId::new("redemption-detection-fail");
+        let id = redemption_aggregate_id("redemption-detection-fail");
 
         harness
             .receive::<EquityRedemption>(
@@ -7213,7 +7219,7 @@ mod tests {
             guard.insert(symbol.clone());
         }
 
-        let id = RedemptionAggregateId::new("redemption-rejected");
+        let id = redemption_aggregate_id("redemption-rejected");
 
         harness
             .receive::<EquityRedemption>(
@@ -7592,7 +7598,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-blocks");
+        let id = redemption_aggregate_id("redemption-blocks");
 
         // Verify imbalance triggers before reactor events
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -7645,7 +7651,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-rebalances");
+        let id = redemption_aggregate_id("redemption-rebalances");
 
         // Full redemption flow: WithdrawnFromRaindex -> Completed
         harness
@@ -13708,7 +13714,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-transfer-cancel");
+        let id = redemption_aggregate_id("redemption-transfer-cancel");
 
         // Verify initial imbalance
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -13927,7 +13933,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-rejected-absent-skip");
+        let id = redemption_aggregate_id("redemption-rejected-absent-skip");
 
         // WithdrawnFromRaindex: start inflight
         harness
@@ -13996,7 +14002,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-detection-absent-skip");
+        let id = redemption_aggregate_id("redemption-detection-absent-skip");
 
         harness
             .receive::<EquityRedemption>(
@@ -14062,7 +14068,7 @@ mod tests {
             make_trigger_with_inventory_and_registry(inventory, &symbol).await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("redemption-completed-zeroed");
+        let id = redemption_aggregate_id("redemption-completed-zeroed");
 
         // WithdrawnFromRaindex -> Completed: TransferOp::Complete zeros inflight
         harness
@@ -14294,7 +14300,7 @@ mod tests {
         };
 
         // Simulate: WithdrawnFromRaindex starts inflight for the symbol
-        let redemption_id = RedemptionAggregateId::new("redemption-stale-regression");
+        let redemption_id = redemption_aggregate_id("redemption-stale-regression");
         harness
             .receive::<EquityRedemption>(
                 redemption_id.clone(),
@@ -14460,7 +14466,7 @@ mod tests {
         .await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("timed-out-redemption");
+        let id = redemption_aggregate_id("timed-out-redemption");
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
@@ -14611,7 +14617,7 @@ mod tests {
         .await;
         let trigger = reactor.clone();
         let harness = ReactorHarness::new(Arc::clone(&trigger));
-        let id = RedemptionAggregateId::new("timed-out-redemption-retrigger");
+        let id = redemption_aggregate_id("timed-out-redemption-retrigger");
 
         {
             let mut guard = trigger.equity_in_progress.write().unwrap();
@@ -14709,7 +14715,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = RedemptionAggregateId::new("timed-out-still-pending");
+        let id = redemption_aggregate_id("timed-out-still-pending");
         let redemption_tx = TxHash::random();
         let tokenization_request_id = TokenizationRequestId("stuck-at-alpaca".to_string());
 
@@ -15004,7 +15010,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = RedemptionAggregateId::new("timed-out-redemption-late-withdrawal");
+        let id = redemption_aggregate_id("timed-out-redemption-late-withdrawal");
 
         trigger.redemption_tracking.write().await.insert(
             id.clone(),
@@ -15068,7 +15074,7 @@ mod tests {
     async fn timed_out_redemption_cleanup_clears_active_redemption_id() {
         let symbol = Symbol::new("AAPL").unwrap();
         let now = Utc::now();
-        let id = RedemptionAggregateId::new("timed-out-redemption-active-id");
+        let id = redemption_aggregate_id("timed-out-redemption-active-id");
         let inventory = InventoryView::default()
             .with_equity(symbol.clone(), shares(50), shares(50))
             .update_equity(
@@ -15125,7 +15131,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = RedemptionAggregateId::new("redemption-sync-gate-tombstone");
+        let id = redemption_aggregate_id("redemption-sync-gate-tombstone");
         let sync_guard = trigger.redemption_event_sync.lock().await;
         let trigger_for_task = Arc::clone(&trigger);
         let task_symbol = symbol.clone();
@@ -15457,7 +15463,7 @@ mod tests {
             - ChronoDuration::from_std(TIMEOUT_TOMBSTONE_RETENTION).unwrap()
             - ChronoDuration::seconds(1);
         let mint_id = issuer_request_id("stale-mint");
-        let redemption_id = RedemptionAggregateId::new("stale-redemption");
+        let redemption_id = redemption_aggregate_id("stale-redemption");
         let usdc_id = UsdcRebalanceId(Uuid::new_v4());
 
         trigger
@@ -15602,7 +15608,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = RedemptionAggregateId::new("redemption-active-id");
+        let id = redemption_aggregate_id("redemption-active-id");
 
         trigger
             .on_redemption(id.clone(), make_withdrawn_from_raindex(&symbol, float!(10)))
@@ -15631,7 +15637,7 @@ mod tests {
         )
         .await;
         let trigger = reactor.clone();
-        let id = RedemptionAggregateId::new("redemption-clear-id");
+        let id = redemption_aggregate_id("redemption-clear-id");
 
         trigger
             .on_redemption(id.clone(), make_withdrawn_from_raindex(&symbol, float!(10)))

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -816,6 +816,7 @@ mod tests {
     use st0x_raindex::RaindexVaultId;
     use st0x_wrapper::MockWrapper;
 
+    use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
@@ -1513,7 +1514,7 @@ mod tests {
         let events = detected()
             .transition(
                 UnwrappedEquityRecoveryCommand::DispatchToRedemption {
-                    redemption_id: RedemptionAggregateId("nonexistent".to_string()),
+                    redemption_id: redemption_aggregate_id("nonexistent"),
                 },
                 &services,
             )

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -677,7 +677,9 @@ mod tests {
     use st0x_raindex::{Raindex, RaindexVaultId};
     use st0x_wrapper::{MockWrapper, Wrapper};
 
-    use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand};
+    use crate::equity_redemption::{
+        EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,
+    };
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
     use crate::tokenization::Tokenizer;
@@ -1009,7 +1011,7 @@ mod tests {
     fn decide_dispatch_resolves_all_four_paths() {
         let symbol = Symbol::new("AAPL").unwrap();
         let mint_id = issuer_request_id("ISS001");
-        let redemption_id = RedemptionAggregateId("RED001".to_string());
+        let redemption_id = redemption_aggregate_id("RED001");
 
         assert!(
             matches!(
@@ -1182,7 +1184,7 @@ mod tests {
     #[tokio::test]
     async fn validate_active_redemption_reports_missing_aggregate() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId("RED-NONEXISTENT".to_string());
+        let redemption_id = redemption_aggregate_id("RED-NONEXISTENT");
         let ctx = test_ctx(InventoryView::default(), HashSet::new()).await;
 
         let snapshot = RecoverySnapshot {
@@ -1335,7 +1337,7 @@ mod tests {
     async fn perform_conflict_fails_recovery_without_retrying() {
         let symbol = Symbol::new("AAPL").unwrap();
         let mint_id = issuer_request_id("ISS001");
-        let redemption_id = RedemptionAggregateId("RED001".to_string());
+        let redemption_id = redemption_aggregate_id("RED001");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_mint(symbol.clone(), mint_id.clone())
             .set_active_redemption(symbol.clone(), redemption_id.clone());
@@ -1561,7 +1563,7 @@ mod tests {
     #[tokio::test]
     async fn perform_drives_active_redemption_path_to_dispatched_to_redemption() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let redemption_id = RedemptionAggregateId("RED001".to_string());
+        let redemption_id = redemption_aggregate_id("RED001");
         let view = view_with_unwrapped_balance(&symbol, FractionalShares::new(float!(5)))
             .set_active_redemption(symbol.clone(), redemption_id.clone());
         let tokenizer = Arc::new(

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -583,6 +583,7 @@ mod tests {
     use st0x_raindex::RaindexVaultId;
     use st0x_wrapper::MockWrapper;
 
+    use crate::equity_redemption::redemption_aggregate_id;
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
@@ -787,7 +788,7 @@ mod tests {
     async fn dispatch_to_redemption_records_failure_when_resume_redemption_fails() {
         let services = test_services().await;
         let detected = detected_state();
-        let redemption_id = RedemptionAggregateId("nonexistent".to_string());
+        let redemption_id = redemption_aggregate_id("nonexistent");
 
         let events = detected
             .transition(


### PR DESCRIPTION
## What

Part of RAI-392. Adds the `TransferEquityToHedging` apalis job that drives tokenized equity redemptions (market making -> hedging) through the `EquityRedemption` lifecycle, plus its worker wiring. Purely additive: the `Rebalancer` mpsc channel still routes redemptions in this PR; the flip and channel removal land in the next PR of the stack (#792).

## Why

Redemptions ran as one-off `tokio::spawn` tasks with no persistence: a crash mid-transfer orphaned the in-flight redemption, and `resume_redemption` only fired at startup recovery. The job model gives in-process retries and crash-safe resume, mirroring the mint conversion in #786.

## How

- `CrossVenueEquityTransfer::resume_equity_to_hedging(aggregate_id, symbol, quantity)`: absent aggregate starts a fresh redemption, in-flight one resumes from its persisted state, terminal one is a no-op. The old `CrossVenueTransfer` redemption impl becomes a thin delegation to keep the Rebalancer working until #792.
- `TransferEquityToHedging` job keyed by a `RedemptionAggregateId` generated at enqueue time so apalis retries and restarts re-enter the same aggregate.
- Conductor registers the worker (rebalancing-gated) and re-queues orphaned rows at startup, exactly like the other transfer workers.

## Testing

- Job unit tests: perform forwards the payload, propagates failures for apalis retry, payload JSON roundtrip.
- Dispatch tests: fresh id runs the full redemption flow; existing mid-flight aggregate resumes (crash simulation); completed aggregate is a clean no-op.
- `cargo nextest run -p st0x-hedge --lib`: all green. Clippy and fmt clean.

## Anything else

Stacked on #786 (mint conversion); #792 flips the trigger to enqueue and deletes the Rebalancer, the mpsc channel, and the `CrossVenueTransfer` trait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added equity→hedging transfer workflow so tokenized equity redemptions can be processed/resumed toward hedging venues.

* **Bug Fixes**
  * Crash-orphaned transfers now are requeued for the hedging direction to improve recovery after restarts.

* **Refactor**
  * Redemption aggregate identifiers migrated to UUID-based IDs for more reliable tracking and event recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->