### PR TITLE
feat: force-fail stuck redemptions at TokensSent/Pending

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1625,6 +1625,10 @@ enum EquityRedemption {
         raindex_withdraw_tx: Option<TxHash>,
         redemption_tx: Option<TxHash>,
         tokenization_request_id: Option<TokenizationRequestId>,
+        // Why the redemption failed (operator --reason, rejection reason);
+        // None for automated failures and pre-field aggregates.
+        reason: Option<String>,
+        started_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
 }
@@ -1653,6 +1657,8 @@ enum EquityRedemptionCommand {
     Complete,
     // Alpaca rejected the redemption
     RejectRedemption { reason: String },
+    // Operator or timeout-driven failure before the tokens leave custody
+    FailTransfer { reason: String },
 }
 ```
 
@@ -1700,12 +1706,25 @@ enum EquityRedemptionEvent {
         completed_at: DateTime<Utc>,
     },
     RedemptionRejected {
+        reason: String,
         rejected_at: DateTime<Utc>,
     },
 }
 
-enum DetectionFailure { Timeout, ApiError { status_code: Option<u16> } }
+enum DetectionFailure {
+    Timeout,
+    ApiError { status_code: Option<u16> },
+    // Operator-initiated force-fail of a TokensSent redemption; carries the
+    // operator's --reason so the audit trail records why.
+    Operator { reason: String },
+}
 ```
+
+The operator `fail` verb (`fail-transfer --type redemption`) dispatches per
+state: a redemption stuck before tokens leave custody takes `FailTransfer`, a
+`TokensSent` redemption takes `FailDetection { failure: Operator { reason } }`,
+and a `Pending` redemption takes `RejectRedemption { reason }`. In every case
+the replayed `Failed` state materializes the operator's reason.
 
 ##### Aggregate Services
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -12,7 +12,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
-use st0x_event_sorcery::StoreBuilder;
+use st0x_event_sorcery::{AggregateError, StoreBuilder};
 use st0x_evm::{Evm, IERC20, OpenChainErrorRegistry, ReadOnlyEvm, USDC_BASE, USDC_ETHEREUM};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaWalletService, Executor,
@@ -23,7 +23,9 @@ use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::{Wrapper, WrapperService};
 
 use super::{TransferDirection, TransferType};
-use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
+use crate::equity_redemption::{
+    DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
+};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};
@@ -1103,6 +1105,29 @@ fn format_tokenization_request<Writer: Write>(
     Ok(())
 }
 
+/// Adds operator guidance to a rejected recovery command: between the CLI's
+/// state read and the command dispatch, the running bot may have advanced the
+/// aggregate, so on a typed rejection the operator should re-run to see the
+/// current state. Infrastructure failures pass through without the hint.
+fn stale_state_context<Failure: std::error::Error + Send + Sync + 'static>(
+    kind: &str,
+    id: &str,
+    error: AggregateError<Failure>,
+) -> anyhow::Error {
+    match error {
+        rejection @ (AggregateError::UserError(_) | AggregateError::AggregateConflict) => {
+            anyhow::Error::new(rejection).context(format!(
+                "{kind} {id} rejected the failure command. The state may have \
+                 advanced since it was read (is the bot driving this aggregate \
+                 concurrently?) -- re-run to see the current state."
+            ))
+        }
+        infrastructure @ (AggregateError::DatabaseConnectionError(_)
+        | AggregateError::DeserializationError(_)
+        | AggregateError::UnexpectedError(_)) => anyhow::Error::new(infrastructure),
+    }
+}
+
 /// Manually fail a stuck mint or redemption transfer aggregate.
 ///
 /// Loads the aggregate from the event store, determines its current state,
@@ -1153,7 +1178,8 @@ pub(crate) async fn fail_transfer_command<W: Write>(
             st0x_event_sorcery::send_command::<TokenizedEquityMint>(
                 pool, &mint_id, command, services,
             )
-            .await?;
+            .await
+            .map_err(|error| stale_state_context("Mint", id, error))?;
 
             writeln!(stdout, "Mint {id} marked as failed")?;
         }
@@ -1168,39 +1194,51 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 .ok_or_else(|| anyhow::anyhow!("Redemption aggregate not found: {id}"))?;
 
             use EquityRedemption::*;
