### PR TITLE
fix: reassert configured Raindex vault primaries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2715,8 +2715,12 @@ balances and emitting them as events the system can react to:
 
 - **VaultRegistry** (CQRS aggregate): Auto-discovers Raindex vaults from
   ClearV3/TakeOrderV3 trade events. Tracks multiple equity vaults per token
-  address and multiple USDC vaults per orderbook/owner pair. Inventory polling
-  sums balances across all vaults for each asset.
+  address and multiple USDC vaults per orderbook/owner pair. Startup config
+  seeding registers every configured vault, then explicitly marks the first
+  entry in the configured vault list (config file order) for each asset as the
+  operational primary used by deposit/withdraw/rebalancing paths. Re-running the
+  bot after a vault ID config change must move the primary to the new configured
+  vault while retaining the retired vault in the registry for balance polling.
 - **InventorySnapshot** (CQRS aggregate): Records point-in-time snapshots of
   actual balances fetched from onchain vaults and the offchain broker.
 - **InventoryPollingService**: Periodically polls actual balances from both
@@ -2724,7 +2728,10 @@ balances and emitting them as events the system can react to:
   events to update tracked inventory. Offchain equity polling normalizes active
   configured equities omitted by the broker positions response to explicit zero
   balances, and ignores broker-only symbols that are not configured as active
