### PR TITLE
feat: rebalance stage-timing read model and GET /performance/rebalances

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -78,6 +78,14 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     HedgeCycleReport::export_all_to(out_dir)?;
     HedgeCycleStatus::export_all_to(out_dir)?;
     OpenExposureReport::export_all_to(out_dir)?;
+    RebalanceTimings::export_all_to(out_dir)?;
+    RebalanceOperationTiming::export_all_to(out_dir)?;
+    RebalanceTimingStatus::export_all_to(out_dir)?;
+    RebalanceStageTiming::export_all_to(out_dir)?;
+    StageOutcome::export_all_to(out_dir)?;
+    RebalanceStageName::export_all_to(out_dir)?;
+    RebalanceStageStats::export_all_to(out_dir)?;
+    AttestationSample::export_all_to(out_dir)?;
     std::fs::write(out_dir.join("StatementGuard.ts"), Statement::guard_ts())
         .map_err(ts_rs::ExportError::Io)?;
 

--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -1,11 +1,13 @@
-//! Performance tab DTOs: hedge latency pipeline metrics.
+//! Performance tab DTOs: hedge latency pipeline and rebalance timing metrics.
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use ts_rs::TS;
 use uuid::Uuid;
 
-use st0x_finance::Symbol;
+use st0x_finance::{Symbol, Usdc};
+
+use crate::UsdcBridgeDirection;
 
 /// Response of `GET /performance/latencies`.
 #[derive(Debug, Clone, Serialize, TS)]
@@ -117,6 +119,123 @@ pub struct OpenExposureReport {
     pub oldest_fill_block_timestamp: DateTime<Utc>,
 }
 
+/// Response of `GET /performance/rebalances`.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct RebalanceTimings {
+    /// Most recent operations (stage breakdown rows), newest first.
+    pub operations: Vec<RebalanceOperationTiming>,
+    /// Total operations in range before the `operations` cap was applied.
+    #[ts(type = "number")]
+    pub total_operations: usize,
+    /// Operations dropped because their stored timing JSON failed to
+    /// deserialize. They are excluded from every field above; this count
+    /// surfaces the gap so a malformed read-model row is not silently invisible.
+    #[ts(type = "number")]
+    pub skipped_operations: u32,
+    /// Percentiles per stage across all operations in range.
+    ///
+    /// SPARSE: a stage with no completed (`Succeeded`) samples in range is
+    /// omitted entirely rather than emitted with an empty/zero entry. Consumers
+    /// must look stages up by name and tolerate absence, not index positionally.
+    pub stage_summary: Vec<RebalanceStageStats>,
+    /// CCTP attestation duration over time, oldest first.
+    pub attestation_trend: Vec<AttestationSample>,
+}
+
+/// One USDC rebalance operation's per-stage timing breakdown.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct RebalanceOperationTiming {
+    #[ts(type = "string")]
+    pub operation_id: Uuid,
+    pub direction: Option<UsdcBridgeDirection>,
+    #[ts(type = "string | null")]
+    pub amount: Option<Usdc>,
+    /// Genuine operation start (the first-phase conversion or withdrawal event).
+    /// `null` when the read model first observed the operation mid-stream
+    /// (e.g. after a deploy), in which case its start time is unknown and
+    /// `total_ms` is unmeasured.
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub status: RebalanceTimingStatus,
+    pub stages: Vec<RebalanceStageTiming>,
+    /// Genuine start to terminal success, when both endpoints are known.
+    /// `null` when the operation is unfinished, or when `started_at` is unknown
+    /// (mid-stream first observation), or when completion was an out-of-band
+    /// `OperatorReconciled` (whose manual-response window must not pollute
+    /// round-trip latency metrics).
+    #[ts(type = "number | null")]
+    pub total_ms: Option<i64>,
+}
+
+/// Where a rebalance operation currently stands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum RebalanceTimingStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// Timing of one stage within a rebalance operation.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct RebalanceStageTiming {
+    pub stage: RebalanceStageName,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    #[ts(type = "number | null")]
+    pub duration_ms: Option<i64>,
+    pub outcome: StageOutcome,
+}
+
+/// How a rebalance stage run ended.
+///
+/// Only `Succeeded` runs carry a meaningful `duration_ms` for percentile
+/// aggregation. `Failed` runs are timed but excluded from latency stats so a
+/// failure does not contaminate the metric. `Unmeasured` runs demonstrably
+/// happened but have no measurable duration (e.g. a burn with no submitting
+/// intent, or a mint discovered after the fact by recovery); they carry a
+/// `null` `duration_ms` and never enter percentiles. An in-progress stage that
+/// has not yet ended also reports `Unmeasured` until it closes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum StageOutcome {
+    Succeeded,
+    Failed,
+    Unmeasured,
+}
+
+/// Stages of the USDC rebalance pipeline, in flow order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum RebalanceStageName {
+    Conversion,
+    Withdrawal,
+    Burn,
+    Attestation,
+    Mint,
+    Deposit,
+}
+
+/// Percentiles for one rebalance stage.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct RebalanceStageStats {
+    pub stage: RebalanceStageName,
+    pub stats: LatencyStats,
+}
+
+/// One completed CCTP attestation: burn time and how long Circle took.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct AttestationSample {
+    pub burned_at: DateTime<Utc>,
+    #[ts(type = "number")]
+    pub duration_ms: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -175,6 +294,84 @@ mod tests {
         assert_eq!(json["executionMs"], json!(null));
         assert_eq!(json["exposureWindowMs"], json!(null));
         assert_eq!(json["status"], json!("pending"));
+    }
+
+    #[test]
+    fn rebalance_operation_timing_serializes_camel_case() {
+        let operation = RebalanceOperationTiming {
+            operation_id: "11111111-2222-3333-4444-555555555555".parse().unwrap(),
+            direction: Some(UsdcBridgeDirection::AlpacaToBase),
+            amount: Some(Usdc::new(st0x_float_macro::float!(1000))),
+            started_at: DateTime::from_timestamp(1_750_000_000, 0),
+            completed_at: DateTime::from_timestamp(1_750_000_730, 0),
+            status: RebalanceTimingStatus::Completed,
+            stages: vec![RebalanceStageTiming {
+                stage: RebalanceStageName::Attestation,
+                started_at: DateTime::from_timestamp(1_750_000_070, 0).unwrap(),
+                ended_at: DateTime::from_timestamp(1_750_000_670, 0),
+                duration_ms: Some(600_000),
+                outcome: StageOutcome::Succeeded,
+            }],
+            total_ms: Some(730_000),
+        };
+
+        let json = serde_json::to_value(&operation).expect("serialization should succeed");
+        assert_eq!(
+            json["operationId"],
+            json!("11111111-2222-3333-4444-555555555555")
+        );
+        assert_eq!(json["direction"], json!("alpaca_to_base"));
+        assert_eq!(json["amount"], json!("1000"));
+        assert_eq!(json["startedAt"], json!("2025-06-15T15:06:40Z"));
+        assert_eq!(json["completedAt"], json!("2025-06-15T15:18:50Z"));
+        assert_eq!(json["status"], json!("completed"));
+        assert_eq!(json["totalMs"], json!(730_000));
+        assert_eq!(json["stages"][0]["stage"], json!("attestation"));
+        assert_eq!(
+            json["stages"][0]["startedAt"],
+            json!("2025-06-15T15:07:50Z")
+        );
+        assert_eq!(json["stages"][0]["endedAt"], json!("2025-06-15T15:17:50Z"));
+        assert_eq!(json["stages"][0]["durationMs"], json!(600_000));
+        assert_eq!(json["stages"][0]["outcome"], json!("succeeded"));
+    }
+
+    #[test]
+    fn rebalance_operation_timing_serializes_null_optional_fields() {
+        let operation = RebalanceOperationTiming {
+            operation_id: "22222222-3333-4444-5555-666666666666".parse().unwrap(),
+            direction: None,
+            amount: None,
+            started_at: None,
+            completed_at: None,
+            status: RebalanceTimingStatus::InProgress,
+            stages: Vec::new(),
+            total_ms: None,
+        };
+
+        let json = serde_json::to_value(&operation).expect("serialization should succeed");
+        assert_eq!(json["direction"], json!(null));
+        assert_eq!(json["amount"], json!(null));
+        assert_eq!(json["startedAt"], json!(null));
+        assert_eq!(json["completedAt"], json!(null));
+        assert_eq!(json["totalMs"], json!(null));
+        assert_eq!(json["status"], json!("in_progress"));
+    }
+
+    #[test]
+    fn stage_outcome_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(StageOutcome::Succeeded).unwrap(),
+            json!("succeeded")
+        );
+        assert_eq!(
+            serde_json::to_value(StageOutcome::Failed).unwrap(),
+            json!("failed")
+        );
+        assert_eq!(
+            serde_json::to_value(StageOutcome::Unmeasured).unwrap(),
+            json!("unmeasured")
+        );
     }
 
     #[test]

--- a/crates/dto/src/transfer.rs
+++ b/crates/dto/src/transfer.rs
@@ -89,7 +89,7 @@ pub enum EquityRedemptionStatus {
 }
 
 /// Direction for USDC bridge transfers.
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum UsdcBridgeDirection {
     AlpacaToBase,

--- a/migrations/20260616221000_rebalance_timing_read_model.sql
+++ b/migrations/20260616221000_rebalance_timing_read_model.sql
@@ -1,0 +1,24 @@
+-- Forward-only read model for the rebalance stage-timing report.
+--
+-- This table is maintained exclusively by the RebalanceTimingProjection
+-- reactor from live UsdcRebalance events. The report read path
+-- (load_rebalance_timings) queries ONLY this table and never folds the events
+-- table. One row per UsdcRebalance operation (aggregate id).
+--
+-- `started_at` is stored as RFC3339 TEXT (chrono `to_rfc3339`) so the report
+-- can filter and order operations. This SQL column holds the timestamp of the
+-- FIRST event this reactor observed for the operation (`first_seen_at`) and is
+-- used exclusively for range filtering and ordering -- NOT the genuine business
+-- start. `timing` is the JSON-serialized accumulated operation timing
+-- (direction, amount, status, the genuine `started_at`/`completed_at`, and the
+-- ordered stage list with per-stage durations) that the read path converts into
+-- the dashboard DTO. `total_ms` is derived at read time from the `started_at`
+-- and `completed_at` fields embedded in the `timing` JSON blob (not from this
+-- SQL `started_at` column), and is not stored separately.
+CREATE TABLE rebalance_stage_timing (
+    operation_id TEXT PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    timing TEXT NOT NULL
+);
+
+CREATE INDEX idx_rebalance_stage_timing_started_at ON rebalance_stage_timing (started_at);

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,12 +16,13 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use st0x_dto::{HedgeLatencies, TradingVenue};
+use st0x_dto::{HedgeLatencies, RebalanceTimings, TradingVenue};
 use st0x_execution::FractionalShares;
 
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
+use crate::performance::rebalance::load_rebalance_timings;
 use crate::performance::{ReportRange, hedge_latency_report, load_hedge_performance};
 use crate::rebalancing::RebalancingService;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
@@ -1488,17 +1489,17 @@ fn recheck_error_response(error: &RecheckError) -> (StatusCode, String) {
     }
 }
 
-/// Query window for `GET /performance/latencies`. Defaults to the last
-/// 7 days ending now.
+/// Date-range query window shared by the `/performance/*` endpoints.
+/// Defaults to the last 7 days ending now.
 #[derive(Debug, Deserialize)]