-            match entity {
+            use EquityRedemptionCommand::*;
+            let command = match entity {
                 VaultWithdrawPending { .. }
                 | VaultWithdrawSubmitted { .. }
                 | WithdrawnFromRaindex { .. }
                 | UnwrapPending { .. }
                 | UnwrapSubmitted { .. }
                 | TokensUnwrapped { .. }
-                | SendPending { .. } => {}
-                TokensSent { .. } | Pending { .. } => {
-                    anyhow::bail!(
-                        "Redemption {id} is past the transfer stage -- \
-                         use FailDetection or RejectRedemption instead"
-                    );
-                }
+                | SendPending { .. } => FailTransfer {
+                    reason: reason.to_string(),
+                },
+                // Tokens reached Alpaca's redemption wallet but detection never
+                // fired: force the detection-failure terminal (DetectionFailed
+                // -> Failed), persisting the operator's reason on the event.
+                TokensSent { .. } => FailDetection {
+                    failure: DetectionFailure::Operator {
+                        reason: reason.to_string(),
+                    },
+                },
+                // Alpaca detected the transfer but never completed it: reject
+                // the redemption (RedemptionRejected -> Failed).
+                Pending { .. } => RejectRedemption {
+                    reason: reason.to_string(),
+                },
                 Completed { .. } => {
                     anyhow::bail!("Redemption {id} already completed");
                 }
                 Failed { .. } => {
                     anyhow::bail!("Redemption {id} already failed");
                 }
-            }
+            };
 
             st0x_event_sorcery::send_command::<EquityRedemption>(
                 pool,
                 &redemption_id,
-                EquityRedemptionCommand::FailTransfer {
-                    reason: reason.to_string(),
-                },
+                command,
                 services,
             )
-            .await?;
+            .await
+            .map_err(|error| stale_state_context("Redemption", id, error))?;
 
-            writeln!(stdout, "Redemption {id} marked as failed")?;
+            writeln!(
+                stdout,
+                "Redemption {id} marked as failed (reason: {reason})"
+            )?;
         }
     }
 
@@ -1260,7 +1298,7 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, address, b256};
+    use alloy::primitives::{Address, B256, address, b256};
     use alloy::providers::ProviderBuilder;
     use rain_math_float::Float;
     use url::Url;
@@ -1274,16 +1312,23 @@ mod tests {
         TradingMode,
     };
     use st0x_config::{EvmCtx, IngestionCutoff};
+    use st0x_event_sorcery::LifecycleError;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, ClientOrderId, TimeInForce,
     };
     use st0x_finance::Usdc;
     use st0x_float_macro::float;
+    use st0x_wrapper::MockWrapper;
 
     use super::*;
+    use crate::equity_redemption::{EquityRedemptionError, redemption_aggregate_id};
     use crate::inventory::ImbalanceThreshold;
+    use crate::onchain::mock::MockRaindex;
     use crate::test_utils::setup_test_db;
+    use crate::tokenization::mock::MockTokenizer;
+    use crate::tokenized_equity_mint::TokenizationRequestId;
     use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
+    use crate::vault_lookup::MockVaultLookup;
 
     /// RAI-835: the manual redrive loop must re-invoke `resume` on the same id
     /// after an attestation timeout and drive through to success -- so a single
@@ -1985,8 +2030,6 @@ mod tests {
         );
     }
 
