### PR TITLE
refactor: remove legacy recovery command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,7 @@ nix develop .#ci-backend -c cargo clippy --workspace --all-targets --all-feature
 system using [mprocs](https://github.com/pvolok/mprocs) to run the dashboard and
 the bot side-by-side. `nix run .#simulate-failures` starts the same stack, then
 creates failed mint and redemption rebalances whose mock Alpaca provider later
-completes and prints the (legacy-named) `recheck-transfer` commands that recover
-them; the printed hints move to the new names when the legacy aliases are
-deprecated.
+completes and prints the `transfer recheck` commands that recover them.
 
 What it does:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1720,7 +1720,7 @@ enum DetectionFailure {
 }
 ```
 
-The operator `fail` verb (`fail-transfer --type redemption`) dispatches per
+The operator `fail` verb (`transfer fail --kind redemption`) dispatches per
 state: a redemption stuck before tokens leave custody takes `FailTransfer`, a
 `TokensSent` redemption takes `FailDetection { failure: Operator { reason } }`,
 and a `Pending` redemption takes `RejectRedemption { reason }`. In every case
@@ -2966,8 +2966,8 @@ next restart.
 **Operator reconciliation of a stranded post-burn failure**: A USDC rebalance
 that fails after the CCTP burn holds the rebalancing guard, blocking further
 USDC rebalancing. Because the burned/minted USDC was handled out-of-band, this
-is reconciled rather than re-driven: the `reconcile-usdc-transfer` CLI command
-sends `ReconcileStuckRebalance`, which emits `OperatorReconciled` and drives the
+is reconciled rather than re-driven: the `transfer reconcile` CLI command sends
+`ReconcileStuckRebalance`, which emits `OperatorReconciled` and drives the
 aggregate to a new clearing terminal state, `Reconciled`. The in-progress guard
 then clears via one of two paths: (1) the live reactor processes
 `OperatorReconciled` directly (if the server itself ran the store command) and
@@ -3041,9 +3041,9 @@ proper tracking of asset movements that required manual resolution.
 
 The CLI exposes operator commands for recovering stuck or failed operations.
 These commands share one vocabulary so each command's intent is unambiguous.
-This section is the source of truth for that vocabulary; the rename onto it is
-implemented incrementally (see the recovery-CLI unification epic), with legacy
-command names kept as hidden aliases during the transition.
+This section is the source of truth for that vocabulary. The grouped command
+surface is the only operator recovery interface; the pre-rename flat command
+names were removed with no back-compat.
 
 **Commands are grouped by the object they act on:**
 
@@ -3083,9 +3083,9 @@ effect rather than a generic intent:
   touch no aggregate, so its commands are named for the on-chain action they
   perform and are exempt from the recovery-verb vocabulary.
 - `position release-hedge` -- release a Position's stuck pending-offchain-order
-  pointer so normal hedging can retry; the rename of the legacy
-  `fail-pending-offchain-order`. `fail` would be the wrong verb here: the
-  Position itself never fails -- only its orphaned order does; `--reason`
+  pointer so normal hedging can retry; it replaced the removed
+  `fail-pending-offchain-order` command. `fail` would be the wrong verb here:
+  the Position itself never fails -- only its orphaned order does; `--reason`
   required.
 
 **Standing rules:**
@@ -3101,33 +3101,24 @@ effect rather than a generic intent:
 - **`recover` is not a CLI verb.** It historically meant three different things
   (raw mint completion, provider-truth un-failing, and on-chain mint adoption),
   so it carries no information. The raw bridge primitive is named
-  `cctp complete-mint`; until the rename step of the unification epic lands it
-  remains live under its legacy name `cctp-recover`, which the rename keeps as a
-  hidden alias.
+  `cctp complete-mint`; the legacy `cctp-recover` name has been removed.
 - **Execution mode is part of each command's contract.** Help text states which
   mode the command uses: direct-DB (the operator must ensure the bot is not
   concurrently driving the same id); direct-DB plus a live RPC provider
-  (`transfer resume --kind usdc`, today `resume-usdc-transfer`, drives the
-  on-chain flow against the local aggregate store, with the same
-  no-concurrent-bot caveat); live RPC only (`cctp complete-mint` touches no
-  database state -- the caveat is the bot concurrently driving the same on-chain
-  mint); or the running bot (REST). `recheck` and
-  `transfer resume --kind equity` are the only commands that require the bot.
+  (`transfer resume --kind usdc` drives the on-chain flow against the local
+  aggregate store, with the same no-concurrent-bot caveat); live RPC only
+  (`cctp complete-mint` touches no database state -- the caveat is the bot
+  concurrently driving the same on-chain mint); or the running bot (REST).
+  `recheck` and `transfer resume --kind equity` are the only commands that
+  require the bot.
 - **`--reason` MUST be required, with no default, on every event-emitting
   destructive verb** (`fail`, `reconcile`, `set`, and `position release-hedge`).
   A defaulted reason is an audit-hostile record and violates the
-  no-silent-defaults rule. The pre-existing `fail-pending-offchain-order` and
-  `fail-transfer` predate this rule and carry defaulted reasons, and
-  `reconcile-usdc-transfer` shipped with one just before this rule was codified.
-  The rename step carried those defaults onto the renamed forms unchanged; the
-  defaults-removal step then strips them from the grouped verbs and, with them,
-  from `fail-pending-offchain-order` (a clap alias shares its canonical
-  command's arguments, so the alias cannot keep a default its canonical form
-  lost). The hidden flat `fail-transfer` and `reconcile-usdc-transfer` variants
-  retain their defaulted reasons for runbook compatibility until the deprecation
-  step deletes the legacy names. The standalone `fail-usdc-transfer` command,
-  which is not hidden and has no grouped equivalent in this unification, also
-  still carries a defaulted reason.
+  no-silent-defaults rule. Earlier transitional steps carried defaulted reasons
+  on now-removed legacy command names; with those names deleted, every grouped
+  destructive verb requires an explicit `--reason`, and a present-but-blank
+  value is rejected (at parse time for the string-valued verbs, by the enum
+  domain for `reconcile`).
 - **`fail` and `reconcile` are distinct and must not be conflated.** `fail` is
   for an operation the system is still waiting on (force it to a clean
   terminal); `reconcile` is for an operation that already failed and whose guard

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -253,7 +253,7 @@ describe('recoveryCommand', () => {
     expect(command).toEqual({
       mode: 'simulation',
       command:
-        'nix develop --command cargo run --features mock --bin cli -- --config /tmp/st0x-simulate-failures-8123.config.toml --secrets /tmp/st0x-simulate-failures-8123.secrets.toml recheck-transfer --type mint --id ISS001',
+        'nix develop --command cargo run --features mock --bin cli -- --config /tmp/st0x-simulate-failures-8123.config.toml --secrets /tmp/st0x-simulate-failures-8123.secrets.toml transfer recheck --kind mint --id ISS001',
     })
   })
 
@@ -264,7 +264,7 @@ describe('recoveryCommand', () => {
       kind: 'equity_redemption',
       id: 'RED001',
     })
-    expect(command?.command).toContain('recheck-transfer --type redemption --id RED001')
+    expect(command?.command).toContain('transfer recheck --kind redemption --id RED001')
   })
 
   it('builds the stox command for an equity mint on a live deployment', () => {
@@ -276,7 +276,7 @@ describe('recoveryCommand', () => {
     })
     expect(command).toEqual({
       mode: 'production',
-      command: 'stox recheck-transfer --type mint --id ISS001',
+      command: 'stox transfer recheck --kind mint --id ISS001',
     })
   })
 
@@ -289,7 +289,7 @@ describe('recoveryCommand', () => {
     })
     expect(command).toEqual({
       mode: 'production',
-      command: 'stox recheck-transfer --type redemption --id RED001',
+      command: 'stox transfer recheck --kind redemption --id RED001',
     })
   })
 

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -160,7 +160,7 @@ export const stuckReasonLabel = (reason: string): string =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 
-/// Maps a transfer kind to the `recheck-transfer --type` flag value, or null
+/// Maps a transfer kind to the `transfer recheck --kind` flag value, or null
 /// for kinds that are not equity transfers (e.g. usdc_bridge).
 const recheckTransferType = (kind: string): string | null => {
   switch (kind) {
@@ -173,14 +173,14 @@ const recheckTransferType = (kind: string): string | null => {
   }
 }
 
-/// A `recheck-transfer` command for a stranded transfer. The `mode`
+/// A `transfer recheck` command for a stranded transfer. The `mode`
 /// distinguishes a local simulation command from one an operator runs on the
 /// deployed server, so the UI can label them differently.
 export type RecoveryCommand =
   | { mode: 'simulation'; command: string }
   | { mode: 'production'; command: string }
 
-/// Builds the `recheck-transfer` CLI command shown to operators for a stranded
+/// Builds the `transfer recheck` CLI command shown to operators for a stranded
 /// transfer, or null for kinds with no recovery path (e.g. usdc_bridge).
 ///
 /// Simulation builds set `simulateSourceId` (`PUBLIC_SIMULATE_SOURCE_ID`, set
@@ -203,12 +203,12 @@ export const recoveryCommand = (params: {
     const basePath = `/tmp/st0x-simulate-failures-${params.backendPort}`
     return {
       mode: 'simulation',
-      command: `nix develop --command cargo run --features mock --bin cli -- --config ${basePath}.config.toml --secrets ${basePath}.secrets.toml recheck-transfer --type ${transferType} --id ${params.id}`,
+      command: `nix develop --command cargo run --features mock --bin cli -- --config ${basePath}.config.toml --secrets ${basePath}.secrets.toml transfer recheck --kind ${transferType} --id ${params.id}`,
     }
   }
 
   return {
     mode: 'production',
-    command: `stox recheck-transfer --type ${transferType} --id ${params.id}`,
+    command: `stox transfer recheck --kind ${transferType} --id ${params.id}`,
   }
 }

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -288,13 +288,13 @@ that no recent CCTP burn was submitted from the market-maker wallet (e.g. via
   NOT run `fail-usdc-transfer` (strands the burned funds) and do NOT run
   `transfer reconcile` (its preflight rejects `BridgingSubmitting` -- it only
   accepts persisted post-burn terminals such as `DepositFailed`). Instead, run
-  `transfer resume`: its `find_recent_burn` scan adopts the orphan burn,
-  persists `BridgingInitiated`, and the transfer continues normally.
+  `transfer resume --kind usdc`: its `find_recent_burn` scan adopts the orphan
+  burn, persists `BridgingInitiated`, and the transfer continues normally.
 
 `transfer reconcile` is the path for persisted post-burn terminal failures (e.g.
 `DepositFailed`, `BridgingFailed` with a burn tx recorded). The legacy flat
-`resume-usdc-transfer` / `reconcile-usdc-transfer` names remain valid until
-deprecation.
+`resume-usdc-transfer` / `reconcile-usdc-transfer` names have been removed; only
+the grouped `transfer resume` / `transfer reconcile` forms exist.
 
     stox fail-usdc-transfer --id <uuid> --reason "pre-burn crash, burn not attempted"
 
@@ -305,6 +305,5 @@ nix run .#simulate-failures
 ```
 
 The backend creates failed mint and redemption transfers whose mock Alpaca
-provider later completes, then prints the exact (legacy-named)
-`recheck-transfer` commands for that run's generated config, secrets, database,
-and mock API port.
+provider later completes, then prints the exact `transfer recheck` commands for
+that run's generated config, secrets, database, and mock API port.

--- a/flake.nix
+++ b/flake.nix
@@ -348,7 +348,7 @@
               # Same live dashboard stack as `simulate`, but first creates
               # stuck mint and redemption rebalances whose Alpaca mock
               # provider later completes. The backend logs the
-              # recheck-transfer commands needed to recover them.
+              # `transfer recheck` commands needed to recover them.
               "simulate-failures" = mkSimulation {
                 name = "simulate-failures";
                 testFilter = "simulate_failures";

--- a/src/api.rs
+++ b/src/api.rs
@@ -1472,7 +1472,7 @@ async fn recheck_transfer(
 /// Distinguishes not-recoverable conditions (the persisted aggregate state
 /// does not permit provider-completion recovery -- retrying will not help) and
 /// transient upstream failures (the provider was unreachable -- retry later)
-/// from genuinely internal failures, so the operator running `recheck-transfer`
+/// from genuinely internal failures, so the operator running `transfer recheck`
 /// during an incident learns whether to retry without reading bot logs. Bodies
 /// for the not-recoverable variants carry the typed error's message, which only
 /// references aggregate/request ids; internal failures stay generic so they do

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -52,7 +52,7 @@ pub enum ConvertDirection {
     ToUsdc,
 }
 
-/// Transfer type for the fail-transfer command.
+/// Transfer type for the `transfer fail` command.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum TransferType {
     /// Tokenized equity mint (Alpaca -> onchain)
@@ -127,7 +127,6 @@ pub enum PositionRecoveryCommand {
     ///
     /// Operates directly on the local CQRS state via aggregate commands; does not
     /// require the running bot.
-    #[command(alias = "fail-pending-offchain-order")]
     ReleaseHedge {
         /// Position symbol (e.g., MSTR)
         #[arg(short = 's', long = "symbol")]
@@ -144,7 +143,6 @@ pub enum PositionRecoveryCommand {
     ///
     /// Operates directly on the local CQRS state via aggregate commands; does not
     /// require the running bot.
-    #[command(alias = "set-position")]
     #[command(group(
         ArgGroup::new("target")
             .required(true)
@@ -346,44 +344,6 @@ pub enum Commands {
         amount: Usdc,
     },
 
-    /// Resume an interrupted USDC transfer by its id (Raindex <-> Alpaca)
-    ///
-    /// Re-drives a transfer whose CLI invocation was interrupted after the burn.
-    /// The id is printed by `transfer-usdc` at start. An unknown id is rejected
-    /// (never starts a fresh burn) and `--direction` must match the original;
-    /// the resume always uses the aggregate's persisted amount.
-    #[command(hide = true)]
-    ResumeUsdcTransfer {
-        /// Id of the transfer to resume (printed by `transfer-usdc`)
-        #[arg(long = "id")]
-        id: Uuid,
-        /// Direction of the original transfer (must match the persisted transfer)
-        #[arg(short = 'd', long = "direction")]
-        direction: TransferDirection,
-        /// Required for compatibility with old recovery hints; ignored -- the
-        /// resume uses the persisted amount
-        #[arg(short = 'a', long = "amount")]
-        amount: Usdc,
-    },
-
-    /// Reconcile a USDC transfer stranded in a post-burn terminal failure
-    ///
-    /// Drives a USDC rebalance stranded in a post-burn terminal failure
-    /// (`DepositFailed`, a post-burn `BridgingFailed`, or a `BaseToAlpaca`
-    /// `ConversionFailed`) to the clearing terminal `Reconciled` state: the
-    /// funds were handled out-of-band, so this resolves the transfer (clearing
-    /// the in-progress guard and reconciling source-venue inflight) rather than
-    /// re-driving it. Rejects an unknown id or any other state.
-    #[command(hide = true)]
-    ReconcileUsdcTransfer {
-        /// Id of the stuck transfer to reconcile
-        #[arg(long = "id")]
-        id: Uuid,
-        /// Why the transfer is being reconciled
-        #[arg(short = 'r', long = "reason", default_value = "funds-moved-manually")]
-        reason: ReconcileReasonArg,
-    },
-
     /// Mark a pre-burn USDC rebalance as failed, clearing the in-progress guard.
     ///
     /// Valid only from `BridgingSubmitting` or `WithdrawalComplete`. Refused for
@@ -401,7 +361,7 @@ pub enum Commands {
     /// - Post-burn terminal failures (e.g. `DepositFailed`) use
     ///   `transfer reconcile`. In-flight post-burn states (`Bridging`,
     ///   `AwaitingAttestation`, `Attested`, `Bridged`, `DepositInitiated`)
-    ///   should be resumed with `transfer resume`.
+    ///   should be resumed with `transfer resume --kind usdc`.
     FailUsdcTransfer {
         /// USDC rebalance aggregate ID (UUID)
         #[arg(short = 'i', long = "id")]
@@ -547,21 +507,6 @@ pub enum Commands {
         from: CctpChain,
     },
 
-    /// Recover a stuck CCTP transfer by completing the mint on the destination chain.
-    ///
-    /// Use this when a CCTP burn succeeded but the mint wasn't completed (e.g., due to
-    /// attestation polling being interrupted). Provide the burn transaction hash and
-    /// specify the source chain to recover the transfer.
-    #[command(hide = true)]
-    CctpRecover {
-        /// Transaction hash of the burn transaction on the source chain
-        #[arg(long = "burn-tx")]
-        burn_tx: TxHash,
-        /// Source chain where the burn occurred
-        #[arg(long = "source-chain")]
-        source_chain: CctpChain,
-    },
-
     /// Reset USDC allowance for the orderbook to zero.
     ///
     /// Use this to investigate approval behavior or when switching orderbook addresses.
@@ -670,65 +615,7 @@ pub enum Commands {
         yes: bool,
     },
 
-    /// Manually fail a stuck mint or redemption transfer
-    ///
-    /// Marks a transfer aggregate as failed, transitioning it to a terminal
-    /// state. Use when a transfer is permanently stuck (e.g., timed out,
-    /// unrecoverable error) and needs operator intervention.
-    #[command(hide = true)]
-    FailTransfer {
-        /// Transfer type: "mint" or "redemption"
-        #[arg(short = 't', long = "type")]
-        transfer_type: TransferType,
-        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
-        #[arg(short = 'i', long = "id")]
-        id: String,
-        /// Reason for failure
-        #[arg(
-            short = 'r',
-            long = "reason",
-            default_value = "Manually failed via CLI"
-        )]
-        reason: String,
-    },
-
-    /// Re-check a failed mint or redemption and complete it if the provider settled it
-    ///
-    /// Delegates to the running bot's REST API so recovery dispatches through
-    /// the in-process reactor (correcting live inventory). Requires the bot to
-    /// be running and serving its API on the configured `server_port`.
-    #[command(hide = true)]
-    RecheckTransfer {
-        /// Transfer type: "mint" or "redemption"
-        #[arg(short = 't', long = "type")]
-        transfer_type: TransferType,
-        /// Aggregate ID (issuer_request_id for mint, redemption ID for redemption)
-        #[arg(short = 'i', long = "id")]
-        id: String,
-    },
-
-    /// Rebuild a materialized view by replaying all events from scratch
-    ///
-    /// Use as an escape hatch when a view becomes corrupted (e.g., due to
-    /// lost updates from optimistic lock conflicts). Deletes the view row(s)
-    /// and replays all events to reconstruct correct state.
-    #[command(hide = true)]
-    RebuildView {
-        /// Aggregate type to rebuild (position, offchain-order, vault-registry)
-        #[arg(short = 'a', long = "aggregate")]
-        aggregate: AggregateView,
-        /// Specific aggregate ID to rebuild (e.g., AAPL for position).
-        /// Mutually exclusive with --all.
-        #[arg(long = "id", conflicts_with = "all", required_unless_present = "all")]
-        id: Option<String>,
-        /// Rebuild all views for the aggregate type.
-        /// Mutually exclusive with --id.
-        #[arg(long = "all", conflicts_with = "id", required_unless_present = "id")]
-        all: bool,
-    },
-
     /// Recover stuck positions through aggregate commands.
-    #[command(alias = "repair")]
     Position {
         #[command(subcommand)]
         command: PositionRecoveryCommand,
@@ -1253,9 +1140,7 @@ async fn run_command_with_writers<W: Write>(
 
 // One flat match mapping every CLI command to its internal Simple/Provider
 // dispatch. Kept as a single match (per the repo's "don't split simple-but-long
-// matches" rule) rather than fragmented into per-group helpers; the grouped
-// subcommands added in the recovery-CLI rename pushed it just over the limit.
-#[allow(clippy::too_many_lines)]
+// matches" rule) rather than fragmented into per-group helpers.
 fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand> {
     match command {
         Commands::Buy {
@@ -1334,14 +1219,6 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::TransferUsdc { direction, amount } => {
             Err(ProviderCommand::TransferUsdc { direction, amount })
         }
-        Commands::ResumeUsdcTransfer {
-            id,
-            direction,
-            // Ignored: a resume always uses the persisted aggregate amount. The
-            // flag stays required on the legacy name so old invocations keep
-            // their exact shape.
-            amount: _,
-        } => Err(ProviderCommand::ResumeUsdcTransfer { id, direction }),
         Commands::VaultDeposit {
             amount,
             token,
@@ -1364,13 +1241,6 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::CctpBridge { amount, all, from } => {
             Err(ProviderCommand::CctpBridge { amount, all, from })
         }
-        Commands::CctpRecover {
-            burn_tx,
-            source_chain,
-        } => Err(ProviderCommand::CctpRecover {
-            burn_tx,
-            source_chain,
-        }),
         Commands::ResetAllowance { chain } => Err(ProviderCommand::ResetAllowance { chain }),
         Commands::AlpacaTokenize {
             symbol,
@@ -1395,25 +1265,7 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         }
         Commands::OrderStatus { order_id } => Ok(SimpleCommand::OrderStatus { order_id }),
         Commands::Submit { to, data, yes } => Ok(SimpleCommand::Submit { to, data, yes }),
-        Commands::RebuildView { aggregate, id, all } => {
-            Ok(SimpleCommand::RebuildView { aggregate, id, all })
-        }
         Commands::Position { command } => Ok(SimpleCommand::Position { command }),
-        Commands::FailTransfer {
-            transfer_type,
-            id,
-            reason,
-        } => Ok(SimpleCommand::FailTransfer {
-            transfer_type,
-            id,
-            reason,
-        }),
-        Commands::RecheckTransfer { transfer_type, id } => {
-            Ok(SimpleCommand::RecheckTransfer { transfer_type, id })
-        }
-        Commands::ReconcileUsdcTransfer { id, reason } => {
-            Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason })
-        }
         Commands::FailUsdcTransfer { id, reason } => {
             Ok(SimpleCommand::FailUsdcTransfer { id, reason })
         }
@@ -2089,164 +1941,6 @@ mod tests {
     }
 
     #[test]
-    fn recheck_transfer_command_parses_type_and_id() {
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "recheck-transfer",
-            "--type",
-            "mint",
-            "--id",
-            "ISS001",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::RecheckTransfer { transfer_type, id } => {
-                assert!(matches!(transfer_type, TransferType::Mint));
-                assert_eq!(id, "ISS001");
-            }
-            other => panic!("expected recheck-transfer command, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn resume_usdc_transfer_command_parses_id_direction_and_amount() {
-        let id = Uuid::from_u128(42);
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "resume-usdc-transfer",
-            "--id",
-            &id.to_string(),
-            "--direction",
-            "to-raindex",
-            "--amount",
-            "100",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::ResumeUsdcTransfer {
-                id: parsed_id,
-                direction,
-                amount,
-            } => {
-                assert_eq!(parsed_id, id);
-                assert!(matches!(direction, TransferDirection::ToRaindex));
-                assert_eq!(
-                    amount,
-                    Usdc::new(rain_math_float::Float::parse("100".to_string()).unwrap())
-                );
-            }
-            other => panic!("expected resume-usdc-transfer command, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn reconcile_usdc_transfer_command_parses_id_and_reason() {
-        let id = Uuid::from_u128(77);
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "reconcile-usdc-transfer",
-            "--id",
-            &id.to_string(),
-            "--reason",
-            "deposit-credited-offline",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::ReconcileUsdcTransfer {
-                id: parsed_id,
-                reason,
-            } => {
-                assert_eq!(parsed_id, id);
-                assert!(matches!(reason, ReconcileReasonArg::DepositCreditedOffline));
-            }
-            other => panic!("expected reconcile-usdc-transfer command, got: {other:?}"),
-        }
-    }
-
-    /// The hidden legacy flat command keeps its default reason so existing
-    /// runbooks/scripts that omit --reason still work.
-    #[test]
-    fn legacy_reconcile_usdc_transfer_keeps_default_reason() {
-        let id = Uuid::from_u128(78);
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "reconcile-usdc-transfer",
-            "--id",
-            &id.to_string(),
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::ReconcileUsdcTransfer { reason, .. } => {
-                assert!(matches!(reason, ReconcileReasonArg::FundsMovedManually));
-            }
-            other => panic!("expected reconcile-usdc-transfer command, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn classify_reconcile_usdc_transfer_command_as_simple() {
-        // reconcile-usdc-transfer only loads + sends to the event store, so it
-        // must route without an RPC provider.
-        let command = Commands::ReconcileUsdcTransfer {
-            id: Uuid::from_u128(42),
-            reason: ReconcileReasonArg::FundsMovedManually,
-        };
-
-        match classify_command(command) {
-            Ok(SimpleCommand::ReconcileUsdcTransfer { reason, .. }) => {
-                assert!(matches!(reason, ReconcileReasonArg::FundsMovedManually));
-            }
-            Ok(_) => panic!("expected reconcile-usdc-transfer simple command"),
-            Err(
-                ProviderCommand::ProcessTx { .. }
-                | ProviderCommand::TransferUsdc { .. }
-                | ProviderCommand::ResumeUsdcTransfer { .. }
-                | ProviderCommand::CctpBridge { .. }
-                | ProviderCommand::CctpRecover { .. }
-                | ProviderCommand::ResetAllowance { .. }
-                | ProviderCommand::AlpacaTokenize { .. }
-                | ProviderCommand::AlpacaRedeem { .. }
-                | ProviderCommand::DividendBump { .. }
-                | ProviderCommand::AlpacaTokenizationRequests,
-            ) => panic!("expected simple command classification, got provider command"),
-        }
-    }
-
-    #[test]
-    fn classify_recheck_transfer_command_as_simple() {
-        // The recheck-transfer command must route without an RPC provider:
-        // it delegates to the running bot's REST API rather than touching chain.
-        let command = Commands::RecheckTransfer {
-            transfer_type: TransferType::Redemption,
-            id: "redemption-1".to_string(),
-        };
-
-        match classify_command(command) {
-            Ok(SimpleCommand::RecheckTransfer { transfer_type, id }) => {
-                assert!(matches!(transfer_type, TransferType::Redemption));
-                assert_eq!(id, "redemption-1");
-            }
-            Ok(_) => panic!("expected recheck-transfer simple command"),
-            Err(
-                ProviderCommand::ProcessTx { .. }
-                | ProviderCommand::TransferUsdc { .. }
-                | ProviderCommand::ResumeUsdcTransfer { .. }
-                | ProviderCommand::CctpBridge { .. }
-                | ProviderCommand::CctpRecover { .. }
-                | ProviderCommand::ResetAllowance { .. }
-                | ProviderCommand::AlpacaTokenize { .. }
-                | ProviderCommand::AlpacaRedeem { .. }
-                | ProviderCommand::DividendBump { .. }
-                | ProviderCommand::AlpacaTokenizationRequests,
-            ) => panic!("expected simple command classification, got provider command"),
-        }
-    }
-
-    #[test]
     fn classify_fail_usdc_transfer_routes_without_provider() {
         // fail-usdc-transfer only loads + sends to the event store, so it
         // must route without an RPC provider.
@@ -2434,84 +2128,11 @@ mod tests {
     }
 
     #[test]
-    fn legacy_fail_pending_offchain_order_alias_requires_reason() {
-        // The legacy alias shares the canonical command's arguments, so it
-        // loses the defaulted reason along with `position release-hedge`.
-        let order_id = OffchainOrderId::new();
-        let error = Cli::try_parse_from([
-            "st0x-cli",
-            "repair",
-            "fail-pending-offchain-order",
-            "--symbol",
-            "MSTR",
-            "--order-id",
-            &order_id.to_string(),
-        ])
-        .unwrap_err();
-        assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
-        assert!(
-            error.to_string().contains("reason"),
-            "the missing argument must be --reason, got: {error}",
-        );
-    }
-
-    #[test]
-    fn legacy_fail_transfer_keeps_default_reason() {
-        // The hidden legacy flat command keeps its default reason so existing
-        // runbooks/scripts that omit --reason still work.
-        let cli =
-            Cli::try_parse_from(["st0x-cli", "fail-transfer", "--type", "mint", "--id", "m1"])
-                .unwrap();
-        match cli.command {
-            Commands::FailTransfer { reason, .. } => {
-                assert_eq!(reason, "Manually failed via CLI");
-            }
-            _ => panic!("expected legacy FailTransfer command"),
-        }
-    }
-
-    #[test]
-    fn repair_fail_pending_offchain_order_parses() {
-        let order_id = OffchainOrderId::new();
+    fn position_set_zero_parses() {
         let cli = Cli::try_parse_from([
             "st0x-cli",
-            "repair",
-            "fail-pending-offchain-order",
-            "--symbol",
-            "MSTR",
-            "--order-id",
-            &order_id.to_string(),
-            "--reason",
-            "operator repair",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::Position {
-                command:
-                    PositionRecoveryCommand::ReleaseHedge {
-                        symbol,
-                        order_id: parsed_order_id,
-                        reason,
-                    },
-            } => {
-                assert_eq!(symbol, Symbol::new("MSTR").unwrap());
-                assert_eq!(parsed_order_id, order_id);
-                assert_eq!(reason, "operator repair");
-            }
-            other => panic!("expected repair command, got: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn repair_set_position_zero_parses() {
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "repair",
-            "set-position",
+            "position",
+            "set",
             "--symbol",
             "SPYM",
             "--zero",
@@ -2520,8 +2141,8 @@ mod tests {
         ])
         .unwrap();
 
-        match cli.command {
-            Commands::Position {
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::Position {
                 command:
                     PositionRecoveryCommand::Set {
                         symbol,
@@ -2531,7 +2152,7 @@ mod tests {
                         price,
                         reason,
                     },
-            } => {
+            }) => {
                 assert_eq!(symbol, Symbol::new("SPYM").unwrap());
                 assert!(zero);
                 assert_eq!(long, None);
@@ -2539,16 +2160,16 @@ mod tests {
                 assert!(price.is_none());
                 assert_eq!(reason, "manual rebalance completed");
             }
-            other => panic!("expected repair set-position command, got: {other:?}"),
+            _ => panic!("expected position set simple command"),
         }
     }
 
     #[test]
-    fn repair_set_position_long_and_short_parse_positive_amounts() {
+    fn position_set_long_and_short_parse_positive_amounts() {
         let long = Cli::try_parse_from([
             "st0x-cli",
-            "repair",
-            "set-position",
+            "position",
+            "set",
             "--symbol",
             "SPYM",
             "--long",
@@ -2558,21 +2179,21 @@ mod tests {
         ])
         .unwrap();
 
-        match long.command {
-            Commands::Position {
+        match classify_command(long.command) {
+            Ok(SimpleCommand::Position {
                 command:
                     PositionRecoveryCommand::Set {
                         long: Some(quantity),
                         ..
                     },
-            } => assert_eq!(quantity, positive_shares("100")),
-            other => panic!("expected repair set-position --long, got: {other:?}"),
+            }) => assert_eq!(quantity, positive_shares("100")),
+            _ => panic!("expected position set --long simple command"),
         }
 
         let short = Cli::try_parse_from([
             "st0x-cli",
-            "repair",
-            "set-position",
+            "position",
+            "set",
             "--symbol",
             "SPYM",
             "--short",
@@ -2582,29 +2203,27 @@ mod tests {
         ])
         .unwrap();
 
-        match short.command {
-            Commands::Position {
+        match classify_command(short.command) {
+            Ok(SimpleCommand::Position {
                 command:
                     PositionRecoveryCommand::Set {
                         short: Some(quantity),
                         ..
                     },
-            } => assert_eq!(quantity, positive_shares("12.5")),
-            other => panic!("expected repair set-position --short, got: {other:?}"),
+            }) => assert_eq!(quantity, positive_shares("12.5")),
+            _ => panic!("expected position set --short simple command"),
         }
     }
 
     #[test]
-    fn repair_set_position_rejects_missing_reason() {
-        let error = Cli::try_parse_from([
-            "st0x-cli",
-            "repair",
-            "set-position",
-            "--symbol",
-            "SPYM",
-            "--zero",
-        ])
-        .unwrap_err();
+    fn position_set_rejects_missing_reason() {
+        let error =
+            Cli::try_parse_from(["st0x-cli", "position", "set", "--symbol", "SPYM", "--zero"])
+                .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
         let rendered = error.to_string();
         assert!(
             rendered.contains("reason"),
@@ -2613,18 +2232,18 @@ mod tests {
     }
 
     #[test]
-    fn repair_set_position_rejects_multiple_targets() {
+    fn position_set_rejects_multiple_targets() {
         let error = Cli::try_parse_from([
             "st0x-cli",
-            "repair",
-            "set-position",
+            "position",
+            "set",
             "--symbol",
             "SPYM",
             "--zero",
             "--long",
             "1",
             "--reason",
-            "operator repair",
+            "operator correction",
         ])
         .unwrap_err();
         let rendered = error.to_string();
@@ -2637,17 +2256,17 @@ mod tests {
     }
 
     #[test]
-    fn repair_set_position_rejects_zero_long_amount() {
+    fn position_set_rejects_zero_long_amount() {
         let error = Cli::try_parse_from([
             "st0x-cli",
-            "repair",
-            "set-position",
+            "position",
+            "set",
             "--symbol",
             "SPYM",
             "--long",
             "0",
             "--reason",
-            "operator repair",
+            "operator correction",
         ])
         .unwrap_err();
         let rendered = error.to_string();
@@ -2660,7 +2279,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_repair_command_as_simple() {
+    fn classify_position_command_as_simple() {
         let order_id = OffchainOrderId::new();
         let command = Commands::Position {
             command: PositionRecoveryCommand::ReleaseHedge {
@@ -2683,7 +2302,7 @@ mod tests {
                 assert_eq!(parsed_order_id, order_id);
                 assert_eq!(reason, "operator repair");
             }
-            Ok(_) => panic!("expected repair simple command"),
+            Ok(_) => panic!("expected position simple command"),
             Err(
                 ProviderCommand::ProcessTx { .. }
                 | ProviderCommand::TransferUsdc { .. }
@@ -2700,7 +2319,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_command_with_writers_executes_repair_set_position() {
+    async fn run_command_with_writers_executes_position_set() {
         let ctx = create_test_ctx();
         let pool = setup_test_db().await;
         let symbol = Symbol::new("SPYM").unwrap();
@@ -2963,6 +2582,25 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "guarantees id and direction")]
+    fn classify_usdc_resume_without_id_or_direction_is_unreachable() {
+        // The production path is doubly guarded (clap `required_if_eq` plus
+        // `validate_command`), but `classify_command` is called directly in
+        // tests; constructing the impossible shape by hand must hit the
+        // documented `unreachable!`, pinning that invariant independently.
+        let command = Commands::Transfer {
+            command: TransferCommand::Resume {
+                kind: TransferResumeKind::Usdc,
+                id: None,
+                direction: None,
+                amount: None,
+            },
+        };
+
+        let _ = classify_command(command);
+    }
+
+    #[test]
     fn transfer_reconcile_parses_and_classifies_as_simple() {
         let id = Uuid::from_u128(77);
         let cli = Cli::try_parse_from([
@@ -3013,7 +2651,7 @@ mod tests {
                 assert_eq!(id, "ISS001");
                 assert_eq!(reason, "stuck forever");
             }
-            _ => panic!("expected fail-transfer simple command"),
+            _ => panic!("expected transfer fail simple command"),
         }
     }
 
@@ -3058,7 +2696,7 @@ mod tests {
                 assert_eq!(id.as_deref(), Some("AAPL"));
                 assert!(!all);
             }
-            _ => panic!("expected rebuild-view simple command"),
+            _ => panic!("expected view rebuild simple command"),
         }
     }
 
@@ -3084,31 +2722,6 @@ mod tests {
                 assert!(matches!(source_chain, CctpChain::Ethereum));
             }
             _ => panic!("expected cctp complete-mint provider command"),
-        }
-    }
-
-    #[test]
-    fn position_set_zero_parses_under_new_name() {
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "position",
-            "set",
-            "--symbol",
-            "SPYM",
-            "--zero",
-            "--reason",
-            "manual rebalance completed",
-        ])
-        .unwrap();
-
-        match classify_command(cli.command) {
-            Ok(SimpleCommand::Position {
-                command: PositionRecoveryCommand::Set { symbol, zero, .. },
-            }) => {
-                assert_eq!(symbol, Symbol::new("SPYM").unwrap());
-                assert!(zero);
-            }
-            _ => panic!("expected position set to classify as a simple position command"),
         }
     }
 
@@ -3286,168 +2899,40 @@ mod tests {
         );
     }
 
-    #[test]
-    fn legacy_repair_alias_still_parses() {
-        let cli = Cli::try_parse_from([
-            "st0x-cli",
-            "repair",
-            "set-position",
-            "--symbol",
-            "SPYM",
-            "--zero",
-            "--reason",
-            "legacy alias",
-        ])
-        .unwrap();
-
-        assert!(matches!(
-            classify_command(cli.command),
-            Ok(SimpleCommand::Position {
-                command: PositionRecoveryCommand::Set { .. }
-            })
-        ));
-    }
-
-    /// The legacy flat resume keeps its exact shape: `--amount` stays required
-    /// (even though the resume ignores it for the persisted amount), so old
-    /// invocations and old recovery hints behave identically.
-    #[test]
-    fn legacy_resume_without_amount_is_rejected() {
-        let result = Cli::try_parse_from([
-            "st0x-cli",
-            "resume-usdc-transfer",
-            "--id",
-            &Uuid::from_u128(7).to_string(),
-            "--direction",
-            "to-raindex",
-        ]);
-
-        let error = result.unwrap_err();
-        assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument,
-            "legacy resume-usdc-transfer must keep requiring --amount",
-        );
-    }
-
-    #[test]
-    fn legacy_flat_transfer_names_still_parse() {
-        let resume_id = Uuid::from_u128(7);
-        let resume = Cli::try_parse_from([
-            "st0x-cli",
-            "resume-usdc-transfer",
-            "--id",
-            &resume_id.to_string(),
-            "--direction",
-            "to-raindex",
-            "--amount",
-            "100",
-        ])
-        .unwrap();
-        assert!(matches!(
-            classify_command(resume.command),
-            Err(ProviderCommand::ResumeUsdcTransfer { .. })
-        ));
-
-        let fail = Cli::try_parse_from([
-            "st0x-cli",
-            "fail-transfer",
-            "--type",
-            "mint",
-            "--id",
-            "ISS001",
-        ])
-        .unwrap();
-        match classify_command(fail.command) {
-            Ok(SimpleCommand::FailTransfer { reason, .. }) => {
-                assert_eq!(reason, "Manually failed via CLI");
-            }
-            _ => panic!("expected legacy fail-transfer to classify as FailTransfer"),
-        }
-
-        let recheck = Cli::try_parse_from([
-            "st0x-cli",
-            "recheck-transfer",
-            "--type",
-            "redemption",
-            "--id",
-            "redemption-1",
-        ])
-        .unwrap();
-        assert!(matches!(
-            classify_command(recheck.command),
-            Ok(SimpleCommand::RecheckTransfer { .. })
-        ));
-
-        let reconcile_id = Uuid::from_u128(8);
-        let reconcile = Cli::try_parse_from([
-            "st0x-cli",
-            "reconcile-usdc-transfer",
-            "--id",
-            &reconcile_id.to_string(),
-            "--reason",
-            "funds-moved-manually",
-        ])
-        .unwrap();
-        assert!(matches!(
-            classify_command(reconcile.command),
-            Ok(SimpleCommand::ReconcileUsdcTransfer { .. })
-        ));
-    }
-
-    #[test]
-    fn legacy_flat_view_and_cctp_names_still_parse() {
-        let rebuild = Cli::try_parse_from([
-            "st0x-cli",
-            "rebuild-view",
-            "--aggregate",
-            "position",
-            "--all",
-        ])
-        .unwrap();
-        assert!(matches!(
-            classify_command(rebuild.command),
-            Ok(SimpleCommand::RebuildView { .. })
-        ));
-
-        let cctp = Cli::try_parse_from([
-            "st0x-cli",
-            "cctp-recover",
-            "--burn-tx",
-            &TxHash::ZERO.to_string(),
-            "--source-chain",
-            "base",
-        ])
-        .unwrap();
-        assert!(matches!(
-            classify_command(cctp.command),
-            Err(ProviderCommand::CctpRecover { .. })
-        ));
-    }
-
     /// The legacy `--type`/`-t` discriminator must keep working on the new
-    /// grouped names, so mechanically translated runbook invocations parse.
+    /// grouped `transfer fail`, so mechanically translated runbook invocations
+    /// parse and carry the right `TransferType`.
     #[test]
-    fn grouped_transfer_commands_accept_legacy_type_flag() {
-        let fail_long = Cli::try_parse_from([
+    fn transfer_fail_accepts_type_alias() {
+        let long = Cli::try_parse_from([
             "st0x-cli", "transfer", "fail", "--type", "mint", "--id", "ISS001", "--reason", "stuck",
         ])
         .unwrap();
-        assert!(matches!(
-            classify_command(fail_long.command),
-            Ok(SimpleCommand::FailTransfer { .. })
-        ));
+        match classify_command(long.command) {
+            Ok(SimpleCommand::FailTransfer { transfer_type, .. }) => {
+                assert!(matches!(transfer_type, TransferType::Mint));
+            }
+            _ => panic!("expected transfer fail simple command via --type"),
+        }
 
-        let fail_short = Cli::try_parse_from([
+        let short = Cli::try_parse_from([
             "st0x-cli", "transfer", "fail", "-t", "mint", "--id", "ISS001", "-r", "stuck",
         ])
         .unwrap();
-        assert!(matches!(
-            classify_command(fail_short.command),
-            Ok(SimpleCommand::FailTransfer { .. })
-        ));
+        match classify_command(short.command) {
+            Ok(SimpleCommand::FailTransfer { transfer_type, .. }) => {
+                assert!(matches!(transfer_type, TransferType::Mint));
+            }
+            _ => panic!("expected transfer fail simple command via -t"),
+        }
+    }
 
-        let recheck_long = Cli::try_parse_from([
+    /// The legacy `--type`/`-t` discriminator must keep working on the new
+    /// grouped `transfer recheck`, so mechanically translated runbook
+    /// invocations parse and carry the right `TransferType`.
+    #[test]
+    fn transfer_recheck_accepts_type_alias() {
+        let long = Cli::try_parse_from([
             "st0x-cli",
             "transfer",
             "recheck",
@@ -3457,12 +2942,14 @@ mod tests {
             "redemption-1",
         ])
         .unwrap();
-        assert!(matches!(
-            classify_command(recheck_long.command),
-            Ok(SimpleCommand::RecheckTransfer { .. })
-        ));
+        match classify_command(long.command) {
+            Ok(SimpleCommand::RecheckTransfer { transfer_type, .. }) => {
+                assert!(matches!(transfer_type, TransferType::Redemption));
+            }
+            _ => panic!("expected transfer recheck simple command via --type"),
+        }
 
-        let recheck_short = Cli::try_parse_from([
+        let short = Cli::try_parse_from([
             "st0x-cli",
             "transfer",
             "recheck",
@@ -3472,10 +2959,48 @@ mod tests {
             "redemption-1",
         ])
         .unwrap();
-        assert!(matches!(
-            classify_command(recheck_short.command),
-            Ok(SimpleCommand::RecheckTransfer { .. })
-        ));
+        match classify_command(short.command) {
+            Ok(SimpleCommand::RecheckTransfer { transfer_type, .. }) => {
+                assert!(matches!(transfer_type, TransferType::Redemption));
+            }
+            _ => panic!("expected transfer recheck simple command via -t"),
+        }
+    }
+
+    /// The legacy recovery names were removed (no back-compat). Pin that each
+    /// removed flat command and clap alias now fails to parse, so a future
+    /// merge cannot silently re-introduce one. One representative per removed
+    /// namespace: flat top-level commands, the `repair` group alias, and the
+    /// `set-position`/`fail-pending-offchain-order` subcommand aliases.
+    #[test]
+    fn removed_legacy_recovery_names_no_longer_parse() {
+        for argv in [
+            ["st0x-cli", "fail-transfer", "--id", "ISS001"].as_slice(),
+            ["st0x-cli", "recheck-transfer", "--id", "ISS001"].as_slice(),
+            ["st0x-cli", "resume-usdc-transfer", "--id", "x"].as_slice(),
+            ["st0x-cli", "reconcile-usdc-transfer", "--id", "x"].as_slice(),
+            ["st0x-cli", "rebuild-view", "--all"].as_slice(),
+            ["st0x-cli", "cctp-recover", "--burn-tx", "0x0"].as_slice(),
+            ["st0x-cli", "repair", "set-position", "--symbol", "SPYM"].as_slice(),
+            ["st0x-cli", "position", "set-position", "--symbol", "SPYM"].as_slice(),
+            [
+                "st0x-cli",
+                "position",
+                "fail-pending-offchain-order",
+                "--symbol",
+                "MSTR",
+                "--order-id",
+                "00000000-0000-0000-0000-000000000000",
+            ]
+            .as_slice(),
+        ] {
+            let error = Cli::try_parse_from(argv.iter().copied()).unwrap_err();
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::InvalidSubcommand,
+                "removed name still parses: {argv:?}",
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -635,7 +635,7 @@ pub(super) async fn fail_usdc_transfer_command<Writer: Write>(
         anyhow::bail!(
             "fail-usdc-transfer: transfer {id} is in a post-burn state. \
              A CCTP burn may have already been broadcast. Refusing to act -- \
-             use reconcile-usdc-transfer for post-burn failures."
+             use transfer reconcile for post-burn failures."
         );
     }
 
@@ -733,8 +733,8 @@ pub(super) async fn fail_usdc_transfer_command<Writer: Write>(
         FailBridgingOutcome::ConcurrentBurn => {
             anyhow::bail!(
                 "fail-usdc-transfer: a CCTP burn was recorded concurrently for transfer {id}. \
-                 The guard was NOT cleared. Use reconcile-usdc-transfer for this post-burn \
-                 failure. NOTE: reconcile-usdc-transfer must only be used after confirming \
+                 The guard was NOT cleared. Use transfer reconcile for this post-burn \
+                 failure. NOTE: transfer reconcile must only be used after confirming \
                  on-chain that the CCTP burn did NOT complete (or the minted USDC was \
                  accounted for out-of-band); premature reconciliation on an in-flight bridge \
                  strands the arriving funds."
@@ -2840,7 +2840,7 @@ mod tests {
     async fn fail_usdc_transfer_rejects_conversion_failed_base_to_alpaca() {
         // ConversionFailed{BaseToAlpaca} is post-deposit/post-burn and holds the
         // rebalancing guard (per holds_rebalance_guard()). The is_post_burn gate
-        // must reject it so the operator is routed to reconcile-usdc-transfer.
+        // must reject it so the operator is routed to transfer reconcile.
         let pool = setup_test_db().await;
         let id = Uuid::from_u128(0xBEEF_000E);
 
@@ -3283,7 +3283,7 @@ mod tests {
         store.send(id, command).await.unwrap();
     }
 
-    /// `fail-transfer --type redemption` on a redemption stuck in `TokensSent`
+    /// `transfer fail --kind redemption` on a redemption stuck in `TokensSent`
     /// must dispatch `FailDetection { Operator }` and persist the operator's
     /// `--reason`, recoverable from the replayed `Failed` state.
     #[tokio::test]
@@ -3326,7 +3326,7 @@ mod tests {
         );
     }
 
-    /// `fail-transfer --type redemption` on a redemption stuck in `Pending`
+    /// `transfer fail --kind redemption` on a redemption stuck in `Pending`
     /// (Alpaca detected the transfer but never completed it) must dispatch
     /// `RejectRedemption` and persist the operator's `--reason`.
     #[tokio::test]

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -406,7 +406,7 @@ impl RebalanceTimingProjection {
                         %operation_id,
                         sequence,
                         %error,
-                        "Skipping rebalance event: corrupt stored timing row (repair with rebuild-view --all)"
+                        "Skipping rebalance event: corrupt stored timing row (repair with view rebuild --all)"
                     );
                     poisoned_aggregates.insert(aggregate_id);
                     continue;

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -191,7 +191,7 @@ impl EquityTransferServices {
     ///
     /// Safe for sending commands that never invoke services (e.g., the
     /// `FailWrapping`, `FailAcceptance`, `FailRaindexDeposit`, and
-    /// `FailTransfer` commands). Used by the CLI `fail-transfer`
+    /// `FailTransfer` commands). Used by the CLI `transfer fail`
     /// subcommand where no real broker/RPC connection exists.
     pub(crate) fn panicking() -> Self {
         Self {
@@ -1929,7 +1929,7 @@ mod tests {
     /// Recovery must not double-count an in-flight that is ALREADY established.
     ///
     /// The realistic stuck state -- what the simulate-failures harness and the
-    /// CLI `fail-transfer` ops tool both produce -- is: `MintAccepted` ran
+    /// CLI `transfer fail` ops tool both produce -- is: `MintAccepted` ran
     /// `start` so the quantity sits in Hedging in-flight, but the failure was
     /// recorded out-of-process so the reactor never ran `cancel`. Recovery then
     /// runs against an in-flight already at the mint quantity; re-establishing

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -917,7 +917,7 @@ impl RebalancingService {
         //   The durable-Reconciled check is safe to run at any age: it only
         //   fires when the store already shows Reconciled, and clearing the guard
         //   at that point is always correct. This ensures that a CLI
-        //   `reconcile-usdc-transfer` issued before the failed transfer ages past
+        //   `transfer reconcile` issued before the failed transfer ages past
         //   `transfer_timeout` still takes effect on the next sweep tick.
         //
         // - Pre-burn entries (not yet post-burn) are only selected after the
@@ -1075,7 +1075,7 @@ impl RebalancingService {
     /// re-arming it would re-drive a known-failing transfer on every restart and
     /// bypass the retry budget, contradicting [`JobQueue::requeue_orphaned`]'s
     /// policy of leaving `Failed` rows latched. The operator path for such a
-    /// transfer is the manual `resume-usdc-transfer` CLI, not an automatic re-arm.
+    /// transfer is the manual `transfer resume --kind usdc` CLI, not an automatic re-arm.
     ///
     /// A recoverable post-burn `BridgingFailed` is the exception: it gates on
     /// [`Self::transfer_in_flight_for_id`] instead (only an in-flight row blocks),
@@ -1311,7 +1311,7 @@ impl RebalancingService {
             // The Reconciled check is always safe: it only fires when the
             // aggregate is actually Reconciled and clearing the guard at that
             // point is always correct. Running it before the timeout gate means
-            // that a CLI `reconcile-usdc-transfer` issued before the failed
+            // that a CLI `transfer reconcile` issued before the failed
             // transfer ages past `transfer_timeout` takes effect on the next
             // sweep tick rather than waiting for the full timeout window.
             let usdc_store_guard = self.usdc_store.read().await;
@@ -3515,7 +3515,7 @@ impl RebalancingService {
     }
 
     /// Rebuilds in-memory tracking for a failed mint being recovered via
-    /// `recheck-transfer`, so the live reactor applies the
+    /// `transfer recheck`, so the live reactor applies the
     /// `ProviderCompletionRecovered` inventory effect and the terminal
     /// cleanup once the recovery event is dispatched.
     ///
@@ -3559,7 +3559,7 @@ impl RebalancingService {
         // A third shape the timeout/explicit branches below do not cover: the
         // failure left the in-flight already established (a `Start` ran but the
         // failure never cancelled it back to available -- e.g. an out-of-process
-        // `fail-transfer`, or a reactor that recorded the failure without
+        // `transfer fail`, or a reactor that recorded the failure without
         // running `cancel`). That is already the canonical pre-complete shape,
         // so re-establishing it with another `Start` would double-count
         // (quantity -> 2*quantity) and strand the quantity in-flight after the
@@ -3695,7 +3695,7 @@ impl RebalancingService {
     }
 
     /// Rebuilds in-memory tracking for a failed redemption being recovered
-    /// via `recheck-transfer`. See [`Self::rebuild_mint_tracking_for_recovery`]
+    /// via `transfer recheck`. See [`Self::rebuild_mint_tracking_for_recovery`]
     /// for why inventory balances are left untouched on the explicit-failure
     /// path: a failed redemption never cancelled its in-flight transfer, so the
     /// recovery event's inventory arm completes that still-pending transfer.
@@ -11283,7 +11283,7 @@ mod tests {
     }
 
     /// The main RAI-1017 regression test: the operator runs
-    /// `reconcile-usdc-transfer` in a separate CLI process, which writes
+    /// `transfer reconcile` in a separate CLI process, which writes
     /// `OperatorReconciled` to durable storage. The live server's
     /// `usdc_in_progress` guard must clear on the next sweep tick without
     /// requiring a restart.
@@ -11414,7 +11414,7 @@ mod tests {
 
     /// Reconciled check fires even when `last_progress_at` is RECENT (within
     /// `transfer_timeout`). This is the key correctness invariant: a CLI
-    /// `reconcile-usdc-transfer` run before the failure has aged past the
+    /// `transfer reconcile` run before the failure has aged past the
     /// timeout must still clear the guard on the next sweep tick, not wait
     /// for the full timeout window to elapse.
     #[tokio::test]
@@ -12016,7 +12016,7 @@ mod tests {
     /// Exercises the real restart-then-CLI-reconcile path end-to-end:
     /// `recover_usdc_guard` seeds tracking for a stranded `DepositFailed`
     /// aggregate (path 1), then the sweep detects the operator's CLI
-    /// `reconcile-usdc-transfer` via durable `Reconciled` state and clears
+    /// `transfer reconcile` via durable `Reconciled` state and clears
     /// the guard (path 2). Calling `recover_usdc_guard` directly (rather than
     /// manually planting tracking) ensures both paths are regression-tested
     /// together: a break in path 1 is caught here, not silently missed.
@@ -12079,7 +12079,7 @@ mod tests {
         // which is well above the 1s test timeout, regardless of how fast the
         // store.send calls completed.
 
-        // Simulate the operator running `reconcile-usdc-transfer` in a
+        // Simulate the operator running `transfer reconcile` in a
         // separate CLI process (the store emits OperatorReconciled).
 
         store
@@ -12151,7 +12151,7 @@ mod tests {
 
     /// Restart + CLI reconcile for `ConversionFailed{BaseToAlpaca}`:
     /// the post-deposit USDC->USD conversion failure that holds the guard,
-    /// cannot self-recover, and accepts `reconcile-usdc-transfer`.
+    /// cannot self-recover, and accepts `transfer reconcile`.
     /// After restart, `recover_usdc_guard` must seed tracking for it so the
     /// sweep can detect the CLI-emitted `Reconciled` state and clear the guard
     /// without a second restart.
@@ -12280,7 +12280,7 @@ mod tests {
             "recover_usdc_guard must latch the guard for ConversionFailed(BtA)"
         );
 
-        // Simulate the operator running `reconcile-usdc-transfer` in a
+        // Simulate the operator running `transfer reconcile` in a
         // separate CLI process.
         store
             .send(
@@ -12434,7 +12434,7 @@ mod tests {
             "non-resumable AlpacaToBase BridgingFailed must not be re-armed"
         );
 
-        // Simulate the operator running `reconcile-usdc-transfer` in a
+        // Simulate the operator running `transfer reconcile` in a
         // separate CLI process.
         store
             .send(
@@ -12966,7 +12966,8 @@ mod tests {
     /// retry budget (a terminal `Failed` row) must NOT be re-armed -- re-driving
     /// it every restart would bypass the retry budget and silently retry a
     /// known-failing transfer. It latches for operator reconciliation (recoverable
-    /// via the `resume-usdc-transfer` CLI), matching `requeue_orphaned`'s policy of
+    /// via the `transfer resume --kind usdc` CLI), matching `requeue_orphaned`'s
+    /// policy of
     /// leaving `Failed` rows alone.
     #[tokio::test]
     async fn recover_usdc_guard_does_not_rearm_when_job_already_failed() {

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -1059,8 +1059,8 @@ impl UsdcRebalance {
     }
 
     /// The rebalance direction, present in every non-initial state and invariant
-    /// across the whole lifecycle. Used by the CLI `resume-usdc-transfer` command
-    /// to validate the operator-supplied `--direction` against the persisted
+    /// across the whole lifecycle. Used by the CLI `transfer resume --kind usdc`
+    /// command to validate the operator-supplied `--direction` against the persisted
     /// transfer, so a wrong flag is rejected rather than mis-driving the aggregate
     /// through the opposite-direction resume path.
     ///
@@ -1107,7 +1107,7 @@ impl UsdcRebalance {
     ///   startup via `resumable_post_burn_transfer`).
     ///
     /// All three are accepted by `transition_reconcile_stuck_rebalance` (the
-    /// CLI `reconcile-usdc-transfer` target), hold the guard on restart
+    /// CLI `transfer reconcile` target), hold the guard on restart
     /// (`holds_rebalance_guard` returns `true`), and are NOT auto-re-armed:
     /// without a tracking seed the sweep has no entry to iterate and the guard
     /// stays latched forever after a CLI reconcile.

--- a/tests/e2e/full_system.rs
+++ b/tests/e2e/full_system.rs
@@ -14,7 +14,7 @@
 //!
 //! - [`simulate_failures`]: Same live simulation, but first creates stuck
 //!   mint and redemption rebalances where the local aggregate failed while
-//!   the mock provider later completed, so `recheck-transfer` can recover them.
+//!   the mock provider later completed, so `transfer recheck` can recover them.
 //!   Run via `nix run .#simulate-failures`.
 
 use std::collections::HashMap;
@@ -456,7 +456,7 @@ fn log_recheck_command(
     };
     let command = format!(
         "nix develop --command cargo run --features mock --bin cli -- \
-         --config {} --secrets {} recheck-transfer --type {} --id {}",
+         --config {} --secrets {} transfer recheck --kind {} --id {}",
         config_path.display(),
         secrets_path.display(),
         transfer_type_arg,
@@ -963,7 +963,7 @@ async fn simulate() -> anyhow::Result<()> {
 /// Failure-injection simulation: starts the full system, performs normal trades
 /// to create recoverable AAPL mint and TSLA redemption failures, then advances
 /// the mock issuer/provider to Completed. The dashboard should show the failed
-/// transfers until `recheck-transfer` recovers them.
+/// transfers until `transfer recheck` recovers them.
 ///
 /// Run via `nix run .#simulate-failures`. Set
 /// `SIMULATE_EXIT_AFTER_SELF_HEAL=1` when running under automated verification
@@ -1247,7 +1247,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         // `ProviderCompletionRecovered` is the terminal recovery event: the
         // redemption aggregate evolves straight to the `Completed` state from
         // it (no separate `Completed` event is ever written), so its presence
-        // is the end-to-end proof that recheck-transfer completed the redemption.
+        // is the end-to-end proof that transfer recheck completed the redemption.
         poll_for_events_with_timeout(
             &mut bot,
             &infra.db_path,
@@ -1257,7 +1257,7 @@ async fn simulate_failures() -> anyhow::Result<()> {
         )
         .await;
         info!(
-            "Recovery verified: recheck-transfer completed stuck mint and redemption rebalances."
+            "Recovery verified: transfer recheck completed stuck mint and redemption rebalances."
         );
         bot.abort();
         return Ok(());


### PR DESCRIPTION
## What
[RAI-986](https://linear.app/makeitrain/issue/RAI-986) — repurposed. **Removes the legacy recovery command names entirely** (no back-compat), instead of deprecating them. After Step 1 ([#809](https://github.com/ST0x-Technology/st0x.liquidity/pull/809)) the old names were kept as hidden aliases/flat variants; this drops them so the CLI exposes only the grouped `transfer`/`position`/`view`/`cctp` surface.

## Why
This is an in-development operator tool that is rarely used, so carrying a dual command surface (and deprecation-warning machinery) isn't worth it. Clean single surface.

## How
Removes the 6 hidden flat `Commands` variants (`resume-usdc-transfer`, `reconcile-usdc-transfer`, `fail-transfer`, `recheck-transfer`, `rebuild-view`, `cctp-recover`), the 3 clap aliases (`repair`, `set-position`, `fail-pending-offchain-order`), their `classify_command` arms, and the (originally-planned) deprecation-notice code. The internal `SimpleCommand`/`ProviderCommand` dispatch and `run_*` handlers are untouched — the grouped commands still map to them. `classify_command` dropped under the line limit, so the `#[allow(clippy::too_many_lines)]` is removed too. Legacy-name tests deleted; clap-validation tests for the removed `repair set-position` rewritten under `position set` to preserve coverage.

## Testing
132 `cli::` tests pass; clippy clean (no allows); fmt clean. No legacy command names remain in `src/`.

## Anything else
Part of epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978). (Branch name still says "deprecate" — the change is removal.)