-  assets.
+  assets. Onchain polling sums all registered vaults for each asset and warns
+  when a registered vault that is no longer present in current config still has
+  a positive balance, so stranded funds are visible without sending new
+  rebalancing transfers to the retired vault.
 - **Polling runs on a 60-second interval** during market hours as a background
   conductor task. Onchain polling uses the `vaultBalance2` contract call;
   offchain polling uses the `Executor::get_inventory()` trait method.

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -84,6 +84,42 @@ stox sell -s COIN -q 10
 stox order-status --order-id <order-id>
 ```
 
+### Moving Stranded Raindex Equity Vault Funds
+
+Use this when an equity vault ID was removed from config but inventory polling
+warns that the retired vault still has a positive balance. After the bot has
+restarted with the new config, new deposits and rebalancing paths use the first
+entry in the configured vault list (config file order), but the old vault
+remains registered for balance visibility.
+
+Use the token address stored in
+`assets.equities.symbols.<SYMBOL>.tokenized_equity_derivative`, not the
+unwrapped token address table above. For the symbol you are moving, confirm the
+configured destination vault ID in the current config before moving funds.
+
+**Step 1: Withdraw from the retired vault**
+
+```bash
+stox vault-withdraw \
+  --amount <shares> \
+  --token <tokenized-equity-derivative-address> \
+  --vault-id <retired-vault-id>
+```
+
+**Step 2: Deposit the same tokens into the configured vault**
+
+```bash
+stox vault-deposit \
+  --amount <shares> \
+  --token <tokenized-equity-derivative-address> \
+  --vault-id <configured-vault-id>
+```
+
+The commands print the amount, token, wallet, orderbook, vault ID, decimals, and
+smallest-unit amount before submitting the transaction. Verify those values
+match the retired source vault and configured destination vault before relying
+on the printed transaction hash.
+
 ## Alpaca Crypto Wallet Management
 
 ### USDC Deposits and Withdrawals

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -265,6 +265,14 @@ registry. The same `SeedVaultRegistry` job is also registered as an apalis
 worker so the queue can retry on failure if seeding is re-triggered later (e.g.
 from a recovery flow).
 
+Seeding is additive for vault discovery history but authoritative for the
+configured primary vault. Each startup registers every configured vault ID and
+then marks the first entry in the configured vault list (config file order) for
+each asset as primary. A config change from an old vault ID to a new one
+therefore moves deposit/withdraw/rebalancing paths to the new vault after
+restart, while the old vault remains registered so inventory polling can surface
+any stranded balance.
+
 Ingestion is checkpoint-driven `eth_getLogs` polling, not a live subscription,
 so no events are missed across downtime. Deriving the cutoff
 (`tip - required_confirmations`) is not a startup phase -- the

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -4,7 +4,7 @@ use alloy::providers::Provider;
 use apalis::prelude::Monitor;
 use apalis_core::worker::ext::circuit_breaker::config::CircuitBreakerConfig;
 use sqlx::SqlitePool;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 use task_supervisor::SupervisorBuilder;
 use tokio::task::JoinHandle;
@@ -164,6 +164,21 @@ where
         .cloned()
         .collect();
 
+    let mut configured_equity_vaults: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+    for equity_config in context.ctx.assets.equities.symbols.values() {
+        configured_equity_vaults
+            .entry(equity_config.tokenized_equity_derivative)
+            .or_default()
+            .extend(equity_config.vault_ids.iter().copied());
+    }
+
+    let configured_usdc_vaults = context
+        .ctx
+        .assets
+        .cash
+        .as_ref()
+        .map(|cash| cash.vault_ids.iter().copied().collect());
+
     let wallet_polling = context.wallet_polling;
     let tokenizer = context.tokenizer;
 
@@ -177,7 +192,8 @@ where
         tokenizer,
         reserved_cash,
     )
-    .with_configured_equity_symbols(configured_equity_symbols);
+    .with_configured_equity_symbols(configured_equity_symbols)
+    .with_configured_vaults(configured_equity_vaults, configured_usdc_vaults);
 
     if let Some(rebalancing_service) = &rebalancing_service {
         polling_service =

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -6,20 +6,20 @@
 //! the fetched values. The InventoryView reacts to these events to reconcile
 //! tracked inventory.
 
-use alloy::primitives::{Address, TxHash};
+use alloy::primitives::{Address, B256, TxHash};
 use alloy::providers::RootProvider;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures_util::future::try_join_all;
 use rain_math_float::FloatError;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 use tracing::{debug, warn};
 
 use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
 use st0x_execution::{Executor, FractionalShares, InventoryResult, SharesConversionError, Symbol};
-use st0x_finance::{HasZero, Usd, UsdToCentsError};
+use st0x_finance::{HasZero, Usd, UsdToCentsError, Usdc};
 use st0x_raindex::{RaindexError, RaindexService, RaindexVaultId};
 
 use crate::bindings::IERC20;
@@ -118,7 +118,11 @@ where
     pending_request_ownership: Option<Arc<dyn PendingRequestOwnership>>,
     external_pending_warnings: Mutex<HashSet<TokenizationRequestId>>,
     unconfigured_symbol_warnings: Mutex<HashSet<Symbol>>,
+    retired_equity_vault_warnings: Mutex<HashSet<(Address, B256)>>,
+    retired_usdc_vault_warnings: Mutex<HashSet<B256>>,
     configured_equity_symbols: Option<HashSet<Symbol>>,
+    configured_equity_vaults: Option<BTreeMap<Address, BTreeSet<B256>>>,
+    configured_usdc_vaults: Option<BTreeSet<B256>>,
     reserved_cash: Usd,
 }
 
@@ -149,7 +153,11 @@ where
             pending_request_ownership: None,
             external_pending_warnings: Mutex::new(HashSet::new()),
             unconfigured_symbol_warnings: Mutex::new(HashSet::new()),
+            retired_equity_vault_warnings: Mutex::new(HashSet::new()),
+            retired_usdc_vault_warnings: Mutex::new(HashSet::new()),
             configured_equity_symbols: None,
+            configured_equity_vaults: None,
+            configured_usdc_vaults: None,
             reserved_cash,
         }
     }
@@ -159,6 +167,16 @@ where
         configured_equity_symbols: HashSet<Symbol>,
     ) -> Self {
         self.configured_equity_symbols = Some(configured_equity_symbols);
+        self
+    }
+
+    pub(crate) fn with_configured_vaults(
+        mut self,
+        configured_equity_vaults: BTreeMap<Address, BTreeSet<B256>>,
+        configured_usdc_vaults: Option<BTreeSet<B256>>,
+    ) -> Self {
+        self.configured_equity_vaults = Some(configured_equity_vaults);
+        self.configured_usdc_vaults = configured_usdc_vaults;
         self
     }
 
@@ -275,6 +293,15 @@ where
 
                 let vault_balances = try_join_all(vault_futures).await?;
 
+                for (vault, balance) in vaults_for_token.values().zip(vault_balances.iter()) {
+                    self.warn_if_retired_equity_vault_has_balance(
+                        &symbol,
+                        token,
+                        vault.vault_id,
+                        *balance,
+                    )?;
+                }
+
                 let total = vault_balances[1..]
                     .iter()
                     .copied()
@@ -328,6 +355,10 @@ where
         });
 
         let vault_balances = try_join_all(balance_futures).await?;
+
+        for (vault, balance) in registry.usdc_vaults.values().zip(vault_balances.iter()) {
+            self.warn_if_retired_usdc_vault_has_balance(vault.vault_id, *balance)?;
+        }
 
         let usdc_balance = vault_balances[1..]
             .iter()
@@ -590,6 +621,91 @@ where
                 warn!(
                     target: "inventory",
                     "Unconfigured symbol warning tracker was poisoned; recovering state"
+                );
+                poisoned.into_inner()
+            })
+    }
+
+    fn warn_if_retired_equity_vault_has_balance(
+        &self,
+        symbol: &Symbol,
+        token: Address,
+        vault_id: B256,
+        balance: FractionalShares,
+    ) -> Result<(), FloatError> {
+        let Some(configured_equity_vaults) = &self.configured_equity_vaults else {
+            return Ok(());
+        };
+
+        if configured_equity_vaults
+            .get(&token)
+            .is_some_and(|configured_vaults| configured_vaults.contains(&vault_id))
+            || balance.is_zero()?
+        {
+            return Ok(());
+        }
+
+        if self
+            .lock_retired_equity_vault_warnings()
+            .insert((token, vault_id))
+        {
+            warn!(
+                target: "inventory",
+                %symbol,
+                %token,
+                %vault_id,
+                ?balance,
+                "Registered equity vault has a positive balance but is no longer configured"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn lock_retired_equity_vault_warnings(&self) -> MutexGuard<'_, HashSet<(Address, B256)>> {
+        self.retired_equity_vault_warnings
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                warn!(
+                    target: "inventory",
+                    "Retired equity vault warning tracker was poisoned; recovering state"
+                );
+                poisoned.into_inner()
+            })
+    }
+
+    fn warn_if_retired_usdc_vault_has_balance(
+        &self,
+        vault_id: B256,
+        balance: Usdc,
+    ) -> Result<(), FloatError> {
+        let Some(configured_usdc_vaults) = &self.configured_usdc_vaults else {
+            return Ok(());
+        };
+
+        if configured_usdc_vaults.contains(&vault_id) || balance.is_zero()? {
+            return Ok(());
+        }
+
+        if self.lock_retired_usdc_vault_warnings().insert(vault_id) {
+            warn!(
+                target: "inventory",
+                %vault_id,
+                ?balance,
+                "Registered USDC vault has a positive balance but is no longer configured"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn lock_retired_usdc_vault_warnings(&self) -> MutexGuard<'_, HashSet<B256>> {
+        self.retired_usdc_vault_warnings
+            .lock()
+            .unwrap_or_else(|poisoned| {
+                warn!(
+                    target: "inventory",
+                    "Retired USDC vault warning tracker was poisoned; recovering state"
                 );
                 poisoned.into_inner()
             })
@@ -1056,6 +1172,19 @@ mod tests {
 
     fn configured_symbols(symbols: &[&str]) -> HashSet<Symbol> {
         symbols.iter().map(|symbol| test_symbol(symbol)).collect()
+    }
+
+    fn configured_equity_vaults(
+        token: Address,
+        vault_ids: impl IntoIterator<Item = B256>,
+    ) -> BTreeMap<Address, BTreeSet<B256>> {
+        let mut configured = BTreeMap::new();
+        configured.insert(token, vault_ids.into_iter().collect());
+        configured
+    }
+
+    fn vault_balance_hex(balance: rain_math_float::Float) -> String {
+        alloy::hex::encode_prefixed(balance.get_inner())
     }
 
     fn create_test_raindex_service(
@@ -2021,6 +2150,121 @@ mod tests {
         assert!(
             matches!(error, InventoryPollingError::Raindex(_)),
             "Expected Vault error when RPC fails, got {error:?}"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn poll_onchain_warns_when_retired_equity_vault_has_positive_balance() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let retired_vault_id = TEST_VAULT_ID;
+        let configured_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000002");
+
+        discover_equity_vault(
+            &pool,
+            orderbook,
+            order_owner,
+            TEST_TOKEN,
+            retired_vault_id,
+            test_symbol("SGOV"),
+        )
+        .await;
+        discover_equity_vault(
+            &pool,
+            orderbook,
+            order_owner,
+            TEST_TOKEN,
+            configured_vault_id,
+            test_symbol("SGOV"),
+        )
+        .await;
+
+        let retired_balance = vault_balance_hex(float!(5));
+        let asserter = Asserter::new();
+        asserter.push_success(&retired_balance);
+        asserter.push_success(&ZERO_FLOAT_HEX);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(provider);
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        )
+        .with_configured_vaults(
+            configured_equity_vaults(TEST_TOKEN, [configured_vault_id]),
+            None,
+        );
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        service.poll_onchain(&snapshot_id).await.unwrap();
+
+        assert!(
+            logs_contain(
+                "Registered equity vault has a positive balance but is no longer configured"
+            ),
+            "Should warn when a retired equity vault still holds funds"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn poll_onchain_warns_when_retired_usdc_vault_has_positive_balance() {
+        let pool = setup_test_db().await;
+        let (orderbook, order_owner) = test_addresses();
+        let retired_vault_id = TEST_VAULT_ID;
+        let configured_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000002");
+
+        discover_usdc_vault(&pool, orderbook, order_owner, retired_vault_id).await;
+        discover_usdc_vault(&pool, orderbook, order_owner, configured_vault_id).await;
+
+        let retired_balance = vault_balance_hex(float!(125));
+        let asserter = Asserter::new();
+        asserter.push_success(&retired_balance);
+        asserter.push_success(&ZERO_FLOAT_HEX);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let raindex_service = create_test_raindex_service(provider);
+
+        let service = InventoryPollingService::new(
+            raindex_service,
+            MockExecutor::new(),
+            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            InventorySnapshotId {
+                orderbook,
+                owner: order_owner,
+            },
+            Arc::new(test_store(pool.clone(), ())),
+            None,
+            None,
+            Usd::ZERO,
+        )
+        .with_configured_vaults(BTreeMap::new(), Some(BTreeSet::from([configured_vault_id])));
+
+        let snapshot_id = InventorySnapshotId {
+            orderbook,
+            owner: order_owner,
+        };
+        service.poll_onchain(&snapshot_id).await.unwrap();
+
+        assert!(
+            logs_contain(
+                "Registered USDC vault has a positive balance but is no longer configured"
+            ),
+            "Should warn when a retired USDC vault still holds funds"
         );
     }
 

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -126,6 +126,20 @@ impl EventSourced for VaultRegistry {
                 }
             }
 
+            VaultRegistryCommand::SetPrimaryEquityVaultFromConfig {
+                token, vault_id, ..
+            } => {
+                if self.primary_equity_vault.get(token) == Some(vault_id) {
+                    return Ok(vec![]);
+                }
+            }
+
+            VaultRegistryCommand::SetPrimaryUsdcVaultFromConfig { vault_id } => {
+                if self.primary_usdc_vault == Some(*vault_id) {
+                    return Ok(vec![]);
+                }
+            }
+
             VaultRegistryCommand::DiscoverEquityVault { .. }
             | VaultRegistryCommand::DiscoverUsdcVault { .. } => {}
         }
@@ -140,20 +154,20 @@ impl EventSourced for VaultRegistry {
 /// address, with each token mapping to a set of vaults keyed by vault ID.
 /// Multiple USDC vaults are supported, keyed by vault ID.
 ///
-/// Each asset also tracks a **primary** vault ID — the first vault seeded
-/// from config (or the first discovered, if none was configured). The
-/// primary vault is used for single-vault operations like deposits and
-/// withdrawals, preserving operator intent from config ordering.
+/// Each asset also tracks a **primary** vault ID. Config seeding reasserts
+/// the first vault currently configured for the asset; otherwise the first
+/// discovered vault remains primary. The primary vault is used for
+/// single-vault operations like deposits and withdrawals, preserving
+/// operator intent from current config ordering.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct VaultRegistry {
     /// Equity vaults, grouped by token address then keyed by vault ID.
     pub(crate) equity_vaults: BTreeMap<Address, BTreeMap<B256, EquityVault>>,
     /// USDC vaults, keyed by vault ID.
     pub(crate) usdc_vaults: BTreeMap<B256, UsdcVault>,
-    /// Primary equity vault per token — the first config-seeded or discovered
-    /// vault ID for each token. Used by deposit/withdraw operations.
+    /// Primary equity vault per token, used by deposit/withdraw operations.
     primary_equity_vault: BTreeMap<Address, B256>,
-    /// Primary USDC vault — the first config-seeded or discovered vault ID.
+    /// Primary USDC vault, used by deposit/withdraw operations.
     primary_usdc_vault: Option<B256>,
     pub(crate) last_updated: DateTime<Utc>,
 }
@@ -196,8 +210,7 @@ impl VaultRegistry {
             .map(|(token, _)| *token)
     }
 
-    /// Returns the primary vault ID for a token — the first config-seeded
-    /// or discovered vault, preserving operator intent from config ordering.
+    /// Returns the primary vault ID for a token.
     pub(crate) fn primary_vault_id_by_token(&self, token: Address) -> Option<B256> {
         self.primary_equity_vault.get(&token).copied()
     }
@@ -319,6 +332,16 @@ impl VaultRegistry {
                     },
                 );
             }
+
+            VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                token, vault_id, ..
+            } => {
+                self.primary_equity_vault.insert(*token, *vault_id);
+            }
+
+            VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig { vault_id, .. } => {
+                self.primary_usdc_vault = Some(*vault_id);
+            }
         }
     }
 
@@ -363,6 +386,24 @@ impl VaultRegistry {
                     seeded_at: now,
                 }
             }
+
+            VaultRegistryCommand::SetPrimaryEquityVaultFromConfig {
+                token,
+                vault_id,
+                symbol,
+            } => VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                token,
+                vault_id,
+                configured_at: now,
+                symbol,
+            },
+
+            VaultRegistryCommand::SetPrimaryUsdcVaultFromConfig { vault_id } => {
+                VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig {
+                    vault_id,
+                    configured_at: now,
+                }
+            }
         }
     }
 }
@@ -387,6 +428,14 @@ pub(crate) enum VaultRegistryCommand {
     },
     /// Pre-seed the USDC vault from config (no onchain discovery).
     SeedUsdcVaultFromConfig { vault_id: B256 },
+    /// Mark the currently configured primary equity vault.
+    SetPrimaryEquityVaultFromConfig {
+        token: Address,
+        vault_id: B256,
+        symbol: Symbol,
+    },
+    /// Mark the currently configured primary USDC vault.
+    SetPrimaryUsdcVaultFromConfig { vault_id: B256 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -415,6 +464,18 @@ pub(crate) enum VaultRegistryEvent {
         vault_id: B256,
         seeded_at: DateTime<Utc>,
     },
+    /// Primary equity vault selected from current config ordering.
+    PrimaryEquityVaultSetFromConfig {
+        token: Address,
+        vault_id: B256,
+        configured_at: DateTime<Utc>,
+        symbol: Symbol,
+    },
+    /// Primary USDC vault selected from current config ordering.
+    PrimaryUsdcVaultSetFromConfig {
+        vault_id: B256,
+        configured_at: DateTime<Utc>,
+    },
 }
 
 impl VaultRegistryEvent {
@@ -424,6 +485,8 @@ impl VaultRegistryEvent {
             | Self::UsdcVaultDiscovered { discovered_at, .. } => *discovered_at,
             Self::EquityVaultSeededFromConfig { seeded_at, .. }
             | Self::UsdcVaultSeededFromConfig { seeded_at, .. } => *seeded_at,
+            Self::PrimaryEquityVaultSetFromConfig { configured_at, .. }
+            | Self::PrimaryUsdcVaultSetFromConfig { configured_at, .. } => *configured_at,
         }
     }
 }
@@ -442,6 +505,12 @@ impl DomainEvent for VaultRegistryEvent {
             }
             Self::UsdcVaultSeededFromConfig { .. } => {
                 "VaultRegistryEvent::UsdcVaultSeededFromConfig".to_string()
+            }
+            Self::PrimaryEquityVaultSetFromConfig { .. } => {
+                "VaultRegistryEvent::PrimaryEquityVaultSetFromConfig".to_string()
+            }
+            Self::PrimaryUsdcVaultSetFromConfig { .. } => {
+                "VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig".to_string()
             }
         }
     }
@@ -484,7 +553,9 @@ pub(crate) struct SeedVaultRegistryCtx {
     vault_registry: Arc<Store<VaultRegistry>>,
     id: VaultRegistryId,
     equity_seeds: Vec<EquityVaultSeed>,
+    equity_primary_seeds: Vec<EquityVaultSeed>,
     usdc_vault_ids: Vec<B256>,
+    usdc_primary_vault_id: Option<B256>,
 }
 
 impl SeedVaultRegistryCtx {
@@ -528,6 +599,24 @@ impl SeedVaultRegistryCtx {
             })
             .collect();
 
+        let equity_primary_seeds = ctx
+            .assets
+            .equities
+            .symbols
+            .iter()
+            .filter_map(|(symbol, equity_config)| {
+                equity_config
+                    .vault_ids
+                    .first()
+                    .copied()
+                    .map(|vault_id| EquityVaultSeed {
+                        token: equity_config.tokenized_equity_derivative,
+                        vault_id,
+                        symbol: symbol.clone(),
+                    })
+            })
+            .collect();
+
         let usdc_vault_ids = ctx
             .assets
             .cash
@@ -535,11 +624,19 @@ impl SeedVaultRegistryCtx {
             .map(|cash| cash.vault_ids.clone())
             .unwrap_or_default();
 
+        let usdc_primary_vault_id = ctx
+            .assets
+            .cash
+            .as_ref()
+            .and_then(|cash| cash.vault_ids.first().copied());
+
         Ok(Self {
             vault_registry,
             id,
             equity_seeds,
+            equity_primary_seeds,
             usdc_vault_ids,
+            usdc_primary_vault_id,
         })
     }
 }
@@ -585,6 +682,26 @@ impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
                 .await?;
         }
 
+        for seed in &ctx.equity_primary_seeds {
+            info!(
+                symbol = %seed.symbol,
+                vault_id = %seed.vault_id,
+                token = %seed.token,
+                "Setting configured primary equity vault",
+            );
+
+            ctx.vault_registry
+                .send(
+                    &ctx.id,
+                    VaultRegistryCommand::SetPrimaryEquityVaultFromConfig {
+                        token: seed.token,
+                        vault_id: seed.vault_id,
+                        symbol: seed.symbol.clone(),
+                    },
+                )
+                .await?;
+        }
+
         for vault_id in &ctx.usdc_vault_ids {
             info!(%vault_id, "Seeding USDC vault from config");
 
@@ -594,6 +711,17 @@ impl Job<SeedVaultRegistryCtx> for SeedVaultRegistry {
                     VaultRegistryCommand::SeedUsdcVaultFromConfig {
                         vault_id: *vault_id,
                     },
+                )
+                .await?;
+        }
+
+        if let Some(vault_id) = ctx.usdc_primary_vault_id {
+            info!(%vault_id, "Setting configured primary USDC vault");
+
+            ctx.vault_registry
+                .send(
+                    &ctx.id,
+                    VaultRegistryCommand::SetPrimaryUsdcVaultFromConfig { vault_id },
                 )
                 .await?;
         }
@@ -838,6 +966,52 @@ mod tests {
             registry.primary_vault_id_by_token(TEST_TOKEN),
             Some(large_vault_id),
             "Primary vault must preserve config order, not BTreeMap key order"
+        );
+    }
+
+    #[test]
+    fn configured_primary_equity_vault_can_replace_previous_primary() {
+        let new_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+
+        let registry = replay::<VaultRegistry>(vec![
+            VaultRegistryEvent::EquityVaultSeededFromConfig {
+                token: TEST_TOKEN,
+                vault_id: TEST_VAULT_ID,
+                seeded_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+            VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                token: TEST_TOKEN,
+                vault_id: TEST_VAULT_ID,
+                configured_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+            VaultRegistryEvent::EquityVaultSeededFromConfig {
+                token: TEST_TOKEN,
+                vault_id: new_vault_id,
+                seeded_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+            VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                token: TEST_TOKEN,
+                vault_id: new_vault_id,
+                configured_at: Utc::now(),
+                symbol: test_symbol(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            registry.primary_vault_id_by_token(TEST_TOKEN),
+            Some(new_vault_id),
+            "current config must be able to replace the previous primary vault",
+        );
+        assert_eq!(
+            registry.all_vault_ids_by_token(TEST_TOKEN),
+            vec![TEST_VAULT_ID, new_vault_id],
+            "retired vault remains registered for inventory polling",
         );
     }
 
@@ -1110,6 +1284,148 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn set_primary_equity_vault_deduplicates_when_config_unchanged() {
+        let events = TestHarness::<VaultRegistry>::with(())
+            .given(vec![
+                VaultRegistryEvent::EquityVaultSeededFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    seeded_at: Utc::now(),
+                    symbol: test_symbol(),
+                },
+                VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    configured_at: Utc::now(),
+                    symbol: test_symbol(),
+                },
+            ])
+            .when(VaultRegistryCommand::SetPrimaryEquityVaultFromConfig {
+                token: TEST_TOKEN,
+                vault_id: TEST_VAULT_ID,
+                symbol: test_symbol(),
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            0,
+            "Should not emit event when configured primary equity vault is unchanged",
+        );
+    }
+
+    #[tokio::test]
+    async fn set_primary_equity_vault_emits_when_config_changes() {
+        let new_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+
+        let events = TestHarness::<VaultRegistry>::with(())
+            .given(vec![
+                VaultRegistryEvent::EquityVaultSeededFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    seeded_at: Utc::now(),
+                    symbol: test_symbol(),
+                },
+                VaultRegistryEvent::PrimaryEquityVaultSetFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: TEST_VAULT_ID,
+                    configured_at: Utc::now(),
+                    symbol: test_symbol(),
+                },
+                VaultRegistryEvent::EquityVaultSeededFromConfig {
+                    token: TEST_TOKEN,
+                    vault_id: new_vault_id,
+                    seeded_at: Utc::now(),
+                    symbol: test_symbol(),
+                },
+            ])
+            .when(VaultRegistryCommand::SetPrimaryEquityVaultFromConfig {
+                token: TEST_TOKEN,
+                vault_id: new_vault_id,
+                symbol: test_symbol(),
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "Should emit event when configured primary equity vault changes",
+        );
+        assert!(matches!(
+            &events[0],
+            VaultRegistryEvent::PrimaryEquityVaultSetFromConfig { vault_id, .. }
+            if *vault_id == new_vault_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_primary_usdc_vault_deduplicates_when_config_unchanged() {
+        let events = TestHarness::<VaultRegistry>::with(())
+            .given(vec![
+                VaultRegistryEvent::UsdcVaultSeededFromConfig {
+                    vault_id: TEST_VAULT_ID,
+                    seeded_at: Utc::now(),
+                },
+                VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig {
+                    vault_id: TEST_VAULT_ID,
+                    configured_at: Utc::now(),
+                },
+            ])
+            .when(VaultRegistryCommand::SetPrimaryUsdcVaultFromConfig {
+                vault_id: TEST_VAULT_ID,
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            0,
+            "Should not emit event when configured primary USDC vault is unchanged",
+        );
+    }
+
+    #[tokio::test]
+    async fn set_primary_usdc_vault_emits_when_config_changes() {
+        let new_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+
+        let events = TestHarness::<VaultRegistry>::with(())
+            .given(vec![
+                VaultRegistryEvent::UsdcVaultSeededFromConfig {
+                    vault_id: TEST_VAULT_ID,
+                    seeded_at: Utc::now(),
+                },
+                VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig {
+                    vault_id: TEST_VAULT_ID,
+                    configured_at: Utc::now(),
+                },
+                VaultRegistryEvent::UsdcVaultSeededFromConfig {
+                    vault_id: new_vault_id,
+                    seeded_at: Utc::now(),
+                },
+            ])
+            .when(VaultRegistryCommand::SetPrimaryUsdcVaultFromConfig {
+                vault_id: new_vault_id,
+            })
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "Should emit event when configured primary USDC vault changes",
+        );
+        assert!(matches!(
+            &events[0],
+            VaultRegistryEvent::PrimaryUsdcVaultSetFromConfig { vault_id, .. }
+            if *vault_id == new_vault_id
+        ));
+    }
+
     /// Proves that reactors only receive events from commands
     /// executed AFTER the framework is constructed -- existing events
     /// in the store are NOT replayed on construction.
@@ -1316,6 +1632,71 @@ mod tests {
             registry.primary_usdc_vault_id(),
             Some(test_usdc_vault_id()),
             "usdc vault should be seeded as primary",
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_reasserts_configured_equity_primary_after_vault_id_change() {
+        let pool = setup_test_db().await;
+        let initial_ctx = ctx_with_seeded_assets();
+        let initial_seed_ctx = seed_ctx_from(pool.clone(), &initial_ctx).await;
+        SeedVaultRegistry.perform(&initial_seed_ctx).await.unwrap();
+
+        let new_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+        let mut updated_ctx = ctx_with_seeded_assets();
+        updated_ctx
+            .assets
+            .equities
+            .symbols
+            .get_mut(&test_symbol())
+            .unwrap()
+            .vault_ids = vec![new_vault_id];
+
+        let updated_seed_ctx = seed_ctx_from(pool, &updated_ctx).await;
+        SeedVaultRegistry.perform(&updated_seed_ctx).await.unwrap();
+
+        let registry =
+            loaded_registry(&updated_seed_ctx.vault_registry, &updated_seed_ctx.id).await;
+
+        assert_eq!(
+            registry.primary_vault_id_by_token(TEST_TOKEN),
+            Some(new_vault_id),
+            "configured equity vault change must update the primary used by rebalancing",
+        );
+        assert_eq!(
+            registry.all_vault_ids_by_token(TEST_TOKEN),
+            vec![TEST_VAULT_ID, new_vault_id],
+            "old equity vault remains registered so inventory polling can surface stranded funds",
+        );
+    }
+
+    #[tokio::test]
+    async fn perform_reasserts_configured_usdc_primary_after_vault_id_change() {
+        let pool = setup_test_db().await;
+        let initial_ctx = ctx_with_seeded_assets();
+        let initial_seed_ctx = seed_ctx_from(pool.clone(), &initial_ctx).await;
+        SeedVaultRegistry.perform(&initial_seed_ctx).await.unwrap();
+
+        let new_vault_id =
+            b256!("0x0000000000000000000000000000000000000000000000000000000000000099");
+        let mut updated_ctx = ctx_with_seeded_assets();
+        updated_ctx.assets.cash.as_mut().unwrap().vault_ids = vec![new_vault_id];
+
+        let updated_seed_ctx = seed_ctx_from(pool, &updated_ctx).await;
+        SeedVaultRegistry.perform(&updated_seed_ctx).await.unwrap();
+
+        let registry =
+            loaded_registry(&updated_seed_ctx.vault_registry, &updated_seed_ctx.id).await;
+
+        assert_eq!(
+            registry.primary_usdc_vault_id(),
+            Some(new_vault_id),
+            "configured USDC vault change must update the primary",
+        );
+        assert!(
+            registry.usdc_vaults.contains_key(&test_usdc_vault_id()),
+            "old USDC vault remains registered so inventory polling can surface stranded funds",
         );
     }
 


### PR DESCRIPTION
## What

[RAI-1012](https://linear.app/makeitrain/issue/RAI-1012/make-sgov-vault-config-changes-stop-funding-retired-vaults)

- Make `SeedVaultRegistry` reassert the first currently configured equity/USDC vault as primary on every startup.
- Keep retired vault IDs registered for inventory polling instead of using them for new rebalancing, deposit, or withdraw operations.
- Warn from inventory polling when a registered-but-unconfigured equity or USDC vault still has a positive balance.
- Add an ops runbook for moving stranded Raindex equity vault funds with existing `stox vault-withdraw` and `stox vault-deposit`.

## Why

- A config change from SGOV vault `0xfab4` to `0xfab` did not move funds because the first historical vault stayed primary after restart.
- Operators need visibility into leftover balances in retired vaults without sending new rebalances back to them.

## How

- Adds explicit `SetPrimary*FromConfig` vault-registry commands/events, emitted after additive config seeding and deduped when unchanged.
- Wires configured vault sets into `InventoryPollingService` so it can compare current config to registry history while continuing to sum all registered balances.
- Treats absent `[assets.cash]` config as "do not compare USDC config" to avoid false warnings in deployments that do not manage cash vaults.

## Testing

- `nix run .#ci`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge vault_registry`
- `nix develop .#ci-backend -c cargo nextest run -p st0x-hedge retired`
- `nix develop .#ci-backend -c cargo check -p st0x-hedge`
- `nix develop .#ci-backend -c cargo clippy -p st0x-hedge --all-targets --all-features`
- `nix develop .#ci-backend -c cargo fmt --check`

## Anything else

- No screenshots; backend/ops change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning alerts when retired vaults retain positive balances, making stranded funds visible.
  * Improved vault reconciliation to detect and report funds in unregistered vaults.

* **Documentation**
  * Added operational guide for moving stranded vault funds when vault IDs are removed from configuration.
  * Updated vault registry documentation to clarify primary vault selection during configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->