-    // Seeds a UsdcRebalance aggregate to WithdrawalComplete state via:
-    // Initiate (Uninitialized->Withdrawing) -> ConfirmWithdrawal (->WithdrawalComplete)
     async fn seed_to_withdrawal_complete(
         store: &st0x_event_sorcery::Store<UsdcRebalance>,
         id: Uuid,
@@ -2910,6 +2953,326 @@ mod tests {
                 .to_string()
                 .contains("equity COIN is not configured in [assets.equities]"),
             "an unconfigured symbol must fail before any network call, got: {error}"
+        );
+    }
+
+    fn redemption_services() -> EquityTransferServices {
+        EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(
+                MockVaultLookup::new().with_default_vault(RaindexVaultId(B256::ZERO)),
+            ),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        }
+    }
+
+    /// Drives a redemption through the real CQRS command flow until the vault
+    /// withdrawal is confirmed (`WithdrawnFromRaindex`) -- stuck before the
+    /// tokens leave the bot's custody.
+    async fn seed_redemption_to_withdrawn(pool: &SqlitePool, id: &RedemptionAggregateId) {
+        use EquityRedemptionCommand::*;
+
+        let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .build(redemption_services())
+            .await
+            .unwrap();
+
+        store
+            .send(
+                id,
+                Redeem {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(50.25),
+                    token: Address::random(),
+                    amount: U256::from(50_250_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+        store.send(id, SubmitWithdraw).await.unwrap();
+        store.send(id, ConfirmWithdraw).await.unwrap();
+    }
+
+    /// Continues the real CQRS command flow until the redemption is stuck in
+    /// `TokensSent`: tokens reached Alpaca's redemption wallet but detection
+    /// never fired.
+    async fn seed_redemption_to_tokens_sent(pool: &SqlitePool, id: &RedemptionAggregateId) {
+        use EquityRedemptionCommand::*;
+
+        seed_redemption_to_withdrawn(pool, id).await;
+
+        let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .build(redemption_services())
+            .await
+            .unwrap();
+        for command in [
+            UnwrapTokens,
+            SubmitUnwrap,
+            ConfirmUnwrap,
+            PrepareSend,
+            SendTokens,
+        ] {
+            store.send(id, command).await.unwrap();
+        }
+    }
+
+    async fn send_redemption_command(
+        pool: &SqlitePool,
+        id: &RedemptionAggregateId,
+        command: EquityRedemptionCommand,
+    ) {
+        let store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .build(redemption_services())
+            .await
+            .unwrap();
+        store.send(id, command).await.unwrap();
+    }
+
+    /// `fail-transfer --type redemption` on a redemption stuck in `TokensSent`
+    /// must dispatch `FailDetection { Operator }` and persist the operator's
+    /// `--reason`, recoverable from the replayed `Failed` state.
+    #[tokio::test]
+    async fn fail_transfer_redemption_tokens_sent_persists_operator_reason() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-stuck-tokens-sent");
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "tokens stranded at Alpaca, ticket 42",
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert_eq!(
+            output,
+            format!(
+                "Redemption {id} marked as failed \
+                 (reason: tokens stranded at Alpaca, ticket 42)\n"
+            ),
+        );
+
+        let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(&pool, &id)
+            .await
+            .unwrap()
+            .expect("force-failed redemption must still materialize");
+        let EquityRedemption::Failed { reason, .. } = entity else {
+            panic!("force-failed redemption must replay to Failed, got {entity:?}");
+        };
+        assert_eq!(
+            reason.as_deref(),
+            Some("tokens stranded at Alpaca, ticket 42"),
+            "operator reason must survive into the replayed Failed state",
+        );
+    }
+
+    /// `fail-transfer --type redemption` on a redemption stuck in `Pending`
+    /// (Alpaca detected the transfer but never completed it) must dispatch
+    /// `RejectRedemption` and persist the operator's `--reason`.
+    #[tokio::test]
+    async fn fail_transfer_redemption_pending_rejects_with_reason() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-stuck-pending");
+
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+        send_redemption_command(
+            &pool,
+            &id,
+            EquityRedemptionCommand::Detect {
+                tokenization_request_id: TokenizationRequestId("tok-cli-test".to_string()),
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "alpaca never completed, ticket 43",
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert_eq!(
+            output,
+            format!(
+                "Redemption {id} marked as failed \
+                 (reason: alpaca never completed, ticket 43)\n"
+            ),
+        );
+
+        let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(&pool, &id)
+            .await
+            .unwrap()
+            .expect("rejected redemption must still materialize");
+        let EquityRedemption::Failed { reason, .. } = entity else {
+            panic!("rejected redemption must replay to Failed, got {entity:?}");
+        };
+        assert_eq!(
+            reason.as_deref(),
+            Some("alpaca never completed, ticket 43"),
+            "rejection reason must survive into the replayed Failed state",
+        );
+    }
+
+    /// A redemption stuck before the tokens leave the bot's custody takes the
+    /// `FailTransfer` arm of the dispatch.
+    #[tokio::test]
+    async fn fail_transfer_redemption_early_state_fails_with_reason() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-stuck-early");
+        seed_redemption_to_withdrawn(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "withdraw orphaned, ticket 44",
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert_eq!(
+            output,
+            format!(
+                "Redemption {id} marked as failed \
+                 (reason: withdraw orphaned, ticket 44)\n"
+            ),
+        );
+
+        let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(&pool, &id)
+            .await
+            .unwrap()
+            .expect("transfer-failed redemption must still materialize");
+        let EquityRedemption::Failed { reason, .. } = entity else {
+            panic!("transfer-failed redemption must replay to Failed, got {entity:?}");
+        };
+        assert_eq!(
+            reason.as_deref(),
+            Some("withdraw orphaned, ticket 44"),
+            "transfer-fail reason must survive into the replayed Failed state",
+        );
+    }
+
+    /// A completed redemption must be refused, not force-failed.
+    #[tokio::test]
+    async fn fail_transfer_redemption_refuses_already_completed() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-already-completed");
+
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+        send_redemption_command(
+            &pool,
+            &id,
+            EquityRedemptionCommand::Detect {
+                tokenization_request_id: TokenizationRequestId("tok-done".to_string()),
+            },
+        )
+        .await;
+        send_redemption_command(&pool, &id, EquityRedemptionCommand::Complete).await;
+
+        let mut stdout = Vec::new();
+        let result = fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "should be refused",
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already completed"),
+            "failing a completed redemption must refuse; got: {err_msg}"
+        );
+    }
+
+    /// A typed command rejection (the TOCTOU case: the bot advanced the
+    /// aggregate between the CLI's read and its write) gets the operator
+    /// re-run hint, with the original error preserved in the chain.
+    #[test]
+    fn stale_state_context_adds_rerun_hint_for_command_rejections() {
+        let error: AggregateError<LifecycleError<EquityRedemption>> =
+            AggregateError::UserError(LifecycleError::Apply(EquityRedemptionError::AlreadyFailed));
+
+        let wrapped = stale_state_context("Redemption", "some-id", error);
+
+        let message = format!("{wrapped:#}");
+        assert!(
+            message.contains("Redemption some-id rejected the failure command"),
+            "got: {message}"
+        );
+        assert!(
+            message.contains("re-run to see the current state"),
+            "got: {message}"
+        );
+        assert!(
+            wrapped.source().is_some(),
+            "the original aggregate error must be preserved as the source"
+        );
+    }
+
+    /// Infrastructure failures must pass through untouched -- the stale-state
+    /// hint would misattribute a database problem to a concurrency race.
+    #[test]
+    fn stale_state_context_passes_infrastructure_errors_through() {
+        let error: AggregateError<LifecycleError<EquityRedemption>> =
+            AggregateError::UnexpectedError(Box::new(std::io::Error::other("db on fire")));
+
+        let wrapped = stale_state_context("Redemption", "some-id", error);
+
+        let message = format!("{wrapped:#}");
+        assert!(
+            !message.contains("re-run"),
+            "infrastructure errors must not get the stale-state hint; got: {message}"
+        );
+        assert!(message.contains("db on fire"), "got: {message}");
+    }
+
+    /// A redemption already in a terminal state must be refused, not
+    /// double-failed.
+    #[tokio::test]
+    async fn fail_transfer_redemption_refuses_already_failed() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-already-failed");
+
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+        send_redemption_command(
+            &pool,
+            &id,
+            EquityRedemptionCommand::FailDetection {
+                failure: DetectionFailure::Timeout,
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        let result = fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "should be refused",
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already failed"),
+            "failing an already-failed redemption must refuse; got: {err_msg}"
         );
     }
 }

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -288,11 +288,19 @@ pub(crate) enum EquityRedemptionCommand {
     PrepareSend,
 }
 
