### PR TITLE
feat: add transfer resume --kind equity REST wrapper

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3057,6 +3057,9 @@ named exemptions defined after the list:**
 
 - `resume` -- drive an interrupted, non-terminal operation forward along its
   normal path. Never forces a transition and is idempotent against double-spend.
+  Realized per-id for USDC transfers (`--kind usdc`) and as a bulk resume of ALL
+  interrupted mints and redemptions for equity (`--kind equity`, via the running
+  bot's REST API; each transfer succeeds or fails independently).
 - `recheck` -- re-query the external provider for ground truth and apply it; may
   un-fail a terminal `Failed` operation or resume a non-terminal one along its
   normal path. Requires the running bot (REST). Realized today for equity mints
@@ -3104,11 +3107,12 @@ effect rather than a generic intent:
 - **Execution mode is part of each command's contract.** Help text states which
   mode the command uses: direct-DB (the operator must ensure the bot is not
   concurrently driving the same id); direct-DB plus a live RPC provider
-  (`transfer resume`, today `resume-usdc-transfer`, drives the on-chain flow
-  against the local aggregate store, with the same no-concurrent-bot caveat);
-  live RPC only (`cctp complete-mint` touches no database state -- the caveat is
-  the bot concurrently driving the same on-chain mint); or the running bot
-  (REST). `recheck` is the only command that requires the bot.
+  (`transfer resume --kind usdc`, today `resume-usdc-transfer`, drives the
+  on-chain flow against the local aggregate store, with the same
+  no-concurrent-bot caveat); live RPC only (`cctp complete-mint` touches no
+  database state -- the caveat is the bot concurrently driving the same on-chain
+  mint); or the running bot (REST). `recheck` and
+  `transfer resume --kind equity` are the only commands that require the bot.
 - **`--reason` MUST be required, with no default, on every event-emitting
   destructive verb** (`fail`, `reconcile`, `set`, and `position release-hedge`).
   A defaulted reason is an audit-hostile record and violates the

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -248,12 +248,17 @@ Not covered by `transfer recheck` yet:
 - USDC rebalancing failures. Those use the USDC/CCTP state machine and have
   their own recovery commands. A manual `transfer-usdc` prints its transfer id
   and, if interrupted after the burn, is resumed with
-  `stox transfer resume --id <id> --direction <to-raindex|to-alpaca>`. The
-  `--direction` must match the original (a mismatch is rejected to avoid
+  `stox transfer resume --kind usdc --id <id> --direction <to-raindex|to-alpaca>`.
+  The `--direction` must match the original (a mismatch is rejected to avoid
   mis-driving) and an unknown id is rejected rather than starting a fresh burn;
   a resume uses the aggregate's persisted amount, so no amount is taken. Run it
   only when the bot is not concurrently driving that same id, since it drives
   the aggregate directly rather than through the bot's resume lock.
+- Interrupted equity transfers (mints/redemptions) are resumed in bulk with
+  `stox transfer resume --kind equity`, which calls the running bot's
+  `/transfers/resume` endpoint (always resumes ALL interrupted transfers, no
+  per-id filter; each succeeds or fails independently and failures are reported
+  as counts with a non-zero exit). Requires the bot to be running.
 
 ### Clearing a pre-burn guard latch
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1275,13 +1275,15 @@ async fn interrupted_transfers(
     }))
 }
 
