### PR TITLE
feat: surface per-object recovery commands in dashboard

### DIFF
--- a/crates/dto/src/transfer.rs
+++ b/crates/dto/src/transfer.rs
@@ -122,8 +122,22 @@ pub enum UsdcBridgeStatus {
     Withdrawing,
     Bridging,
     Depositing,
-    Completed { completed_at: DateTime<Utc> },
-    Failed { failed_at: DateTime<Utc> },
+    Completed {
+        completed_at: DateTime<Utc>,
+    },
+    Failed {
+        failed_at: DateTime<Utc>,
+        // True when the failure happened post-burn (`DepositFailed`, a post-burn
+        // `BridgingFailed`, or a `BaseToAlpaca ConversionFailed`) -- the only USDC
+        // failures `transfer reconcile --kind usdc` accepts. False for pre-burn
+        // failures, which strand nothing and the CLI rejects, so the dashboard can
+        // offer reconcile per-object only when this is true. NOTE: a plain `//`
+        // comment, not `///` -- ts-rs emits doc comments into the generated TS
+        // binding, and a field-level doc lands awkwardly inside the object type
+        // literal (`{ failedAt: string, /** ... */ postBurn: boolean }`), which
+        // trips the dashboard's type-aware eslint. Keep the rationale here in Rust.
+        post_burn: bool,
+    },
 }
 
 impl TransferOperation {
@@ -252,6 +266,43 @@ mod tests {
         assert_eq!(serialized["direction"], json!("alpaca_to_base"));
     }
 
+    #[test]
+    fn usdc_bridge_failed_serializes_post_burn_flag() {
+        let post_burn = TransferOperation::UsdcBridge(UsdcBridgeOperation {
+            id: Id::new("bridge-001"),
+            direction: UsdcBridgeDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(1000)),
+            status: UsdcBridgeStatus::Failed {
+                failed_at: Utc::now(),
+                post_burn: true,
+            },
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        let serialized = serde_json::to_value(&post_burn).expect("serialization should succeed");
+        assert_eq!(serialized["status"]["status"], json!("failed"));
+        assert_eq!(serialized["status"]["postBurn"], json!(true));
+        assert!(serialized["status"]["failedAt"].is_string());
+
+        let pre_burn = TransferOperation::UsdcBridge(UsdcBridgeOperation {
+            id: Id::new("bridge-002"),
+            direction: UsdcBridgeDirection::AlpacaToBase,
+            amount: Usdc::new(float!(1000)),
+            status: UsdcBridgeStatus::Failed {
+                failed_at: Utc::now(),
+                post_burn: false,
+            },
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        let serialized = serde_json::to_value(&pre_burn).expect("serialization should succeed");
+        assert_eq!(serialized["status"]["status"], json!("failed"));
+        assert_eq!(serialized["status"]["postBurn"], json!(false));
+        assert!(serialized["status"]["failedAt"].is_string());
+    }
+
     fn mint_operation(status: EquityMintStatus, updated_at: DateTime<Utc>) -> TransferOperation {
         TransferOperation::EquityMint(EquityMintOperation {
             id: Id::new("mint-001"),
@@ -330,7 +381,29 @@ mod tests {
         assert!(
             bridge_operation(UsdcBridgeStatus::Completed { completed_at: now }, now).is_terminal()
         );
-        assert!(bridge_operation(UsdcBridgeStatus::Failed { failed_at: now }, now).is_terminal());
+        assert!(
+            bridge_operation(
+                UsdcBridgeStatus::Failed {
+                    failed_at: now,
+                    post_burn: true
+                },
+                now
+            )
+            .is_terminal()
+        );
+
+        // `post_burn` gates whether reconcile is offered, not terminality: a
+        // pre-burn failure is just as terminal as a post-burn one.
+        assert!(
+            bridge_operation(
+                UsdcBridgeStatus::Failed {
+                    failed_at: now,
+                    post_burn: false
+                },
+                now
+            )
+            .is_terminal()
+        );
 
         assert!(!bridge_operation(UsdcBridgeStatus::Converting, now).is_terminal());
         assert!(!bridge_operation(UsdcBridgeStatus::Withdrawing, now).is_terminal());

--- a/dashboard/src/lib/components/cli-command-block.svelte
+++ b/dashboard/src/lib/components/cli-command-block.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte'
+  import { reactive } from '$lib/frp.svelte'
+  import { recoveryModeColor, recoveryModeLabel, type RecoveryCommand } from '$lib/transfer'
+
+  type Props = {
+    entry: RecoveryCommand
+  }
+
+  const { entry }: Props = $props()
+
+  const copied = reactive(false)
+  let resetTimer: ReturnType<typeof setTimeout> | undefined
+
+  // Clear the copy-feedback timer if the block unmounts before it fires, so it
+  // never calls reactive.update() on a destroyed component.
+  onDestroy(() => clearTimeout(resetTimer))
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(entry.command)
+      copied.update(() => true)
+      clearTimeout(resetTimer)
+      resetTimer = setTimeout(() => {
+        copied.update(() => false)
+      }, 1500)
+    } catch (error) {
+      console.error('Failed to copy command to clipboard', error)
+    }
+  }
+
+  const modeClass = $derived(recoveryModeColor(entry.mode).badge)
+</script>
+
+<div class="rounded-md border bg-muted/20 px-3 py-2">
+  <div class="flex items-center justify-between gap-2">
+    <span class="text-xs font-medium text-foreground">{entry.label}</span>
+    <span class="rounded border px-1.5 py-0.5 text-[10px] font-medium {modeClass}">
+      {recoveryModeLabel(entry.mode)}
+    </span>
+  </div>
+
+  <div class="mt-1 text-[11px] text-muted-foreground">{entry.description}</div>
+
+  <div class="mt-1.5 flex items-start gap-2">
+    <pre
+      class="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-all rounded bg-background/80 p-2 font-mono text-[11px] text-foreground">{entry.command}</pre>
+    <button
+      class="shrink-0 rounded border bg-background px-2 py-1 text-[11px] hover:bg-accent"
+      title="Copy command"
+      onclick={copy}
+    >
+      {copied.current ? 'Copied ✓' : 'Copy'}
+    </button>
+  </div>
+</div>

--- a/dashboard/src/lib/components/header-bar.svelte
+++ b/dashboard/src/lib/components/header-bar.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { Badge } from '$lib/components/ui/badge'
+  import RecoveryGuide from '$lib/components/recovery-guide.svelte'
   import type { ConnectionState } from '$lib/websocket'
   import {
     getApiBaseUrl,
     getSimulateRev,
     getSimulateBackendPort,
     getSimulateSourceId,
-    isDashboardMockMode,
+    isDashboardMockMode
   } from '$lib/env'
   import { formatUtcClock, FETCH_TIMEOUT_MS } from '$lib/time'
   import { reactive } from '$lib/frp.svelte'
@@ -22,9 +23,7 @@
       }${simulateSourceId ? ` · ${simulateSourceId}` : ''}`
     : null
 
-  const pageTitle = simulateLabel
-    ? `${simulateLabel} · st0x.liquidity`
-    : 'st0x.liquidity'
+  const pageTitle = simulateLabel ? `${simulateLabel} · st0x.liquidity` : 'st0x.liquidity'
 
   const hashString = (input: string): number => {
     let hash = 0
@@ -34,13 +33,10 @@
     return hash
   }
 
-  const simulateHue = simulateSourceId !== null
-    ? Math.abs(hashString(simulateSourceId)) % 360
-    : null
+  const simulateHue =
+    simulateSourceId !== null ? Math.abs(hashString(simulateSourceId)) % 360 : null
 
-  const simulateBackground = simulateHue !== null
-    ? `hsl(${String(simulateHue)} 70% 35%)`
-    : null
+  const simulateBackground = simulateHue !== null ? `hsl(${String(simulateHue)} 70% 35%)` : null
 
   type Props = {
     connectionStatus: ConnectionState
@@ -75,7 +71,7 @@
         return
       }
 
-      const data = await response.json() as HealthInfo
+      const data = (await response.json()) as HealthInfo
       health.update(() => data)
       botReachable.update(() => true)
     } catch {
@@ -95,8 +91,12 @@
 
   onMount(() => {
     void fetchHealth()
-    const healthInterval = setInterval(() => { void fetchHealth() }, 30_000)
-    const clockInterval = setInterval(() => { now.update(() => new Date()) }, 1000)
+    const healthInterval = setInterval(() => {
+      void fetchHealth()
+    }, 30_000)
+    const clockInterval = setInterval(() => {
+      now.update(() => new Date())
+    }, 1000)
     return () => {
       clearInterval(healthInterval)
       clearInterval(clockInterval)
@@ -140,6 +140,8 @@
     </h1>
 
     <div class="flex items-center gap-2 md:gap-4">
+      <RecoveryGuide />
+
       <span class="font-mono text-xs text-muted-foreground">
         {formatUtcClock(now.current)}
       </span>
@@ -147,7 +149,9 @@
       {#if health.current && botReachable.current}
         <span class="hidden text-xs text-muted-foreground md:inline-flex md:items-center md:gap-3">
           {#if health.current.gitCommit !== 'dev'}
-            <span title="Deployed commit"><span class="font-mono">{health.current.gitCommit.slice(0, 7)}</span></span>
+            <span title="Deployed commit"
+              ><span class="font-mono">{health.current.gitCommit.slice(0, 7)}</span></span
+            >
           {/if}
           <span title="Bot uptime">up {formatUptime(health.current.uptimeSeconds)}</span>
         </span>

--- a/dashboard/src/lib/components/recovery-guide.svelte
+++ b/dashboard/src/lib/components/recovery-guide.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import { getSimulateSourceId } from '$lib/env'
+  import { RECOVERY_GUIDE, recoveryModeColor, recoveryModeLabel } from '$lib/transfer'
+
+  let dialogEl: HTMLDialogElement | undefined = $state()
+
+  const open = () => dialogEl?.showModal()
+
+  // A simulation build runs the mock CLI against a /tmp harness config, so the
+  // guide's hardcoded `stox` commands are not runnable as written. Steer the
+  // operator to the per-object modal commands, which carry the right prefix.
+  const isSimulation = getSimulateSourceId() !== null
+</script>
+
+<button
+  class="rounded border bg-background px-2 py-1 text-xs hover:bg-accent"
+  title="CLI recovery guide"
+  onclick={open}
+>
+  CLI recovery guide
+</button>
+
+<dialog
+  bind:this={dialogEl}
+  class="w-full max-w-2xl rounded-lg border bg-card p-0 text-foreground shadow-lg backdrop:bg-black/50"
+  onclick={(event) => {
+    if (event.target === dialogEl) dialogEl.close()
+  }}
+>
+  <div class="flex items-center justify-between border-b px-5 py-3">
+    <div class="text-sm font-semibold">CLI recovery guide</div>
+    <button
+      class="text-lg leading-none text-muted-foreground hover:text-foreground"
+      onclick={() => dialogEl?.close()}
+    >
+      &times;
+    </button>
+  </div>
+
+  <div class="max-h-[70vh] overflow-y-auto px-5 py-4">
+    {#if isSimulation}
+      <div
+        class="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-500"
+      >
+        <span class="font-semibold">Simulation build.</span> The
+        <span class="font-mono">stox</span> commands below are not runnable here -- this build drives
+        the mock CLI against a temporary harness config. Use the per-object recovery commands in each
+        transfer/trade modal instead; they carry the correct prefix.
+      </div>
+    {/if}
+
+    <p class="mb-4 text-xs text-muted-foreground">
+      Every recovery command, grouped by object. The <span class="font-mono">stox</span> prefix is the
+      production wrapper (run on the server via Tailscale ssh). Each command notes whether it mutates
+      the local CQRS state directly or dispatches through the running bot.
+    </p>
+
+    <div class="space-y-5">
+      {#each RECOVERY_GUIDE as group (group.object)}
+        <section>
+          <h3 class="mb-2 font-mono text-sm font-semibold capitalize text-foreground">
+            {group.object}
+          </h3>
+
+          <div class="space-y-3">
+            {#each group.commands as entry (entry.command)}
+              <div class="rounded-md border bg-muted/20 px-3 py-2">
+                <pre
+                  class="overflow-x-auto whitespace-pre-wrap break-all rounded bg-background/80 p-2 font-mono text-[11px] text-foreground">{entry.command}</pre>
+
+                <div class="mt-1.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+                  <span class="text-muted-foreground">What</span>
+                  <span>{entry.description}</span>
+                  <span class="text-muted-foreground">When</span>
+                  <span>{entry.whenToUse}</span>
+                  <span class="text-muted-foreground">Applies to</span>
+                  <span>{entry.appliesTo}</span>
+                  <span class="text-muted-foreground">Mode</span>
+                  <span class={recoveryModeColor(entry.mode).text}>
+                    {recoveryModeLabel(entry.mode)}
+                  </span>
+                </div>
+              </div>
+            {/each}
+          </div>
+        </section>
+      {/each}
+    </div>
+  </div>
+</dialog>

--- a/dashboard/src/lib/components/trade-history-panel.svelte
+++ b/dashboard/src/lib/components/trade-history-panel.svelte
@@ -4,14 +4,20 @@
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
+  import CliCommandBlock from '$lib/components/cli-command-block.svelte'
   import type { Position } from '$lib/api/Position'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
-  import { getApiBaseUrl } from '$lib/env'
+  import {
+    getApiBaseUrl,
+    getExplorerTxUrl,
+    getSimulateBackendPort,
+    getSimulateSourceId
+  } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
   import { formatDecimal } from '$lib/decimal'
-  import { getExplorerTxUrl } from '$lib/env'
   import { equityUsdTooltip } from '$lib/inventory-value'
+  import { tradeRecoveryCommands } from '$lib/transfer'
 
   type TradeEvent = {
     step: string
@@ -676,6 +682,24 @@
             </div>
           {/each}
         </div>
+
+        {@const recoveryCommands = tradeRecoveryCommands({
+          deployment: {
+            simulateSourceId: getSimulateSourceId(),
+            backendPort: getSimulateBackendPort()
+          },
+          symbol: trade.symbol
+        })}
+        {#if recoveryCommands.length > 0}
+          <div class="mt-5 border-t pt-4">
+            <div class="mb-2 text-xs font-semibold text-foreground">CLI commands</div>
+            <div class="space-y-2">
+              {#each recoveryCommands as entry (entry.command)}
+                <CliCommandBlock {entry} />
+              {/each}
+            </div>
+          </div>
+        {/if}
       {/if}
     </div>
   {/if}

--- a/dashboard/src/lib/components/transfer-panel.svelte
+++ b/dashboard/src/lib/components/transfer-panel.svelte
@@ -4,7 +4,9 @@
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import HoverTooltip from '$lib/components/hover-tooltip.svelte'
+  import CliCommandBlock from '$lib/components/cli-command-block.svelte'
   import type { Position } from '$lib/api/Position'
+  import type { TransferCategory } from '$lib/transfer'
   import type { UsdcBridgeDirection } from '$lib/api/UsdcBridgeDirection'
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
@@ -12,7 +14,7 @@
     getApiBaseUrl,
     getExplorerTxUrl,
     getSimulateBackendPort,
-    getSimulateSourceId,
+    getSimulateSourceId
   } from '$lib/env'
   import { formatUtc, toDatetimeLocal, TIME_PRESETS, FETCH_TIMEOUT_MS, toRfc3339 } from '$lib/time'
   import { formatDecimal } from '$lib/decimal'
@@ -32,7 +34,7 @@
     apiErrorStatus,
     stuckLocationLabel,
     stuckReasonLabel,
-    recoveryCommand
+    transferRecoveryCommands
   } from '$lib/transfer'
 
   const isNumeric = (value: unknown): boolean =>
@@ -50,13 +52,13 @@
   }
 
   type TransferEntry = {
-    kind: string
+    kind: TransferCategory
     id: string
     symbol?: string
     quantity?: string
     amount?: string
     direction?: UsdcBridgeDirection
-    status: { status: string }
+    status: { status: string; postBurn?: boolean }
     startedAt: string
     updatedAt: string
   }
@@ -287,7 +289,6 @@
       }
     }
   }
-
 </script>
 
 <Card.Root class="flex h-full flex-col overflow-hidden border-l-4 border-l-purple-500/50">
@@ -584,162 +585,177 @@
           Failed to load events: {detailError.current}
         </div>
       {:else}
-        <svelte:boundary onerror={(error) => console.error('Failed to render transfer detail', error)}>
-        {#if detailStuck.current}
-          {@const recovery = recoveryCommand({
-            simulateSourceId: getSimulateSourceId(),
-            backendPort: getSimulateBackendPort(),
-            kind: transfer.kind,
-            id: transfer.id
-          })}
-          <div class="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs">
-            <div class="font-medium text-destructive">Stranded equity</div>
-            <div class="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono">
-              <span class="text-muted-foreground">Amount</span>
-              <span>{formatDecimal(detailStuck.current.stuckAmount, 3)}</span>
-              <span class="text-muted-foreground">Location</span>
-              <span>{stuckLocationLabel(detailStuck.current.stuckLocation)}</span>
-              <span class="text-muted-foreground">Reason</span>
-              <span>{stuckReasonLabel(detailStuck.current.stuckReason)}</span>
+        <svelte:boundary
+          onerror={(error) => console.error('Failed to render transfer detail', error)}
+        >
+          {#if detailStuck.current}
+            <div
+              class="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs"
+            >
+              <div class="font-medium text-destructive">Stranded equity</div>
+              <div class="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono">
+                <span class="text-muted-foreground">Amount</span>
+                <span>{formatDecimal(detailStuck.current.stuckAmount, 3)}</span>
+                <span class="text-muted-foreground">Location</span>
+                <span>{stuckLocationLabel(detailStuck.current.stuckLocation)}</span>
+                <span class="text-muted-foreground">Reason</span>
+                <span>{stuckReasonLabel(detailStuck.current.stuckReason)}</span>
+              </div>
             </div>
-            {#if recovery}
-              <div class="mt-2 border-t border-destructive/20 pt-2">
-                <div class="font-medium text-destructive">Recovery command</div>
-                {#if recovery.mode === 'production'}
-                  <div class="mt-1 text-muted-foreground">Run on the server (ssh via Tailscale):</div>
-                {/if}
-                <pre class="mt-1 whitespace-pre-wrap break-all rounded bg-background/80 p-2 font-mono text-[11px] text-foreground">{recovery.command}</pre>
-              </div>
-            {/if}
-          </div>
-        {/if}
+          {/if}
 
-        <div class="relative space-y-0 border-l-2 border-muted pl-4">
-          {#each detailEvents.current as event (event.sequence)}
-            <svelte:boundary onerror={(error) => console.error('Failed to render transfer event', error)}>
-            {@const stepStyle = statusStyle(event.step)}
-            {@const timestamp = extractTimestamp(event.payload)}
-            {@const fields = detailFields(event.payload)}
-            <div class="relative pb-4">
-              <!-- Timeline dot -->
-              <div
-                class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepStyle.dot}"
-              ></div>
+          <div class="relative space-y-0 border-l-2 border-muted pl-4">
+            {#each detailEvents.current as event (event.sequence)}
+              <svelte:boundary
+                onerror={(error) => console.error('Failed to render transfer event', error)}
+              >
+                {@const stepStyle = statusStyle(event.step)}
+                {@const timestamp = extractTimestamp(event.payload)}
+                {@const fields = detailFields(event.payload)}
+                <div class="relative pb-4">
+                  <!-- Timeline dot -->
+                  <div
+                    class="absolute -left-[calc(0.25rem+1px+1rem)] top-0.5 h-2 w-2 rounded-full {stepStyle.dot}"
+                  ></div>
 
-              <div class="text-xs font-medium {stepStyle.text}">
-                {humanizeStep(event.step)}
-              </div>
+                  <div class="text-xs font-medium {stepStyle.text}">
+                    {humanizeStep(event.step)}
+                  </div>
 
-              {#if timestamp}
-                <div class="mt-0.5 font-mono text-xs text-muted-foreground">
-                  {formatUtc(timestamp)}
-                </div>
-              {/if}
+                  {#if timestamp}
+                    <div class="mt-0.5 font-mono text-xs text-muted-foreground">
+                      {formatUtc(timestamp)}
+                    </div>
+                  {/if}
 
-              {#if fields.length > 0}
-                <div class="mt-1.5 space-y-1">
-                  {#each fields as [key, value] (key)}
-                    <div class="flex items-start gap-2 font-mono text-xs">
-                      <span class="shrink-0 text-muted-foreground">{formatFieldName(key)}</span>
-                      <span class="min-w-0 break-all">
-                        {#if key === 'reason'}
-                          <span class="text-destructive">{value}</span>
-                        {:else if key === 'failure'}
-                          <span class="text-destructive">
-                            {#if typeof value === 'object' && value !== null}
-                              {#if 'ApiError' in value}
-                                API error{@const status = apiErrorStatus(value)}{#if status}
-                                  (status {status}){/if}
-                              {:else if 'Timeout' in value}
-                                Timeout
+                  {#if fields.length > 0}
+                    <div class="mt-1.5 space-y-1">
+                      {#each fields as [key, value] (key)}
+                        <div class="flex items-start gap-2 font-mono text-xs">
+                          <span class="shrink-0 text-muted-foreground">{formatFieldName(key)}</span>
+                          <span class="min-w-0 break-all">
+                            {#if key === 'reason'}
+                              <span class="text-destructive">{value}</span>
+                            {:else if key === 'failure'}
+                              <span class="text-destructive">
+                                {#if typeof value === 'object' && value !== null}
+                                  {#if 'ApiError' in value}
+                                    API error{@const status = apiErrorStatus(value)}{#if status}
+                                      (status {status}){/if}
+                                  {:else if 'Timeout' in value}
+                                    Timeout
+                                  {:else}
+                                    {JSON.stringify(value)}
+                                  {/if}
+                                {:else if isNumeric(value)}
+                                  {formatNumericDetailValue(key, String(value))}
+                                {:else}
+                                  {String(value)}
+                                {/if}
+                              </span>
+                            {:else if isTxHash(value)}
+                              <a
+                                href={getExplorerTxUrl(value)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                              >
+                                {value.slice(0, 10)}...{value.slice(-8)}
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  viewBox="0 0 16 16"
+                                  fill="currentColor"
+                                  class="h-3 w-3"
+                                >
+                                  <path
+                                    d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                                  />
+                                  <path
+                                    d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                                  />
+                                </svg>
+                              </a>
+                            {:else if isTransferRef(value)}
+                              {#if 'OnchainTx' in value}
+                                {@const txHash = value['OnchainTx']}
+                                <a
+                                  href={getExplorerTxUrl(txHash)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
+                                >
+                                  {txHash.slice(0, 10)}...{txHash.slice(-8)}
+                                  <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 16 16"
+                                    fill="currentColor"
+                                    class="h-3 w-3"
+                                  >
+                                    <path
+                                      d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
+                                    />
+                                    <path
+                                      d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
+                                    />
+                                  </svg>
+                                </a>
+                              {:else if 'AlpacaId' in value}
+                                <span class="text-muted-foreground"
+                                  >Alpaca: {value['AlpacaId']}</span
+                                >
                               {:else}
                                 {JSON.stringify(value)}
                               {/if}
+                            {:else if typeof value === 'object' && value !== null}
+                              {JSON.stringify(value)}
                             {:else if isNumeric(value)}
                               {formatNumericDetailValue(key, String(value))}
                             {:else}
                               {String(value)}
                             {/if}
                           </span>
-                        {:else if isTxHash(value)}
-                          <a
-                            href={getExplorerTxUrl(value)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
-                          >
-                            {value.slice(0, 10)}...{value.slice(-8)}
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              viewBox="0 0 16 16"
-                              fill="currentColor"
-                              class="h-3 w-3"
-                            >
-                              <path
-                                d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
-                              />
-                              <path
-                                d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
-                              />
-                            </svg>
-                          </a>
-                        {:else if isTransferRef(value)}
-                          {#if 'OnchainTx' in value}
-                            {@const txHash = value['OnchainTx']}
-                            <a
-                              href={getExplorerTxUrl(txHash)}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              class="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300"
-                            >
-                              {txHash.slice(0, 10)}...{txHash.slice(-8)}
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                                class="h-3 w-3"
-                              >
-                                <path
-                                  d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z"
-                                />
-                                <path
-                                  d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z"
-                                />
-                              </svg>
-                            </a>
-                          {:else if 'AlpacaId' in value}
-                            <span class="text-muted-foreground">Alpaca: {value['AlpacaId']}</span>
-                          {:else}
-                            {JSON.stringify(value)}
-                          {/if}
-                        {:else if typeof value === 'object' && value !== null}
-                          {JSON.stringify(value)}
-                        {:else if isNumeric(value)}
-                          {formatNumericDetailValue(key, String(value))}
-                        {:else}
-                          {String(value)}
-                        {/if}
-                      </span>
+                        </div>
+                      {/each}
                     </div>
-                  {/each}
+                  {/if}
                 </div>
-              {/if}
-            </div>
 
-            {#snippet failed()}
-              <div class="relative pb-4 text-xs text-destructive">
-                Something went wrong rendering this event — check the browser console.
-              </div>
-            {/snippet}
-            </svelte:boundary>
-          {/each}
-        </div>
-
-        {#snippet failed()}
-          <div class="flex items-center justify-center py-8 text-sm text-destructive">
-            Something went wrong — check the browser console.
+                {#snippet failed()}
+                  <div class="relative pb-4 text-xs text-destructive">
+                    Something went wrong rendering this event — check the browser console.
+                  </div>
+                {/snippet}
+              </svelte:boundary>
+            {/each}
           </div>
-        {/snippet}
+
+          {@const recoveryCommands = transferRecoveryCommands({
+            deployment: {
+              simulateSourceId: getSimulateSourceId(),
+              backendPort: getSimulateBackendPort()
+            },
+            kind: transfer.kind,
+            id: transfer.id,
+            status: transfer.status.status,
+            direction: transfer.direction ?? null,
+            postBurn: transfer.status.postBurn ?? null
+          })}
+          {#if recoveryCommands.length > 0}
+            <div class="mt-5 border-t pt-4">
+              <div class="mb-2 text-xs font-semibold text-foreground">CLI commands</div>
+              <div class="space-y-2">
+                {#each recoveryCommands as entry (entry.command)}
+                  <CliCommandBlock {entry} />
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          {#snippet failed()}
+            <div class="flex items-center justify-center py-8 text-sm text-destructive">
+              Something went wrong — check the browser console.
+            </div>
+          {/snippet}
         </svelte:boundary>
       {/if}
     </div>

--- a/dashboard/src/lib/transfer.test.ts
+++ b/dashboard/src/lib/transfer.test.ts
@@ -10,7 +10,11 @@ import {
   apiErrorStatus,
   stuckLocationLabel,
   stuckReasonLabel,
-  recoveryCommand,
+  transferRecoveryCommands,
+  tradeRecoveryCommands,
+  recoveryModeLabel,
+  recoveryModeColor,
+  RECOVERY_GUIDE
 } from './transfer'
 
 describe('transferTypeLabel', () => {
@@ -242,87 +246,354 @@ describe('stuckReasonLabel', () => {
   })
 })
 
-describe('recoveryCommand', () => {
-  it('builds the mock recheck command for an equity mint in a simulation build', () => {
-    const command = recoveryCommand({
-      simulateSourceId: 'sim-1',
-      backendPort: '8123',
+const PROD = { simulateSourceId: null, backendPort: null }
+const SIM = { simulateSourceId: 'sim-1', backendPort: '8123' }
+const SIM_PREFIX =
+  'nix develop --command cargo run --features mock --bin cli -- --config /tmp/st0x-simulate-failures-8123.config.toml --secrets /tmp/st0x-simulate-failures-8123.secrets.toml'
+
+const commandFor = (commands: { label: string; command: string }[], label: string): string => {
+  const found = commands.find((entry) => entry.label === label)
+  if (!found) throw new Error(`no command labeled ${label}`)
+  return found.command
+}
+
+describe('transferRecoveryCommands', () => {
+  it('shows recheck/resume/fail for an in-flight (stuck, non-terminal) equity mint', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
       kind: 'equity_mint',
       id: 'ISS001',
+      status: 'wrapping'
     })
-    expect(command).toEqual({
-      mode: 'simulation',
-      command:
-        'nix develop --command cargo run --features mock --bin cli -- --config /tmp/st0x-simulate-failures-8123.config.toml --secrets /tmp/st0x-simulate-failures-8123.secrets.toml transfer recheck --kind mint --id ISS001',
-    })
+    expect(commands.map((entry) => entry.label)).toEqual(['Recheck', 'Resume (all equity)', 'Fail'])
+    expect(commandFor(commands, 'Recheck')).toBe('stox transfer recheck --kind mint --id ISS001')
+    expect(commandFor(commands, 'Resume (all equity)')).toBe('stox transfer resume --kind equity')
+    expect(commandFor(commands, 'Fail')).toBe(
+      'stox transfer fail --kind mint --id ISS001 -r "<reason>"'
+    )
   })
 
-  it('maps equity_redemption to the redemption transfer type', () => {
-    const command = recoveryCommand({
-      simulateSourceId: 'sim-1',
-      backendPort: '8123',
-      kind: 'equity_redemption',
-      id: 'RED001',
-    })
-    expect(command?.command).toContain('transfer recheck --kind redemption --id RED001')
-  })
-
-  it('builds the stox command for an equity mint on a live deployment', () => {
-    const command = recoveryCommand({
-      simulateSourceId: null,
-      backendPort: '8123',
+  it('shows recheck + reconcile (not resume/fail) for a failed equity mint', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
       kind: 'equity_mint',
       id: 'ISS001',
+      status: 'failed'
     })
-    expect(command).toEqual({
-      mode: 'production',
-      command: 'stox transfer recheck --kind mint --id ISS001',
-    })
+    expect(commands.map((entry) => entry.label)).toEqual(['Recheck', 'Reconcile'])
+    expect(commandFor(commands, 'Reconcile')).toBe(
+      'stox transfer reconcile --kind mint --id ISS001 -r "<reason>"'
+    )
   })
 
-  it('builds the stox command for an equity redemption on a live deployment', () => {
-    const command = recoveryCommand({
-      simulateSourceId: null,
-      backendPort: null,
+  it('maps an in-flight equity redemption to the redemption kind', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
       kind: 'equity_redemption',
       id: 'RED001',
+      status: 'sending'
     })
-    expect(command).toEqual({
-      mode: 'production',
-      command: 'stox transfer recheck --kind redemption --id RED001',
-    })
+    expect(commandFor(commands, 'Recheck')).toBe(
+      'stox transfer recheck --kind redemption --id RED001'
+    )
+    expect(commandFor(commands, 'Fail')).toBe(
+      'stox transfer fail --kind redemption --id RED001 -r "<reason>"'
+    )
   })
 
-  it('returns null in a simulation build when the backend port is unknown', () => {
+  it('marks recheck as requires-bot and fail/reconcile as direct-db', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'equity_mint',
+      id: 'ISS001',
+      status: 'failed'
+    })
+    const modeFor = (label: string) => commands.find((entry) => entry.label === label)?.mode
+    expect(modeFor('Recheck')).toBe('requires-bot')
+    expect(modeFor('Reconcile')).toBe('direct-db')
+  })
+
+  it('shows only resume for a post-burn in-flight usdc bridge, placeholder direction when unknown', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'usdc_bridge',
+      id: 'BRIDGE001',
+      status: 'bridging'
+    })
+    expect(commands.map((entry) => entry.label)).toEqual(['Resume'])
+    expect(commandFor(commands, 'Resume')).toBe(
+      'stox transfer resume --kind usdc --id BRIDGE001 --direction <to-raindex|to-alpaca>'
+    )
+    expect(commands.find((entry) => entry.label === 'Resume')?.mode).toBe('direct-db-live-rpc')
+  })
+
+  it('offers resume for the depositing (post-burn) usdc bridge status', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'usdc_bridge',
+      id: 'BRIDGE001',
+      status: 'depositing'
+    })
+    expect(commands.map((entry) => entry.label)).toEqual(['Resume'])
+  })
+
+  it('offers fail-usdc-transfer (not resume) for a pre-burn in-flight usdc bridge', () => {
+    // converting/withdrawing precede the CCTP burn: nothing has left the source
+    // venue, so the safe in-flight action is to terminalize, not resume.
+    for (const status of ['converting', 'withdrawing']) {
+      const commands = transferRecoveryCommands({
+        deployment: PROD,
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+        status,
+        direction: 'alpaca_to_base'
+      })
+      expect(commands.map((entry) => entry.label)).toEqual(['Fail (pre-burn)'])
+      expect(commandFor(commands, 'Fail (pre-burn)')).toBe(
+        'stox fail-usdc-transfer --id BRIDGE001 -r "<reason>"'
+      )
+      expect(commands.find((entry) => entry.label === 'Fail (pre-burn)')?.mode).toBe('direct-db')
+    }
+  })
+
+  it('translates the DTO direction to the CLI flag vocabulary on the usdc resume command', () => {
+    // The DTO names the venue flow (alpaca_to_base) while the CLI names the
+    // Raindex-relative leg (to-raindex); the command must carry the CLI value.
+    const toRaindex = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'usdc_bridge',
+      id: 'BRIDGE001',
+      status: 'bridging',
+      direction: 'alpaca_to_base'
+    })
+    expect(commandFor(toRaindex, 'Resume')).toBe(
+      'stox transfer resume --kind usdc --id BRIDGE001 --direction to-raindex'
+    )
+
+    const toAlpaca = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'usdc_bridge',
+      id: 'BRIDGE002',
+      status: 'bridging',
+      direction: 'base_to_alpaca'
+    })
+    expect(commandFor(toAlpaca, 'Resume')).toBe(
+      'stox transfer resume --kind usdc --id BRIDGE002 --direction to-alpaca'
+    )
+  })
+
+  it('shows reconcile for a post-burn failed usdc bridge (any casing)', () => {
+    // The CLI accepts `transfer reconcile --kind usdc` only for post-burn
+    // failures, which the postBurn discriminator marks true.
+    for (const status of ['failed', 'Failed', 'FAILED']) {
+      const commands = transferRecoveryCommands({
+        deployment: PROD,
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+        status,
+        postBurn: true
+      })
+      expect(commands.map((entry) => entry.label)).toEqual(['Reconcile'])
+      expect(commandFor(commands, 'Reconcile')).toBe(
+        'stox transfer reconcile --kind usdc --id BRIDGE001 -r "<reason>"'
+      )
+      expect(commands.find((entry) => entry.label === 'Reconcile')?.mode).toBe('direct-db')
+    }
+  })
+
+  it('shows no per-object command for a pre-burn failed usdc bridge', () => {
+    // A pre-burn failure strands nothing on-chain, so the CLI rejects reconcile;
+    // postBurn=false must surface nothing rather than a false affordance.
+    for (const postBurn of [false, null]) {
+      expect(
+        transferRecoveryCommands({
+          deployment: PROD,
+          kind: 'usdc_bridge',
+          id: 'BRIDGE001',
+          status: 'failed',
+          postBurn
+        })
+      ).toEqual([])
+    }
+  })
+
+  it('shows no per-object command for a failed usdc bridge with no discriminator', () => {
+    // An absent postBurn (older payloads / non-failed-shaped status) is treated
+    // as not-post-burn -- the reconcile affordance requires an explicit true.
     expect(
-      recoveryCommand({
-        simulateSourceId: 'sim-1',
-        backendPort: null,
+      transferRecoveryCommands({
+        deployment: PROD,
+        kind: 'usdc_bridge',
+        id: 'BRIDGE001',
+        status: 'failed'
+      })
+    ).toEqual([])
+  })
+
+  it('treats the failed status case-insensitively for equity (recheck + reconcile)', () => {
+    const commands = transferRecoveryCommands({
+      deployment: PROD,
+      kind: 'equity_mint',
+      id: 'ISS001',
+      status: 'Failed'
+    })
+    expect(commands.map((entry) => entry.label)).toEqual(['Recheck', 'Reconcile'])
+    expect(commandFor(commands, 'Reconcile')).toBe(
+      'stox transfer reconcile --kind mint --id ISS001 -r "<reason>"'
+    )
+  })
+
+  it('returns no commands for a completed transfer (any casing)', () => {
+    for (const status of ['completed', 'Completed', 'COMPLETED']) {
+      expect(
+        transferRecoveryCommands({
+          deployment: PROD,
+          kind: 'equity_mint',
+          id: 'ISS001',
+          status
+        })
+      ).toEqual([])
+    }
+  })
+
+  it('uses the mock cli prefix in a simulation build', () => {
+    const commands = transferRecoveryCommands({
+      deployment: SIM,
+      kind: 'equity_mint',
+      id: 'ISS001',
+      status: 'wrapping'
+    })
+    expect(commandFor(commands, 'Recheck')).toBe(
+      `${SIM_PREFIX} transfer recheck --kind mint --id ISS001`
+    )
+  })
+
+  it('returns no commands in a simulation build with an unknown backend port', () => {
+    expect(
+      transferRecoveryCommands({
+        deployment: { simulateSourceId: 'sim-1', backendPort: null },
         kind: 'equity_mint',
         id: 'ISS001',
-      }),
-    ).toBeNull()
+        status: 'wrapping'
+      })
+    ).toEqual([])
+  })
+})
+
+describe('tradeRecoveryCommands', () => {
+  it('does not offer process-tx -- only the position/view commands', () => {
+    // process-tx re-accounts a MISSED fill, but a trade only reaches the history
+    // panel once recorded, and re-running it on an older trade is not guarded by
+    // the Position single-slot last_acknowledged_trade_id. It stays in the static
+    // guide for the genuinely-missed case, not the per-trade modal.
+    const commands = tradeRecoveryCommands({
+      deployment: PROD,
+      symbol: 'MSTR'
+    })
+    expect(commands.map((entry) => entry.label)).toEqual([
+      'Release hedge',
+      'Set position',
+      'Rebuild view'
+    ])
+    expect(commands.every((entry) => !entry.command.includes('process-tx'))).toBe(true)
+    expect(commandFor(commands, 'Release hedge')).toBe(
+      'stox position release-hedge -s MSTR -o <order-id> -r "<reason>"'
+    )
+    expect(commandFor(commands, 'Rebuild view')).toBe('stox view rebuild -a position --id MSTR')
   })
 
-  it('returns null for non-equity transfer kinds in a simulation build', () => {
-    expect(
-      recoveryCommand({
-        simulateSourceId: 'sim-1',
-        backendPort: '8123',
-        kind: 'usdc_bridge',
-        id: 'BRIDGE001',
-      }),
-    ).toBeNull()
+  it('uses the mock cli prefix in a simulation build', () => {
+    const commands = tradeRecoveryCommands({
+      deployment: SIM,
+      symbol: 'MSTR'
+    })
+    expect(commandFor(commands, 'Set position')).toBe(
+      `${SIM_PREFIX} position set -s MSTR (--zero | --long <N> | --short <N>) [--price <USDC_PER_SHARE>] -r "<reason>"`
+    )
   })
 
-  it('returns null for non-equity transfer kinds on a live deployment', () => {
-    expect(
-      recoveryCommand({
-        simulateSourceId: null,
-        backendPort: null,
-        kind: 'usdc_bridge',
-        id: 'BRIDGE001',
-      }),
-    ).toBeNull()
+  it('returns no commands for a trade in a simulation build with an unknown backend port', () => {
+    const commands = tradeRecoveryCommands({
+      deployment: { simulateSourceId: 'sim-1', backendPort: null },
+      symbol: 'MSTR'
+    })
+    expect(commands).toEqual([])
+  })
+})
+
+describe('RECOVERY_GUIDE', () => {
+  it('groups commands by object and uses the unified verb names', () => {
+    expect(RECOVERY_GUIDE.map((group) => group.object)).toEqual([
+      'transfer',
+      'position',
+      'view',
+      'cctp',
+      'trade'
+    ])
+
+    const allCommands = RECOVERY_GUIDE.flatMap((group) => group.commands)
+    expect(allCommands.some((entry) => entry.command.startsWith('stox transfer recheck'))).toBe(
+      true
+    )
+    expect(allCommands.some((entry) => entry.command.startsWith('stox cctp complete-mint'))).toBe(
+      true
+    )
+    expect(allCommands.some((entry) => entry.command.startsWith('stox fail-usdc-transfer'))).toBe(
+      true
+    )
+    expect(allCommands.every((entry) => !entry.command.includes('recheck-transfer'))).toBe(true)
+  })
+
+  it('labels each guide command with the SPEC execution mode', () => {
+    const modeOf = (prefix: string): string | undefined =>
+      RECOVERY_GUIDE.flatMap((group) => group.commands).find((entry) =>
+        entry.command.startsWith(prefix)
+      )?.mode
+
+    // requires-bot: only recheck and equity resume dispatch through the bot.
+    expect(modeOf('stox transfer recheck')).toBe('requires-bot')
+    expect(modeOf('stox transfer resume --kind equity')).toBe('requires-bot')
+    // live-rpc-only: cctp touches no DB state.
+    expect(modeOf('stox cctp complete-mint')).toBe('live-rpc-only')
+    // direct-db-live-rpc: usdc resume and process-tx drive on-chain from the CLI.
+    expect(modeOf('stox transfer resume --kind usdc')).toBe('direct-db-live-rpc')
+    expect(modeOf('stox process-tx')).toBe('direct-db-live-rpc')
+    // direct-db: pure local CQRS mutations.
+    expect(modeOf('stox transfer fail')).toBe('direct-db')
+    expect(modeOf('stox fail-usdc-transfer')).toBe('direct-db')
+    expect(modeOf('stox transfer reconcile')).toBe('direct-db')
+    expect(modeOf('stox position release-hedge')).toBe('direct-db')
+    expect(modeOf('stox position set')).toBe('direct-db')
+    expect(modeOf('stox view rebuild')).toBe('direct-db')
+  })
+})
+
+describe('recoveryModeLabel', () => {
+  it('renders a distinct badge for each of the four execution modes', () => {
+    expect(recoveryModeLabel('requires-bot')).toBe('REST — requires the running bot')
+    expect(recoveryModeLabel('live-rpc-only')).toBe(
+      'live RPC — ensure the bot is not driving this same on-chain action'
+    )
+    expect(recoveryModeLabel('direct-db-live-rpc')).toBe(
+      'direct DB + live RPC — stop the bot / ensure it is not driving this id'
+    )
+    expect(recoveryModeLabel('direct-db')).toBe(
+      'direct DB — stop the bot / ensure it is not driving this id'
+    )
+  })
+})
+
+describe('recoveryModeColor', () => {
+  it('gives live-rpc-only its own sky tone, distinct from the bot-stop red', () => {
+    // live-rpc-only writes no DB state and is safe while the bot runs, so it must
+    // not share the red of the direct-db modes that require stopping the bot.
+    const liveRpc = recoveryModeColor('live-rpc-only')
+    expect(liveRpc.text).toBe('text-sky-500')
+    expect(liveRpc.badge).toContain('text-sky-500')
+
+    expect(recoveryModeColor('requires-bot').text).toBe('text-amber-500')
+
+    expect(recoveryModeColor('direct-db').text).toBe('text-destructive')
+    expect(recoveryModeColor('direct-db-live-rpc').text).toBe('text-destructive')
   })
 })

--- a/dashboard/src/lib/transfer.ts
+++ b/dashboard/src/lib/transfer.ts
@@ -1,6 +1,15 @@
+import type { TransferOperation } from './api/TransferOperation'
 import type { UsdcBridgeDirection } from './api/UsdcBridgeDirection'
 import { formatDecimal } from './decimal'
 import { formatBalance } from './format'
+
+/// The transfer `kind` discriminator, derived from the generated
+/// `TransferOperation` binding (an internally-tagged enum keyed on `kind`).
+/// There is deliberately no standalone `TransferCategory` Rust DTO -- the
+/// `TransferOperation` variant names encode the category -- so the dashboard
+/// extracts the union from the real binding rather than importing a phantom
+/// `api/TransferCategory` file that `st0x-dto` never generates.
+export type TransferCategory = TransferOperation['kind']
 
 export type StatusStyle = {
   text: string
@@ -76,7 +85,7 @@ const TOKEN_UNIT_FIELDS = new Set([
   'shares_minted',
   'unwrapped_amount',
   'wrapped_amount',
-  'wrapped_shares',
+  'wrapped_shares'
 ])
 const ADDRESS_FIELDS = new Set(['token', 'underlying_token', 'wallet', 'redemption_wallet'])
 
@@ -160,55 +169,499 @@ export const stuckReasonLabel = (reason: string): string =>
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')
 
-/// Maps a transfer kind to the `transfer recheck --kind` flag value, or null
-/// for kinds that are not equity transfers (e.g. usdc_bridge).
-const recheckTransferType = (kind: string): string | null => {
+/// Maps a transfer kind to the `--kind` flag value used by the equity-only
+/// `transfer fail` / `transfer recheck` verbs, or null for kinds that are not
+/// equity transfers (e.g. usdc_bridge).
+const equityTransferKind = (kind: TransferCategory): 'mint' | 'redemption' | null => {
   switch (kind) {
     case 'equity_mint':
       return 'mint'
     case 'equity_redemption':
       return 'redemption'
-    default:
+    case 'usdc_bridge':
       return null
   }
 }
 
-/// A `transfer recheck` command for a stranded transfer. The `mode`
-/// distinguishes a local simulation command from one an operator runs on the
-/// deployed server, so the UI can label them differently.
-export type RecoveryCommand =
-  | { mode: 'simulation'; command: string }
-  | { mode: 'production'; command: string }
+/// Execution mode for a recovery command, mirroring SPEC's four execution-mode
+/// contracts in the Operator Recovery Surface section:
+///   - `direct-db`: mutates local CQRS state directly; the bot must not be
+///     concurrently driving the same id.
+///   - `direct-db-live-rpc`: same direct-DB caveat, and also drives an on-chain
+///     flow against a live RPC provider (e.g. `transfer resume --kind usdc`,
+///     `process-tx`).
+///   - `live-rpc-only`: touches no database state, runs against a live RPC
+///     provider only; the caveat is the bot concurrently driving the same
+///     on-chain action (e.g. `cctp complete-mint`).
+///   - `requires-bot`: dispatches through the bot's REST API and only works
+///     while the bot is running (`recheck`, `transfer resume --kind equity`).
+export type RecoveryMode = 'direct-db' | 'direct-db-live-rpc' | 'live-rpc-only' | 'requires-bot'
 
-/// Builds the `transfer recheck` CLI command shown to operators for a stranded
-/// transfer, or null for kinds with no recovery path (e.g. usdc_bridge).
+/// A single copy-pasteable recovery command applicable to one object in its
+/// current state. `label` names the action, `description` says when to use it,
+/// and `mode` drives the inline execution-mode warning.
+export type RecoveryCommand = {
+  command: string
+  label: string
+  description: string
+  mode: RecoveryMode
+}
+
+/// Deployment context that determines the CLI invocation prefix.
 ///
 /// Simulation builds set `simulateSourceId` (`PUBLIC_SIMULATE_SOURCE_ID`, set
 /// solely by the `simulate-failures` flake apps) and run the mock CLI against
 /// the harness's `/tmp` config, so they also need `backendPort`. Live
 /// deployments invoke the `stox` wrapper, which auto-loads prod config/secrets,
 /// so the production command needs no config paths or port.
-export const recoveryCommand = (params: {
+export type DeploymentContext = {
   simulateSourceId: string | null
   backendPort: string | null
-  kind: string
+}
+
+/// Builds the CLI invocation prefix for the current deployment, or null when a
+/// simulation build is missing the backend port it needs to locate its config.
+///
+/// Production -> the bare `stox` wrapper. Simulation -> the mock `cli` binary
+/// pointed at the harness's `/tmp/st0x-simulate-failures-<port>` config/secrets.
+const commandPrefix = (deployment: DeploymentContext): string | null => {
+  if (deployment.simulateSourceId === null) return 'stox'
+
+  if (deployment.backendPort === null) return null
+
+  const basePath = `/tmp/st0x-simulate-failures-${deployment.backendPort}`
+  return `nix develop --command cargo run --features mock --bin cli -- --config ${basePath}.config.toml --secrets ${basePath}.secrets.toml`
+}
+
+/// Whether a transfer status string (snake_case DTO status) is the terminal
+/// `failed` state. Used to gate reconcile (terminal-only) versus the in-flight
+/// recovery verbs.
+const isFailedStatus = (status: string): boolean => status.toLowerCase() === 'failed'
+
+/// Whether a transfer status is a terminal state (failed or completed); no
+/// recovery commands apply to a completed transfer.
+const isTerminalStatus = (status: string): boolean => {
+  const lower = status.toLowerCase()
+  return lower === 'failed' || lower === 'completed'
+}
+
+/// Builds the full set of recovery commands an operator could legitimately run
+/// against a single transfer in its current state, with `--kind`/`--id`
+/// pre-filled and the execution-mode warning attached. Returns an empty array
+/// when no command applies (e.g. a completed transfer, or a simulation build
+/// missing its backend port).
+///
+/// Gating by status:
+///   - in-flight (non-terminal): `recheck`, `resume`, and `fail` -- the
+///     stuck-but-not-yet-failed case the modal must surface.
+///   - failed (terminal): `recheck` (the provider may have settled it after the
+///     failure) and `reconcile` (book the residue as resolved).
+///   - completed (terminal): none.
+///
+/// USDC bridges have no equity recovery verbs; only `resume` (in-flight) and
+/// `reconcile` (post-burn failure only -- see `usdcBridgeRecoveryCommands`)
+/// apply to them, both taking the bridge id directly. `postBurn` is the
+/// `UsdcBridgeStatus::Failed` discriminator that gates the latter.
+export const transferRecoveryCommands = (params: {
+  deployment: DeploymentContext
+  kind: TransferCategory
   id: string
-}): RecoveryCommand | null => {
-  const transferType = recheckTransferType(params.kind)
-  if (transferType === null) return null
+  status: string
+  direction?: UsdcBridgeDirection | null
+  postBurn?: boolean | null
+}): RecoveryCommand[] => {
+  const prefix = commandPrefix(params.deployment)
+  if (prefix === null) return []
 
-  if (params.simulateSourceId !== null) {
-    if (params.backendPort === null) return null
+  if (params.status.toLowerCase() === 'completed') return []
 
-    const basePath = `/tmp/st0x-simulate-failures-${params.backendPort}`
-    return {
-      mode: 'simulation',
-      command: `nix develop --command cargo run --features mock --bin cli -- --config ${basePath}.config.toml --secrets ${basePath}.secrets.toml transfer recheck --kind ${transferType} --id ${params.id}`,
-    }
+  if (params.kind === 'usdc_bridge') {
+    return usdcBridgeRecoveryCommands(
+      prefix,
+      params.id,
+      params.status,
+      params.direction ?? null,
+      params.postBurn ?? null
+    )
   }
 
-  return {
-    mode: 'production',
-    command: `stox transfer recheck --kind ${transferType} --id ${params.id}`,
+  const equityKind = equityTransferKind(params.kind)
+  if (equityKind === null) return []
+
+  return equityRecoveryCommands(prefix, equityKind, params.id, params.status)
+}
+
+/// Recovery commands for an equity mint or redemption. `recheck` is always
+/// applicable while non-completed (the provider may settle it at any point);
+/// `resume` and `fail` apply only while in-flight; `reconcile` only once failed.
+const equityRecoveryCommands = (
+  prefix: string,
+  kind: 'mint' | 'redemption',
+  id: string,
+  status: string
+): RecoveryCommand[] => {
+  const commands: RecoveryCommand[] = [
+    {
+      command: `${prefix} transfer recheck --kind ${kind} --id ${id}`,
+      label: 'Recheck',
+      description:
+        'Ask the running bot to re-poll the provider and complete the transfer if it settled.',
+      mode: 'requires-bot'
+    }
+  ]
+
+  if (!isTerminalStatus(status)) {
+    commands.push({
+      command: `${prefix} transfer resume --kind equity`,
+      label: 'Resume (all equity)',
+      description:
+        'Re-drive ALL interrupted mints and redemptions via the bot (no id; best-effort per ' +
+        'transfer, each succeeds or fails independently and failures are reported as counts).',
+      mode: 'requires-bot'
+    })
+
+    commands.push({
+      command: `${prefix} transfer fail --kind ${kind} --id ${id} -r "<reason>"`,
+      label: 'Fail',
+      description:
+        'Force this stuck transfer into the terminal Failed state. Use when it is permanently stuck.',
+      mode: 'direct-db'
+    })
+  }
+
+  if (isFailedStatus(status)) {
+    commands.push({
+      command: `${prefix} transfer reconcile --kind ${kind} --id ${id} -r "<reason>"`,
+      label: 'Reconcile',
+      description:
+        'Mark a Failed transfer as Reconciled once its residue was handled out-of-band (bookkeeping).',
+      mode: 'direct-db'
+    })
+  }
+
+  return commands
+}
+
+/// Maps a `UsdcBridgeDirection` DTO value to the CLI's `--direction` flag
+/// vocabulary. The two namespaces deliberately differ: the DTO names the
+/// venue-to-venue flow (`alpaca_to_base` / `base_to_alpaca`) while the CLI names
+/// the Raindex-relative leg (`to-raindex` / `to-alpaca`), so this is a real
+/// translation, not a casing change. Returns null for an unexpected value so the
+/// caller can fall back to the operator-editable placeholder.
+const usdcDirectionToCliFlag = (direction: UsdcBridgeDirection | null): string | null => {
+  switch (direction) {
+    case 'alpaca_to_base':
+      return 'to-raindex'
+    case 'base_to_alpaca':
+      return 'to-alpaca'
+    case null:
+      return null
+  }
+}
+
+/// Recovery commands for a USDC bridge, gated by status:
+///   - failed (terminal): `reconcile`, but ONLY for a post-burn failure. The CLI
+///     accepts `transfer reconcile --kind usdc` only when USDC was actually
+///     stranded on-chain (`DepositFailed`, a post-burn `BridgingFailed`, or a
+///     `BaseToAlpaca ConversionFailed`) and rejects pre-burn failures, which
+///     strand nothing. The `postBurn` discriminator on `UsdcBridgeStatus::Failed`
+///     tells the two apart; when it is not `true` we surface nothing rather than
+///     a false affordance the CLI would reject.
+///   - completed (terminal): none.
+///   - in-flight pre-burn (`converting`/`withdrawing`): `fail-usdc-transfer` --
+///     nothing has burned, so the safe action is to terminalize, not resume.
+///   - in-flight post-burn (`bridging`/`depositing`): `resume` -- the burn went
+///     through, so the bridge is re-drivable against a live RPC provider.
+const usdcBridgeRecoveryCommands = (
+  prefix: string,
+  id: string,
+  status: string,
+  direction: UsdcBridgeDirection | null,
+  postBurn: boolean | null
+): RecoveryCommand[] => {
+  if (isFailedStatus(status)) {
+    if (postBurn !== true) return []
+
+    return [
+      {
+        command: `${prefix} transfer reconcile --kind usdc --id ${id} -r "<reason>"`,
+        label: 'Reconcile',
+        description:
+          'Mark this post-burn failed USDC bridge as Reconciled once its stranded USDC was ' +
+          'recovered out-of-band (bookkeeping).',
+        mode: 'direct-db'
+      }
+    ]
+  }
+
+  if (isTerminalStatus(status)) return []
+
+  const lower = status.toLowerCase()
+
+  if (lower === 'converting' || lower === 'withdrawing') {
+    return [
+      {
+        command: `${prefix} fail-usdc-transfer --id ${id} -r "<reason>"`,
+        label: 'Fail (pre-burn)',
+        description:
+          'Force a pre-burn stuck USDC bridge into the terminal Failed state. Nothing left the ' +
+          'source venue, so no reconcile is needed afterwards. Verify on-chain that no CCTP burn ' +
+          'was broadcast before running.',
+        mode: 'direct-db'
+      }
+    ]
+  }
+
+  // Post-burn in-flight (`bridging`/`depositing`): the CLI requires --direction
+  // and rejects a mismatch against the persisted value, so fill the bridge's
+  // known direction (translated into the CLI's flag vocabulary) when we have it
+  // rather than leaving a placeholder.
+  const directionArg = usdcDirectionToCliFlag(direction) ?? '<to-raindex|to-alpaca>'
+  return [
+    {
+      command: `${prefix} transfer resume --kind usdc --id ${id} --direction ${directionArg}`,
+      label: 'Resume',
+      description:
+        'Re-drive this USDC bridge whose CLI invocation was interrupted after the burn. Drives ' +
+        'the on-chain flow against a live RPC provider.',
+      mode: 'direct-db-live-rpc'
+    }
+  ]
+}
+
+/// Builds the position/trade recovery commands applicable to a given symbol,
+/// pre-filling `-s <symbol>`.
+///
+/// `process-tx` is deliberately NOT offered here. A trade only reaches the
+/// history panel once it has already been recorded, and re-accounting a fill is
+/// not guarded against re-running on an older trade: the Position's single-slot
+/// `last_acknowledged_trade_id` only blocks re-applying the most recent trade,
+/// so a `process-tx` on a historical fill would double-account it. `process-tx`
+/// stays in the static recovery guide for the genuinely-missed-fill case.
+///
+/// `release-hedge` needs the pending offchain order id, which the dashboard
+/// does not have, so it is left as a `<order-id>` placeholder for the operator.
+export const tradeRecoveryCommands = (params: {
+  deployment: DeploymentContext
+  symbol: string
+}): RecoveryCommand[] => {
+  const prefix = commandPrefix(params.deployment)
+  if (prefix === null) return []
+
+  const { symbol } = params
+
+  const commands: RecoveryCommand[] = []
+
+  commands.push({
+    command: `${prefix} position release-hedge -s ${symbol} -o <order-id> -r "<reason>"`,
+    label: 'Release hedge',
+    description:
+      "Clear a position's stuck pending offchain order so normal hedging can retry. Needs the order id.",
+    mode: 'direct-db'
+  })
+
+  commands.push({
+    command: `${prefix} position set -s ${symbol} (--zero | --long <N> | --short <N>) [--price <USDC_PER_SHARE>] -r "<reason>"`,
+    label: 'Set position',
+    description:
+      'Override the net exposure after a manual correction. Pick exactly one target. ' +
+      '--price is required for a nonzero target unless the position already has a last price.',
+    mode: 'direct-db'
+  })
+
+  commands.push({
+    command: `${prefix} view rebuild -a position --id ${symbol}`,
+    label: 'Rebuild view',
+    description: 'Replay all events to reconstruct a corrupted position view.',
+    mode: 'direct-db'
+  })
+
+  return commands
+}
+
+/// A documented recovery command for the static CLI recovery guide.
+export type GuideCommand = {
+  command: string
+  description: string
+  whenToUse: string
+  appliesTo: string
+  mode: RecoveryMode
+}
+
+/// A group of recovery commands sharing an object.
+export type GuideObject = 'transfer' | 'position' | 'view' | 'cctp' | 'trade'
+
+export type GuideGroup = {
+  object: GuideObject
+  commands: GuideCommand[]
+}
+
+/// The static CLI recovery guide: every recovery command grouped by object,
+/// mirroring the verb glossary in `docs/domain.md`. Commands are shown with
+/// `<...>` placeholders since the guide is a general reference, not bound to a
+/// specific object. The `stox ` prefix shown is the production wrapper; in a
+/// simulation build the modals render the mock-cli prefix instead.
+export const RECOVERY_GUIDE: GuideGroup[] = [
+  {
+    object: 'transfer',
+    commands: [
+      {
+        command: 'stox transfer recheck --kind <mint|redemption> --id <id>',
+        description: 'Re-poll the provider and complete the transfer if it has settled.',
+        whenToUse: 'A mint/redemption is stuck or failed but the provider may have settled it.',
+        appliesTo: 'Equity mint / redemption (any non-completed state)',
+        mode: 'requires-bot'
+      },
+      {
+        command: 'stox transfer resume --kind equity',
+        description:
+          'Re-drive ALL interrupted mints and redemptions (no id; best-effort per transfer, ' +
+          'failures reported as counts).',
+        whenToUse: 'Equity transfers were interrupted mid-flight and need re-driving via the bot.',
+        appliesTo: 'All in-flight equity transfers',
+        mode: 'requires-bot'
+      },
+      {
+        command: 'stox transfer resume --kind usdc --id <id> --direction <to-raindex|to-alpaca>',
+        description:
+          'Re-drive a single USDC bridge interrupted after its burn (against a live RPC provider).',
+        whenToUse: 'A USDC bridge CLI invocation was interrupted after the burn went through.',
+        appliesTo: 'USDC bridge (in-flight)',
+        mode: 'direct-db-live-rpc'
+      },
+      {
+        command: 'stox transfer fail --kind <mint|redemption> --id <id> -r "<reason>"',
+        description: 'Force a stuck transfer into the terminal Failed state.',
+        whenToUse: 'A mint/redemption is permanently stuck and unrecoverable.',
+        appliesTo: 'Equity mint / redemption (non-terminal)',
+        mode: 'direct-db'
+      },
+      {
+        command: 'stox fail-usdc-transfer --id <id> -r "<reason>"',
+        description:
+          'Force a pre-burn stuck USDC bridge into the terminal Failed state (no reconcile ' +
+          'needed; nothing left the source venue).',
+        whenToUse:
+          'A USDC bridge is stuck before its CCTP burn and must be terminalized. Verify on-chain ' +
+          'that no burn was broadcast first.',
+        appliesTo: 'USDC bridge (pre-burn stuck)',
+        mode: 'direct-db'
+      },
+      {
+        command: 'stox transfer reconcile --kind <usdc|mint|redemption> --id <id> -r "<reason>"',
+        description:
+          'Mark a terminally-failed transfer Reconciled after handling residue manually.',
+        whenToUse:
+          'A transfer is in a terminal failure and its residue was settled out-of-band (bookkeeping).',
+        appliesTo:
+          'Failed equity transfer / post-burn USDC failure (DepositFailed, post-burn ' +
+          'BridgingFailed, or BaseToAlpaca ConversionFailed)',
+        mode: 'direct-db'
+      }
+    ]
+  },
+  {
+    object: 'position',
+    commands: [
+      {
+        command: 'stox position release-hedge -s <symbol> -o <order-id> -r "<reason>"',
+        description: "Clear a position's pending offchain order pointer so hedging can retry.",
+        whenToUse: 'A position is wedged on a hedge order that never resolved.',
+        appliesTo: 'Position with a stuck pending offchain order',
+        mode: 'direct-db'
+      },
+      {
+        command:
+          'stox position set -s <symbol> (--zero | --long <N> | --short <N>) ' +
+          '[--price <USDC_PER_SHARE>] -r "<reason>"',
+        description: 'Override a position’s net exposure after a manual correction.',
+        whenToUse: 'The recorded net exposure has drifted from reality and must be set explicitly.',
+        appliesTo: 'Any position',
+        mode: 'direct-db'
+      }
+    ]
+  },
+  {
+    object: 'view',
+    commands: [
+      {
+        command:
+          'stox view rebuild -a <position|offchain-order|vault-registry> (--id <id> | --all)',
+        description: 'Replay all events to reconstruct a corrupted materialized view.',
+        whenToUse: 'A view became corrupted (e.g. lost updates from optimistic-lock conflicts).',
+        appliesTo: 'Position / offchain-order / vault-registry views',
+        mode: 'direct-db'
+      }
+    ]
+  },
+  {
+    object: 'cctp',
+    commands: [
+      {
+        command: 'stox cctp complete-mint --burn-tx <hash> --source-chain <ethereum|base>',
+        description:
+          'Complete the destination-chain mint of a stuck CCTP transfer (live RPC only; touches ' +
+          'no database state).',
+        whenToUse: 'A CCTP burn succeeded but attestation polling was interrupted before the mint.',
+        appliesTo: 'CCTP cross-chain USDC transfer',
+        mode: 'live-rpc-only'
+      }
+    ]
+  },
+  {
+    object: 'trade',
+    commands: [
+      {
+        command: 'stox process-tx --tx-hash <hash>',
+        description:
+          'Re-account a missed onchain fill: record the trade and place the hedge. Runs in the ' +
+          'CLI process (own RPC + broker) -- does not need the bot.',
+        whenToUse: 'The bot missed an onchain fill and the position/hedge was never updated.',
+        appliesTo: 'Onchain (Raindex) fills',
+        mode: 'direct-db-live-rpc'
+      }
+    ]
+  }
+]
+
+/// Human label for an execution mode, used for the inline warning badge.
+export const recoveryModeLabel = (mode: RecoveryMode): string => {
+  switch (mode) {
+    case 'requires-bot':
+      return 'REST — requires the running bot'
+    case 'live-rpc-only':
+      return 'live RPC — ensure the bot is not driving this same on-chain action'
+    case 'direct-db-live-rpc':
+      return 'direct DB + live RPC — stop the bot / ensure it is not driving this id'
+    case 'direct-db':
+      return 'direct DB — stop the bot / ensure it is not driving this id'
+  }
+}
+
+/// Colour classes for an execution-mode badge. `live-rpc-only` writes no DB
+/// state and is safe while the bot runs, so it gets its own sky tone rather than
+/// the bot-stop red shared by the two direct-db modes; `requires-bot` is amber.
+/// `text` is the bare foreground class (static guide cell); `badge` adds the
+/// border + tint for the per-object modal pill.
+export const recoveryModeColor = (mode: RecoveryMode): { text: string; badge: string } => {
+  switch (mode) {
+    case 'requires-bot':
+      return {
+        text: 'text-amber-500',
+        badge: 'text-amber-500 border-amber-500/40 bg-amber-500/10'
+      }
+
+    case 'live-rpc-only':
+      return {
+        text: 'text-sky-500',
+        badge: 'text-sky-500 border-sky-500/40 bg-sky-500/10'
+      }
+
+    case 'direct-db-live-rpc':
+    case 'direct-db':
+      return {
+        text: 'text-destructive',
+        badge: 'text-destructive border-destructive/40 bg-destructive/10'
+      }
   }
 }

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -714,6 +714,54 @@ pub(crate) enum UsdcRebalance {
 }
 
 impl UsdcRebalance {
+    /// Whether a failed rebalance failed POST-burn -- the only USDC failures
+    /// `transfer reconcile --kind usdc` accepts (a pre-burn failure strands
+    /// nothing and the CLI rejects it). MUST stay in sync with the reconcilable
+    /// set in `transition_reconcile_stuck_rebalance`. A new (non-failure or
+    /// future) state defaults to `false`, i.e. not reconcilable -- the safe
+    /// default for surfacing the command on the dashboard.
+    fn is_post_burn_failure(&self) -> bool {
+        match self {
+            Self::DepositFailed { .. }
+            | Self::ConversionFailed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                ..
+            } => true,
+            Self::BridgingFailed {
+                burn_tx_hash,
+                cctp_nonce,
+                ..
+            } => burn_tx_hash.is_some() || cctp_nonce.is_some(),
+            // Everything else is not a post-burn failure: pre-burn failures
+            // strand nothing on-chain (WithdrawalFailed, and an AlpacaToBase
+            // ConversionFailed which is pre-withdrawal), and in-flight or
+            // clearable-terminal states (success / Reconciled) are not failures
+            // at all -- so the CLI rejects `transfer reconcile --kind usdc` for
+            // all of them. Enumerated exhaustively rather than via a wildcard so
+            // a new variant forces a conscious post-burn classification here
+            // instead of silently defaulting to false and diverging from the
+            // reconcilable set in `transition_reconcile_stuck_rebalance`.
+            Self::WithdrawalFailed { .. }
+            | Self::ConversionFailed {
+                direction: RebalanceDirection::AlpacaToBase,
+                ..
+            }
+            | Self::Converting { .. }
+            | Self::ConversionComplete { .. }
+            | Self::WithdrawalSubmitting { .. }
+            | Self::Withdrawing { .. }
+            | Self::WithdrawalComplete { .. }
+            | Self::BridgingSubmitting { .. }
+            | Self::Bridging { .. }
+            | Self::AwaitingAttestation { .. }
+            | Self::Attested { .. }
+            | Self::Bridged { .. }
+            | Self::DepositInitiated { .. }
+            | Self::DepositConfirmed { .. }
+            | Self::Reconciled { .. } => false,
+        }
+    }
+
     // A single state-dispatch match mapping each state to its DTO tuple, one
     // trivial arm per state. Splitting it would scatter the mapping across
     // pointless helpers; per the project guidance, suppress the length lint.
@@ -790,6 +838,7 @@ impl UsdcRebalance {
                 *amount,
                 UsdcBridgeStatus::Failed {
                     failed_at: *failed_at,
+                    post_burn: self.is_post_burn_failure(),
                 },
                 *initiated_at,
                 *failed_at,
@@ -7314,7 +7363,174 @@ mod tests {
 
         assert!(matches!(
             bridge.status,
-            UsdcBridgeStatus::Failed { failed_at: fa } if fa == failed_at
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: true
+            } if fa == failed_at
+        ));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_withdrawal_failed_maps_to_pre_burn_failed_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let failed_at = initiated_at + chrono::Duration::seconds(60);
+        let state = UsdcRebalance::WithdrawalFailed {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(750)),
+            withdrawal_ref: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            reason: "withdrawal rejected".to_string(),
+            initiated_at,
+            failed_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // A withdrawal failure strands nothing on-chain, so the CLI rejects
+        // `transfer reconcile --kind usdc` -- the discriminator must be false.
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: false
+            } if fa == failed_at
+        ));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_bridging_failed_with_burn_tx_maps_to_post_burn_failed_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let failed_at = initiated_at + chrono::Duration::seconds(60);
+        let burn_tx =
+            fixed_bytes!("0x0000000000000000000000000000000000000000000000000000000000000007");
+        let state = UsdcRebalance::BridgingFailed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(750)),
+            burn_tx_hash: Some(burn_tx),
+            cctp_nonce: None,
+            reason: "dropped from mempool".to_string(),
+            initiated_at,
+            failed_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // The burn landed on-chain, so funds left the source venue and the CLI
+        // accepts `transfer reconcile --kind usdc` -- the discriminator is true.
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: true
+            } if fa == failed_at
+        ));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_bridging_failed_without_burn_artifacts_maps_to_pre_burn_failed_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let failed_at = initiated_at + chrono::Duration::seconds(60);
+        let state = UsdcRebalance::BridgingFailed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(750)),
+            burn_tx_hash: None,
+            cctp_nonce: None,
+            reason: "pre-burn failure".to_string(),
+            initiated_at,
+            failed_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // No burn tx and no CCTP nonce means nothing left the source venue, so
+        // the CLI rejects reconcile -- the discriminator must be false.
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: false
+            } if fa == failed_at
+        ));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_conversion_failed_base_to_alpaca_maps_to_post_burn_failed_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let failed_at = initiated_at + chrono::Duration::seconds(60);
+        let state = UsdcRebalance::ConversionFailed {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(750)),
+            order_id: ClientOrderId::from_uuid(Uuid::from_u128(13)),
+            reason: "broker rejected".to_string(),
+            initiated_at,
+            failed_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // BaseToAlpaca conversion is the post-deposit USDC->USD leg: the burn
+        // already happened, so the CLI accepts reconcile -- discriminator true.
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: true
+            } if fa == failed_at
+        ));
+        assert_eq!(bridge.started_at, initiated_at);
+        assert_eq!(bridge.updated_at, failed_at);
+    }
+
+    #[test]
+    fn to_dto_conversion_failed_alpaca_to_base_maps_to_pre_burn_failed_status() {
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let initiated_at = Utc::now();
+        let failed_at = initiated_at + chrono::Duration::seconds(60);
+        let state = UsdcRebalance::ConversionFailed {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(750)),
+            order_id: ClientOrderId::from_uuid(Uuid::from_u128(14)),
+            reason: "broker rejected".to_string(),
+            initiated_at,
+            failed_at,
+        };
+
+        let dto = state.to_dto(&id);
+        let TransferOperation::UsdcBridge(bridge) = dto else {
+            panic!("expected UsdcBridge variant");
+        };
+
+        // AlpacaToBase conversion is the pre-withdrawal USD->USDC leg: nothing
+        // has burned yet, so the CLI rejects reconcile -- discriminator false.
+        assert!(matches!(
+            bridge.status,
+            UsdcBridgeStatus::Failed {
+                failed_at: fa,
+                post_burn: false
+            } if fa == failed_at
         ));
         assert_eq!(bridge.started_at, initiated_at);
         assert_eq!(bridge.updated_at, failed_at);


### PR DESCRIPTION
## What
Implements [RAI-987](https://linear.app/makeitrain/issue/RAI-987) — Step 9 of [RAI-978](https://linear.app/makeitrain/issue/RAI-978). Turns the dashboard detail modals into a recovery command palette and adds a CLI recovery guide.

## Why
The dashboard only surfaced a recovery command in one narrow case (the "Stranded equity" hint, and only once a transfer reached a recognized failed/stranded terminal). A transfer stuck mid-flight but not yet failed showed no actionable command, so operators had to recall the exact `stox` invocation from memory or hunt through docs.

## How
- `dashboard/src/lib/transfer.ts`: replaces the single `recoveryCommand` with per-object generators (`transferRecoveryCommands`, `tradeRecoveryCommands`) returning every command valid for the object's `kind`+`status` — including the stuck-but-not-failed case — each as `{ command, label, description, mode }` with the **new** grouped command names (`transfer recheck|resume|fail|reconcile --kind ...`, `position release-hedge|set`, `view rebuild`, `process-tx`). Keeps the deployment prefix logic (`stox` vs sim `nix develop … cli --`).
- Transfer + trade detail modals render a "CLI commands" section: one copy-paste block per applicable command with its execution-mode badge (direct-DB vs requires-bot).
- New `cli-command-block.svelte` (reusable copy block) and `recovery-guide.svelte` (persistent button → dialog documenting every command grouped by object), wired into `header-bar.svelte`. The modals and guide read from the same `transfer.ts` source.

## Testing
17 new/updated assertions in `transfer.test.ts` (per-kind/per-status command sets, exact new-name strings, prod+sim prefix behavior, exec-mode flags). `bun run test:run` → 143 passed; eslint/prettier clean on all changed files.

## Anything else
The 4 `svelte-check` errors on this branch are pre-existing `alpacaUsdc` generated-DTO drift in `inventory-cash.*`/`connection.svelte.test.ts` (present on master, files untouched here; CI's DTO-regen step resolves them locally-stale types) — unrelated to this change. `position release-hedge` shows an `<order-id>` placeholder since the trade modal has no offchain order id. Completes epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978).
