### PR TITLE
feat: add equity transfer reconcile terminal and CLI

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2987,6 +2987,27 @@ pre-burn failure already reconciles to source on its own. Because `Reconciled`
 is a clearable terminal, a restart does not re-latch the guard, and automatic
 USDC rebalancing resumes.
 
+Reconcile also applies to the equity transfer aggregates (`TokenizedEquityMint`,
+`EquityRedemption`): a mint or redemption stuck in its `Failed` terminal whose
+residue was handled out-of-band (e.g. via `wrap-equity` / `vault-deposit`) is
+declared resolved by sending the `Reconcile { reason }` command, which emits
+`OperatorReconciled` and drives the aggregate to a terminal `Reconciled` state.
+Unlike USDC, the equity aggregates hold no in-progress guard, so the `Reconcile`
+command emits **no reactor effect and dispatches no inventory update** -- it is
+a pure bookkeeping terminal transition. One nuance for redemptions: a redemption
+that ended in `DetectionFailed` / `RedemptionRejected` has its stranded exposure
+seeded into live inflight at startup (see `symbols_with_stuck_redemptions`).
+Reconcile moves the latest event to `OperatorReconciled`, so that redemption is
+no longer seeded as stuck on the **next** restart; the running process's live
+inflight retains the startup-seeded amount until then. Mint failures and
+pre-send redemption failures settle inventory at failure time, so they need no
+such clearing. `Reconciled` is valid ONLY from `Failed`; every other state is
+rejected. The `Reconciled` state retains the identifying fields (symbol,
+quantity, original failure reason, request/redemption identifiers) so the
+dashboard projection still reports the real transfer, and maps to the existing
+terminal `Completed` DTO status (no new status). The CLI surface is
+`transfer reconcile --kind mint|redemption` (alongside `--kind usdc`).
+
 The operator-facing verb vocabulary that this command and the rest of the
 recovery CLI follow is defined in the "Operator Recovery Surface" section below.
 
@@ -3068,10 +3089,14 @@ named exemptions defined after the list:**
 - `fail` -- force a stuck non-terminal operation to its clean `Failed` terminal
   so the system stops waiting on it; `--reason` required.
 - `reconcile` -- declare an already-terminal-failed operation resolved
-  out-of-band, releasing its guard and inflight accounting. Applies once funds
-  have left the source venue, whether stuck in transit or failed after arrival
-  (the terminal state strands a guard); pre-departure failures strand nothing
-  and need no reconcile; `--reason` required.
+  out-of-band. For the USDC realization this releases the guard and inflight
+  accounting the failed state stranded; it applies once funds have left the
+  source venue, whether stuck in transit or failed after arrival, while a
+  pre-departure failure strands nothing and needs no reconcile. For the equity
+  realization (`mint`/`redemption`) the `Failed` state holds no guard or
+  surviving inflight, so reconcile is a pure bookkeeping terminal transition
+  declaring the residue -- already handled out-of-band -- resolved; `--reason`
+  required.
 - `set` -- overwrite aggregate-derived state to an operator-asserted value, with
   a mandatory audit reason.
 - `rebuild` -- recompute a projection from the event log; emits no events.
@@ -3117,8 +3142,10 @@ effect rather than a generic intent:
   no-silent-defaults rule. Earlier transitional steps carried defaulted reasons
   on now-removed legacy command names; with those names deleted, every grouped
   destructive verb requires an explicit `--reason`, and a present-but-blank
-  value is rejected (at parse time for the string-valued verbs, by the enum
-  domain for `reconcile`).
+  value is rejected at parse time. `reconcile --kind usdc` additionally
+  constrains its reason to a fixed vocabulary (`funds-moved-manually` /
+  `deposit-credited-offline`); `mint`/`redemption` reconcile reasons are free
+  text.
 - **`fail` and `reconcile` are distinct and must not be conflated.** `fail` is
   for an operation the system is still waiting on (force it to a clean
   terminal); `reconcile` is for an operation that already failed and whose guard

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -298,6 +298,44 @@ the grouped `transfer resume` / `transfer reconcile` forms exist.
 
     stox fail-usdc-transfer --id <uuid> --reason "pre-burn crash, burn not attempted"
 
+### Reconciling Stuck Failed Transfers
+
+Use `transfer reconcile` when an operation is stranded in a terminal failure and
+its residue was already handled out-of-band, so it should be declared resolved
+rather than re-driven. It operates directly on the local CQRS state (the bot
+need not be running) and goes through the aggregate command flow. `--reason` is
+required and persisted as the audit record.
+
+```
+# USDC rebalance stuck in a post-burn DepositFailed (minted USDC moved manually)
+stox transfer reconcile --kind usdc --id <usdc-rebalance-id> \
+  --reason funds-moved-manually        # or deposit-credited-offline
+
+# Equity mint stuck in Failed (tokens were wrapped/deposited manually)
+stox transfer reconcile --kind mint --id <issuer-request-id> \
+  --reason "wrapped + deposited via wrap-equity/vault-deposit"
+
+# Equity redemption stuck in Failed (equity resolved out-of-band)
+stox transfer reconcile --kind redemption --id <redemption-aggregate-id> \
+  --reason "redeemed manually"
+```
+
+- `--kind usdc` drives a stuck post-burn USDC rebalance to the clearing terminal
+  `Reconciled` state, releasing the rebalancing guard. It is accepted from any
+  of the post-burn terminal failures: `DepositFailed` (any direction), a
+  post-burn `BridgingFailed` (one carrying a `burn_tx_hash` or `cctp_nonce`),
+  and a `BaseToAlpaca` `ConversionFailed`. Its `--reason` must be one of
+  `funds-moved-manually` or `deposit-credited-offline`; any other value is
+  rejected. Valid only from a post-burn terminal failure.
+- `--kind mint` / `--kind redemption` mark an equity transfer stuck in `Failed`
+  as terminal `Reconciled`. This is a pure bookkeeping transition: it emits no
+  reactor effect and dispatches no inventory update. One nuance for redemptions
+  that ended in `DetectionFailed` / `RedemptionRejected` -- their stranded
+  exposure is seeded into live inflight at startup, and reconcile clears that
+  seeding only on the **next** bot restart (the running process keeps the seeded
+  amount until then). Valid only from `Failed`; a transfer in any other state is
+  rejected. The `--reason` is free text.
+
 For local dashboard testing, run:
 
 ```

--- a/src/api.rs
+++ b/src/api.rs
@@ -943,13 +943,17 @@ fn stuck_mint_info(rows: &[(String, String, i64)]) -> Option<StuckTransferInfo> 
                 ));
             }
 
-            // Neither strands equity: a rejected mint never left the issuer,
-            // and a deposited mint completed successfully.
-            MintRejected { .. } | DepositedIntoRaindex { .. } => return None,
-
-            // Recovery un-failed the mint and put it back on the success path,
-            // so any stuck state observed before it no longer applies; the
-            // mint is re-derived from subsequent events (it may fail again).
+            // Terminal "not stuck" states with no further events to scan: a
+            // rejected mint never left the issuer, a deposited mint completed
+            // successfully, and an operator-reconciled mint was resolved
+            // out-of-band (drives to the `Reconciled` terminal).
+            MintRejected { .. } | DepositedIntoRaindex { .. } | OperatorReconciled { .. } => {
+                return None;
+            }
+            // ProviderCompletionRecovered un-failed the mint and put it back on
+            // the success path, so any stuck state observed before it no longer
+            // applies; the mint is re-derived from subsequent events (it may fail
+            // again), hence a soft reset rather than an early return.
             ProviderCompletionRecovered { .. } => terminal = None,
             MintAcceptanceFailed { .. }
             | TokensReceived { .. }
@@ -1032,8 +1036,11 @@ fn stuck_redemption_info(rows: &[(String, String, i64)]) -> Option<StuckTransfer
             }
 
             // A terminal success (including recovery, which evolves straight to
-            // Completed) means nothing is stranded.
-            TransferFailed { .. } | Completed { .. } | ProviderCompletionRecovered { .. } => {
+            // Completed) or an operator reconciliation means nothing is stranded.
+            TransferFailed { .. }
+            | Completed { .. }
+            | ProviderCompletionRecovered { .. }
+            | OperatorReconciled { .. } => {
                 return None;
             }
 
@@ -1856,6 +1863,68 @@ mod tests {
         assert!(
             stuck_transfer_info(TransferKind::EquityRedemption, &rows).is_none(),
             "a recovered redemption must not be reported as stranded"
+        );
+    }
+
+    #[test]
+    fn stuck_mint_info_cleared_after_operator_reconciled() {
+        let rows = vec![
+            event_row(
+                "TokenizedEquityMintEvent::MintRequested",
+                r#"{"MintRequested":{"symbol":"AAPL","quantity":"12.5","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::MintAccepted",
+                r#"{"MintAccepted":{"issuer_request_id":"mint-1","tokenization_request_id":"tok-1","accepted_at":"2026-01-01T00:00:01Z"}}"#,
+                1,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::MintAcceptanceFailed",
+                r#"{"MintAcceptanceFailed":{"reason":"timeout","failed_at":"2026-01-01T00:01:00Z"}}"#,
+                2,
+            ),
+            event_row(
+                "TokenizedEquityMintEvent::OperatorReconciled",
+                r#"{"OperatorReconciled":{"reason":"wrapped manually via wrap-equity","reconciled_at":"2026-01-01T00:02:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        assert!(
+            stuck_transfer_info(TransferKind::EquityMint, &rows).is_none(),
+            "an operator-reconciled mint must not be reported as stranded"
+        );
+    }
+
+    #[test]
+    fn stuck_redemption_info_cleared_after_operator_reconciled() {
+        let rows = vec![
+            event_row(
+                "EquityRedemptionEvent::VaultWithdrawPending",
+                r#"{"VaultWithdrawPending":{"symbol":"AAPL","quantity":"10","token":"0x0000000000000000000000000000000000000001","wrapped_amount":"10000000000000000000","pending_at":"2026-01-01T00:00:00Z"}}"#,
+                0,
+            ),
+            event_row(
+                "EquityRedemptionEvent::TokensSent",
+                r#"{"TokensSent":{"redemption_wallet":"0x0000000000000000000000000000000000000003","redemption_tx":"0x2222222222222222222222222222222222222222222222222222222222222222","sent_at":"2026-01-01T00:00:02Z"}}"#,
+                1,
+            ),
+            event_row(
+                "EquityRedemptionEvent::RedemptionRejected",
+                r#"{"RedemptionRejected":{"reason":"rejected","rejected_at":"2026-01-01T00:01:00Z"}}"#,
+                2,
+            ),
+            event_row(
+                "EquityRedemptionEvent::OperatorReconciled",
+                r#"{"OperatorReconciled":{"reason":"deposited manually via vault-deposit","reconciled_at":"2026-01-01T00:02:00Z"}}"#,
+                3,
+            ),
+        ];
+
+        assert!(
+            stuck_transfer_info(TransferKind::EquityRedemption, &rows).is_none(),
+            "an operator-reconciled redemption must not be reported as stranded"
         );
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,6 +93,18 @@ pub enum TransferResumeKind {
     Equity,
 }
 
+/// What kind of transfer to reconcile.
+///
+/// `usdc` reconciles a post-burn `DepositFailed` USDC rebalance; `mint` and
+/// `redemption` reconcile an equity transfer stuck in `Failed`. All operate
+/// directly on the local CQRS state via aggregate commands.
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum ReconcileKind {
+    Usdc,
+    Mint,
+    Redemption,
+}
+
 /// Read models rebuildable by replaying events from scratch.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AggregateView {
@@ -677,23 +689,31 @@ pub enum TransferCommand {
         amount: Option<Usdc>,
     },
 
-    /// Reconcile a USDC transfer stranded in a post-burn terminal failure.
+    /// Reconcile a transfer stuck in a terminal failure to a resolved terminal.
     ///
-    /// Drives a USDC rebalance stranded in a post-burn terminal failure that
-    /// strands the in-progress guard (`DepositFailed`, a post-burn
+    /// `--kind usdc` drives a USDC rebalance stranded in a post-burn terminal
+    /// failure that strands the in-progress guard (`DepositFailed`, a post-burn
     /// `BridgingFailed`, or a `BaseToAlpaca` `ConversionFailed`) to the clearing
-    /// terminal `Reconciled` state: the funds were handled out-of-band, so this
-    /// resolves the transfer rather than re-driving it. Rejects an unknown id or
-    /// any other state. Operates directly on the local CQRS state; does not
-    /// require the running bot, but the bot must not be concurrently driving
-    /// the same id.
+    /// terminal `Reconciled` state (the funds were handled out-of-band).
+    /// `--kind mint` / `--kind redemption` mark an equity transfer stuck in
+    /// `Failed` as `Reconciled` once its residue was handled out-of-band (e.g.
+    /// via wrap-equity/vault-deposit) -- a pure bookkeeping resolution. Rejects
+    /// an unknown id or an aggregate not in the expected failure state. Operates
+    /// directly on the local CQRS state; does not require the running bot, but
+    /// the bot must not be concurrently driving the same id.
     Reconcile {
-        /// Id of the stuck transfer to reconcile
+        /// What to reconcile: `usdc`, `mint`, or `redemption`
+        #[arg(short = 'k', long = "kind")]
+        kind: ReconcileKind,
+        /// Aggregate id (USDC rebalance id for `usdc`, issuer_request_id for
+        /// `mint`, redemption id for `redemption`)
         #[arg(long = "id")]
-        id: Uuid,
-        /// Why the transfer is being reconciled (required; persisted as the audit record)
-        #[arg(short = 'r', long = "reason")]
-        reason: ReconcileReasonArg,
+        id: String,
+        /// Why the transfer is being reconciled (required; persisted as the audit
+        /// record). For `usdc` this must be one of `funds-moved-manually` or
+        /// `deposit-credited-offline`; for `mint`/`redemption` it is free text.
+        #[arg(short = 'r', long = "reason", value_parser = parse_non_empty_reason)]
+        reason: String,
     },
 
     /// Manually fail a stuck mint or redemption transfer.
@@ -927,13 +947,36 @@ enum SimpleCommand {
     },
     ResumeInterruptedTransfers,
     ReconcileUsdcTransfer {
-        id: Uuid,
-        reason: ReconcileReasonArg,
+        /// Raw operator-supplied `--id` from `transfer reconcile --kind usdc`,
+        /// parsed into a `Uuid` in the handler so a malformed id surfaces a
+        /// clear operator error.
+        id: String,
+        /// Raw operator-supplied `--reason` from `transfer reconcile --kind
+        /// usdc`, parsed into [`ReconcileReasonArg`] in the handler so an
+        /// unknown value surfaces a clear error.
+        reason: String,
     },
     FailUsdcTransfer {
         id: Uuid,
         reason: String,
     },