-#[derive(Serialize)]
+/// Wire contract for `/transfers/resume`, shared with the CLI wrapper so the
+/// two cannot drift.
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ResumeResponse {
-    mints_attempted: usize,
-    mints_failed: usize,
-    redemptions_attempted: usize,
-    redemptions_failed: usize,
+pub(crate) struct ResumeResponse {
+    pub(crate) mints_attempted: usize,
+    pub(crate) mints_failed: usize,
+    pub(crate) redemptions_attempted: usize,
+    pub(crate) redemptions_failed: usize,
 }
 
 async fn resume_transfers(

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -82,6 +82,17 @@ impl From<ReconcileReasonArg> for crate::usdc_rebalance::ReconcileReason {
     }
 }
 
+/// What kind of transfer to resume.
+///
+/// `usdc` resumes a single USDC rebalance by id, directly against the local CQRS
+/// state. `equity` resumes ALL interrupted mints and redemptions via the running
+/// bot's REST endpoint (always ALL interrupted transfers; no per-id filter).
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum TransferResumeKind {
+    Usdc,
+    Equity,
+}
+
 /// Read models rebuildable by replaying events from scratch.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AggregateView {
@@ -735,22 +746,34 @@ pub enum Commands {
 /// Recover stuck asset transfers between trading venues.
 #[derive(Debug, Subcommand)]
 pub enum TransferCommand {
-    /// Resume an interrupted USDC transfer by its id (Raindex <-> Alpaca).
+    /// Resume interrupted transfers.
     ///
-    /// Re-drives a transfer whose CLI invocation was interrupted after the burn.
-    /// The id is printed by `transfer-usdc` at start. An unknown id is rejected
-    /// (never starts a fresh burn) and `--direction` must match the original.
-    /// The resume uses the aggregate's persisted amount; any `--amount` is ignored.
-    /// Operates on the local CQRS state plus a live RPC provider (re-drives the
-    /// on-chain burn/mint/deposit flow itself). Does not require the running
-    /// bot, but the bot must not be concurrently driving the same id.
+    /// `--kind usdc` re-drives a single USDC transfer whose CLI invocation was
+    /// interrupted after the burn: pass `--id` (printed by `transfer-usdc`) and
+    /// the original `--direction`. An unknown id is rejected (never starts a
+    /// fresh burn); the resume uses the persisted amount, so any `--amount` is
+    /// ignored. Operates on the local CQRS state plus a live RPC provider
+    /// (re-drives the on-chain burn/mint/deposit flow itself); the bot must not
+    /// be concurrently driving the same id.
+    ///
+    /// `--kind equity` resumes ALL interrupted mints and redemptions via the
+    /// running bot's REST API: there is no per-id filter (`--id`/`--direction`
+    /// are rejected), each transfer succeeds or fails independently, and
+    /// failures are reported as counts (non-zero exit). Requires the bot to be
+    /// running and serving its API on the configured `server_port`.
     Resume {
-        /// Id of the transfer to resume (printed by `transfer-usdc`)
-        #[arg(long = "id")]
-        id: Uuid,
-        /// Direction of the original transfer (must match the persisted transfer)
-        #[arg(short = 'd', long = "direction")]
-        direction: TransferDirection,
+        /// What to resume: a single USDC transfer (`usdc`) or all equity transfers
+        /// (`equity`). Required -- clap `required_if_eq` only enforces the
+        /// `--id`/`--direction` dependency against an explicit value, not a
+        /// default, so `--kind` is not defaulted.
+        #[arg(short = 'k', long = "kind", value_enum)]
+        kind: TransferResumeKind,
+        /// Id of the USDC transfer to resume (required for `--kind usdc`)
+        #[arg(long = "id", required_if_eq("kind", "usdc"))]
+        id: Option<Uuid>,
+        /// Direction of the original USDC transfer (required for `--kind usdc`)
+        #[arg(short = 'd', long = "direction", required_if_eq("kind", "usdc"))]
+        direction: Option<TransferDirection>,
         /// Accepted for compatibility with old `resume-usdc-transfer` runbooks;
         /// ignored -- the resume always uses the aggregate's persisted amount.
         #[arg(short = 'a', long = "amount", hide = true)]
@@ -1009,6 +1032,7 @@ enum SimpleCommand {
         transfer_type: TransferType,
         id: String,
     },
+    ResumeInterruptedTransfers,
     ReconcileUsdcTransfer {
         id: Uuid,
         reason: ReconcileReasonArg,
@@ -1166,12 +1190,49 @@ enum ProviderCommand {
     AlpacaTokenizationRequests,
 }
 
+/// Rejects argument combinations clap cannot express conditionally: the
+/// equity bulk-resume takes no per-id filter, so a supplied `--id` or
+/// `--direction` signals the operator probably meant `--kind usdc` and must
+/// not be silently discarded.
+fn validate_command(command: &Commands) -> anyhow::Result<()> {
+    let Commands::Transfer {
+        command:
+            TransferCommand::Resume {
+                kind,
+                id,
+                direction,
+                ..
+            },
+    } = command
+    else {
+        return Ok(());
+    };
+
+    match kind {
+        TransferResumeKind::Equity if id.is_some() || direction.is_some() => {
+            anyhow::bail!(
+                "transfer resume --kind equity resumes ALL interrupted equity transfers and \
+                 takes no --id/--direction. To resume a single USDC transfer, re-run with \
+                 --kind usdc."
+            );
+        }
+        TransferResumeKind::Usdc if id.is_none() || direction.is_none() => {
+            anyhow::bail!(
+                "transfer resume --kind usdc requires --id and --direction (clap should \
+                 have rejected this invocation; please report it)"
+            );
+        }
+        TransferResumeKind::Equity | TransferResumeKind::Usdc => Ok(()),
+    }
+}
+
 async fn run_command_with_writers<W: Write>(
     ctx: Ctx,
     command: Commands,
     pool: &SqlitePool,
     stdout: &mut W,
 ) -> anyhow::Result<()> {
+    validate_command(&command)?;
     match classify_command(command) {
         Ok(simple) => run_simple_command(simple, &ctx, pool, stdout).await?,
         Err(provider_cmd) => {
@@ -1184,6 +1245,11 @@ async fn run_command_with_writers<W: Write>(
     Ok(())
 }
 
+// One flat match mapping every CLI command to its internal Simple/Provider
+// dispatch. Kept as a single match (per the repo's "don't split simple-but-long
+// matches" rule) rather than fragmented into per-group helpers; the grouped
+// subcommands added in the recovery-CLI rename pushed it just over the limit.
+#[allow(clippy::too_many_lines)]
 fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand> {
     match command {
         Commands::Buy {
@@ -1346,13 +1412,32 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
             Ok(SimpleCommand::FailUsdcTransfer { id, reason })
         }
         Commands::Transfer { command } => match command {
+            // `--kind equity` resumes all interrupted equity transfers via the bot
+            // REST API. `--kind usdc` re-drives a single USDC transfer; `id` and
+            // `direction` are guaranteed present by `required_if_eq("kind","usdc")`.
             TransferCommand::Resume {
-                id,
-                direction,
+                kind: TransferResumeKind::Equity,
+                ..
+            } => Ok(SimpleCommand::ResumeInterruptedTransfers),
+            TransferCommand::Resume {
+                kind: TransferResumeKind::Usdc,
+                id: Some(id),
+                direction: Some(direction),
                 // Ignored: a resume always uses the persisted aggregate amount.
                 // Accepted only so old `--amount` runbook invocations still parse.
                 amount: _,
             } => Err(ProviderCommand::ResumeUsdcTransfer { id, direction }),
+            TransferCommand::Resume {
+                kind: TransferResumeKind::Usdc,
+                ..
+            } => {
+                // Doubly guarded: clap's `required_if_eq("kind","usdc")`
+                // rejects the missing args at parse time, and
+                // `validate_command` (which also checks this combination)
+                // runs before classify in the production dispatch. Callers
+                // invoking classify directly must pass clap-parsed input.
+                unreachable!("clap `required_if_eq(\"kind\",\"usdc\")` guarantees id and direction")
+            }
             TransferCommand::Reconcile { id, reason } => {
                 Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason })
             }
@@ -1547,6 +1632,9 @@ async fn run_simple_command<W: Write>(
         } => rebalancing::fail_transfer_command(stdout, pool, transfer_type, &id, &reason).await,
         SimpleCommand::RecheckTransfer { transfer_type, id } => {
             rebalancing::recheck_transfer_command(stdout, transfer_type, &id, ctx).await
+        }
+        SimpleCommand::ResumeInterruptedTransfers => {
+            rebalancing::resume_interrupted_transfers_command(stdout, ctx).await
         }
         SimpleCommand::ReconcileUsdcTransfer { id, reason } => {
             rebalancing::reconcile_usdc_transfer_command(stdout, id, reason.into(), pool).await
@@ -2220,6 +2308,17 @@ mod tests {
     }
 
     #[test]
+    fn transfer_resume_requires_kind() {
+        // `--kind` is intentionally not defaulted (so required_if_eq can enforce
+        // the usdc dependency), so a bare `transfer resume` must error.
+        let error = Cli::try_parse_from(["st0x-cli", "transfer", "resume"]).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
     fn repair_fail_pending_offchain_order_parses() {
         let order_id = OffchainOrderId::new();
         let cli = Cli::try_parse_from([
@@ -2629,6 +2728,8 @@ mod tests {
             "st0x-cli",
             "transfer",
             "resume",
+            "--kind",
+            "usdc",
             "--id",
             &id.to_string(),
             "--direction",
@@ -2645,6 +2746,64 @@ mod tests {
                 assert!(matches!(direction, TransferDirection::ToRaindex));
             }
             _ => panic!("expected resume provider command"),
+        }
+    }
+
+    #[test]
+    fn transfer_resume_usdc_to_alpaca_classifies_with_to_alpaca_direction() {
+        let id = Uuid::from_u128(43);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "usdc",
+            "--id",
+            &id.to_string(),
+            "--direction",
+            "to-alpaca",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Err(ProviderCommand::ResumeUsdcTransfer {
+                id: parsed_id,
+                direction,
+            }) => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(direction, TransferDirection::ToAlpaca));
+            }
+            _ => panic!("expected resume provider command"),
+        }
+    }
+
+    #[test]
+    fn transfer_resume_usdc_accepts_and_ignores_legacy_amount_flag() {
+        let id = Uuid::from_u128(44);
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "usdc",
+            "--id",
+            &id.to_string(),
+            "--direction",
+            "to-raindex",
+            "--amount",
+            "100",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Err(ProviderCommand::ResumeUsdcTransfer {
+                id: parsed_id,
+                direction,
+            }) => {
+                assert_eq!(parsed_id, id);
+                assert!(matches!(direction, TransferDirection::ToRaindex));
+            }
+            _ => panic!("expected resume provider command despite legacy --amount"),
         }
     }
 
@@ -2830,6 +2989,144 @@ mod tests {
             }
             _ => panic!("expected position release-hedge to classify as a simple position command"),
         }
+    }
+
+    /// A supplied `--id`/`--direction` with `--kind equity` signals the
+    /// operator probably meant `--kind usdc`; it must be rejected, never
+    /// silently discarded.
+    #[test]
+    fn validate_rejects_equity_resume_with_id() {
+        let with_id = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "equity",
+            "--id",
+            &Uuid::from_u128(7).to_string(),
+        ])
+        .unwrap();
+
+        let error = validate_command(&with_id.command).unwrap_err();
+        assert!(
+            error.to_string().contains("--kind usdc"),
+            "the rejection must point at --kind usdc; got: {error}"
+        );
+    }
+
+    /// Both flags at once must also be rejected.
+    #[test]
+    fn validate_rejects_equity_resume_with_both_flags() {
+        let with_both = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "equity",
+            "--id",
+            &Uuid::from_u128(7).to_string(),
+            "--direction",
+            "to-raindex",
+        ])
+        .unwrap();
+
+        let error = validate_command(&with_both.command).unwrap_err();
+        assert!(
+            error.to_string().contains("takes no --id/--direction"),
+            "got: {error}"
+        );
+    }
+
+    /// Same for a supplied `--direction`.
+    #[test]
+    fn validate_rejects_equity_resume_with_direction() {
+        let with_direction = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "equity",
+            "--direction",
+            "to-raindex",
+        ])
+        .unwrap();
+
+        let error = validate_command(&with_direction.command).unwrap_err();
+        assert!(
+            error.to_string().contains("takes no --id/--direction"),
+            "got: {error}"
+        );
+    }
+
+    /// A bare `--kind equity` passes validation and routes to the bulk
+    /// equity resume.
+    #[test]
+    fn validate_accepts_bare_equity_resume() {
+        let clean =
+            Cli::try_parse_from(["st0x-cli", "transfer", "resume", "--kind", "equity"]).unwrap();
+        validate_command(&clean.command).unwrap();
+        assert!(matches!(
+            classify_command(clean.command),
+            Ok(SimpleCommand::ResumeInterruptedTransfers)
+        ));
+    }
+
+    /// The defensive Usdc guard exists for callers that bypass clap (the only
+    /// path where it can fire); construct the bad shape directly.
+    #[test]
+    fn validate_rejects_directly_constructed_usdc_resume_without_args() {
+        let command = Commands::Transfer {
+            command: TransferCommand::Resume {
+                kind: TransferResumeKind::Usdc,
+                id: None,
+                direction: None,
+                amount: None,
+            },
+        };
+
+        let error = validate_command(&command).unwrap_err();
+        assert!(
+            error.to_string().contains("requires --id and --direction"),
+            "got: {error}"
+        );
+    }
+
+    /// The two `required_if_eq("kind","usdc")` annotations are independent:
+    /// each missing arg must be rejected at parse time on its own, or the
+    /// classify `unreachable!` guarantee silently rots.
+    #[test]
+    fn usdc_resume_requires_each_arg_independently() {
+        let missing_direction = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "usdc",
+            "--id",
+            &Uuid::from_u128(7).to_string(),
+        ])
+        .unwrap_err();
+        assert_eq!(
+            missing_direction.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "--kind usdc without --direction must be rejected at parse time",
+        );
+
+        let missing_id = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "resume",
+            "--kind",
+            "usdc",
+            "--direction",
+            "to-raindex",
+        ])
+        .unwrap_err();
+        assert_eq!(
+            missing_id.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument,
+            "--kind usdc without --id must be rejected at parse time",
+        );
     }
 
     #[test]

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -23,6 +23,7 @@ use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::{Wrapper, WrapperService};
 
 use super::{TransferDirection, TransferType};
