### PR TITLE
feat: dashboard performance tab with SLO cards

### DIFF
--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -56,6 +56,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
+    location /performance {
+        set $alpaca_upstream alpacabot;
+        proxy_pass http://$alpaca_upstream:8080/performance;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import * as Card from '$lib/components/ui/card'
+  import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+  import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
+  import { reactive } from '$lib/frp.svelte'
+  import { fetchHedgeLatencies, fetchReliabilityReport } from '$lib/performance/api'
+  import {
+    detectionCard,
+    errorsCard,
+    exposureCard,
+    openExposureCard,
+  } from '$lib/performance/cards'
+  import { type SloStatus } from '$lib/performance/slo'
+
+  const POLL_INTERVAL_MS = 30_000
+  const CARD_WINDOW_HOURS = 24
+
+  const latencies = reactive<HedgeLatencies | null>(null)
+  const reliability = reactive<ReliabilityReport | null>(null)
+  const error = reactive<string | null>(null)
+  const lastRefreshed = reactive<Date | null>(null)
+  let fetchSeq = 0
+
+  const refresh = async () => {
+    const seq = ++fetchSeq
+    const to = new Date()
+    const from = new Date(to.getTime() - CARD_WINDOW_HOURS * 3_600_000)
+
+    try {
+      const [latencyReport, reliabilityReport] = await Promise.all([
+        fetchHedgeLatencies({ from, to }),
+        fetchReliabilityReport({ from, to }),
+      ])
+
+      if (seq !== fetchSeq) return
+
+      const refreshedAt = new Date()
+
+      latencies.update(() => latencyReport)
+      reliability.update(() => reliabilityReport)
+      lastRefreshed.update(() => refreshedAt)
+      error.update(() => null)
+    } catch (fetchError) {
+      if (seq !== fetchSeq) return
+
+      error.update(() =>
+        fetchError instanceof Error ? fetchError.message : 'Unknown error',
+      )
+    }
+  }
+
+  onMount(() => {
+    void refresh()
+    const interval = setInterval(() => {
+      void refresh()
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      clearInterval(interval)
+    }
+  })
+
+  const cards = $derived([
+    detectionCard(latencies.current),
+    exposureCard(latencies.current),
+    errorsCard(reliability.current, CARD_WINDOW_HOURS),
+    openExposureCard(latencies.current, lastRefreshed.current),
+  ])
+
+  const statusClasses = (status: SloStatus): string => {
+    if (status === 'unknown') {
+      return 'border-l-slate-500/70'
+    }
+
+    if (status === 'good') {
+      return 'border-l-emerald-500/70'
+    }
+
+    if (status === 'warning') {
+      return 'border-l-amber-500/70'
+    }
+
+    return 'border-l-red-500/70'
+  }
+
+  const statusDot = (status: SloStatus): string => {
+    if (status === 'unknown') {
+      return 'bg-slate-500'
+    }
+
+    if (status === 'good') {
+      return 'bg-emerald-500'
+    }
+
+    if (status === 'warning') {
+      return 'bg-amber-500'
+    }
+
+    return 'bg-red-500'
+  }
+</script>
+
+<div class="flex h-full flex-col gap-4 overflow-y-auto">
+  {#if error.current}
+    <div
+      class="rounded-md border border-destructive bg-destructive/10 px-4 py-2
+        text-sm text-destructive"
+    >
+      Failed to load performance data: {error.current}
+    </div>
+  {/if}
+
+  <section>
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {#each cards as card (card.title)}
+        <Card.Root class={`border-l-4 ${statusClasses(card.status)}`}>
+          <Card.Header class="pb-1">
+            <Card.Title
+              class="flex items-center gap-2 text-sm font-medium
+                text-muted-foreground"
+            >
+              <span class={`h-2 w-2 rounded-full ${statusDot(card.status)}`}></span>
+              {card.title}
+            </Card.Title>
+          </Card.Header>
+          <Card.Content>
+            <div class="text-2xl font-semibold">{card.primary}</div>
+            <div class="text-xs text-muted-foreground">{card.secondary}</div>
+          </Card.Content>
+        </Card.Root>
+      {/each}
+    </div>
+    <p class="mt-2 text-xs text-muted-foreground">
+      Last {CARD_WINDOW_HOURS}h ·
+      {#if lastRefreshed.current}
+        refreshed {lastRefreshed.current.toLocaleTimeString()}
+      {:else}
+        loading…
+      {/if}
+    </p>
+  </section>
+</div>

--- a/dashboard/src/lib/performance/api.test.ts
+++ b/dashboard/src/lib/performance/api.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchHedgeLatencies, rangeParams } from './api'
+
+describe('rangeParams', () => {
+  it('returns an empty string when no bounds are given', () => {
+    expect(rangeParams({})).toBe('')
+  })
+
+  it('encodes a lone lower bound', () => {
+    expect(rangeParams({ from: new Date('2026-06-01T00:00:00Z') })).toBe(
+      '?from=2026-06-01T00%3A00%3A00.000Z',
+    )
+  })
+
+  it('encodes both bounds', () => {
+    expect(
+      rangeParams({
+        from: new Date('2026-06-01T00:00:00Z'),
+        to: new Date('2026-06-02T00:00:00Z'),
+      }),
+    ).toBe('?from=2026-06-01T00%3A00%3A00.000Z&to=2026-06-02T00%3A00%3A00.000Z')
+  })
+})
+
+describe('fetchHedgeLatencies error handling', () => {
+  const fetchMock = vi.fn()
+  let originalWindow: PropertyDescriptor | undefined
+  let originalFetch: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+    originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch')
+
+    Object.defineProperty(globalThis, 'window', {
+      value: { location: { origin: 'http://localhost:8001' } },
+      writable: true,
+      configurable: true,
+    })
+
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    fetchMock.mockReset()
+
+    if (originalWindow) {
+      Object.defineProperty(globalThis, 'window', originalWindow)
+    } else {
+      delete (globalThis as { window?: unknown }).window
+    }
+
+    if (originalFetch) {
+      Object.defineProperty(globalThis, 'fetch', originalFetch)
+    } else {
+      delete (globalThis as { fetch?: unknown }).fetch
+    }
+  })
+
+  it('throws an HTTP error message for non-ok responses', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+    } as Response)
+
+    await expect(fetchHedgeLatencies()).rejects.toThrow('HTTP 503')
+  })
+})