+    ReconcileEquityTransfer {
+        transfer_type: TransferType,
+        id: String,
+        reason: String,
+    },
+}
+
+/// Parses the operator `--reason` string for a USDC reconcile into the typed
+/// [`ReconcileReasonArg`]. Returns an error for an unknown reason so the
+/// operator gets a clear message instead of a silent fallback.
+fn parse_usdc_reconcile_reason(reason: &str) -> anyhow::Result<ReconcileReasonArg> {
+    ReconcileReasonArg::from_str(reason, false).map_err(|_| {
+        anyhow::anyhow!(
+            "transfer reconcile --kind usdc: unknown --reason {reason:?} \
+             (expected `funds-moved-manually` or `deposit-credited-offline`)"
+        )
+    })
 }
 
 #[cfg(feature = "test-support")]
@@ -1296,9 +1339,22 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
                 // invoking classify directly must pass clap-parsed input.
                 unreachable!("clap `required_if_eq(\"kind\",\"usdc\")` guarantees id and direction")
             }
-            TransferCommand::Reconcile { id, reason } => {
-                Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason })
-            }
+            // Classification stays pure (routing only): the usdc id/reason are
+            // parsed and validated in the handler so a bad value surfaces a clear
+            // operator error rather than a panic here.
+            TransferCommand::Reconcile { kind, id, reason } => match kind {
+                ReconcileKind::Usdc => Ok(SimpleCommand::ReconcileUsdcTransfer { id, reason }),
+                ReconcileKind::Mint => Ok(SimpleCommand::ReconcileEquityTransfer {
+                    transfer_type: TransferType::Mint,
+                    id,
+                    reason,
+                }),
+                ReconcileKind::Redemption => Ok(SimpleCommand::ReconcileEquityTransfer {
+                    transfer_type: TransferType::Redemption,
+                    id,
+                    reason,
+                }),
+            },
             TransferCommand::Fail { kind, id, reason } => Ok(SimpleCommand::FailTransfer {
                 transfer_type: kind,
                 id,
@@ -1495,10 +1551,25 @@ async fn run_simple_command<W: Write>(
             rebalancing::resume_interrupted_transfers_command(stdout, ctx).await
         }
         SimpleCommand::ReconcileUsdcTransfer { id, reason } => {
+            let id = id.parse::<Uuid>().map_err(|error| {
+                anyhow::anyhow!("transfer reconcile --kind usdc: invalid id {id:?}: {error}")
+            })?;
+            // A blank reason was already rejected by `parse_non_empty_reason` at
+            // clap parse time; this enum-domain parse is the secondary check that
+            // also constrains the value to the usdc vocabulary.
+            let reason = parse_usdc_reconcile_reason(&reason)?;
             rebalancing::reconcile_usdc_transfer_command(stdout, id, reason.into(), pool).await
         }
         SimpleCommand::FailUsdcTransfer { id, reason } => {
             rebalancing::fail_usdc_transfer_command(stdout, id, &reason, pool).await
+        }
+        SimpleCommand::ReconcileEquityTransfer {
+            transfer_type,
+            id,
+            reason,
+        } => {
+            rebalancing::reconcile_equity_transfer_command(stdout, transfer_type, &id, reason, pool)
+                .await
         }
     }
 }
@@ -2040,10 +2111,19 @@ mod tests {
 
     #[test]
     fn transfer_reconcile_requires_reason() {
+        // Supply --kind and --id so the only missing required arg is --reason,
+        // isolating the audit-record requirement from the other required flags.
         let id = Uuid::from_u128(7);
-        let error =
-            Cli::try_parse_from(["st0x-cli", "transfer", "reconcile", "--id", &id.to_string()])
-                .unwrap_err();
+        let error = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "reconcile",
+            "--kind",
+            "usdc",
+            "--id",
+            &id.to_string(),
+        ])
+        .unwrap_err();
         assert_eq!(
             error.kind(),
             clap::error::ErrorKind::MissingRequiredArgument
@@ -2601,12 +2681,14 @@ mod tests {
     }
 
     #[test]
-    fn transfer_reconcile_parses_and_classifies_as_simple() {
+    fn transfer_reconcile_usdc_parses_and_classifies_as_simple() {
         let id = Uuid::from_u128(77);
         let cli = Cli::try_parse_from([
             "st0x-cli",
             "transfer",
             "reconcile",
+            "--kind",
+            "usdc",
             "--id",
             &id.to_string(),
             "--reason",
@@ -2619,10 +2701,107 @@ mod tests {
                 id: parsed_id,
                 reason,
             }) => {
-                assert_eq!(parsed_id, id);
-                assert!(matches!(reason, ReconcileReasonArg::DepositCreditedOffline));
+                assert_eq!(parsed_id, id.to_string());
+                assert_eq!(reason, "deposit-credited-offline");
             }
-            _ => panic!("expected reconcile simple command"),
+            _ => panic!("expected reconcile usdc simple command"),
+        }
+    }
+
+    #[test]
+    fn transfer_reconcile_mint_parses_and_classifies_as_equity() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "reconcile",
+            "--kind",
+            "mint",
+            "--id",
+            "ISS001",
+            "--reason",
+            "wrapped manually via wrap-equity",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::ReconcileEquityTransfer {
+                transfer_type,
+                id,
+                reason,
+            }) => {
+                assert!(matches!(transfer_type, TransferType::Mint));
+                assert_eq!(id, "ISS001");
+                assert_eq!(reason, "wrapped manually via wrap-equity");
+            }
+            _ => panic!("expected reconcile equity (mint) simple command"),
+        }
+    }
+
+    #[test]
+    fn transfer_reconcile_redemption_parses_and_classifies_as_equity() {
+        let cli = Cli::try_parse_from([
+            "st0x-cli",
+            "transfer",
+            "reconcile",
+            "--kind",
+            "redemption",
+            "--id",
+            "RED-001",
+            "--reason",
+            "deposited manually",
+        ])
+        .unwrap();
+
+        match classify_command(cli.command) {
+            Ok(SimpleCommand::ReconcileEquityTransfer {
+                transfer_type,
+                id,
+                reason,
+            }) => {
+                assert!(matches!(transfer_type, TransferType::Redemption));
+                assert_eq!(id, "RED-001");
+                assert_eq!(reason, "deposited manually");
+            }
+            _ => panic!("expected reconcile equity (redemption) simple command"),
+        }
+    }
+
+    #[test]
+    fn transfer_reconcile_usdc_rejects_unknown_reason() {
+        let error = parse_usdc_reconcile_reason("bogus-reason").unwrap_err();
+        assert!(
+            error.to_string().contains("unknown --reason"),
+            "unknown usdc reconcile reason must surface a clear error, got: {error}"
+        );
+    }
+
+    #[test]
+    fn transfer_reconcile_rejects_blank_reason() {
+        // `OperatorReconciled { reason }` is the permanent audit record; a
+        // present-but-blank reason must be rejected at parse time for every
+        // kind, not just usdc (whose enum domain rejects it).
+        for kind in ["usdc", "mint", "redemption"] {
+            let error = Cli::try_parse_from([
+                "st0x-cli",
+                "transfer",
+                "reconcile",
+                "--kind",
+                kind,
+                "--id",
+                "x",
+                "--reason",
+                "   ",
+            ])
+            .unwrap_err();
+            assert_eq!(
+                error.kind(),
+                clap::error::ErrorKind::ValueValidation,
+                "blank --reason must be rejected for --kind {kind}",
+            );
+            assert!(
+                error.to_string().contains("must not be blank"),
+                "unexpected error for --kind {kind}: {error}",
+            );
         }
     }
 

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -1182,6 +1182,9 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 Failed { .. } => {
                     anyhow::bail!("Mint {id} already failed");
                 }
