### PR TITLE
fix: align prod SGOV vault_id with other equities (0xfab4 -> 0xfab)

### DIFF
--- a/config/prod/st0x-hedge.toml
+++ b/config/prod/st0x-hedge.toml
@@ -120,7 +120,7 @@ pyth_feed_id = "0x8d6a29bb5ed522931d711bb12c4bbf92af986936e52af582032913b5ffcbf4
 trading = "enabled"
 rebalancing = "enabled"
 wrapped_equity_recovery = "enabled"
-vault_id = "0xfab4"
+vault_id = "0xfab"
 tokenized_equity = "0xc941C1506B7555Ba8C506Fb6c9b9CC259902d612"
 tokenized_equity_derivative = "0x78c31580c97101694c70022c83d570150c11e935"
 


### PR DESCRIPTION
## What

- Change prod SGOV `vault_id` from `0xfab4` to `0xfab` in `config/prod/st0x-hedge.toml`.

## Why

- SGOV was the only prod equity on vault `0xfab4`; every other prod equity (and staging SGOV) uses `0xfab`.

## How

- One-line config change.

## Testing

Config-only change; no code or test changes.

## Screenshots

N/A

## Anything else

The prod `[assets.cash]` USDC vault still uses `0xfab4` — intentionally untouched; the scope here is SGOV only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minor correction to the SGOV equity configuration in production to ensure the correct identifier is used. This is a small, non-functional configuration update with no expected change to user-facing behavior. Low-risk, low-effort change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Linear: RAI-1007