-/// Reason for detection failure when polling Alpaca for redemption detection.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+/// Why redemption detection failed.
+///
+/// `Timeout` and `ApiError` are emitted automatically by the detection-polling
+/// reactor. `Operator` marks an operator-initiated force-fail of a redemption
+/// stuck in `TokensSent` (the tokens reached Alpaca but detection never fired),
+/// distinguishing a manual intervention from an automated polling failure in
+/// the event log; it carries the operator's `--reason` so the audit trail
+/// records why the redemption was force-failed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum DetectionFailure {
     Timeout,
     ApiError { status_code: Option<u16> },
+    Operator { reason: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1082,7 +1090,11 @@ impl EventSourced for EquityRedemption {
     const PROJECTION: Nil = Nil;
     // v3: added the `ProviderCompletionRecovered` event for in-process
     // failed-transfer recovery.
-    const SCHEMA_VERSION: u64 = 3;
+    // v4: `Failed.reason` is now materialized from `DetectionFailed`
+    // (`Operator` failures) and `RedemptionRejected` events instead of always
+    // `None`. Bumped to clear stale snapshots so historical rejections rebuild
+    // from events under the corrected evolve logic.
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use EquityRedemptionEvent::*;
@@ -1480,10 +1492,7 @@ impl EventSourced for EquityRedemption {
                 })
             }
 