+                Reconciled { .. } => {
+                    anyhow::bail!("Mint {id} already reconciled");
+                }
             };
 
             st0x_event_sorcery::send_command::<TokenizedEquityMint>(
@@ -1233,6 +1236,9 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 Failed { .. } => {
                     anyhow::bail!("Redemption {id} already failed");
                 }
+                Reconciled { .. } => {
+                    anyhow::bail!("Redemption {id} already reconciled");
+                }
             };
 
             st0x_event_sorcery::send_command::<EquityRedemption>(
@@ -1263,6 +1269,90 @@ fn connect_error(url: &str, error: reqwest::Error) -> anyhow::Error {
     } else {
         anyhow::Error::new(error)
     }
+}
+
+/// Reconciles a mint or redemption stranded in the terminal `Failed` state to
+/// the terminal `Reconciled` state.
+///
+/// Loads the aggregate, verifies it is in `Failed` (bails with a clear operator
+/// error otherwise -- the aggregate command also gates this, but the preflight
+/// gives a clearer message first), and sends the `Reconcile` command. This is a
+/// pure bookkeeping resolution: the residual equity was handled out-of-band
+/// (e.g. via wrap-equity/vault-deposit), so there is no inventory side-effect.
+pub(crate) async fn reconcile_equity_transfer_command<W: Write>(
+    stdout: &mut W,
+    transfer_type: TransferType,
+    id: &str,
+    reason: String,
+    pool: &SqlitePool,
+) -> anyhow::Result<()> {
+    let services = EquityTransferServices::panicking();
+
+    match transfer_type {
+        TransferType::Mint => {
+            let mint_id: IssuerRequestId = id.parse().map_err(|error| {
+                anyhow::anyhow!("transfer reconcile: invalid mint id {id:?}: {error}")
+            })?;
+
+            let entity = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(pool, &mint_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Mint aggregate not found: {id}"))?;
+
+            if !matches!(entity, TokenizedEquityMint::Failed { .. }) {
+                anyhow::bail!(
+                    "transfer reconcile: mint {id} is not in the Failed state. Refusing to act \
+                     -- reconcile only resolves a transfer stuck in the Failed terminal; check \
+                     its current state on the dashboard."
+                );
+            }
+
+            st0x_event_sorcery::send_command::<TokenizedEquityMint>(
+                pool,
+                &mint_id,
+                TokenizedEquityMintCommand::Reconcile { reason },
+                services,
+            )
+            .await?;
+
+            writeln!(stdout, "Mint {id} reconciled")?;
+        }
+
+        TransferType::Redemption => {
+            let redemption_id: RedemptionAggregateId = id.parse().map_err(|error| {
+                anyhow::anyhow!("transfer reconcile: invalid redemption id {id:?}: {error}")
+            })?;
+
+            let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(pool, &redemption_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Redemption aggregate not found: {id}"))?;
+
+            if !matches!(entity, EquityRedemption::Failed { .. }) {
+                anyhow::bail!(
+                    "transfer reconcile: redemption {id} is not in the Failed state. Refusing to \
+                     act -- reconcile only resolves a transfer stuck in the Failed terminal; \
+                     check its current state on the dashboard."
+                );
+            }
+
+            st0x_event_sorcery::send_command::<EquityRedemption>(
+                pool,
+                &redemption_id,
+                EquityRedemptionCommand::Reconcile { reason },
+                services,
+            )
+            .await?;
+
+            writeln!(
+                stdout,
+                "Redemption {id} reconciled. If it had ended in DetectionFailed/RedemptionRejected, \
+                 its stranded exposure was seeded into live inflight at startup; reconcile only \
+                 stops it being re-seeded on the next restart, so a running bot still needs a \
+                 restart before rebalancing resumes for this symbol."
+            )?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Re-checks a stuck transfer by calling the running bot's
@@ -1411,7 +1501,7 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::test_utils::setup_test_db;
     use crate::tokenization::mock::MockTokenizer;
-    use crate::tokenized_equity_mint::TokenizationRequestId;
+    use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
     use crate::usdc_rebalance::{ReconcileReason, TransferRef, UsdcRebalanceCommand};
     use crate::vault_lookup::MockVaultLookup;
 
@@ -3494,6 +3584,351 @@ mod tests {
             "infrastructure errors must not get the stale-state hint; got: {message}"
         );
         assert!(message.contains("db on fire"), "got: {message}");
+    }
+
+    /// Drives a redemption through the real command flow to its terminal
+    /// `Reconciled` state: stuck in `TokensSent`, force-failed, then reconciled.
+    async fn seed_redemption_to_reconciled(pool: &SqlitePool, id: &RedemptionAggregateId) {
+        seed_redemption_to_tokens_sent(pool, id).await;
+        send_redemption_command(
+            pool,
+            id,
+            EquityRedemptionCommand::FailDetection {
+                failure: DetectionFailure::Timeout,
+            },
+        )
+        .await;
+        send_redemption_command(
+            pool,
+            id,
+            EquityRedemptionCommand::Reconcile {
+                reason: "deposited manually via vault-deposit".to_string(),
+            },
+        )
+        .await;
+    }
+
+    /// Drives a mint through the real command flow to its `Failed` terminal:
+    /// requested, then acceptance force-failed. (`redemption_services()` returns
+    /// the shared `EquityTransferServices`, used by both aggregate stores.)
+    async fn seed_mint_to_failed(pool: &SqlitePool, id: &IssuerRequestId) {
+        let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .build(redemption_services())
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: Address::ZERO,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "seed: timed out".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn send_mint_command(
+        pool: &SqlitePool,
+        id: &IssuerRequestId,
+        command: TokenizedEquityMintCommand,
+    ) {
+        let store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .build(redemption_services())
+            .await
+            .unwrap();
+        store.send(id, command).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_mint_rejects_unknown_id() {
+        let pool = setup_test_db().await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Mint,
+            &issuer_request_id("cli-no-such-mint").to_string(),
+            "handled out-of-band".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found"),
+            "reconcile of an unknown mint must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_mint_rejects_non_failed() {
+        let pool = setup_test_db().await;
+        let id = issuer_request_id("cli-mint-reconcile-non-failed");
+        send_mint_command(
+            &pool,
+            &id,
+            TokenizedEquityMintCommand::RequestMint {
+                issuer_request_id: id.clone(),
+                symbol: Symbol::new("AAPL").unwrap(),
+                quantity: float!(10),
+                wallet: Address::ZERO,
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Mint,
+            &id.to_string(),
+            "handled out-of-band".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not in the Failed state"),
+            "reconcile of a non-failed mint must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_mint_succeeds_from_failed() {
+        let pool = setup_test_db().await;
+        let id = issuer_request_id("cli-mint-reconcile-from-failed");
+        seed_mint_to_failed(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Mint,
+            &id.to_string(),
+            "wrapped manually via wrap-equity".to_string(),
+            &pool,
+        )
+        .await
+        .unwrap();
+
+        let entity = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap();
+        let TokenizedEquityMint::Reconciled {
+            reconcile_reason, ..
+        } = entity
+        else {
+            panic!("a reconciled mint must reach the Reconciled terminal, got: {entity:?}");
+        };
+        assert_eq!(reconcile_reason, "wrapped manually via wrap-equity");
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_mint_refuses_double_reconcile() {
+        let pool = setup_test_db().await;
+        let id = issuer_request_id("cli-mint-double-reconcile");
+        seed_mint_to_failed(&pool, &id).await;
+        send_mint_command(
+            &pool,
+            &id,
+            TokenizedEquityMintCommand::Reconcile {
+                reason: "wrapped manually via wrap-equity".to_string(),
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Mint,
+            &id.to_string(),
+            "second reconcile attempt".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not in the Failed state"),
+            "a second reconcile of an already-reconciled mint must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_mint_refuses_already_reconciled() {
+        let pool = setup_test_db().await;
+        let id = issuer_request_id("cli-mint-already-reconciled");
+        seed_mint_to_failed(&pool, &id).await;
+        send_mint_command(
+            &pool,
+            &id,
+            TokenizedEquityMintCommand::Reconcile {
+                reason: "wrapped manually via wrap-equity".to_string(),
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        let result = fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Mint,
+            &id.to_string(),
+            "should be refused",
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already reconciled"),
+            "failing an already-reconciled mint must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_redemption_rejects_unknown_id() {
+        let pool = setup_test_db().await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Redemption,
+            &redemption_aggregate_id("cli-no-such-redemption").to_string(),
+            "handled out-of-band".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found"),
+            "reconcile of an unknown redemption must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_redemption_rejects_non_failed() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-reconcile-non-failed");
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Redemption,
+            &id.to_string(),
+            "handled out-of-band".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not in the Failed state"),
+            "reconcile of a non-failed redemption must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_redemption_succeeds_from_failed() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-reconcile-from-failed");
+        seed_redemption_to_tokens_sent(&pool, &id).await;
+        send_redemption_command(
+            &pool,
+            &id,
+            EquityRedemptionCommand::FailDetection {
+                failure: DetectionFailure::Timeout,
+            },
+        )
+        .await;
+
+        let mut stdout = Vec::new();
+        reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Redemption,
+            &id.to_string(),
+            "deposited manually via vault-deposit".to_string(),
+            &pool,
+        )
+        .await
+        .unwrap();
+
+        let entity = st0x_event_sorcery::load_entity::<EquityRedemption>(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap();
+        let EquityRedemption::Reconciled {
+            reconcile_reason, ..
+        } = entity
+        else {
+            panic!("a reconciled redemption must reach the Reconciled terminal, got: {entity:?}");
+        };
+        assert_eq!(reconcile_reason, "deposited manually via vault-deposit");
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("restart"),
+            "redemption reconcile success line must warn a restart is still required; got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_equity_redemption_refuses_double_reconcile() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-redemption-double-reconcile");
+        seed_redemption_to_reconciled(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        let result = reconcile_equity_transfer_command(
+            &mut stdout,
+            TransferType::Redemption,
+            &id.to_string(),
+            "second reconcile attempt".to_string(),
+            &pool,
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not in the Failed state"),
+            "a second reconcile of an already-reconciled redemption must refuse; got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_redemption_refuses_already_reconciled() {
+        let pool = setup_test_db().await;
+        let id = redemption_aggregate_id("cli-already-reconciled");
+        seed_redemption_to_reconciled(&pool, &id).await;
+
+        let mut stdout = Vec::new();
+        let result = fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Redemption,
+            &id.to_string(),
+            "should be refused",
+        )
+        .await;
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already reconciled"),
+            "failing an already-reconciled redemption must refuse; got: {err_msg}"
+        );
     }
 
     /// A redemption already in a terminal state must be refused, not

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -239,6 +239,15 @@ pub(crate) enum EquityRedemptionError {
     /// an RPC edge case (e.g. pending or uncle-block receipt).
     #[error("Raindex withdrawal receipt for {tx_hash} is missing block number")]
     MissingWithdrawBlock { tx_hash: TxHash },
+    /// Attempted to reconcile a redemption that is not in the `Failed` state
+    #[error("Cannot reconcile: redemption is not in the Failed state")]
+    NotFailed,
+    /// Attempted to act on a redemption already resolved out-of-band (`Reconciled`)
+    #[error("Already reconciled")]
+    AlreadyReconciled,
+    /// Attempted to reconcile without an operator-supplied reason.
+    #[error("Cannot reconcile: reason is required")]
+    ReconcileReasonRequired,
 }
 
 #[derive(Debug, Clone)]
@@ -286,6 +295,11 @@ pub(crate) enum EquityRedemptionCommand {
     /// Prepares sending tokens (pure, no side effects).
     /// Valid from `TokensUnwrapped`.
     PrepareSend,
+    /// Reconcile a redemption stranded in the terminal `Failed` state to the
+    /// terminal `Reconciled` state. The residual equity was handled out-of-band
+    /// (e.g. via wrap-equity/vault-deposit), so this is a bookkeeping resolution
+    /// rather than a re-drive. Valid ONLY from `Failed`.
+    Reconcile { reason: String },
 }
 
 /// Why redemption detection failed.
@@ -427,6 +441,12 @@ pub(crate) enum EquityRedemptionEvent {
     ProviderCompletionRecovered {
         tokenization_request_id: TokenizationRequestId,
         recovered_at: DateTime<Utc>,
+    },
+    /// An operator reconciled a terminal `Failed` redemption out-of-band. Marks
+    /// the transfer resolved without re-driving the failed leg.
+    OperatorReconciled {
+        reason: String,
+        reconciled_at: DateTime<Utc>,
     },
 }
 
@@ -664,6 +684,16 @@ impl PartialEq for EquityRedemptionEvent {
                     recovered_at: t2,
                 },
             ) => id1 == id2 && t1 == t2,
+            (
+                Self::OperatorReconciled {
+                    reason: r1,
+                    reconciled_at: t1,
+                },
+                Self::OperatorReconciled {
+                    reason: r2,
+                    reconciled_at: t2,
+                },
+            ) => r1 == r2 && t1 == t2,
             _ => false,
         }
     }
@@ -697,6 +727,7 @@ impl DomainEvent for EquityRedemptionEvent {
             ProviderCompletionRecovered { .. } => {
                 "EquityRedemptionEvent::ProviderCompletionRecovered".to_string()
             }
+            OperatorReconciled { .. } => "EquityRedemptionEvent::OperatorReconciled".to_string(),
         }
     }
 
@@ -903,6 +934,28 @@ pub(crate) enum EquityRedemption {
         started_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
     },
+
+    /// An operator reconciled a terminal `Failed` redemption out-of-band
+    /// (terminal state). Retains the identifying fields carried by `Failed` so
+    /// the projection still reports the real transfer instead of a zero-value
+    /// record.
+    Reconciled {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        raindex_withdraw_tx: Option<TxHash>,
+        redemption_tx: Option<TxHash>,
+        tokenization_request_id: Option<TokenizationRequestId>,
+        /// The failure reason carried over from the `Failed` state.
+        failure_reason: Option<String>,
+        /// The operator-supplied reconciliation reason.
+        reconcile_reason: String,
+        started_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
+    },
 }
 
 impl EquityRedemption {
@@ -921,7 +974,8 @@ impl EquityRedemption {
             | Self::TokensSent { quantity, .. }
             | Self::Pending { quantity, .. }
             | Self::Completed { quantity, .. }
-            | Self::Failed { quantity, .. } => *quantity,
+            | Self::Failed { quantity, .. }
+            | Self::Reconciled { quantity, .. } => *quantity,
         }
     }
 
@@ -1073,6 +1127,26 @@ impl EquityRedemption {
                 started_at: *started_at,
                 updated_at: *failed_at,
             }),
+
+            // Reconciliation is a terminal operator resolution, so it maps to the
+            // existing `Completed` DTO status (no new status needed) -- mirrors the
+            // USDC `Reconciled -> Completed` mapping.
+            Self::Reconciled {
+                symbol,
+                quantity,
+                started_at,
+                reconciled_at,
+                ..
+            } => TransferOperation::EquityRedemption(EquityRedemptionOperation {
+                id: Id::new(id.to_string()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: EquityRedemptionStatus::Completed {
+                    completed_at: *reconciled_at,
+                },
+                started_at: *started_at,
+                updated_at: *reconciled_at,
+            }),
         }
     }
 }
@@ -1094,7 +1168,11 @@ impl EventSourced for EquityRedemption {
     // (`Operator` failures) and `RedemptionRejected` events instead of always
     // `None`. Bumped to clear stale snapshots so historical rejections rebuild
     // from events under the corrected evolve logic.
-    const SCHEMA_VERSION: u64 = 4;
+    // v5: added the terminal `Reconciled` state and the `OperatorReconciled`
+    // event for operator reconciliation of stuck `Failed` redemptions. Additive
+    // only; bumped to clear stale snapshots so they rebuild from events under the
+    // new schema (existing events replay unchanged).
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use EquityRedemptionEvent::*;
@@ -1597,6 +1675,37 @@ impl EventSourced for EquityRedemption {
                     completed_at: *recovered_at,
                 })
             }
+
+            OperatorReconciled {
+                reason,
+                reconciled_at,
+            } => {
+                let Self::Failed {
+                    symbol,
+                    quantity,
+                    raindex_withdraw_tx,
+                    redemption_tx,
+                    tokenization_request_id,
+                    reason: failure_reason,
+                    started_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::Reconciled {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    raindex_withdraw_tx: *raindex_withdraw_tx,
+                    redemption_tx: *redemption_tx,
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    failure_reason: failure_reason.clone(),
+                    reconcile_reason: reason.clone(),
+                    started_at: *started_at,
+                    reconciled_at: *reconciled_at,
+                })
+            }
         })
     }
 
