### PR TITLE
feat: reliability metrics endpoint

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -86,6 +86,11 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     RebalanceStageName::export_all_to(out_dir)?;
     RebalanceStageStats::export_all_to(out_dir)?;
     AttestationSample::export_all_to(out_dir)?;
+    ReliabilityReport::export_all_to(out_dir)?;
+    LogVolumeBucket::export_all_to(out_dir)?;
+    LogTargetCount::export_all_to(out_dir)?;
+    FailureEventCount::export_all_to(out_dir)?;
+    JobQueueHealth::export_all_to(out_dir)?;
     std::fs::write(out_dir.join("StatementGuard.ts"), Statement::guard_ts())
         .map_err(ts_rs::ExportError::Io)?;
 

--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -236,6 +236,92 @@ pub struct AttestationSample {
     pub duration_ms: i64,
 }
 
+/// Response of `GET /performance/reliability`.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct ReliabilityReport {
+    /// Error/warning log volume over time, oldest bucket first.
+    pub log_buckets: Vec<LogVolumeBucket>,
+    /// Error/warning counts per log target, highest count first.
+    pub log_targets: Vec<LogTargetCount>,
+    /// Money-at-risk lifecycle failure events in range, by event type.
+    pub failure_events: Vec<FailureEventCount>,
+    /// Current job queue health per job type. This is an instantaneous
+    /// snapshot of the queue, NOT windowed by the report range: counts span
+    /// all rows currently in the `Jobs` table regardless of `from`/`to`, so a
+    /// short range shows all-time `done`/`failed` next to windowed failures
+    /// and logs. Queue types with no rows are absent rather than zero.
+    pub job_queues: Vec<JobQueueHealth>,
+    /// `true` when the error/warning log scan hit its entry cap, so
+    /// `log_buckets` and `log_targets` undercount the noisiest windows. Lets
+    /// the dashboard render an honest partial-data state. Failure events are
+    /// aggregated in SQL and are never capped.
+    pub log_entries_truncated: bool,
+}
+
+/// Error and warning counts within one time bucket.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct LogVolumeBucket {
+    pub start: DateTime<Utc>,
+    #[ts(type = "number")]
+    pub errors: usize,
+    #[ts(type = "number")]
+    pub warnings: usize,
+}
+
+/// How often one log target emitted at one level.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct LogTargetCount {
+    pub target: String,
+    pub level: String,
+    #[ts(type = "number")]
+    pub count: usize,
+}
+
+/// Occurrences of one lifecycle failure event type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct FailureEventCount {
+    pub event_type: String,
+    #[ts(type = "number")]
+    pub count: usize,
+    pub last_at: DateTime<Utc>,
+}
+
+/// Snapshot of one apalis job queue's health.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct JobQueueHealth {
+    pub job_type: String,
+    #[ts(type = "number")]
+    pub pending: usize,
+    #[ts(type = "number")]
+    pub running: usize,
+    #[ts(type = "number")]
+    pub done: usize,
+    /// Terminal failures from retry exhaustion. apalis writes status `Killed`
+    /// (not `Failed`) once a job exhausts `max_attempts`, carrying
+    /// `attempts >= max_attempts`, so this counts `Killed AND attempts >=
+    /// max_attempts`. Disjoint from `awaiting_retry` and `killed`.
+    #[ts(type = "number")]
+    pub failed: usize,
+    /// Failed jobs apalis will retry (status `Failed`, attempts <
+    /// max_attempts): live backlog, also included in `oldest_pending_run_at`.
+    #[ts(type = "number")]
+    pub awaiting_retry: usize,
+    /// Jobs killed before exhausting retries (status `Killed`, attempts <
+    /// max_attempts), e.g. an explicit non-retryable abort. Disjoint from the
+    /// exhaustion-driven `failed` count.
+    #[ts(type = "number")]
+    pub killed: usize,
+    /// Jobs that needed more than one attempt.
+    #[ts(type = "number")]
+    pub retried: usize,
+    pub oldest_pending_run_at: Option<DateTime<Utc>>,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;

