### PR TITLE
feat: error matrix and rebalance stage breakdown panels

### DIFF
--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -278,6 +278,9 @@ pub struct LogTargetCount {
     pub level: String,
     #[ts(type = "number")]
     pub count: usize,
+    /// Per-bucket counts aligned with the report's `log_buckets`.
+    #[ts(type = "number[]")]
+    pub sparkline: Vec<usize>,
 }
 
 /// Occurrences of one lifecycle failure event type.

--- a/dashboard/src/lib/components/log-panel.svelte
+++ b/dashboard/src/lib/components/log-panel.svelte
@@ -4,6 +4,7 @@
   import MultiSelect from '$lib/components/multi-select.svelte'
   import { reactive } from '$lib/frp.svelte'
   import { getApiBaseUrl } from '$lib/env'
+  import { resolveLogFilter, takeRequestedLogTarget } from '$lib/log-filter-request.svelte'
   import { formatUtcMs, toDatetimeLocal, TIME_PRESETS, toRfc3339 } from '$lib/time'
 
   /** Log queries scan files on disk and can be slow at trace level. */
@@ -110,9 +111,13 @@
   }
 
   const fetchLogs = async (mode: 'replace' | 'append') => {
+    // Skip the fetch when there is nothing to narrow results by. A non-empty
+    // search term is always sufficient on its own (no target filter needed),
+    // but an empty target selection with no search term would return everything.
+    const hasSearch = search.current.trim().length > 0
     const noFilters =
       selectedLevels.current.size === 0 ||
-      (selectedCategories.current.size === 0 && selectedCrates.current.size === 0)
+      (!hasSearch && selectedCategories.current.size === 0 && selectedCrates.current.size === 0)
 
     if (noFilters) {
       error.update(() => null)
@@ -202,7 +207,42 @@
     !setsEqual(selectedCrates.current, OUR_CRATES)
   )
 
-  onMount(() => { void fetchLogs('replace') })
+  /**
+   * Seed filters from a Performance-tab click-through before the first
+   * fetch: known categories/crates narrow their checkbox filters, anything
+   * else lands in the free-text search so the click never silently no-ops.
+   */
+  const applyRequestedTarget = () => {
+    const requested = takeRequestedLogTarget()
+    if (requested === null) return
+
+    const resolution = resolveLogFilter(requested, ALL_CATEGORIES, ALL_CRATES)
+
+    if (resolution.kind === 'category') {
+      selectedCategories.update(() => new Set([resolution.target]))
+      selectedCrates.update(() => new Set<string>())
+      return
+    }
+
+    if (resolution.kind === 'crate') {
+      selectedCategories.update(() => new Set<string>())
+      selectedCrates.update(() => new Set([resolution.target]))
+      return
+    }
+
+    // Clear target filters so the free-text search is authoritative. Leaving
+    // the default category/crate filters active would AND them with the search
+    // term, producing zero results for log targets outside the st0x_* crates
+    // (e.g. `apalis::pool`).
+    selectedCategories.update(() => new Set<string>())
+    selectedCrates.update(() => new Set<string>())
+    search.update(() => resolution.target)
+  }
+
+  onMount(() => {
+    applyRequestedTarget()
+    void fetchLogs('replace')
+  })
 
   // Debounced search
   let debounceTimer: ReturnType<typeof setTimeout> | undefined

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -2,10 +2,17 @@
   import { onMount } from 'svelte'
   import * as Card from '$lib/components/ui/card'
   import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+  import type { RebalanceStageName } from '$lib/api/RebalanceStageName'
+  import type { RebalanceTimings } from '$lib/api/RebalanceTimings'
   import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
   import type { StageLatencies } from '$lib/api/StageLatencies'
+  import type { UsdcBridgeDirection } from '$lib/api/UsdcBridgeDirection'
   import { reactive } from '$lib/frp.svelte'
-  import { fetchHedgeLatencies, fetchReliabilityReport } from '$lib/performance/api'
+  import {
+    fetchHedgeLatencies,
+    fetchRebalanceTimings,
+    fetchReliabilityReport,
+  } from '$lib/performance/api'
   import {
     detectionCard,
     errorsCard,
@@ -15,10 +22,14 @@
   import {
     type WaterfallSegmentName,
     type WaterfallSort,
+    layoutAttestationTrend,
     layoutPercentileSeries,
+    layoutRebalanceBars,
     layoutWaterfall,
   } from '$lib/performance/charts'
   import { type SloStatus, formatDurationMs } from '$lib/performance/slo'
+
+  const { onOpenLogs }: { onOpenLogs?: (target: string) => void } = $props()
 
   const POLL_INTERVAL_MS = 30_000
   const CARD_WINDOW_HOURS = 24
@@ -27,10 +38,13 @@
   const reliability = reactive<ReliabilityReport | null>(null)
   const error = reactive<string | null>(null)
   const lastRefreshed = reactive<Date | null>(null)
-  let fetchSeq = 0
+
+  // Discard out-of-date responses: a slow earlier fetch resolving after a
+  // newer one must not overwrite fresher data (same pattern as pnl-panel).
+  let cardFetchSeq = 0
 
   const refresh = async () => {
-    const seq = ++fetchSeq
+    const seq = ++cardFetchSeq
     const to = new Date()
     const from = new Date(to.getTime() - CARD_WINDOW_HOURS * 3_600_000)
 
@@ -39,8 +53,7 @@
         fetchHedgeLatencies({ from, to }),
         fetchReliabilityReport({ from, to }),
       ])
-
-      if (seq !== fetchSeq) return
+      if (seq !== cardFetchSeq) return
 
       const refreshedAt = new Date()
 
@@ -49,7 +62,7 @@
       lastRefreshed.update(() => refreshedAt)
       error.update(() => null)
     } catch (fetchError) {
-      if (seq !== fetchSeq) return
+      if (seq !== cardFetchSeq) return
 
       error.update(() =>
         fetchError instanceof Error ? fetchError.message : 'Unknown error',
@@ -86,22 +99,32 @@
 
   const chartRange = reactive<RangePreset>('1W')
   const chartLatencies = reactive<HedgeLatencies | null>(null)
+  const chartRebalances = reactive<RebalanceTimings | null>(null)
   const chartError = reactive<string | null>(null)
+  // Timestamp captured at the moment the chart fetch was initiated, used as
+  // `now` for in-progress cycle and operation elapsed-time calculations.
+  const chartRefreshedAt = reactive<Date | null>(null)
   let chartFetchSeq = 0
 
   const refreshCharts = async () => {
     const seq = ++chartFetchSeq
     const to = new Date()
+    const range = {
+      from: rangeStart(chartRange.current, to),
+      to,
+    }
 
     try {
-      const report = await fetchHedgeLatencies({
-        from: rangeStart(chartRange.current, to),
-        to,
-      })
+      const [latencyReport, rebalanceReport] = await Promise.all([
+        fetchHedgeLatencies(range),
+        fetchRebalanceTimings(range),
+      ])
 
       if (seq !== chartFetchSeq) return
 
-      chartLatencies.update(() => report)
+      chartLatencies.update(() => latencyReport)
+      chartRebalances.update(() => rebalanceReport)
+      chartRefreshedAt.update(() => to)
       chartError.update(() => null)
     } catch (fetchError) {
       if (seq !== chartFetchSeq) return
@@ -196,6 +219,7 @@
       plotWidth: WATERFALL_PLOT_WIDTH,
       sort: waterfallSort.current,
       maxRows: WATERFALL_MAX_ROWS,
+      now: chartRefreshedAt.current ?? new Date(),
     }),
   )
 
@@ -230,6 +254,43 @@
 
   const rangeButtonClass = (active: boolean): string =>
     `rounded px-2 py-1 text-xs font-medium transition-colors ${active ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`
+
+  const REBALANCE_PLOT_WIDTH = 600
+  const REBALANCE_MAX_ROWS = 15
+  const TREND_PLOT_WIDTH = 600
+  const TREND_PLOT_HEIGHT = 80
+
+  const STAGE_COLORS: Record<RebalanceStageName, string> = {
+    conversion: '#c084fc',
+    withdrawal: '#38bdf8',
+    burn: '#fb923c',
+    attestation: '#fbbf24',
+    mint: '#34d399',
+    deposit: '#818cf8',
+  }
+
+  const rebalanceRows = $derived(
+    layoutRebalanceBars(chartRebalances.current?.operations ?? [], {
+      plotWidth: REBALANCE_PLOT_WIDTH,
+      maxRows: REBALANCE_MAX_ROWS,
+      now: chartRefreshedAt.current ?? new Date(),
+    }),
+  )
+
+  const attestationTrend = $derived(
+    layoutAttestationTrend(chartRebalances.current?.attestationTrend ?? [], {
+      plotWidth: TREND_PLOT_WIDTH,
+      plotHeight: TREND_PLOT_HEIGHT,
+    }),
+  )
+
+  const DIRECTION_LABELS: Record<UsdcBridgeDirection, string> = {
+    alpaca_to_base: 'Alpaca → Base',
+    base_to_alpaca: 'Base → Alpaca',
+  }
+
+  const directionLabel = (direction: UsdcBridgeDirection | null): string =>
+    direction === null ? '—' : DIRECTION_LABELS[direction]
 </script>
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto">
@@ -447,6 +508,154 @@
               >
                 {xLabel.label}
               </text>
+            {/each}
+          </svg>
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <Card.Title class="text-sm font-medium">
+        Errors &amp; warnings by module (24h)
+      </Card.Title>
+    </Card.Header>
+    <Card.Content>
+      {#if reliability.current !== null && reliability.current.logTargets.length === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No errors or warnings in the last {CARD_WINDOW_HOURS}h.
+        </p>
+      {:else}
+        <div class="flex flex-col gap-1">
+          {#each reliability.current?.logTargets ?? [] as row (`${row.target}:${row.level}`)}
+            <div class="flex items-center gap-2 text-xs">
+              <span
+                class={`w-12 shrink-0 font-semibold ${row.level === 'ERROR' ? 'text-red-400' : 'text-amber-400'}`}
+              >
+                {row.level}
+              </span>
+              <span class="w-36 shrink-0 truncate font-mono">{row.target}</span>
+              <svg
+                viewBox={`0 0 ${String(row.sparkline.length * 6)} 14`}
+                class="h-3.5 w-28 shrink-0"
+                preserveAspectRatio="none"
+              >
+                {#each row.sparkline as bucketCount, bucketIndex (bucketIndex)}
+                  <rect
+                    x={bucketIndex * 6}
+                    y={14 - (bucketCount / Math.max(1, ...row.sparkline)) * 12 - 1}
+                    width="4"
+                    height={(bucketCount / Math.max(1, ...row.sparkline)) * 12 + 1}
+                    fill={row.level === 'ERROR' ? '#f87171' : '#fbbf24'}
+                    opacity={bucketCount === 0 ? 0.15 : 0.9}
+                  />
+                {/each}
+              </svg>
+              <span class="w-10 shrink-0 text-right tabular-nums">{row.count}</span>
+              <button
+                class="text-muted-foreground underline-offset-2 hover:text-foreground
+                  hover:underline"
+                onclick={() => {
+                  onOpenLogs?.(row.target)
+                }}
+              >
+                logs →
+              </button>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      {#if reliability.current !== null && reliability.current.failureEvents.length > 0}
+        <div class="mt-4 border-t pt-2">
+          <p class="mb-1 text-xs font-medium text-red-400">
+            Lifecycle failures (money-at-risk)
+          </p>
+          {#each reliability.current.failureEvents as failure (failure.eventType)}
+            <div class="flex items-center gap-2 text-xs">
+              <span class="w-72 shrink-0 truncate font-mono">{failure.eventType}</span>
+              <span class="w-10 shrink-0 text-right tabular-nums">{failure.count}</span>
+              <span class="text-muted-foreground">
+                last {new Date(failure.lastAt).toLocaleString()}
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <Card.Title class="text-sm font-medium">Rebalance stage breakdown</Card.Title>
+      <div class="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        {#each Object.entries(STAGE_COLORS) as [stage, color] (stage)}
+          <span class="flex items-center gap-1">
+            <span class="inline-block h-2 w-2 rounded-sm" style:background={color}
+            ></span>
+            {stage}
+          </span>
+        {/each}
+      </div>
+    </Card.Header>
+    <Card.Content>
+      {#if rebalanceRows.length === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No rebalance operations in the selected range.
+        </p>
+      {:else}
+        <div class="flex flex-col gap-1">
+          {#each rebalanceRows as row (row.id)}
+            <div class="flex items-center gap-2 text-xs">
+              <span class="w-28 shrink-0">{directionLabel(row.direction)}</span>
+              <span class="w-20 shrink-0 text-right tabular-nums text-muted-foreground">
+                {row.amount ?? '—'} USDC
+              </span>
+              <svg
+                viewBox={`0 0 ${String(REBALANCE_PLOT_WIDTH)} 14`}
+                class="h-3.5 min-w-0 flex-1"
+                preserveAspectRatio="none"
+              >
+                {#each row.segments as segment, segmentIndex (segmentIndex)}
+                  <rect
+                    x={segment.x}
+                    y="2"
+                    width={Math.max(segment.width, segment.ms > 0 ? 1 : 0)}
+                    height="10"
+                    rx="1"
+                    fill={segment.failed ? '#f87171' : STAGE_COLORS[segment.stage]}
+                  >
+                    <title>{segment.stage}: {formatDurationMs(segment.ms)}</title>
+                  </rect>
+                {/each}
+              </svg>
+              <span class="w-16 shrink-0 text-right tabular-nums text-muted-foreground">
+                {formatDurationMs(row.totalMs)}
+              </span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      {#if attestationTrend.points.length > 0}
+        <div class="mt-4 border-t pt-2">
+          <p class="mb-1 text-xs font-medium text-muted-foreground">
+            CCTP attestation time trend (max {formatDurationMs(attestationTrend.maxMs)})
+          </p>
+          <svg
+            viewBox={`0 0 ${String(TREND_PLOT_WIDTH)} ${String(TREND_PLOT_HEIGHT)}`}
+            class="h-20 w-full"
+            preserveAspectRatio="none"
+          >
+            <polyline
+              points={attestationTrend.path}
+              fill="none"
+              stroke="#fbbf24"
+              stroke-width="1.5"
+            />
+            {#each attestationTrend.points as point, pointIndex (pointIndex)}
+              <circle cx={point.x} cy={point.y} r="2" fill="#fbbf24" />
             {/each}
           </svg>
         </div>

--- a/dashboard/src/lib/log-filter-request.svelte.ts
+++ b/dashboard/src/lib/log-filter-request.svelte.ts
@@ -1,0 +1,54 @@
+/**
+ * Cross-tab handoff for "view logs for this target" click-throughs.
+ *
+ * The Performance tab's error matrix sets a target here before switching to
+ * the Logs tab; the log panel consumes (and clears) it on mount to seed its
+ * filters.
+ */
+
+import { reactive } from '$lib/frp.svelte'
+
+export const requestedLogTarget = reactive<string | null>(null)
+
+/** Read and clear the pending request, if any. */
+export const takeRequestedLogTarget = (): string | null => {
+  const target = requestedLogTarget.current
+  requestedLogTarget.update(() => null)
+  return target
+}
+
+export type LogFilterResolution =
+  | { kind: 'category'; target: string }
+  | { kind: 'crate'; target: string }
+  | { kind: 'search'; target: string }
+
+/**
+ * Decide how a clicked log target maps onto the log panel's filters: known
+ * categories and crates use their checkbox filters; anything else (e.g. a
+ * full module path) falls back to the free-text search, which the backend
+ * matches as a substring.
+ */
+export const resolveLogFilter = (
+  target: string,
+  categories: readonly string[],
+  crates: readonly string[],
+): LogFilterResolution => {
+  if (categories.includes(target)) {
+    return {
+      kind: 'category',
+      target,
+    }
+  }
+
+  if (crates.includes(target)) {
+    return {
+      kind: 'crate',
+      target,
+    }
+  }
+
+  return {
+    kind: 'search',
+    target,
+  }
+}

--- a/dashboard/src/lib/log-filter-request.test.ts
+++ b/dashboard/src/lib/log-filter-request.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveLogFilter } from './log-filter-request.svelte'
+
+const CATEGORIES = ['hedge', 'rebalance'] as const
+const CRATES = ['st0x_hedge', 'apalis'] as const
+
+describe('resolveLogFilter', () => {
+  it('maps known categories to the category filter', () => {
+    expect(resolveLogFilter('hedge', CATEGORIES, CRATES)).toEqual({
+      kind: 'category',
+      target: 'hedge',
+    })
+  })
+
+  it('maps known crates to the crate filter', () => {
+    expect(resolveLogFilter('apalis', CATEGORIES, CRATES)).toEqual({
+      kind: 'crate',
+      target: 'apalis',
+    })
+  })
+
+  it('falls back to free-text search for unknown targets', () => {
+    expect(
+      resolveLogFilter('st0x_hedge::conductor::monitor', CATEGORIES, CRATES),
+    ).toEqual({
+      kind: 'search',
+      target: 'st0x_hedge::conductor::monitor',
+    })
+  })
+})
+
+describe('takeRequestedLogTarget', () => {
+  // Reset module state between tests so the shared `requestedLogTarget`
+  // reactive does not carry state from one test into the next.
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns the stored value and clears it on the second call', async () => {
+    const { requestedLogTarget, takeRequestedLogTarget } = await import(
+      './log-filter-request.svelte'
+    )
+
+    requestedLogTarget.update(() => 'apalis::pool')
+
+    const first = takeRequestedLogTarget()
+    expect(first).toBe('apalis::pool')
+
+    const second = takeRequestedLogTarget()
+    expect(second).toBeNull()
+  })
+
+  it('returns null when no target has been set', async () => {
+    const { takeRequestedLogTarget } = await import('./log-filter-request.svelte')
+
+    expect(takeRequestedLogTarget()).toBeNull()
+  })
+})

--- a/dashboard/src/lib/performance/charts.test.ts
+++ b/dashboard/src/lib/performance/charts.test.ts
@@ -3,8 +3,14 @@ import { describe, expect, it } from 'vitest'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
 import type { LatencyStats } from '$lib/api/LatencyStats'
+import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
 
-import { layoutPercentileSeries, layoutWaterfall } from './charts'
+import {
+  layoutAttestationTrend,
+  layoutPercentileSeries,
+  layoutRebalanceBars,
+  layoutWaterfall,
+} from './charts'
 
 const cycle = (overrides: Partial<HedgeCycleReport>): HedgeCycleReport => ({
   symbol: 'AAPL',
@@ -28,6 +34,7 @@ describe('layoutWaterfall', () => {
       plotWidth: 100,
       sort: 'slowest',
       maxRows: 10,
+      now: new Date('2026-06-02T00:00:00Z'),
     })
 
     expect(rows).toHaveLength(1)
@@ -63,6 +70,7 @@ describe('layoutWaterfall', () => {
       plotWidth: 100,
       sort: 'slowest',
       maxRows: 2,
+      now: new Date('2026-06-02T00:00:00Z'),
     })
 
     expect(rows.map((row) => row.id)).toEqual(['slow', 'mid'])
@@ -82,12 +90,13 @@ describe('layoutWaterfall', () => {
       plotWidth: 100,
       sort: 'newest',
       maxRows: 10,
+      now: new Date('2026-06-02T00:00:00Z'),
     })
 
     expect(rows.map((row) => row.id)).toEqual(['later', 'earlier'])
   })
 
-  it('renders a pending cycle without submission or execution segments', () => {
+  it('renders a pending cycle as live exposure up to now', () => {
     const pending = cycle({
       status: 'pending',
       submittedAt: null,
@@ -98,17 +107,33 @@ describe('layoutWaterfall', () => {
       plotWidth: 100,
       sort: 'slowest',
       maxRows: 10,
+      now: new Date('2026-06-01T00:01:00Z'),
     })
 
     expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged'])
+    // Earliest fill was at 00:00:00; the exposure is still open at now.
+    expect(rows[0]?.totalMs).toBe(60_000)
   })
 
-  it('renders a submitted-but-not-completed cycle with unhedged and submission segments only', () => {
+  it('returns an empty array for no cycles', () => {
+    expect(
+      layoutWaterfall([], {
+        plotWidth: 100,
+        sort: 'slowest',
+        maxRows: 10,
+        now: new Date('2026-06-02T00:00:00Z'),
+      }),
+    ).toEqual([])
+  })
+
+  it('renders an incomplete cycle as a single unhedged live-exposure segment', () => {
     const submitted = cycle({
       status: 'pending',
-      // placedAt: '2026-06-01T00:00:10Z' (from defaults)
-      // earliestFillBlockTimestamp: '2026-06-01T00:00:00Z' (from defaults) -> unhedged = 10s
-      submittedAt: '2026-06-01T00:00:15Z', // submission = 5s
+      // earliestFillBlockTimestamp default '2026-06-01T00:00:00Z'. A cycle with
+      // no terminal state (completedAt null) is live exposure: the whole elapsed
+      // window (now - earliest fill) counts as unhedged so it ranks correctly in
+      // the slowest sort, regardless of whether it was already submitted.
+      submittedAt: '2026-06-01T00:00:15Z',
       completedAt: null,
     })
 
@@ -116,10 +141,235 @@ describe('layoutWaterfall', () => {
       plotWidth: 100,
       sort: 'slowest',
       maxRows: 10,
+      now: new Date('2026-06-02T00:00:00Z'),
     })
 
-    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged', 'submission'])
-    expect(rows[0]?.segments[1]?.ms).toBe(5_000)
+    expect(rows[0]?.segments.map((segment) => segment.name)).toEqual(['unhedged'])
+    expect(rows[0]?.segments[0]?.ms).toBe(86_400_000)
+  })
+})
+
+const operation = (
+  overrides: Partial<RebalanceOperationTiming>,
+): RebalanceOperationTiming => ({
+  operationId: 'op-1',
+  direction: 'alpaca_to_base',
+  amount: '1000',
+  startedAt: '2026-06-01T00:00:00Z',
+  completedAt: '2026-06-01T00:12:10Z',
+  status: 'completed',
+  stages: [
+    {
+      stage: 'withdrawal',
+      startedAt: '2026-06-01T00:00:00Z',
+      endedAt: '2026-06-01T00:00:30Z',
+      durationMs: 30_000,
+      outcome: 'succeeded',
+    },
+    {
+      stage: 'attestation',
+      startedAt: '2026-06-01T00:01:00Z',
+      endedAt: '2026-06-01T00:11:00Z',
+      durationMs: 600_000,
+      outcome: 'succeeded',
+    },
+    {
+      stage: 'deposit',
+      startedAt: '2026-06-01T00:11:30Z',
+      endedAt: null,
+      durationMs: null,
+      outcome: 'unmeasured',
+    },
+  ],
+  totalMs: 730_000,
+  ...overrides,
+})
+
+const NOW_REBALANCE = new Date('2026-06-01T00:12:10Z')
+
+describe('layoutRebalanceBars', () => {
+  it('lays out completed stages proportionally and skips open ones', () => {
+    const rows = layoutRebalanceBars([operation({})], {
+      plotWidth: 100,
+      maxRows: 10,
+      now: NOW_REBALANCE,
+    })
+
+    expect(rows).toHaveLength(1)
+    // The DTO's elapsed time wins over the sum of completed stages so an
+    // open stage does not understate the operation.
+    expect(rows[0]?.totalMs).toBe(730_000)
+    expect(rows[0]?.segments.map((segment) => segment.stage)).toEqual([
+      'withdrawal',
+      'attestation',
+    ])
+    const lastSegment = rows[0]?.segments.at(-1)
+    // Completed stages cover 630s of the 730s elapsed total; the unfilled
+    // remainder represents the still-open deposit stage.
+    expect((lastSegment?.x ?? 0) + (lastSegment?.width ?? 0)).toBeCloseTo(
+      (630_000 / 730_000) * 100,
+    )
+  })
+
+  it('uses now - startedAt as totalMs for in-progress operations', () => {
+    // Operation started at T+0; now is T+3600s = 3600000ms.
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T01:00:00Z')
+
+    const rows = layoutRebalanceBars(
+      [
+        operation({
+          startedAt,
+          completedAt: null,
+          status: 'in_progress',
+          totalMs: null,
+          stages: [
+            {
+              stage: 'withdrawal',
+              startedAt,
+              endedAt: null,
+              durationMs: null,
+              outcome: 'unmeasured',
+            },
+          ],
+        }),
+      ],
+      {
+        plotWidth: 100,
+        maxRows: 10,
+        now,
+      },
+    )
+
+    // Elapsed = now - startedAt = 3600000ms. No completed stages.
+    expect(rows[0]?.totalMs).toBe(3_600_000)
+    // The open stage has durationMs null so it is filtered out of segments.
+    expect(rows[0]?.segments).toHaveLength(0)
+  })
+
+  it('falls back to now - startedAt when totalMs is null and startedAt equals now', () => {
+    // totalMs: null with one closed stage — fallback is now - startedAt.
+    // When now equals startedAt the elapsed basis is zero, so totalMs is 0.
+    const startedAt = '2026-06-01T00:00:00Z'
+    const now = new Date('2026-06-01T00:00:00Z')
+
+    const rows = layoutRebalanceBars(
+      [
+        operation({
+          startedAt,
+          totalMs: null,
+          stages: [
+            {
+              stage: 'withdrawal',
+              startedAt,
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'succeeded',
+            },
+          ],
+        }),
+      ],
+      {
+        plotWidth: 100,
+        maxRows: 10,
+        now,
+      },
+    )
+
+    // now - startedAt = 0, so totalMs = 0. The clamped result is 0.
+    expect(rows[0]?.totalMs).toBe(0)
+  })
+
+  it('caps rows preserving newest-first input order', () => {
+    const rows = layoutRebalanceBars(
+      [
+        operation({ operationId: 'newest' }),
+        operation({ operationId: 'older' }),
+        operation({ operationId: 'oldest' }),
+      ],
+      {
+        plotWidth: 100,
+        maxRows: 2,
+        now: NOW_REBALANCE,
+      },
+    )
+
+    expect(rows.map((row) => row.id)).toEqual(['newest', 'older'])
+  })
+
+  it('marks a failed stage as a failed segment', () => {
+    const rows = layoutRebalanceBars(
+      [
+        operation({
+          status: 'failed',
+          completedAt: null,
+          totalMs: null,
+          stages: [
+            {
+              stage: 'burn',
+              startedAt: '2026-06-01T00:00:00Z',
+              endedAt: '2026-06-01T00:00:30Z',
+              durationMs: 30_000,
+              outcome: 'failed',
+            },
+          ],
+        }),
+      ],
+      {
+        plotWidth: 100,
+        maxRows: 10,
+        now: NOW_REBALANCE,
+      },
+    )
+
+    expect(rows[0]?.segments[0]?.failed).toBe(true)
+  })
+})
+
+describe('layoutAttestationTrend', () => {
+  it('centers a single sample', () => {
+    const layout = layoutAttestationTrend(
+      [
+        {
+          burnedAt: '2026-06-01T00:00:00Z',
+          durationMs: 300_000,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    expect(layout.points[0]?.x).toBeCloseTo(50)
+    // The only sample is also the max, so y = plotHeight - (max/max)*plotHeight = 0.
+    expect(layout.points[0]?.y).toBeCloseTo(0)
+    expect(layout.maxMs).toBe(300_000)
+    expect(layout.path.length).toBeGreaterThan(0)
+  })
+
+  it('scales durations to the slowest sample', () => {
+    const layout = layoutAttestationTrend(
+      [
+        {
+          burnedAt: '2026-06-01T00:00:00Z',
+          durationMs: 300_000,
+        },
+        {
+          burnedAt: '2026-06-02T00:00:00Z',
+          durationMs: 600_000,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    expect(layout.maxMs).toBe(600_000)
+    expect(layout.points[0]?.y).toBeCloseTo(25)
+    expect(layout.points[1]?.y).toBeCloseTo(0)
+    expect(layout.points[1]?.x).toBeCloseTo(100)
   })
 })
 

--- a/dashboard/src/lib/performance/charts.ts
+++ b/dashboard/src/lib/performance/charts.ts
@@ -1,7 +1,10 @@
 /** Pure SVG layout math for the Performance tab's latency charts. */
 
+import type { AttestationSample } from '$lib/api/AttestationSample'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
+import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
+import type { RebalanceStageName } from '$lib/api/RebalanceStageName'
 import type { StageLatencies } from '$lib/api/StageLatencies'
 
 export type WaterfallSegmentName = 'unhedged' | 'submission' | 'execution'
@@ -25,6 +28,7 @@ export type WaterfallSort = 'slowest' | 'newest'
 
 const segmentDurations = (
   cycle: HedgeCycleReport,
+  now: Date,
 ): { name: WaterfallSegmentName; ms: number }[] => {
   const placedAt = new Date(cycle.placedAt).getTime()
   const earliestFill =
@@ -35,6 +39,18 @@ const segmentDurations = (
     cycle.submittedAt !== null ? new Date(cycle.submittedAt).getTime() : null
   const completedAt =
     cycle.completedAt !== null ? new Date(cycle.completedAt).getTime() : null
+
+  // A cycle that has not reached a terminal state is live exposure: its
+  // whole elapsed time still counts as unhedged, so it ranks where it
+  // belongs in the slowest sort instead of rendering as an invisible bar.
+  if (completedAt === null) {
+    return [
+      {
+        name: 'unhedged',
+        ms: Math.max(0, now.getTime() - earliestFill),
+      },
+    ]
+  }
 
   const segments: { name: WaterfallSegmentName; ms: number }[] = [
     {
@@ -48,13 +64,10 @@ const segmentDurations = (
       name: 'submission',
       ms: Math.max(0, submittedAt - placedAt),
     })
-
-    if (completedAt !== null) {
-      segments.push({
-        name: 'execution',
-        ms: Math.max(0, completedAt - submittedAt),
-      })
-    }
+    segments.push({
+      name: 'execution',
+      ms: Math.max(0, completedAt - submittedAt),
+    })
   }
 
   return segments
@@ -70,10 +83,11 @@ export const layoutWaterfall = (
     plotWidth: number
     sort: WaterfallSort
     maxRows: number
+    now: Date
   },
 ): WaterfallRow[] => {
   const rows = cycles.map((cycle) => {
-    const durations = segmentDurations(cycle)
+    const durations = segmentDurations(cycle, options.now)
     const totalMs = durations.reduce((sum, segment) => sum + segment.ms, 0)
 
     return {
@@ -135,6 +149,129 @@ export type SeriesLayout = {
   lines: SeriesLine[]
   maxMs: number
   xLabels: { x: number; label: string }[]
+}
+
+export type RebalanceBarSegment = {
+  stage: RebalanceStageName
+  ms: number
+  x: number
+  width: number
+  failed: boolean
+}
+
+export type RebalanceBarRow = {
+  id: string
+  direction: RebalanceOperationTiming['direction']
+  amount: string | null
+  status: RebalanceOperationTiming['status']
+  totalMs: number
+  segments: RebalanceBarSegment[]
+}
+
+/**
+ * Lays out rebalance operations as horizontal stacked bars, one segment per
+ * completed stage, normalized to the slowest visible operation. Operations
+ * arrive newest-first from the backend and stay in that order.
+ *
+ * Pass `now` so that in-progress operations (where the backend has not yet
+ * set `totalMs`) are rendered with their true elapsed time instead of just
+ * the sum of completed stages.
+ */
+export const layoutRebalanceBars = (
+  operations: RebalanceOperationTiming[],
+  options: {
+    plotWidth: number
+    maxRows: number
+    now: Date
+  },
+): RebalanceBarRow[] => {
+  const rows = operations.slice(0, options.maxRows).map((operation) => {
+    const durations = operation.stages
+      .filter((stage) => stage.durationMs !== null)
+      .map((stage) => ({
+        stage: stage.stage,
+        ms: stage.durationMs ?? 0,
+        failed: stage.outcome === 'failed',
+      }))
+
+    // For in-progress operations the backend sets totalMs only on completion,
+    // so use wall-clock elapsed since startedAt instead of summing completed
+    // stages (which would understate a stuck operation on an open stage).
+    // startedAt is null when the read model first observed the operation
+    // mid-stream (no genuine start event), so there is no elapsed basis.
+    const totalMs =
+      operation.totalMs ??
+      (operation.startedAt !== null
+        ? Math.max(0, options.now.getTime() - new Date(operation.startedAt).getTime())
+        : 0)
+
+    return {
+      id: operation.operationId,
+      direction: operation.direction,
+      amount: operation.amount,
+      status: operation.status,
+      totalMs,
+      durations,
+    }
+  })
+
+  const maxTotal = Math.max(1, ...rows.map((row) => row.totalMs))
+
+  return rows.map((row) => {
+    let cursor = 0
+    const segments = row.durations.map((segment) => {
+      const width = (segment.ms / maxTotal) * options.plotWidth
+      const positioned = {
+        ...segment,
+        x: cursor,
+        width,
+      }
+      cursor += width
+      return positioned
+    })
+
+    return {
+      id: row.id,
+      direction: row.direction,
+      amount: row.amount,
+      status: row.status,
+      totalMs: row.totalMs,
+      segments,
+    }
+  })
+}
+
+export type TrendLayout = {
+  points: SeriesPoint[]
+  path: string
+  maxMs: number
+}
+
+/** Lays out attestation durations over time as a single polyline. */
+export const layoutAttestationTrend = (
+  samples: AttestationSample[],
+  options: {
+    plotWidth: number
+    plotHeight: number
+  },
+): TrendLayout => {
+  const maxMs = Math.max(1, ...samples.map((sample) => sample.durationMs))
+  const xDenominator = Math.max(1, samples.length - 1)
+  const points = samples.map((sample, index) => ({
+    x:
+      samples.length <= 1
+        ? options.plotWidth / 2
+        : (index / xDenominator) * options.plotWidth,
+    y: options.plotHeight - (sample.durationMs / maxMs) * options.plotHeight,
+  }))
+
+  return {
+    points,
+    path: points
+      .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
+      .join(' '),
+    maxMs,
+  }
 }
 
 const PERCENTILE_KEYS: PercentileKey[] = ['p50Ms', 'p90Ms', 'p99Ms']

--- a/dashboard/src/routes/+page.svelte
+++ b/dashboard/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import PnlPanel from '$lib/components/pnl-panel.svelte'
   import { getWebSocketUrl, isDashboardMockMode } from '$lib/env'
   import { reactive } from '$lib/frp.svelte'
+  import { requestedLogTarget } from '$lib/log-filter-request.svelte'
   import { createWebSocket, type WebSocketConnection } from '$lib/websocket'
 
   const queryClient = useQueryClient()
@@ -224,7 +225,12 @@
     </main>
   {:else if activeTab.current === 'performance'}
     <main class="flex-1 overflow-hidden p-2 md:p-4">
-      <PerformancePanel />
+      <PerformancePanel
+        onOpenLogs={(target: string) => {
+          requestedLogTarget.update(() => target)
+          activeTab.update(() => 'logs')
+        }}
+      />
     </main>
   {:else}
     <main class="flex-1 overflow-hidden p-2 md:p-4">

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -879,16 +879,20 @@ impl ReportRange {
     }
 
     /// Bucket width mirroring the P&L tab's cadence: daily up to a month,
-    /// weekly up to half a year, otherwise ~monthly.
+    /// weekly up to half a year, otherwise ~monthly -- with hourly buckets for
+    /// short windows so a 24h report still shows a trend.
     ///
-    /// Uses the P&L tab's INCLUSIVE day count -- `floor(span_in_days) + 1` --
-    /// stepping up past 31 and 183 days, rather than the exclusive span. A
-    /// range whose endpoints are exactly 31 (or 183) days apart spans 32 (184)
-    /// calendar days, so it must already step to the coarser cadence, matching
-    /// the P&L tab at the exact boundary.
+    /// The daily/weekly/monthly thresholds use the P&L tab's INCLUSIVE day
+    /// count -- `floor(span_in_days) + 1`, stepping up past 31 and 183 days --
+    /// rather than the exclusive span. A range whose endpoints are exactly 31
+    /// (or 183) days apart spans 32 (184) calendar days, so it must already
+    /// step to the coarser cadence, matching the P&L tab at the exact boundary.
     fn bucket_width(&self) -> Duration {
-        let inclusive_days = (self.to - self.from).num_days() + 1;
-        if inclusive_days <= 31 {
+        let span = self.to - self.from;
+        let inclusive_days = span.num_days() + 1;
+        if span <= Duration::days(2) {
+            Duration::hours(1)
+        } else if inclusive_days <= 31 {
             Duration::days(1)
         } else if inclusive_days <= 183 {
             Duration::days(7)
@@ -1773,6 +1777,25 @@ mod tests {
             from: timestamp(from_offset),
             to: timestamp(to_offset),
         }
+    }
+
+    #[test]
+    fn bucket_width_is_hourly_for_24h_range() {
+        let range = report_range(0, 86_400);
+        assert_eq!(range.bucket_width(), Duration::hours(1));
+    }
+
+    #[test]
+    fn bucket_width_is_hourly_at_exactly_2_days() {
+        let range = report_range(0, 2 * 86_400);
+        assert_eq!(range.bucket_width(), Duration::hours(1));
+    }
+
+    #[test]
+    fn bucket_width_is_daily_just_past_2_days() {
+        // 2 days + 1 second exceeds the hourly threshold.
+        let range = report_range(0, 2 * 86_400 + 1);
+        assert_eq!(range.bucket_width(), Duration::days(1));
     }
 
     /// Drive `Position` events through the reactor and return the full

--- a/src/performance/reliability.rs
+++ b/src/performance/reliability.rs
@@ -270,7 +270,7 @@ pub(crate) fn aggregate_log_entries(
 ) -> (Vec<LogVolumeBucket>, Vec<LogTargetCount>) {
     let width = range.bucket_width();
     let mut buckets: BTreeMap<i64, (usize, usize)> = BTreeMap::new();
-    let mut targets: BTreeMap<(String, String), usize> = BTreeMap::new();
+    let mut targets: BTreeMap<(String, String), BTreeMap<i64, usize>> = BTreeMap::new();
 
     for entry in entries {
         let Some(timestamp) = entry["timestamp"]
@@ -294,12 +294,18 @@ pub(crate) fn aggregate_log_entries(
             _ => continue,
         }
 
-        *targets.entry((target, level)).or_default() += 1;
+        *targets
+            .entry((target, level))
+            .or_default()
+            .entry(index)
+            .or_default() += 1;
     }
 
+    let bucket_indices: Vec<i64> = buckets.keys().copied().collect();
+
     let log_buckets = buckets
-        .into_iter()
-        .map(|(index, (errors, warnings))| LogVolumeBucket {
+        .iter()
+        .map(|(&index, &(errors, warnings))| LogVolumeBucket {
             start: range.from + chrono::Duration::seconds(width.num_seconds() * index),
             errors,
             warnings,
@@ -308,10 +314,18 @@ pub(crate) fn aggregate_log_entries(
 
     let mut log_targets: Vec<LogTargetCount> = targets
         .into_iter()
-        .map(|((target, level), count)| LogTargetCount {
-            target,
-            level,
-            count,
+        .map(|((target, level), per_bucket)| {
+            let sparkline: Vec<usize> = bucket_indices
+                .iter()
+                .map(|index| per_bucket.get(index).copied().unwrap_or_default())
+                .collect();
+
+            LogTargetCount {
+                target,
+                level,
+                count: per_bucket.values().sum(),
+                sparkline,
+            }
         })
         .collect();
     log_targets.sort_by(|left, right| right.count.cmp(&left.count));
@@ -452,9 +466,39 @@ mod tests {
                 target: "hedge".to_string(),
                 level: "ERROR".to_string(),
                 count: 2,
+                sparkline: vec![2],
             }
         );
         assert_eq!(targets.len(), 3);
+    }
+
+    #[test]
+    fn aggregate_log_entries_aligns_sparklines_with_buckets() {
+        let day = 86_400;
+        let wide_range = ReportRange {
+            from: timestamp(0),
+            to: timestamp(10 * day),
+        };
+        let entries = vec![
+            log_entry(10, "ERROR", "hedge"),
+            log_entry(3 * day, "WARN", "rebalance"),
+            log_entry(3 * day + 5, "ERROR", "hedge"),
+        ];
+
+        let (buckets, targets) = aggregate_log_entries(&entries, &wide_range);
+
+        assert_eq!(buckets.len(), 2);
+        let hedge_errors = targets
+            .iter()
+            .find(|target| target.target == "hedge")
+            .unwrap();
+        assert_eq!(hedge_errors.sparkline, vec![1, 1]);
+
+        let rebalance_warnings = targets
+            .iter()
+            .find(|target| target.target == "rebalance")
+            .unwrap();
+        assert_eq!(rebalance_warnings.sparkline, vec![0, 1]);
     }
 
     #[test]


### PR DESCRIPTION
## What

[RAI-996](https://linear.app/makeitrain/issue/RAI-996)

- Reliability panel: error/warning counts by module with per-bucket sparklines, a money-at-risk lifecycle-failure list, and a click-through to the Logs tab pre-filtered to the clicked target.
- Rebalance stage breakdown: stacked bars per operation colored by stage, plus a CCTP attestation-time trend line.

## Why

- Completes phase 1 of the Performance tab: reliability and roundtrip data from the two earlier backend PRs had no visualization.

## How

- Backend: `LogTargetCount` gains a `sparkline` aligned with the report's log buckets; `ReportRange::bucket_width` adds hourly buckets for windows ≤ 2 days so a 24h sparkline actually shows a trend.
- Click-through resolves via `resolveLogFilter`: known categories/crates narrow the Logs tab's checkbox filters; anything else (e.g. a module path) lands in the free-text search and also clears the default category/crate filters so non-`st0x_*` targets like `apalis::pool` aren't silently filtered out.
- Rebalance bars reuse stage timings from `/performance/rebalances`; row totals prefer the backend's elapsed time so an operation stuck on an open stage is not understated.
- In-progress waterfall cycles render as live unhedged exposure up to `now` (a captured fetch timestamp), ranking truthfully in the slowest sort instead of as zero-length bars.
- Stale-response guards (`fetchSeq` → split into `cardFetchSeq` / `chartFetchSeq`) prevent out-of-order responses from overwriting fresher data.

## Testing

- Backend sparkline alignment tests (2-bucket spread, zero-fill, boundary); vitest coverage for `layoutRebalanceBars` (proportions, in-progress elapsed, row cap), `layoutAttestationTrend` (centering, scaling), and `resolveLogFilter` (category/crate/search fallback, take-and-clear).

## Anything else

- Cross-tab handoff uses a small shared reactive store (`log-filter-request.svelte.ts`) set by the Performance panel and consumed (then cleared) by the log panel on mount.