@@ -1631,6 +1740,7 @@ impl EventSourced for EquityRedemption {
             | Complete
             | RejectRedemption { .. }
             | RecoverProviderCompletion { .. }
+            | Reconcile { .. }
             | FailTransfer { .. } => Err(EquityRedemptionError::NotStarted),
         }
     }
@@ -1647,6 +1757,7 @@ impl EventSourced for EquityRedemption {
             Redeem { .. } => match self {
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
@@ -1700,6 +1811,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
@@ -1740,6 +1852,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
             },
 
@@ -1749,6 +1862,7 @@ impl EventSourced for EquityRedemption {
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
             },
 
@@ -1793,6 +1907,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
             },
 
@@ -1850,6 +1965,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::CannotUnwrapAlreadyStarted),
             },
 
@@ -1859,6 +1975,7 @@ impl EventSourced for EquityRedemption {
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::TokensNotUnwrapped),
             },
 
@@ -1925,6 +2042,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::TokensNotUnwrapped),
             },
 
@@ -1944,6 +2062,7 @@ impl EventSourced for EquityRedemption {
                 | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
                 Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             },
 
@@ -1968,6 +2087,7 @@ impl EventSourced for EquityRedemption {
                 | Self::SendPending { .. } => Err(EquityRedemptionError::TokensNotSent),
                 Self::Pending { .. } => Err(EquityRedemptionError::AlreadyDetected),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
             },
 
@@ -1985,6 +2105,7 @@ impl EventSourced for EquityRedemption {
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
             },
 
             RejectRedemption { reason } => match self {
@@ -2009,6 +2130,7 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
             },
 
             RecoverProviderCompletion {
@@ -2022,6 +2144,7 @@ impl EventSourced for EquityRedemption {
                     recovered_at: Utc::now(),
                 }]),
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::TokensNotSent),
             },
 
@@ -2046,7 +2169,28 @@ impl EventSourced for EquityRedemption {
                 }
                 Self::Completed { .. } => Err(EquityRedemptionError::AlreadyCompleted),
                 Self::Failed { .. } => Err(EquityRedemptionError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
                 _ => Err(EquityRedemptionError::AlreadyStarted),
+            },
+
+            Reconcile { reason } => match self {
+                Self::Failed { symbol, .. } => {
+                    if reason.trim().is_empty() {
+                        return Err(EquityRedemptionError::ReconcileReasonRequired);
+                    }
+
+                    warn!(
+                        target: "rebalance",
+                        %symbol, %reason,
+                        "Reconciling stuck failed redemption out-of-band"
+                    );
+                    Ok(vec![OperatorReconciled {
+                        reason,
+                        reconciled_at: Utc::now(),
+                    }])
+                }
+                Self::Reconciled { .. } => Err(EquityRedemptionError::AlreadyReconciled),
+                _ => Err(EquityRedemptionError::NotFailed),
             },
         }
     }
