### PR TITLE
feat: latency waterfall and percentile time-series charts

### DIFF
--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -3,6 +3,7 @@
   import * as Card from '$lib/components/ui/card'
   import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
   import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
+  import type { StageLatencies } from '$lib/api/StageLatencies'
   import { reactive } from '$lib/frp.svelte'
   import { fetchHedgeLatencies, fetchReliabilityReport } from '$lib/performance/api'
   import {
@@ -11,7 +12,13 @@
     exposureCard,
     openExposureCard,
   } from '$lib/performance/cards'
-  import { type SloStatus } from '$lib/performance/slo'
+  import {
+    type WaterfallSegmentName,
+    type WaterfallSort,
+    layoutPercentileSeries,
+    layoutWaterfall,
+  } from '$lib/performance/charts'
+  import { type SloStatus, formatDurationMs } from '$lib/performance/slo'
 
   const POLL_INTERVAL_MS = 30_000
   const CARD_WINDOW_HOURS = 24
@@ -50,10 +57,72 @@
     }
   }
 
+  type RangePreset = '1W' | '1M' | 'YTD' | '1Y' | 'ALL'
+
+  const RANGE_PRESETS: RangePreset[] = ['1W', '1M', 'YTD', '1Y', 'ALL']
+
+  /** Pre-dates the system's first deployment, so ALL covers everything. */
+  const ALL_TIME_START = new Date('2025-01-01T00:00:00Z')
+
+  const rangeStart = (preset: RangePreset, now: Date): Date => {
+    if (preset === '1W') {
+      return new Date(now.getTime() - 7 * 86_400_000)
+    }
+
+    if (preset === '1M') {
+      return new Date(now.getTime() - 31 * 86_400_000)
+    }
+
+    if (preset === 'YTD') {
+      return new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
+    }
+
+    if (preset === '1Y') {
+      return new Date(now.getTime() - 365 * 86_400_000)
+    }
+
+    return ALL_TIME_START
+  }
+
+  const chartRange = reactive<RangePreset>('1W')
+  const chartLatencies = reactive<HedgeLatencies | null>(null)
+  const chartError = reactive<string | null>(null)
+  let chartFetchSeq = 0
+
+  const refreshCharts = async () => {
+    const seq = ++chartFetchSeq
+    const to = new Date()
+
+    try {
+      const report = await fetchHedgeLatencies({
+        from: rangeStart(chartRange.current, to),
+        to,
+      })
+
+      if (seq !== chartFetchSeq) return
+
+      chartLatencies.update(() => report)
+      chartError.update(() => null)
+    } catch (fetchError) {
+      if (seq !== chartFetchSeq) return
+
+      chartError.update(() =>
+        fetchError instanceof Error ? fetchError.message : 'Unknown error',
+      )
+    }
+  }
+
+  const selectRange = (preset: RangePreset) => {
+    chartRange.update(() => preset)
+    void refreshCharts()
+  }
+
   onMount(() => {
     void refresh()
+    void refreshCharts()
     const interval = setInterval(() => {
       void refresh()
+      void refreshCharts()
     }, POLL_INTERVAL_MS)
 
     return () => {
@@ -99,6 +168,68 @@
 
     return 'bg-red-500'
   }
+
+  const WATERFALL_PLOT_WIDTH = 600
+  const WATERFALL_MAX_ROWS = 20
+
+  const waterfallSort = reactive<WaterfallSort>('slowest')
+
+  const SEGMENT_COLORS: Record<WaterfallSegmentName, string> = {
+    unhedged: '#64748b',
+    submission: '#38bdf8',
+    execution: '#34d399',
+  }
+
+  const SEGMENT_LABELS: Record<WaterfallSegmentName, string> = {
+    unhedged: 'unhedged (fill -> placed)',
+    submission: 'submission (placed -> accepted)',
+    execution: 'execution (accepted -> filled)',
+  }
+
+  const segmentColor = (
+    name: WaterfallSegmentName,
+    status: string,
+  ): string => (name === 'execution' && status === 'failed' ? '#f87171' : SEGMENT_COLORS[name])
+
+  const waterfallRows = $derived(
+    layoutWaterfall(chartLatencies.current?.cycles ?? [], {
+      plotWidth: WATERFALL_PLOT_WIDTH,
+      sort: waterfallSort.current,
+      maxRows: WATERFALL_MAX_ROWS,
+    }),
+  )
+
+  type StageKey = keyof StageLatencies
+
+  const STAGE_OPTIONS: { key: StageKey; label: string }[] = [
+    { key: 'exposureWindow', label: 'Exposure window' },
+    { key: 'detection', label: 'Detection' },
+    { key: 'decision', label: 'Decision' },
+    { key: 'submission', label: 'Submission' },
+    { key: 'execution', label: 'Execution' },
+  ]
+
+  const SERIES_PLOT_WIDTH = 600
+  const SERIES_PLOT_HEIGHT = 160
+
+  const PERCENTILE_COLORS = {
+    p50Ms: '#34d399',
+    p90Ms: '#fbbf24',
+    p99Ms: '#f87171',
+  } as const
+
+  const selectedStage = reactive<StageKey>('exposureWindow')
+
+  const seriesLayout = $derived(
+    layoutPercentileSeries(chartLatencies.current?.buckets ?? [], selectedStage.current, {
+      plotWidth: SERIES_PLOT_WIDTH,
+      plotHeight: SERIES_PLOT_HEIGHT,
+      maxXLabels: 8,
+    }),
+  )
+
+  const rangeButtonClass = (active: boolean): string =>
+    `rounded px-2 py-1 text-xs font-medium transition-colors ${active ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`
 </script>
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto">
@@ -140,4 +271,186 @@
       {/if}
     </p>
   </section>
+
+  <section class="flex items-center gap-1">
+    {#each RANGE_PRESETS as preset (preset)}
+      <button
+        class={rangeButtonClass(chartRange.current === preset)}
+        onclick={() => {
+          selectRange(preset)
+        }}
+      >
+        {preset}
+      </button>
+    {/each}
+    {#if chartError.current}
+      <span class="ml-2 text-xs text-destructive">
+        Failed to load charts: {chartError.current}
+      </span>
+    {/if}
+  </section>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <div class="flex items-center justify-between">
+        <Card.Title class="text-sm font-medium">Hedge cycle waterfall</Card.Title>
+        <div class="flex gap-1">
+          <button
+            class={rangeButtonClass(waterfallSort.current === 'slowest')}
+            onclick={() => {
+              waterfallSort.update(() => 'slowest')
+            }}
+          >
+            Slowest
+          </button>
+          <button
+            class={rangeButtonClass(waterfallSort.current === 'newest')}
+            onclick={() => {
+              waterfallSort.update(() => 'newest')
+            }}
+          >
+            Newest
+          </button>
+        </div>
+      </div>
+      <div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        {#each Object.entries(SEGMENT_LABELS) as [name, label] (name)}
+          <span class="flex items-center gap-1">
+            <span
+              class="inline-block h-2 w-2 rounded-sm"
+              style:background={SEGMENT_COLORS[name as WaterfallSegmentName]}
+            ></span>
+            {label}
+          </span>
+        {/each}
+      </div>
+    </Card.Header>
+    <Card.Content>
+      {#if waterfallRows.length === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No hedge cycles in the selected range.
+        </p>
+      {:else}
+        <div class="flex flex-col gap-1">
+          {#each waterfallRows as row (row.id)}
+            <div class="flex items-center gap-2 text-xs">
+              <span class="w-14 shrink-0 font-medium">{row.symbol}</span>
+              <svg
+                viewBox={`0 0 ${String(WATERFALL_PLOT_WIDTH)} 14`}
+                class="h-3.5 min-w-0 flex-1"
+                preserveAspectRatio="none"
+              >
+                {#each row.segments as segment (segment.name)}
+                  <rect
+                    x={segment.x}
+                    y="2"
+                    width={Math.max(segment.width, segment.ms > 0 ? 1 : 0)}
+                    height="10"
+                    rx="1"
+                    fill={segmentColor(segment.name, row.status)}
+                  >
+                    <title>
+                      {SEGMENT_LABELS[segment.name]}: {formatDurationMs(segment.ms)}
+                    </title>
+                  </rect>
+                {/each}
+              </svg>
+              <span class="w-16 shrink-0 text-right tabular-nums text-muted-foreground">
+                {formatDurationMs(row.totalMs)}
+              </span>
+            </div>
+          {/each}
+        </div>
+        {#if (chartLatencies.current?.totalCycles ?? 0) > waterfallRows.length}
+          <p class="mt-2 text-xs text-muted-foreground">
+            Showing {waterfallRows.length} of {chartLatencies.current?.totalCycles} cycles
+            in range{waterfallSort.current === 'slowest'
+              ? ' — slowest among the most recent cycles shown, not full-range'
+              : ''}.
+          </p>
+        {/if}
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <div class="flex items-center justify-between">
+        <Card.Title class="text-sm font-medium">Latency percentiles over time</Card.Title>
+        <div class="flex gap-1">
+          {#each STAGE_OPTIONS as option (option.key)}
+            <button
+              class={rangeButtonClass(selectedStage.current === option.key)}
+              onclick={() => {
+                selectedStage.update(() => option.key)
+              }}
+            >
+              {option.label}
+            </button>
+          {/each}
+        </div>
+      </div>
+      <div class="flex gap-3 text-xs text-muted-foreground">
+        {#each Object.entries(PERCENTILE_COLORS) as [percentile, color] (percentile)}
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-0.5 w-3" style:background={color}></span>
+            {percentile.replace('Ms', '')}
+          </span>
+        {/each}
+      </div>
+    </Card.Header>
+    <Card.Content>
+      {#if (seriesLayout.lines[0]?.points.length ?? 0) === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No samples for this stage in the selected range.
+        </p>
+      {:else}
+        <div class="flex items-start gap-2">
+          <span class="shrink-0 text-xs tabular-nums text-muted-foreground">
+            {formatDurationMs(seriesLayout.maxMs)}
+          </span>
+          <svg
+            viewBox={`0 0 ${String(SERIES_PLOT_WIDTH)} ${String(SERIES_PLOT_HEIGHT + 18)}`}
+            class="min-w-0 flex-1"
+          >
+            <line
+              x1="0"
+              y1={SERIES_PLOT_HEIGHT}
+              x2={SERIES_PLOT_WIDTH}
+              y2={SERIES_PLOT_HEIGHT}
+              stroke="currentColor"
+              stroke-opacity="0.15"
+            />
+            {#each seriesLayout.lines as line (line.percentile)}
+              <polyline
+                points={line.path}
+                fill="none"
+                stroke={PERCENTILE_COLORS[line.percentile]}
+                stroke-width="1.5"
+              />
+              {#each line.points as point, pointIndex (pointIndex)}
+                <circle
+                  cx={point.x}
+                  cy={point.y}
+                  r="2"
+                  fill={PERCENTILE_COLORS[line.percentile]}
+                />
+              {/each}
+            {/each}
+            {#each seriesLayout.xLabels as xLabel (xLabel.x)}
+              <text
+                x={xLabel.x}
+                y={SERIES_PLOT_HEIGHT + 14}
+                text-anchor="middle"
+                class="fill-muted-foreground"
+                font-size="10"
+              >
+                {xLabel.label}
+              </text>
+            {/each}
+          </svg>
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
 </div>

--- a/dashboard/src/lib/performance/charts.test.ts
+++ b/dashboard/src/lib/performance/charts.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest'
+
+import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
+import type { LatencyBucket } from '$lib/api/LatencyBucket'
+import type { LatencyStats } from '$lib/api/LatencyStats'
+
+import { layoutPercentileSeries, layoutWaterfall } from './charts'
+
+const cycle = (overrides: Partial<HedgeCycleReport>): HedgeCycleReport => ({
+  symbol: 'AAPL',
+  offchainOrderId: 'order-1',
+  placedAt: '2026-06-01T00:00:10Z',
+  coveredFillCount: 1,
+  earliestFillBlockTimestamp: '2026-06-01T00:00:00Z',
+  submittedAt: '2026-06-01T00:00:12Z',
+  status: 'filled',
+  completedAt: '2026-06-01T00:00:20Z',
+  decisionMs: 5_000,
+  submissionMs: 2_000,
+  executionMs: 8_000,
+  exposureWindowMs: 20_000,
+  ...overrides,
+})
+
+describe('layoutWaterfall', () => {
+  it('splits a filled cycle into unhedged, submission, and execution segments', () => {
+    const rows = layoutWaterfall([cycle({})], {
+      plotWidth: 100,
+      sort: 'slowest',
+      maxRows: 10,
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.totalMs).toBe(20_000)
+    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual([
+      'unhedged',
+      'submission',
+      'execution',
+    ])
+    expect(rows[0]?.segments.map((segment) => segment.ms)).toEqual([
+      10_000, 2_000, 8_000,
+    ])
+    // Slowest row spans the full plot width.
+    const lastSegment = rows[0]?.segments.at(-1)
+    expect((lastSegment?.x ?? 0) + (lastSegment?.width ?? 0)).toBeCloseTo(100)
+  })
+
+  it('sorts slowest first and caps rows', () => {
+    const fast = cycle({
+      offchainOrderId: 'fast',
+      completedAt: '2026-06-01T00:00:13Z',
+    })
+    const slow = cycle({
+      offchainOrderId: 'slow',
+      completedAt: '2026-06-01T00:01:00Z',
+    })
+    const mid = cycle({
+      offchainOrderId: 'mid',
+      completedAt: '2026-06-01T00:00:30Z',
+    })
+
+    const rows = layoutWaterfall([fast, slow, mid], {
+      plotWidth: 100,
+      sort: 'slowest',
+      maxRows: 2,
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['slow', 'mid'])
+  })
+
+  it('sorts newest first by placement time', () => {
+    const earlier = cycle({
+      offchainOrderId: 'earlier',
+      placedAt: '2026-06-01T00:00:10Z',
+    })
+    const later = cycle({
+      offchainOrderId: 'later',
+      placedAt: '2026-06-02T00:00:10Z',
+    })
+
+    const rows = layoutWaterfall([earlier, later], {
+      plotWidth: 100,
+      sort: 'newest',
+      maxRows: 10,
+    })
+
+    expect(rows.map((row) => row.id)).toEqual(['later', 'earlier'])
+  })
+
+  it('renders a pending cycle without submission or execution segments', () => {
+    const pending = cycle({
+      status: 'pending',
+      submittedAt: null,
+      completedAt: null,
+    })
+
+    const rows = layoutWaterfall([pending], {
+      plotWidth: 100,
+      sort: 'slowest',
+      maxRows: 10,
+    })
+
+    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged'])
+  })
+
+  it('renders a submitted-but-not-completed cycle with unhedged and submission segments only', () => {
+    const submitted = cycle({
+      status: 'pending',
+      // placedAt: '2026-06-01T00:00:10Z' (from defaults)
+      // earliestFillBlockTimestamp: '2026-06-01T00:00:00Z' (from defaults) -> unhedged = 10s
+      submittedAt: '2026-06-01T00:00:15Z', // submission = 5s
+      completedAt: null,
+    })
+
+    const rows = layoutWaterfall([submitted], {
+      plotWidth: 100,
+      sort: 'slowest',
+      maxRows: 10,
+    })
+
+    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged', 'submission'])
+    expect(rows[0]?.segments[1]?.ms).toBe(5_000)
+  })
+})
+
+const stats = (p50: number, p90: number, p99: number): LatencyStats => ({
+  p50Ms: p50,
+  p90Ms: p90,
+  p95Ms: p90,
+  p99Ms: p99,
+  maxMs: p99,
+  sampleCount: 10,
+})
+
+const bucket = (start: string, detection: LatencyStats | null): LatencyBucket => ({
+  start,
+  stages: {
+    detection,
+    decision: null,
+    submission: null,
+    execution: null,
+    exposureWindow: null,
+  },
+})
+
+describe('layoutPercentileSeries', () => {
+  it('lays out p50/p90/p99 lines scaled to the largest p99', () => {
+    const plotHeight = 50
+    // maxMs = 800 (largest p99 across both buckets)
+    const layout = layoutPercentileSeries(
+      [
+        bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
+        bucket('2026-06-02T00:00:00Z', stats(150, 300, 800)),
+      ],
+      'detection',
+      {
+        plotWidth: 100,
+        plotHeight,
+        maxXLabels: 6,
+      },
+    )
+
+    expect(layout.maxMs).toBe(800)
+    expect(layout.lines).toHaveLength(3)
+
+    // y = plotHeight - (ms / maxMs) * plotHeight, maxMs = 800
+    const p99 = layout.lines.find((line) => line.percentile === 'p99Ms')
+    expect(p99?.points[1]?.y).toBeCloseTo(0)
+    expect(p99?.points[0]?.y).toBeCloseTo(25)
+    expect(p99?.points[0]?.x).toBeCloseTo(0)
+    expect(p99?.points[1]?.x).toBeCloseTo(100)
+
+    // bucket 0: p50=100, p90=200; bucket 1: p50=150, p90=300 — all scaled to maxMs=800
+    const p50 = layout.lines.find((line) => line.percentile === 'p50Ms')
+    // bucket 0: y = 50 - (100/800)*50 = 50 - 6.25 = 43.75
+    expect(p50?.points[0]?.y).toBeCloseTo(43.75)
+    // bucket 1: y = 50 - (150/800)*50 = 50 - 9.375 = 40.625
+    expect(p50?.points[1]?.y).toBeCloseTo(40.625)
+
+    const p90 = layout.lines.find((line) => line.percentile === 'p90Ms')
+    // bucket 0: y = 50 - (200/800)*50 = 50 - 12.5 = 37.5
+    expect(p90?.points[0]?.y).toBeCloseTo(37.5)
+    // bucket 1: y = 50 - (300/800)*50 = 50 - 18.75 = 31.25
+    expect(p90?.points[1]?.y).toBeCloseTo(31.25)
+  })
+
+  it('skips buckets where the stage has no samples', () => {
+    const layout = layoutPercentileSeries(
+      [
+        bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
+        bucket('2026-06-02T00:00:00Z', null),
+        bucket('2026-06-03T00:00:00Z', stats(100, 200, 400)),
+      ],
+      'detection',
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+        maxXLabels: 6,
+      },
+    )
+
+    expect(layout.lines[0]?.points).toHaveLength(2)
+  })
+
+  it('centers a single bucket', () => {
+    const layout = layoutPercentileSeries(
+      [bucket('2026-06-01T00:00:00Z', stats(100, 200, 400))],
+      'detection',
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+        maxXLabels: 6,
+      },
+    )
+
+    expect(layout.lines[0]?.points[0]?.x).toBeCloseTo(50)
+  })
+
+  it('always includes the last bucket label even when it does not fall on a step boundary', () => {
+    // 5 buckets, maxXLabels=2 -> labelStep = ceil(5/2) = 3
+    // Step-aligned indices: 0, 3. Index 4 (last) is NOT on a step -> must still appear.
+    const buckets = [
+      bucket('2026-06-01T00:00:00Z', stats(100, 200, 400)),
+      bucket('2026-06-02T00:00:00Z', stats(100, 200, 400)),
+      bucket('2026-06-03T00:00:00Z', stats(100, 200, 400)),
+      bucket('2026-06-04T00:00:00Z', stats(100, 200, 400)),
+      bucket('2026-06-05T00:00:00Z', stats(100, 200, 400)),
+    ]
+
+    const layout = layoutPercentileSeries(buckets, 'detection', {
+      plotWidth: 100,
+      plotHeight: 50,
+      maxXLabels: 2,
+    })
+
+    // Expect 3 labels: indices 0, 3, and 4 (last)
+    expect(layout.xLabels).toHaveLength(3)
+    // Last label x should equal the rightmost point (index 4 out of 4 -> x=100)
+    expect(layout.xLabels.at(-1)?.x).toBeCloseTo(100)
+  })
+})

--- a/dashboard/src/lib/performance/charts.ts
+++ b/dashboard/src/lib/performance/charts.ts
@@ -1,0 +1,209 @@
+/** Pure SVG layout math for the Performance tab's latency charts. */
+
+import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
+import type { LatencyBucket } from '$lib/api/LatencyBucket'
+import type { StageLatencies } from '$lib/api/StageLatencies'
+
+export type WaterfallSegmentName = 'unhedged' | 'submission' | 'execution'
+
+export type WaterfallSegment = {
+  name: WaterfallSegmentName
+  ms: number
+  x: number
+  width: number
+}
+
+export type WaterfallRow = {
+  id: string
+  symbol: string
+  status: HedgeCycleReport['status']
+  totalMs: number
+  segments: WaterfallSegment[]
+}
+
+export type WaterfallSort = 'slowest' | 'newest'
+
+const segmentDurations = (
+  cycle: HedgeCycleReport,
+): { name: WaterfallSegmentName; ms: number }[] => {
+  const placedAt = new Date(cycle.placedAt).getTime()
+  const earliestFill =
+    cycle.earliestFillBlockTimestamp !== null
+      ? new Date(cycle.earliestFillBlockTimestamp).getTime()
+      : placedAt
+  const submittedAt =
+    cycle.submittedAt !== null ? new Date(cycle.submittedAt).getTime() : null
+  const completedAt =
+    cycle.completedAt !== null ? new Date(cycle.completedAt).getTime() : null
+
+  const segments: { name: WaterfallSegmentName; ms: number }[] = [
+    {
+      name: 'unhedged',
+      ms: Math.max(0, placedAt - earliestFill),
+    },
+  ]
+
+  if (submittedAt !== null) {
+    segments.push({
+      name: 'submission',
+      ms: Math.max(0, submittedAt - placedAt),
+    })
+
+    if (completedAt !== null) {
+      segments.push({
+        name: 'execution',
+        ms: Math.max(0, completedAt - submittedAt),
+      })
+    }
+  }
+
+  return segments
+}
+
+/**
+ * Lays out hedge cycles as horizontal stacked bars whose segment widths are
+ * proportional to wall-clock time, normalized to the slowest visible cycle.
+ */
+export const layoutWaterfall = (
+  cycles: HedgeCycleReport[],
+  options: {
+    plotWidth: number
+    sort: WaterfallSort
+    maxRows: number
+  },
+): WaterfallRow[] => {
+  const rows = cycles.map((cycle) => {
+    const durations = segmentDurations(cycle)
+    const totalMs = durations.reduce((sum, segment) => sum + segment.ms, 0)
+
+    return {
+      id: cycle.offchainOrderId,
+      symbol: cycle.symbol,
+      status: cycle.status,
+      placedAt: new Date(cycle.placedAt).getTime(),
+      totalMs,
+      durations,
+    }
+  })
+
+  rows.sort((left, right) =>
+    options.sort === 'slowest'
+      ? right.totalMs - left.totalMs
+      : right.placedAt - left.placedAt,
+  )
+  const visible = rows.slice(0, options.maxRows)
+
+  const maxTotal = Math.max(1, ...visible.map((row) => row.totalMs))
+
+  return visible.map((row) => {
+    let cursor = 0
+    const segments = row.durations.map((segment) => {
+      const width = (segment.ms / maxTotal) * options.plotWidth
+      const positioned = {
+        ...segment,
+        x: cursor,
+        width,
+      }
+      cursor += width
+      return positioned
+    })
+
+    return {
+      id: row.id,
+      symbol: row.symbol,
+      status: row.status,
+      totalMs: row.totalMs,
+      segments,
+    }
+  })
+}
+
+export type PercentileKey = 'p50Ms' | 'p90Ms' | 'p99Ms'
+
+export type SeriesPoint = {
+  x: number
+  y: number
+}
+
+export type SeriesLine = {
+  percentile: PercentileKey
+  points: SeriesPoint[]
+  path: string
+}
+
+export type SeriesLayout = {
+  lines: SeriesLine[]
+  maxMs: number
+  xLabels: { x: number; label: string }[]
+}
+
+const PERCENTILE_KEYS: PercentileKey[] = ['p50Ms', 'p90Ms', 'p99Ms']
+
+/**
+ * Lays out one stage's percentiles across time buckets as polyline charts.
+ * Buckets where the stage has no samples are skipped, keeping the lines
+ * continuous across gaps.
+ */
+export const layoutPercentileSeries = (
+  buckets: LatencyBucket[],
+  stage: keyof StageLatencies,
+  options: {
+    plotWidth: number
+    plotHeight: number
+    maxXLabels: number
+  },
+): SeriesLayout => {
+  const sampled = buckets
+    .map((bucket) => ({
+      start: bucket.start,
+      stats: bucket.stages[stage],
+    }))
+    .filter((bucket) => bucket.stats !== null)
+
+  const maxMs = Math.max(1, ...sampled.map((bucket) => bucket.stats?.p99Ms ?? 0))
+  const xDenominator = Math.max(1, sampled.length - 1)
+  const xFor = (index: number): number =>
+    sampled.length <= 1
+      ? options.plotWidth / 2
+      : (index / xDenominator) * options.plotWidth
+  const yFor = (ms: number): number =>
+    options.plotHeight - (ms / maxMs) * options.plotHeight
+
+  const lines = PERCENTILE_KEYS.map((percentile) => {
+    const points = sampled.map((bucket, index) => ({
+      x: xFor(index),
+      y: yFor(bucket.stats?.[percentile] ?? 0),
+    }))
+
+    return {
+      percentile,
+      points,
+      path: points
+        .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
+        .join(' '),
+    }
+  })
+
+  const labelStep = Math.max(1, Math.ceil(sampled.length / options.maxXLabels))
+  const lastIndex = sampled.length - 1
+  const xLabels = sampled
+    .map((bucket, index) => ({
+      x: xFor(index),
+      label: new Date(bucket.start).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      }),
+      index,
+    }))
+    .filter(({ index }) => index % labelStep === 0 || index === lastIndex)
+    .map(({ x, label }) => ({
+      x,
+      label,
+    }))
+
+  return {
+    lines,
+    maxMs,
+    xLabels,
+  }
+}


### PR DESCRIPTION
## What

[RAI-995](https://linear.app/makeitrain/issue/RAI-995/dashboard-latency-waterfall-percentile-time-series-charts)

- Hedge-cycle waterfall: horizontal stacked bars proportional to wall-clock time (unhedged -> submission -> execution). Shows up to 20 fetched cycles, sortable by slowest or newest.
- Latency percentile time series: selectable stage chart for p50/p90/p99 over the selected range, using presets matching the P&L tab (1W/1M/YTD/1Y/ALL).
- Charts fetch independently from the 24h SLO cards, refresh on the same 30s polling interval, and surface fetch errors inline.

## Why

- The SLO cards show aggregates; these charts show which pipeline stage regressed and how latency evolves over time.

## How

- Hand-rolled SVG per the existing P&L chart convention; all geometry lives in pure `dashboard/src/lib/performance/charts.ts` (`layoutWaterfall`, `layoutPercentileSeries`).
- Waterfall segments derive from absolute timestamps so bar length equals the true exposure window; pending cycles render without submission/execution segments.
- Charts fetch with the selected preset range, separate from the cards' fixed 24h window.

## Testing

- Chart-layout vitest tests: segment splitting and proportions, slowest/newest sort and row cap, pending cycles rendering without submission/execution segments, percentile line scaling, gap skipping, single-bucket centering, and x-axis always-show-last-label behavior.

## Anything else

- ALL preset uses 2025-01-01 as its range start (pre-dates the system's first deployment).