-            DetectionFailed {
-                failure: _,
-                failed_at,
-            } => {
+            DetectionFailed { failure, failed_at } => {
                 let Self::TokensSent {
                     symbol,
                     quantity,
@@ -1496,13 +1505,18 @@ impl EventSourced for EquityRedemption {
                     return Ok(None);
                 };
 
+                let reason = match failure {
+                    DetectionFailure::Operator { reason } => Some(reason.clone()),
+                    DetectionFailure::Timeout | DetectionFailure::ApiError { .. } => None,
+                };
+
                 Some(Self::Failed {
                     symbol: symbol.clone(),
                     quantity: *quantity,
                     raindex_withdraw_tx: Some(*raindex_withdraw_tx),
                     redemption_tx: Some(*redemption_tx),
                     tokenization_request_id: None,
-                    reason: None,
+                    reason,
                     started_at: *sent_at,
                     failed_at: *failed_at,
                 })
@@ -1531,7 +1545,10 @@ impl EventSourced for EquityRedemption {
                 })
             }
 
-            RedemptionRejected { rejected_at, .. } => {
+            RedemptionRejected {
+                reason,
+                rejected_at,
+            } => {
                 let Self::Pending {
                     symbol,
                     quantity,
@@ -1550,7 +1567,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: None,
                     redemption_tx: Some(*redemption_tx),
                     tokenization_request_id: Some(tokenization_request_id.clone()),
-                    reason: None,
+                    reason: Some(reason.clone()),
                     started_at: *sent_at,
                     failed_at: *rejected_at,
                 })
@@ -1931,10 +1948,17 @@ impl EventSourced for EquityRedemption {
             },
 
             FailDetection { failure } => match self {
-                Self::TokensSent { .. } => Ok(vec![DetectionFailed {
-                    failure,
-                    failed_at: Utc::now(),
-                }]),
+                Self::TokensSent { symbol, .. } => {
+                    warn!(
+                        target: "rebalance",
+                        %symbol, ?failure,
+                        "Marking redemption as detection-failed"
+                    );
+                    Ok(vec![DetectionFailed {
+                        failure,
+                        failed_at: Utc::now(),
+                    }])
+                }
                 Self::VaultWithdrawPending { .. }
                 | Self::VaultWithdrawSubmitted { .. }
                 | Self::WithdrawnFromRaindex { .. }
@@ -1972,10 +1996,17 @@ impl EventSourced for EquityRedemption {
                 | Self::TokensUnwrapped { .. }
                 | Self::SendPending { .. }
                 | Self::TokensSent { .. } => Err(EquityRedemptionError::NotPendingForRejection),
-                Self::Pending { .. } => Ok(vec![RedemptionRejected {
-                    reason,
-                    rejected_at: Utc::now(),
-                }]),
+                Self::Pending { symbol, .. } => {
+                    warn!(
+                        target: "rebalance",
+                        %symbol, %reason,
+                        "Rejecting detected redemption"
+                    );
+                    Ok(vec![RedemptionRejected {
+                        reason,
+                        rejected_at: Utc::now(),
+                    }])
+                }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
             },
@@ -3001,8 +3032,10 @@ mod tests {
 
     #[tokio::test]
     async fn fail_detection_from_tokens_sent_state() {
+        let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
+
         let events = TestHarness::<EquityRedemption>::with(mock_services())
-            .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
+            .given(history.clone())
             .when(EquityRedemptionCommand::FailDetection {
                 failure: DetectionFailure::Timeout,
             })
@@ -3017,16 +3050,100 @@ mod tests {
                 ..
             }
         ));
+
+        let state = replay::<EquityRedemption>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let EquityRedemption::Failed { reason, .. } = state else {
+            panic!("timeout detection failure must terminate in Failed, got {state:?}");
+        };
+        assert_eq!(
+            reason, None,
+            "automated timeout failures carry no operator reason",
+        );
+    }
+
+    #[test]
+    fn detection_failure_operator_serde_roundtrip() {
+        let failure = DetectionFailure::Operator {
+            reason: "ticket 42".to_string(),
+        };
+
+        let json = serde_json::to_string(&failure).unwrap();
+        assert_eq!(json, r#"{"Operator":{"reason":"ticket 42"}}"#);
+
+        let back: DetectionFailure = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, failure);
+    }
+
+    #[test]
+    fn detection_failed_operator_event_deserializes_from_raw_json() {
+        let raw = r#"{"DetectionFailed":{"failure":{"Operator":{"reason":"ticket 42"}},"failed_at":"2026-01-01T00:00:00Z"}}"#;
+
+        let event: EquityRedemptionEvent = serde_json::from_str(raw).unwrap();
+        let EquityRedemptionEvent::DetectionFailed { failure, .. } = event else {
+            panic!("expected DetectionFailed, got {event:?}");
+        };
+        assert_eq!(
+            failure,
+            DetectionFailure::Operator {
+                reason: "ticket 42".to_string(),
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_detection_operator_from_tokens_sent_reaches_failed() {
+        // Operator force-fail of a redemption stuck in TokensSent: unlike an
+        // automated `Timeout`, the `Operator` failure carries the operator's
+        // reason, which must be persisted on the event and recoverable from
+        // the replayed `Failed` state.
+        let history = vec![withdrawn_from_raindex_event(), tokens_sent_event()];
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(history.clone())
+            .when(EquityRedemptionCommand::FailDetection {
+                failure: DetectionFailure::Operator {
+                    reason: "tokens stuck at Alpaca, support ticket 42".to_string(),
+                },
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::DetectionFailed { failure, .. } = &events[0] else {
+            panic!("expected DetectionFailed, got {:?}", events[0]);
+        };
+        assert_eq!(
+            *failure,
+            DetectionFailure::Operator {
+                reason: "tokens stuck at Alpaca, support ticket 42".to_string(),
+            },
+        );
+
+        let state = replay::<EquityRedemption>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let EquityRedemption::Failed { reason, .. } = state else {
+            panic!("operator detection failure must terminate in Failed, got {state:?}");
+        };
+        assert_eq!(
+            reason.as_deref(),
+            Some("tokens stuck at Alpaca, support ticket 42"),
+            "operator reason must be recoverable from the replayed Failed state",
+        );
     }
 
     #[tokio::test]
     async fn reject_redemption_from_pending_state() {
+        let history = vec![
+            withdrawn_from_raindex_event(),
+            tokens_sent_event(),
+            detected_event(),
+        ];
+
         let events = TestHarness::<EquityRedemption>::with(mock_services())
-            .given(vec![
-                withdrawn_from_raindex_event(),
-                tokens_sent_event(),
-                detected_event(),
-            ])
+            .given(history.clone())
             .when(EquityRedemptionCommand::RejectRedemption {
                 reason: "test rejection".to_string(),
             })
@@ -3034,10 +3151,22 @@ mod tests {
             .events();
 
         assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0],
-            EquityRedemptionEvent::RedemptionRejected { .. }
-        ));
+        let EquityRedemptionEvent::RedemptionRejected { reason, .. } = &events[0] else {
+            panic!("expected RedemptionRejected, got {:?}", events[0]);
+        };
+        assert_eq!(reason, "test rejection");
+
+        let state = replay::<EquityRedemption>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let EquityRedemption::Failed { reason, .. } = state else {
+            panic!("rejected redemption must terminate in Failed, got {state:?}");
+        };
+        assert_eq!(
+            reason.as_deref(),
+            Some("test rejection"),
+            "rejection reason must be recoverable from the replayed Failed state",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Implements [RAI-983](https://linear.app/makeitrain/issue/RAI-983) — Step 5 of the recovery-CLI epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978). Lets the operator force-fail a redemption stuck past the transfer stage.

## Why

A redemption stuck at `TokensSent` (provider never detected) or `Pending` (Alpaca detected but never completed) had **no force-fail path**: `fail-transfer --type redemption` bailed telling the operator to use `FailDetection`/`RejectRedemption`, neither of which had a CLI. Same no-exit class of bug as RAI-957.

## How

The CLI now dispatches per state instead of bailing:
- `TokensSent` → `FailDetection { failure: Operator }` (→ `DetectionFailed` → `Failed`)
- `Pending` → `RejectRedemption { reason }` (→ `RedemptionRejected` → `Failed`)

Adds a `DetectionFailure::Operator` variant (unit; keeps `Copy`) so an operator-initiated fail is distinguishable from an automated polling timeout in the event log. All via the CQRS aggregate-command flow.

## Testing

Aggregate test `fail_detection_operator_from_tokens_sent_reaches_failed` (Operator path → `Failed`); existing reject-from-`Pending` test covers the other path. `nextest` + `clippy` + `fmt` green.

## Anything else

The free-text `--reason` is persisted on the `Pending`→`RejectRedemption` path; the `TokensSent`→`FailDetection{Operator}` path records the `Operator` marker only (`DetectionFailure` is `Copy`) and surfaces the reason in CLI output. Part of epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978).