@@ -3942,6 +4086,70 @@ mod tests {
         );
     }
 
+    /// A redemption that was `DetectionFailed` and then operator-reconciled must
+    /// not re-seed stranded inflight at the next startup: its latest event is
+    /// `OperatorReconciled`, which the query's terminal allowlist excludes.
+    #[tokio::test]
+    async fn stuck_redemptions_excludes_operator_reconciled() {
+        let pool = crate::test_utils::setup_test_db().await;
+
+        // AAPL: DetectionFailed, still stuck.
+        insert_event(
+            &pool,
+            &redemption_aggregate_id("stuck"),
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("AAPL"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &redemption_aggregate_id("stuck"),
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // MSFT: DetectionFailed then operator-reconciled, no longer stuck.
+        insert_event(
+            &pool,
+            &redemption_aggregate_id("reconciled"),
+            0,
+            "EquityRedemptionEvent::WithdrawnFromRaindex",
+            &withdrawn_payload("MSFT"),
+        )
+        .await;
+        insert_event(
+            &pool,
+            &redemption_aggregate_id("reconciled"),
+            1,
+            "EquityRedemptionEvent::DetectionFailed",
+            r#"{"DetectionFailed":{"failure":"Timeout","failed_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+        insert_event(
+            &pool,
+            &redemption_aggregate_id("reconciled"),
+            2,
+            "EquityRedemptionEvent::OperatorReconciled",
+            r#"{"OperatorReconciled":{"reason":"deposited manually via vault-deposit","reconciled_at":"2026-01-01T00:01:00Z"}}"#,
+        )
+        .await;
+
+        let result = symbols_with_stuck_redemptions(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "only the un-reconciled DetectionFailed redemption should seed inflight: {result:?}"
+        );
+        assert!(result.contains_key(&Symbol::new("AAPL").unwrap()));
+        assert!(
+            !result.contains_key(&Symbol::new("MSFT").unwrap()),
+            "an operator-reconciled redemption must not re-seed stranded inflight"
+        );
+    }
+
     #[tokio::test]
     async fn interrupted_redemption_ids_returns_only_non_terminal_redemptions() {
         let pool = crate::test_utils::setup_test_db().await;
@@ -4447,6 +4655,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recover_provider_completion_rejected_for_reconciled_redemption() {
+        let mut history = failed_redemption_history();
+        history.push(EquityRedemptionEvent::OperatorReconciled {
+            reason: "deposited manually".to_string(),
+            reconciled_at: Utc::now(),
+        });
+
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(history)
+            .when(EquityRedemptionCommand::RecoverProviderCompletion {
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::AlreadyReconciled)
+            ),
+            "a reconciled redemption must report AlreadyReconciled, not recover, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn fail_transfer_from_withdrawn_transitions_to_failed() {
         let events = TestHarness::<EquityRedemption>::with(mock_services())
             .given(vec![withdrawn_from_raindex_event()])
@@ -4808,6 +5041,154 @@ mod tests {
                 })
             ),
             "expected NodeSyncFailed {{ required_block: 42, attempts: {NODE_SYNC_MAX_ATTEMPTS} }}, got: {error:?}",
+        );
+    }
+
+    fn failed_redemption_history() -> Vec<EquityRedemptionEvent> {
+        vec![
+            withdrawn_from_raindex_event(),
+            tokens_sent_event(),
+            EquityRedemptionEvent::DetectionFailed {
+                failure: DetectionFailure::Operator {
+                    reason: "operator forced terminal".to_string(),
+                },
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
+        let history = failed_redemption_history();
+
+        let events = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(history.clone())
+            .when(EquityRedemptionCommand::Reconcile {
+                reason: "deposited manually via vault-deposit".to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let EquityRedemptionEvent::OperatorReconciled { reason, .. } = &events[0] else {
+            panic!("Expected OperatorReconciled, got {:?}", events[0]);
+        };
+        assert_eq!(reason, "deposited manually via vault-deposit");
+
+        let state = replay::<EquityRedemption>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let EquityRedemption::Reconciled {
+            reconcile_reason,
+            quantity,
+            ..
+        } = state
+        else {
+            panic!("reconciled redemption should be Reconciled, got {state:?}");
+        };
+        assert_eq!(reconcile_reason, "deposited manually via vault-deposit");
+        assert!(
+            quantity.eq(float!(50.25)).unwrap(),
+            "reconciled state must preserve the requested quantity, got {quantity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_non_failed_is_rejected() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(vec![withdrawn_from_raindex_event(), tokens_sent_event()])
+            .when(EquityRedemptionCommand::Reconcile {
+                reason: "should be rejected".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::NotFailed)
+            ),
+            "reconcile from a non-failed redemption must be rejected, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_with_blank_reason_is_rejected() {
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(failed_redemption_history())
+            .when(EquityRedemptionCommand::Reconcile {
+                reason: "   ".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::ReconcileReasonRequired)
+            ),
+            "reconcile with a blank reason must be rejected as ReconcileReasonRequired, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_reconciled_state_is_rejected() {
+        let mut history = failed_redemption_history();
+        history.push(EquityRedemptionEvent::OperatorReconciled {
+            reason: "already reconciled".to_string(),
+            reconciled_at: Utc::now(),
+        });
+
+        let error = TestHarness::<EquityRedemption>::with(mock_services())
+            .given(history)
+            .when(EquityRedemptionCommand::Reconcile {
+                reason: "second attempt".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::AlreadyReconciled)
+            ),
+            "reconcile from an already-reconciled redemption reports AlreadyReconciled, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn reconciled_to_dto_reports_completed_preserving_quantity() {
+        let started_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled = EquityRedemption::Reconciled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(50.25),
+            raindex_withdraw_tx: Some(TxHash::random()),
+            redemption_tx: Some(TxHash::random()),
+            tokenization_request_id: None,
+            failure_reason: None,
+            reconcile_reason: "deposited manually".to_string(),
+            started_at,
+            reconciled_at,
+        };
+
+        let TransferOperation::EquityRedemption(operation) =
+            reconciled.to_dto(&redemption_aggregate_id("RED-001"))
+        else {
+            panic!("expected an EquityRedemption operation");
+        };
+        let EquityRedemptionStatus::Completed { completed_at } = operation.status else {
+            panic!(
+                "reconciled redemption must map to the Completed DTO status, got {:?}",
+                operation.status
+            );
+        };
+        assert_eq!(completed_at, reconciled_at);
+        assert_eq!(operation.updated_at, reconciled_at);
+        assert_eq!(operation.started_at, started_at);
+        assert_eq!(
+            operation.quantity.to_string(),
+            FractionalShares::new(float!(50.25)).to_string()
         );
     }
 }

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -500,7 +500,8 @@ fn equity_redemption_failure(
         | EquityRedemptionEvent::TokensSent { .. }
         | EquityRedemptionEvent::Detected { .. }
         | EquityRedemptionEvent::Completed { .. }
-        | EquityRedemptionEvent::ProviderCompletionRecovered { .. } => None,
+        | EquityRedemptionEvent::ProviderCompletionRecovered { .. }
+        | EquityRedemptionEvent::OperatorReconciled { .. } => None,
     }
 }
 
@@ -528,7 +529,8 @@ fn tokenized_equity_mint_failure(
         | TokenizedEquityMintEvent::TokensWrapped { .. }
         | TokenizedEquityMintEvent::VaultDepositSubmitted { .. }
         | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
-        | TokenizedEquityMintEvent::ProviderCompletionRecovered { .. } => None,
+        | TokenizedEquityMintEvent::ProviderCompletionRecovered { .. }
+        | TokenizedEquityMintEvent::OperatorReconciled { .. } => None,
     }
 }
 

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -190,9 +190,10 @@ impl EquityTransferServices {
     /// Constructs a services instance whose methods all panic.
     ///
     /// Safe for sending commands that never invoke services (e.g., the
-    /// `FailWrapping`, `FailAcceptance`, `FailRaindexDeposit`, and
-    /// `FailTransfer` commands). Used by the CLI `transfer fail`
-    /// subcommand where no real broker/RPC connection exists.
+    /// `FailWrapping`, `FailAcceptance`, `FailRaindexDeposit`, `FailTransfer`,
+    /// and `Reconcile` commands). Used by the CLI `transfer fail` and
+    /// `transfer reconcile` subcommands where no real broker/RPC connection
+    /// exists.
     pub(crate) fn panicking() -> Self {
         Self {
             raindex: Arc::new(PanickingRaindex),
@@ -933,7 +934,8 @@ impl CrossVenueEquityTransfer {
                     return Ok(());
                 }
                 TokenizedEquityMint::DepositedIntoRaindex { .. }
-                | TokenizedEquityMint::Failed { .. } => return Ok(()),
+                | TokenizedEquityMint::Failed { .. }
+                | TokenizedEquityMint::Reconciled { .. } => return Ok(()),
                 entity @ TokenizedEquityMint::MintRequested { .. } => {
                     return Err(MintError::UnexpectedState {
                         issuer_request_id: issuer_request_id.clone(),
@@ -1187,7 +1189,9 @@ impl CrossVenueEquityTransfer {
                         .resume_pending_redemption(aggregate_id, &tokenization_request_id)
                         .await;
                 }
-                EquityRedemption::Completed { .. } | EquityRedemption::Failed { .. } => {
+                EquityRedemption::Completed { .. }
+                | EquityRedemption::Failed { .. }
+                | EquityRedemption::Reconciled { .. } => {
                     return Ok(());
                 }
             }
@@ -1267,7 +1271,9 @@ impl CrossVenueEquityTransfer {
     ) -> Result<bool, RedemptionError> {
         Ok(matches!(
             self.load_redemption_entity(aggregate_id).await?,
-            EquityRedemption::Completed { .. } | EquityRedemption::Failed { .. }
+            EquityRedemption::Completed { .. }
+                | EquityRedemption::Failed { .. }
+                | EquityRedemption::Reconciled { .. }
         ))
     }
 
@@ -1287,7 +1293,9 @@ impl CrossVenueEquityTransfer {
         let entity = self.load_mint_entity(issuer_request_id).await?;
 
         let (symbol, quantity) = match &entity {
-            TokenizedEquityMint::DepositedIntoRaindex { .. } => {
+            // Both terminals are already settled: nothing to recheck.
+            TokenizedEquityMint::DepositedIntoRaindex { .. }
+            | TokenizedEquityMint::Reconciled { .. } => {
                 return Ok(RecheckOutcome::AlreadyCompleted);
             }
             TokenizedEquityMint::Failed {
@@ -1438,7 +1446,10 @@ impl CrossVenueEquityTransfer {
         let entity = self.load_redemption_entity(aggregate_id).await?;
 
         let (symbol, tokenization_request_id, redemption_tx) = match &entity {
-            EquityRedemption::Completed { .. } => return Ok(RecheckOutcome::AlreadyCompleted),
+            // Both terminals are already settled: nothing to recheck.
+            EquityRedemption::Completed { .. } | EquityRedemption::Reconciled { .. } => {
+                return Ok(RecheckOutcome::AlreadyCompleted);
+            }
             EquityRedemption::Failed {
                 symbol,
                 redemption_tx: Some(redemption_tx),
@@ -2064,6 +2075,301 @@ mod tests {
             Some(FractionalShares::new(float!(10))),
             "recovered quantity should land in MarketMaking available"
         );
+    }
+
+    /// A reconciled mint is terminal: `resume_mint` must be a clean no-op for
+    /// an apalis retry, leaving the aggregate in `Reconciled`.
+    #[tokio::test]
+    async fn resume_mint_is_noop_on_reconciled_mint() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-RECONCILED");
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "stranded mid-flight".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::Reconcile {
+                    reason: "wrapped manually via wrap-equity".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .resume_mint(&id)
+            .await
+            .expect("a reconciled mint must be a clean no-op for the job retry");
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::Reconciled { .. }),
+            "resume must leave a reconciled mint terminal, got: {entity:?}"
+        );
+    }
+
+    /// A reconciled redemption is terminal: `resume_redemption` must be a clean
+    /// no-op for an apalis retry, leaving the aggregate in `Reconciled`.
+    #[tokio::test]
+    async fn resume_redemption_is_noop_on_reconciled_redemption() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::new()),
+        )
+        .await;
+
+        let id = redemption_aggregate_id("redeem-reconciled");
+        let symbol = Symbol::new("TEST").unwrap();
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = FractionalShares::new(float!(50))
+            .to_u256_18_decimals()
+            .unwrap();
+
+        transfer
+            .withdraw_from_raindex(
+                &id,
+                &symbol,
+                FractionalShares::new(float!(50)),
+                token,
+                amount,
+            )
+            .await
+            .unwrap();
+        transfer.unwrap_and_send(&id).await.unwrap();
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::FailDetection {
+                    failure: DetectionFailure::Timeout,
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Reconcile {
+                    reason: "deposited manually via vault-deposit".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .resume_redemption(&id)
+            .await
+            .expect("a reconciled redemption must be a clean no-op for the job retry");
+
+        let entity = transfer.redemption_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, EquityRedemption::Reconciled { .. }),
+            "resume must leave a reconciled redemption terminal, got: {entity:?}"
+        );
+    }
+
+    /// A reconciled mint is already settled, so the operator recheck path
+    /// reports `AlreadyCompleted` without attempting provider recovery.
+    #[tokio::test]
+    async fn recover_mint_reports_already_completed_on_reconciled_mint() {
+        let (transfer, service, pool) = transfer_with_rebalancing_service().await;
+
+        let id = issuer_request_id("mint-recover-reconciled");
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::FailAcceptance {
+                    reason: "stranded mid-flight".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::Reconcile {
+                    reason: "wrapped manually via wrap-equity".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let outcome = transfer.recover_mint(&id, &pool, &service).await.unwrap();
+        assert!(
+            matches!(outcome, RecheckOutcome::AlreadyCompleted),
+            "a reconciled mint must recheck as AlreadyCompleted, got {outcome:?}"
+        );
+    }
+
+    /// A reconciled redemption is already settled, so the operator recheck path
+    /// reports `AlreadyCompleted` without attempting provider recovery.
+    #[tokio::test]
+    async fn recover_redemption_reports_already_completed_on_reconciled_redemption() {
+        let (transfer, service, _pool) = transfer_with_rebalancing_service().await;
+
+        let id = redemption_aggregate_id("redeem-recover-reconciled");
+        let symbol = Symbol::new("TEST").unwrap();
+        let token = transfer
+            .vault_lookup
+            .vault_token_for_symbol(&symbol)
+            .await
+            .unwrap();
+        let amount = FractionalShares::new(float!(50))
+            .to_u256_18_decimals()
+            .unwrap();
+
+        transfer
+            .withdraw_from_raindex(
+                &id,
+                &symbol,
+                FractionalShares::new(float!(50)),
+                token,
+                amount,
+            )
+            .await
+            .unwrap();
+        transfer.unwrap_and_send(&id).await.unwrap();
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::FailDetection {
+                    failure: DetectionFailure::Timeout,
+                },
+            )
+            .await
+            .unwrap();
+        transfer
+            .redemption_store
+            .send(
+                &id,
+                EquityRedemptionCommand::Reconcile {
+                    reason: "deposited manually via vault-deposit".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let outcome = transfer.recover_redemption(&id, &service).await.unwrap();
+        assert!(
+            matches!(outcome, RecheckOutcome::AlreadyCompleted),
+            "a reconciled redemption must recheck as AlreadyCompleted, got {outcome:?}"
+        );
+    }
+
+    /// Builds a transfer wired to a real `RebalancingService` sharing the same
+    /// command stores, so a seeded aggregate is visible to the `recover_*`
+    /// recheck entry points.
+    async fn transfer_with_rebalancing_service() -> (
+        CrossVenueEquityTransfer,
+        Arc<RebalancingService>,
+        SqlitePool,
+    ) {
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let (event_sender, _event_receiver) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(
+            InventoryView::default(),
+            event_sender,
+        ));
+
+        let service = Arc::new(RebalancingService::new(
+            RebalancingServiceConfig {
+                equity: ImbalanceThreshold {
+                    target: float!(0.5),
+                    deviation: float!(0.2),
+                },
+                usdc: None,
+                transfer_timeout: Duration::from_secs(1800),
+                assets: AssetsConfig {
+                    equities: EquitiesConfig::default(),
+                    cash: None,
+                },
+            },
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            address!("0x0000000000000000000000000000000000000001"),
+            address!("0x0000000000000000000000000000000000000002"),
+            inventory,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool),
+        ));
+
+        let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        let redemption_store = StoreBuilder::<EquityRedemption>::new(pool.clone())
+            .with(service.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+        service
+            .set_stores(
+                mint_store.clone(),
+                redemption_store.clone(),
+                Arc::new(test_store::<UsdcRebalance>(pool.clone(), ())),
+            )
+            .await;
+
+        let transfer = CrossVenueEquityTransfer::new(
+            Arc::new(MockRaindex::new()),
+            Arc::new(mock_vault_lookup()),
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockWrapper::new()),
+            address!("0x0000000000000000000000000000000000000001"),
+            mint_store,
+            redemption_store,
+        );
+
+        (transfer, service, pool)
     }
 
     async fn create_equity_transfer(

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -267,7 +267,8 @@ impl MintTracking {
             | TokenizedEquityMintEvent::MintAcceptanceFailed { .. }
             | TokenizedEquityMintEvent::WrappingFailed { .. }
             | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
-            | TokenizedEquityMintEvent::RaindexDepositFailed { .. } => {}
+            | TokenizedEquityMintEvent::RaindexDepositFailed { .. }
+            | TokenizedEquityMintEvent::OperatorReconciled { .. } => {}
         }
     }
 }
@@ -417,6 +418,7 @@ impl RedemptionTracking {
             | EquityRedemptionEvent::DetectionFailed { .. }
             | EquityRedemptionEvent::RedemptionRejected { .. }
             | EquityRedemptionEvent::ProviderCompletionRecovered { .. }
+            | EquityRedemptionEvent::OperatorReconciled { .. }
             | EquityRedemptionEvent::Completed { .. } => {}
         }
 
@@ -445,7 +447,8 @@ fn mint_event_tokenization_request_id(
         | TokenizedEquityMintEvent::WrappingFailed { .. }
         | TokenizedEquityMintEvent::VaultDepositSubmitted { .. }
         | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
-        | TokenizedEquityMintEvent::RaindexDepositFailed { .. } => None,
+        | TokenizedEquityMintEvent::RaindexDepositFailed { .. }
+        | TokenizedEquityMintEvent::OperatorReconciled { .. } => None,
     }
 }
 
@@ -2296,7 +2299,10 @@ impl RebalancingService {
             | TokensWrapped { .. }
             | VaultDepositSubmitted { .. }
             | WrappingFailed { .. }
-            | RaindexDepositFailed { .. } => None,
+            | RaindexDepositFailed { .. }
+            // Reconciliation is a pure bookkeeping terminal transition from
+            // `Failed`: the failure already settled inventory, so nothing to do.
+            | OperatorReconciled { .. } => None,
         }
     }
 
@@ -2389,6 +2395,9 @@ impl RebalancingService {
             | TokensSent { .. }
             | DetectionFailed { .. }
             | Detected { .. }
+            // Reconciliation is a pure bookkeeping terminal transition from
+            // `Failed`: the failure already settled inventory, so nothing to do.
+            | OperatorReconciled { .. }
             | RedemptionRejected { .. } => None,
         }
     }
@@ -2428,7 +2437,7 @@ impl RebalancingService {
             | SendPending {
                 unwrapped_amount, ..
             } => FractionalShares::from_u256_18_decimals(*unwrapped_amount),
-            Completed { .. } | Failed { .. } => Ok(FractionalShares::ZERO),
+            Completed { .. } | Failed { .. } | Reconciled { .. } => Ok(FractionalShares::ZERO),
         }
     }
 
@@ -3508,7 +3517,7 @@ impl RebalancingService {
                 }
                 *inventory = updated.set_active_mint(symbol.clone(), id.clone());
             }
-            DepositedIntoRaindex { .. } | Failed { .. } => {}
+            DepositedIntoRaindex { .. } | Failed { .. } | Reconciled { .. } => {}
         }
 
         Ok(())
@@ -3962,7 +3971,7 @@ impl RebalancingService {
                 )?;
                 *inventory = updated.set_active_redemption(symbol.clone(), id.clone());
             }
-            Completed { .. } | Failed { .. } => {}
+            Completed { .. } | Failed { .. } | Reconciled { .. } => {}
         }
 
         Ok(())
