### PR TITLE
feat: force-fail mints stuck at MintRequested

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2766,8 +2766,10 @@ know about cross-venue inventory.
   await retry or manual recovery)
 - `TokenizedEquityMintEvent::MintRejected` - No balance change (rejected before
   shares left Alpaca)
-- `TokenizedEquityMintEvent::MintAcceptanceFailed` - Reconciles inflight back to
-  Alpaca available
+- `TokenizedEquityMintEvent::MintAcceptanceFailed` - When emitted after
+  `MintAccepted`, reconciles the started inflight back to Alpaca available. When
+  emitted by an operator force-fail from `MintRequested` (pre-acceptance), no
+  inflight was ever started, so there is no balance change
 - `EquityRedemptionEvent::WithdrawnFromRaindex` - Moves tokens to inflight
   (leaving Raindex vault)
 - `EquityRedemptionEvent::TokensUnwrapped` - No balance change (conversion

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -1164,7 +1164,10 @@ pub(crate) async fn fail_transfer_command<W: Write>(
             use TokenizedEquityMint::*;
             use TokenizedEquityMintCommand::*;
             let command = match entity {
-                MintAccepted { .. } => FailAcceptance {
+                // A mint stuck at MintRequested (requested at the provider but
+                // never accepted) is force-failed via FailAcceptance, which the
+                // aggregate now accepts from MintRequested.
+                MintRequested { .. } | MintAccepted { .. } => FailAcceptance {
                     reason: reason.to_string(),
                 },
                 TokensReceived { .. } | WrapSubmitted { .. } => FailWrapping {
@@ -1173,9 +1176,6 @@ pub(crate) async fn fail_transfer_command<W: Write>(
                 TokensWrapped { .. } | VaultDepositSubmitted { .. } => FailRaindexDeposit {
                     reason: reason.to_string(),
                 },
-                MintRequested { .. } => {
-                    anyhow::bail!("Mint {id} is at MintRequested -- cannot fail before acceptance");
-                }
                 DepositedIntoRaindex { .. } => {
                     anyhow::bail!("Mint {id} already completed (DepositedIntoRaindex)");
                 }
@@ -3794,6 +3794,94 @@ mod tests {
         assert!(
             err_msg.contains("already reconciled"),
             "failing an already-reconciled mint must refuse; got: {err_msg}"
+        );
+    }
+
+    /// Inserts a raw event row for a `TokenizedEquityMint` aggregate. The
+    /// `MintRequested`-only state is unreachable via commands by design (the bot
+    /// requests and accepts/rejects in one atomic command), so a mint genuinely
+    /// stuck pre-acceptance only exists in an abnormal event log and must be
+    /// seeded as a raw event -- the established test-only pattern for states
+    /// unreachable via commands, mirroring this aggregate's own test module.
+    /// Sequences are 1-based (the snapshot-aware loader reads `sequence > 0`).
+    async fn insert_mint_event(
+        pool: &SqlitePool,
+        id: &IssuerRequestId,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, payload, metadata) \
+             VALUES ('TokenizedEquityMint', ?, ?, ?, '1.0', ?, '{}')",
+        )
+        .bind(id.to_string())
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn fail_transfer_mint_force_fails_from_requested() {
+        // RAI-999: a mint stuck at MintRequested (requested at the provider but
+        // never accepted) must force-fail via the CLI -- previously the CLI
+        // bailed with "cannot fail before acceptance". The state is unreachable
+        // via commands, so seed a bare MintRequested raw event.
+        let pool = setup_test_db().await;
+        let id = issuer_request_id("cli-mint-requested");
+        insert_mint_event(
+            &pool,
+            &id,
+            1,
+            "TokenizedEquityMintEvent::MintRequested",
+            r#"{"MintRequested":{"symbol":"AAPL","quantity":"10","wallet":"0x0000000000000000000000000000000000000001","requested_at":"2026-01-01T00:00:00Z"}}"#,
+        )
+        .await;
+
+        // Guard: the precondition must actually be MintRequested, so the test
+        // cannot silently drift to exercising a different dispatch arm.
+        let seeded = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(seeded, TokenizedEquityMint::MintRequested { .. }),
+            "precondition must be MintRequested, got: {seeded:?}"
+        );
+
+        let mut stdout = Vec::new();
+        fail_transfer_command(
+            &mut stdout,
+            &pool,
+            TransferType::Mint,
+            &id.to_string(),
+            "stuck at provider, never accepted",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8(stdout).unwrap(),
+            format!("Mint {id} marked as failed\n"),
+            "the operator-facing confirmation message must be printed"
+        );
+
+        let entity = st0x_event_sorcery::load_entity::<TokenizedEquityMint>(&pool, &id)
+            .await
+            .unwrap()
+            .unwrap();
+        let TokenizedEquityMint::Failed { reason, .. } = entity else {
+            panic!(
+                "a force-failed MintRequested mint must reach the Failed terminal, got: {entity:?}"
+            );
+        };
+        assert_eq!(
+            reason, "stuck at provider, never accepted",
+            "the operator reason must survive the full CLI dispatch into the Failed state"
         );
     }
 

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -2271,6 +2271,7 @@ impl RebalancingService {
     fn mint_inventory_update(
         event: &TokenizedEquityMintEvent,
         quantity: FractionalShares,
+        stage: MintTrackingStage,
     ) -> Option<EquityInventoryUpdate> {
         use TokenizedEquityMintEvent::*;
 
@@ -2278,10 +2279,28 @@ impl RebalancingService {
             MintAccepted { .. } => {
                 Some(Self::start_equity_transfer_update(Venue::Hedging, quantity))
             }
-            MintAcceptanceFailed { .. } => Some(Self::cancel_equity_transfer_update(
-                Venue::Hedging,
-                quantity,
-            )),
+            // Cancel the Hedging inflight that `MintAccepted` started -- but ONLY
+            // if acceptance actually happened. The operator force-fail from
+            // `MintRequested` (RAI-999) emits this same event PRE-acceptance,
+            // where no inflight was ever started; cancelling there would be an
+            // unmatched Cancel. Gating on the tracking stage makes this honour
+            // SPEC's "no balance change for a pre-acceptance force-fail" rule by
+            // construction -- independent of process topology (the CLI's
+            // separate-process write also keeps it off this reactor today, but
+            // this guard is what keeps it correct if `transfer fail` is ever
+            // routed through the running bot). `track_mint_progress` does not
+            // advance the stage on `MintAcceptanceFailed`, so the stage here is
+            // `Requested` for a pre-acceptance fail and `Accepted` otherwise.
+            MintAcceptanceFailed { .. } => match stage {
+                MintTrackingStage::Requested => None,
+                MintTrackingStage::Accepted
+                | MintTrackingStage::TokensReceived
+                | MintTrackingStage::WrapSubmitted
+                | MintTrackingStage::TokensWrapped
+                | MintTrackingStage::VaultDepositSubmitted => Some(
+                    Self::cancel_equity_transfer_update(Venue::Hedging, quantity),
+                ),
+            },
             // TokensReceived completes the normal mint; ProviderCompletionRecovered
             // completes a recovered one. rebuild_mint_tracking_for_recovery restores
             // the canonical in-flight shape (Hedging in-flight = quantity, available
@@ -3996,7 +4015,8 @@ impl RebalancingService {
         };
         let symbol = tracking.symbol;
 
-        if let Some(update) = Self::mint_inventory_update(&event, tracking.quantity) {
+        if let Some(update) = Self::mint_inventory_update(&event, tracking.quantity, tracking.stage)
+        {
             self.apply_equity_update(&symbol, update).await?;
         }
 
@@ -4296,6 +4316,58 @@ mod tests {
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
     };
     use crate::vault_registry::VaultRegistryCommand;
+
+    #[test]
+    fn mint_inventory_update_skips_cancel_for_pre_acceptance_fail() {
+        // RAI-999: a pre-acceptance force-fail (tracking stage still Requested)
+        // started no Hedging inflight, so it must produce NO inventory update --
+        // a Cancel there would be unmatched. (The post-acceptance Cancel path is
+        // covered end-to-end by `recover_mint_clears_hedging_inflight`.)
+        let event = TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "operator force-fail".to_string(),
+            failed_at: Utc::now(),
+        };
+        let quantity = FractionalShares::new(float!(10));
+
+        let update = RebalancingService::mint_inventory_update(
+            &event,
+            quantity,
+            MintTrackingStage::Requested,
+        );
+        assert!(
+            update.is_none(),
+            "pre-acceptance MintAcceptanceFailed must not produce an inventory update"
+        );
+    }
+
+    #[test]
+    fn mint_inventory_update_cancels_for_post_acceptance_fail() {
+        // Once acceptance happened `MintAccepted` started a Hedging inflight, so
+        // every later `MintAcceptanceFailed` (operator force-fail or poll-driven)
+        // MUST cancel it. This pins the cancel arms in place: the pre-acceptance
+        // skip test alone would still pass if they were collapsed to `None`. The
+        // end-to-end cancel effect lives in `recover_mint_clears_hedging_inflight`
+        // (a distant file); this guards the match wiring locally.
+        let event = TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "operator force-fail".to_string(),
+            failed_at: Utc::now(),
+        };
+        let quantity = FractionalShares::new(float!(10));
+
+        for stage in [
+            MintTrackingStage::Accepted,
+            MintTrackingStage::TokensReceived,
+            MintTrackingStage::WrapSubmitted,
+            MintTrackingStage::TokensWrapped,
+            MintTrackingStage::VaultDepositSubmitted,
+        ] {
+            let update = RebalancingService::mint_inventory_update(&event, quantity, stage);
+            assert!(
+                update.is_some(),
+                "post-acceptance MintAcceptanceFailed (stage {stage}) must cancel the Hedging inflight"
+            );
+        }
+    }
 
     fn test_config() -> RebalancingServiceConfig {
         RebalancingServiceConfig {

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -274,7 +274,10 @@ pub(crate) enum TokenizedEquityMintCommand {
     DepositToVault {
         vault_deposit_tx_hash: TxHash,
     },
-    /// Operator or timeout-driven failure from `MintAccepted` state.
+    /// Operator or timeout-driven failure from `MintAccepted` state, or operator
+    /// force-fail from `MintRequested` (requested at the provider but never
+    /// accepted). Both emit `MintAcceptanceFailed`; the pre-acceptance case
+    /// moved no shares to inflight, so there is nothing to restore.
     FailAcceptance {
         reason: String,
     },
@@ -333,8 +336,14 @@ pub(crate) enum TokenizedEquityMintEvent {
         tokenization_request_id: TokenizationRequestId,
         accepted_at: DateTime<Utc>,
     },
-    /// Mint failed after acceptance but before tokens were received.
-    /// Shares were moved to inflight, can be safely restored to offchain available.
+    /// Mint failed before tokens were received. Two cases:
+    /// - failed after `MintAccepted`: shares were moved to inflight (Hedging),
+    ///   so the inventory reactor restores them to offchain available (Cancel).
+    /// - operator force-fail from `MintRequested` (pre-acceptance): NO shares
+    ///   were moved to inflight, so there is nothing to restore.
+    ///
+    /// `mint_inventory_update` gates the Cancel on the tracking stage having
+    /// reached `Accepted`, so the pre-acceptance case is a no-op there.
     MintAcceptanceFailed {
         reason: String,
         failed_at: DateTime<Utc>,
@@ -1486,12 +1495,21 @@ impl EventSourced for TokenizedEquityMint {
             }
 
             MintAcceptanceFailed { reason, failed_at } => {
-                let Self::MintAccepted {
+                // Emitted from `MintAccepted` (post-acceptance failure) or
+                // `MintRequested` (operator force-fail before acceptance); both
+                // carry the symbol/quantity/requested_at the `Failed` state needs.
+                let (Self::MintAccepted {
                     symbol,
                     quantity,
                     requested_at,
                     ..
-                } = entity
+                }
+                | Self::MintRequested {
+                    symbol,
+                    quantity,
+                    requested_at,
+                    ..
+                }) = entity
                 else {
                     return Ok(None);
                 };
@@ -2066,16 +2084,31 @@ impl EventSourced for TokenizedEquityMint {
             },
 
             TokenizedEquityMintCommand::FailAcceptance { reason } => match self {
-                Self::MintAccepted { .. } => Ok(vec![MintAcceptanceFailed {
-                    reason,
-                    failed_at: Utc::now(),
-                }]),
+                // `MintRequested` is pre-acceptance: a mint stuck there (requested
+                // at the provider but never accepted) is force-failed by the
+                // operator. Acceptance never happened, so `MintAcceptanceFailed`
+                // is the honest terminal -- the same event the post-acceptance
+                // failure emits, broadened in `evolve` to also start from here.
+                Self::MintRequested { .. } | Self::MintAccepted { .. } => {
+                    Ok(vec![MintAcceptanceFailed {
+                        reason,
+                        failed_at: Utc::now(),
+                    }])
+                }
                 Self::DepositedIntoRaindex { .. } => {
                     Err(TokenizedEquityMintError::AlreadyCompleted)
                 }
                 Self::Failed { .. } => Err(TokenizedEquityMintError::AlreadyFailed),
                 Self::Reconciled { .. } => Err(TokenizedEquityMintError::AlreadyReconciled),
-                _ => Err(TokenizedEquityMintError::AlreadyInProgress),
+                // Past acceptance and mid-pipeline: failing acceptance no longer
+                // applies. Listed explicitly (not `_`) so a new state variant is
+                // a compile error here rather than a silent AlreadyInProgress.
+                Self::TokensReceived { .. }
+                | Self::WrapSubmitted { .. }
+                | Self::TokensWrapped { .. }
+                | Self::VaultDepositSubmitted { .. } => {
+                    Err(TokenizedEquityMintError::AlreadyInProgress)
+                }
             },
 
             TokenizedEquityMintCommand::FailWrapping { reason } => match self {
@@ -2500,21 +2533,43 @@ mod tests {
     }
 
     #[test]
-    fn test_evolve_acceptance_failed_rejects_non_accepted_states() {
-        let requested = TokenizedEquityMint::MintRequested {
+    fn test_evolve_acceptance_failed_rejects_inapplicable_states() {
+        // MintAcceptanceFailed applies from MintRequested (operator force-fail)
+        // and MintAccepted (post-acceptance failure); it must NOT apply to a
+        // state past acceptance -- a mid-pipeline TokensReceived or a terminal
+        // Failed mint.
+        let already_failed = TokenizedEquityMint::Failed {
             symbol: Symbol::new("AAPL").unwrap(),
             quantity: float!(100.5),
-            wallet: Address::random(),
+            reason: "previous failure".to_string(),
             requested_at: Utc::now(),
+            failed_at: Utc::now(),
         };
+        // Mid-pipeline (past acceptance) and a terminal failure: the two classes
+        // of state that must reject the event. TokensReceived stands in for the
+        // mid-pipeline states (WrapSubmitted/TokensWrapped/VaultDepositSubmitted),
+        // which the production `evolve` treats identically (anything that is not
+        // MintRequested/MintAccepted maps to None).
+        let tokens_received = replay::<TokenizedEquityMint>(vec![
+            mint_requested_event(),
+            mint_accepted_event(),
+            tokens_received_event(),
+        ])
+        .unwrap()
+        .unwrap();
 
         let event = TokenizedEquityMintEvent::MintAcceptanceFailed {
             reason: "Should not apply".to_string(),
             failed_at: Utc::now(),
         };
 
-        let result = TokenizedEquityMint::evolve(&requested, &event).unwrap();
-        assert_eq!(result, None);
+        for state in [already_failed, tokens_received] {
+            assert_eq!(
+                TokenizedEquityMint::evolve(&state, &event).unwrap(),
+                None,
+                "MintAcceptanceFailed must not apply to {state:?}"
+            );
+        }
     }
 
     #[test]
@@ -3220,6 +3275,74 @@ mod tests {
         assert!(
             matches!(entity, TokenizedEquityMint::Failed { .. }),
             "Expected Failed state, got: {entity:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_acceptance_from_requested_force_fails_to_failed() {
+        // A mint stuck at MintRequested (requested but never accepted) can be
+        // operator-force-failed via FailAcceptance, emitting MintAcceptanceFailed
+        // and terminating in Failed.
+        let history = vec![mint_requested_event()];
+
+        let reason = "stuck pre-acceptance; operator force-fail";
+        let events = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(history.clone())
+            .when(TokenizedEquityMintCommand::FailAcceptance {
+                reason: reason.to_string(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: event_reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("expected MintAcceptanceFailed, got {:?}", events[0]);
+        };
+        assert_eq!(event_reason, reason);
+
+        let state = replay::<TokenizedEquityMint>([history, events].concat())
+            .expect("event stream should replay")
+            .expect("event stream should materialize a state");
+        let TokenizedEquityMint::Failed {
+            reason: state_reason,
+            ..
+        } = state
+        else {
+            panic!("force-fail from MintRequested must terminate in Failed, got {state:?}");
+        };
+        assert_eq!(
+            state_reason, reason,
+            "the operator reason must survive into the Failed terminal state"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_acceptance_from_mid_pipeline_is_rejected() {
+        // FailAcceptance broadened to accept MintRequested/MintAccepted; a mint
+        // that moved past acceptance (TokensReceived) must still be rejected, so
+        // the success arm did not over-widen.
+        let error = TestHarness::<TokenizedEquityMint>::with(mint_services(MockTokenizer::new()))
+            .given(vec![
+                mint_requested_event(),
+                mint_accepted_event(),
+                tokens_received_event(),
+            ])
+            .when(TokenizedEquityMintCommand::FailAcceptance {
+                reason: "should be rejected".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(TokenizedEquityMintError::AlreadyInProgress)
+            ),
+            "FailAcceptance from a mid-pipeline state must be AlreadyInProgress, got {error:?}"
         );
     }
 


### PR DESCRIPTION
## What
Implements [RAI-999](https://linear.app/makeitrain/issue/RAI-999) — Step 10 (final gap) of [RAI-978](https://linear.app/makeitrain/issue/RAI-978). `transfer fail --kind mint` can now force-fail a mint stuck at `MintRequested`.

## Why
A mint stuck at `MintRequested` (requested at the provider but never accepted) had no operator force-fail path — the CLI bailed with "cannot fail before acceptance," and the aggregate returned `AlreadyInProgress`. RAI-978's coverage matrix flagged this as the last gap.

## How
`FailAcceptance` is now valid from `MintRequested` (emitting `MintAcceptanceFailed`), and that event's `evolve` is broadened to start from `MintRequested` as well as `MintAccepted` → `Failed`. No new event or schema bump (reuses `MintAcceptanceFailed`). The CLI maps a `MintRequested` mint to `FailAcceptance` instead of bailing. CQRS aggregate-command flow throughout.

## Testing
Aggregate test: `FailAcceptance` from `MintRequested` → `MintAcceptanceFailed` → `Failed`. Adjusted an existing evolve test (the case it guarded, `MintAcceptanceFailed` from `MintRequested`, is now intentionally valid) to assert rejection from a terminal `Failed` state instead. 179 mint/cli tests pass; clippy + fmt clean.

## Anything else
Closes the recovery-CLI epic [RAI-978](https://linear.app/makeitrain/issue/RAI-978) coverage matrix.