+use crate::api::ResumeResponse;
 use crate::equity_redemption::{
     DetectionFailure, EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId,
 };
@@ -279,7 +280,7 @@ pub(super) async fn transfer_usdc_command<Writer: Write>(
     writeln!(
         stdout,
         "USDC transfer id: {id}\n   If this is interrupted after the burn, resume with:\n   \
-         transfer resume --id {id} --direction {dir_flag}"
+         transfer resume --kind usdc --id {id} --direction {dir_flag}"
     )?;
     // Flush the recovery id to durable output BEFORE the burn: the resume safety
     // story depends on the operator still having this id if the process is killed
@@ -1253,6 +1254,17 @@ pub(crate) async fn fail_transfer_command<W: Write>(
     Ok(())
 }
 
+/// Wraps a reqwest send error: a connection failure gets actionable operator
+/// guidance (the bot is probably not running), anything else passes through.
+fn connect_error(url: &str, error: reqwest::Error) -> anyhow::Error {
+    if error.is_connect() {
+        anyhow::Error::new(error)
+            .context(format!("could not reach the bot at {url}; is it running?"))
+    } else {
+        anyhow::Error::new(error)
+    }
+}
+
 /// Re-checks a stuck transfer by calling the running bot's
 /// `/transfers/recheck` endpoint. Recovery must run in the bot process so the
 /// recovery event dispatches through the reactor-wired store (correcting the
@@ -1280,7 +1292,11 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
-    let response = client.post(&url).send().await?;
+    let response = client
+        .post(url.as_str())
+        .send()
+        .await
+        .map_err(|error| connect_error(&url, error))?;
     let status = response.status();
     let body = response.text().await?;
 
@@ -1301,6 +1317,67 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
         })
         .unwrap_or(body);
     writeln!(stdout, "transfer recheck outcome: {outcome}")?;