@@ -4157,7 +4166,8 @@ impl RebalancingService {
             | MintRejected { .. }
             | MintAcceptanceFailed { .. }
             | RaindexDepositFailed { .. }
-            | WrappingFailed { .. } => true,
+            | WrappingFailed { .. }
+            | OperatorReconciled { .. } => true,
 
             MintRequested { .. }
             | MintAccepted { .. }
@@ -4185,7 +4195,8 @@ impl RebalancingService {
             | ProviderCompletionRecovered { .. }
             | TransferFailed { .. }
             | DetectionFailed { .. }
-            | RedemptionRejected { .. } => true,
+            | RedemptionRejected { .. }
+            | OperatorReconciled { .. } => true,
 
             VaultWithdrawPending { .. }
             | VaultWithdrawSubmitted { .. }
@@ -7627,6 +7638,18 @@ mod tests {
     }
 
     #[test]
+    fn operator_reconciled_is_terminal_mint_event() {
+        // Gates clear_equity_in_progress: a reconciled mint must read as terminal
+        // so the in-progress flag is released and rebalancing can resume.
+        assert!(RebalancingService::is_terminal_mint_event(
+            &TokenizedEquityMintEvent::OperatorReconciled {
+                reason: "credited offline".to_string(),
+                reconciled_at: Utc::now(),
+            }
+        ));
+    }
+
+    #[test]
     fn extract_mint_info_returns_symbol_and_quantity() {
         let symbol = Symbol::new("AAPL").unwrap();
         let event = make_mint_requested(&symbol, float!(42.5));
@@ -10340,6 +10363,18 @@ mod tests {
     fn detection_failure_is_terminal_redemption_event() {
         assert!(RebalancingService::is_terminal_redemption_event(
             &make_detection_failed()
+        ));
+    }
+
+    #[test]
+    fn operator_reconciled_is_terminal_redemption_event() {
+        // Gates clear_equity_in_progress: a reconciled redemption must read as
+        // terminal so the in-progress flag is released and rebalancing resumes.
+        assert!(RebalancingService::is_terminal_redemption_event(
+            &EquityRedemptionEvent::OperatorReconciled {
+                reason: "deposited manually".to_string(),
+                reconciled_at: Utc::now(),
+            }
         ));
     }
 

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -128,6 +128,15 @@ pub(crate) enum TokenizedEquityMintError {
     /// Attempted to modify a failed mint operation
     #[error("Already failed")]
     AlreadyFailed,
+    /// Attempted to reconcile a mint that is not in the `Failed` state
+    #[error("Cannot reconcile: mint is not in the Failed state")]
+    NotFailed,
+    /// Attempted to act on a mint already resolved out-of-band (`Reconciled`)
+    #[error("Already reconciled")]
+    AlreadyReconciled,
+    /// Attempted to reconcile without an operator-supplied reason.
+    #[error("Cannot reconcile: reason is required")]
+    ReconcileReasonRequired,
     /// Tokenizer API failed to submit the mint request.
     /// Tokenizer errors can't be wrapped with #[from] because they may
     /// contain types that don't implement Serialize/Deserialize (required
@@ -182,6 +191,9 @@ impl PartialEq for TokenizedEquityMintError {
             | (Self::TokensNotReceivedForWrap, Self::TokensNotReceivedForWrap)
             | (Self::AlreadyCompleted, Self::AlreadyCompleted)
             | (Self::AlreadyFailed, Self::AlreadyFailed)
+            | (Self::NotFailed, Self::NotFailed)
+            | (Self::AlreadyReconciled, Self::AlreadyReconciled)
+            | (Self::ReconcileReasonRequired, Self::ReconcileReasonRequired)
             | (Self::MissingTxHash, Self::MissingTxHash)
             | (Self::VaultDepositFailed, Self::VaultDepositFailed) => true,
             (
@@ -281,6 +293,19 @@ pub(crate) enum TokenizedEquityMintCommand {
         tokenization_request_id: TokenizationRequestId,
         tx_hash: TxHash,
         fees: Option<Float>,
+    },
+    /// Reconcile a mint stranded in the terminal `Failed` state to the terminal
+    /// `Reconciled` state. The residual tokens/equity were handled out-of-band
+    /// (e.g. via wrap-equity/vault-deposit), so this is a bookkeeping resolution
+    /// rather than a re-drive. Valid ONLY from `Failed`.
+    ///
+    /// Accepts any `Failed` variant, including a pre-departure `MintRejected`
+    /// failure that stranded nothing. Such a mint needs no reconcile (the
+    /// dashboard already excludes it from the stuck list); reconciling it is a
+    /// harmless no-residue bookkeeping close, so the operator decides whether it
+    /// is warranted rather than the aggregate second-guessing the failure cause.
+    Reconcile {
+        reason: String,
     },
 }
 
@@ -391,6 +416,12 @@ pub(crate) enum TokenizedEquityMintEvent {
         fees: Option<Float>,
         recovered_at: DateTime<Utc>,
     },
+    /// An operator reconciled a terminal `Failed` mint out-of-band. Marks the
+    /// transfer resolved without re-driving the failed leg.
+    OperatorReconciled {
+        reason: String,
+        reconciled_at: DateTime<Utc>,
+    },
 }
 
 impl PartialEq for TokenizedEquityMintEvent {
@@ -443,6 +474,16 @@ impl PartialEq for TokenizedEquityMintEvent {
                 Self::RaindexDepositFailed {
                     reason: reason_b,
                     failed_at: time_b,
+                },
+            )
+            | (
+                Self::OperatorReconciled {
+                    reason: reason_a,
+                    reconciled_at: time_a,
+                },
+                Self::OperatorReconciled {
+                    reason: reason_b,
+                    reconciled_at: time_b,
                 },
             ) => reason_a == reason_b && time_a == time_b,
             (
@@ -606,6 +647,9 @@ impl DomainEvent for TokenizedEquityMintEvent {
             }
             Self::ProviderCompletionRecovered { .. } => {
                 "TokenizedEquityMintEvent::ProviderCompletionRecovered".to_string()
+            }
+            Self::OperatorReconciled { .. } => {
+                "TokenizedEquityMintEvent::OperatorReconciled".to_string()
             }
         }
     }
@@ -776,6 +820,25 @@ pub(crate) enum TokenizedEquityMint {
         reason: String,
         requested_at: DateTime<Utc>,
         failed_at: DateTime<Utc>,
+    },
+
+    /// An operator reconciled a terminal `Failed` mint out-of-band (terminal
+    /// state). Retains the identifying symbol/quantity and the original failure
+    /// reason so the projection still reports the real transfer instead of a
+    /// zero-value record.
+    Reconciled {
+        symbol: Symbol,
+        #[serde(
+            serialize_with = "st0x_float_serde::serialize_float_as_string",
+            deserialize_with = "st0x_float_serde::deserialize_float_from_number_or_string"
+        )]
+        quantity: Float,
+        /// The failure reason carried over from the `Failed` state.
+        failure_reason: String,
+        /// The operator-supplied reconciliation reason.
+        reconcile_reason: String,
+        requested_at: DateTime<Utc>,
+        reconciled_at: DateTime<Utc>,
     },
 }
 
@@ -1076,6 +1139,31 @@ impl PartialEq for TokenizedEquityMint {
                     && req_a == req_b
                     && fail_a == fail_b
             }
+            (
+                Self::Reconciled {
+                    symbol: sym_a,
+                    quantity: qty_a,
+                    failure_reason: fail_reason_a,
+                    reconcile_reason: rec_reason_a,
+                    requested_at: req_a,
+                    reconciled_at: reconciled_a,
+                },
+                Self::Reconciled {
+                    symbol: sym_b,
+                    quantity: qty_b,
+                    failure_reason: fail_reason_b,
+                    reconcile_reason: rec_reason_b,
+                    requested_at: req_b,
+                    reconciled_at: reconciled_b,
+                },
+            ) => {
+                sym_a == sym_b
+                    && qty_a.eq(*qty_b).unwrap_or(false)
+                    && fail_reason_a == fail_reason_b
+                    && rec_reason_a == rec_reason_b
+                    && req_a == req_b
+                    && reconciled_a == reconciled_b
+            }
             _ => false,
         }
     }
