### PR TITLE
refactor: regroup recovery CLI into transfer/position/view/cctp

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,17 @@ cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.to
 Manual repair of local position tracking after an operator trade or rebalance:
 
 ```bash
-cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --zero --reason "manual rebalance completed"
-cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --long 100 --price 200 --reason "manual buy not observed by bot"
-cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml repair set-position --symbol SPYM --short 12.5 --price 200 --reason "manual sell not observed by bot"
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml position set --symbol SPYM --zero --reason "manual rebalance completed"
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml position set --symbol SPYM --long 100 --price 200 --reason "manual buy not observed by bot"
+cargo run --bin cli -- --config path/to/config.toml --secrets path/to/secrets.toml position set --symbol SPYM --short 12.5 --price 200 --reason "manual sell not observed by bot"
 ```
 
 `--price` (USDC per share) is required for a nonzero target when the symbol uses
 a dollar-value execution threshold and no price is already known; without it the
 repaired exposure could never be valued and would never hedge.
 
-`set-position` is rejected while the symbol still has a pending offchain hedge
-order; resolve it first with `repair fail-pending-offchain-order`, then retry.
+`position set` is rejected while the symbol still has a pending offchain hedge
+order; resolve it first with `position release-hedge`, then retry.
 
 ### Brokerage Setup
 
