### PR TITLE
ci: label Graphite MQ closed PRs externally-merged for Linear

### DIFF
--- a/.github/workflows/externally-merged.yaml
+++ b/.github/workflows/externally-merged.yaml
@@ -1,0 +1,87 @@
+name: Externally merged label
+
+# Graphite merge-queue optimizations land batched PRs by pushing their squash
+# commits to master and then CLOSING the PRs instead of merging them, so
+# Linear's GitHub integration never sees a merge event and the linked issues
+# stay open. Linear treats a closed PR as merged when it carries the
+# `externally-merged` label (handled even when the label arrives after the
+# close event, per Linear's 2026-04-30 changelog fix). This workflow applies
+# that label to every PR Graphite closes as part of a merge-queue merge.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label:
+    # Only PRs that Graphite closed without a GitHub-native merge. The head-ref
+    # guard skips Graphite's synthetic `[Graphite MQ] Draft PR GROUP:...` PRs,
+    # which live on gtmq* branches and have no Linear issue.
+    if: >-
+      github.event.pull_request.merged == false &&
+      github.event.sender.login == 'graphite-app[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'gtmq')
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      # Graphite also closes PRs when a user abandons them from the Graphite
+      # UI, with the same graphite-app[bot] sender. Distinguish a real
+      # merge-queue merge by Graphite's "Merge activity" comment, which it
+      # updates with this marker a few seconds BEFORE closing the PR.
+      - name: Check Graphite merged this PR
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          merged=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --jq '[.[]
+              | select(.user.login == "graphite-app[bot]")
+              | .body
+              | contains("Merged by the [Graphite merge queue]")
+            ] | any')
+          echo "Graphite merge marker found: $merged"
+          echo "merged=$merged" >> "$GITHUB_OUTPUT"
+
+      - name: Create externally-merged label if missing
+        if: steps.check.outputs.merged == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/labels/externally-merged" \
+            --silent
+          then
+            gh api -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/$GITHUB_REPOSITORY/labels" \
+              -f name=externally-merged \
+              -f color=6f42c1 \
+              -f description="Graphite MQ merged this PR; Linear should treat the close as a merge"
+          fi
+
+      - name: Apply externally-merged label
+        if: steps.check.outputs.merged == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+            -f "labels[]=externally-merged"


### PR DESCRIPTION
## What

- Adds `.github/workflows/externally-merged.yaml`: on `pull_request: closed`, applies the `externally-merged` label to PRs that the Graphite merge queue merged by closing.

## Why

- Graphite MQ optimizations land batched PRs by pushing their squash commits to `master` and then *closing* the PRs instead of merging them, so Linear's GitHub integration never sees a merge event and the linked issues stay open.
- Linear treats a closed PR as merged when it carries the `externally-merged` label; since Linear's [2026-04-30 fix](https://linear.app/changelog/2026-04-30-releases) this works even when the label is added after the close, so no pre-close hook or gtmq-branch mapping is needed.

## How

- Job gate: `merged == false` + sender is `graphite-app[bot]` + head ref not `gtmq*` (excludes Graphite's synthetic `[Graphite MQ] Draft PR GROUP:...` PRs, which have no Linear issue).
- Verify step: requires a `graphite-app[bot]` comment containing `Merged by the [Graphite merge queue]` — Graphite updates its "Merge activity" comment with that marker seconds before closing (verified on #785: comment updated 00:21:29Z, close at 00:21:33Z), so PRs merely *abandoned* via the Graphite UI (same bot sender) are never mislabeled as merged.
- Creates the `externally-merged` label on first use, then applies it via the issues labels API.

## Testing

- No automated tests — single GitHub Actions workflow. The gating and verification signals were validated against real repo data: close-event actor, Graphite merge-activity comment timing, and batch commits on `master` for the #781–#803 MQ batch.
- First real exercise will be the next Graphite MQ merge after this lands on `master`.

## Screenshots

n/a

## Anything else

- `pull_request: closed` runs the workflow definition from the base branch, so this only takes effect for MQ merges that happen after it lands on `master`.
- Already-affected closed PRs (e.g. #781–#785, #803) can be backfilled by adding the label manually if their Linear issues are still open.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783816284&installation_id=125569124&pr_number=828&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F828&signature=c3cf5cb7344abbdc639a5f88e3234b0aa9e49cfb6118489a8534b1d093220dc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Linear: RAI-1008