@@ -1096,7 +1184,8 @@ impl TokenizedEquityMint {
             | Self::TokensWrapped { quantity, .. }
             | Self::VaultDepositSubmitted { quantity, .. }
             | Self::DepositedIntoRaindex { quantity, .. }
-            | Self::Failed { quantity, .. } => *quantity,
+            | Self::Failed { quantity, .. }
+            | Self::Reconciled { quantity, .. } => *quantity,
         }
     }
 
@@ -1212,6 +1301,26 @@ impl TokenizedEquityMint {
                 started_at: *requested_at,
                 updated_at: *failed_at,
             }),
+
+            // Reconciliation is a terminal operator resolution, so it maps to the
+            // existing `Completed` DTO status (no new status needed) -- mirrors the
+            // USDC `Reconciled -> Completed` mapping.
+            Self::Reconciled {
+                symbol,
+                quantity,
+                requested_at,
+                reconciled_at,
+                ..
+            } => TransferOperation::EquityMint(EquityMintOperation {
+                id: Id::new(issuer_request_id.to_string()),
+                symbol: symbol.clone(),
+                quantity: FractionalShares::new(*quantity),
+                status: Completed {
+                    completed_at: *reconciled_at,
+                },
+                started_at: *requested_at,
+                updated_at: *reconciled_at,
+            }),
         }
     }
 }
@@ -1281,7 +1390,11 @@ impl EventSourced for TokenizedEquityMint {
     const PROJECTION: Nil = Nil;
     // v3: removed the vestigial `receipt_id` field and added the
     // `ProviderCompletionRecovered` event for in-process failed-transfer recovery.
-    const SCHEMA_VERSION: u64 = 3;
+    // v4: added the terminal `Reconciled` state and the `OperatorReconciled`
+    // event for operator reconciliation of stuck `Failed` mints. Additive only;
+    // bumped to clear stale snapshots so they rebuild from events under the new
+    // schema (existing events replay unchanged).
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use TokenizedEquityMintEvent::*;
@@ -1647,6 +1760,31 @@ impl EventSourced for TokenizedEquityMint {
                 }),
                 _ => None,
             },
+
+            OperatorReconciled {
+                reason,
+                reconciled_at,
+            } => {
+                let Self::Failed {
+                    symbol,
+                    quantity,
+                    reason: failure_reason,
+                    requested_at,
+                    ..
+                } = entity
+                else {
+                    return Ok(None);
+                };
+
+                Some(Self::Reconciled {
+                    symbol: symbol.clone(),
+                    quantity: *quantity,
+                    failure_reason: failure_reason.clone(),
+                    reconcile_reason: reason.clone(),
+                    requested_at: *requested_at,
+                    reconciled_at: *reconciled_at,
+                })
+            }
         })
     }
 