-struct PerformanceLatenciesQuery {
+struct PerformanceRangeQuery {
     from: Option<DateTime<Utc>>,
     to: Option<DateTime<Utc>>,
 }
 
 async fn performance_latencies(
     State(state): State<AppState>,
-    Query(query): Query<PerformanceLatenciesQuery>,
+    Query(query): Query<PerformanceRangeQuery>,
 ) -> Result<Json<HedgeLatencies>, StatusCode> {
     let to = query.to.unwrap_or_else(Utc::now);
     let from = query.from.unwrap_or(to - chrono::Duration::days(7));
@@ -1515,10 +1516,29 @@ async fn performance_latencies(
     Ok(Json(hedge_latency_report(&performances, &report_range)))
 }
 
+async fn performance_rebalances(
+    State(state): State<AppState>,
+    Query(query): Query<PerformanceRangeQuery>,
+) -> Result<Json<RebalanceTimings>, StatusCode> {
+    let to = query.to.unwrap_or_else(Utc::now);
+    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
+    if from >= to {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let timings = load_rebalance_timings(&state.pool, &ReportRange { from, to })
+        .await
+        .inspect_err(|error| error!(%error, "Failed to load rebalance timings"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(timings))
+}
+
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health))
         .route("/performance/latencies", get(performance_latencies))
+        .route("/performance/rebalances", get(performance_rebalances))
         .route("/logs", get(logs))
         .route("/orders/pending", get(pending_orders))
         .route("/trades", get(trades))
@@ -1992,6 +2012,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn performance_rebalances_returns_empty_report_on_fresh_database() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/rebalances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["totalOperations"], serde_json::json!(0));
+        assert_eq!(report["operations"], serde_json::json!([]));
+        assert_eq!(report["stageSummary"], serde_json::json!([]));
+        assert_eq!(report["attestationTrend"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
     async fn performance_latencies_rejects_inverted_range() {
         let ctx = create_test_ctx_with_order_owner(Address::ZERO);
         let app = build_app(empty_app_state(ctx).await);
@@ -2098,6 +2142,85 @@ mod tests {
         assert_eq!(
             report["summary"]["stages"]["detection"]["p50Ms"],
             serde_json::json!(3000)
+        );
+    }
+
+    #[tokio::test]
+    async fn performance_rebalances_rejects_inverted_range() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/rebalances\
+                         ?from=2026-01-02T00:00:00Z&to=2026-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_rebalances_reports_seeded_operations() {
+        use st0x_event_sorcery::ReactorHarness;
+        use st0x_float_macro::float;
+
+        use crate::performance::rebalance::RebalanceTimingProjection;
+        use crate::usdc_rebalance::{
+            RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
+        };
+
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+
+        // Drive the real reactor (not a hand-crafted JSON blob) so this test
+        // stays at the public API surface and is decoupled from the private
+        // StoredOperation serde schema. One BaseToAlpaca WithdrawalSubmitting
+        // event leaves an open, in-progress Withdrawal stage.
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(state.pool.clone()));
+        let operation_id = UsdcRebalanceId(uuid::Uuid::new_v4());
+        harness
+            .receive::<UsdcRebalance>(
+                operation_id,
+                UsdcRebalanceEvent::WithdrawalSubmitting {
+                    direction: RebalanceDirection::BaseToAlpaca,
+                    amount: st0x_finance::Usdc::new(float!(500)),
+                    from_block: 1,
+                    submitting_at: chrono::Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/rebalances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["totalOperations"], serde_json::json!(1));
+        assert_eq!(
+            report["operations"][0]["status"],
+            serde_json::json!("in_progress")
+        );
+        assert_eq!(
+            report["operations"][0]["direction"],
+            serde_json::json!("base_to_alpaca")
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -62,6 +62,7 @@ use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
 use crate::performance::HedgeLatencyProjection;
+use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::position::{Position, PositionCommand, PositionError, TradeId};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
@@ -1185,7 +1186,13 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
 
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(deps.pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster, hedge_latency);
+        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(deps.pool.clone()));
+        let manifest = QueryManifest::new(
+            rebalancing_service.clone(),
+            broadcaster,
+            hedge_latency,
+            rebalance_timing,
+        );
 
         let built = manifest
             .build(deps.pool.clone(), equity_transfer_services)

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -22,6 +22,7 @@ use crate::dashboard::Broadcaster;
 use crate::equity_redemption::EquityRedemption;
 use crate::inventory::InventorySnapshot;
 use crate::performance::HedgeLatencyProjection;
+use crate::performance::rebalance::RebalanceTimingProjection;
 use crate::position::Position;
 use crate::rebalancing::{RebalancingService, equity::EquityTransferServices};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
@@ -36,6 +37,7 @@ pub(super) struct QueryManifest {
     rebalancing_service: Arc<RebalancingService>,
     broadcaster: Arc<Broadcaster>,
     hedge_latency: Arc<HedgeLatencyProjection>,
+    rebalance_timing: Arc<RebalanceTimingProjection>,
 }
 
 /// Built CQRS frameworks from the wiring process.
@@ -57,11 +59,13 @@ impl QueryManifest {
         rebalancing_service: Arc<RebalancingService>,
         broadcaster: Arc<Broadcaster>,
         hedge_latency: Arc<HedgeLatencyProjection>,
+        rebalance_timing: Arc<RebalanceTimingProjection>,
     ) -> Self {
         Self {
             rebalancing_service,
             broadcaster,
             hedge_latency,
+            rebalance_timing,
         }
     }
 
@@ -79,6 +83,7 @@ impl QueryManifest {
             rebalancing_service,
             broadcaster,
             hedge_latency,
+            rebalance_timing,
         } = self;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
@@ -103,6 +108,7 @@ impl QueryManifest {
         let usdc = StoreBuilder::<UsdcRebalance>::new(pool.clone())
             .with(rebalancing_service.clone())
             .with(broadcaster)
+            .with(rebalance_timing)
             .build(())
             .await?;
 
@@ -197,7 +203,13 @@ mod tests {
 
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_service, broadcaster, hedge_latency);
+        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let manifest = QueryManifest::new(
+            rebalancing_service,
+            broadcaster,
+            hedge_latency,
+            rebalance_timing,
+        );
 
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
@@ -246,7 +258,13 @@ mod tests {
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_service, broadcaster, hedge_latency);
+        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let manifest = QueryManifest::new(
+            rebalancing_service,
+            broadcaster,
+            hedge_latency,
+            rebalance_timing,
+        );
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
             vault_lookup: Arc::new(MockVaultLookup::new()),
@@ -354,7 +372,13 @@ mod tests {
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
-        let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster, hedge_latency);
+        let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let manifest = QueryManifest::new(
+            rebalancing_service.clone(),
+            broadcaster,
+            hedge_latency,
+            rebalance_timing,
+        );
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
             vault_lookup: Arc::new(MockVaultLookup::new()),

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -43,6 +43,8 @@ use st0x_execution::Symbol;
 use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
 use crate::position::{Position, PositionEvent, TradeId};
 
+pub(crate) mod rebalance;
+
 /// Waterfall rows returned per report; the full cycle count is still
 /// reported via `total_cycles`.
 const MAX_CYCLE_REPORTS: usize = 100;

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -1,0 +1,1801 @@
+//! Rebalance stage timing read model maintained forward-only by a reactor.
+//!
+//! [`RebalanceTimingProjection`] subscribes to the `UsdcRebalance` event
+//! stream and maintains the `rebalance_stage_timing` table: one row per
+//! operation holding the accumulated per-stage breakdown (conversion,
+//! withdrawal, CCTP burn -> attestation -> mint, deposit). The report read
+//! path ([`load_rebalance_timings`]) queries ONLY that table and never folds
+//! the `events` table.
+//!
+//! Each operation's accumulated state is stored as a JSON [`StoredOperation`]
+//! so the reactor can apply one event at a time (load -> apply -> upsert),
+//! reproducing the same stage breakdown the old fold computed over a full
+//! stream. The read path converts each stored operation into the dashboard DTO.
+//!
+//! Forward-only: the reactor processes only events emitted after construction.
+//! There is NO startup backfill of pre-existing history. A crash between an
+//! event being persisted and this reactor's table being updated can drop that
+//! single event from the read model -- accepted as best-effort, matching the
+//! `Broadcaster` reactor's guarantees.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{Sqlite, SqlitePool, Transaction};
+use thiserror::Error;
+use tracing::warn;
+
+use st0x_dto::{
+    AttestationSample, RebalanceOperationTiming, RebalanceStageName, RebalanceStageStats,
+    RebalanceStageTiming, RebalanceTimingStatus, RebalanceTimings, StageOutcome,
+};
+use st0x_event_sorcery::{EntityList, Reactor, deps};
+use st0x_finance::Usdc;
+
+use super::{PerformanceError, ReportRange, latency_stats};
+use crate::usdc_rebalance::{
+    RebalanceDirection, UsdcRebalance, UsdcRebalanceEvent, UsdcRebalanceId,
+};
+
+/// Stage-breakdown rows returned per report; the full operation count is
+/// still reported via `total_operations`.
+const MAX_OPERATION_REPORTS: usize = 100;
+
+/// Load rebalance stage timings for operations started within `range`.
+///
+/// Reads ONLY the reactor-maintained `rebalance_stage_timing` table. Rows whose
+/// stored timing is undeserializable are skipped with a warning rather than
+/// failing the whole report.
+pub(crate) async fn load_rebalance_timings(
+    pool: &SqlitePool,
+    range: &ReportRange,
+) -> Result<RebalanceTimings, PerformanceError> {
+    let from = range.from.to_rfc3339();
+    let to = range.to.to_rfc3339();
+
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT operation_id, timing FROM rebalance_stage_timing \
+         WHERE started_at >= ? AND started_at <= ?",
+    )
+    .bind(&from)
+    .bind(&to)
+    .fetch_all(pool)
+    .await?;
+
+    let mut skipped_operations: u32 = 0;
+    let operations = rows
+        .into_iter()
+        .filter_map(|(operation_id, timing)| {
+            match serde_json::from_str::<StoredOperation>(&timing) {
+                Ok(stored) => Some(stored),
+                Err(error) => {
+                    warn!(%operation_id, %error, "Skipping undeserializable rebalance timing row");
+                    skipped_operations = skipped_operations.saturating_add(1);
+                    None
+                }
+            }
+        })
+        .map(WindowedOperation::from_stored)
+        .collect();
+
+    Ok(rebalance_timing_report(
+        operations,
+        range,
+        skipped_operations,
+    ))
+}
+
+/// A report operation paired with its observation time (`first_seen_at`), the
+/// timestamp the SQL window/sort key uses. Mid-stream-first operations have a
+/// `None` genuine `started_at` but always carry a `first_seen_at`, so windowing
+/// and ordering by it keeps them visible instead of sorting them to the tail and
+/// dropping them first on truncation.
+struct WindowedOperation {
+    first_seen_at: DateTime<Utc>,
+    operation: RebalanceOperationTiming,
+}
+
+impl WindowedOperation {
+    fn from_stored(stored: StoredOperation) -> Self {
+        Self {
+            first_seen_at: stored.first_seen_at,
+            operation: stored.into_dto(),
+        }
+    }
+}
+
+/// Assemble the dashboard report from windowed operations.
+///
+/// `skipped_operations` is the count of read-model rows that failed to
+/// deserialize upstream; it is surfaced verbatim so a malformed row is visible.
+fn rebalance_timing_report(
+    operations: Vec<WindowedOperation>,
+    range: &ReportRange,
+    skipped_operations: u32,
+) -> RebalanceTimings {
+    // Window by observation time (`first_seen_at`), not the genuine `started_at`:
+    // an operation first observed mid-stream has no known start but a valid
+    // observation time, so filtering by `first_seen_at` keeps it in range instead
+    // of dropping it on a `None` start.
+    let mut operations: Vec<WindowedOperation> = operations
+        .into_iter()
+        .filter(|windowed| range.contains(windowed.first_seen_at))
+        .collect();
+
+    let stage_summary = stage_summary(&operations);
+
+    let mut attestation_trend: Vec<AttestationSample> = operations
+        .iter()
+        .flat_map(|windowed| &windowed.operation.stages)
+        .filter(|stage| {
+            stage.stage == RebalanceStageName::Attestation
+                && stage.outcome == StageOutcome::Succeeded
+        })
+        .filter_map(|stage| {
+            Some(AttestationSample {
+                burned_at: stage.started_at,
+                duration_ms: stage.duration_ms?,
+            })
+        })
+        .collect();
+    attestation_trend.sort_by_key(|sample| sample.burned_at);
+
+    // Order by observation time (`first_seen_at`), not the genuine `started_at`:
+    // a mid-stream-first operation has no genuine start but must still keep its
+    // recency-ranked slot, otherwise it would sort to the tail and be the first
+    // dropped when the row cap fires.
+    operations.sort_unstable_by_key(|windowed| std::cmp::Reverse(windowed.first_seen_at));
+    let total_operations = operations.len();
+    operations.truncate(MAX_OPERATION_REPORTS);
+
+    RebalanceTimings {
+        operations: operations
+            .into_iter()
+            .map(|windowed| windowed.operation)
+            .collect(),
+        total_operations,
+        skipped_operations,
+        stage_summary,
+        attestation_trend,
+    }
+}
+
+/// Percentiles per stage over `Succeeded` stage runs only.
+///
+/// Returns a SPARSE list: a stage with no successful samples is omitted, not
+/// emitted with a zero entry. Only `Succeeded` runs carry a duration meaningful
+/// for percentiles -- `Failed` and `Unmeasured` runs are excluded.
+fn stage_summary(operations: &[WindowedOperation]) -> Vec<RebalanceStageStats> {
+    use RebalanceStageName::*;
+
+    [Conversion, Withdrawal, Burn, Attestation, Mint, Deposit]
+        .into_iter()
+        .filter_map(|name| {
+            let mut samples: Vec<i64> = operations
+                .iter()
+                .flat_map(|windowed| &windowed.operation.stages)
+                .filter(|stage| stage.stage == name && stage.outcome == StageOutcome::Succeeded)
+                .filter_map(|stage| stage.duration_ms)
+                .collect();
+            Some(RebalanceStageStats {
+                stage: name,
+                stats: latency_stats(&mut samples)?,
+            })
+        })
+        .collect()
+}
+
+/// Reactor maintaining the rebalance stage-timing read model from live events.
+pub(crate) struct RebalanceTimingProjection {
+    pool: SqlitePool,
+}
+
+deps!(RebalanceTimingProjection, [UsdcRebalance]);
+
+impl RebalanceTimingProjection {
+    pub(crate) fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    async fn load_operation_tx(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation_id: &UsdcRebalanceId,
+    ) -> Result<Option<StoredOperation>, ProjectionError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT timing FROM rebalance_stage_timing WHERE operation_id = ?")
+                .bind(operation_id.to_string())
+                .fetch_optional(&mut **tx)
+                .await?;
+
+        row.map(|(timing,)| serde_json::from_str::<StoredOperation>(&timing))
+            .transpose()
+            .map_err(Into::into)
+    }
+
+    async fn save_operation_tx(
+        tx: &mut Transaction<'_, Sqlite>,
+        operation: &StoredOperation,
+    ) -> Result<(), ProjectionError> {
+        let timing = serde_json::to_string(operation)?;
+        sqlx::query(
+            "INSERT INTO rebalance_stage_timing (operation_id, started_at, timing) \
+             VALUES (?, ?, ?) \
+             ON CONFLICT(operation_id) DO UPDATE SET \
+             started_at = excluded.started_at, timing = excluded.timing",
+        )
+        .bind(operation.operation_id.to_string())
+        // The `started_at` column orders and windows rows, so it tracks the
+        // first OBSERVED event even when the genuine start is still unknown
+        // (`StoredOperation::started_at` is `None`); without this a mid-stream
+        // operation would have no sort/filter key.
+        .bind(operation.first_seen_at.to_rfc3339())
+        .bind(timing)
+        .execute(&mut **tx)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn on_event(
+        &self,
+        operation_id: UsdcRebalanceId,
+        event: UsdcRebalanceEvent,
+    ) -> Result<(), ProjectionError> {
+        // Load, apply, and save in one transaction so a save failure cannot
+        // drop the event after a partial in-memory apply.
+        let mut tx = self.pool.begin().await?;
+
+        let mut operation = Self::load_operation_tx(&mut tx, &operation_id)
+            .await?
+            .unwrap_or_else(|| StoredOperation::new(operation_id.clone(), observed_at(&event)));
+        operation.apply(&operation_id, &event);
+        Self::save_operation_tx(&mut tx, &operation).await?;
+
+        tx.commit().await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ProjectionError {
+    #[error("rebalance stage-timing read-model write failed")]
+    Database(#[from] sqlx::Error),
+    #[error("rebalance operation timing (de)serialization failed")]
+    State(#[from] serde_json::Error),
+}
+
+#[async_trait]
+impl Reactor for RebalanceTimingProjection {
+    type Error = ProjectionError;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        event
+            .on(|id, event| async move { self.on_event(id, event).await })
+            .exhaustive()
+            .await
+    }
+}
+
+/// Accumulated per-operation timing state, persisted as JSON.
+///
+/// Mirrors the dashboard [`RebalanceOperationTiming`] DTO but with serde-
+/// friendly domain types so the reactor can load, apply one event, and upsert.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredOperation {
+    operation_id: UsdcRebalanceId,
+    direction: Option<RebalanceDirection>,
+    amount: Option<Usdc>,
+    /// Timestamp of the FIRST event this read model observed for the operation.
+    /// Always set, even when the genuine start was missed. It backs the
+    /// `started_at` SQL column so every row has a stable sort/window key.
+    first_seen_at: DateTime<Utc>,
+    /// Genuine operation start, seeded ONLY by a first-phase start event:
+    /// `ConversionInitiated` (the AlpacaToBase pre-withdrawal conversion) or
+    /// `WithdrawalSubmitting` / `Initiated` (the BaseToAlpaca withdrawal). Stays
+    /// `None` when the operation was first observed mid-stream (e.g. at
+    /// `BridgeAttestationReceived` after a deploy), leaving `total_ms`
+    /// unmeasured rather than folding in an arbitrary mid-pipeline timestamp.
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    status: StoredStatus,
+    /// Set when an `OperatorReconciled` resolved the operation out-of-band. Its
+    /// `completed_at` is the manual reconciliation time, so the round-trip
+    /// `total_ms` is suppressed to keep the operator-response window out of
+    /// liquidity latency metrics. The operation still reports as `Completed`.
+    operator_reconciled: bool,
+    stages: Vec<StoredStage>,
+}
+
+/// Operation status, mirroring [`RebalanceTimingStatus`] with serde support.
+//
+// These leaf enums (`StoredStatus`, `StoredStageName`) mirror their DTO
+// counterparts because the DTO enums derive `Serialize` + `TS` but not
+// `Deserialize`; the persisted JSON must round-trip through the read model, so
+// the reactor needs serde-deserializable stand-ins it converts into the DTO at
+// read time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+/// One stage run, mirroring [`RebalanceStageTiming`] with serde support.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredStage {
+    stage: StoredStageName,
+    started_at: DateTime<Utc>,
+    ended_at: Option<DateTime<Utc>>,
+    duration_ms: Option<i64>,
+    outcome: StoredStageOutcome,
+}
+
+/// Outcome of a stage run, mirroring [`StageOutcome`] with serde support.
+//
+// Same rationale as `StoredStatus`: the DTO `StageOutcome` derives
+// `Serialize` + `TS` but not `Deserialize`, so the persisted state needs this
+// deserializable stand-in. `InProgress` is read-model-internal: a stage that
+// has opened but not closed has no DTO outcome yet, surfacing as `Unmeasured`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStageOutcome {
+    InProgress,
+    Succeeded,
+    Failed,
+    Unmeasured,
+}
+
+/// Stage identity, mirroring [`RebalanceStageName`] with serde support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum StoredStageName {
+    Conversion,
+    Withdrawal,
+    Burn,
+    Attestation,
+    Mint,
+    Deposit,
+}
+
+impl StoredOperation {
+    fn new(operation_id: UsdcRebalanceId, first_seen_at: DateTime<Utc>) -> Self {
+        Self {
+            operation_id,
+            direction: None,
+            amount: None,
+            first_seen_at,
+            started_at: None,
+            completed_at: None,
+            status: StoredStatus::InProgress,
+            operator_reconciled: false,
+            stages: Vec::new(),
+        }
+    }
+
+    /// Apply one event to the accumulated state, mirroring the per-event arms
+    /// of the original full-stream fold.
+    ///
+    /// Idempotent under redelivery: every stage open goes through
+    /// [`Self::open_if_closed`] and every close/record-unmeasured arm is a no-op
+    /// when the target run is already in its terminal shape, so replaying a
+    /// fully-applied event sequence yields the same stage list and durations.
+    fn apply(&mut self, operation_id: &UsdcRebalanceId, event: &UsdcRebalanceEvent) {
+        use StoredStageName::*;
+
+        match event {
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction,
+                amount,
+                initiated_at,
+                ..
+            } => {
+                self.direction.get_or_insert(*direction);
+                self.amount.get_or_insert(*amount);
+                // `ConversionInitiated` is the genuine first phase only for
+                // `AlpacaToBase` (the pre-withdrawal conversion). For
+                // `BaseToAlpaca` it is the LAST phase (post-deposit), so seeding
+                // a start from it would record a mid-pipeline timestamp when the
+                // reactor first observes a `BaseToAlpaca` op here after a deploy.
+                if *direction == RebalanceDirection::AlpacaToBase {
+                    self.started_at.get_or_insert(*initiated_at);
+                }
+                self.open_once(Conversion, *initiated_at);
+            }
+            UsdcRebalanceEvent::ConversionConfirmed {
+                direction,
+                converted_at,
+                ..
+            } => {
+                self.close(
+                    operation_id,
+                    Conversion,
+                    *converted_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                if *direction == RebalanceDirection::BaseToAlpaca {
+                    self.status = StoredStatus::Completed;
+                    self.completed_at = Some(*converted_at);
+                }
+            }
+            UsdcRebalanceEvent::ConversionFailed { failed_at, .. } => {
+                self.close(
+                    operation_id,
+                    Conversion,
+                    *failed_at,
+                    StoredStageOutcome::Failed,
+                );
+                self.status = StoredStatus::Failed;
+            }
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction,
+                amount,
+                submitting_at,
+                ..
+            } => {
+                self.direction.get_or_insert(*direction);
+                self.amount.get_or_insert(*amount);
+                // The withdrawal is the genuine first phase only for
+                // `BaseToAlpaca`. For `AlpacaToBase` it runs mid-pipeline (after
+                // the initial conversion), so seeding a start from it would
+                // record a mid-pipeline timestamp when the reactor first
+                // observes an `AlpacaToBase` op here after a deploy.
+                if *direction == RebalanceDirection::BaseToAlpaca {
+                    self.started_at.get_or_insert(*submitting_at);
+                }
+                self.open_once(Withdrawal, *submitting_at);
+            }
+            UsdcRebalanceEvent::Initiated {
+                direction,
+                amount,
+                initiated_at,
+                ..
+            } => {
+                self.direction.get_or_insert(*direction);
+                self.amount.get_or_insert(*amount);
+                // Same direction gating as `WithdrawalSubmitting`: the
+                // withdrawal is the genuine first phase only for `BaseToAlpaca`.
+                if *direction == RebalanceDirection::BaseToAlpaca {
+                    self.started_at.get_or_insert(*initiated_at);
+                }
+                self.open_once(Withdrawal, *initiated_at);
+            }
+            UsdcRebalanceEvent::WithdrawalConfirmed { confirmed_at, .. } => {
+                self.close(
+                    operation_id,
+                    Withdrawal,
+                    *confirmed_at,
+                    StoredStageOutcome::Succeeded,
+                );
+            }
+            UsdcRebalanceEvent::WithdrawalFailed { failed_at, .. } => {
+                self.close(
+                    operation_id,
+                    Withdrawal,
+                    *failed_at,
+                    StoredStageOutcome::Failed,
+                );
+                self.status = StoredStatus::Failed;
+            }
+            UsdcRebalanceEvent::BridgingSubmitting { submitting_at, .. } => {
+                self.open_once(Burn, *submitting_at);
+            }
+            UsdcRebalanceEvent::BridgingInitiated { burned_at, .. } => {
+                // Streams without a BridgingSubmitting intent (direct path or
+                // pre-intent history) have no measurable burn duration; a
+                // synthetic zero would drag the stage percentiles down.
+                if self.open_run_index(Burn).is_some() {
+                    self.close(
+                        operation_id,
+                        Burn,
+                        *burned_at,
+                        StoredStageOutcome::Succeeded,
+                    );
+                } else {
+                    self.record_unmeasured(Burn, *burned_at);
+                }
+                self.open_once(Attestation, *burned_at);
+            }
+            UsdcRebalanceEvent::BridgeAttestationReceived { attested_at, .. } => {
+                self.close(
+                    operation_id,
+                    Attestation,
+                    *attested_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                self.open_once(Mint, *attested_at);
+            }
+            // Recoverable stall: the attestation stage simply stays open
+            // until BridgeAttestationReceived or BridgingFailed.
+            UsdcRebalanceEvent::AttestationTimedOut { .. } => {}
+            UsdcRebalanceEvent::Bridged { minted_at, .. } => {
+                self.close(
+                    operation_id,
+                    Mint,
+                    *minted_at,
+                    StoredStageOutcome::Succeeded,
+                );
+            }
+            UsdcRebalanceEvent::BridgingFailed { failed_at, .. } => {
+                self.close_open_stages(*failed_at, StoredStageOutcome::Failed);
+                self.status = StoredStatus::Failed;
+            }
+            UsdcRebalanceEvent::BridgingCompletionRecovered { recovered_at, .. } => {
+                self.close_open_stages(*recovered_at, StoredStageOutcome::Succeeded);
+                // The mint demonstrably happened, but its true duration is
+                // unknown (it was discovered after the fact).
+                self.record_unmeasured(Mint, *recovered_at);
+                self.status = StoredStatus::InProgress;
+            }
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_initiated_at,
+                ..
+            } => {
+                self.open_once(Deposit, *deposit_initiated_at);
+            }
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction,
+                deposit_confirmed_at,
+            } => {
+                self.close(
+                    operation_id,
+                    Deposit,
+                    *deposit_confirmed_at,
+                    StoredStageOutcome::Succeeded,
+                );
+                if *direction == RebalanceDirection::AlpacaToBase {
+                    self.status = StoredStatus::Completed;
+                    self.completed_at = Some(*deposit_confirmed_at);
+                }
+            }
+            UsdcRebalanceEvent::DepositFailed { failed_at, .. } => {
+                self.close(
+                    operation_id,
+                    Deposit,
+                    *failed_at,
+                    StoredStageOutcome::Failed,
+                );
+                self.status = StoredStatus::Failed;
+            }
+            UsdcRebalanceEvent::OperatorReconciled {
+                direction,
+                amount,
+                reconciled_at,
+                ..
+            } => {
+                self.direction.get_or_insert(*direction);
+                self.amount.get_or_insert(*amount);
+                // Funds were settled out-of-band: the operation is resolved
+                // at reconciliation time, but no pipeline stage ran -- the
+                // failed Deposit stage stays failed so percentiles ignore it.
+                // `reconciled_at` is a manual operator action (possibly hours
+                // or days later), so flag the operation to exclude its
+                // round-trip total_ms from latency metrics.
+                self.status = StoredStatus::Completed;
+                self.completed_at = Some(*reconciled_at);
+                self.operator_reconciled = true;
+            }
+        }
+    }
+
+    /// Open `stage` only if no run for it exists yet. Each pipeline stage runs
+    /// at most once per operation, so this guards two cases: a redundant start
+    /// marker (e.g. `Initiated` after `WithdrawalSubmitting`, while the run is
+    /// still open) must not reset the clock, and a redelivered start event
+    /// (whose run already closed) must not push a duplicate run.
+    fn open_once(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        if self.has_run(stage) {
+            return;
+        }
+
+        self.stages.push(StoredStage {
+            stage,
+            started_at: at,
+            ended_at: None,
+            duration_ms: None,
+            outcome: StoredStageOutcome::InProgress,
+        });
+    }
+
+    fn close(
+        &mut self,
+        operation_id: &UsdcRebalanceId,
+        stage: StoredStageName,
+        at: DateTime<Utc>,
+        outcome: StoredStageOutcome,
+    ) {
+        let Some(index) = self.open_run_index(stage) else {
+            // No OPEN run to close. Either a genuine end-without-start, or a
+            // redelivered end event whose run already closed -- both are no-ops
+            // here. The already-closed run keeps its recorded duration, so
+            // redelivery is idempotent. Only warn when no run for the stage
+            // exists at all (the true end-without-start case).
+            if !self.has_run(stage) {
+                warn!(
+                    %operation_id,
+                    ?stage,
+                    "Stage end event without a matching start; skipping stage timing"
+                );
+            }
+
+            return;
+        };
+        let run = &mut self.stages[index];
+        run.ended_at = Some(at);
+        // Clamped like the hedge pipeline samples: clock skew between event
+        // sources must not push negative durations into percentiles.
+        run.duration_ms = Some((at - run.started_at).num_milliseconds().max(0));
+        run.outcome = outcome;
+    }
+
+    /// Close every open stage, e.g. when bridging fails or recovers without
+    /// per-stage end markers. A no-op when no stage is open, so a redelivered
+    /// terminal event does not re-close already-closed runs.
+    fn close_open_stages(&mut self, at: DateTime<Utc>, outcome: StoredStageOutcome) {
+        for run in self.stages.iter_mut().filter(|run| run.ended_at.is_none()) {
+            run.ended_at = Some(at);
+            run.duration_ms = Some((at - run.started_at).num_milliseconds().max(0));
+            run.outcome = outcome;
+        }
+    }
+
+    /// Record a stage that demonstrably happened but whose duration cannot
+    /// be measured from the stream; excluded from percentile summaries. A no-op
+    /// when any run for the stage already exists, so a redelivered event does
+    /// not push a duplicate (whether the prior run was measured or unmeasured).
+    fn record_unmeasured(&mut self, stage: StoredStageName, at: DateTime<Utc>) {
+        if self.has_run(stage) {
+            return;
+        }
+
+        self.stages.push(StoredStage {
+            stage,
+            started_at: at,
+            ended_at: Some(at),
+            duration_ms: None,
+            outcome: StoredStageOutcome::Unmeasured,
+        });
+    }
+
+    fn open_run_index(&self, stage: StoredStageName) -> Option<usize> {
+        self.stages
+            .iter()
+            .rposition(|run| run.stage == stage && run.ended_at.is_none())
+    }
+
+    fn has_run(&self, stage: StoredStageName) -> bool {
+        self.stages.iter().any(|run| run.stage == stage)
+    }
+
+    /// Convert the accumulated state into the dashboard DTO.
+    fn into_dto(self) -> RebalanceOperationTiming {
+        // Round-trip latency requires a genuine start and a completion; an
+        // out-of-band operator reconciliation is excluded so the manual
+        // response window never pollutes the metric.
+        let total_ms = match (self.started_at, self.completed_at, self.operator_reconciled) {
+            (Some(started_at), Some(completed_at), false) => {
+                Some((completed_at - started_at).num_milliseconds().max(0))
+            }
+            _ => None,
+        };
+        let UsdcRebalanceId(operation_id) = self.operation_id;
+
+        RebalanceOperationTiming {
+            operation_id,
+            direction: self.direction.map(Into::into),
+            amount: self.amount,
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            status: self.status.into(),
+            stages: self.stages.into_iter().map(StoredStage::into_dto).collect(),
+            total_ms,
+        }
+    }
+}
+
+impl StoredStage {
+    fn into_dto(self) -> RebalanceStageTiming {
+        RebalanceStageTiming {
+            stage: self.stage.into(),
+            started_at: self.started_at,
+            ended_at: self.ended_at,
+            duration_ms: self.duration_ms,
+            outcome: self.outcome.into(),
+        }
+    }
+}
+
+impl From<StoredStageOutcome> for StageOutcome {
+    fn from(outcome: StoredStageOutcome) -> Self {
+        match outcome {
+            // An open stage has no terminal DTO outcome yet; surface it as
+            // unmeasured so it is excluded from percentiles like any other
+            // duration-less run.
+            StoredStageOutcome::InProgress | StoredStageOutcome::Unmeasured => Self::Unmeasured,
+            StoredStageOutcome::Succeeded => Self::Succeeded,
+            StoredStageOutcome::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<StoredStatus> for RebalanceTimingStatus {
+    fn from(status: StoredStatus) -> Self {
+        match status {
+            StoredStatus::InProgress => Self::InProgress,
+            StoredStatus::Completed => Self::Completed,
+            StoredStatus::Failed => Self::Failed,
+        }
+    }
+}
+
+impl From<StoredStageName> for RebalanceStageName {
+    fn from(stage: StoredStageName) -> Self {
+        match stage {
+            StoredStageName::Conversion => Self::Conversion,
+            StoredStageName::Withdrawal => Self::Withdrawal,
+            StoredStageName::Burn => Self::Burn,
+            StoredStageName::Attestation => Self::Attestation,
+            StoredStageName::Mint => Self::Mint,
+            StoredStageName::Deposit => Self::Deposit,
+        }
+    }
+}
+
+/// The timestamp at which the read model observed `event`, used to anchor a
+/// freshly-seen operation's `first_seen_at` (the SQL window/sort key).
+///
+/// For `OperatorReconciled` this is `reconciled_at` -- when the reconciliation
+/// actually happened -- NOT the original `initiated_at` (which may be weeks old).
+/// A recently-reconciled old operation must fall inside recent query windows;
+/// anchoring it to the stale `initiated_at` would hide exactly the out-of-band
+/// recoveries operators want to see after a restart.
+fn observed_at(event: &UsdcRebalanceEvent) -> DateTime<Utc> {
+    match event {
+        UsdcRebalanceEvent::ConversionInitiated { initiated_at, .. }
+        | UsdcRebalanceEvent::Initiated { initiated_at, .. } => *initiated_at,
+        UsdcRebalanceEvent::OperatorReconciled { reconciled_at, .. } => *reconciled_at,
+        UsdcRebalanceEvent::ConversionConfirmed { converted_at, .. } => *converted_at,
+        UsdcRebalanceEvent::ConversionFailed { failed_at, .. }
+        | UsdcRebalanceEvent::WithdrawalFailed { failed_at, .. }
+        | UsdcRebalanceEvent::BridgingFailed { failed_at, .. }
+        | UsdcRebalanceEvent::DepositFailed { failed_at, .. } => *failed_at,
+        UsdcRebalanceEvent::WithdrawalSubmitting { submitting_at, .. }
+        | UsdcRebalanceEvent::BridgingSubmitting { submitting_at, .. } => *submitting_at,
+        UsdcRebalanceEvent::WithdrawalConfirmed { confirmed_at, .. } => *confirmed_at,
+        UsdcRebalanceEvent::BridgingInitiated { burned_at, .. } => *burned_at,
+        UsdcRebalanceEvent::BridgeAttestationReceived { attested_at, .. } => *attested_at,
+        UsdcRebalanceEvent::AttestationTimedOut { timed_out_at, .. } => *timed_out_at,
+        UsdcRebalanceEvent::Bridged { minted_at, .. } => *minted_at,
+        UsdcRebalanceEvent::BridgingCompletionRecovered { recovered_at, .. } => *recovered_at,
+        UsdcRebalanceEvent::DepositInitiated {
+            deposit_initiated_at,
+            ..
+        } => *deposit_initiated_at,
+        UsdcRebalanceEvent::DepositConfirmed {
+            deposit_confirmed_at,
+            ..
+        } => *deposit_confirmed_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{B256, TxHash};
+    use chrono::TimeZone;
+    use uuid::Uuid;
+
+    use st0x_dto::UsdcBridgeDirection;
+    use st0x_event_sorcery::ReactorHarness;
+    use st0x_execution::ClientOrderId;
+    use st0x_finance::Usdc;
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::test_utils::setup_test_db;
+    use crate::usdc_rebalance::{ReconcileReason, TransferRef};
+
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
+    }
+
+    fn range() -> ReportRange {
+        ReportRange {
+            from: timestamp(0),
+            to: timestamp(1_000_000),
+        }
+    }
+
+    fn alpaca_to_base_happy_path() -> Vec<UsdcRebalanceEvent> {
+        vec![
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::ConversionConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                filled_amount: Usdc::new(float!(1000)),
+                converted_at: timestamp(10),
+            },
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                from_block: 1,
+                submitting_at: timestamp(20),
+            },
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                withdrawal_ref: TransferRef::OnchainTx(TxHash::random()),
+                initiated_at: timestamp(21),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: timestamp(50),
+                withdrawal_tx: None,
+            },
+            UsdcRebalanceEvent::BridgingSubmitting {
+                from_block: 2,
+                submitting_at: timestamp(60),
+                burn_amount: None,
+            },
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: TxHash::random(),
+                burned_at: timestamp(70),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![1],
+                cctp_nonce: B256::random(),
+                message: None,
+                mint_scan_from_block: None,
+                attested_at: timestamp(670),
+            },
+            UsdcRebalanceEvent::Bridged {
+                mint_tx_hash: TxHash::random(),
+                amount_received: Usdc::new(float!(999)),
+                fee_collected: Usdc::new(float!(1)),
+                minted_at: timestamp(700),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(710),
+            },
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                deposit_confirmed_at: timestamp(730),
+            },
+        ]
+    }
+
+    fn stage(
+        operation: &RebalanceOperationTiming,
+        name: RebalanceStageName,
+    ) -> &RebalanceStageTiming {
+        operation
+            .stages
+            .iter()
+            .find(|stage| stage.stage == name)
+            .unwrap()
+    }
+
+    /// Fold an event stream by applying each event to a fresh stored operation,
+    /// exactly as the reactor would, retaining the observation time so it can be
+    /// fed to [`rebalance_timing_report`] like the production load path does.
+    fn fold_windowed(
+        operation_id: &str,
+        events: &[UsdcRebalanceEvent],
+    ) -> Option<WindowedOperation> {
+        let id = UsdcRebalanceId(Uuid::new_v5(&Uuid::NAMESPACE_OID, operation_id.as_bytes()));
+        let first = events.first()?;
+        let mut operation = StoredOperation::new(id.clone(), observed_at(first));
+
+        for event in events {
+            operation.apply(&id, event);
+        }
+
+        Some(WindowedOperation::from_stored(operation))
+    }
+
+    /// Fold an event stream into the dashboard DTO, exactly as the reactor would.
+    fn fold_operation(
+        operation_id: &str,
+        events: &[UsdcRebalanceEvent],
+    ) -> Option<RebalanceOperationTiming> {
+        Some(fold_windowed(operation_id, events)?.operation)
+    }
+
+    /// Drives a sequence of `UsdcRebalance` events through the reactor, then
+    /// loads the report from the read-model table.
+    async fn run_through_reactor(
+        events: &[UsdcRebalanceEvent],
+    ) -> (SqlitePool, UsdcRebalanceId, RebalanceTimings) {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(pool.clone()));
+        let operation_id = UsdcRebalanceId(Uuid::new_v4());
+
+        for event in events {
+            harness
+                .receive::<UsdcRebalance>(operation_id.clone(), event.clone())
+                .await
+                .unwrap();
+        }
+
+        let report = load_rebalance_timings(&pool, &range()).await.unwrap();
+
+        (pool, operation_id, report)
+    }
+
+    #[test]
+    fn alpaca_to_base_completes_with_all_stage_durations() {
+        let operation = fold_operation("op-1", &alpaca_to_base_happy_path()).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.direction, Some(UsdcBridgeDirection::AlpacaToBase));
+        // The happy path opens with ConversionInitiated, which seeds the
+        // genuine start.
+        assert_eq!(operation.started_at, Some(timestamp(0)));
+        assert_eq!(operation.completed_at, Some(timestamp(730)));
+        assert_eq!(operation.total_ms, Some(730_000));
+
+        use RebalanceStageName::*;
+        assert_eq!(stage(&operation, Conversion).duration_ms, Some(10_000));
+        assert_eq!(stage(&operation, Withdrawal).duration_ms, Some(30_000));
+        assert_eq!(stage(&operation, Burn).duration_ms, Some(10_000));
+        assert_eq!(stage(&operation, Attestation).duration_ms, Some(600_000));
+        assert_eq!(stage(&operation, Mint).duration_ms, Some(30_000));
+        assert_eq!(stage(&operation, Deposit).duration_ms, Some(20_000));
+    }
+
+    #[test]
+    fn base_to_alpaca_completes_on_final_conversion() {
+        let events = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                from_block: 1,
+                submitting_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: timestamp(30),
+                withdrawal_tx: None,
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::AlpacaId(Uuid::new_v4().into()),
+                deposit_initiated_at: timestamp(40),
+            },
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                deposit_confirmed_at: timestamp(100),
+            },
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: timestamp(110),
+            },
+            UsdcRebalanceEvent::ConversionConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                filled_amount: Usdc::new(float!(500)),
+                converted_at: timestamp(150),
+            },
+        ];
+
+        let operation = fold_operation("op-2", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.direction, Some(UsdcBridgeDirection::BaseToAlpaca));
+        assert_eq!(operation.completed_at, Some(timestamp(150)));
+        assert_eq!(operation.total_ms, Some(150_000));
+        // The mid-flow deposit confirmation must not complete the operation.
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Deposit).duration_ms,
+            Some(60_000)
+        );
+    }
+
+    #[test]
+    fn withdrawal_failure_marks_operation_failed() {
+        let events = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                from_block: 1,
+                submitting_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::WithdrawalFailed {
+                reason: "revert".to_string(),
+                failed_at: timestamp(5),
+            },
+        ];
+
+        let operation = fold_operation("op-3", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        assert_eq!(operation.completed_at, None);
+        assert_eq!(operation.total_ms, None);
+        let withdrawal = stage(&operation, RebalanceStageName::Withdrawal);
+        assert_eq!(withdrawal.outcome, StageOutcome::Failed);
+        assert_eq!(withdrawal.duration_ms, Some(5_000));
+    }
+
+    #[test]
+    fn attestation_timeout_keeps_stage_open_until_received() {
+        let events = vec![
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: TxHash::random(),
+                burned_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::AttestationTimedOut {
+                burn_tx_hash: TxHash::random(),
+                retry_deadline_at: timestamp(10_000),
+                timed_out_at: timestamp(1_800),
+            },
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![1],
+                cctp_nonce: B256::random(),
+                message: None,
+                mint_scan_from_block: None,
+                attested_at: timestamp(3_600),
+            },
+        ];
+
+        let operation = fold_operation("op-4", &events).unwrap();
+
+        let attestation = stage(&operation, RebalanceStageName::Attestation);
+        assert_eq!(attestation.duration_ms, Some(3_600_000));
+        assert_eq!(attestation.outcome, StageOutcome::Succeeded);
+    }
+
+    #[test]
+    fn bridging_failure_then_recovery_returns_to_in_progress() {
+        let events = vec![
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: TxHash::random(),
+                burned_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::BridgingFailed {
+                burn_tx_hash: Some(TxHash::random()),
+                cctp_nonce: None,
+                reason: "poll exhausted".to_string(),
+                failed_at: timestamp(100),
+            },
+            UsdcRebalanceEvent::BridgingCompletionRecovered {
+                mint_tx_hash: TxHash::random(),
+                amount_received: Usdc::new(float!(999)),
+                fee_collected: Usdc::new(float!(1)),
+                recovered_at: timestamp(200),
+            },
+        ];
+
+        let operation = fold_operation("op-5", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::InProgress);
+        // Burn (unmeasured: no submitting intent), Attestation, Mint
+        // (unmeasured: discovered by recovery).
+        assert_eq!(operation.stages.len(), 3);
+        let burn = stage(&operation, RebalanceStageName::Burn);
+        assert_eq!(burn.duration_ms, None);
+        assert_eq!(burn.outcome, StageOutcome::Unmeasured);
+        let attestation = stage(&operation, RebalanceStageName::Attestation);
+        assert_eq!(attestation.outcome, StageOutcome::Failed);
+        assert_eq!(attestation.duration_ms, Some(100_000));
+        // The recovered mint happened but its duration is unknowable.
+        let mint = stage(&operation, RebalanceStageName::Mint);
+        assert_eq!(mint.duration_ms, None);
+        assert_eq!(mint.outcome, StageOutcome::Unmeasured);
+    }
+
+    #[test]
+    fn deposit_failure_marks_operation_failed() {
+        let events = vec![
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::DepositFailed {
+                deposit_ref: None,
+                reason: "deposit revert".to_string(),
+                failed_at: timestamp(20),
+            },
+        ];
+
+        let operation = fold_operation("op-6", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        let deposit = stage(&operation, RebalanceStageName::Deposit);
+        assert_eq!(deposit.outcome, StageOutcome::Failed);
+        assert_eq!(deposit.duration_ms, Some(20_000));
+    }
+
+    #[test]
+    fn operator_reconcile_completes_stranded_deposit_failure() {
+        let events = vec![
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::DepositFailed {
+                deposit_ref: None,
+                reason: "deposit revert".to_string(),
+                failed_at: timestamp(20),
+            },
+            UsdcRebalanceEvent::OperatorReconciled {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                reason: ReconcileReason::FundsMovedManually,
+                initiated_at: timestamp(0),
+                reconciled_at: timestamp(500),
+            },
+        ];
+
+        let operation = fold_operation("op-7", &events).unwrap();
+
+        // The operation is resolved, but the failed Deposit stage keeps its
+        // failure so stage percentiles never absorb a manual recovery.
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(500)));
+        // OperatorReconciled completion is out-of-band: total_ms is suppressed
+        // so the operator-response window stays out of latency metrics. The
+        // stream here also never carried a genuine start, so started_at is None.
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.total_ms, None);
+        assert_eq!(
+            operation.direction,
+            Some(st0x_dto::UsdcBridgeDirection::AlpacaToBase)
+        );
+        let deposit = stage(&operation, RebalanceStageName::Deposit);
+        assert_eq!(deposit.outcome, StageOutcome::Failed);
+    }
+
+    #[test]
+    fn conversion_failure_marks_operation_failed() {
+        let events = vec![
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::ConversionFailed {
+                reason: "order rejected".to_string(),
+                failed_at: timestamp(8),
+            },
+        ];
+
+        let operation = fold_operation("op-7", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Failed);
+        let conversion = stage(&operation, RebalanceStageName::Conversion);
+        assert_eq!(conversion.outcome, StageOutcome::Failed);
+        assert_eq!(conversion.duration_ms, Some(8_000));
+    }
+
+    #[test]
+    fn negative_stage_durations_clamp_to_zero() {
+        // Clock skew: the confirmation timestamp precedes the submission.
+        let events = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                from_block: 1,
+                submitting_at: timestamp(10),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: timestamp(5),
+                withdrawal_tx: None,
+            },
+        ];
+
+        let operation = fold_operation("op-8", &events).unwrap();
+
+        let withdrawal = stage(&operation, RebalanceStageName::Withdrawal);
+        assert_eq!(withdrawal.duration_ms, Some(0));
+    }
+
+    #[test]
+    fn report_caps_operation_rows_but_counts_all() {
+        let operations: Vec<WindowedOperation> = (0..=i64::try_from(MAX_OPERATION_REPORTS)
+            .unwrap())
+            .map(|index| {
+                fold_windowed(
+                    &format!("op-{index}"),
+                    &[UsdcRebalanceEvent::WithdrawalSubmitting {
+                        direction: RebalanceDirection::BaseToAlpaca,
+                        amount: Usdc::new(float!(1)),
+                        from_block: 1,
+                        submitting_at: timestamp(index),
+                    }],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let report = rebalance_timing_report(operations, &range(), 0);
+
+        assert_eq!(report.total_operations, MAX_OPERATION_REPORTS + 1);
+        assert_eq!(report.operations.len(), MAX_OPERATION_REPORTS);
+    }
+
+    #[test]
+    fn report_summarizes_stages_and_attestation_trend() {
+        let first = fold_windowed("op-1", &alpaca_to_base_happy_path()).unwrap();
+
+        let report = rebalance_timing_report(vec![first], &range(), 0);
+
+        assert_eq!(report.total_operations, 1);
+        assert_eq!(report.operations.len(), 1);
+        assert_eq!(report.skipped_operations, 0);
+        assert_eq!(report.attestation_trend.len(), 1);
+        assert_eq!(report.attestation_trend[0].burned_at, timestamp(70));
+        assert_eq!(report.attestation_trend[0].duration_ms, 600_000);
+
+        let attestation_stats = report
+            .stage_summary
+            .iter()
+            .find(|entry| entry.stage == RebalanceStageName::Attestation)
+            .unwrap();
+        assert_eq!(attestation_stats.stats.p50_ms, 600_000);
+        assert_eq!(attestation_stats.stats.sample_count, 1);
+    }
+
+    #[test]
+    fn report_excludes_operations_outside_range() {
+        // The happy path is first observed at timestamp(0), which is outside the
+        // narrow window, so windowing by `first_seen_at` excludes it entirely.
+        let operation = fold_windowed("op-1", &alpaca_to_base_happy_path()).unwrap();
+        let narrow = ReportRange {
+            from: timestamp(100_000),
+            to: timestamp(200_000),
+        };
+
+        let report = rebalance_timing_report(vec![operation], &narrow, 0);
+
+        assert_eq!(report.total_operations, 0);
+        assert!(report.operations.is_empty());
+        assert!(report.stage_summary.is_empty());
+        assert!(report.attestation_trend.is_empty());
+    }
+
+    #[test]
+    fn report_keeps_mid_stream_operation_with_unknown_start_in_window() {
+        // A mid-stream-first operation has a `None` genuine start but a valid
+        // observation time inside the window. It must be retained and windowed by
+        // `first_seen_at`, not dropped because its `started_at` is unknown.
+        let mid_stream = fold_windowed(
+            "op-mid-stream-window",
+            &[
+                UsdcRebalanceEvent::BridgeAttestationReceived {
+                    attestation: vec![1],
+                    cctp_nonce: B256::random(),
+                    message: None,
+                    mint_scan_from_block: None,
+                    attested_at: timestamp(150_000),
+                },
+                UsdcRebalanceEvent::Bridged {
+                    mint_tx_hash: TxHash::random(),
+                    amount_received: Usdc::new(float!(999)),
+                    fee_collected: Usdc::new(float!(1)),
+                    minted_at: timestamp(150_030),
+                },
+            ],
+        )
+        .unwrap();
+        // Sanity: the genuine start is unknown, only the observation time backs it.
+        assert_eq!(mid_stream.operation.started_at, None);
+        let narrow = ReportRange {
+            from: timestamp(100_000),
+            to: timestamp(200_000),
+        };
+
+        let report = rebalance_timing_report(vec![mid_stream], &narrow, 0);
+
+        assert_eq!(report.total_operations, 1);
+        assert_eq!(report.operations.len(), 1);
+        assert_eq!(report.operations[0].started_at, None);
+        assert_eq!(report.operations[0].total_ms, None);
+    }
+
+    #[tokio::test]
+    async fn load_rebalance_timings_reads_reactor_table() {
+        let (_pool, operation_id, report) = run_through_reactor(&alpaca_to_base_happy_path()).await;
+
+        assert_eq!(report.total_operations, 1);
+        let operation = &report.operations[0];
+        let UsdcRebalanceId(expected_id) = operation_id;
+        assert_eq!(operation.operation_id, expected_id);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        // Stage timings must survive the per-event reactor -> DB -> read path.
+        assert_eq!(operation.total_ms, Some(730_000));
+        assert_eq!(
+            stage(operation, RebalanceStageName::Attestation).duration_ms,
+            Some(600_000)
+        );
+        assert_eq!(
+            stage(operation, RebalanceStageName::Deposit).duration_ms,
+            Some(20_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn range_filter_excludes_out_of_range_reactor_written_operations() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(pool.clone()));
+        let operation_id = UsdcRebalanceId(Uuid::new_v4());
+
+        for event in alpaca_to_base_happy_path() {
+            harness
+                .receive::<UsdcRebalance>(operation_id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        let narrow = ReportRange {
+            from: timestamp(100_000),
+            to: timestamp(200_000),
+        };
+        let report = load_rebalance_timings(&pool, &narrow).await.unwrap();
+
+        assert_eq!(report.total_operations, 0);
+        assert!(report.operations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn operator_reconcile_windowed_by_reconciled_at_not_initiated_at() {
+        // A manual reconciliation done today for an operation initiated weeks ago
+        // (the reactor's only observed event) must be windowed by reconciled_at,
+        // not the stale initiated_at -- otherwise a recent out-of-band recovery
+        // would vanish from a recent-window query right when operators need it.
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(pool.clone()));
+        let operation_id = UsdcRebalanceId(Uuid::new_v4());
+
+        harness
+            .receive::<UsdcRebalance>(
+                operation_id.clone(),
+                UsdcRebalanceEvent::OperatorReconciled {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(1000)),
+                    reason: ReconcileReason::FundsMovedManually,
+                    // initiated_at is far outside the window below.
+                    initiated_at: timestamp(0),
+                    // reconciled_at falls inside the window below.
+                    reconciled_at: timestamp(150_000),
+                },
+            )
+            .await
+            .unwrap();
+
+        let recent_window = ReportRange {
+            from: timestamp(100_000),
+            to: timestamp(200_000),
+        };
+        let report = load_rebalance_timings(&pool, &recent_window).await.unwrap();
+
+        // The operation is windowed by reconciled_at, so it appears.
+        assert_eq!(report.total_operations, 1);
+        let operation = &report.operations[0];
+        let UsdcRebalanceId(expected_id) = operation_id;
+        assert_eq!(operation.operation_id, expected_id);
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        // No genuine start event was observed, so the round-trip stays
+        // unmeasured even though completion is known.
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.completed_at, Some(timestamp(150_000)));
+        assert_eq!(operation.total_ms, None);
+    }
+
+    #[test]
+    fn operator_reconcile_as_only_event_has_no_start_and_no_total_ms() {
+        // When the reactor only sees OperatorReconciled, there is no genuine
+        // start event, so started_at stays None and the round-trip total_ms is
+        // unmeasured -- doubly so, because operator-reconciled completion is an
+        // out-of-band manual action that must never enter latency metrics.
+        let events = vec![UsdcRebalanceEvent::OperatorReconciled {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(1000)),
+            reason: ReconcileReason::FundsMovedManually,
+            initiated_at: timestamp(100),
+            reconciled_at: timestamp(600),
+        }];
+
+        let operation = fold_operation("op-reconcile-first", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.completed_at, Some(timestamp(600)));
+        assert_eq!(operation.total_ms, None);
+    }
+
+    #[test]
+    fn operator_reconcile_excluded_from_total_ms_even_with_genuine_start() {
+        // A fully-tracked operation that ends in OperatorReconciled has a known
+        // start, yet its round-trip total_ms is still suppressed so the
+        // operator-response window (initiated_at -> reconciled_at) never folds
+        // into the liquidity latency metric. The genuine first phase for
+        // AlpacaToBase is the pre-withdrawal conversion, so the stream opens with
+        // ConversionInitiated to seed a real start.
+        let events = vec![
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(10),
+            },
+            UsdcRebalanceEvent::DepositFailed {
+                deposit_ref: None,
+                reason: "deposit revert".to_string(),
+                failed_at: timestamp(20),
+            },
+            UsdcRebalanceEvent::OperatorReconciled {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                reason: ReconcileReason::FundsMovedManually,
+                initiated_at: timestamp(0),
+                reconciled_at: timestamp(90_000),
+            },
+        ];
+
+        let operation = fold_operation("op-reconcile-tracked", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, Some(timestamp(0)));
+        assert_eq!(operation.completed_at, Some(timestamp(90_000)));
+        // Despite a known start and completion, the manual reconciliation keeps
+        // this out of round-trip latency.
+        assert_eq!(operation.total_ms, None);
+    }
+
+    #[test]
+    fn mid_stream_first_event_leaves_start_and_total_ms_unmeasured() {
+        // The reactor first observes the operation at BridgeAttestationReceived
+        // (e.g. it started before a deploy). No genuine start event is ever
+        // seen, so started_at must stay None and total_ms unmeasured rather than
+        // adopting the mid-pipeline attestation timestamp as the start.
+        let events = vec![
+            UsdcRebalanceEvent::BridgeAttestationReceived {
+                attestation: vec![1],
+                cctp_nonce: B256::random(),
+                message: None,
+                mint_scan_from_block: None,
+                attested_at: timestamp(670),
+            },
+            UsdcRebalanceEvent::Bridged {
+                mint_tx_hash: TxHash::random(),
+                amount_received: Usdc::new(float!(999)),
+                fee_collected: Usdc::new(float!(1)),
+                minted_at: timestamp(700),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(710),
+            },
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                deposit_confirmed_at: timestamp(730),
+            },
+        ];
+
+        let operation = fold_operation("op-mid-stream", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.completed_at, Some(timestamp(730)));
+        assert_eq!(operation.total_ms, None);
+        // The mint stage still measures from attestation -> Bridged.
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Mint).duration_ms,
+            Some(30_000)
+        );
+    }
+
+    #[test]
+    fn alpaca_to_base_first_observed_at_withdrawal_leaves_start_unmeasured() {
+        // For AlpacaToBase the genuine first phase is the pre-withdrawal
+        // conversion (ConversionInitiated). The withdrawal runs mid-pipeline, so
+        // if the reactor first observes the operation at WithdrawalSubmitting
+        // (e.g. after a deploy that missed the conversion), started_at must stay
+        // None rather than adopt the mid-pipeline withdrawal timestamp.
+        let events = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(1000)),
+                from_block: 1,
+                submitting_at: timestamp(20),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: timestamp(50),
+                withdrawal_tx: None,
+            },
+        ];
+
+        let operation = fold_operation("op-a2b-mid-withdrawal", &events).unwrap();
+
+        assert_eq!(operation.direction, Some(UsdcBridgeDirection::AlpacaToBase));
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.total_ms, None);
+        // The withdrawal stage still measures since both endpoints were seen.
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Withdrawal).duration_ms,
+            Some(30_000)
+        );
+    }
+
+    #[test]
+    fn base_to_alpaca_first_observed_at_conversion_leaves_start_unmeasured() {
+        // For BaseToAlpaca the genuine first phase is the withdrawal. The
+        // post-deposit conversion (ConversionInitiated) runs LAST, so if the
+        // reactor first observes the operation at ConversionInitiated (e.g. after
+        // a deploy that missed the earlier phases), started_at must stay None
+        // rather than adopt the late-pipeline conversion timestamp.
+        let events = vec![
+            UsdcRebalanceEvent::ConversionInitiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+                initiated_at: timestamp(110),
+            },
+            UsdcRebalanceEvent::ConversionConfirmed {
+                direction: RebalanceDirection::BaseToAlpaca,
+                filled_amount: Usdc::new(float!(500)),
+                converted_at: timestamp(150),
+            },
+        ];
+
+        let operation = fold_operation("op-b2a-mid-conversion", &events).unwrap();
+
+        assert_eq!(operation.direction, Some(UsdcBridgeDirection::BaseToAlpaca));
+        // BaseToAlpaca completes on the final conversion, so it is Completed with
+        // a known completed_at -- but no genuine start was observed, so the
+        // round-trip total_ms stays unmeasured.
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.completed_at, Some(timestamp(150)));
+        assert_eq!(operation.total_ms, None);
+        // The conversion stage still measures since both endpoints were seen.
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Conversion).duration_ms,
+            Some(40_000)
+        );
+    }
+
+    #[test]
+    fn redelivering_full_event_sequence_is_idempotent() {
+        // Replaying an already-applied sequence (event redelivery) must not
+        // double-push stages or change any duration.
+        let events = alpaca_to_base_happy_path();
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        let mut once = StoredOperation::new(id.clone(), observed_at(&events[0]));
+        for event in &events {
+            once.apply(&id, event);
+        }
+
+        let mut twice = once.clone();
+        for event in &events {
+            twice.apply(&id, event);
+        }
+
+        let once_dto = once.into_dto();
+        let twice_dto = twice.into_dto();
+
+        assert_eq!(once_dto.stages.len(), twice_dto.stages.len());
+        assert_eq!(once_dto.total_ms, twice_dto.total_ms);
+        for (single, redelivered) in once_dto.stages.iter().zip(twice_dto.stages.iter()) {
+            assert_eq!(single.stage, redelivered.stage);
+            assert_eq!(single.started_at, redelivered.started_at);
+            assert_eq!(single.ended_at, redelivered.ended_at);
+            assert_eq!(single.duration_ms, redelivered.duration_ms);
+            assert_eq!(single.outcome, redelivered.outcome);
+        }
+    }
+
+    #[tokio::test]
+    async fn load_rebalance_timings_counts_skipped_undeserializable_rows() {
+        // A malformed `timing` JSON row that survives the SQL window must be
+        // skipped from `operations` but surfaced via `skipped_operations` rather
+        // than vanishing silently. This drives the real DB read path so the
+        // `serde_json::from_str` skip-and-increment branch is exercised.
+        let pool = setup_test_db().await;
+
+        // Seed one well-formed operation through the reactor so the report is not
+        // empty, proving the malformed row is dropped while the good row remains.
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(pool.clone()));
+        let good_id = UsdcRebalanceId(Uuid::new_v4());
+        for event in alpaca_to_base_happy_path() {
+            harness
+                .receive::<UsdcRebalance>(good_id.clone(), event)
+                .await
+                .unwrap();
+        }
+
+        // Insert a row with a valid in-window `started_at` but unparseable timing.
+        sqlx::query(
+            "INSERT INTO rebalance_stage_timing (operation_id, started_at, timing) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(timestamp(5).to_rfc3339())
+        .bind("not-valid-json")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let report = load_rebalance_timings(&pool, &range()).await.unwrap();
+
+        assert_eq!(report.skipped_operations, 1);
+        // Only the well-formed operation survives; the malformed row is absent.
+        assert_eq!(report.total_operations, 1);
+        assert_eq!(report.operations.len(), 1);
+        let UsdcRebalanceId(expected_id) = good_id;
+        assert_eq!(report.operations[0].operation_id, expected_id);
+    }
+
+    #[test]
+    fn stage_summary_excludes_failed_withdrawal_from_percentiles() {
+        // A failed withdrawal stage must not contaminate the Withdrawal percentiles.
+        let failed_withdrawal = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                from_block: 1,
+                submitting_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::WithdrawalFailed {
+                reason: "revert".to_string(),
+                failed_at: timestamp(5),
+            },
+        ];
+        let successful_withdrawal = vec![
+            UsdcRebalanceEvent::WithdrawalSubmitting {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(500)),
+                from_block: 2,
+                submitting_at: timestamp(100),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: timestamp(130),
+                withdrawal_tx: None,
+            },
+        ];
+
+        let failed_op = fold_windowed("op-fail", &failed_withdrawal).unwrap();
+        let success_op = fold_windowed("op-success", &successful_withdrawal).unwrap();
+        let report = rebalance_timing_report(vec![failed_op, success_op], &range(), 0);
+
+        let withdrawal_stats = report
+            .stage_summary
+            .iter()
+            .find(|entry| entry.stage == RebalanceStageName::Withdrawal)
+            .unwrap();
+        // Only the successful withdrawal (30_000 ms) must appear in the sample.
+        assert_eq!(withdrawal_stats.stats.sample_count, 1);
+        assert_eq!(withdrawal_stats.stats.p50_ms, 30_000);
+    }
+
+    #[test]
+    fn attestation_trend_excludes_failed_attestation_in_bridging_recovery() {
+        // An operation where attestation fails (BridgingFailed) and is later
+        // recovered must have its failed attestation excluded from the trend.
+        let events = vec![
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: TxHash::random(),
+                burned_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::BridgingFailed {
+                burn_tx_hash: Some(TxHash::random()),
+                cctp_nonce: None,
+                reason: "poll exhausted".to_string(),
+                failed_at: timestamp(100),
+            },
+            UsdcRebalanceEvent::BridgingCompletionRecovered {
+                mint_tx_hash: TxHash::random(),
+                amount_received: Usdc::new(float!(999)),
+                fee_collected: Usdc::new(float!(1)),
+                recovered_at: timestamp(200),
+            },
+        ];
+
+        let operation = fold_windowed("op-bridging-recovery", &events).unwrap();
+        let report = rebalance_timing_report(vec![operation], &range(), 0);
+
+        // The failed attestation stage must not appear in the trend.
+        assert!(report.attestation_trend.is_empty());
+    }
+
+    #[test]
+    fn bridging_recovery_then_deposit_completes_operation() {
+        // After BridgingCompletionRecovered the operation returns to InProgress.
+        // Subsequent DepositInitiated + DepositConfirmed (AlpacaToBase) must
+        // complete the operation with a correct total_ms.
+        let events = vec![
+            UsdcRebalanceEvent::BridgingInitiated {
+                burn_tx_hash: TxHash::random(),
+                burned_at: timestamp(0),
+            },
+            UsdcRebalanceEvent::BridgingFailed {
+                burn_tx_hash: Some(TxHash::random()),
+                cctp_nonce: None,
+                reason: "poll exhausted".to_string(),
+                failed_at: timestamp(100),
+            },
+            UsdcRebalanceEvent::BridgingCompletionRecovered {
+                mint_tx_hash: TxHash::random(),
+                amount_received: Usdc::new(float!(999)),
+                fee_collected: Usdc::new(float!(1)),
+                recovered_at: timestamp(200),
+            },
+            UsdcRebalanceEvent::DepositInitiated {
+                deposit_ref: TransferRef::OnchainTx(TxHash::random()),
+                deposit_initiated_at: timestamp(210),
+            },
+            UsdcRebalanceEvent::DepositConfirmed {
+                direction: RebalanceDirection::AlpacaToBase,
+                deposit_confirmed_at: timestamp(250),
+            },
+        ];
+
+        let operation = fold_operation("op-recovery-complete", &events).unwrap();
+
+        assert_eq!(operation.status, RebalanceTimingStatus::Completed);
+        assert_eq!(operation.completed_at, Some(timestamp(250)));
+        // The stream opens at BridgingInitiated (no genuine start event), so
+        // started_at stays None and the round-trip total_ms is unmeasured;
+        // per-stage durations are still measured where their endpoints are known.
+        assert_eq!(operation.started_at, None);
+        assert_eq!(operation.total_ms, None);
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Deposit).duration_ms,
+            Some(40_000)
+        );
+        assert_eq!(
+            stage(&operation, RebalanceStageName::Deposit).outcome,
+            StageOutcome::Succeeded
+        );
+    }
+
+    #[tokio::test]
+    async fn reactor_redelivery_does_not_double_count_stages() {
+        // Drive the full sequence through the reactor, then redeliver every
+        // event. The persisted read-model row must be byte-identical in stage
+        // shape: no doubled stages, no changed durations.
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(RebalanceTimingProjection::new(pool.clone()));
+        let operation_id = UsdcRebalanceId(Uuid::new_v4());
+        let events = alpaca_to_base_happy_path();
+
+        for event in &events {
+            harness
+                .receive::<UsdcRebalance>(operation_id.clone(), event.clone())
+                .await
+                .unwrap();
+        }
+
+        let first_pass = load_rebalance_timings(&pool, &range()).await.unwrap();
+
+        for event in &events {
+            harness
+                .receive::<UsdcRebalance>(operation_id.clone(), event.clone())
+                .await
+                .unwrap();
+        }
+
+        let second_pass = load_rebalance_timings(&pool, &range()).await.unwrap();
+
+        assert_eq!(first_pass.total_operations, 1);
+        assert_eq!(second_pass.total_operations, 1);
+        let before = &first_pass.operations[0];
+        let after = &second_pass.operations[0];
+        assert_eq!(before.stages.len(), after.stages.len());
+        assert_eq!(before.total_ms, after.total_ms);
+        for (single, redelivered) in before.stages.iter().zip(after.stages.iter()) {
+            assert_eq!(single.stage, redelivered.stage);
+            assert_eq!(single.duration_ms, redelivered.duration_ms);
+            assert_eq!(single.outcome, redelivered.outcome);
+        }
+    }
+}

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -55,7 +55,7 @@ pub(super) struct UsdcRebalanceTracking {
 /// the USDC physically leaves. Both `UsdcRebalanceTracking::source_venue` and the
 /// restart-safe operator-reconciliation path (which has no tracking instance to
 /// call the method on) derive from this, so the two cannot drift.
-fn source_venue(direction: &RebalanceDirection) -> Venue {
+fn source_venue(direction: RebalanceDirection) -> Venue {
     match direction {
         RebalanceDirection::AlpacaToBase => Venue::Hedging,
         RebalanceDirection::BaseToAlpaca => Venue::MarketMaking,
@@ -64,7 +64,7 @@ fn source_venue(direction: &RebalanceDirection) -> Venue {
 
 impl UsdcRebalanceTracking {
     pub(super) fn source_venue(&self) -> Venue {
-        source_venue(&self.direction)
+        source_venue(self.direction)
     }
 
     fn source_transfer_started(&self) -> bool {
@@ -773,7 +773,7 @@ impl RebalancingService {
         let mut inventory = self.inventory.write().await;
         *inventory = inventory
             .clone()
-            .clear_usdc_inflight(source_venue(direction), now)?;
+            .clear_usdc_inflight(source_venue(*direction), now)?;
         drop(inventory);
 
         Ok(())
@@ -814,7 +814,7 @@ impl RebalancingService {
         let mut tracking = self.usdc_tracking.write().await;
         if let Some(existing) = tracking.get_mut(id) {
             let tracking_entry = UsdcRebalanceTracking {
-                direction: direction.clone(),
+                direction: *direction,
                 initiated_amount: amount,
                 bridged_amount_received: existing.bridged_amount_received,
                 stage,
@@ -845,7 +845,7 @@ impl RebalancingService {
         drop(tracking);
 
         let tracking_entry = UsdcRebalanceTracking {
-            direction: direction.clone(),
+            direction: *direction,
             initiated_amount: amount,
             bridged_amount_received: None,
             stage,
@@ -895,7 +895,7 @@ impl RebalancingService {
         let mut tracking = self.usdc_tracking.write().await;
 
         if let Some(existing) = tracking.get_mut(id) {
-            existing.direction = direction.clone();
+            existing.direction = *direction;
             if !existing.source_transfer_started() {
                 existing.initiated_amount = amount;
             }
@@ -905,7 +905,7 @@ impl RebalancingService {
         }
 
         let tracking_entry = UsdcRebalanceTracking {
-            direction: direction.clone(),
+            direction: *direction,
             initiated_amount: amount,
             bridged_amount_received: None,
             stage,

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -1670,7 +1670,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 from_block,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 let amount_u256 = usdc_to_u256(amount)?;
                 self.resume_withdrawal_submitting(id, amount, amount_u256, from_block)
                     .await?;
@@ -1680,7 +1680,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             Some(UsdcRebalance::Withdrawing {
                 direction, amount, ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.cqrs
                     .send(
                         id,
@@ -1695,7 +1695,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             Some(UsdcRebalance::WithdrawalComplete {
                 direction, amount, ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_withdrawal_complete(id, amount).await
             }
 
@@ -1705,7 +1705,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 from_block,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 let amount_u256 = usdc_to_u256(amount)?;
                 let burn_receipt = self
                     .resume_bridging_submitting(id, amount_u256, from_block)
@@ -1720,7 +1720,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 burn_tx_hash,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_bridging(id, amount, burn_tx_hash).await
             }
 
@@ -1731,7 +1731,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 retry_deadline_at,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_awaiting_attestation(id, amount, burn_tx_hash, retry_deadline_at)
                     .await
             }
@@ -1745,7 +1745,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 mint_scan_from_block,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_attested(
                     id,
                     direction,
@@ -1764,7 +1764,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 mint_tx_hash,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.continue_from_bridged_resume(id, amount_received, mint_tx_hash)
                     .await
             }
@@ -1775,7 +1775,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 deposit_ref,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 // The recorded `deposit_ref` is the USDC SEND tx (minted USDC
                 // forwarded to Alpaca's deposit address), not the mint tx. The
                 // send already moved funds before `InitiateDeposit` was recorded,
@@ -1815,12 +1815,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 order_id,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.resume_converting(id, order_id).await
             }
 
             Some(UsdcRebalance::ConversionComplete { direction, .. }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 Ok(())
             }
 
@@ -1833,7 +1833,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 burn_tx_hash,
                 ..
             }) => {
-                Self::require_base_to_alpaca(id, &direction)?;
+                Self::require_base_to_alpaca(id, direction)?;
                 self.recover_from_bridging_failed(id, burn_tx_hash).await
             }
 
@@ -1934,14 +1934,14 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
     fn require_base_to_alpaca(
         id: &UsdcRebalanceId,
-        direction: &RebalanceDirection,
+        direction: RebalanceDirection,
     ) -> Result<(), UsdcTransferError> {
         if matches!(direction, RebalanceDirection::BaseToAlpaca) {
             Ok(())
         } else {
             Err(UsdcTransferError::ResumeDirectionMismatch {
                 id: id.clone(),
-                direction: direction.clone(),
+                direction,
             })
         }
     }

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -115,10 +115,19 @@ pub(crate) enum TransferRef {
 }
 
 /// Direction of the USDC rebalancing operation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum RebalanceDirection {
     AlpacaToBase,
     BaseToAlpaca,
+}
+
+impl From<RebalanceDirection> for st0x_dto::UsdcBridgeDirection {
+    fn from(direction: RebalanceDirection) -> Self {
+        match direction {
+            RebalanceDirection::AlpacaToBase => Self::AlpacaToBase,
+            RebalanceDirection::BaseToAlpaca => Self::BaseToAlpaca,
+        }
+    }
 }
 
 /// Why an operator reconciled a USDC rebalance stranded in the post-burn
@@ -1046,7 +1055,7 @@ impl UsdcRebalance {
                 amount,
                 burn_tx_hash: Some(_),
                 ..
-            } => Some((direction.clone(), *amount)),
+            } => Some((*direction, *amount)),
             _ => None,
         }
     }
@@ -1080,7 +1089,7 @@ impl UsdcRebalance {
             | Self::DepositInitiated { direction, .. }
             | Self::DepositConfirmed { direction, .. }
             | Self::DepositFailed { direction, .. }
-            | Self::Reconciled { direction, .. } => direction.clone(),
+            | Self::Reconciled { direction, .. } => *direction,
         }
     }
 
@@ -1149,7 +1158,7 @@ impl UsdcRebalance {
                 burn_tx_hash: Some(_),
                 failed_at,
                 ..
-            } => Some((direction.clone(), *amount, *failed_at)),
+            } => Some((*direction, *amount, *failed_at)),
             // Guard-holding in-progress states: self-recover via
             // reactor/apalis once resumed; seeding would wedge
             // `DepositConfirmed`.
@@ -1310,7 +1319,7 @@ impl EventSourced for UsdcRebalance {
                 order_id,
                 initiated_at,
             } => Some(Self::Converting {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 order_id: order_id.clone(),
                 initiated_at: *initiated_at,
@@ -1322,7 +1331,7 @@ impl EventSourced for UsdcRebalance {
                 from_block,
                 submitting_at,
             } => Some(Self::WithdrawalSubmitting {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 from_block: *from_block,
                 initiated_at: *submitting_at,
@@ -1334,7 +1343,7 @@ impl EventSourced for UsdcRebalance {
                 withdrawal_ref,
                 initiated_at,
             } => Some(Self::Withdrawing {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 initiated_at: *initiated_at,
@@ -1361,7 +1370,7 @@ impl EventSourced for UsdcRebalance {
                 },
                 Self::DepositConfirmed { initiated_at, .. },
             ) => Self::Converting {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 order_id: order_id.clone(),
                 initiated_at: *initiated_at,
@@ -1380,7 +1389,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::ConversionComplete {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 filled_amount: *filled_amount,
                 initiated_at: *initiated_at,
@@ -1396,7 +1405,7 @@ impl EventSourced for UsdcRebalance {
                     initiated_at,
                 },
             ) => Self::ConversionFailed {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 order_id: order_id.clone(),
                 reason: reason.clone(),
@@ -1413,7 +1422,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::WithdrawalSubmitting {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *filled_amount,
                 from_block: *from_block,
                 initiated_at: *initiated_at,
@@ -1428,7 +1437,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Withdrawing {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 initiated_at: *initiated_at,
@@ -1443,7 +1452,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Withdrawing {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *filled_amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 initiated_at: *initiated_at,
@@ -1461,7 +1470,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::WithdrawalComplete {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 initiated_at: *initiated_at,
                 confirmed_at: *confirmed_at,
@@ -1477,7 +1486,7 @@ impl EventSourced for UsdcRebalance {
                     initiated_at,
                 },
             ) => Self::WithdrawalFailed {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 withdrawal_ref: withdrawal_ref.clone(),
                 reason: reason.clone(),
@@ -1498,7 +1507,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::BridgingSubmitting {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 from_block: *from_block,
                 initiated_at: *initiated_at,
@@ -1518,7 +1527,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Bridging {
-                direction: direction.clone(),
+                direction: *direction,
                 // Carry the actual burned amount (what was received after Alpaca
                 // withdrawal fees) into post-burn states so DTOs, recovery
                 // classification, and reconciliation see what was really burned,
@@ -1542,7 +1551,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Bridging {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 initiated_at: *initiated_at,
@@ -1572,7 +1581,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Attested {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
@@ -1597,7 +1606,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) if burn_tx_hash == state_burn_tx_hash => Self::AwaitingAttestation {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 initiated_at: *initiated_at,
@@ -1620,7 +1629,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Bridged {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 amount_received: *amount_received,
                 fee_collected: *fee_collected,
@@ -1649,7 +1658,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Bridged {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 amount_received: *amount_received,
                 fee_collected: *fee_collected,
@@ -1697,7 +1706,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::BridgingFailed {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 cctp_nonce: *cctp_nonce,
@@ -1720,7 +1729,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::DepositInitiated {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount_received,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
@@ -1743,7 +1752,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::DepositConfirmed {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
@@ -1766,7 +1775,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::DepositFailed {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 burn_tx_hash: *burn_tx_hash,
                 mint_tx_hash: *mint_tx_hash,
@@ -1800,7 +1809,7 @@ impl EventSourced for UsdcRebalance {
                     ..
                 },
             ) => Self::Reconciled {
-                direction: direction.clone(),
+                direction: *direction,
                 amount: *amount,
                 reason: *reason,
                 initiated_at: *initiated_at,
@@ -1981,7 +1990,7 @@ impl UsdcRebalance {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Converting { direction, .. } => Ok(vec![ConversionConfirmed {
-                direction: direction.clone(),
+                direction: *direction,
                 filled_amount,
                 converted_at: Utc::now(),
             }]),
@@ -2031,7 +2040,7 @@ impl UsdcRebalance {
             });
         }
         Ok(vec![ConversionInitiated {
-            direction: direction.clone(),
+            direction: *direction,
             amount: *amount,
             order_id,
             initiated_at: Utc::now(),
@@ -2536,7 +2545,7 @@ impl UsdcRebalance {
             | Self::BridgingFailed { .. }
             | Self::Bridged { .. } => Err(UsdcRebalanceError::DepositNotInitiated),
             Self::DepositInitiated { direction, .. } => Ok(vec![DepositConfirmed {
-                direction: direction.clone(),
+                direction: *direction,
                 deposit_confirmed_at: Utc::now(),
             }]),
             Self::DepositConfirmed { .. }
@@ -2621,7 +2630,7 @@ impl UsdcRebalance {
                 amount,
                 initiated_at,
                 ..
-            } => (direction.clone(), *amount, *initiated_at),
+            } => (*direction, *amount, *initiated_at),
             Self::BridgingFailed {
                 direction,
                 amount,
@@ -2630,7 +2639,7 @@ impl UsdcRebalance {
                 initiated_at,
                 ..
             } if burn_tx_hash.is_some() || cctp_nonce.is_some() => {
-                (direction.clone(), *amount, *initiated_at)
+                (*direction, *amount, *initiated_at)
             }
             _ => {
                 return Err(UsdcRebalanceError::InvalidCommand {


### PR DESCRIPTION
## What

[RAI-992](https://linear.app/makeitrain/issue/RAI-992)

- `GET /performance/rebalances`: per-operation stage breakdowns of USDC rebalances (conversion, withdrawal, CCTP burn → attestation → mint, deposit), per-stage percentile summaries, and a CCTP attestation-time trend.
- New `RebalanceTimingProjection` reactor (`src/performance/rebalance.rs`) subscribing to the `UsdcRebalance` event stream, maintaining the `rebalance_stage_timing` table (one row per operation keyed by `UsdcRebalanceId`).
- Migration `20260616221000_rebalance_timing_read_model.sql`; range filtering on `started_at` pushed into SQL (indexed).
- New rebalance DTOs in `crates/dto/src/performance.rs` (`RebalanceTimings`, `RebalanceOperationTiming`, `RebalanceStageTiming`, …); `PerformanceRangeQuery` replaces the previous per-endpoint duplicate.

## Why

Full round-trip liquidity time (trade → hedge → inventory restored) was invisible; CCTP attestation is the dominant and most variable stage and had no trend data.

## How

- `fold_operation` runs a small stage tracker over each `UsdcRebalance` stream: direction-specific terminal states close the operation (`DepositConfirmed` for AlpacaToBase, `ConversionConfirmed` for BaseToAlpaca); `AttestationTimedOut` keeps the stage open (recoverable stall); `BridgingFailed` closes open stages with `StageOutcome::Failed`; `BridgingCompletionRecovered` un-fails the operation and records the mint as an unmeasured stage (duration `None`) since its true duration is unknowable.
- `OperatorReconciled` completes stranded operations that would otherwise remain open indefinitely after a manual recovery.
- Operations without a `BridgingSubmitting` intent record the burn as unmeasured rather than a synthetic 0 ms sample that would drag percentiles down.
- Stage durations clamp negatives to zero; malformed rows skipped with a warning.
- Adds `impl From<&RebalanceDirection> for UsdcBridgeDirection` to replace a duplicated inline mapping.

## Testing

- 15+ read-model and report tests: both directions' happy paths with exact stage durations, withdrawal/deposit/conversion failures, timeout-then-attested, failure-then-recovery with `OperatorReconciled`, row cap, range exclusion, negative clamp, DB round trip with stage assertions.
- Endpoint tests: empty DB, seeded, inverted range → 400.
- DTO serialization tests asserting wire format against JSON literals.

## Anything else

- Read model is forward-only (no startup backfill); the endpoint reads the reactor-maintained `rebalance_stage_timing` table — never the `events` table directly. A crash between event persistence and the reactor can drop one event — accepted as best-effort.
- `UsdcBridgeDirection` gains `Copy`/`PartialEq`/`Eq` derives.
- Like the latencies endpoint, this relies on the reactor for all history. Covered by the same follow-up [RAI-1005](https://linear.app/makeitrain/issue/RAI-1005/performance-endpoints-re-fold-full-event-history-per-request).