--- a/migrations/20260616223055_lifecycle_failure_event_read_model.sql
+++ b/migrations/20260616223055_lifecycle_failure_event_read_model.sql
@@ -1,0 +1,18 @@
+-- Forward-only read model for lifecycle failure events (money-at-risk signals).
+--
+-- This table is maintained exclusively by the LifecycleFailureProjection
+-- reactor from live OffchainOrder, UsdcRebalance, EquityRedemption, and
+-- TokenizedEquityMint events. The report read path (load_failure_events)
+-- queries ONLY this table and never folds the events table. One append-only
+-- row per failure event the reactor witnesses.
+--
+-- `event_type` is the canonical DomainEvent type string (e.g.
+-- "OffchainOrderEvent::Failed"). `occurred_at` is stored as RFC3339 TEXT
+-- (chrono `to_rfc3339`) so the report can filter by report range.
+CREATE TABLE lifecycle_failure_event (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,
+    occurred_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_lifecycle_failure_event_occurred_at ON lifecycle_failure_event (occurred_at);

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,13 +16,16 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use st0x_dto::{HedgeLatencies, RebalanceTimings, TradingVenue};
+use st0x_dto::{HedgeLatencies, RebalanceTimings, ReliabilityReport, TradingVenue};
 use st0x_execution::FractionalShares;
 
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
 use crate::performance::rebalance::load_rebalance_timings;
+use crate::performance::reliability::{
+    aggregate_log_entries, load_failure_events, load_job_queue_health,
+};
 use crate::performance::{ReportRange, hedge_latency_report, load_hedge_performance};
 use crate::rebalancing::RebalancingService;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
@@ -43,6 +46,9 @@ fn parse_transfer_kind_filter(value: &str) -> Result<Vec<TransferKind>, InvalidT
 static STARTED_AT: LazyLock<DateTime<Utc>> = LazyLock::new(Utc::now);
 const DEFAULT_RAINDEX_ORDERS_PAGE_SIZE: u32 = 50;
 const MAX_RAINDEX_ORDERS_PAGE_SIZE: u32 = 100;
+
+/// Upper bound on ERROR/WARN log entries aggregated per reliability report.
+const MAX_RELIABILITY_LOG_ENTRIES: usize = 50_000;
 
 const GIT_COMMIT: &str = match option_env!("ST0X_GIT_COMMIT") {
     Some(val) => val,
@@ -1534,11 +1540,74 @@ async fn performance_rebalances(
     Ok(Json(timings))
 }
 
+async fn performance_reliability(
+    State(state): State<AppState>,
+    Query(query): Query<PerformanceRangeQuery>,
+) -> Result<Json<ReliabilityReport>, StatusCode> {
+    let to = query.to.unwrap_or_else(Utc::now);
+    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
+    if from >= to {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let range = ReportRange { from, to };
+
+    let (entries, log_entries_truncated) = if let Some(log_dir) = state.ctx.log_dir.as_deref() {
+        let log_dir = log_dir.to_owned();
+        let filter = LogFilter {
+            search_lower: None,
+            levels: Some(vec!["ERROR".to_string(), "WARN".to_string()]),
+            targets: None,
+            since: Some(from),
+            until: Some(to),
+        };
+        // Log scanning is synchronous file I/O; keep it off the async
+        // workers. The cap bounds memory during error storms, slightly
+        // undercounting the noisiest windows rather than exhausting the
+        // dashboard process.
+        let (entries, total, _) = tokio::task::spawn_blocking(move || {
+            read_matching_entries(&log_dir, &filter, 0, MAX_RELIABILITY_LOG_ENTRIES)
+        })
+        .await
+        .inspect_err(|error| error!(%error, "Log aggregation task failed"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let truncated = total > MAX_RELIABILITY_LOG_ENTRIES;
+        if truncated {
+            warn!(
+                total,
+                cap = MAX_RELIABILITY_LOG_ENTRIES,
+                "Reliability log aggregation truncated by entry cap"
+            );
+        }
+        (entries, truncated)
+    } else {
+        (Vec::new(), false)
+    };
+    let (log_buckets, log_targets) = aggregate_log_entries(&entries, &range);
+
+    let failure_events = load_failure_events(&state.pool, &range)
+        .await
+        .inspect_err(|error| error!(%error, "Failed to load failure events"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let job_queues = load_job_queue_health(&state.pool)
+        .await
+        .inspect_err(|error| error!(%error, "Failed to load job queue health"))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(ReliabilityReport {
+        log_buckets,
+        log_targets,
+        failure_events,
+        job_queues,
+        log_entries_truncated,
+    }))
+}
+
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health))
         .route("/performance/latencies", get(performance_latencies))
         .route("/performance/rebalances", get(performance_rebalances))
+        .route("/performance/reliability", get(performance_reliability))
         .route("/logs", get(logs))
         .route("/orders/pending", get(pending_orders))
         .route("/trades", get(trades))
@@ -1561,21 +1630,24 @@ mod tests {
     use alloy::primitives::Address;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use sqlx::SqlitePool;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
     use st0x_config::{Ctx, RestApiCtx, create_test_ctx_with_order_owner};
+    use st0x_event_sorcery::ReactorHarness;
 
     use super::*;
     use crate::dashboard;
     use crate::inventory::{self, BroadcastingInventory};
+    use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
+    use crate::performance::reliability::LifecycleFailureProjection;
     use crate::tokenized_equity_mint::issuer_request_id;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
         let (sender, _) = broadcast::channel(16);
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
+        // Use the shared-cache test pool so the apalis `Jobs` table (set up by
+        // `setup_test_db`) is visible to the reliability job-queue-health query.
+        let pool = crate::test_utils::setup_test_db().await;
 
         AppState {
             settings: dashboard::settings_from_ctx(&ctx),
@@ -2033,6 +2105,183 @@ mod tests {
         assert_eq!(report["operations"], serde_json::json!([]));
         assert_eq!(report["stageSummary"], serde_json::json!([]));
         assert_eq!(report["attestationTrend"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn performance_reliability_returns_empty_report_on_fresh_database() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/reliability")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(report["logBuckets"], serde_json::json!([]));
+        assert_eq!(report["logTargets"], serde_json::json!([]));
+        assert_eq!(report["failureEvents"], serde_json::json!([]));
+        assert_eq!(report["jobQueues"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn performance_reliability_rejects_inverted_range() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/reliability\
+                         ?from=2026-01-02T00:00:00Z&to=2026-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_reliability_rejects_equal_range() {
+        // `from == to` is an empty interval and must be rejected with 400,
+        // matching the latencies and rebalances endpoints.
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/reliability\
+                         ?from=2026-01-01T00:00:00Z&to=2026-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_reliability_reports_seeded_failures_and_jobs() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let now = chrono::Utc::now();
+
+        // The failure read model reads the reactor-maintained table. Drive the
+        // real reactor path (record()) via the harness rather than a raw
+        // INSERT, so a schema change to record() cannot leave this end-to-end
+        // test green while the live reactor breaks.
+        ReactorHarness::new(LifecycleFailureProjection::new(state.pool.clone()))
+            .receive::<OffchainOrder>(
+                OffchainOrderId::new(),
+                OffchainOrderEvent::Failed {
+                    error: "rejected".to_string(),
+                    failed_at: now,
+                },
+            )
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO Jobs (job, id, job_type, status, attempts, run_at) \
+             VALUES ('{}', 'job-1', 'queue::A', 'Pending', 0, 1750000000)",
+        )
+        .execute(&state.pool)
+        .await
+        .unwrap();
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/reliability")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(
+            report["failureEvents"][0]["eventType"],
+            serde_json::json!("OffchainOrderEvent::Failed")
+        );
+        assert_eq!(report["failureEvents"][0]["count"], serde_json::json!(1));
+        assert_eq!(
+            report["jobQueues"][0]["jobType"],
+            serde_json::json!("queue::A")
+        );
+        assert_eq!(report["jobQueues"][0]["pending"], serde_json::json!(1));
+    }
+
+    #[tokio::test]
+    async fn performance_reliability_aggregates_log_dir_entries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        // Three log entries: one ERROR and one WARN within the default 7-day
+        // window, one INFO that must be filtered out.
+        let log_content = concat!(
+            "{\"timestamp\":\"2026-06-15T10:00:00Z\",\"level\":\"ERROR\",",
+            "\"target\":\"hedge\",\"message\":\"crash\"}\n",
+            "{\"timestamp\":\"2026-06-15T10:00:01Z\",\"level\":\"WARN\",",
+            "\"target\":\"rebalance\",\"message\":\"retry\"}\n",
+            "{\"timestamp\":\"2026-06-15T10:00:02Z\",\"level\":\"INFO\",",
+            "\"target\":\"hedge\",\"message\":\"ok\"}",
+        );
+        write_test_logs(temp_dir.path(), "st0x-hedge.log.2026-06-15", log_content);
+
+        let mut ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        ctx.log_dir = Some(temp_dir.path().to_str().unwrap().to_string());
+
+        let app = build_app(empty_app_state(ctx).await);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/reliability\
+                         ?from=2026-06-15T00:00:00Z&to=2026-06-16T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        // Only ERROR and WARN entries appear; INFO is excluded.
+        let buckets = &report["logBuckets"];
+        let targets = &report["logTargets"];
+        assert_eq!(
+            buckets.as_array().unwrap().len(),
+            1,
+            "both entries fall in the same hour -> exactly one bucket"
+        );
+        assert_eq!(buckets[0]["errors"], serde_json::json!(1));
+        assert_eq!(buckets[0]["warnings"], serde_json::json!(1));
+        // Two distinct (target, level) pairs: hedge/ERROR and rebalance/WARN.
+        assert_eq!(targets.as_array().unwrap().len(), 2);
+        // Well under the entry cap, so the partial-data flag must be false.
+        assert_eq!(report["logEntriesTruncated"], serde_json::json!(false));
     }
 
     #[tokio::test]

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -63,6 +63,7 @@ use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vau
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
 use crate::performance::HedgeLatencyProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
+use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::{Position, PositionCommand, PositionError, TradeId};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, ResumeTokenizationAggregate,
@@ -521,6 +522,7 @@ impl Conductor {
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
                 .with(Arc::new(HedgeLatencyProjection::new(pool.clone())))
+                .with(Arc::new(LifecycleFailureProjection::new(pool.clone())))
                 .build(order_placer)
                 .await?;
 
@@ -1217,11 +1219,13 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(deps.pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(deps.pool.clone()));
+        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(deps.pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         );
 
         let built = manifest

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -23,6 +23,7 @@ use crate::equity_redemption::EquityRedemption;
 use crate::inventory::InventorySnapshot;
 use crate::performance::HedgeLatencyProjection;
 use crate::performance::rebalance::RebalanceTimingProjection;
+use crate::performance::reliability::LifecycleFailureProjection;
 use crate::position::Position;
 use crate::rebalancing::{RebalancingService, equity::EquityTransferServices};
 use crate::tokenized_equity_mint::TokenizedEquityMint;
@@ -38,6 +39,7 @@ pub(super) struct QueryManifest {
     broadcaster: Arc<Broadcaster>,
     hedge_latency: Arc<HedgeLatencyProjection>,
     rebalance_timing: Arc<RebalanceTimingProjection>,
+    lifecycle_failure: Arc<LifecycleFailureProjection>,
 }
 
 /// Built CQRS frameworks from the wiring process.
@@ -60,12 +62,14 @@ impl QueryManifest {
         broadcaster: Arc<Broadcaster>,
         hedge_latency: Arc<HedgeLatencyProjection>,
         rebalance_timing: Arc<RebalanceTimingProjection>,
+        lifecycle_failure: Arc<LifecycleFailureProjection>,
     ) -> Self {
         Self {
             rebalancing_service,
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         }
     }
 
@@ -84,6 +88,7 @@ impl QueryManifest {
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         } = self;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
@@ -96,12 +101,14 @@ impl QueryManifest {
         let mint = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())
             .with(rebalancing_service.clone())
             .with(broadcaster.clone())
+            .with(lifecycle_failure.clone())
             .build(services.clone())
             .await?;
 
         let redemption = StoreBuilder::<EquityRedemption>::new(pool.clone())
             .with(rebalancing_service.clone())
             .with(broadcaster.clone())
+            .with(lifecycle_failure.clone())
             .build(services)
             .await?;
 
@@ -109,6 +116,7 @@ impl QueryManifest {
             .with(rebalancing_service.clone())
             .with(broadcaster)
             .with(rebalance_timing)
+            .with(lifecycle_failure)
             .build(())
             .await?;
 
@@ -204,11 +212,13 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         );
 
         let services = EquityTransferServices {
@@ -259,11 +269,13 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service,
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         );
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),
@@ -373,11 +385,13 @@ mod tests {
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let hedge_latency = Arc::new(HedgeLatencyProjection::new(pool.clone()));
         let rebalance_timing = Arc::new(RebalanceTimingProjection::new(pool.clone()));
+        let lifecycle_failure = Arc::new(LifecycleFailureProjection::new(pool.clone()));
         let manifest = QueryManifest::new(
             rebalancing_service.clone(),
             broadcaster,
             hedge_latency,
             rebalance_timing,
+            lifecycle_failure,
         );
         let services = EquityTransferServices {
             raindex: Arc::new(MockRaindex::new()),

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -44,6 +44,7 @@ use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId}
 use crate::position::{Position, PositionEvent, TradeId};
 
 pub(crate) mod rebalance;
+pub(crate) mod reliability;
 
 /// Waterfall rows returned per report; the full cycle count is still
 /// reported via `total_cycles`.
@@ -164,6 +165,8 @@ pub(crate) enum PerformanceError {
     CoveredCount(#[from] std::num::TryFromIntError),
     #[error("read-model row had an earliest_block_timestamp but no covered fills")]
     InconsistentCoveredBatch,
+    #[error("job queue or failure aggregation produced a count outside usize range: {value}")]
+    AggregateCount { value: i64 },
     #[error("read-model row carried an unparseable offchain order id")]
     OrderId(#[from] uuid::Error),
 }

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -1,0 +1,894 @@
+//! Reliability read models: lifecycle failure events, log volume
+//! aggregation, and job queue health.
+//!
+//! Distinguishes money-at-risk failures (failed hedges, failed rebalance
+//! stages) recorded as CQRS events from cosmetic log noise, and surfaces
+//! apalis queue backlogs and retry pressure.
+//!
+//! Lifecycle failure events are maintained forward-only by
+//! [`LifecycleFailureProjection`], which subscribes to the `OffchainOrder`,
+//! `UsdcRebalance`, `EquityRedemption`, and `TokenizedEquityMint` event
+//! streams and records one row per failure event into `lifecycle_failure_event`.
+//! [`load_failure_events`] reads ONLY that table and never folds the `events`
+//! table. The log-aggregation and job-queue-health read paths read their own
+//! sources (structured logs, the apalis `Jobs` table) and are left untouched.
+//!
+//! Forward-only: the reactor processes only events emitted after construction.
+//! There is NO startup backfill of pre-existing history. A single event is
+//! dropped from the read model if it cannot be persisted -- whether a crash
+//! between the source event committing and this reactor's INSERT, or the INSERT
+//! itself erroring (contention, disk full). The drop is logged at error level
+//! with the event's type and timestamp so an operator can reconcile from the
+//! event log. It is deliberately NOT retried: `lifecycle_failure_event` has no
+//! idempotency key, so a retry after a partially-applied write would
+//! double-count a money-at-risk failure. This best-effort guarantee matches the
+//! `Broadcaster` reactor.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+use thiserror::Error;
+use tracing::error;
+
+use st0x_dto::{FailureEventCount, JobQueueHealth, LogTargetCount, LogVolumeBucket};
+use st0x_event_sorcery::{EntityList, Reactor, deps};
+
+use super::{PerformanceError, ReportRange};
+use crate::equity_redemption::{EquityRedemption, EquityRedemptionEvent};
+use crate::offchain::order::{OffchainOrder, OffchainOrderEvent};
+use crate::tokenized_equity_mint::{TokenizedEquityMint, TokenizedEquityMintEvent};
+use crate::usdc_rebalance::{UsdcRebalance, UsdcRebalanceEvent};
+
+/// Count lifecycle failure events within `range`, newest category first.
+///
+/// Reads ONLY the reactor-maintained `lifecycle_failure_event` table,
+/// aggregating per `event_type` in SQL (index-backed on `occurred_at`). Because
+/// the grouping happens in the database there is no row cap, so the per-type
+/// counts stay exact even during a failure storm with millions of rows in
+/// range -- the view this serves is money-at-risk, so it must not undercount.
+///
+/// `occurred_at` is always written by [`LifecycleFailureProjection::record`] as
+/// valid RFC 3339, so an unparseable `MAX(occurred_at)` means data corruption
+/// and fails the report loudly rather than silently dropping a category.
+pub(crate) async fn load_failure_events(
+    pool: &SqlitePool,
+    range: &ReportRange,
+) -> Result<Vec<FailureEventCount>, PerformanceError> {
+    let rows: Vec<(String, i64, String)> = sqlx::query_as(
+        "SELECT event_type, COUNT(*) AS count, MAX(occurred_at) AS last_at \
+         FROM lifecycle_failure_event \
+         WHERE occurred_at >= ? AND occurred_at <= ? \
+         GROUP BY event_type",
+    )
+    .bind(range.from.to_rfc3339())
+    .bind(range.to.to_rfc3339())
+    .fetch_all(pool)
+    .await?;
+
+    let mut failure_events = rows
+        .into_iter()
+        .map(|(event_type, occurrences, last_at)| {
+            Ok(FailureEventCount {
+                event_type,
+                count: count(occurrences)?,
+                last_at: DateTime::parse_from_rfc3339(&last_at)?.with_timezone(&Utc),
+            })
+        })
+        .collect::<Result<Vec<_>, PerformanceError>>()?;
+
+    failure_events.sort_by(|left, right| right.last_at.cmp(&left.last_at));
+    Ok(failure_events)
+}
+
+/// Reactor maintaining the lifecycle-failure read model from live events.
+pub(crate) struct LifecycleFailureProjection {
+    pool: SqlitePool,
+}
+
+deps!(
+    LifecycleFailureProjection,
+    [
+        OffchainOrder,
+        UsdcRebalance,
+        EquityRedemption,
+        TokenizedEquityMint,
+    ]
+);
+
+impl LifecycleFailureProjection {
+    pub(crate) fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// Record a money-at-risk failure event. Non-failure events map to `None`
+    /// and are ignored.
+    async fn record(
+        &self,
+        failure: Option<(&'static str, DateTime<Utc>)>,
+    ) -> Result<(), FailureProjectionError> {
+        let Some((event_type, occurred_at)) = failure else {
+            return Ok(());
+        };
+        sqlx::query("INSERT INTO lifecycle_failure_event (event_type, occurred_at) VALUES (?, ?)")
+            .bind(event_type)
+            .bind(occurred_at.to_rfc3339())
+            .execute(&self.pool)
+            .await
+            .inspect_err(|error| {
+                error!(
+                    ?error,
+                    event_type,
+                    %occurred_at,
+                    "failed to persist lifecycle failure event; this money-at-risk \
+                     failure is dropped from the reliability read model (the source \
+                     event remains in the event log for reconciliation)"
+                );
+            })?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum FailureProjectionError {
+    #[error("lifecycle-failure read-model write failed")]
+    Database(#[from] sqlx::Error),
+}
+
+#[async_trait]
+impl Reactor for LifecycleFailureProjection {
+    type Error = FailureProjectionError;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        event
+            .on(|_id, event| async move { self.record(offchain_order_failure(&event)).await })
+            .on(|_id, event| async move { self.record(usdc_rebalance_failure(&event)).await })
+            .on(|_id, event| async move { self.record(equity_redemption_failure(&event)).await })
+            .on(|_id, event| async move { self.record(tokenized_equity_mint_failure(&event)).await })
+            .exhaustive()
+            .await
+    }
+}
+
+/// Failure signal carried by an `OffchainOrder` event, if any.
+fn offchain_order_failure(event: &OffchainOrderEvent) -> Option<(&'static str, DateTime<Utc>)> {
+    match event {
+        OffchainOrderEvent::Failed { failed_at, .. } => {
+            Some(("OffchainOrderEvent::Failed", *failed_at))
+        }
+        OffchainOrderEvent::Placed { .. }
+        | OffchainOrderEvent::Submitted { .. }
+        | OffchainOrderEvent::PartiallyFilled { .. }
+        | OffchainOrderEvent::Filled { .. } => None,
+    }
+}
+
+/// Failure signal carried by a `UsdcRebalance` event, if any.
+fn usdc_rebalance_failure(event: &UsdcRebalanceEvent) -> Option<(&'static str, DateTime<Utc>)> {
+    match event {
+        UsdcRebalanceEvent::ConversionFailed { failed_at, .. } => {
+            Some(("UsdcRebalanceEvent::ConversionFailed", *failed_at))
+        }
+        UsdcRebalanceEvent::WithdrawalFailed { failed_at, .. } => {
+            Some(("UsdcRebalanceEvent::WithdrawalFailed", *failed_at))
+        }
+        UsdcRebalanceEvent::BridgingFailed { failed_at, .. } => {
+            Some(("UsdcRebalanceEvent::BridgingFailed", *failed_at))
+        }
+        UsdcRebalanceEvent::DepositFailed { failed_at, .. } => {
+            Some(("UsdcRebalanceEvent::DepositFailed", *failed_at))
+        }
+        UsdcRebalanceEvent::AttestationTimedOut { timed_out_at, .. } => {
+            Some(("UsdcRebalanceEvent::AttestationTimedOut", *timed_out_at))
+        }
+        UsdcRebalanceEvent::ConversionInitiated { .. }
+        | UsdcRebalanceEvent::ConversionConfirmed { .. }
+        | UsdcRebalanceEvent::WithdrawalSubmitting { .. }
+        | UsdcRebalanceEvent::Initiated { .. }
+        | UsdcRebalanceEvent::WithdrawalConfirmed { .. }
+        | UsdcRebalanceEvent::BridgingSubmitting { .. }
+        | UsdcRebalanceEvent::BridgingInitiated { .. }
+        | UsdcRebalanceEvent::BridgeAttestationReceived { .. }
+        | UsdcRebalanceEvent::Bridged { .. }
+        | UsdcRebalanceEvent::BridgingCompletionRecovered { .. }
+        | UsdcRebalanceEvent::DepositInitiated { .. }
+        | UsdcRebalanceEvent::DepositConfirmed { .. }
+        | UsdcRebalanceEvent::OperatorReconciled { .. } => None,
+    }
+}
+
+/// Failure signal carried by an `EquityRedemption` event, if any.
+fn equity_redemption_failure(
+    event: &EquityRedemptionEvent,
+) -> Option<(&'static str, DateTime<Utc>)> {
+    match event {
+        EquityRedemptionEvent::TransferFailed { failed_at, .. } => {
+            Some(("EquityRedemptionEvent::TransferFailed", *failed_at))
+        }
+        EquityRedemptionEvent::DetectionFailed { failed_at, .. } => {
+            Some(("EquityRedemptionEvent::DetectionFailed", *failed_at))
+        }
+        EquityRedemptionEvent::RedemptionRejected { rejected_at, .. } => {
+            Some(("EquityRedemptionEvent::RedemptionRejected", *rejected_at))
+        }
+        EquityRedemptionEvent::VaultWithdrawPending { .. }
+        | EquityRedemptionEvent::VaultWithdrawSubmitted { .. }
+        | EquityRedemptionEvent::WithdrawnFromRaindex { .. }
+        | EquityRedemptionEvent::TokensUnwrapped { .. }
+        | EquityRedemptionEvent::UnwrapPending { .. }
+        | EquityRedemptionEvent::UnwrapSubmitted { .. }
+        | EquityRedemptionEvent::SendPending { .. }
+        | EquityRedemptionEvent::TokensSent { .. }
+        | EquityRedemptionEvent::Detected { .. }
+        | EquityRedemptionEvent::Completed { .. }
+        | EquityRedemptionEvent::ProviderCompletionRecovered { .. } => None,
+    }
+}
+
+/// Failure signal carried by a `TokenizedEquityMint` event, if any.
+fn tokenized_equity_mint_failure(
+    event: &TokenizedEquityMintEvent,
+) -> Option<(&'static str, DateTime<Utc>)> {
+    match event {
+        TokenizedEquityMintEvent::MintRejected { rejected_at, .. } => {
+            Some(("TokenizedEquityMintEvent::MintRejected", *rejected_at))
+        }
+        TokenizedEquityMintEvent::MintAcceptanceFailed { failed_at, .. } => {
+            Some(("TokenizedEquityMintEvent::MintAcceptanceFailed", *failed_at))
+        }
+        TokenizedEquityMintEvent::WrappingFailed { failed_at, .. } => {
+            Some(("TokenizedEquityMintEvent::WrappingFailed", *failed_at))
+        }
+        TokenizedEquityMintEvent::RaindexDepositFailed { failed_at, .. } => {
+            Some(("TokenizedEquityMintEvent::RaindexDepositFailed", *failed_at))
+        }
+        TokenizedEquityMintEvent::MintRequested { .. }
+        | TokenizedEquityMintEvent::MintAccepted { .. }
+        | TokenizedEquityMintEvent::TokensReceived { .. }
+        | TokenizedEquityMintEvent::WrapSubmitted { .. }
+        | TokenizedEquityMintEvent::TokensWrapped { .. }
+        | TokenizedEquityMintEvent::VaultDepositSubmitted { .. }
+        | TokenizedEquityMintEvent::DepositedIntoRaindex { .. }
+        | TokenizedEquityMintEvent::ProviderCompletionRecovered { .. } => None,
+    }
+}
+
+/// Aggregate already-filtered ERROR/WARN log entries into time buckets and
+/// per-target counts.
+///
+/// Entries with missing or malformed timestamps are skipped; counts come
+/// from the dashboard's own log files, so a skipped line only understates
+/// noise, never money-at-risk failures.
+pub(crate) fn aggregate_log_entries(
+    entries: &[serde_json::Value],
+    range: &ReportRange,
+) -> (Vec<LogVolumeBucket>, Vec<LogTargetCount>) {
+    let width = range.bucket_width();
+    let mut buckets: BTreeMap<i64, (usize, usize)> = BTreeMap::new();
+    let mut targets: BTreeMap<(String, String), usize> = BTreeMap::new();
+
+    for entry in entries {
+        let Some(timestamp) = entry["timestamp"]
+            .as_str()
+            .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+            .map(|parsed| parsed.with_timezone(&Utc))
+        else {
+            continue;
+        };
+        if !range.contains(timestamp) {
+            continue;
+        }
+
+        let level = entry["level"].as_str().unwrap_or("UNKNOWN").to_uppercase();
+        let target = entry["target"].as_str().unwrap_or("unknown").to_string();
+
+        let index = (timestamp - range.from).num_seconds() / width.num_seconds();
+        match level.as_str() {
+            "ERROR" => buckets.entry(index).or_default().0 += 1,
+            "WARN" => buckets.entry(index).or_default().1 += 1,
+            _ => continue,
+        }
+
+        *targets.entry((target, level)).or_default() += 1;
+    }
+
+    let log_buckets = buckets
+        .into_iter()
+        .map(|(index, (errors, warnings))| LogVolumeBucket {
+            start: range.from + chrono::Duration::seconds(width.num_seconds() * index),
+            errors,
+            warnings,
+        })
+        .collect();
+
+    let mut log_targets: Vec<LogTargetCount> = targets
+        .into_iter()
+        .map(|((target, level), count)| LogTargetCount {
+            target,
+            level,
+            count,
+        })
+        .collect();
+    log_targets.sort_by(|left, right| right.count.cmp(&left.count));
+
+    (log_buckets, log_targets)
+}
+
+/// One aggregated apalis job-queue row: job type, status counts (pending,
+/// running, done, failed, awaiting retry, killed, retried), and the oldest
+/// live-backlog `run_at`.
+#[derive(sqlx::FromRow)]
+struct JobQueueRow {
+    job_type: String,
+    pending: i64,
+    running: i64,
+    done: i64,
+    failed: i64,
+    awaiting_retry: i64,
+    killed: i64,
+    retried: i64,
+    oldest_pending_run_at: Option<i64>,
+}
+
+/// Current health of every apalis job queue.
+pub(crate) async fn load_job_queue_health(
+    pool: &SqlitePool,
+) -> Result<Vec<JobQueueHealth>, PerformanceError> {
+    // apalis's `calculate_status` writes 'Killed' (not 'Failed') once a job
+    // exhausts max_attempts, carrying attempts >= max_attempts; it also writes
+    // 'Killed' on an explicit abort (attempts < max_attempts). A retryable
+    // error stays 'Failed' with attempts < max_attempts and is re-fetched. So
+    // terminal exhaustion is 'Killed' AND attempts >= max_attempts (failed), an
+    // abort is 'Killed' AND attempts < max_attempts (killed), and every 'Failed'
+    // row is live retry backlog (awaiting_retry).
+    let rows: Vec<JobQueueRow> = sqlx::query_as(
+        "SELECT job_type, \
+            SUM(CASE WHEN status IN ('Pending', 'Queued') THEN 1 ELSE 0 END) AS pending, \
+            SUM(CASE WHEN status = 'Running' THEN 1 ELSE 0 END) AS running, \
+            SUM(CASE WHEN status = 'Done' THEN 1 ELSE 0 END) AS done, \
+            SUM(CASE WHEN status = 'Killed' AND attempts >= max_attempts \
+                THEN 1 ELSE 0 END) AS failed, \
+            SUM(CASE WHEN status = 'Failed' AND attempts < max_attempts \
+                THEN 1 ELSE 0 END) AS awaiting_retry, \
+            SUM(CASE WHEN status = 'Killed' AND attempts < max_attempts \
+                THEN 1 ELSE 0 END) AS killed, \
+            SUM(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS retried, \
+            MIN(CASE WHEN status IN ('Pending', 'Queued') \
+                OR (status = 'Failed' AND attempts < max_attempts) \
+                THEN run_at ELSE NULL END) AS oldest_pending_run_at \
+         FROM Jobs \
+         GROUP BY job_type \
+         ORDER BY job_type",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(JobQueueHealth {
+                job_type: row.job_type,
+                pending: count(row.pending)?,
+                running: count(row.running)?,
+                done: count(row.done)?,
+                failed: count(row.failed)?,
+                awaiting_retry: count(row.awaiting_retry)?,
+                killed: count(row.killed)?,
+                retried: count(row.retried)?,
+                oldest_pending_run_at: row
+                    .oldest_pending_run_at
+                    .and_then(|seconds| DateTime::from_timestamp(seconds, 0)),
+            })
+        })
+        .collect()
+}
+
+/// Convert a SQLite SUM/COUNT aggregate to `usize`. These are structurally
+/// non-negative, so a negative value means a corrupted aggregate -- on an
+/// operational-metrics path masking it to a healthy-looking zero would be the
+/// opposite of fail-fast, so it surfaces as an error (a 500 at the endpoint).
+fn count(value: i64) -> Result<usize, PerformanceError> {
+    usize::try_from(value).map_err(|_| PerformanceError::AggregateCount { value })
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use st0x_event_sorcery::ReactorHarness;
+    use st0x_execution::Symbol;
+
+    use crate::offchain::order::OffchainOrderId;
+    use crate::test_utils::setup_test_db;
+    use crate::usdc_rebalance::UsdcRebalanceId;
+
+    use super::*;
+
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
+    }
+
+    fn range() -> ReportRange {
+        ReportRange {
+            from: timestamp(0),
+            to: timestamp(86_400),
+        }
+    }
+
+    fn log_entry(offset: i64, level: &str, target: &str) -> serde_json::Value {
+        json!({
+            "timestamp": timestamp(offset).to_rfc3339(),
+            "level": level,
+            "target": target,
+            "message": "boom",
+        })
+    }
+
+    #[test]
+    fn aggregate_log_entries_buckets_and_counts_targets() {
+        let entries = vec![
+            log_entry(10, "ERROR", "hedge"),
+            log_entry(20, "WARN", "hedge"),
+            log_entry(30, "ERROR", "rebalance"),
+            log_entry(40, "ERROR", "hedge"),
+        ];
+
+        let (buckets, targets) = aggregate_log_entries(&entries, &range());
+
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0].start, timestamp(0));
+        assert_eq!(buckets[0].errors, 3);
+        assert_eq!(buckets[0].warnings, 1);
+
+        assert_eq!(
+            targets[0],
+            LogTargetCount {
+                target: "hedge".to_string(),
+                level: "ERROR".to_string(),
+                count: 2,
+            }
+        );
+        assert_eq!(targets.len(), 3);
+    }
+
+    #[test]
+    fn aggregate_log_entries_skips_malformed_and_out_of_range() {
+        let entries = vec![
+            json!({"level": "ERROR", "target": "hedge", "message": "no timestamp"}),
+            log_entry(-100, "ERROR", "hedge"),
+            log_entry(10, "ERROR", "hedge"),
+        ];
+
+        let (buckets, targets) = aggregate_log_entries(&entries, &range());
+
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0].errors, 1);
+        assert_eq!(targets.len(), 1);
+    }
+
+    #[test]
+    fn aggregate_log_entries_includes_inclusive_range_boundaries() {
+        // Entries exactly at range.from and range.to must both be counted:
+        // the window is inclusive on both ends.
+        let entries = vec![
+            log_entry(0, "ERROR", "hedge"),
+            log_entry(86_400, "WARN", "hedge"),
+        ];
+
+        let (buckets, targets) = aggregate_log_entries(&entries, &range());
+
+        let errors: usize = buckets.iter().map(|bucket| bucket.errors).sum();
+        let warnings: usize = buckets.iter().map(|bucket| bucket.warnings).sum();
+        assert_eq!(errors, 1);
+        assert_eq!(warnings, 1);
+        assert_eq!(targets.iter().map(|target| target.count).sum::<usize>(), 2);
+    }
+
+    fn offchain_order_failed(failed_offset: i64) -> OffchainOrderEvent {
+        OffchainOrderEvent::Failed {
+            error: "rejected".to_string(),
+            failed_at: timestamp(failed_offset),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_failure_events_counts_by_type_within_range() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(LifecycleFailureProjection::new(pool.clone()));
+
+        harness
+            .receive::<OffchainOrder>(OffchainOrderId::new(), offchain_order_failed(100))
+            .await
+            .unwrap();
+        harness
+            .receive::<UsdcRebalance>(
+                UsdcRebalanceId(Uuid::new_v4()),
+                UsdcRebalanceEvent::WithdrawalFailed {
+                    reason: "revert".to_string(),
+                    failed_at: timestamp(200),
+                },
+            )
+            .await
+            .unwrap();
+        // Outside the range: must not be counted.
+        harness
+            .receive::<OffchainOrder>(OffchainOrderId::new(), offchain_order_failed(-999_999))
+            .await
+            .unwrap();
+
+        let failures = load_failure_events(&pool, &range()).await.unwrap();
+
+        assert_eq!(failures.len(), 2);
+        assert_eq!(
+            failures[0].event_type,
+            "UsdcRebalanceEvent::WithdrawalFailed"
+        );
+        assert_eq!(failures[0].count, 1);
+        assert_eq!(failures[0].last_at, timestamp(200));
+        assert_eq!(failures[1].event_type, "OffchainOrderEvent::Failed");
+        assert_eq!(failures[1].count, 1);
+    }
+
+    #[tokio::test]
+    async fn reactor_ignores_non_failure_events() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(LifecycleFailureProjection::new(pool.clone()));
+
+        // A successful confirmation must not land in the failure read model.
+        harness
+            .receive::<UsdcRebalance>(
+                UsdcRebalanceId(Uuid::new_v4()),
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: timestamp(50),
+                    withdrawal_tx: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let failures = load_failure_events(&pool, &range()).await.unwrap();
+
+        assert!(failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn load_failure_events_fails_fast_on_in_range_invalid_timestamp() {
+        let pool = setup_test_db().await;
+
+        // An occurred_at that sorts within [from, to] lexically (so the SQL
+        // range filter admits it) yet is not valid RFC 3339. `record` only ever
+        // writes valid RFC 3339, so this models data corruption: the money-at-
+        // risk view must fail loudly rather than silently drop the category.
+        let invalid = format!("{}T99:99:99Z", timestamp(100).format("%Y-%m-%d"));
+        sqlx::query(
+            "INSERT INTO lifecycle_failure_event (event_type, occurred_at) \
+             VALUES ('OffchainOrderEvent::Failed', $1)",
+        )
+        .bind(&invalid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let error = load_failure_events(&pool, &range()).await.unwrap_err();
+
+        assert!(
+            matches!(error, PerformanceError::Timestamp(_)),
+            "expected fail-fast on unparseable occurred_at, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_failure_events_includes_inclusive_range_boundaries() {
+        let pool = setup_test_db().await;
+        let harness = ReactorHarness::new(LifecycleFailureProjection::new(pool.clone()));
+
+        // Failures exactly at range.from and range.to: both must be counted,
+        // the window is inclusive on both ends.
+        harness
+            .receive::<OffchainOrder>(OffchainOrderId::new(), offchain_order_failed(0))
+            .await
+            .unwrap();
+        harness
+            .receive::<OffchainOrder>(OffchainOrderId::new(), offchain_order_failed(86_400))
+            .await
+            .unwrap();
+
+        let failures = load_failure_events(&pool, &range()).await.unwrap();
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].event_type, "OffchainOrderEvent::Failed");
+        assert_eq!(failures[0].count, 2);
+    }
+
+    #[tokio::test]
+    async fn record_propagates_insert_failure_instead_of_swallowing() {
+        let pool = setup_test_db().await;
+
+        // Drop the read-model table so the INSERT errors, modelling a transient
+        // write failure (contention, disk full). record() must surface the
+        // error (the reactor bridge logs it) instead of silently dropping a
+        // money-at-risk failure.
+        sqlx::query("DROP TABLE lifecycle_failure_event")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let projection = LifecycleFailureProjection::new(pool);
+
+        let error = projection
+            .record(Some(("OffchainOrderEvent::Failed", timestamp(100))))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, FailureProjectionError::Database(_)),
+            "expected the INSERT error to propagate, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn count_rejects_negative_aggregate() {
+        // A negative aggregate is structurally impossible, but if a corrupted
+        // query ever produced one it must fail loud, not mask to zero.
+        let error = count(-1).unwrap_err();
+
+        assert!(
+            matches!(error, PerformanceError::AggregateCount { value: -1 }),
+            "expected AggregateCount, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_job_queue_health_aggregates_per_job_type() {
+        // `setup_test_db` already creates the apalis `Jobs` table on the
+        // shared-cache in-memory database.
+        let pool = setup_test_db().await;
+
+        // (id, job_type, status, attempts, max_attempts, run_at)
+        let jobs = [
+            ("a-1", "queue::A", "Pending", 0, 25, 1_750_000_100_i64),
+            ("a-2", "queue::A", "Queued", 0, 25, 1_750_000_080),
+            ("a-3", "queue::A", "Running", 1, 25, 1_750_000_050),
+            // Retry-eligible failure: live backlog, not terminal.
+            ("a-4", "queue::A", "Failed", 3, 25, 1_750_000_000),
+            // Retry exhaustion: apalis writes 'Killed' with attempts >=
+            // max_attempts (verified against its calculate_status), so this is
+            // the terminal `failed` bucket. A hand-built ('Failed', 25, 25) row
+            // is a state apalis can never persist.
+            ("a-5", "queue::A", "Killed", 25, 25, 1_749_999_000),
+            // Aborted before exhausting retries: 'Killed' with attempts <
+            // max_attempts -> the `killed` bucket, disjoint from `failed`.
+            ("a-6", "queue::A", "Killed", 1, 25, 1_749_998_000),
+            ("b-1", "queue::B", "Done", 2, 25, 1_750_000_000),
+        ];
+        for (id, job_type, status, attempts, max_attempts, run_at) in jobs {
+            sqlx::query(
+                "INSERT INTO Jobs \
+                 (job, id, job_type, status, attempts, max_attempts, run_at) \
+                 VALUES ('{}', $1, $2, $3, $4, $5, $6)",
+            )
+            .bind(id)
+            .bind(job_type)
+            .bind(status)
+            .bind(attempts)
+            .bind(max_attempts)
+            .bind(run_at)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let queues = load_job_queue_health(&pool).await.unwrap();
+
+        assert_eq!(queues.len(), 2);
+        let queue_a = &queues[0];
+        assert_eq!(queue_a.job_type, "queue::A");
+        assert_eq!(queue_a.pending, 2);
+        assert_eq!(queue_a.running, 1);
+        assert_eq!(queue_a.failed, 1);
+        assert_eq!(queue_a.killed, 1);
+        assert_eq!(queue_a.awaiting_retry, 1);
+        assert_eq!(queue_a.retried, 2);
+        // The retry-eligible failure is the oldest live backlog entry; the
+        // exhausted one must not count.
+        assert_eq!(
+            queue_a.oldest_pending_run_at,
+            DateTime::from_timestamp(1_750_000_000, 0)
+        );
+
+        let queue_b = &queues[1];
+        assert_eq!(queue_b.done, 1);
+        assert_eq!(queue_b.retried, 1);
+        assert_eq!(queue_b.awaiting_retry, 0);
+        assert_eq!(queue_b.oldest_pending_run_at, None);
+    }
+
+    #[test]
+    fn aggregate_log_entries_distributes_multi_day_buckets() {
+        let day = 86_400;
+        let wide_range = ReportRange {
+            from: timestamp(0),
+            to: timestamp(7 * day),
+        };
+        let entries = vec![
+            log_entry(10, "ERROR", "hedge"),
+            log_entry(3 * day + 5, "WARN", "rebalance"),
+        ];
+
+        let (buckets, _) = aggregate_log_entries(&entries, &wide_range);
+
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0].start, timestamp(0));
+        assert_eq!(buckets[0].errors, 1);
+        assert_eq!(buckets[1].start, timestamp(3 * day));
+        assert_eq!(buckets[1].warnings, 1);
+    }
+
+    #[test]
+    fn aggregate_log_entries_ignores_unexpected_levels() {
+        let entries = vec![
+            log_entry(10, "INFO", "hedge"),
+            log_entry(20, "ERROR", "hedge"),
+        ];
+
+        let (buckets, targets) = aggregate_log_entries(&entries, &range());
+
+        // The INFO entry must not create a phantom empty bucket or target.
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0].errors, 1);
+        assert_eq!(buckets[0].warnings, 0);
+        assert_eq!(targets.len(), 1);
+    }
+
+    #[test]
+    fn failure_mappers_match_domain_event_names() {
+        use st0x_event_sorcery::DomainEvent;
+        use st0x_float_macro::float;
+
+        use crate::equity_redemption::DetectionFailure;
+
+        // The reactor records the canonical DomainEvent type string. Verify
+        // every mapper's hardcoded string against the event's own `event_type()`
+        // so a rename of any failure variant cannot silently desync the read
+        // model. All 13 tracked failure types are asserted here.
+
+        // --- OffchainOrder (1 variant) ---
+        let offchain = OffchainOrderEvent::Failed {
+            error: "rejected".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            offchain_order_failure(&offchain).unwrap().0,
+            offchain.event_type()
+        );
+
+        // --- UsdcRebalance (5 variants) ---
+        let rebalance_conversion = UsdcRebalanceEvent::ConversionFailed {
+            reason: "revert".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            usdc_rebalance_failure(&rebalance_conversion).unwrap().0,
+            rebalance_conversion.event_type()
+        );
+
+        let rebalance_withdrawal = UsdcRebalanceEvent::WithdrawalFailed {
+            reason: "revert".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            usdc_rebalance_failure(&rebalance_withdrawal).unwrap().0,
+            rebalance_withdrawal.event_type()
+        );
+
+        let rebalance_bridging = UsdcRebalanceEvent::BridgingFailed {
+            burn_tx_hash: None,
+            cctp_nonce: None,
+            reason: "revert".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            usdc_rebalance_failure(&rebalance_bridging).unwrap().0,
+            rebalance_bridging.event_type()
+        );
+
+        let rebalance_deposit = UsdcRebalanceEvent::DepositFailed {
+            deposit_ref: None,
+            reason: "revert".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            usdc_rebalance_failure(&rebalance_deposit).unwrap().0,
+            rebalance_deposit.event_type()
+        );
+
+        let rebalance_attestation = UsdcRebalanceEvent::AttestationTimedOut {
+            burn_tx_hash: alloy::primitives::TxHash::ZERO,
+            retry_deadline_at: timestamp(1),
+            timed_out_at: timestamp(0),
+        };
+        assert_eq!(
+            usdc_rebalance_failure(&rebalance_attestation).unwrap().0,
+            rebalance_attestation.event_type()
+        );
+
+        // --- EquityRedemption (3 variants) ---
+        let redemption_transfer = EquityRedemptionEvent::TransferFailed {
+            tx_hash: None,
+            reason: None,
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            equity_redemption_failure(&redemption_transfer).unwrap().0,
+            redemption_transfer.event_type()
+        );
+
+        let redemption_detection = EquityRedemptionEvent::DetectionFailed {
+            failure: DetectionFailure::Timeout,
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            equity_redemption_failure(&redemption_detection).unwrap().0,
+            redemption_detection.event_type()
+        );
+
+        let redemption_rejected = EquityRedemptionEvent::RedemptionRejected {
+            reason: "rejected".to_string(),
+            rejected_at: timestamp(0),
+        };
+        assert_eq!(
+            equity_redemption_failure(&redemption_rejected).unwrap().0,
+            redemption_rejected.event_type()
+        );
+
+        // --- TokenizedEquityMint (4 variants) ---
+        let mint_rejected = TokenizedEquityMintEvent::MintRejected {
+            reason: "rejected".to_string(),
+            rejected_at: timestamp(0),
+        };
+        assert_eq!(
+            tokenized_equity_mint_failure(&mint_rejected).unwrap().0,
+            mint_rejected.event_type()
+        );
+
+        let mint_acceptance_failed = TokenizedEquityMintEvent::MintAcceptanceFailed {
+            reason: "timeout".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            tokenized_equity_mint_failure(&mint_acceptance_failed)
+                .unwrap()
+                .0,
+            mint_acceptance_failed.event_type()
+        );
+
+        let mint_wrapping_failed = TokenizedEquityMintEvent::WrappingFailed {
+            symbol: Symbol::new("AAPL").unwrap(),
+            quantity: float!(1),
+            reason: None,
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            tokenized_equity_mint_failure(&mint_wrapping_failed)
+                .unwrap()
+                .0,
+            mint_wrapping_failed.event_type()
+        );
+
+        let mint_raindex_deposit_failed = TokenizedEquityMintEvent::RaindexDepositFailed {
+            reason: "revert".to_string(),
+            failed_at: timestamp(0),
+        };
+        assert_eq!(
+            tokenized_equity_mint_failure(&mint_raindex_deposit_failed)
+                .unwrap()
+                .0,
+            mint_raindex_deposit_failed.event_type()
+        );
+    }
+}


### PR DESCRIPTION
## What

[RAI-993](https://linear.app/makeitrain/issue/RAI-993/reliability-metrics-endpoint-errors-lifecycle-failures-job-queue)

- `GET /performance/reliability`: error/warning log volume (time-bucketed + per-target counts), money-at-risk lifecycle failure events, and apalis job-queue health per job type.

## Why

- Errors were scattered across log files, terminal `Failed` events, and the jobs table with no aggregated view separating money-at-risk failures from cosmetic noise.

## How

- 13 failure event types are counted: hedge failures, all USDC-rebalance stage failures/timeouts, and equity mint/redemption failures and rejections. A `LifecycleFailureProjection` reactor maintains a `lifecycle_failure_event` read model (forward-only — historical events before wiring are not backfilled). A drift test pins representative strings from each event family against `DomainEvent::event_type()` so renames can't silently drop coverage. The query is capped at the 10k newest rows.
- Log aggregation reuses the `/logs` file-reading machinery, runs in `spawn_blocking` (sync file I/O off the async workers), and caps at 50k entries with a truncation warning so an error storm cannot exhaust the dashboard process.
- `JobQueueHealth` distinguishes apalis semantics: retry-eligible `Failed` jobs (`attempts < max_attempts`) surface as `awaiting_retry` live backlog and feed `oldest_pending_run_at`; exhausted `Failed` jobs (`attempts >= max_attempts`) count as `failed`; status `Killed` counts separately.

## Testing

- Unit tests for log aggregation (multi-day buckets, level discrimination, malformed/out-of-range entries, phantom-bucket prevention), failure-event counting with range filtering, the event-type drift test, and job-queue aggregation incl. Queued status and retry/exhausted split; endpoint tests for empty DB, seeded data, and inverted range.

## Anything else

- Stringly-typed `level`/`event_type` DTO fields are tracked as [RAI-1006](https://linear.app/makeitrain/issue/RAI-1006/type-reliability-dto-level-and-failure-event-type-fields-as-enums).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/performance/reliability` endpoint providing performance and reliability metrics, including time-series log volume data, per-target log counts, lifecycle failure event tracking, and job queue health snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->