@@ -1843,6 +1981,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
             },
 
             TokenizedEquityMintCommand::SubmitWrap { wrap_tx_hash } => match self {
@@ -1860,6 +1999,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
             },
 
             TokenizedEquityMintCommand::SubmitVaultDeposit {
@@ -1877,6 +2017,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
             },
 
             TokenizedEquityMintCommand::WrapTokens {
@@ -1901,6 +2042,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
             },
 
             TokenizedEquityMintCommand::DepositToVault {
@@ -1920,6 +2062,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
             },
 
             TokenizedEquityMintCommand::FailAcceptance { reason } => match self {
@@ -1931,6 +2074,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
                 _ => Err(TokenizedEquityMintError::AlreadyInProgress),
             },
 
@@ -1957,6 +2101,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
                 _ => Err(TokenizedEquityMintError::AlreadyInProgress),
             },
 
@@ -1971,6 +2116,7 @@ impl EventSourced for TokenizedEquityMint {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
                 _ => Err(TokenizedEquityMintError::AlreadyInProgress),
             },
 
@@ -1990,10 +2136,31 @@ impl EventSourced for TokenizedEquityMint {
                     fees,
                     recovered_at: Utc::now(),
                 }]),
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
                 Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+            },
+
+            TokenizedEquityMintCommand::Reconcile { reason } => match self {
+                Self::Failed { symbol, .. } => {
+                    if reason.trim().is_empty() {
+                        return Err(TokenizedEquityMintError::ReconcileReasonRequired);
+                    }
+
+                    warn!(
+                        target: "rebalance",
+                        %symbol, %reason,
+                        "Reconciling stuck failed mint out-of-band"
+                    );
+                    Ok(vec![OperatorReconciled {
+                        reason,
+                        reconciled_at: Utc::now(),
+                    }])
+                }
+                Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
+                _ => Err(TokenizedEquityMintError::NotFailed),
             },
         }
     }
@@ -2005,7 +2172,7 @@ mod tests {
     use sqlx::SqlitePool;
     use std::sync::Arc;
 
-    use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore};
+    use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
     use st0x_float_macro::float;
     use st0x_raindex::RaindexVaultId;
     use st0x_wrapper::MockWrapper;
@@ -3004,6 +3171,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn recover_provider_completion_rejected_for_reconciled_mint() {
+        let mut history = failed_mint_history();
+        history.push(TokenizedEquityMintEvent::OperatorReconciled {
+            reason: "credited offline".to_string(),
+            reconciled_at: Utc::now(),
+        });
+
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(history)
+            .when(TokenizedEquityMintCommand::RecoverProviderCompletion {
+                issuer_request_id: issuer_request_id("ISS001"),
+                wallet: Address::ZERO,
+                tokenization_request_id: TokenizationRequestId("TOK001".to_string()),
+                tx_hash: TxHash::ZERO,
+                fees: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::AlreadyReconciled)
+            ),
+            "a reconciled mint must report AlreadyReconciled, not recover, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn fail_acceptance_from_accepted_transitions_to_failed() {
         let store = TestStore::<TokenizedEquityMint>::new(mint_services(MockTokenizer::new()));
         let id = issuer_request_id("ISS001");
@@ -3145,6 +3341,196 @@ mod tests {
         assert!(
             result.is_err(),
             "FailAcceptance should fail from Failed state"
+        );
+    }
+
+    fn failed_mint_history() -> Vec<TokenizedEquityMintEvent> {
+        vec![
+            mint_requested_event(),
+            mint_accepted_event(),
+            TokenizedEquityMintEvent::MintAcceptanceFailed {
+                reason: "timed out".to_string(),
+                failed_at: Utc::now(),
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_failed_emits_operator_reconciled_and_replays_to_reconciled() {
+        let history = failed_mint_history();
+
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(history.clone())
+            .when(TokenizedEquityMintCommand::Reconcile {
+                reason: "wrapped manually via wrap-equity".to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let TokenizedEquityMintEvent::OperatorReconciled { reason, .. } = &events[0] else {
+            panic!("Expected OperatorReconciled, got {:?}", events[0]);
+        };
+        assert_eq!(reason, "wrapped manually via wrap-equity");
+
+        let state = replay::<TokenizedEquityMint>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let TokenizedEquityMint::Reconciled {
+            failure_reason,
+            reconcile_reason,
+            quantity,
+            ..
+        } = state
+        else {
+            panic!("reconciled mint should be Reconciled, got {state:?}");
+        };
+        assert_eq!(failure_reason, "timed out");
+        assert_eq!(reconcile_reason, "wrapped manually via wrap-equity");
+        assert!(
+            quantity.eq(float!(100.5)).unwrap(),
+            "reconciled state must preserve the requested quantity, got {quantity:?}"
+        );
+    }
+
+    #[test]
+    fn evolve_operator_reconciled_from_failed_yields_reconciled() {
+        let failed = replay::<TokenizedEquityMint>(failed_mint_history())
+            .unwrap()
+            .unwrap();
+        let reconciled_at = Utc::now();
+
+        let next = TokenizedEquityMint::evolve(
+            &failed,
+            &TokenizedEquityMintEvent::OperatorReconciled {
+                reason: "credited offline".to_string(),
+                reconciled_at,
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            matches!(
+                next,
+                TokenizedEquityMint::Reconciled {
+                    ref reconcile_reason,
+                    ..
+                } if reconcile_reason == "credited offline"
+            ),
+            "OperatorReconciled from Failed must yield Reconciled, got {next:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_non_failed_is_rejected() {
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![mint_requested_event(), mint_accepted_event()])
+            .when(TokenizedEquityMintCommand::Reconcile {
+                reason: "should be rejected".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::NotFailed)
+            ),
+            "reconcile from a non-failed mint must be rejected as NotFailed, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_with_blank_reason_is_rejected() {
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(failed_mint_history())
+            .when(TokenizedEquityMintCommand::Reconcile {
+                reason: "   ".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::ReconcileReasonRequired)
+            ),
+            "reconcile with a blank reason must be rejected as ReconcileReasonRequired, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_from_reconciled_state_is_rejected() {
+        let mut history = failed_mint_history();
+        history.push(TokenizedEquityMintEvent::OperatorReconciled {
+            reason: "already reconciled".to_string(),
+            reconciled_at: Utc::now(),
+        });
+
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(history)
+            .when(TokenizedEquityMintCommand::Reconcile {
+                reason: "second attempt".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::AlreadyReconciled)
+            ),
+            "reconcile from an already-reconciled mint reports AlreadyReconciled, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn mint_error_partial_eq_is_reflexive_for_reconcile_variants() {
+        assert_eq!(
+            TokenizedEquityMintError::AlreadyReconciled,
+            TokenizedEquityMintError::AlreadyReconciled
+        );
+        assert_eq!(
+            TokenizedEquityMintError::NotFailed,
+            TokenizedEquityMintError::NotFailed
+        );
+        assert_ne!(
+            TokenizedEquityMintError::NotFailed,
+            TokenizedEquityMintError::AlreadyReconciled
+        );
+    }
+
+    #[test]
+    fn reconciled_to_dto_reports_completed_preserving_quantity() {
+        let requested_at = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled_at = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let reconciled = TokenizedEquityMint::Reconciled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(10),
+            failure_reason: "timed out".to_string(),
+            reconcile_reason: "credited offline".to_string(),
+            requested_at,
+            reconciled_at,
+        };
+
+        let TransferOperation::EquityMint(operation) =
+            reconciled.to_dto(&issuer_request_id("ISS001"))
+        else {
+            panic!("expected an EquityMint operation");
+        };
+        let EquityMintStatus::Completed { completed_at } = operation.status else {
+            panic!(
+                "reconciled mint must map to the Completed DTO status, got {:?}",
+                operation.status
+            );
+        };
+        assert_eq!(completed_at, reconciled_at);
+        assert_eq!(operation.started_at, requested_at);
+        assert_eq!(operation.updated_at, reconciled_at);
+        assert_eq!(
+            operation.quantity.to_string(),
+            FractionalShares::new(float!(10)).to_string()
         );
     }
 }


### PR DESCRIPTION
## What
Implements [RAI-985](https://linear.app/makeitrain/issue/RAI-985) — Step 7 of [RAI-978](https://linear.app/makeitrain/issue/RAI-978). Adds an operator "reconcile" terminal to the equity mint/redemption aggregates and `transfer reconcile --kind mint|redemption`.

## Why
A mint/redemption stuck in `Failed` whose residue was handled out-of-band (wrap-equity/vault-deposit runbook) had no way to be marked resolved — it lingered as `Failed` and could mislead operators/bookkeeping. Mirrors the USDC operator-reconcile (RAI-957), minus the guard/inventory machinery (equity transfers hold no in-progress guard, so this is a pure bookkeeping terminal).

## How
Both `TokenizedEquityMint` and `EquityRedemption` gain a `Reconciled` terminal state, an `OperatorReconciled { reason }` event, and a `Reconcile { reason }` command valid only from `Failed` (rejected elsewhere). `evolve`: `(OperatorReconciled, Failed) -> Reconciled`. Schema bumped 3→4 (additive — old events replay; bump clears stale snapshots). `Reconciled` maps to the `Completed` DTO status (matches the USDC reconcile mapping). CLI: `transfer reconcile` gains `--kind {usdc|mint|redemption}` (mirrors `transfer resume`/`fail`); usdc keeps its typed reason, equity passes a free-text reason; routed through the CQRS aggregate-command flow via a new `reconcile_equity_transfer_command` that preflight-verifies `Failed`.

## Testing
Aggregate tests (reconcile-from-Failed → Reconciled; rejection from non-Failed via `matches!`; DTO maps to Completed) on both aggregates; CLI parse/classify tests for all three kinds + usdc unknown-reason rejection. Full verify: 249 aggregate/cli tests pass, clippy clean (no allows), fmt clean.

## Anything else
Completes the implementable scope of epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978). One new error variant `EquityRedemptionError::NotFailed` (the redemption error enum had no InvalidCommand-style catch-all).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `transfer reconcile` support for stuck equity mints and redemptions, alongside existing USDC reconciliation.
  * Reconciled equity transfers now move to a terminal completed state and appear as completed in status views.

* **Bug Fixes**
  * Improved recovery for failed equity transfers so operator reconciliation clears stuck in-progress tracking and guard states.
  * Reconciled transfers are now excluded from “stuck transfer” reporting and recovery checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->