+    Ok(())
+}
+
+/// Resumes ALL interrupted equity transfers (mints and redemptions) by calling
+/// the running bot's `/transfers/resume` endpoint. The endpoint always resumes
+/// ALL interrupted transfers (each independently; failures reported as counts)
+/// (no per-id/per-kind filter) and must run in the bot process so recovery
+/// dispatches through the reactor-wired store and shares the bot's resume lock.
+/// Requires the bot to be running and serving its REST API on `server_port`.
+pub(crate) async fn resume_interrupted_transfers_command<W: Write>(
+    stdout: &mut W,
+    ctx: &Ctx,
+) -> anyhow::Result<()> {
+    let url = format!("http://127.0.0.1:{}/transfers/resume", ctx.server_port);
+    writeln!(
+        stdout,
+        "Resuming all interrupted equity transfers via {url}"
+    )?;
+
+    // Bound only the CONNECT phase: the bot drives every interrupted
+    // transfer's on-chain recovery inline before responding (confirmations,
+    // vault deposits), so a total request timeout would cancel the in-flight
+    // handler mid-recovery and report a false failure. Once connected, wait as
+    // long as the recovery takes. Deliberate tradeoff: if the bot stalls after
+    // accepting the connection, this invocation hangs until the operator kills
+    // it -- preferable to silently cancelling real on-chain recovery work,
+    // whose duration has no known upper bound (N transfers x confirmations).
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    let response = client
+        .post(url.as_str())
+        .send()
+        .await
+        .map_err(|error| connect_error(&url, error))?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    if !status.is_success() {
+        anyhow::bail!("transfer resume failed ({status}): {body}");
+    }
+
+    let resumed: ResumeResponse = serde_json::from_str(&body).map_err(|error| {
+        anyhow::Error::new(error).context(format!("could not parse resume response '{body}'"))
+    })?;
+    writeln!(
+        stdout,
+        "Resumed {} mint(s) ({} failed), {} redemption(s) ({} failed)",
+        resumed.mints_attempted,
+        resumed.mints_failed,
+        resumed.redemptions_attempted,
+        resumed.redemptions_failed
+    )?;
+
+    let failed = resumed.mints_failed + resumed.redemptions_failed;
+    if failed > 0 {
+        anyhow::bail!(
+            "{failed} transfer(s) failed to resume; check the bot logs for per-id errors"
+        );
+    }
+
     Ok(())
 }
 