@@ -276,7 +276,9 @@ nix develop .#ci-backend -c cargo clippy --workspace --all-targets --all-feature
 system using [mprocs](https://github.com/pvolok/mprocs) to run the dashboard and
 the bot side-by-side. `nix run .#simulate-failures` starts the same stack, then
 creates failed mint and redemption rebalances whose mock Alpaca provider later
-completes and prints the `recheck-transfer` commands that recover them.
+completes and prints the (legacy-named) `recheck-transfer` commands that recover
+them; the printed hints move to the new names when the legacy aliases are
+deprecated.
 
 What it does:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -3114,8 +3114,12 @@ effect rather than a generic intent:
   A defaulted reason is an audit-hostile record and violates the
   no-silent-defaults rule. The pre-existing `fail-pending-offchain-order` and
   `fail-transfer` predate this rule and carry defaulted reasons, and
-  `reconcile-usdc-transfer` shipped with one just before this rule was codified;
-  a later step of the unification epic removes all three defaults.
+  `reconcile-usdc-transfer` shipped with one just before this rule was codified.
+  The rename step carries those defaults onto the renamed forms unchanged
+  (`fail-pending-offchain-order` is a clap alias sharing its canonical command's
+  arguments, and the flat `fail-transfer` / `reconcile-usdc-transfer` variants
+  keep their legacy shape for compatibility); the next step of the unification
+  epic removes the defaults everywhere.
 - **`fail` and `reconcile` are distinct and must not be conflated.** `fail` is
   for an operation the system is still waiting on (force it to a clean
   terminal); `reconcile` is for an operation that already failed and whose guard

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -199,10 +199,10 @@ stox alpaca-tokenization-requests
 
 ### Rechecking Failed Equity Transfers
 
-Use `recheck-transfer` when the bot marked an equity mint or redemption as
+Use `transfer recheck` when the bot marked an equity mint or redemption as
 failed, but Alpaca later shows the same provider request as completed.
 
-**The bot must be running.** `recheck-transfer` delegates to the bot's REST API
+**The bot must be running.** `transfer recheck` delegates to the bot's REST API
 (`POST /transfers/recheck/<kind>/<id>` on the configured `server_port`) rather
 than mutating the database directly. Recovery has to run inside the bot process
 so the recovery event dispatches through the in-process inventory reactor (which
@@ -219,22 +219,22 @@ Recoverable cases:
 
 - Mint failed at acceptance (accepted by Alpaca, but tokens never received),
   then Alpaca later reports the mint completed.
-  `stox recheck-transfer --type mint --id <issuer-request-id>` records provider
+  `stox transfer recheck --kind mint --id <issuer-request-id>` records provider
   completion and resumes wrapping/depositing to Raindex. A mint that already
   received tokens and then failed while wrapping or depositing is **not**
   recoverable this way (recovery would re-wrap tokens that already moved); the
   command reports it as not recoverable.
 - Redemption failed after tokens were sent, with a redemption tx in the
   aggregate.
-  `stox recheck-transfer --type redemption --id <redemption-aggregate-id>`
+  `stox transfer recheck --kind redemption --id <redemption-aggregate-id>`
   completes it if Alpaca now reports completed.
-- Non-failed active mints/redemptions can also be passed to `recheck-transfer`;
+- Non-failed active mints/redemptions can also be passed to `transfer recheck`;
   the command resumes the normal workflow instead of forcing recovery.
 
 The command prints the recovery outcome: `recovered`, `resumed`,
 `already_completed`, `left_unchanged`, `not_detected_yet`, or `not_recoverable`.
 
-Not covered by `recheck-transfer` yet:
+Not covered by `transfer recheck` yet:
 
 - Mint requests rejected before Alpaca acceptance. There is no provider
   completion to discover.
@@ -248,14 +248,12 @@ Not covered by `recheck-transfer` yet:
 - USDC rebalancing failures. Those use the USDC/CCTP state machine and have
   their own recovery commands. A manual `transfer-usdc` prints its transfer id
   and, if interrupted after the burn, is resumed with
-  `stox resume-usdc-transfer --id <id> --direction <to-raindex|to-alpaca>
-  --amount <amount>`.
-  The `--direction` must match the original (a mismatch is rejected to avoid
+  `stox transfer resume --id <id> --direction <to-raindex|to-alpaca>`. The
+  `--direction` must match the original (a mismatch is rejected to avoid
   mis-driving) and an unknown id is rejected rather than starting a fresh burn;
-  the `--amount` is required for symmetry with `transfer-usdc` but a resume uses
-  the aggregate's persisted amount. Run it only when the bot is not concurrently
-  driving that same id, since it drives the aggregate directly rather than
-  through the bot's resume lock.
+  a resume uses the aggregate's persisted amount, so no amount is taken. Run it
+  only when the bot is not concurrently driving that same id, since it drives
+  the aggregate directly rather than through the bot's resume lock.
 
 ### Clearing a pre-burn guard latch
 
@@ -283,13 +281,15 @@ that no recent CCTP burn was submitted from the market-maker wallet (e.g. via
 - **If no burn is found**: run `fail-usdc-transfer` to clear the guard.
 - **If a burn IS found** while the aggregate is still `BridgingSubmitting`: do
   NOT run `fail-usdc-transfer` (strands the burned funds) and do NOT run
-  `reconcile-usdc-transfer` (its preflight rejects `BridgingSubmitting` -- it
-  only accepts persisted post-burn terminals such as `DepositFailed`). Instead,
-  run `resume-usdc-transfer`: its `find_recent_burn` scan adopts the orphan
-  burn, persists `BridgingInitiated`, and the transfer continues normally.
+  `transfer reconcile` (its preflight rejects `BridgingSubmitting` -- it only
+  accepts persisted post-burn terminals such as `DepositFailed`). Instead, run
+  `transfer resume`: its `find_recent_burn` scan adopts the orphan burn,
+  persists `BridgingInitiated`, and the transfer continues normally.
 
-`reconcile-usdc-transfer` is the path for persisted post-burn terminal failures
-(e.g. `DepositFailed`, `BridgingFailed` with a burn tx recorded).
+`transfer reconcile` is the path for persisted post-burn terminal failures (e.g.
+`DepositFailed`, `BridgingFailed` with a burn tx recorded). The legacy flat
+`resume-usdc-transfer` / `reconcile-usdc-transfer` names remain valid until
+deprecation.
 
     stox fail-usdc-transfer --id <uuid> --reason "pre-burn crash, burn not attempted"
 
@@ -300,5 +300,6 @@ nix run .#simulate-failures
 ```
 
 The backend creates failed mint and redemption transfers whose mock Alpaca
-provider later completes, then prints the exact `recheck-transfer` commands for
-that run's generated config, secrets, database, and mock API port.
+provider later completes, then prints the exact (legacy-named)
+`recheck-transfer` commands for that run's generated config, secrets, database,
+and mock API port.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -109,11 +109,15 @@ pub enum CctpChain {
     Base,
 }
 
-/// Manual repair operations for stuck local CQRS state.
+/// Manual position-recovery operations for stuck local CQRS state.
 #[derive(Debug, Subcommand)]
-pub enum RepairCommand {
-    /// Fail a position's pending offchain order pointer so normal hedging can retry.
-    FailPendingOffchainOrder {
+pub enum PositionRecoveryCommand {
+    /// Release a position's pending offchain order pointer so normal hedging can retry.
+    ///
+    /// Operates directly on the local CQRS state via aggregate commands; does not
+    /// require the running bot.
+    #[command(alias = "fail-pending-offchain-order")]
+    ReleaseHedge {
         /// Position symbol (e.g., MSTR)
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
@@ -129,13 +133,17 @@ pub enum RepairCommand {
         reason: String,
     },
     /// Set a position's net exposure after an operator manual correction.
+    ///
+    /// Operates directly on the local CQRS state via aggregate commands; does not
+    /// require the running bot.
+    #[command(alias = "set-position")]
     #[command(group(
         ArgGroup::new("target")
             .required(true)
             .multiple(false)
             .args(["zero", "long", "short"])
     ))]
-    SetPosition {
+    Set {
         /// Position symbol (e.g., SPYM)
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
@@ -322,8 +330,8 @@ pub enum Commands {
     /// Re-drives a transfer whose CLI invocation was interrupted after the burn.
     /// The id is printed by `transfer-usdc` at start. An unknown id is rejected
     /// (never starts a fresh burn) and `--direction` must match the original;
-    /// `--amount` is required for symmetry with the printed recovery command but
-    /// is not validated -- the resume uses the aggregate's persisted amount.
+    /// the resume always uses the aggregate's persisted amount.
+    #[command(hide = true)]
     ResumeUsdcTransfer {
         /// Id of the transfer to resume (printed by `transfer-usdc`)
         #[arg(long = "id")]
@@ -331,19 +339,21 @@ pub enum Commands {
         /// Direction of the original transfer (must match the persisted transfer)
         #[arg(short = 'd', long = "direction")]
         direction: TransferDirection,
-        /// Amount printed by `transfer-usdc`; required for symmetry but not
-        /// validated -- the resume uses the persisted amount
+        /// Required for compatibility with old recovery hints; ignored -- the
+        /// resume uses the persisted amount
         #[arg(short = 'a', long = "amount")]
         amount: Usdc,
     },
 
-    /// Reconcile a USDC transfer stuck in the post-burn DepositFailed state
+    /// Reconcile a USDC transfer stranded in a post-burn terminal failure
     ///
-    /// Drives a post-burn `DepositFailed` USDC rebalance to the clearing
-    /// terminal `Reconciled` state: the minted USDC was handled out-of-band, so
-    /// this resolves the transfer (clearing the in-progress guard and
-    /// reconciling source-venue inflight) rather than re-driving the deposit.
-    /// Rejects an unknown id or an aggregate not in `DepositFailed`.
+    /// Drives a USDC rebalance stranded in a post-burn terminal failure
+    /// (`DepositFailed`, a post-burn `BridgingFailed`, or a `BaseToAlpaca`
+    /// `ConversionFailed`) to the clearing terminal `Reconciled` state: the
+    /// funds were handled out-of-band, so this resolves the transfer (clearing
+    /// the in-progress guard and reconciling source-venue inflight) rather than
+    /// re-driving it. Rejects an unknown id or any other state.
+    #[command(hide = true)]
     ReconcileUsdcTransfer {
         /// Id of the stuck transfer to reconcile
         #[arg(long = "id")]
@@ -368,9 +378,9 @@ pub enum Commands {
     ///   CCTP burn left the market-maker wallet before running (a crash at this
     ///   state may have broadcast a burn whose event never persisted).
     /// - Post-burn terminal failures (e.g. `DepositFailed`) use
-    ///   `reconcile-usdc-transfer`. In-flight post-burn states (`Bridging`,
+    ///   `transfer reconcile`. In-flight post-burn states (`Bridging`,
     ///   `AwaitingAttestation`, `Attested`, `Bridged`, `DepositInitiated`)
-    ///   should be resumed with `resume-usdc-transfer`.
+    ///   should be resumed with `transfer resume`.
     FailUsdcTransfer {
         /// USDC rebalance aggregate ID (UUID)
         #[arg(short = 'i', long = "id")]
@@ -521,6 +531,7 @@ pub enum Commands {
     /// Use this when a CCTP burn succeeded but the mint wasn't completed (e.g., due to
     /// attestation polling being interrupted). Provide the burn transaction hash and
     /// specify the source chain to recover the transfer.
+    #[command(hide = true)]
     CctpRecover {
         /// Transaction hash of the burn transaction on the source chain
         #[arg(long = "burn-tx")]
@@ -643,6 +654,7 @@ pub enum Commands {
     /// Marks a transfer aggregate as failed, transitioning it to a terminal
     /// state. Use when a transfer is permanently stuck (e.g., timed out,
     /// unrecoverable error) and needs operator intervention.
+    #[command(hide = true)]
     FailTransfer {
         /// Transfer type: "mint" or "redemption"
         #[arg(short = 't', long = "type")]
@@ -664,6 +676,7 @@ pub enum Commands {
     /// Delegates to the running bot's REST API so recovery dispatches through
     /// the in-process reactor (correcting live inventory). Requires the bot to
     /// be running and serving its API on the configured `server_port`.
+    #[command(hide = true)]
     RecheckTransfer {
         /// Transfer type: "mint" or "redemption"
         #[arg(short = 't', long = "type")]
@@ -678,6 +691,7 @@ pub enum Commands {
     /// Use as an escape hatch when a view becomes corrupted (e.g., due to
     /// lost updates from optimistic lock conflicts). Deletes the view row(s)
     /// and replays all events to reconstruct correct state.
+    #[command(hide = true)]
     RebuildView {
         /// Aggregate type to rebuild (position, offchain-order, vault-registry)
         #[arg(short = 'a', long = "aggregate")]
@@ -692,10 +706,158 @@ pub enum Commands {
         all: bool,
     },
 
-    /// Repair stuck local CQRS state through aggregate commands.
-    Repair {
+    /// Recover stuck positions through aggregate commands.
+    #[command(alias = "repair")]
+    Position {
         #[command(subcommand)]
-        command: RepairCommand,
+        command: PositionRecoveryCommand,
+    },
+
+    /// Recover stuck asset transfers (USDC rebalances, mints, redemptions).
+    Transfer {
+        #[command(subcommand)]
+        command: TransferCommand,
+    },
+
+    /// Maintain materialized views.
+    View {
+        #[command(subcommand)]
+        command: ViewCommand,
+    },
+
+    /// Recover stuck CCTP (cross-chain USDC) transfers.
+    Cctp {
+        #[command(subcommand)]
+        command: CctpCommand,
+    },
+}
+
+/// Recover stuck asset transfers between trading venues.
+#[derive(Debug, Subcommand)]
+pub enum TransferCommand {
+    /// Resume an interrupted USDC transfer by its id (Raindex <-> Alpaca).
+    ///
+    /// Re-drives a transfer whose CLI invocation was interrupted after the burn.
+    /// The id is printed by `transfer-usdc` at start. An unknown id is rejected
+    /// (never starts a fresh burn) and `--direction` must match the original.
+    /// The resume uses the aggregate's persisted amount; any `--amount` is ignored.
+    /// Operates on the local CQRS state plus a live RPC provider (re-drives the
+    /// on-chain burn/mint/deposit flow itself). Does not require the running
+    /// bot, but the bot must not be concurrently driving the same id.
+    Resume {
+        /// Id of the transfer to resume (printed by `transfer-usdc`)
+        #[arg(long = "id")]
+        id: Uuid,
+        /// Direction of the original transfer (must match the persisted transfer)
+        #[arg(short = 'd', long = "direction")]
+        direction: TransferDirection,
+        /// Accepted for compatibility with old `resume-usdc-transfer` runbooks;
+        /// ignored -- the resume always uses the aggregate's persisted amount.
+        #[arg(short = 'a', long = "amount", hide = true)]
+        amount: Option<Usdc>,
+    },
+
+    /// Reconcile a USDC transfer stranded in a post-burn terminal failure.
+    ///
+    /// Drives a USDC rebalance stranded in a post-burn terminal failure that
+    /// strands the in-progress guard (`DepositFailed`, a post-burn
+    /// `BridgingFailed`, or a `BaseToAlpaca` `ConversionFailed`) to the clearing
+    /// terminal `Reconciled` state: the funds were handled out-of-band, so this
+    /// resolves the transfer rather than re-driving it. Rejects an unknown id or
+    /// any other state. Operates directly on the local CQRS state; does not
+    /// require the running bot, but the bot must not be concurrently driving
+    /// the same id.
+    Reconcile {
+        /// Id of the stuck transfer to reconcile
+        #[arg(long = "id")]
+        id: Uuid,
+        /// Why the transfer is being reconciled
+        #[arg(short = 'r', long = "reason", default_value = "funds-moved-manually")]
+        reason: ReconcileReasonArg,
+    },
+
+    /// Manually fail a stuck mint or redemption transfer.
+    ///
+    /// Marks a transfer aggregate as failed, transitioning it to a terminal state.
+    /// Use when a transfer is permanently stuck and needs operator intervention.
+    /// Operates directly on the local CQRS state; does not require the running
+    /// bot, but the bot must not be concurrently driving the same id.
+    Fail {
+        /// Transfer type: "mint" or "redemption"
+        #[arg(short = 'k', long = "kind", alias = "type", short_alias = 't')]
+        kind: TransferType,
+        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
+        #[arg(short = 'i', long = "id")]
+        id: String,
+        /// Reason for failure
+        #[arg(
+            short = 'r',
+            long = "reason",
+            default_value = "Manually failed via CLI"
+        )]
+        reason: String,
+    },
+
+    /// Re-check a failed mint or redemption and complete it if the provider settled it.
+    ///
+    /// Delegates to the running bot's REST API so recovery dispatches through the
+    /// in-process reactor (correcting live inventory). Requires the bot to be
+    /// running and serving its API on the configured `server_port`.
+    Recheck {
+        /// Transfer type: "mint" or "redemption"
+        #[arg(short = 'k', long = "kind", alias = "type", short_alias = 't')]
+        kind: TransferType,
+        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
+        #[arg(short = 'i', long = "id")]
+        id: String,
+    },
+}
+
+/// Maintain materialized views derived from the event log.
+#[derive(Debug, Subcommand)]
+pub enum ViewCommand {
+    /// Rebuild a materialized view by replaying all events from scratch.
+    ///
+    /// Use as an escape hatch when a view becomes corrupted (e.g., due to lost
+    /// updates from optimistic lock conflicts). Deletes the view row(s) and
+    /// replays all events to reconstruct correct state. Operates directly on the
+    /// local CQRS state; does not require the running bot.
+    Rebuild {
+        /// Aggregate type to rebuild (position, offchain-order, vault-registry)
+        #[arg(short = 'a', long = "aggregate")]
+        aggregate: AggregateView,
+        /// Specific aggregate ID to rebuild (e.g., AAPL for position).
+        /// Mutually exclusive with --all.
+        #[arg(long = "id", conflicts_with = "all", required_unless_present = "all")]
+        id: Option<String>,
+        /// Rebuild all views for the aggregate type.
+        /// Mutually exclusive with --id.
+        #[arg(long = "all", conflicts_with = "id", required_unless_present = "id")]
+        all: bool,
+    },
+}
+
+/// Recover stuck CCTP (cross-chain USDC) transfers.
+#[derive(Debug, Subcommand)]
+pub enum CctpCommand {
+    /// Complete the mint of a stuck CCTP transfer on the destination chain.
+    ///
+    /// Use this when a CCTP burn succeeded but the mint wasn't completed (e.g.,
+    /// due to attestation polling being interrupted). Provide the burn
+    /// transaction hash and specify the source chain to recover the transfer.
+    ///
+    /// Live RPC only: touches no database state or aggregate. Ensure the bot is
+    /// not concurrently driving the same on-chain mint. After completing the
+    /// mint, bring a stuck `UsdcRebalance` aggregate back in sync: `transfer
+    /// resume` while it is still non-terminal (it adopts the existing mint), or
+    /// `transfer reconcile` if it already reached a post-burn terminal failure.
+    CompleteMint {
+        /// Transaction hash of the burn transaction on the source chain
+        #[arg(long = "burn-tx")]
+        burn_tx: TxHash,
+        /// Source chain where the burn occurred
+        #[arg(long = "source-chain")]
+        source_chain: CctpChain,
     },
 }
 
@@ -835,8 +997,8 @@ enum SimpleCommand {
         id: Option<String>,
         all: bool,
     },
-    Repair {
-        command: RepairCommand,
+    Position {
+        command: PositionRecoveryCommand,
     },
     FailTransfer {
         transfer_type: TransferType,
@@ -974,7 +1136,6 @@ enum ProviderCommand {
     ResumeUsdcTransfer {
         id: Uuid,
         direction: TransferDirection,
-        amount: Usdc,
     },
     CctpBridge {
         amount: Option<Usdc>,
@@ -1104,12 +1265,11 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::ResumeUsdcTransfer {
             id,
             direction,
-            amount,
-        } => Err(ProviderCommand::ResumeUsdcTransfer {
-            id,
-            direction,
-            amount,
-        }),
+            // Ignored: a resume always uses the persisted aggregate amount. The
+            // flag stays required on the legacy name so old invocations keep
+            // their exact shape.
+            amount: _,
+        } => Err(ProviderCommand::ResumeUsdcTransfer { id, direction }),
         Commands::VaultDeposit {
             amount,
             token,
@@ -1166,7 +1326,7 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::RebuildView { aggregate, id, all } => {
             Ok(SimpleCommand::RebuildView { aggregate, id, all })
         }
-        Commands::Repair { command } => Ok(SimpleCommand::Repair { command }),
+        Commands::Position { command } => Ok(SimpleCommand::Position { command }),
         Commands::FailTransfer {
             transfer_type,
             id,
@@ -1185,6 +1345,41 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::FailUsdcTransfer { id, reason } => {
             Ok(SimpleCommand::FailUsdcTransfer { id, reason })
         }
+        Commands::Transfer { command } => match command {
+            TransferCommand::Resume {
+                id,
+                direction,
+                // Ignored: a resume always uses the persisted aggregate amount.
+                // Accepted only so old `--amount` runbook invocations still parse.
+                amount: _,
+            } => Err(ProviderCommand::ResumeUsdcTransfer { id, direction }),
+            TransferCommand::Reconcile { id, reason } => {
+                Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason })
+            }
+            TransferCommand::Fail { kind, id, reason } => Ok(SimpleCommand::FailTransfer {
+                transfer_type: kind,
+                id,
+                reason,
+            }),
+            TransferCommand::Recheck { kind, id } => Ok(SimpleCommand::RecheckTransfer {
+                transfer_type: kind,
+                id,
+            }),
+        },
+        Commands::View { command } => match command {
+            ViewCommand::Rebuild { aggregate, id, all } => {
+                Ok(SimpleCommand::RebuildView { aggregate, id, all })
+            }
+        },
+        Commands::Cctp { command } => match command {
+            CctpCommand::CompleteMint {
+                burn_tx,
+                source_chain,
+            } => Err(ProviderCommand::CctpRecover {
+                burn_tx,
+                source_chain,
+            }),
+        },
     }
 }
 
@@ -1342,8 +1537,8 @@ async fn run_simple_command<W: Write>(
         SimpleCommand::RebuildView { aggregate, id, all } => {
             rebuild_view(stdout, pool, aggregate, id, all).await
         }
-        SimpleCommand::Repair { command } => {
-            run_repair_command(stdout, pool, command, ctx.execution_threshold).await
+        SimpleCommand::Position { command } => {
+            run_position_command(stdout, pool, command, ctx.execution_threshold).await
         }
         SimpleCommand::FailTransfer {
             transfer_type,
@@ -1449,14 +1644,14 @@ async fn rebuild_view<W: Write>(
     Ok(())
 }
 
-async fn run_repair_command<W: Write>(
+async fn run_position_command<W: Write>(
     stdout: &mut W,
     pool: &SqlitePool,
-    command: RepairCommand,
+    command: PositionRecoveryCommand,
     execution_threshold: st0x_config::ExecutionThreshold,
 ) -> anyhow::Result<()> {
     match command {
-        RepairCommand::FailPendingOffchainOrder {
+        PositionRecoveryCommand::ReleaseHedge {
             symbol,
             order_id,
             reason,
@@ -1464,7 +1659,7 @@ async fn run_repair_command<W: Write>(
             repair::fail_pending_offchain_order_command(stdout, pool, &symbol, order_id, reason)
                 .await
         }
-        RepairCommand::SetPosition {
+        PositionRecoveryCommand::Set {
             symbol,
             zero,
             long,
@@ -1487,7 +1682,7 @@ async fn run_repair_command<W: Write>(
     }
 }
 
-/// Operator-chosen target for `repair set-position`, converted from the mutually
+/// Operator-chosen target for `position set`, converted from the mutually
 /// exclusive `--zero`/`--long`/`--short` clap flags at the parser boundary so
 /// internal code carries one valid state instead of three flags.
 enum ManualPositionTarget {
@@ -1546,13 +1741,8 @@ async fn run_provider_command<W: Write>(
         ProviderCommand::TransferUsdc { direction, amount } => {
             rebalancing::transfer_usdc_command(stdout, direction, amount, ctx, pool).await
         }
-        ProviderCommand::ResumeUsdcTransfer {
-            id,
-            direction,
-            amount,
-        } => {
-            rebalancing::resume_usdc_transfer_command(stdout, id, direction, amount, ctx, pool)
-                .await
+        ProviderCommand::ResumeUsdcTransfer { id, direction } => {
+            rebalancing::resume_usdc_transfer_command(stdout, id, direction, ctx, pool).await
         }
         ProviderCommand::CctpBridge { amount, all, from } => {
             cctp::cctp_bridge_command::<OpenChainErrorRegistry, _>(stdout, amount, all, from, ctx)
@@ -2046,9 +2236,9 @@ mod tests {
         .unwrap();
 
         match cli.command {
-            Commands::Repair {
+            Commands::Position {
                 command:
-                    RepairCommand::FailPendingOffchainOrder {
+                    PositionRecoveryCommand::ReleaseHedge {
                         symbol,
                         order_id: parsed_order_id,
                         reason,
@@ -2077,9 +2267,9 @@ mod tests {
         .unwrap();
 
         match cli.command {
-            Commands::Repair {
+            Commands::Position {
                 command:
-                    RepairCommand::SetPosition {
+                    PositionRecoveryCommand::Set {
                         symbol,
                         zero,
                         long,
@@ -2115,9 +2305,9 @@ mod tests {
         .unwrap();
 
         match long.command {
-            Commands::Repair {
+            Commands::Position {
                 command:
-                    RepairCommand::SetPosition {
+                    PositionRecoveryCommand::Set {
                         long: Some(quantity),
                         ..
                     },
@@ -2139,9 +2329,9 @@ mod tests {
         .unwrap();
 
         match short.command {
-            Commands::Repair {
+            Commands::Position {
                 command:
-                    RepairCommand::SetPosition {
+                    PositionRecoveryCommand::Set {
                         short: Some(quantity),
                         ..
                     },
@@ -2218,8 +2408,8 @@ mod tests {
     #[test]
     fn classify_repair_command_as_simple() {
         let order_id = OffchainOrderId::new();
-        let command = Commands::Repair {
-            command: RepairCommand::FailPendingOffchainOrder {
+        let command = Commands::Position {
+            command: PositionRecoveryCommand::ReleaseHedge {
                 symbol: Symbol::new("MSTR").unwrap(),
                 order_id,
                 reason: "operator repair".to_string(),
@@ -2227,9 +2417,9 @@ mod tests {
         };
 
         match classify_command(command) {
-            Ok(SimpleCommand::Repair {
+            Ok(SimpleCommand::Position {
                 command:
-                    RepairCommand::FailPendingOffchainOrder {
+                    PositionRecoveryCommand::ReleaseHedge {
                         symbol,
                         order_id: parsed_order_id,
                         reason,
@@ -2260,8 +2450,8 @@ mod tests {
         let ctx = create_test_ctx();
         let pool = setup_test_db().await;
         let symbol = Symbol::new("SPYM").unwrap();
-        let command = Commands::Repair {
-            command: RepairCommand::SetPosition {
+        let command = Commands::Position {
+            command: PositionRecoveryCommand::Set {
                 symbol: symbol.clone(),
                 zero: false,
                 long: Some(positive_shares("100")),
@@ -2430,6 +2620,439 @@ mod tests {
         let expected = (FractionalShares::ZERO - positive_shares("12.5").inner()).unwrap();
 
         assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn transfer_resume_parses_and_classifies_as_resume_provider() {
+        let id = Uuid::from_u128(42);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--id",
+            &id.to_string(),
+            "--direction",
+            "to-raindex",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Err(ProviderCommand::ResumeUsdcTransfer {
+                id: parsed_id,
+                direction,
+            }) => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(direction, TransferDirection::ToRaindex));
+            }
+            _ => panic!("expected resume provider command"),
+        }
+    }
+
+    #[test]
+    fn transfer_reconcile_parses_and_classifies_as_simple() {
+        let id = Uuid::from_u128(77);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "reconcile",
+            "--id",
+            &id.to_string(),
+            "--reason",
+            "deposit-credited-offline",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::ReconcileUsdcTransfer {
+                id: parsed_id,
+                reason,
+            }) => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(reason, ReconcileReasonArg::DepositCreditedOffline));
+            }
+            _ => panic!("expected reconcile simple command"),
+        }
+    }
+
+    #[test]
+    fn transfer_fail_parses_and_classifies_as_simple() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "fail",
+            "--kind",
+            "mint",
+            "--id",
+            "ISS001",
+            "--reason",
+            "stuck forever",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::FailTransfer {
+                transfer_type,
+                id,
+                reason,
+            }) => {
+                assert!(matches!(transfer_type, TransferType::Mint));
+                assert_eq!(id, "ISS001");
+                assert_eq!(reason, "stuck forever");
+            }
+            _ => panic!("expected fail-transfer simple command"),
+        }
+    }
+
+    #[test]
+    fn transfer_recheck_parses_and_classifies_as_simple() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "recheck",
+            "--kind",
+            "redemption",
+            "--id",
+            "redemption-1",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::RecheckTransfer { transfer_type, id }) => {
+                assert!(matches!(transfer_type, TransferType::Redemption));
+                assert_eq!(id, "redemption-1");
+            }
+            _ => panic!("expected recheck simple command"),
+        }
+    }
+
+    #[test]
+    fn view_rebuild_parses_and_classifies_as_simple() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "view",
+            "rebuild",
+            "--aggregate",
+            "position",
+            "--id",
+            "AAPL",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::RebuildView { aggregate, id, all }) => {
+                assert!(matches!(aggregate, AggregateView::Position));
+                assert_eq!(id.as_deref(), Some("AAPL"));
+                assert!(!all);
+            }
+            _ => panic!("expected rebuild-view simple command"),
+        }
+    }
+
+    #[test]
+    fn cctp_complete_mint_parses_and_classifies_as_provider() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "cctp",
+            "complete-mint",
+            "--burn-tx",
+            &TxHash::ZERO.to_string(),
+            "--source-chain",
+            "ethereum",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Err(ProviderCommand::CctpRecover {
+                burn_tx,
+                source_chain,
+            }) => {
+                assert_eq!(burn_tx, TxHash::ZERO);
+                assert!(matches!(source_chain, CctpChain::Ethereum));
+            }
+            _ => panic!("expected cctp complete-mint provider command"),
+        }
+    }
+
+    #[test]
+    fn position_set_zero_parses_under_new_name() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "position",
+            "set",
+            "--symbol",
+            "SPYM",
+            "--zero",
+            "--reason",
+            "manual rebalance completed",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::Position {
+                command: PositionRecoveryCommand::Set { symbol, zero, .. },
+            }) => {
+                assert_eq!(symbol, Symbol::new("SPYM").unwrap());
+                assert!(zero);
+            }
+            _ => panic!("expected position set to classify as a simple position command"),
+        }
+    }
+
+    #[test]
+    fn position_release_hedge_parses_under_new_name() {
+        let order_id = OffchainOrderId::new();
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "position",
+            "release-hedge",
+            "--symbol",
+            "MSTR",
+            "--order-id",
+            &order_id.to_string(),
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::Position {
+                command:
+                    PositionRecoveryCommand::ReleaseHedge {
+                        symbol,
+                        order_id: parsed_order_id,
+                        reason,
+                    },
+            }) => {
+                assert_eq!(symbol, Symbol::new("MSTR").unwrap());
+                assert_eq!(parsed_order_id, order_id);
+                assert_eq!(
+                    reason, "Manually failed pending offchain order via CLI",
+                    "omitted --reason must fall back to the documented legacy default",
+                );
+            }
+            _ => panic!("expected position release-hedge to classify as a simple position command"),
+        }
+    }
+
+    #[test]
+    fn legacy_repair_alias_still_parses() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "repair",
+            "set-position",
+            "--symbol",
+            "SPYM",
+            "--zero",
+            "--reason",
+            "legacy alias",
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            classify_command(cli.command),
+            Ok(SimpleCommand::Position {
+                command: PositionRecoveryCommand::Set { .. }
+            })
+        ));
+    }
+
+    /// The legacy flat resume keeps its exact shape: `--amount` stays required
+    /// (even though the resume ignores it for the persisted amount), so old
+    /// invocations and old recovery hints behave identically.
+    #[test]
+    fn legacy_resume_without_amount_is_rejected() {
+        let result = Cli::try_parse_from([
+            "st0x-cli",
+            "resume-usdc-transfer",
+            "--id",
+            &Uuid::from_u128(7).to_string(),
+            "--direction",
+            "to-raindex",
+        ]);
+
+        let error = result.unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "legacy resume-usdc-transfer must keep requiring --amount",
+        );
+    }
+
+    #[test]
+    fn legacy_flat_transfer_names_still_parse() {
+        let resume_id = Uuid::from_u128(7);
+        let resume = Cli::try_parse_from([
+            "st0x-cli",
+            "resume-usdc-transfer",
+            "--id",
+            &resume_id.to_string(),
+            "--direction",
+            "to-raindex",
+            "--amount",
+            "100",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(resume.command),
+            Err(ProviderCommand::ResumeUsdcTransfer { .. })
+        ));
+
+        let fail = Cli::try_parse_from([
+            "st0x-cli",
+            "fail-transfer",
+            "--type",
+            "mint",
+            "--id",
+            "ISS001",
+        ])
+        .unwrap();
+        match classify_command(fail.command) {
+            Ok(SimpleCommand::FailTransfer { reason, .. }) => {
+                assert_eq!(reason, "Manually failed via CLI");
+            }
+            _ => panic!("expected legacy fail-transfer to classify as FailTransfer"),
+        }
+
+        let recheck = Cli::try_parse_from([
+            "st0x-cli",
+            "recheck-transfer",
+            "--type",
+            "redemption",
+            "--id",
+            "redemption-1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(recheck.command),
+            Ok(SimpleCommand::RecheckTransfer { .. })
+        ));
+
+        let reconcile_id = Uuid::from_u128(8);
+        let reconcile = Cli::try_parse_from([
+            "st0x-cli",
+            "reconcile-usdc-transfer",
+            "--id",
+            &reconcile_id.to_string(),
+            "--reason",
+            "funds-moved-manually",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(reconcile.command),
+            Ok(SimpleCommand::ReconcileUsdcTransfer { .. })
+        ));
+    }
+
+    #[test]
+    fn legacy_flat_view_and_cctp_names_still_parse() {
+        let rebuild = Cli::try_parse_from([
+            "st0x-cli",
+            "rebuild-view",
+            "--aggregate",
+            "position",
+            "--all",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(rebuild.command),
+            Ok(SimpleCommand::RebuildView { .. })
+        ));
+
+        let cctp = Cli::try_parse_from([
+            "st0x-cli",
+            "cctp-recover",
+            "--burn-tx",
+            &TxHash::ZERO.to_string(),
+            "--source-chain",
+            "base",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(cctp.command),
+            Err(ProviderCommand::CctpRecover { .. })
+        ));
+    }
+
+    /// The legacy `--type`/`-t` discriminator must keep working on the new
+    /// grouped names, so mechanically translated runbook invocations parse.
+    #[test]
+    fn grouped_transfer_commands_accept_legacy_type_flag() {
+        let fail_long = Cli::try_parse_from([
+            "st0x-cli", "transfer", "fail", "--type", "mint", "--id", "ISS001",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(fail_long.command),
+            Ok(SimpleCommand::FailTransfer { .. })
+        ));
+
+        let fail_short = Cli::try_parse_from([
+            "st0x-cli", "transfer", "fail", "-t", "mint", "--id", "ISS001",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(fail_short.command),
+            Ok(SimpleCommand::FailTransfer { .. })
+        ));
+
+        let recheck_long = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "recheck",
+            "--type",
+            "redemption",
+            "--id",
+            "redemption-1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(recheck_long.command),
+            Ok(SimpleCommand::RecheckTransfer { .. })
+        ));
+
+        let recheck_short = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "recheck",
+            "-t",
+            "redemption",
+            "--id",
+            "redemption-1",
+        ])
+        .unwrap();
+        assert!(matches!(
+            classify_command(recheck_short.command),
+            Ok(SimpleCommand::RecheckTransfer { .. })
+        ));
+    }
+
+    /// The new grouped destructive commands keep the documented legacy default
+    /// reasons until the next epic step removes them.
+    #[test]
+    fn grouped_transfer_commands_keep_legacy_default_reasons() {
+        let fail = Cli::try_parse_from([
+            "st0x-cli", "transfer", "fail", "--kind", "mint", "--id", "ISS001",
+        ])
+        .unwrap();
+        match classify_command(fail.command) {
+            Ok(SimpleCommand::FailTransfer { reason, .. }) => {
+                assert_eq!(reason, "Manually failed via CLI");
+            }
+            _ => panic!("expected transfer fail to classify as FailTransfer"),
+        }
+
+        let reconcile = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "reconcile",
+            "--id",
+            &Uuid::from_u128(9).to_string(),
+        ])
+        .unwrap();
+        match classify_command(reconcile.command) {
+            Ok(SimpleCommand::ReconcileUsdcTransfer { reason, .. }) => {
+                assert!(matches!(reason, ReconcileReasonArg::FundsMovedManually));
+            }
+            _ => panic!("expected transfer reconcile to classify as ReconcileUsdcTransfer"),
+        }
     }
 
     #[tokio::test]

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -247,9 +247,6 @@ where
     }
 }
 
-/// Starts a fresh manual USDC transfer. Surfaces the generated id up front so an
-/// operator can resume it (via `resume-usdc-transfer`) if the process is
-/// interrupted, then drives it to terminal with attestation-timeout redrive.
 /// Whether a USDC transfer command may start a fresh transfer or must resume an
 /// existing one. Drives the `None`-state policy in [`run_usdc_transfer`]: a
 /// freshly generated id is expected to have no state (first run), but an
@@ -257,10 +254,16 @@ where
 /// must be rejected -- never burned into a brand-new transfer.
 #[derive(Clone, Copy)]
 enum UsdcTransferStartMode {
-    Fresh,
+    /// First run of a brand-new transfer; the operator supplies the amount.
+    Fresh { amount: Usdc },
+    /// Re-entry on an existing id; the amount always comes from the persisted
+    /// aggregate, never from the CLI.
     Resume,
 }
 
+/// Starts a fresh manual USDC transfer. Surfaces the generated id up front so an
+/// operator can resume it (via `transfer resume`) if the process is interrupted,
+/// then drives it to terminal with attestation-timeout redrive.
 pub(super) async fn transfer_usdc_command<Writer: Write>(
     stdout: &mut Writer,
     direction: TransferDirection,
@@ -276,7 +279,7 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
     writeln!(
         stdout,
         "USDC transfer id: {id}\n   If this is interrupted after the burn, resume with:\n   \
-         resume-usdc-transfer --id {id} --direction {dir_flag} --amount {amount}"
+         transfer resume --id {id} --direction {dir_flag}"
     )?;
     // Flush the recovery id to durable output BEFORE the burn: the resume safety
     // story depends on the operator still having this id if the process is killed
@@ -285,9 +288,8 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
     run_usdc_transfer(
         stdout,
         direction,
-        amount,
         id,
-        UsdcTransferStartMode::Fresh,
+        UsdcTransferStartMode::Fresh { amount },
         ctx,
         pool,
     )
@@ -297,23 +299,19 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
 /// Resumes an interrupted manual USDC transfer by its id, driving it to terminal
 /// with the same attestation-timeout redrive as a fresh transfer. Refuses to run
 /// if the id has no persisted transfer (a wrong/typoed id would otherwise start a
-/// brand-new burn) or if `--direction` disagrees with the persisted transfer. The
-/// `--amount` is required for symmetry with the `transfer-usdc` recovery hint but
-/// is not validated -- a resume uses the aggregate's persisted amount.
+/// brand-new burn) or if `--direction` disagrees with the persisted transfer.
+/// The amount always comes from the persisted aggregate, never from the CLI.
 pub(super) async fn resume_usdc_transfer_command<Writer: Write>(
     stdout: &mut Writer,
     id: Uuid,
     direction: TransferDirection,
-    amount: Usdc,
     ctx: &Ctx,
     pool: &SqlitePool,
 ) -> anyhow::Result<()> {
     let id = UsdcRebalanceId(id);
-    writeln!(stdout, "Resuming USDC transfer id: {id}")?;
     run_usdc_transfer(
         stdout,
         direction,
-        amount,
         id,
         UsdcTransferStartMode::Resume,
         ctx,
@@ -325,7 +323,6 @@ pub(super) async fn resume_usdc_transfer_command<Writer: Write>(
 async fn run_usdc_transfer<Writer: Write>(
     stdout: &mut Writer,
     direction: TransferDirection,
-    amount: Usdc,
     id: UsdcRebalanceId,
     mode: UsdcTransferStartMode,
     ctx: &Ctx,
@@ -335,7 +332,6 @@ async fn run_usdc_transfer<Writer: Write>(
         TransferDirection::ToRaindex => "Alpaca -> Raindex",
         TransferDirection::ToAlpaca => "Raindex -> Alpaca",
     };
-    writeln!(stdout, "Transferring USDC: {dir}, Amount: {amount} USDC")?;
 
     let usdc_store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
         .build(())
@@ -348,31 +344,43 @@ async fn run_usdc_transfer<Writer: Write>(
     // operator-supplied resume id that is mistyped or points at the wrong
     // database. Reject `None`, and reject a `--direction` that disagrees with the
     // persisted transfer (driving the opposite-direction resume path would
-    // mis-drive the aggregate). The `--amount` is NOT validated: it stays in the
-    // recovery command for symmetry with `transfer-usdc`, but a resume uses the
-    // aggregate's persisted amount, and the persisted state amount is the
-    // post-conversion/post-fee effective amount, not the original requested one.
-    if matches!(mode, UsdcTransferStartMode::Resume) {
-        let Some(state) = usdc_store.load(&id).await? else {
-            anyhow::bail!(
-                "resume-usdc-transfer: no transfer found for id {id}. Refusing to start a new \
-                 burn -- check the id and that you are pointed at the right database."
-            );
-        };
-
-        let expected_direction = match direction {
-            TransferDirection::ToRaindex => RebalanceDirection::AlpacaToBase,
-            TransferDirection::ToAlpaca => RebalanceDirection::BaseToAlpaca,
-        };
-
-        if state.direction() != expected_direction {
-            anyhow::bail!(
-                "resume-usdc-transfer: --direction does not match the persisted transfer for id \
-                 {id} (persisted {:?}). Refusing to mis-drive the transfer.",
-                state.direction()
-            );
+    // mis-drive the aggregate). A resume uses the aggregate's persisted amount --
+    // the post-conversion/post-fee effective amount, not the original requested
+    // one -- so the CLI never fabricates a financial value for it.
+    let amount = match mode {
+        UsdcTransferStartMode::Fresh { amount } => {
+            writeln!(stdout, "Transferring USDC: {dir}, Amount: {amount} USDC")?;
+            amount
         }
-    }
+        UsdcTransferStartMode::Resume => {
+            let Some(state) = usdc_store.load(&id).await? else {
+                anyhow::bail!(
+                    "transfer resume: no transfer found for id {id}. Refusing to start a new \
+                     burn -- check the id and that you are pointed at the right database."
+                );
+            };
+
+            let expected_direction = match direction {
+                TransferDirection::ToRaindex => RebalanceDirection::AlpacaToBase,
+                TransferDirection::ToAlpaca => RebalanceDirection::BaseToAlpaca,
+            };
+
+            if state.direction() != expected_direction {
+                anyhow::bail!(
+                    "transfer resume: --direction does not match the persisted transfer for \
+                     id {id} (persisted {:?}). Refusing to mis-drive the transfer.",
+                    state.direction()
+                );
+            }
+
+            let amount = state.amount();
+            writeln!(
+                stdout,
+                "Resuming USDC transfer {id}: {dir}, persisted amount: {amount} USDC"
+            )?;
+            amount
+        }
+    };
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
         anyhow::bail!("transfer-usdc requires Alpaca Broker API configuration");
@@ -769,7 +777,7 @@ pub(super) async fn reconcile_usdc_transfer_command<Writer: Write>(
 
     let Some(state) = usdc_store.load(&id).await? else {
         anyhow::bail!(
-            "reconcile-usdc-transfer: no transfer found for id {id}. Refusing to act -- check \
+            "transfer reconcile: no transfer found for id {id}. Refusing to act -- check \
              the id and that you are pointed at the right database."
         );
     };
@@ -796,7 +804,7 @@ pub(super) async fn reconcile_usdc_transfer_command<Writer: Write>(
 
     if !is_post_burn_failure {
         anyhow::bail!(
-            "reconcile-usdc-transfer: transfer {id} is in state {state:?}, not a post-burn \
+            "transfer reconcile: transfer {id} is in state {state:?}, not a post-burn \
              terminal failure that strands the in-progress guard (DepositFailed, post-burn \
              BridgingFailed, or a BaseToAlpaca ConversionFailed). Refusing to act."
         );
@@ -1277,7 +1285,7 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
     let body = response.text().await?;
 
     if !status.is_success() {
-        anyhow::bail!("recheck-transfer failed ({status}): {body}");
+        anyhow::bail!("transfer recheck failed ({status}): {body}");
     }
 
     // The endpoint returns `{"outcome":"<snake_case>"}`; surface the outcome
@@ -1292,7 +1300,7 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
                 .map(str::to_owned)
         })
         .unwrap_or(body);
-    writeln!(stdout, "recheck-transfer outcome: {outcome}")?;
+    writeln!(stdout, "transfer recheck outcome: {outcome}")?;
     Ok(())
 }
 
@@ -1614,14 +1622,13 @@ mod tests {
 
     #[tokio::test]
     async fn resume_usdc_transfer_rejects_unknown_id_without_burning() {
-        // The core safety contract of `resume-usdc-transfer`: an id that has no
+        // The core safety contract of `transfer resume`: an id that has no
         // persisted transfer (a typo, or the wrong database) MUST be rejected up
         // front rather than falling through to the manager's `None` -> fresh-burn
         // path. The existence check runs before any broker/bridge setup, so a bare
         // ctx and an empty pool reach it directly.
         let ctx = create_ctx_without_rebalancing();
         let pool = setup_test_db().await;
-        let amount = Usdc::new(Float::parse("100".to_string()).unwrap());
         let unknown_id = Uuid::from_u128(0xDEAD_BEEF);
 
         let mut stdout = Vec::new();
@@ -1629,7 +1636,6 @@ mod tests {
             &mut stdout,
             unknown_id,
             TransferDirection::ToRaindex,
-            amount,
             &ctx,
             &pool,
         )
@@ -1735,15 +1741,9 @@ mod tests {
             .unwrap();
 
         let mut stdout = Vec::new();
-        let result = resume_usdc_transfer_command(
-            &mut stdout,
-            id,
-            TransferDirection::ToAlpaca,
-            amount,
-            &ctx,
-            &pool,
-        )
-        .await;
+        let result =
+            resume_usdc_transfer_command(&mut stdout, id, TransferDirection::ToAlpaca, &ctx, &pool)
+                .await;
 
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -1753,18 +1753,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resume_usdc_transfer_accepts_amount_differing_from_persisted() {
-        // Regression guard: a resume with the CORRECT direction but a `--amount`
-        // different from the persisted state amount must NOT be rejected. The
-        // persisted amount is the post-slippage/post-fee effective amount, not the
-        // original requested one the operator types, so validating against it
-        // would wrongly reject legitimate resumes (the iter2 bug). The preflight
-        // guard must let it through -- here it then fails at broker setup, proving
-        // the guard accepted it.
+    async fn resume_usdc_transfer_reports_persisted_amount() {
+        // A resume takes no amount: it loads the persisted state amount (the
+        // post-slippage/post-fee effective amount) and reports it to the
+        // operator. The preflight guard must accept the correct direction --
+        // here it then fails at broker setup, proving the guard accepted it.
         let ctx = create_ctx_without_rebalancing();
         let pool = setup_test_db().await;
         let seeded_amount = Usdc::new(Float::parse("100".to_string()).unwrap());
-        let different_amount = Usdc::new(Float::parse("250".to_string()).unwrap());
         let id = Uuid::from_u128(123);
 
         let store = StoreBuilder::<UsdcRebalance>::new(pool.clone())
@@ -1791,7 +1787,6 @@ mod tests {
             &mut stdout,
             id,
             TransferDirection::ToRaindex,
-            different_amount,
             &ctx,
             &pool,
         )
@@ -1800,11 +1795,17 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             !err_msg.contains("does not match"),
-            "a differing --amount must pass the guard (resume uses persisted amount); got: {err_msg}"
+            "the correct direction must pass the guard; got: {err_msg}"
         );
         assert!(
             err_msg.contains("requires Alpaca Broker API configuration"),
             "past the guard, the bare ctx must fail at broker setup; got: {err_msg}"
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("persisted amount: 100 USDC"),
+            "the resume must report the persisted effective amount; got: {output}"
         );
     }
 

--- a/src/cli/repair.rs
+++ b/src/cli/repair.rs
@@ -372,7 +372,7 @@ pub(super) async fn set_position_command<W: Write>(
     {
         bail!(
             "position {symbol} has pending offchain order {pending}; \
-             run repair fail-pending-offchain-order before setting position"
+             run position release-hedge before setting position"
         );
     }
 

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -1191,6 +1191,44 @@ impl UsdcRebalance {
             | Self::Reconciled { .. } => None,
         }
     }
+
+    /// The persisted effective amount of the transfer (post-conversion /
+    /// post-fee where applicable), as opposed to whatever an operator typed
+    /// on a CLI resume.
+    pub(crate) fn amount(&self) -> Usdc {
+        match self {
+            // Post-conversion / post-bridge, the actually received amount is
+            // the effective one; `amount` is the originally requested figure.
+            Self::ConversionComplete { filled_amount, .. } => *filled_amount,
+            Self::Bridged {
+                amount_received, ..
+            } => *amount_received,
+            // The burn adopts the post-withdrawal-fee `burn_amount` when one was
+            // persisted -- matching the `BridgingInitiated` transition and the
+            // manager's resume scan -- so the effective amount is that, not the
+            // nominal. `None` (aggregates persisted before `burn_amount`) falls
+            // back to the nominal `amount`.
+            Self::BridgingSubmitting {
+                amount,
+                burn_amount,
+                ..
+            } => burn_amount.unwrap_or(*amount),
+            Self::Converting { amount, .. }
+            | Self::ConversionFailed { amount, .. }
+            | Self::WithdrawalSubmitting { amount, .. }
+            | Self::Withdrawing { amount, .. }
+            | Self::WithdrawalComplete { amount, .. }
+            | Self::WithdrawalFailed { amount, .. }
+            | Self::Bridging { amount, .. }
+            | Self::AwaitingAttestation { amount, .. }
+            | Self::Attested { amount, .. }
+            | Self::BridgingFailed { amount, .. }
+            | Self::DepositInitiated { amount, .. }
+            | Self::DepositConfirmed { amount, .. }
+            | Self::DepositFailed { amount, .. }
+            | Self::Reconciled { amount, .. } => *amount,
+        }
+    }
 }
 
 /// Candidate `UsdcRebalance` aggregates whose latest event leaves them
@@ -4105,6 +4143,123 @@ mod tests {
             failed_at: now,
         };
         assert_eq!(deposit_failed.direction(), RebalanceDirection::AlpacaToBase);
+    }
+
+    /// `amount()` must return the persisted EFFECTIVE amount: the conversion
+    /// fill once a conversion completed, the post-withdrawal-fee burn amount once
+    /// a `BridgingSubmitting` carries one, and the requested amount otherwise.
+    #[test]
+    fn amount_reads_persisted_effective_amount() {
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000002");
+        let now = Utc::now();
+        let requested = Usdc::new(float!(321));
+
+        let bridged = UsdcRebalance::Bridged {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: requested,
+            amount_received: Usdc::new(float!(320)),
+            fee_collected: Usdc::new(float!(1)),
+            burn_tx_hash: burn_tx,
+            mint_tx_hash: burn_tx,
+            initiated_at: now,
+            minted_at: now,
+        };
+        assert_eq!(
+            bridged.amount(),
+            Usdc::new(float!(320)),
+            "post-bridge the received amount is the effective amount",
+        );
+
+        let conversion_failed = UsdcRebalance::ConversionFailed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: requested,
+            order_id: ClientOrderId::from_uuid(Uuid::from_u128(11)),
+            reason: "broker rejected".to_string(),
+            initiated_at: now,
+            failed_at: now,
+        };
+        assert_eq!(conversion_failed.amount(), requested);
+
+        let conversion_complete = UsdcRebalance::ConversionComplete {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: requested,
+            filled_amount: Usdc::new(float!(319)),
+            initiated_at: now,
+            converted_at: now,
+        };
+        assert_eq!(
+            conversion_complete.amount(),
+            Usdc::new(float!(319)),
+            "post-conversion the filled amount is the effective amount",
+        );
+
+        let deposit_failed = UsdcRebalance::DepositFailed {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: requested,
+            burn_tx_hash: burn_tx,
+            mint_tx_hash: burn_tx,
+            deposit_ref: None,
+            reason: "deposit reverted".to_string(),
+            initiated_at: now,
+            failed_at: now,
+        };
+        assert_eq!(
+            deposit_failed.amount(),
+            requested,
+            "the common reconcile target state reports the requested amount",
+        );
+
+        let bridging_submitting_with_burn = UsdcRebalance::BridgingSubmitting {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: requested,
+            from_block: 100,
+            initiated_at: now,
+            burn_amount: Some(Usdc::new(float!(318))),
+        };
+        assert_eq!(
+            bridging_submitting_with_burn.amount(),
+            Usdc::new(float!(318)),
+            "BridgingSubmitting reports the persisted burn_amount the manager resumes with",
+        );
+
+        let bridging_submitting_legacy = UsdcRebalance::BridgingSubmitting {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: requested,
+            from_block: 100,
+            initiated_at: now,
+            burn_amount: None,
+        };
+        assert_eq!(
+            bridging_submitting_legacy.amount(),
+            requested,
+            "BridgingSubmitting without a persisted burn_amount falls back to the nominal",
+        );
+
+        let converting = UsdcRebalance::Converting {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: requested,
+            order_id: ClientOrderId::from_uuid(Uuid::from_u128(12)),
+            initiated_at: now,
+        };
+        assert_eq!(
+            converting.amount(),
+            requested,
+            "Converting reports the requested amount until a conversion completes",
+        );
+
+        let bridging = UsdcRebalance::Bridging {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: requested,
+            burn_tx_hash: burn_tx,
+            initiated_at: now,
+            burned_at: now,
+        };
+        assert_eq!(
+            bridging.amount(),
+            requested,
+            "Bridging reports the requested amount until the mint lands",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Implements [RAI-980](https://linear.app/makeitrain/issue/RAI-980) — Step 1 of the recovery-CLI epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978). Regroups the operator recovery commands into object-based subcommand groups. **No behavior change**; every old command name still works.

## Why

The recovery commands grew into 8 flat/ad-hoc commands with no semantic grouping and inconsistent naming. This locks them onto the verb vocabulary defined in the SPEC (Step 0): one verb per intent, grouped by object.

## How

New grouped subcommands, all mapping to the **same** internal `SimpleCommand`/`ProviderCommand` dispatch (so `run_simple_command`/`run_provider_command` are untouched):
- `transfer resume|reconcile|fail|recheck`
- `position set|release-hedge`
- `view rebuild`
- `cctp complete-mint`

Backward compatibility:
- `repair`, `set-position`, `fail-pending-offchain-order` keep working via clap **aliases** (the `position` group is a clean rename — no arg duplication).
- The flat recovery commands (`resume-usdc-transfer`, `reconcile-usdc-transfer`, `fail-transfer`, `recheck-transfer`, `rebuild-view`, `cctp-recover`) are marked `#[command(hide = true)]` and still parse + dispatch identically (clap can't alias a flat name onto a nested path). Deprecation warnings come in a follow-up (Step 8).

The new `transfer resume` drops the old unvalidated `--amount` flag (resume uses the persisted amount); the legacy `resume-usdc-transfer` keeps it. Printed hints + `docs/cli-ops.md` + `README.md` updated to the new names.

## Testing

Added classify/parse tests for every new grouped name and for the legacy names (proving aliases + hidden flat commands still parse). 137 `cli::` tests pass; `clippy` (no allows) + `fmt` green.

## Anything else

Unblocks Steps 2/3/8. Part of epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978).