--- a/dashboard/src/lib/performance/api.ts
+++ b/dashboard/src/lib/performance/api.ts
@@ -1,0 +1,60 @@
+import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { RebalanceTimings } from '$lib/api/RebalanceTimings'
+import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
+import { getApiBaseUrl } from '$lib/env'
+
+const PERFORMANCE_TIMEOUT_MS = 15_000
+
+export type PerformanceRange = {
+  from?: Date
+  to?: Date
+}
+
+/** Exported for tests: the cards' time window depends on these params. */
+export const rangeParams = (range: PerformanceRange): string => {
+  const params = new URLSearchParams()
+
+  if (range.from) {
+    params.set('from', range.from.toISOString())
+  }
+
+  if (range.to) {
+    params.set('to', range.to.toISOString())
+  }
+
+  const encoded = params.toString()
+  return encoded === '' ? '' : `?${encoded}`
+}
+
+const fetchPerformanceJson = async <Response>(
+  path: string,
+  range: PerformanceRange,
+): Promise<Response> => {
+  const response = await fetch(`${getApiBaseUrl()}${path}${rangeParams(range)}`, {
+    signal: AbortSignal.timeout(PERFORMANCE_TIMEOUT_MS),
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${String(response.status)}`, {
+      cause: {
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+      },
+    })
+  }
+
+  return response.json() as Promise<Response>
+}
+
+export const fetchHedgeLatencies = async (
+  range: PerformanceRange = {},
+): Promise<HedgeLatencies> => fetchPerformanceJson('/performance/latencies', range)
+
+export const fetchRebalanceTimings = async (
+  range: PerformanceRange = {},
+): Promise<RebalanceTimings> => fetchPerformanceJson('/performance/rebalances', range)
+
+export const fetchReliabilityReport = async (
+  range: PerformanceRange = {},
+): Promise<ReliabilityReport> => fetchPerformanceJson('/performance/reliability', range)

--- a/dashboard/src/lib/performance/cards.test.ts
+++ b/dashboard/src/lib/performance/cards.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { JobQueueHealth } from '$lib/api/JobQueueHealth'
+import type { LatencyStats } from '$lib/api/LatencyStats'
+import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
+
+import { detectionCard, errorsCard, exposureCard, openExposureCard } from './cards'
+
+const makeStats = (overrides: Partial<LatencyStats> = {}): LatencyStats => ({
+  p50Ms: 5_000,
+  p90Ms: 20_000,
+  p95Ms: 25_000,
+  p99Ms: 60_000,
+  maxMs: 61_000,
+  sampleCount: 12,
+  ...overrides,
+})
+
+const latencies = (overrides: Partial<HedgeLatencies>): HedgeLatencies => ({
+  summary: {
+    fillCount: 12,
+    stages: {
+      detection: makeStats(),
+      decision: null,
+      submission: null,
+      execution: null,
+      exposureWindow: null,
+    },
+  },
+  buckets: [],
+  cycles: [],
+  totalCycles: 0,
+  openExposures: [],
+  ...overrides,
+})
+
+const reliability = (overrides: Partial<ReliabilityReport>): ReliabilityReport => ({
+  logBuckets: [],
+  logTargets: [],
+  failureEvents: [],
+  jobQueues: [],
+  logEntriesTruncated: false,
+  ...overrides,
+})
+
+describe('detectionCard', () => {
+  it('reports unknown while the report has not loaded', () => {
+    const card = detectionCard(null)
+
+    expect(card.status).toBe('unknown')
+    expect(card.primary).toBe('—')
+  })
+
+  it('classifies p95 against the detection thresholds', () => {
+    const card = detectionCard(latencies({}))
+
+    expect(card.status).toBe('good')
+    expect(card.primary).toBe('p95 25.0s')
+  })
+
+  it('reports good with no-fills secondary when detection stats are null', () => {
+    const card = detectionCard(
+      latencies({
+        summary: {
+          fillCount: 0,
+          stages: {
+            detection: null,
+            decision: null,
+            submission: null,
+            execution: null,
+            exposureWindow: null,
+          },
+        },
+      }),
+    )
+
+    expect(card.status).toBe('good')
+    expect(card.secondary).toBe('no fills in window')
+  })
+})
+
+describe('errorsCard', () => {
+  it('forces critical when any lifecycle failure exists', () => {
+    const card = errorsCard(
+      reliability({
+        failureEvents: [
+          {
+            eventType: 'OffchainOrderEvent::Failed',
+            count: 1,
+            lastAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      }),
+      24,
+    )
+
+    expect(card.status).toBe('critical')
+  })
+
+  it('degrades on high warning volume even with zero errors', () => {
+    const card = errorsCard(
+      reliability({
+        logBuckets: [
+          {
+            start: '2026-06-01T00:00:00Z',
+            errors: 0,
+            warnings: 1_000,
+          },
+        ],
+      }),
+      24,
+    )
+
+    expect(card.status).toBe('critical')
+    expect(card.primary).toBe('0')
+  })
+
+  it('interpolates the window hours into the title', () => {
+    expect(errorsCard(reliability({}), 48).title).toBe('Errors (48h)')
+  })
+
+  it('reports critical when any queue has killed jobs', () => {
+    const queue: JobQueueHealth = {
+      jobType: 'DexTradeAccounting',
+      pending: 0,
+      running: 0,
+      done: 100,
+      failed: 0,
+      awaitingRetry: 0,
+      killed: 2,
+      retried: 0,
+      oldestPendingRunAt: null,
+    }
+
+    const card = errorsCard(reliability({ jobQueues: [queue] }), 24)
+
+    expect(card.status).toBe('critical')
+    expect(card.secondary).toContain('1 queue(s) killed')
+  })
+
+  it('reports warning when a queue has failed jobs but none killed', () => {
+    const queue: JobQueueHealth = {
+      jobType: 'DexTradeAccounting',
+      pending: 0,
+      running: 0,
+      done: 100,
+      failed: 3,
+      awaitingRetry: 0,
+      killed: 0,
+      retried: 0,
+      oldestPendingRunAt: null,
+    }
+
+    const card = errorsCard(reliability({ jobQueues: [queue] }), 24)
+
+    expect(card.status).toBe('warning')
+    expect(card.secondary).toContain('1 queue(s) failed')
+  })
+
+  it('reports good when all queues are healthy', () => {
+    const queue: JobQueueHealth = {
+      jobType: 'DexTradeAccounting',
+      pending: 0,
+      running: 1,
+      done: 100,
+      failed: 0,
+      awaitingRetry: 0,
+      killed: 0,
+      retried: 0,
+      oldestPendingRunAt: null,
+    }
+
+    const card = errorsCard(reliability({ jobQueues: [queue] }), 24)
+
+    expect(card.status).toBe('good')
+    expect(card.secondary).not.toContain('queue')
+  })
+})
+
+describe('openExposureCard', () => {
+  it('selects the oldest exposure across symbols', () => {
+    const now = new Date('2026-06-01T01:00:00Z')
+    const card = openExposureCard(
+      latencies({
+        openExposures: [
+          {
+            symbol: 'AAPL',
+            fillCount: 2,
+            oldestFillBlockTimestamp: '2026-06-01T00:50:00Z',
+          },
+          {
+            symbol: 'TSLA',
+            fillCount: 3,
+            oldestFillBlockTimestamp: '2026-06-01T00:30:00Z',
+          },
+        ],
+      }),
+      now,
+    )
+
+    expect(card.primary).toBe('30m 00s')
+    expect(card.secondary).toBe('TSLA oldest · 5 uncovered fills across 2 symbols')
+    // 30m sits exactly on the warning bound (inclusive).
+    expect(card.status).toBe('warning')
+  })
+
+  it('reports unknown before the first refresh', () => {
+    expect(openExposureCard(null, null).status).toBe('unknown')
+  })
+
+  it('reports good when every fill is hedged', () => {
+    const card = openExposureCard(latencies({}), new Date())
+
+    expect(card.status).toBe('good')
+    expect(card.primary).toBe('none')
+  })
+
+  it('clamps a negative age to zero when block timestamp is ahead of client clock', () => {
+    // Block timestamp 1 minute in the future relative to `now`.
+    const now = new Date('2026-06-01T01:00:00Z')
+    const card = openExposureCard(
+      latencies({
+        openExposures: [
+          {
+            symbol: 'AAPL',
+            fillCount: 1,
+            oldestFillBlockTimestamp: '2026-06-01T01:01:00Z',
+          },
+        ],
+      }),
+      now,
+    )
+
+    expect(card.primary).toBe('0ms')
+    expect(card.status).toBe('good')
+  })
+})
+
+describe('exposureCard', () => {
+  it('reports unknown when report is null', () => {
+    const card = exposureCard(null)
+
+    expect(card.status).toBe('unknown')
+    expect(card.primary).toBe('—')
+  })
+
+  it('reports good with no-completed-hedges secondary when exposureWindow stats are null', () => {
+    const card = exposureCard(latencies({}))
+
+    expect(card.status).toBe('good')
+    expect(card.secondary).toBe('no completed hedges in window')
+  })
+
+  it('classifies p95 within good threshold as good and shows p95/p50 display', () => {
+    const card = exposureCard(
+      latencies({
+        summary: {
+          fillCount: 5,
+          stages: {
+            detection: null,
+            decision: null,
+            submission: null,
+            execution: null,
+            exposureWindow: {
+              p50Ms: 10_000,
+              p90Ms: 40_000,
+              p95Ms: 50_000,
+              p99Ms: 55_000,
+              maxMs: 60_000,
+              sampleCount: 5,
+            },
+          },
+        },
+      }),
+    )
+
+    expect(card.status).toBe('good')
+    expect(card.primary).toBe('p95 50.0s')
+    expect(card.secondary).toContain('p50 10.0s')
+    expect(card.secondary).toContain('5 hedges')
+  })
+
+  it('classifies p95 above warning threshold as critical', () => {
+    // EXPOSURE_WINDOW_THRESHOLDS.warning = 300_000ms; above is critical.
+    const card = exposureCard(
+      latencies({
+        summary: {
+          fillCount: 3,
+          stages: {
+            detection: null,
+            decision: null,
+            submission: null,
+            execution: null,
+            exposureWindow: {
+              p50Ms: 200_000,
+              p90Ms: 310_000,
+              p95Ms: 400_000,
+              p99Ms: 450_000,
+              maxMs: 500_000,
+              sampleCount: 3,
+            },
+          },
+        },
+      }),
+    )
+
+    expect(card.status).toBe('critical')
+  })
+})

--- a/dashboard/src/lib/performance/cards.ts
+++ b/dashboard/src/lib/performance/cards.ts
@@ -1,0 +1,157 @@
+/** Pure SLO card derivation for the Performance tab. */
+
+import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
+import {
+  DETECTION_THRESHOLDS,
+  ERROR_COUNT_THRESHOLDS,
+  EXPOSURE_WINDOW_THRESHOLDS,
+  OPEN_EXPOSURE_AGE_THRESHOLDS,
+  WARNING_COUNT_THRESHOLDS,
+  type SloStatus,
+  classifySlo,
+  formatDurationMs,
+  worstStatus,
+} from './slo'
+
+export type SloCard = {
+  title: string
+  primary: string
+  secondary: string
+  status: SloStatus
+}
+
+/** Shown while a report has not loaded: unknown must not look healthy. */
+const loadingCard = (title: string): SloCard => ({
+  title,
+  primary: '—',
+  secondary: 'loading',
+  status: 'unknown',
+})
+
+export const detectionCard = (report: HedgeLatencies | null): SloCard => {
+  if (!report) {
+    return loadingCard('Detection latency')
+  }
+
+  const stats = report.summary.stages.detection
+
+  if (!stats) {
+    return {
+      title: 'Detection latency',
+      primary: '—',
+      secondary: 'no fills in window',
+      status: 'good',
+    }
+  }
+
+  return {
+    title: 'Detection latency',
+    primary: `p95 ${formatDurationMs(stats.p95Ms)}`,
+    secondary: `p50 ${formatDurationMs(stats.p50Ms)} · ${String(stats.sampleCount)} fills`,
+    status: classifySlo(stats.p95Ms, DETECTION_THRESHOLDS),
+  }
+}
+
+export const exposureCard = (report: HedgeLatencies | null): SloCard => {
+  if (!report) {
+    return loadingCard('Exposure window')
+  }
+
+  const stats = report.summary.stages.exposureWindow
+
+  if (!stats) {
+    return {
+      title: 'Exposure window',
+      primary: '—',
+      secondary: 'no completed hedges in window',
+      status: 'good',
+    }
+  }
+
+  return {
+    title: 'Exposure window',
+    primary: `p95 ${formatDurationMs(stats.p95Ms)}`,
+    secondary: `p50 ${formatDurationMs(stats.p50Ms)} · ${String(stats.sampleCount)} hedges`,
+    status: classifySlo(stats.p95Ms, EXPOSURE_WINDOW_THRESHOLDS),
+  }
+}
+
+export const errorsCard = (
+  report: ReliabilityReport | null,
+  windowHours: number,
+): SloCard => {
+  const title = `Errors (${String(windowHours)}h)`
+
+  if (!report) {
+    return loadingCard(title)
+  }
+
+  const errors = report.logBuckets.reduce((sum, bucket) => sum + bucket.errors, 0)
+  const warnings = report.logBuckets.reduce((sum, bucket) => sum + bucket.warnings, 0)
+  const failures = report.failureEvents.reduce((sum, event) => sum + event.count, 0)
+  const killedQueues = report.jobQueues.filter((queue) => queue.killed > 0)
+  const failedQueues = report.jobQueues.filter((queue) => queue.failed > 0)
+
+  const queueStatus: SloStatus =
+    killedQueues.length > 0 ? 'critical' : failedQueues.length > 0 ? 'warning' : 'good'
+
+  const queueSuffix =
+    killedQueues.length > 0
+      ? ` · ${String(killedQueues.length)} queue(s) killed`
+      : failedQueues.length > 0
+        ? ` · ${String(failedQueues.length)} queue(s) failed`
+        : ''
+
+  return {
+    title,
+    primary: String(errors),
+    secondary: `${String(warnings)} warnings · ${String(failures)} lifecycle failures${queueSuffix}`,
+    status:
+      failures > 0
+        ? 'critical'
+        : worstStatus([
+            classifySlo(errors, ERROR_COUNT_THRESHOLDS),
+            classifySlo(warnings, WARNING_COUNT_THRESHOLDS),
+            queueStatus,
+          ]),
+  }
+}
+
+export const openExposureCard = (
+  report: HedgeLatencies | null,
+  now: Date | null,
+): SloCard => {
+  if (!report || !now) {
+    return loadingCard('Oldest unhedged fill')
+  }
+
+  const exposures = report.openExposures
+
+  if (exposures.length === 0) {
+    return {
+      title: 'Oldest unhedged fill',
+      primary: 'none',
+      secondary: 'all fills hedged',
+      status: 'good',
+    }
+  }
+
+  const oldest = exposures.reduce((candidate, exposure) =>
+    new Date(exposure.oldestFillBlockTimestamp).getTime() <
+    new Date(candidate.oldestFillBlockTimestamp).getTime()
+      ? exposure
+      : candidate,
+  )
+  const ageMs = Math.max(0, now.getTime() - new Date(oldest.oldestFillBlockTimestamp).getTime())
+  const fillCount = exposures.reduce((sum, exposure) => sum + exposure.fillCount, 0)
+
+  return {
+    title: 'Oldest unhedged fill',
+    primary: formatDurationMs(ageMs),
+    secondary:
+      `${oldest.symbol} oldest · ${String(fillCount)} uncovered fills ` +
+      `across ${String(exposures.length)} symbols`,
+    status: classifySlo(ageMs, OPEN_EXPOSURE_AGE_THRESHOLDS),
+  }
+}

--- a/dashboard/src/lib/performance/slo.test.ts
+++ b/dashboard/src/lib/performance/slo.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifySlo, formatDurationMs, worstStatus } from './slo'
+
+describe('classifySlo', () => {
+  const thresholds = {
+    good: 100,
+    warning: 500,
+  }
+
+  it('classifies values at or below the good bound as good', () => {
+    expect(classifySlo(0, thresholds)).toBe('good')
+    expect(classifySlo(100, thresholds)).toBe('good')
+  })
+
+  it('classifies values between the bounds as warning', () => {
+    expect(classifySlo(101, thresholds)).toBe('warning')
+    expect(classifySlo(500, thresholds)).toBe('warning')
+  })
+
+  it('classifies values above the warning bound as critical', () => {
+    expect(classifySlo(501, thresholds)).toBe('critical')
+  })
+})
+
+describe('formatDurationMs', () => {
+  it('renders sub-second durations in milliseconds', () => {
+    expect(formatDurationMs(850)).toBe('850ms')
+  })
+
+  it('renders sub-minute durations in seconds', () => {
+    expect(formatDurationMs(12_400)).toBe('12.4s')
+  })
+
+  it('renders sub-hour durations as minutes and seconds', () => {
+    expect(formatDurationMs(200_000)).toBe('3m 20s')
+  })
+
+  it('renders hours with zero-padded minutes', () => {
+    expect(formatDurationMs(7_500_000)).toBe('2h 05m')
+  })
+
+  it('renders negative durations with a sign', () => {
+    expect(formatDurationMs(-1_500)).toBe('-1.5s')
+  })
+
+  it('pins the millisecond-to-second boundary', () => {
+    expect(formatDurationMs(1_000)).toBe('1.0s')
+  })
+
+  it('pins the second-to-minute boundary', () => {
+    expect(formatDurationMs(60_000)).toBe('1m 00s')
+  })
+
+  it('carries seconds that round to a full minute', () => {
+    expect(formatDurationMs(59_950)).toBe('1m 00s')
+    expect(formatDurationMs(179_500)).toBe('3m 00s')
+  })
+
+  it('carries minutes that round to a full hour', () => {
+    expect(formatDurationMs(3_599_500)).toBe('1h 00m')
+  })
+})
+
+describe('worstStatus', () => {
+  it('returns the most severe status', () => {
+    expect(worstStatus(['good', 'critical', 'warning'])).toBe('critical')
+    expect(worstStatus(['good', 'warning'])).toBe('warning')
+    expect(worstStatus(['good'])).toBe('good')
+    expect(worstStatus([])).toBe('unknown')
+  })
+})

--- a/dashboard/src/lib/performance/slo.ts
+++ b/dashboard/src/lib/performance/slo.ts
@@ -1,0 +1,93 @@
+/** Pure SLO classification and formatting for the Performance tab. */
+
+export type SloStatus = 'unknown' | 'good' | 'warning' | 'critical'
+
+export type SloThresholds = {
+  /** Inclusive upper bound for `good`. */
+  good: number
+  /** Inclusive upper bound for `warning`; above is `critical`. */
+  warning: number
+}
+
+/** How quickly the bot should observe an onchain fill (p95, ms). */
+export const DETECTION_THRESHOLDS: SloThresholds = {
+  good: 30_000,
+  warning: 120_000,
+}
+
+/** How long unhedged delta should live, block to broker fill (p95, ms). */
+export const EXPOSURE_WINDOW_THRESHOLDS: SloThresholds = {
+  good: 60_000,
+  warning: 300_000,
+}
+
+/** Error log lines per 24h. */
+export const ERROR_COUNT_THRESHOLDS: SloThresholds = {
+  good: 0,
+  warning: 10,
+}
+
+/** Warning log lines per 24h: noisier than errors, so wider bounds. */
+export const WARNING_COUNT_THRESHOLDS: SloThresholds = {
+  good: 25,
+  warning: 250,
+}
+
+/** Age of the oldest fill not yet covered by a hedge (ms). */
+export const OPEN_EXPOSURE_AGE_THRESHOLDS: SloThresholds = {
+  good: 300_000,
+  warning: 1_800_000,
+}
+
+const STATUS_RANK: Record<SloStatus, number> = {
+  unknown: 0,
+  good: 1,
+  warning: 2,
+  critical: 3,
+}
+
+/** The most severe of the given statuses. */
+export const worstStatus = (statuses: SloStatus[]): SloStatus =>
+  statuses.reduce(
+    (worst, status) => (STATUS_RANK[status] > STATUS_RANK[worst] ? status : worst),
+    'unknown',
+  )
+
+export const classifySlo = (value: number, thresholds: SloThresholds): SloStatus => {
+  if (value <= thresholds.good) {
+    return 'good'
+  }
+
+  if (value <= thresholds.warning) {
+    return 'warning'
+  }
+
+  return 'critical'
+}
+
+/** Renders a millisecond duration at human scale: 850ms, 12.4s, 3m 20s, 2h 05m. */
+export const formatDurationMs = (ms: number): string => {
+  if (ms < 0) {
+    return `-${formatDurationMs(-ms)}`
+  }
+
+  if (ms < 1_000) {
+    return `${String(Math.round(ms))}ms`
+  }
+
+  // Round before choosing the unit so a value like 59.95s carries into
+  // "1m 00s" instead of rendering as "60.0s" or "1m 60s".
+  const tenths = Math.round(ms / 100)
+  if (tenths < 600) {
+    return `${(tenths / 10).toFixed(1)}s`
+  }
+
+  const totalSeconds = Math.round(ms / 1_000)
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  if (totalMinutes < 60) {
+    return `${String(totalMinutes)}m ${String(totalSeconds % 60).padStart(2, '0')}s`
+  }
+
+  const hours = Math.floor(totalMinutes / 60)
+  return `${String(hours)}h ${String(totalMinutes % 60).padStart(2, '0')}m`
+}

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   import TransferPanel from '$lib/components/transfer-panel.svelte'
   import LogPanel from '$lib/components/log-panel.svelte'
   import OrdersPanel from '$lib/components/orders-panel.svelte'
+  import PerformancePanel from '$lib/components/performance-panel.svelte'
   import PnlPanel from '$lib/components/pnl-panel.svelte'
   import { getWebSocketUrl, isDashboardMockMode } from '$lib/env'
   import { reactive } from '$lib/frp.svelte'
@@ -49,7 +50,7 @@
     }
   })
 
-  type Tab = 'dashboard' | 'orders' | 'pnl' | 'logs'
+  type Tab = 'dashboard' | 'orders' | 'pnl' | 'performance' | 'logs'
   type MobilePanel = 'inventory' | 'trades' | 'transfers'
 
   const activeTab = reactive<Tab>('dashboard')
@@ -120,6 +121,17 @@
     </button>
     <button
       class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current ===
+      'performance'
+        ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
+        : 'text-muted-foreground hover:text-foreground'}"
+      onclick={() => {
+        activeTab.update((tab) => (tab === 'performance' ? 'dashboard' : 'performance'))
+      }}
+    >
+      Performance
+    </button>
+    <button
+      class="relative whitespace-nowrap px-3 py-2 text-sm font-medium transition-colors {activeTab.current ===
       'logs'
         ? 'text-foreground after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-primary'
         : 'text-muted-foreground hover:text-foreground'}"
@@ -158,6 +170,15 @@
       }}
     >
       PnL
+    </button>
+
+    <button
+      class={desktopTabClass(activeTab.current === 'performance')}
+      onclick={() => {
+        activeTab.update(() => 'performance')
+      }}
+    >
+      Performance
     </button>
 
     <button
@@ -200,6 +221,10 @@
   {:else if activeTab.current === 'pnl'}
     <main class="flex-1 overflow-hidden p-2 md:p-4">
       <PnlPanel />
+    </main>
+  {:else if activeTab.current === 'performance'}
+    <main class="flex-1 overflow-hidden p-2 md:p-4">
+      <PerformancePanel />
     </main>
   {:else}
     <main class="flex-1 overflow-hidden p-2 md:p-4">

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -137,6 +137,47 @@ const mockApi = () => ({
         return
       }
 
+      if (path === '/performance/latencies') {
+        mockJson(response, {
+          summary: {
+            fillCount: 0,
+            stages: {
+              detection: null,
+              decision: null,
+              submission: null,
+              execution: null,
+              exposureWindow: null,
+            },
+          },
+          buckets: [],
+          cycles: [],
+          totalCycles: 0,
+          openExposures: [],
+        })
+        return
+      }
+
+      if (path === '/performance/rebalances') {
+        mockJson(response, {
+          operations: [],
+          totalOperations: 0,
+          skippedOperations: 0,
+          stageSummary: [],
+          attestationTrend: [],
+        })
+        return
+      }
+
+      if (path === '/performance/reliability') {
+        mockJson(response, {
+          logBuckets: [],
+          logTargets: [],
+          failureEvents: [],
+          jobQueues: [],
+        })
+        return
+      }
+
       goNext()
     })
   }
@@ -154,6 +195,7 @@ export default defineConfig({
           '/orders': backendProxy(),
           '/trades': backendProxy(),
           '/transfers': backendProxy(),
+          '/performance': backendProxy(),
           ...pnlSqlProxy()
         }
   }


### PR DESCRIPTION
## What

[RAI-994](https://linear.app/makeitrain/issue/RAI-994/dashboard-performance-tab-skeleton-slo-cards)

- New **Performance** tab in the dashboard (desktop + mobile nav, tab order: Dashboard / Orders / PnL / Performance / Logs) with four threshold-colored SLO cards over the last 24h: detection latency p50/p95, total exposure window p50/p95, error/warning/lifecycle-failure counts, and oldest unhedged fill age.
- Typed fetch layer `dashboard/src/lib/performance/api.ts` over the three `/performance/*` endpoints (`/performance/latency`, `/performance/reliability`, `/performance/rebalances`).
- `/performance` proxy wired in `vite.config.ts` dev proxy and `nginx.conf` so the tab works in dev, mock, and prod.

## Why

- First user-facing slice of the Performance tab: the headline signals (how fast we detect, how long we sit unhedged, whether anything is failing) at a glance.

## How

- Pure modules per dashboard conventions: `slo.ts` (threshold classification, `worstStatus`, duration formatting that rounds before choosing units so boundaries can't render "60.0s"/"2m 60s") and `cards.ts` (card derivation), with the Svelte panel reduced to fetching and rendering.
- A fourth SLO state `unknown` (gray) distinguishes not-yet-loaded data from a genuinely healthy empty report; any lifecycle failure forces the errors card red, and high warning volume degrades it via separate thresholds.
- 30s polling refreshes the latency and reliability reports; a `fetchSeq` stale-response guard is already in place in this PR.

## Testing

- 20 vitest tests across `slo.test.ts` (classification, formatting incl. the rounding boundaries), `cards.test.ts` (failure override, warning degradation, multi-symbol oldest-exposure selection, unknown states), and `api.test.ts` (query-param encoding). `svelte-check` and eslint run clean locally.

## Anything else

- `fetchRebalanceTimings` is exported and proxy-wired here but first consumed by the charts panel upstack.
- SLO thresholds are display heuristics as named constants: detection p95 30s/120s, exposure window 60s/300s, errors 0/10, warnings 25/250, open exposure age 5m/30m.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Performance tab to the dashboard displaying real-time performance metrics
  * Shows four key metrics: detection latency, exposure coverage, error counts, and unhedged exposure status
  * Metrics automatically refresh every 30 seconds with color-coded status indicators (good, warning, critical)
  * Includes last-refresh timestamp and error notifications for troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->