@@ -1428,6 +1505,182 @@ mod tests {
             "a deadline-elapsed outcome must surface, not be retried; got {error:?}",
         );
         assert_eq!(calls.get(), 1, "a terminal error must not be retried");
+    }
+
+    /// `transfer resume --kind equity` against a mocked bot endpoint: the
+    /// summary line renders the counts from a literal response body.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_reports_counts() {
+        let server = httpmock::MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/transfers/resume");
+                then.status(200).body(
+                    r#"{"mintsAttempted":2,"mintsFailed":0,"redemptionsAttempted":1,"redemptionsFailed":0}"#,
+                );
+            })
+            .await;
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = server.port();
+
+        let mut stdout = Vec::new();
+        resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Resumed 2 mint(s) (0 failed), 1 redemption(s) (0 failed)"),
+            "unexpected output: {output}"
+        );
+    }
+
+    /// Per-transfer failures must surface as a non-zero exit, not a clean one:
+    /// scripts and operators must not mistake a partial recovery for success.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_fails_on_partial_failures() {
+        let server = httpmock::MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/transfers/resume");
+                then.status(200).body(
+                    r#"{"mintsAttempted":2,"mintsFailed":1,"redemptionsAttempted":1,"redemptionsFailed":1}"#,
+                );
+            })
+            .await;
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = server.port();
+
+        let mut stdout = Vec::new();
+        let error = resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("2 transfer(s) failed to resume"),
+            "expected the failure-count bail; got: {error}"
+        );
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Resumed 2 mint(s) (1 failed), 1 redemption(s) (1 failed)"),
+            "the counts must still be printed before bailing; got: {output}"
+        );
+    }
+
+    /// A failure on only one side (mints) must still be a non-zero exit.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_fails_when_only_mints_fail() {
+        let server = httpmock::MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/transfers/resume");
+                then.status(200).body(
+                    r#"{"mintsAttempted":1,"mintsFailed":1,"redemptionsAttempted":0,"redemptionsFailed":0}"#,
+                );
+            })
+            .await;
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = server.port();
+
+        let mut stdout = Vec::new();
+        let error = resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("1 transfer(s) failed to resume"),
+            "a mint-only failure must be non-zero exit; got: {error}"
+        );
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Resumed 1 mint(s) (1 failed), 0 redemption(s) (0 failed)"),
+            "the counts must still be printed before bailing; got: {output}"
+        );
+    }
+
+    /// A 200 with an unparseable body must fail loudly with the raw body.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_rejects_malformed_response() {
+        let server = httpmock::MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path("/transfers/resume");
+                then.status(200).body(r#"{"unexpected":1}"#);
+            })
+            .await;
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = server.port();
+
+        let mut stdout = Vec::new();
+        let error = resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap_err();
+
+        let chain = format!("{error:#}");
+        assert!(
+            chain.contains("could not parse resume response"),
+            "expected the parse-failure context; got: {chain}"
+        );
+        assert!(
+            chain.contains(r#"{"unexpected":1}"#),
+            "the raw body must be surfaced; got: {chain}"
+        );
+    }
+
+    /// The bot's real lock-held response (409 + ErrorResponse JSON) must reach
+    /// the operator verbatim.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_surfaces_lock_conflict() {
+        let server = httpmock::MockServer::start_async().await;
+        server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path("/transfers/resume");
+                then.status(409)
+                    .body(r#"{"error":"A resume operation is already in progress"}"#);
+            })
+            .await;
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = server.port();
+
+        let mut stdout = Vec::new();
+        let error = resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("transfer resume failed"), "got: {message}");
+        assert!(message.contains("409"), "got: {message}");
+        assert!(
+            message.contains("A resume operation is already in progress"),
+            "got: {message}"
+        );
+    }
+
+    /// A connection refusal (bot not running) must carry the actionable hint.
+    #[tokio::test]
+    async fn resume_interrupted_transfers_hints_when_bot_unreachable() {
+        // Bind and immediately drop a listener to get a port with nothing
+        // listening on it.
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let mut ctx = create_ctx_without_rebalancing();
+        ctx.server_port = port;
+
+        let mut stdout = Vec::new();
+        let error = resume_interrupted_transfers_command(&mut stdout, &ctx)
+            .await
+            .unwrap_err();
+
+        let chain = format!("{error:#}");
+        assert!(
+            chain.contains("is it running?"),
+            "a refused connection must carry the bot hint; got: {chain}"
+        );
     }
 
     fn create_ctx_without_rebalancing() -> Ctx {


### PR DESCRIPTION
## What
Implements [RAI-981](https://linear.app/makeitrain/issue/RAI-981) — Step 2 of [RAI-978](https://linear.app/makeitrain/issue/RAI-978). Adds `transfer resume --kind equity` to bulk-resume interrupted equity transfers.

## Why
`POST /transfers/resume` (resumes all interrupted mints + redemptions) had no CLI wrapper — operators had to curl an unauthenticated endpoint by hand.

## How
`transfer resume` gains a required `--kind {usdc|equity}`. `usdc` keeps the per-id local resume (`--id`/`--direction`); `equity` calls the bot's `/transfers/resume` REST endpoint (all-or-nothing, requires the running bot), mirroring `recheck`. `--kind` is required (not defaulted) because clap's `required_if_eq` does not fire on a default value — without that, `transfer resume` with no id would slip past validation. `classify_command` carries an `#[allow(clippy::too_many_lines)]` (approved) as it's one flat match over all commands.

## Testing
classify/parse tests for usdc (provider) and equity (simple) routing, plus `--kind` required and `--kind usdc` requires `--id`. 148 `cli::` tests pass; clippy + fmt clean.

## Anything else
Part of epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978).
