### PR TITLE
fix: pin event-sorcery to a version with sqlite-es bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -286,7 +286,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
@@ -940,7 +940,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1081,7 +1081,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "thiserror 2.0.18",
  "tokio",
  "ulid",
@@ -1610,7 +1610,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -1749,6 +1749,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,10 +1893,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1913,7 +1933,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1958,6 +1978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,7 +2022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2073,6 +2099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cqrs-es"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2117,19 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "cqrs-es"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de58236a73fe80ff6cd1af71c5205ce5652033f0cb47b42f820d82481903fe12"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2163,12 +2211,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -2353,10 +2419,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2513,7 +2590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2525,6 +2602,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2551,14 +2638,14 @@ dependencies = [
 [[package]]
 name = "event-sorcery"
 version = "0.1.0"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=1557172049c8a43add209a86c7d809e89a5fbc82#1557172049c8a43add209a86c7d809e89a5fbc82"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
 dependencies = [
  "async-trait",
- "cqrs-es",
+ "cqrs-es 0.5.0",
  "serde",
  "serde_json",
  "sqlite-es",
- "sqlx",
+ "sqlx 0.9.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2641,6 +2728,17 @@ name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2853,6 +2951,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2986,6 +3085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2997,7 +3105,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3042,7 +3150,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3052,6 +3169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3174,6 +3300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,7 +3416,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3592,7 +3727,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3601,7 +3736,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3758,6 +3893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,7 +3958,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4115,7 +4260,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4371,7 +4516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4574,7 +4719,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4611,7 +4756,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4699,6 +4844,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,6 +4892,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -5078,7 +5240,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5112,7 +5274,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5247,7 +5409,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5546,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -5684,8 +5846,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5695,8 +5868,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5805,7 +5989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5830,14 +6014,13 @@ dependencies = [
 [[package]]
 name = "sqlite-es"
 version = "0.1.0"
-source = "git+https://github.com/ST0x-Technology/event-sorcery.git?rev=1557172049c8a43add209a86c7d809e89a5fbc82#1557172049c8a43add209a86c7d809e89a5fbc82"
+source = "git+https://github.com/ST0x-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
 dependencies = [
- "async-trait",
  "chrono",
- "cqrs-es",
+ "cqrs-es 0.5.0",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.9.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5849,11 +6032,24 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-macros 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core 0.9.0",
+ "sqlx-macros 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
 ]
 
 [[package]]
@@ -5874,7 +6070,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
@@ -5883,7 +6079,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5894,6 +6090,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "sqlx-macros"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5901,8 +6134,21 @@ checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
- "sqlx-core",
- "sqlx-macros-core",
+ "sqlx-core 0.8.6",
+ "sqlx-macros-core 0.8.6",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core 0.9.0",
+ "sqlx-macros-core 0.9.0",
  "syn 2.0.117",
 ]
 
@@ -5921,12 +6167,38 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sha2 0.10.9",
+ "sqlx-core 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
  "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -5953,25 +6225,52 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core 0.9.0",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -5987,29 +6286,65 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.1",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera 0.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core 0.9.0",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 2.1.2",
 ]
 
 [[package]]
@@ -6020,7 +6355,7 @@ checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -6031,7 +6366,32 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_urlencoded",
- "sqlx-core",
+ "sqlx-core 0.8.6",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core 0.9.0",
  "thiserror 2.0.18",
  "tracing",
  "url",
@@ -6080,7 +6440,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sqlx",
+ "sqlx 0.9.0",
  "st0x-bridge",
  "st0x-evm",
  "st0x-execution",
@@ -6156,7 +6516,7 @@ dependencies = [
  "bon",
  "chrono",
  "chrono-tz",
- "cqrs-es",
+ "cqrs-es 0.4.12",
  "flate2",
  "httpmock",
  "num-decimal",
@@ -6168,7 +6528,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sqlx",
+ "sqlx 0.9.0",
  "st0x-dto",
  "st0x-finance",
  "st0x-float-macro",
@@ -6259,7 +6619,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sqlx",
+ "sqlx 0.8.6",
+ "sqlx 0.9.0",
  "st0x-bridge",
  "st0x-config",
  "st0x-dto",
@@ -6571,7 +6932,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7222,7 +7583,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "url",
  "utf-8",
@@ -7240,7 +7601,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -7257,7 +7618,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -7387,7 +7748,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -7703,6 +8064,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7714,7 +8081,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,10 +90,11 @@ rsa = { version = "0.9.10", features = ["pem"] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.140"
 serial_test = "3.2.0"
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.9.0", features = [
   "sqlite",
   "chrono",
-  "runtime-tokio-rustls",
+  "runtime-tokio",
+  "tls-rustls",
 ] }
 st0x-bridge = { path = "crates/bridge" }
 st0x-config = { path = "crates/config" }
@@ -138,12 +139,12 @@ wasm-bindgen = "=0.2.122"
 
 [workspace.dependencies.sqlite-es]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"
-rev = "1557172049c8a43add209a86c7d809e89a5fbc82"
+tag = "0.1.1"
 package = "sqlite-es"
 
 [workspace.dependencies.st0x-event-sorcery]
 git = "https://github.com/ST0x-Technology/event-sorcery.git"
-rev = "1557172049c8a43add209a86c7d809e89a5fbc82"
+tag = "0.1.1"
 package = "event-sorcery"
 
 [package]
@@ -233,6 +234,11 @@ apalis-workflow.workspace = true
 axum.workspace = true
 apalis-board.workspace = true
 st0x-wrapper = { workspace = true, features = ["erc4626"] }
+sqlx-apalis = { version = "0.8.6", package = "sqlx", features = [
+  "sqlite",
+  "chrono",
+  "runtime-tokio-rustls",
+] }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1213,6 +1213,16 @@ impl CtxError {
     }
 }
 
+/// Normalizes database URLs so multiple connection pools (sqlx 0.9 for CQRS,
+/// apalis's sqlx 0.8 for workers) address the same in-memory database.
+pub fn effective_sqlite_url(database_url: &str) -> String {
+    if database_url == ":memory:" {
+        "file:st0x-hedge?mode=memory&cache=shared".to_owned()
+    } else {
+        database_url.to_owned()
+    }
+}
+
 pub async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
     // PRAGMAs are set via SqliteConnectOptions so they apply to every
     // connection the pool opens, not just the first one.
@@ -1225,7 +1235,7 @@ pub async fn configure_sqlite_pool(database_url: &str) -> Result<SqlitePool, sql
     // process, SQLite will wait up to 10 seconds before failing with
     // "database is locked". Reporter must keep transactions SHORT
     // (single INSERT per trade) to avoid blocking the main bot.
-    let options: SqliteConnectOptions = database_url
+    let options: SqliteConnectOptions = effective_sqlite_url(database_url)
         .parse::<SqliteConnectOptions>()?
         .create_if_missing(true)
         .auto_vacuum(SqliteAutoVacuum::Incremental)

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -13,6 +13,7 @@ use anyhow::Context;
 use apalis::prelude::Status;
 use chrono::Utc;
 use sqlx::SqlitePool;
+use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -90,9 +91,34 @@ use crate::wrapped_equity_recovery::{
 pub(crate) use builder::CqrsFrameworks;
 use manifest::QueryManifest;
 
+/// CQRS/event-store and apalis worker pools over the same SQLite database.
+#[derive(Clone)]
+pub(crate) struct DatabasePools {
+    pub(crate) cqrs: SqlitePool,
+    pub(crate) apalis: apalis_sqlite::SqlitePool,
+}
+
+/// Opens an apalis-side pool (sqlx 0.8) against the same database as the
+/// CQRS pool (sqlx 0.9). apalis workers read the `Jobs` table through this
+/// pool; the event store writes events through the CQRS pool.
+pub(crate) async fn connect_apalis_pool(
+    database_url: &str,
+) -> Result<apalis_sqlite::SqlitePool, apalis_sqlite::SqlxError> {
+    let options: SqliteConnectOptions = st0x_config::effective_sqlite_url(database_url)
+        .parse::<SqliteConnectOptions>()?
+        .create_if_missing(true)
+        .auto_vacuum(SqliteAutoVacuum::Incremental)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(std::time::Duration::from_secs(10));
+
+    apalis_sqlite::SqlitePool::connect_with(options).await
+}
+
 /// Sets up apalis SQLite storage tables, tolerating pre-existing
 /// application migrations in the shared `_sqlx_migrations` table.
-pub(crate) async fn setup_apalis_tables(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub(crate) async fn setup_apalis_tables(
+    pool: &apalis_sqlite::SqlitePool,
+) -> Result<(), apalis_sqlite::SqlxError> {
     apalis_sqlite::SqliteStorage::migrations()
         .set_ignore_missing(true)
         .run(pool)
@@ -220,7 +246,7 @@ impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
         ctx: Ctx,
-        pool: SqlitePool,
+        pools: DatabasePools,
         event_sender: broadcast::Sender<Statement>,
         inventory: Arc<BroadcastingInventory>,
         shutdown_token: CancellationToken,
@@ -233,6 +259,10 @@ impl Conductor {
         TradeAccountingError: From<E::Error>,
         crate::offchain::order::JobError: From<E::Error>,
     {
+        let DatabasePools {
+            cqrs: pool,
+            apalis: apalis_pool,
+        } = pools;
         let executor = executor_ctx.try_into_executor().await?;
 
         // Single HTTP transport: drives continuous eth_getLogs fill polling
@@ -250,10 +280,10 @@ impl Conductor {
             .context("failed to reach RPC endpoint at startup")?;
         let cache = SymbolCache::default();
 
-        setup_apalis_tables(&pool).await?;
-        let job_queue = DexTradeAccountingJobQueue::new(&pool);
-        let backfill_queue = BackfillJobQueue::new(&pool);
-        let schedulers = RebalancingSchedulers::new(&pool);
+        setup_apalis_tables(&apalis_pool).await?;
+        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
+        let backfill_queue = BackfillJobQueue::new(&apalis_pool);
+        let schedulers = RebalancingSchedulers::new(&apalis_pool);
 
         let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
             .build(())
@@ -264,7 +294,7 @@ impl Conductor {
                 .build(())
                 .await?;
 
-        let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&pool);
+        let seed_vault_registry_queue = SeedVaultRegistryJobQueue::new(&apalis_pool);
         let seed_vault_registry_ctx = Arc::new(
             SeedVaultRegistryCtx::from_config(vault_registry.clone(), &ctx).map_err(|err| *err)?,
         );
@@ -366,13 +396,13 @@ impl Conductor {
             snapshot,
         };
 
-        let hedge_queue = crate::conductor::job::JobQueue::new(&pool);
-        let mut poll_status_queue = PollOrderStatusJobQueue::new(&pool);
-        let reconcile_queue = ReconcileOrderFillJobQueue::new(&pool);
-        let rejection_queue = HandleOrderRejectionJobQueue::new(&pool);
+        let hedge_queue = crate::conductor::job::JobQueue::new(&apalis_pool);
+        let mut poll_status_queue = PollOrderStatusJobQueue::new(&apalis_pool);
+        let reconcile_queue = ReconcileOrderFillJobQueue::new(&apalis_pool);
+        let rejection_queue = HandleOrderRejectionJobQueue::new(&apalis_pool);
 
-        let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&pool);
-        let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&pool);
+        let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&apalis_pool);
+        let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
 
         let wrapped_equity_recovery_ctx = match (
             wrapped_equity_recovery_store,
@@ -411,7 +441,7 @@ impl Conductor {
             requeue_recovery_orphans(&unwrapped_equity_recovery_queue, "unwrapped equity").await?;
         }
 
-        let check_positions_queue = CheckPositionsJobQueue::new(&pool);
+        let check_positions_queue = CheckPositionsJobQueue::new(&apalis_pool);
 
         recover_submitted_offchain_orders(
             &frameworks.offchain_order_projection,
@@ -420,10 +450,11 @@ impl Conductor {
         )
         .await?;
 
-        bootstrap_check_positions(&pool, &check_positions_queue).await?;
+        bootstrap_check_positions(&apalis_pool, &check_positions_queue).await?;
 
         let job_cleanup = spawn_finished_job_cleanup(
             pool.clone(),
+            apalis_pool.clone(),
             Duration::from_secs(ctx.apalis_finished_job_cleanup_interval_secs),
         );
 
@@ -718,7 +749,11 @@ fn check_monitor_drain_result(
     }
 }
 
-fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> JoinHandle<()> {
+fn spawn_finished_job_cleanup(
+    pool: SqlitePool,
+    apalis_pool: apalis_sqlite::SqlitePool,
+    cleanup_interval: Duration,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(cleanup_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -726,7 +761,7 @@ fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> J
         loop {
             interval.tick().await;
 
-            let cleanup_result = sqlx::query(
+            let cleanup_result = sqlx_apalis::query(
                 "DELETE FROM Jobs \
                  WHERE status = ? \
                  OR status = ? \
@@ -735,7 +770,7 @@ fn spawn_finished_job_cleanup(pool: SqlitePool, cleanup_interval: Duration) -> J
             .bind(Status::Done.to_string())
             .bind(Status::Killed.to_string())
             .bind(Status::Failed.to_string())
-            .execute(&pool)
+            .execute(&apalis_pool)
             .await
             .map(|outcome| outcome.rows_affected());
 
@@ -796,27 +831,12 @@ async fn hydrate_single_snapshot(
         return;
     };
 
-    let events = snapshot.hydration_events();
-    if events.is_empty() {
+    let event_count = snapshot.hydrate_inventory(inventory).await;
+    if event_count == 0 {
         return;
     }
 
-    apply_hydration_events(inventory, &events).await;
-    info!(%id, event_count = events.len(), "Hydrated InventoryView from persisted snapshot");
-}
-
-async fn apply_hydration_events(
-    inventory: &Arc<BroadcastingInventory>,
-    events: &[crate::inventory::snapshot::InventorySnapshotEvent],
-) {
-    let now = chrono::Utc::now();
-    let mut view = inventory.write().await;
-
-    for event in events {
-        if let Ok(updated) = view.clone().apply_snapshot_event(event, now) {
-            *view = updated;
-        }
-    }
+    info!(%id, event_count, "Hydrated InventoryView from persisted snapshot");
 }
 
 struct RebalancingInfrastructure {
@@ -2311,7 +2331,9 @@ mod tests {
     use crate::offchain::order::OrderPlacementResult;
     use crate::onchain::trade::OnchainTrade;
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService, TriggeredOperation};
-    use crate::test_utils::{OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db};
+    use crate::test_utils::{
+        OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db, setup_test_pools,
+    };
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
@@ -2340,8 +2362,8 @@ mod tests {
         (Arc::new(Broadcaster::new(sender, pool.clone())), receiver)
     }
 
-    async fn insert_finished_job(pool: &SqlitePool, id: &str) {
-        sqlx::query(
+    async fn insert_finished_job(apalis_pool: &apalis_sqlite::SqlitePool, id: &str) {
+        sqlx_apalis::query(
             "INSERT INTO Jobs \
              (job, id, job_type, status, attempts, max_attempts, run_at, priority) \
              VALUES (?, ?, 'test', ?, 1, 25, 0, 0)",
@@ -2349,16 +2371,15 @@ mod tests {
         .bind(vec![0_u8])
         .bind(id)
         .bind(Status::Done.to_string())
-        .execute(pool)
+        .execute(apalis_pool)
         .await
         .unwrap();
     }
 
     #[tokio::test]
     async fn requeue_recovery_orphans_resets_unwrapped_recovery_rows() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
-        let mut queue = UnwrappedEquityRecoveryJobQueue::new(&pool);
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let mut queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
         let job_type = std::any::type_name::<UnwrappedEquityRecoveryJob>();
 
         queue
@@ -2369,10 +2390,10 @@ mod tests {
             .await
             .unwrap();
 
-        sqlx::query("UPDATE Jobs SET status = ?, lock_at = 1 WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = ?, lock_at = 1 WHERE job_type = ?")
             .bind(Status::Running.to_string())
             .bind(job_type)
-            .execute(&pool)
+            .execute(&apalis_pool)
             .await
             .unwrap();
 
@@ -2381,26 +2402,26 @@ mod tests {
             .unwrap();
 
         let (status, lock_by): (String, Option<String>) =
-            sqlx::query_as("SELECT status, lock_by FROM Jobs WHERE job_type = ?")
+            sqlx_apalis::query_as("SELECT status, lock_by FROM Jobs WHERE job_type = ?")
                 .bind(job_type)
-                .fetch_one(&pool)
+                .fetch_one(&apalis_pool)
                 .await
                 .unwrap();
         assert_eq!(status, Status::Pending.to_string());
         assert_eq!(lock_by, None);
     }
 
-    async fn job_count(pool: &SqlitePool) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs")
-            .fetch_one(pool)
+    async fn job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
 
-    async fn wait_for_job_count(pool: &SqlitePool, expected_count: i64) {
+    async fn wait_for_job_count(apalis_pool: &apalis_sqlite::SqlitePool, expected_count: i64) {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
-                let count = job_count(pool).await;
+                let count = job_count(apalis_pool).await;
                 if count == expected_count {
                     return;
                 }
@@ -2450,13 +2471,13 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_finished_job_cleanup_runs_until_aborted() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
-        insert_finished_job(&pool, "done").await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        insert_finished_job(&apalis_pool, "done").await;
 
-        let handle = spawn_finished_job_cleanup(pool.clone(), Duration::from_secs(60));
+        let handle =
+            spawn_finished_job_cleanup(pool.clone(), apalis_pool.clone(), Duration::from_secs(60));
 
-        wait_for_job_count(&pool, 0).await;
+        wait_for_job_count(&apalis_pool, 0).await;
         handle.abort();
         let join_error = handle.await.unwrap_err();
 
@@ -3009,14 +3030,11 @@ mod tests {
         )
     }
 
-    async fn trade_processing_cqrs_with_threshold(
+    fn trade_processing_cqrs_with_threshold(
         frameworks: &CqrsFrameworks,
         threshold: ExecutionThreshold,
-        pool: &SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
     ) -> TradeProcessingCqrs {
-        // Tests reuse this helper; constructing PollOrderStatusJobQueue is
-        // cheap but pushing into it requires apalis tables to exist.
-        setup_apalis_tables(pool).await.unwrap();
         TradeProcessingCqrs {
             onchain_trade: frameworks.onchain_trade.clone(),
             position: frameworks.position.clone(),
@@ -3028,7 +3046,7 @@ mod tests {
                 cash: None,
             },
             counter_trade_submission_lock: Arc::new(Mutex::new(())),
-            poll_status_queue: PollOrderStatusJobQueue::new(pool),
+            poll_status_queue: PollOrderStatusJobQueue::new(apalis_pool),
         }
     }
 
@@ -3058,15 +3076,14 @@ mod tests {
 
     #[tokio::test]
     async fn trade_below_threshold_does_not_place_order() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(10);
         let trade = test_trade_with_amount(float!(0.5), 10);
@@ -3099,15 +3116,14 @@ mod tests {
 
     #[tokio::test]
     async fn trade_above_threshold_places_offchain_order() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(20);
         let trade = test_trade_with_amount(float!(1.5), 20);
@@ -3147,15 +3163,14 @@ mod tests {
 
     #[tokio::test]
     async fn trade_above_threshold_skips_counter_trade_without_offchain_inventory() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(21);
         let trade = test_trade_with_amount_and_direction(float!(1.5), 21, Direction::Buy);
@@ -3199,15 +3214,14 @@ mod tests {
 
     #[tokio::test]
     async fn trade_above_threshold_places_partial_hedge_with_available_inventory() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(22);
         // Onchain buy of 5 shares -> position net = +5 -> hedge needs to sell 5
@@ -3264,15 +3278,14 @@ mod tests {
 
     #[tokio::test]
     async fn trade_above_threshold_still_skips_with_zero_inventory() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(23);
         let trade = test_trade_with_amount_and_direction(float!(1.5), 23, Direction::Buy);
@@ -3311,15 +3324,14 @@ mod tests {
 
     #[tokio::test]
     async fn multiple_trades_accumulate_then_trigger() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event_1 = make_trade_event(30);
         let trade_1 = test_trade_with_amount(float!(0.5), 30);
@@ -3357,15 +3369,14 @@ mod tests {
 
     #[tokio::test]
     async fn pending_order_blocks_new_execution() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event_1 = make_trade_event(40);
         let trade_1 = test_trade_with_amount(float!(1.5), 40);
@@ -3408,15 +3419,14 @@ mod tests {
 
     #[tokio::test]
     async fn periodic_checker_executes_after_order_completion() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         // Process first trade -> places order
         let trade_event_1 = make_trade_event(50);
@@ -3505,15 +3515,14 @@ mod tests {
 
     #[tokio::test]
     async fn periodic_checker_skips_counter_trade_without_buying_power() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         acknowledge_fill(&cqrs.position, "AAPL", "1", Direction::Sell, 1).await;
 
@@ -3567,15 +3576,14 @@ mod tests {
 
     #[tokio::test]
     async fn periodic_checker_reserves_buying_power_across_batch() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         acknowledge_fill(&cqrs.position, "AAPL", "1", Direction::Sell, 1).await;
         acknowledge_fill(&cqrs.position, "MSFT", "1", Direction::Sell, 2).await;
@@ -3632,15 +3640,14 @@ mod tests {
 
     #[tokio::test]
     async fn periodic_checker_places_partial_hedge_with_limited_inventory() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         // Onchain buy -> positive net -> hedge needs to sell
         acknowledge_fill(&cqrs.position, "AAPL", "5", Direction::Buy, 1).await;
@@ -3729,7 +3736,7 @@ mod tests {
             }
         }
 
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let order_placer: Arc<dyn OrderPlacer> = Arc::new(FailOnceOrderPlacer {
             attempts: AtomicUsize::new(0),
         });
@@ -3738,9 +3745,8 @@ mod tests {
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         acknowledge_fill(&cqrs.position, "AAPL", "1", Direction::Sell, 1).await;
         acknowledge_fill(&cqrs.position, "MSFT", "1", Direction::Sell, 2).await;
@@ -3825,7 +3831,7 @@ mod tests {
 
     #[tokio::test]
     async fn position_events_reach_rebalancing_service() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         let orderbook = address!("0x0000000000000000000000000000000000000001");
@@ -3883,7 +3889,7 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -3925,7 +3931,7 @@ mod tests {
 
     #[tokio::test]
     async fn inventory_updated_after_fill_via_cqrs() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         let orderbook = address!("0x0000000000000000000000000000000000000001");
@@ -3978,7 +3984,7 @@ mod tests {
             Arc::clone(&inventory),
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -4022,7 +4028,7 @@ mod tests {
 
     #[tokio::test]
     async fn balanced_position_event_does_not_trigger_rebalancing() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         let orderbook = address!("0x0000000000000000000000000000000000000001");
@@ -4099,7 +4105,7 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -4147,7 +4153,7 @@ mod tests {
         Symbol,
         Arc<RebalancingService>,
     ) {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         let orderbook = address!("0x0000000000000000000000000000000000000001");
@@ -4230,7 +4236,7 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -4488,7 +4494,7 @@ mod tests {
 
     #[tokio::test]
     async fn disabled_rebalancing_setup_broadcasts_live_position_updates() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
         let ctx = create_test_ctx_with_order_owner(Address::ZERO);
         let (event_sender, mut event_receiver) = broadcast::channel(16);
@@ -4510,7 +4516,7 @@ mod tests {
             event_sender,
             vault_registry,
             vault_registry_projection,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         )
         .await
         .unwrap();
@@ -4576,15 +4582,14 @@ mod tests {
             Arc::new(RejectingOrderPlacer)
         }
 
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, failing_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(70);
         let trade = test_trade_with_amount(float!(1.5), 70);
@@ -4618,9 +4623,8 @@ mod tests {
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let executor = st0x_execution::MockExecutor::new();
 
@@ -4671,7 +4675,7 @@ mod tests {
             Arc::new(RejectingOrderPlacer)
         }
 
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
 
         // Build CQRS with a rejecting broker
         let (frameworks, _) =
@@ -4679,9 +4683,8 @@ mod tests {
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         // Accumulate a position by acknowledging an onchain fill
         let symbol = Symbol::new("AAPL").unwrap();
@@ -4746,15 +4749,14 @@ mod tests {
 
     #[tokio::test]
     async fn enrichment_fields_present_emits_enrich_event() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(50);
 
@@ -4799,15 +4801,14 @@ mod tests {
 
     #[tokio::test]
     async fn missing_enrichment_fields_skips_enrich_event() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _offchain_order_projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let trade_event = make_trade_event(60);
 
@@ -5287,15 +5288,14 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_post_place_state_none_clears_position_pending() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let symbol = Symbol::new("AAPL").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
@@ -5334,15 +5334,14 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_post_place_state_pending_clears_position_pending() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let symbol = Symbol::new("AAPL").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
@@ -5464,15 +5463,14 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_post_place_state_filled_clears_position_pending() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let symbol = Symbol::new("AAPL").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();
@@ -5518,15 +5516,14 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_post_place_state_failed_clears_position_pending() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, _projection) =
             create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
         let cqrs = trade_processing_cqrs_with_threshold(
             &frameworks,
             ExecutionThreshold::whole_share(),
-            &pool,
-        )
-        .await;
+            &apalis_pool,
+        );
 
         let symbol = Symbol::new("AAPL").unwrap();
         let shares = Positive::new(FractionalShares::new(float!(2))).unwrap();

--- a/src/conductor/job.rs
+++ b/src/conductor/job.rs
@@ -11,10 +11,9 @@ use apalis_core::backend::TaskSinkError;
 use apalis_core::backend::poll_strategy::{BackoffConfig, IntervalStrategy, StrategyBuilder};
 use apalis_core::worker::context::WorkerContext;
 use apalis_core::worker::event::Event;
-use apalis_sqlite::{Config, SqliteContext, SqliteStorage};
+use apalis_sqlite::{Config, SqliteContext, SqlitePool, SqliteStorage, SqlxError};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use sqlx::SqlitePool;
 use std::fmt;
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
@@ -79,7 +78,7 @@ pub(crate) struct JobQueue<Task>(Storage<Task>);
 /// `#[from]` it into their own error enums instead of boxing.
 #[derive(Debug, thiserror::Error)]
 #[error("Failed to enqueue apalis job: {0}")]
-pub(crate) struct QueuePushError(#[from] pub(crate) TaskSinkError<sqlx::Error>);
+pub(crate) struct QueuePushError(#[from] pub(crate) TaskSinkError<SqlxError>);
 
 impl<Task> Clone for JobQueue<Task> {
     fn clone(&self) -> Self {
@@ -154,7 +153,7 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
     /// invalidates everything queued before it.
     pub(crate) async fn cancel_all_pending(&self) {
         let job_type = std::any::type_name::<Task>();
-        if let Err(error) = sqlx::query(
+        if let Err(error) = sqlx_apalis::query(
             "UPDATE Jobs SET status = 'Done' \
              WHERE status = 'Pending' AND job_type = ?",
         )
@@ -188,9 +187,9 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
     /// so a latched job awaiting operator reconciliation is not re-driven on
     /// every restart. `attempts` is preserved because a crash is not a failed
     /// attempt against the retry budget.
-    pub(crate) async fn requeue_orphaned(&self) -> Result<u64, sqlx::Error> {
+    pub(crate) async fn requeue_orphaned(&self) -> Result<u64, SqlxError> {
         let job_type = std::any::type_name::<Task>();
-        let result = sqlx::query(
+        let result = sqlx_apalis::query(
             "UPDATE Jobs SET status = 'Pending', lock_by = NULL, lock_at = NULL \
              WHERE job_type = ? AND status IN ('Running', 'Queued')",
         )
@@ -210,9 +209,9 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static> JobQueu
     /// Used by the order-fill poller to avoid stacking overlapping backfill
     /// ranges: while a previous range is still being processed the checkpoint
     /// has not advanced yet, so re-enqueuing would re-scan the same blocks.
-    pub(crate) async fn has_in_flight(&self) -> Result<bool, sqlx::Error> {
+    pub(crate) async fn has_in_flight(&self) -> Result<bool, SqlxError> {
         let job_type = std::any::type_name::<Task>();
-        let in_flight = sqlx::query_scalar::<_, i64>(
+        let in_flight = sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs \
              WHERE job_type = ? AND status NOT IN ('Done', 'Failed', 'Killed')",
         )
@@ -588,19 +587,16 @@ mod tests {
     use apalis_core::worker::event::Event;
     use apalis_core::worker::ext::circuit_breaker::{CircuitBreaker, config::CircuitBreakerConfig};
     use apalis_core::worker::ext::event_listener::EventListenerExt;
-    use sqlx::SqlitePool;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::setup_test_apalis_pool;
 
     #[tokio::test]
     async fn has_in_flight_detects_pending_and_ignores_terminal() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
-        let mut queue = JobQueue::<u32>::new(&pool);
+        let apalis_pool = setup_test_apalis_pool().await;
+        let mut queue = JobQueue::<u32>::new(&apalis_pool);
 
         assert!(
             !queue.has_in_flight().await.unwrap(),
@@ -614,9 +610,9 @@ mod tests {
         );
 
         // Drive the row to a terminal state; it must no longer count.
-        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE job_type = ?")
             .bind(std::any::type_name::<u32>())
-            .execute(&pool)
+            .execute(&apalis_pool)
             .await
             .unwrap();
         assert!(
@@ -804,10 +800,9 @@ mod tests {
     /// the worker must not pick up the next job with stale state.
     #[tokio::test]
     async fn job_failure_after_retries_halts_processing() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
+        let apalis_pool = setup_test_apalis_pool().await;
 
-        let mut queue: JobQueue<TestJob> = JobQueue::new(&pool);
+        let mut queue: JobQueue<TestJob> = JobQueue::new(&apalis_pool);
         queue.push(TestJob { should_fail: true }).await.unwrap();
         queue.push(TestJob { should_fail: false }).await.unwrap();
 
@@ -859,13 +854,13 @@ mod tests {
     }
 
     async fn insert_job(
-        pool: &SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
         id: &str,
         status: Status,
         attempts: i64,
         max_attempts: i64,
     ) {
-        sqlx::query(
+        sqlx_apalis::query(
             "INSERT INTO Jobs \
              (job, id, job_type, status, attempts, max_attempts, run_at, priority) \
              VALUES (?, ?, 'test', ?, ?, ?, 0, 0)",
@@ -875,31 +870,30 @@ mod tests {
         .bind(status.to_string())
         .bind(attempts)
         .bind(max_attempts)
-        .execute(pool)
+        .execute(apalis_pool)
         .await
         .unwrap();
     }
 
-    async fn job_ids(pool: &SqlitePool) -> Vec<String> {
-        sqlx::query_scalar::<_, String>("SELECT id FROM Jobs ORDER BY id")
-            .fetch_all(pool)
+    async fn job_ids(apalis_pool: &apalis_sqlite::SqlitePool) -> Vec<String> {
+        sqlx_apalis::query_scalar::<_, String>("SELECT id FROM Jobs ORDER BY id")
+            .fetch_all(apalis_pool)
             .await
             .unwrap()
     }
 
     #[tokio::test]
     async fn cleanup_finished_jobs_deletes_terminal_rows() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
+        let apalis_pool = setup_test_apalis_pool().await;
 
-        insert_job(&pool, "done", Status::Done, 1, 25).await;
-        insert_job(&pool, "killed", Status::Killed, 1, 25).await;
-        insert_job(&pool, "failed-terminal", Status::Failed, 25, 25).await;
-        insert_job(&pool, "failed-retryable", Status::Failed, 3, 25).await;
-        insert_job(&pool, "pending", Status::Pending, 0, 25).await;
-        insert_job(&pool, "running", Status::Running, 1, 25).await;
+        insert_job(&apalis_pool, "done", Status::Done, 1, 25).await;
+        insert_job(&apalis_pool, "killed", Status::Killed, 1, 25).await;
+        insert_job(&apalis_pool, "failed-terminal", Status::Failed, 25, 25).await;
+        insert_job(&apalis_pool, "failed-retryable", Status::Failed, 3, 25).await;
+        insert_job(&apalis_pool, "pending", Status::Pending, 0, 25).await;
+        insert_job(&apalis_pool, "running", Status::Running, 1, 25).await;
 
-        let deleted = sqlx::query(
+        let deleted = sqlx_apalis::query(
             "DELETE FROM Jobs \
              WHERE status = ? \
              OR status = ? \
@@ -908,14 +902,14 @@ mod tests {
         .bind(Status::Done.to_string())
         .bind(Status::Killed.to_string())
         .bind(Status::Failed.to_string())
-        .execute(&pool)
+        .execute(&apalis_pool)
         .await
         .unwrap()
         .rows_affected();
 
         assert_eq!(deleted, 3);
         assert_eq!(
-            job_ids(&pool).await,
+            job_ids(&apalis_pool).await,
             vec![
                 "failed-retryable".to_string(),
                 "pending".to_string(),
@@ -925,13 +919,13 @@ mod tests {
     }
 
     async fn insert_locked_job(
-        pool: &SqlitePool,
+        apalis_pool: &apalis_sqlite::SqlitePool,
         id: &str,
         job_type: &str,
         status: &str,
         lock_by: Option<&str>,
     ) {
-        sqlx::query(
+        sqlx_apalis::query(
             "INSERT INTO Jobs \
              (job, id, job_type, status, attempts, max_attempts, run_at, priority, lock_by, lock_at) \
              VALUES (?, ?, ?, ?, 0, 25, 0, 0, ?, ?)",
@@ -942,74 +936,102 @@ mod tests {
         .bind(status)
         .bind(lock_by)
         .bind(lock_by.map(|_| 0_i64))
-        .execute(pool)
+        .execute(apalis_pool)
         .await
         .unwrap();
     }
 
-    async fn status_of(pool: &SqlitePool, id: &str) -> String {
-        sqlx::query_scalar::<_, String>("SELECT status FROM Jobs WHERE id = ?")
+    async fn status_of(apalis_pool: &apalis_sqlite::SqlitePool, id: &str) -> String {
+        sqlx_apalis::query_scalar::<_, String>("SELECT status FROM Jobs WHERE id = ?")
             .bind(id)
-            .fetch_one(pool)
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
 
-    async fn lock_by_of(pool: &SqlitePool, id: &str) -> Option<String> {
-        sqlx::query_scalar::<_, Option<String>>("SELECT lock_by FROM Jobs WHERE id = ?")
+    async fn lock_by_of(apalis_pool: &apalis_sqlite::SqlitePool, id: &str) -> Option<String> {
+        sqlx_apalis::query_scalar::<_, Option<String>>("SELECT lock_by FROM Jobs WHERE id = ?")
             .bind(id)
-            .fetch_one(pool)
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
 
-    async fn insert_worker(pool: &SqlitePool, id: &str) {
-        sqlx::query(
+    async fn insert_worker(apalis_pool: &apalis_sqlite::SqlitePool, id: &str) {
+        sqlx_apalis::query(
             "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, 'test', 'test')",
         )
         .bind(id)
-        .execute(pool)
+        .execute(apalis_pool)
         .await
         .unwrap();
     }
 
     #[tokio::test]
     async fn requeue_orphaned_resets_only_in_flight_rows_of_this_queue() {
-        let pool = setup_test_db().await;
+        let apalis_pool = setup_test_apalis_pool().await;
         let job_type = std::any::type_name::<TestJob>();
 
         // A previous process died holding the lock on these in-flight rows.
-        insert_worker(&pool, "dead-worker").await;
-        insert_locked_job(&pool, "running", job_type, "Running", Some("dead-worker")).await;
-        insert_locked_job(&pool, "queued", job_type, "Queued", Some("dead-worker")).await;
-        insert_locked_job(&pool, "pending", job_type, "Pending", None).await;
-        insert_locked_job(&pool, "failed", job_type, "Failed", Some("dead-worker")).await;
-        insert_locked_job(&pool, "done", job_type, "Done", Some("dead-worker")).await;
+        insert_worker(&apalis_pool, "dead-worker").await;
+        insert_locked_job(
+            &apalis_pool,
+            "running",
+            job_type,
+            "Running",
+            Some("dead-worker"),
+        )
+        .await;
+        insert_locked_job(
+            &apalis_pool,
+            "queued",
+            job_type,
+            "Queued",
+            Some("dead-worker"),
+        )
+        .await;
+        insert_locked_job(&apalis_pool, "pending", job_type, "Pending", None).await;
+        insert_locked_job(
+            &apalis_pool,
+            "failed",
+            job_type,
+            "Failed",
+            Some("dead-worker"),
+        )
+        .await;
+        insert_locked_job(&apalis_pool, "done", job_type, "Done", Some("dead-worker")).await;
         // A Running row of a different queue's job type must be left alone.
-        insert_locked_job(&pool, "other", "other::Job", "Running", Some("dead-worker")).await;
+        insert_locked_job(
+            &apalis_pool,
+            "other",
+            "other::Job",
+            "Running",
+            Some("dead-worker"),
+        )
+        .await;
 
-        let queue = JobQueue::<TestJob>::new(&pool);
+        let queue = JobQueue::<TestJob>::new(&apalis_pool);
         let reset = queue.requeue_orphaned().await.unwrap();
 
         assert_eq!(reset, 2, "only this queue's Running + Queued rows reset");
-        assert_eq!(status_of(&pool, "running").await, "Pending");
-        assert_eq!(status_of(&pool, "queued").await, "Pending");
+        assert_eq!(status_of(&apalis_pool, "running").await, "Pending");
+        assert_eq!(status_of(&apalis_pool, "queued").await, "Pending");
         assert_eq!(
-            lock_by_of(&pool, "running").await,
+            lock_by_of(&apalis_pool, "running").await,
             None,
             "lock cleared so the apalis monitor re-picks the row",
         );
-        assert_eq!(lock_by_of(&pool, "queued").await, None);
+        assert_eq!(lock_by_of(&apalis_pool, "queued").await, None);
 
-        assert_eq!(status_of(&pool, "pending").await, "Pending");
+        assert_eq!(status_of(&apalis_pool, "pending").await, "Pending");
         assert_eq!(
-            status_of(&pool, "failed").await,
+            status_of(&apalis_pool, "failed").await,
             "Failed",
             "a latched failure awaiting operator reconciliation is not re-driven",
         );
-        assert_eq!(status_of(&pool, "done").await, "Done");
+        assert_eq!(status_of(&apalis_pool, "done").await, "Done");
         assert_eq!(
-            status_of(&pool, "other").await,
+            status_of(&apalis_pool, "other").await,
             "Running",
             "another queue's in-flight row is untouched",
         );

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -143,7 +143,7 @@ mod tests {
         RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, TriggeredOperation,
         drain_pending_jobs,
     };
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::setup_test_pools;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
@@ -171,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_frameworks_produces_working_stores() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (operation_sender, _operation_receiver) = mpsc::channel(10);
         let (event_sender, _event_receiver) = broadcast::channel(10);
 
@@ -190,7 +190,7 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
 
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
@@ -222,7 +222,7 @@ mod tests {
     /// does not `catch_up` reactor subscribers.
     #[tokio::test]
     async fn build_frameworks_dispatches_live_snapshot_events_to_view() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (operation_sender, _operation_receiver) = mpsc::channel(10);
         let (event_sender, _event_receiver) = broadcast::channel(10);
 
@@ -241,7 +241,7 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let manifest = QueryManifest::new(rebalancing_service, broadcaster);
@@ -287,7 +287,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_frameworks_broadcasts_live_position_updates() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let (operation_sender, mut operation_receiver) = mpsc::channel(10);
         let (event_sender, mut event_receiver) = broadcast::channel(10);
 
@@ -350,7 +350,7 @@ mod tests {
             inventory,
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
         let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster);

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -117,7 +117,7 @@ enum OrderFillMonitorError {
     #[error(transparent)]
     Enqueue(#[from] QueuePushError),
     #[error("failed to query backfill job status: {0}")]
-    JobStatus(#[from] sqlx::Error),
+    JobStatus(#[from] apalis_sqlite::SqlxError),
 }
 
 impl<P: Provider + Clone> OrderFillMonitor<P> {
@@ -195,8 +195,7 @@ mod tests {
     use sqlx::SqlitePool;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::setup_test_pools;
 
     /// Builds a mock provider whose `eth_blockNumber` resolves the tip to
     /// `block`, so `latest_confirmed_block` returns `block - confs`.
@@ -206,11 +205,11 @@ mod tests {
         ProviderBuilder::new().connect_mocked_client(asserter)
     }
 
-    async fn backfill_job_count(pool: &SqlitePool) -> i64 {
-        sqlx::query_scalar::<_, i64>(
+    async fn backfill_job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE job_type LIKE '%BackfillRange%'",
         )
-        .fetch_one(pool)
+        .fetch_one(apalis_pool)
         .await
         .unwrap()
     }
@@ -218,10 +217,14 @@ mod tests {
     async fn setup<P>(
         provider: P,
         required_confirmations: u64,
-    ) -> (OrderFillMonitor<P>, SqlitePool, EvmCtx) {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
-        let backfill_queue = BackfillJobQueue::new(&pool);
+    ) -> (
+        OrderFillMonitor<P>,
+        SqlitePool,
+        apalis_sqlite::SqlitePool,
+        EvmCtx,
+    ) {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let backfill_queue = BackfillJobQueue::new(&apalis_pool);
 
         let evm_ctx = EvmCtx {
             rpc_url: url::Url::parse("http://localhost:8545").unwrap(),
@@ -238,14 +241,14 @@ mod tests {
             Duration::from_secs(5),
         );
 
-        (monitor, pool, evm_ctx)
+        (monitor, pool, apalis_pool, evm_ctx)
     }
 
-    async fn loaded_backfill(pool: &SqlitePool) -> BackfillRange {
-        let job_payload = sqlx::query_scalar::<_, Vec<u8>>(
+    async fn loaded_backfill(apalis_pool: &apalis_sqlite::SqlitePool) -> BackfillRange {
+        let job_payload = sqlx_apalis::query_scalar::<_, Vec<u8>>(
             "SELECT job FROM Jobs WHERE job_type LIKE '%BackfillRange%'",
         )
-        .fetch_one(pool)
+        .fetch_one(apalis_pool)
         .await
         .unwrap();
         serde_json::from_slice(&job_payload).unwrap()
@@ -254,15 +257,15 @@ mod tests {
     #[tokio::test]
     async fn poll_once_enqueues_range_capped_at_confirmation_boundary() {
         // checkpoint=99, tip=105, confs=3 -> cutoff=102, from=100.
-        let (mut monitor, pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
             .await
             .unwrap();
 
         monitor.poll_once().await.unwrap();
 
-        assert_eq!(backfill_job_count(&pool).await, 1);
-        let job = loaded_backfill(&pool).await;
+        assert_eq!(backfill_job_count(&apalis_pool).await, 1);
+        let job = loaded_backfill(&apalis_pool).await;
         assert_eq!(job.from_block, 100, "backfill must resume after checkpoint");
         assert_eq!(
             job.to_block, 102,
@@ -273,11 +276,11 @@ mod tests {
     #[tokio::test]
     async fn poll_once_uses_deployment_block_without_checkpoint() {
         // No checkpoint: from_block falls back to deployment_block (1).
-        let (mut monitor, pool, _evm_ctx) = setup(provider_at_tip(50), 0).await;
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at_tip(50), 0).await;
 
         monitor.poll_once().await.unwrap();
 
-        let job = loaded_backfill(&pool).await;
+        let job = loaded_backfill(&apalis_pool).await;
         assert_eq!(job.from_block, 1, "first run resumes from deployment_block");
         assert_eq!(job.to_block, 50);
     }
@@ -285,7 +288,7 @@ mod tests {
     #[tokio::test]
     async fn poll_once_skips_when_caught_up() {
         // checkpoint=105, tip=105, confs=3 -> cutoff=102, from=106 > cutoff.
-        let (mut monitor, pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 105)
             .await
             .unwrap();
@@ -293,7 +296,7 @@ mod tests {
         monitor.poll_once().await.unwrap();
 
         assert_eq!(
-            backfill_job_count(&pool).await,
+            backfill_job_count(&apalis_pool).await,
             0,
             "nothing to enqueue when checkpoint is past the confirmation boundary"
         );
@@ -303,12 +306,12 @@ mod tests {
     async fn poll_once_does_not_enqueue_when_no_block_is_safe_yet() {
         // Chain shallower than confs: latest_confirmed_block -> None -> 0.
         // checkpoint absent so from_block = deployment_block = 1 > 0: skip.
-        let (mut monitor, pool, _evm_ctx) = setup(provider_at_tip(2), 5).await;
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at_tip(2), 5).await;
 
         monitor.poll_once().await.unwrap();
 
         assert_eq!(
-            backfill_job_count(&pool).await,
+            backfill_job_count(&apalis_pool).await,
             0,
             "no safe block to ingest yet -> no enqueue"
         );
@@ -321,12 +324,12 @@ mod tests {
         // so the empty asserter is never polled).
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
-        let (mut monitor, pool, evm_ctx) = setup(provider, 0).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider, 0).await;
 
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
             .unwrap();
-        let mut other_handle = BackfillJobQueue::new(&pool);
+        let mut other_handle = BackfillJobQueue::new(&apalis_pool);
         other_handle
             .push(BackfillRange {
                 from_block: 11,
@@ -334,12 +337,12 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(backfill_job_count(&pool).await, 1);
+        assert_eq!(backfill_job_count(&apalis_pool).await, 1);
 
         monitor.poll_once().await.unwrap();
 
         assert_eq!(
-            backfill_job_count(&pool).await,
+            backfill_job_count(&apalis_pool).await,
             1,
             "overlap guard must prevent a second enqueue while one is in flight"
         );
@@ -352,13 +355,13 @@ mod tests {
         // indefinitely -- the deterministic worker name means apalis never
         // ages the orphan out. `requeue_orphaned`, wired at conductor startup,
         // is what unwedges it.
-        let (mut monitor, pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
             .unwrap();
 
-        let queue = BackfillJobQueue::new(&pool);
-        BackfillJobQueue::new(&pool)
+        let queue = BackfillJobQueue::new(&apalis_pool);
+        BackfillJobQueue::new(&apalis_pool)
             .push(BackfillRange {
                 from_block: 11,
                 to_block: 20,
@@ -367,15 +370,17 @@ mod tests {
             .unwrap();
         // Simulate a crash mid-process: the row is stuck `Running` with no
         // live worker owning it.
-        sqlx::query("UPDATE Jobs SET status = 'Running' WHERE job_type LIKE '%BackfillRange%'")
-            .execute(&pool)
-            .await
-            .unwrap();
+        sqlx_apalis::query(
+            "UPDATE Jobs SET status = 'Running' WHERE job_type LIKE '%BackfillRange%'",
+        )
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
 
         // The wedge: the poller skips while the orphan counts as in flight.
         monitor.poll_once().await.unwrap();
         assert_eq!(
-            backfill_job_count(&pool).await,
+            backfill_job_count(&apalis_pool).await,
             1,
             "orphaned Running range still blocks the overlap guard"
         );
@@ -384,10 +389,10 @@ mod tests {
         let reset = queue.requeue_orphaned().await.unwrap();
         assert_eq!(reset, 1, "the orphaned backfill range is requeued");
 
-        let status = sqlx::query_scalar::<_, String>(
+        let status = sqlx_apalis::query_scalar::<_, String>(
             "SELECT status FROM Jobs WHERE job_type LIKE '%BackfillRange%'",
         )
-        .fetch_one(&pool)
+        .fetch_one(&apalis_pool)
         .await
         .unwrap();
         assert_eq!(status, "Pending", "requeue makes the orphan re-drivable");

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -51,7 +51,7 @@ use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::position::{Position, PositionCommand};
 use crate::symbol::cache::SymbolCache;
-use crate::test_utils::{deploy_tofu_singleton, setup_test_db};
+use crate::test_utils::{deploy_tofu_singleton, setup_test_pools};
 use crate::tokenization::alpaca::tests::setup_anvil;
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::TradeAccountingError;
@@ -662,6 +662,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
 /// dispatches, while the same projection is returned for type-safe loading.
 async fn create_test_cqrs(
     pool: &SqlitePool,
+    apalis_pool: &apalis_sqlite::SqlitePool,
 ) -> (
     TradeProcessingCqrs,
     Arc<Store<Position>>,
@@ -671,6 +672,7 @@ async fn create_test_cqrs(
 ) {
     create_test_cqrs_with_assets(
         pool,
+        apalis_pool,
         AssetsConfig {
             equities: EquitiesConfig {
                 operational_limit: None,
@@ -684,6 +686,7 @@ async fn create_test_cqrs(
 
 async fn create_test_cqrs_with_assets(
     pool: &SqlitePool,
+    apalis_pool: &apalis_sqlite::SqlitePool,
     assets: AssetsConfig,
 ) -> (
     TradeProcessingCqrs,
@@ -708,7 +711,6 @@ async fn create_test_cqrs_with_assets(
             .await
             .unwrap();
 
-    crate::conductor::setup_apalis_tables(pool).await.unwrap();
     let cqrs = TradeProcessingCqrs {
         onchain_trade,
         position: position.clone(),
@@ -717,7 +719,7 @@ async fn create_test_cqrs_with_assets(
         execution_threshold: ExecutionThreshold::whole_share(),
         assets,
         counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-        poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(pool),
+        poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(apalis_pool),
     };
 
     (
@@ -733,9 +735,9 @@ async fn create_test_cqrs_with_assets(
 async fn onchain_trades_accumulate_and_trigger_offchain_fill()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // Checkpoint 1: before any trades -- no Position aggregate exists
@@ -885,9 +887,9 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
 #[tokio::test]
 async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // Two trades: 0.5 + 0.7 = 1.2 shares, crosses threshold
@@ -1027,9 +1029,9 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
 #[allow(clippy::too_many_lines)]
 async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let aapl = Symbol::new(TEST_AAPL).unwrap();
     let msft = Symbol::new(TEST_MSFT).unwrap();
 
@@ -1293,9 +1295,9 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // Trade 1: Buy 0.5 shares, below threshold
@@ -1420,8 +1422,9 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
 #[tokio::test]
 async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _position, position_query, _offchain_order, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _position, position_query, _offchain_order, _) =
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     let trade1 = orderbook
@@ -1489,9 +1492,9 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
 #[tokio::test]
 async fn position_checker_noop_when_hedged() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
 
     // Complete a full hedge cycle so position net=0
     let trade1 = orderbook
@@ -1546,9 +1549,9 @@ async fn position_checker_noop_when_hedged() -> Result<(), Box<dyn std::error::E
 #[tokio::test]
 async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // First cycle: 1.0 share sell -> hedge -> fill
@@ -1668,8 +1671,8 @@ async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::E
 #[tokio::test]
 async fn take_order_discovers_equity_vault() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _, _, _, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _, _, _, _) = create_test_cqrs(&pool, &apalis_pool).await;
 
     let trade1 = orderbook
         .take_order()
@@ -1758,8 +1761,9 @@ async fn take_order_discovers_equity_vault() -> Result<(), Box<dyn std::error::E
 #[tokio::test]
 async fn tiny_fractional_trade_tracks_precisely() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _position, position_query, _offchain_order, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _position, position_query, _offchain_order, _) =
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     let trade1 = orderbook
@@ -1803,8 +1807,9 @@ async fn tiny_fractional_trade_tracks_precisely() -> Result<(), Box<dyn std::err
 #[tokio::test]
 async fn large_trade_triggers_immediate_execution() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _position, position_query, _offchain_order, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _position, position_query, _offchain_order, _) =
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     let trade1 = orderbook
@@ -1859,9 +1864,9 @@ async fn large_trade_triggers_immediate_execution() -> Result<(), Box<dyn std::e
 #[tokio::test]
 async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs(&pool).await;
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // Trade 1: Buy 0.8 AAPL -> net=+0.8, below threshold
@@ -2017,8 +2022,9 @@ async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::er
 #[tokio::test]
 async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _position, position_query, _offchain_order, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _position, position_query, _offchain_order, _) =
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // Trade 1: Sell 1.5 AAPL -> crosses threshold, offchain order placed
@@ -2105,8 +2111,9 @@ async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::
 #[tokio::test]
 async fn duplicate_onchain_event_is_idempotent() -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
-    let (cqrs, _position, position_query, _offchain_order, _) = create_test_cqrs(&pool).await;
+    let (pool, apalis_pool) = setup_test_pools().await;
+    let (cqrs, _position, position_query, _offchain_order, _) =
+        create_test_cqrs(&pool, &apalis_pool).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     let trade1 = orderbook
@@ -2158,7 +2165,7 @@ async fn duplicate_onchain_event_is_idempotent() -> Result<(), Box<dyn std::erro
 async fn operational_limits_dollar_cap_constrains_counter_trades_across_cycles()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // Per-asset limit = 1 share. A 3-share onchain sell requires
     // 3 cycles of 1-share hedges to fully close.
@@ -2184,7 +2191,7 @@ async fn operational_limits_dollar_cap_constrains_counter_trades_across_cycles()
         cash: None,
     };
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs_with_assets(&pool, assets.clone()).await;
+        create_test_cqrs_with_assets(&pool, &apalis_pool, assets.clone()).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // 3-share sell -> net = -3
@@ -2365,7 +2372,7 @@ async fn operational_limits_dollar_cap_constrains_counter_trades_across_cycles()
 async fn operational_limits_shares_cap_constrains_counter_trades_with_failure_and_retry()
 -> Result<(), Box<dyn std::error::Error>> {
     let mut orderbook = setup_anvil_orderbook().await;
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // Per-asset shares limit = 2. A 5-share onchain sell hedges 2 shares,
     // fails, retries (also capped to 2), and the pending order blocks
@@ -2392,7 +2399,7 @@ async fn operational_limits_shares_cap_constrains_counter_trades_with_failure_an
         cash: None,
     };
     let (cqrs, position, position_query, offchain_order, offchain_order_projection) =
-        create_test_cqrs_with_assets(&pool, assets.clone()).await;
+        create_test_cqrs_with_assets(&pool, &apalis_pool, assets.clone()).await;
     let symbol = Symbol::new(TEST_AAPL).unwrap();
 
     // 5-share sell -> net = -5, capped to 2 shares by max_shares

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -50,7 +50,7 @@ use crate::rebalancing::{
     Rebalancer, RebalancingSchedulers, RebalancingService, RebalancingServiceConfig,
     TriggeredOperation, drain_pending_jobs,
 };
-use crate::test_utils::setup_test_db;
+use crate::test_utils::setup_test_pools;
 use crate::tokenization::Tokenizer;
 use crate::tokenization::alpaca::tests::{
     TEST_REDEMPTION_WALLET, create_test_service_from_mock, setup_anvil, tokenization_mint_path,
@@ -194,7 +194,7 @@ struct EquityTriggerFixture {
 }
 
 async fn setup_equity_trigger() -> EquityTriggerFixture {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
     let symbol = Symbol::new("AAPL").unwrap();
     let aggregate_id = symbol.to_string();
 
@@ -223,7 +223,7 @@ async fn setup_equity_trigger() -> EquityTriggerFixture {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     ));
 
     let position_cqrs = build_position_cqrs_with_service(&pool, &service).await;
@@ -340,18 +340,20 @@ enum EnqueuedUsdcOperation {
 
 /// Drains every pending USDC transfer row (both directions) from the apalis
 /// Jobs table, marks them Done, and returns them in `run_at` order.
-async fn drain_pending_usdc_transfer_jobs(pool: &SqlitePool) -> Vec<EnqueuedUsdcOperation> {
+async fn drain_pending_usdc_transfer_jobs(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+) -> Vec<EnqueuedUsdcOperation> {
     let to_hedging_type = std::any::type_name::<TransferUsdcToHedging>();
     let to_market_making_type = std::any::type_name::<TransferUsdcToMarketMaking>();
 
-    let rows: Vec<(String, Vec<u8>, String)> = sqlx::query_as(
+    let rows: Vec<(String, Vec<u8>, String)> = sqlx_apalis::query_as(
         "SELECT id, job, job_type FROM Jobs \
          WHERE status = 'Pending' AND (job_type = ? OR job_type = ?) \
          ORDER BY run_at",
     )
     .bind(to_hedging_type)
     .bind(to_market_making_type)
-    .fetch_all(pool)
+    .fetch_all(apalis_pool)
     .await
     .expect("query pending USDC transfer jobs");
 
@@ -367,9 +369,9 @@ async fn drain_pending_usdc_transfer_jobs(pool: &SqlitePool) -> Vec<EnqueuedUsdc
             EnqueuedUsdcOperation::AlpacaToBase { amount: job.amount }
         };
 
-        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
             .bind(&row_id)
-            .execute(pool)
+            .execute(apalis_pool)
             .await
             .expect("mark drained USDC transfer job Done");
 
@@ -1047,7 +1049,7 @@ async fn equity_onchain_imbalance_triggers_redemption() {
 /// expected amount. No work flows through the Rebalancer mpsc channel.
 #[tokio::test]
 async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // 100 onchain, 900 offchain = 10% onchain ratio -> below 30% -> TooMuchOffchain
     // Excess = target_onchain - onchain = 500 - 100 = 400 USDC (above $51 minimum)
@@ -1077,19 +1079,19 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     trigger.check_and_trigger_usdc().await;
 
     let job_type = std::any::type_name::<TransferUsdcToMarketMaking>();
 
-    let pending: i64 = sqlx::query_scalar(
+    let pending: i64 = sqlx_apalis::query_scalar(
         "SELECT COUNT(*) FROM Jobs \
          WHERE status = 'Pending' AND job_type = ?",
     )
     .bind(job_type)
-    .fetch_one(&pool)
+    .fetch_one(&apalis_pool)
     .await
     .unwrap();
 
@@ -1098,12 +1100,12 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         "Expected exactly one pending TransferUsdcToMarketMaking job"
     );
 
-    let payload: Vec<u8> = sqlx::query_scalar(
+    let payload: Vec<u8> = sqlx_apalis::query_scalar(
         "SELECT job FROM Jobs \
          WHERE status = 'Pending' AND job_type = ?",
     )
     .bind(job_type)
-    .fetch_one(&pool)
+    .fetch_one(&apalis_pool)
     .await
     .unwrap();
 
@@ -1115,12 +1117,13 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
         "Expected excess of $400 (target $500 - actual $100)"
     );
 
-    let opposite: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-            .bind(std::any::type_name::<TransferUsdcToHedging>())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    let opposite: i64 = sqlx_apalis::query_scalar(
+        "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(std::any::type_name::<TransferUsdcToHedging>())
+    .fetch_one(&apalis_pool)
+    .await
+    .unwrap();
 
     assert_eq!(
         opposite, 0,
@@ -1133,7 +1136,7 @@ async fn usdc_offchain_imbalance_triggers_alpaca_to_base() {
 /// with excess = 900 - 500 = $400.
 #[tokio::test]
 async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // 900 onchain, 100 offchain = 90% onchain ratio -> above 70% -> TooMuchOnchain
     // Excess = onchain - target_onchain = 900 - 500 = 400 USDC
@@ -1163,7 +1166,7 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1173,12 +1176,12 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
     // with the expected payload.
     let job_type = std::any::type_name::<TransferUsdcToHedging>();
 
-    let pending: i64 = sqlx::query_scalar(
+    let pending: i64 = sqlx_apalis::query_scalar(
         "SELECT COUNT(*) FROM Jobs \
          WHERE status = 'Pending' AND job_type = ?",
     )
     .bind(job_type)
-    .fetch_one(&pool)
+    .fetch_one(&apalis_pool)
     .await
     .unwrap();
 
@@ -1187,12 +1190,12 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         "Expected exactly one pending TransferUsdcToHedging job"
     );
 
-    let payload: Vec<u8> = sqlx::query_scalar(
+    let payload: Vec<u8> = sqlx_apalis::query_scalar(
         "SELECT job FROM Jobs \
          WHERE status = 'Pending' AND job_type = ?",
     )
     .bind(job_type)
-    .fetch_one(&pool)
+    .fetch_one(&apalis_pool)
     .await
     .unwrap();
 
@@ -1204,12 +1207,13 @@ async fn usdc_onchain_imbalance_triggers_base_to_alpaca() {
         "Expected excess of $400 (actual $900 - target $500)"
     );
 
-    let opposite: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    let opposite: i64 = sqlx_apalis::query_scalar(
+        "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+    .fetch_one(&apalis_pool)
+    .await
+    .unwrap();
 
     assert_eq!(
         opposite, 0,
@@ -1240,7 +1244,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     use crate::inventory::InventoryPollingService;
     use crate::inventory::snapshot::{InventorySnapshotCommand, InventorySnapshotId};
 
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
@@ -1268,7 +1272,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     ));
 
     // Build snapshot store with the service as the CQRS subscriber — mirrors
@@ -1355,19 +1359,21 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
     drop(polling_service);
     drop(receiver);
 
-    let to_hedging: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-            .bind(std::any::type_name::<TransferUsdcToHedging>())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    let to_hedging: i64 = sqlx_apalis::query_scalar(
+        "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(std::any::type_name::<TransferUsdcToHedging>())
+    .fetch_one(&apalis_pool)
+    .await
+    .unwrap();
 
-    let to_market_making: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+    let to_market_making: i64 = sqlx_apalis::query_scalar(
+        "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+    )
+    .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+    .fetch_one(&apalis_pool)
+    .await
+    .unwrap();
 
     assert_eq!(
         to_hedging, 0,
@@ -1385,7 +1391,7 @@ async fn cash_reserve_does_not_shift_rebalancing_ratio() {
 /// `cash_reserve_does_not_shift_rebalancing_ratio`.
 #[tokio::test]
 async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
@@ -1413,7 +1419,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1434,7 +1440,7 @@ async fn balanced_usdc_without_reserve_triggers_no_rebalancing() {
 /// which covers the balanced case.
 #[tokio::test]
 async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
@@ -1472,7 +1478,7 @@ async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve()
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1490,7 +1496,7 @@ async fn usdc_alpaca_to_base_skips_when_withdrawable_cash_missing_with_reserve()
 /// `check_and_trigger_usdc` dispatches no operations.
 #[tokio::test]
 async fn usdc_none_disables_usdc_rebalancing() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     let (event_sender, _) = broadcast::channel::<Statement>(16);
     let inventory = Arc::new(BroadcastingInventory::new(
@@ -1521,7 +1527,7 @@ async fn usdc_none_disables_usdc_rebalancing() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     trigger.check_and_trigger_usdc().await;
@@ -1678,7 +1684,7 @@ async fn mint_api_failure_produces_rejected_event() {
 /// remaining imbalance, and so on until the inventory is balanced.
 #[tokio::test]
 async fn usdc_operational_limits_cap_across_trigger_cycles() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // 50 onchain, 950 offchain = 5% ratio -> TooMuchOffchain
     // Excess to reach 50% target = 500 - 50 = 450 USDC
@@ -1726,12 +1732,12 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     // Cycle 1: excess = 450, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let cycle1 = drain_pending_usdc_transfer_jobs(&pool).await;
+    let cycle1 = drain_pending_usdc_transfer_jobs(&apalis_pool).await;
     assert_eq!(
         cycle1.as_slice(),
         [EnqueuedUsdcOperation::AlpacaToBase {
@@ -1753,7 +1759,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // Cycle 2: excess = 350, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let cycle2 = drain_pending_usdc_transfer_jobs(&pool).await;
+    let cycle2 = drain_pending_usdc_transfer_jobs(&apalis_pool).await;
     assert_eq!(
         cycle2.as_slice(),
         [EnqueuedUsdcOperation::AlpacaToBase {
@@ -1775,7 +1781,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     // Cycle 3: excess = 250, capped to 100
     trigger.check_and_trigger_usdc().await;
-    let cycle3 = drain_pending_usdc_transfer_jobs(&pool).await;
+    let cycle3 = drain_pending_usdc_transfer_jobs(&apalis_pool).await;
     assert_eq!(
         cycle3.as_slice(),
         [EnqueuedUsdcOperation::AlpacaToBase {
@@ -1797,7 +1803,9 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 
     trigger.check_and_trigger_usdc().await;
     assert!(
-        drain_pending_usdc_transfer_jobs(&pool).await.is_empty(),
+        drain_pending_usdc_transfer_jobs(&apalis_pool)
+            .await
+            .is_empty(),
         "Balanced inventory should not trigger"
     );
 }
@@ -1808,7 +1816,7 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
 /// trigger fires again.
 #[tokio::test]
 async fn usdc_in_progress_blocks_concurrent_triggers() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // Large imbalance: 100 onchain, 900 offchain
     let (event_sender, _) = broadcast::channel::<Statement>(16);
@@ -1854,13 +1862,15 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         Arc::clone(&inventory),
         sender,
         wrapper,
-        RebalancingSchedulers::new(&pool),
+        RebalancingSchedulers::new(&apalis_pool),
     );
 
     // First trigger fires: excess = 400, capped to 100
     trigger.check_and_trigger_usdc().await;
     assert_eq!(
-        drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+        drain_pending_usdc_transfer_jobs(&apalis_pool)
+            .await
+            .as_slice(),
         [EnqueuedUsdcOperation::AlpacaToBase {
             amount: Usdc::new(float!(100))
         }],
@@ -1870,7 +1880,9 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     // Without clearing in_progress, second trigger is blocked
     trigger.check_and_trigger_usdc().await;
     assert!(
-        drain_pending_usdc_transfer_jobs(&pool).await.is_empty(),
+        drain_pending_usdc_transfer_jobs(&apalis_pool)
+            .await
+            .is_empty(),
         "In-progress guard should block second trigger"
     );
 
@@ -1880,7 +1892,9 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
     // Trigger fires again: same inventory, same excess = 400, capped to 100
     trigger.check_and_trigger_usdc().await;
     assert_eq!(
-        drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+        drain_pending_usdc_transfer_jobs(&apalis_pool)
+            .await
+            .as_slice(),
         [EnqueuedUsdcOperation::AlpacaToBase {
             amount: Usdc::new(float!(100))
         }],
@@ -1894,7 +1908,7 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
 /// dispatch a rebalancing operation.
 #[tokio::test]
 async fn threshold_config_controls_trigger_sensitivity() {
-    let pool = setup_test_db().await;
+    let (pool, apalis_pool) = setup_test_pools().await;
 
     // Inventory: 350 onchain / 650 offchain = 35% onchain ratio.
     // Wide config (deviation=0.4, bounds: 10%-90%): 35% is within bounds -> no trigger.
@@ -1947,7 +1961,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -2009,7 +2023,7 @@ async fn threshold_config_controls_trigger_sensitivity() {
             Arc::clone(&inventory),
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -2017,7 +2031,9 @@ async fn threshold_config_controls_trigger_sensitivity() {
 
         // Excess = target_onchain - actual_onchain = 500 - 350 = $150
         assert_eq!(
-            drain_pending_usdc_transfer_jobs(&pool).await.as_slice(),
+            drain_pending_usdc_transfer_jobs(&apalis_pool)
+                .await
+                .as_slice(),
             [EnqueuedUsdcOperation::AlpacaToBase {
                 amount: Usdc::new(float!(150))
             }],

--- a/src/inventory/snapshot.rs
+++ b/src/inventory/snapshot.rs
@@ -11,7 +11,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
+
+use super::BroadcastingInventory;
 
 use st0x_event_sorcery::{CompactionPolicy, DomainEvent, EventSourced, Never, Nil};
 use st0x_execution::{FractionalShares, Symbol};
@@ -389,20 +392,44 @@ impl EventSourced for InventorySnapshot {
 }
 
 impl InventorySnapshot {
+    /// Fold persisted snapshot fields into the in-memory [`InventoryView`].
+    ///
+    /// Each field is applied as it is emitted -- no intermediate event
+    /// buffer -- so startup hydration matches the persisted snapshot even
+    /// when deduplication suppresses the first post-restart poll.
+    pub(crate) async fn hydrate_inventory(&self, inventory: &Arc<BroadcastingInventory>) -> usize {
+        let now = Utc::now();
+        let mut view = inventory.write().await;
+        let mut event_count = 0usize;
+
+        self.each_hydration_event(|event| {
+            event_count += 1;
+            if let Ok(updated) = view.clone().apply_snapshot_event(&event, now) {
+                *view = updated;
+            }
+        });
+
+        event_count
+    }
+
     /// Produce events representing the full persisted state.
     ///
-    /// Used to hydrate the in-memory [`InventoryView`] on startup so
-    /// that the runtime projection has the same state as the
-    /// persisted snapshot, even when deduplication suppresses the
-    /// first post-restart poll (unchanged values emit no events).
+    /// Test helper for verifying hydration event coverage; production
+    /// startup uses [`Self::hydrate_inventory`] instead.
+    #[cfg(test)]
     pub(crate) fn hydration_events(&self) -> Vec<InventorySnapshotEvent> {
-        let fetched_at = self.last_updated;
         let mut events = Vec::new();
+        self.each_hydration_event(|event| events.push(event));
+        events
+    }
+
+    fn each_hydration_event(&self, mut emit: impl FnMut(InventorySnapshotEvent)) {
+        let fetched_at = self.last_updated;
 
         if let Some(fetched_at) = self.onchain_equity_fetched_at
             && !self.onchain_equity.is_empty()
         {
-            events.push(InventorySnapshotEvent::OnchainEquity {
+            emit(InventorySnapshotEvent::OnchainEquity {
                 balances: self.onchain_equity.clone(),
                 fetched_at,
             });
@@ -411,7 +438,7 @@ impl InventorySnapshot {
         if let (Some(usdc_balance), Some(fetched_at)) =
             (self.onchain_usdc, self.onchain_usdc_fetched_at)
         {
-            events.push(InventorySnapshotEvent::OnchainUsdc {
+            emit(InventorySnapshotEvent::OnchainUsdc {
                 usdc_balance,
                 fetched_at,
             });
@@ -420,7 +447,7 @@ impl InventorySnapshot {
         if let Some(fetched_at) = self.offchain_equity_fetched_at
             && !self.offchain_equity.is_empty()
         {
-            events.push(InventorySnapshotEvent::OffchainEquity {
+            emit(InventorySnapshotEvent::OffchainEquity {
                 positions: self.offchain_equity.clone(),
                 fetched_at,
             });
@@ -429,7 +456,7 @@ impl InventorySnapshot {
         if let (Some(usd_balance_cents), Some(fetched_at)) =
             (self.offchain_usd_cents, self.offchain_usd_fetched_at)
         {
-            events.push(InventorySnapshotEvent::OffchainUsd {
+            emit(InventorySnapshotEvent::OffchainUsd {
                 usd_balance_cents,
                 gross_usd_cents: self.offchain_gross_usd_cents,
                 fetched_at,
@@ -437,49 +464,49 @@ impl InventorySnapshot {
         }
 
         if self.offchain_cash_buying_power_cents.is_some() {
-            events.push(InventorySnapshotEvent::OffchainCashBuyingPower {
+            emit(InventorySnapshotEvent::OffchainCashBuyingPower {
                 cash_buying_power_cents: self.offchain_cash_buying_power_cents,
                 fetched_at,
             });
         }
 
         if self.offchain_cash_withdrawable_cents.is_some() {
-            events.push(InventorySnapshotEvent::OffchainCashWithdrawable {
+            emit(InventorySnapshotEvent::OffchainCashWithdrawable {
                 cash_withdrawable_cents: self.offchain_cash_withdrawable_cents,
                 fetched_at,
             });
         }
 
         if let Some(usdc_balance) = self.alpaca_usdc {
-            events.push(InventorySnapshotEvent::AlpacaUsdc {
+            emit(InventorySnapshotEvent::AlpacaUsdc {
                 usdc_balance,
                 fetched_at,
             });
         }
 
         if let Some(usdc_balance) = self.ethereum_usdc {
-            events.push(InventorySnapshotEvent::EthereumUsdc {
+            emit(InventorySnapshotEvent::EthereumUsdc {
                 usdc_balance,
                 fetched_at,
             });
         }
 
         if let Some(usdc_balance) = self.base_wallet_usdc {
-            events.push(InventorySnapshotEvent::BaseWalletUsdc {
+            emit(InventorySnapshotEvent::BaseWalletUsdc {
                 usdc_balance,
                 fetched_at,
             });
         }
 
         if !self.base_wallet_unwrapped_equity.is_empty() {
-            events.push(InventorySnapshotEvent::BaseWalletUnwrappedEquity {
+            emit(InventorySnapshotEvent::BaseWalletUnwrappedEquity {
                 balances: self.base_wallet_unwrapped_equity.clone(),
                 fetched_at,
             });
         }
 
         if !self.base_wallet_wrapped_equity.is_empty() {
-            events.push(InventorySnapshotEvent::BaseWalletWrappedEquity {
+            emit(InventorySnapshotEvent::BaseWalletWrappedEquity {
                 balances: self.base_wallet_wrapped_equity.clone(),
                 fetched_at,
             });
@@ -488,14 +515,12 @@ impl InventorySnapshot {
         if let Some(fetched_at) = self.inflight_equity_fetched_at
             && (!self.inflight_mints.is_empty() || !self.inflight_redemptions.is_empty())
         {
-            events.push(InventorySnapshotEvent::InflightEquity {
+            emit(InventorySnapshotEvent::InflightEquity {
                 mints: self.inflight_mints.clone(),
                 redemptions: self.inflight_redemptions.clone(),
                 fetched_at,
             });
         }
-
-        events
     }
 
     fn apply_event(&mut self, event: &InventorySnapshotEvent) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use st0x_execution::MockExecutorCtx;
 
 use crate::trading::offchain::hedge::HedgeJobQueue;
 use crate::trading::onchain::trade_accountant::DexTradeAccountingJobQueue;
+use conductor::DatabasePools;
 
 /// Outer timeout for the entire graceful shutdown sequence. Must exceed
 /// the rebalancer drain timeout (60s) plus margin for supervisor shutdown
@@ -176,8 +177,9 @@ async fn run_bot_session_inner(
     #[cfg(any(test, feature = "test-support"))] failure_injector: FailureInjector,
 ) -> anyhow::Result<()> {
     let pool = ctx.get_sqlite_pool().await?;
+    let apalis_pool = conductor::connect_apalis_pool(&ctx.database_url).await?;
     sqlx::migrate!().set_ignore_missing(true).run(&pool).await?;
-    conductor::setup_apalis_tables(&pool).await?;
+    conductor::setup_apalis_tables(&apalis_pool).await?;
 
     let inventory = Arc::new(inventory::BroadcastingInventory::new(
         inventory::InventoryView::default(),
@@ -197,9 +199,14 @@ async fn run_bot_session_inner(
         .await
         .with_context(|| format!("failed to bind apalis-board on port {}", ctx.board_port))?;
 
+    let pools = DatabasePools {
+        cqrs: pool,
+        apalis: apalis_pool,
+    };
+
     let server_supervisor = spawn_server_supervisor(
         &ctx,
-        &pool,
+        &pools,
         event_sender.clone(),
         inventory.clone(),
         recovery_cell.clone(),
@@ -209,7 +216,7 @@ async fn run_bot_session_inner(
     );
     let bot_task = tokio::spawn(Box::pin(run_conductor_session(
         ctx,
-        pool,
+        pools,
         event_sender,
         inventory,
         shutdown_token.clone(),
@@ -275,7 +282,7 @@ impl SupervisedTask for ServerTask {
 
 fn spawn_server_supervisor(
     ctx: &Ctx,
-    pool: &SqlitePool,
+    pools: &DatabasePools,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
     recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
@@ -285,7 +292,7 @@ fn spawn_server_supervisor(
 ) -> SupervisorHandle {
     let state = AppState {
         ctx: ctx.clone(),
-        pool: pool.clone(),
+        pool: pools.cqrs.clone(),
         event_sender,
         inventory,
         settings: dashboard::settings_from_ctx(ctx),
@@ -302,8 +309,8 @@ fn spawn_server_supervisor(
     // (`/apalis-board-web-*`) and the wasm calls `/api/v1/*` directly,
     // so it must own its origin. Run it on its own port instead of
     // nesting under the main router.
-    let dex_storage = DexTradeAccountingJobQueue::new(pool).into_storage();
-    let hedge_storage = HedgeJobQueue::new(pool).into_storage();
+    let dex_storage = DexTradeAccountingJobQueue::new(&pools.apalis).into_storage();
+    let hedge_storage = HedgeJobQueue::new(&pools.apalis).into_storage();
     let board_api = ApiBuilder::new(Router::new())
         .register(dex_storage)
         .register(hedge_storage)
@@ -448,7 +455,7 @@ fn check_bot_result(result: Result<anyhow::Result<()>, JoinError>) -> anyhow::Re
 #[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
 async fn run_conductor_session(
     ctx: Ctx,
-    pool: SqlitePool,
+    pools: DatabasePools,
     event_sender: broadcast::Sender<Statement>,
     inventory: Arc<inventory::BroadcastingInventory>,
     shutdown_token: tokio_util::sync::CancellationToken,
@@ -458,10 +465,11 @@ async fn run_conductor_session(
     let result = match ctx.broker.clone() {
         BrokerCtx::DryRun => {
             info!(target: "startup", "Initializing test executor for dry-run mode");
+            let pools = pools.clone();
             Box::pin(conductor::Conductor::run(
                 MockExecutorCtx,
                 ctx,
-                pool,
+                pools,
                 event_sender,
                 inventory,
                 shutdown_token,
@@ -476,7 +484,7 @@ async fn run_conductor_session(
             Box::pin(conductor::Conductor::run(
                 alpaca_auth,
                 ctx,
-                pool,
+                pools,
                 event_sender,
                 inventory,
                 shutdown_token,
@@ -512,12 +520,6 @@ mod tests {
     // `Ctx::load_files` parses `orderbook` into `Address`, so runtime tests
     // only exercise already-validated addresses. Invalid orderbook input is
     // covered in `config::tests::load_files_rejects_invalid_orderbook_address`.
-
-    async fn create_test_pool() -> SqlitePool {
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        pool
-    }
 
     fn create_test_event_sender() -> broadcast::Sender<Statement> {
         let (sender, _) = broadcast::channel(16);
@@ -680,13 +682,16 @@ mod tests {
         let mut ctx = create_test_ctx_with_order_owner(address!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ));
-        let pool = create_test_pool().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         // Port 1 refuses connections immediately, so the startup RPC probe
         // fails fast rather than hanging on a retry loop.
         ctx.evm.rpc_url = "http://127.0.0.1:1".parse().unwrap();
         let error = Box::pin(run_conductor_session(
             ctx,
-            pool,
+            DatabasePools {
+                cqrs: pool,
+                apalis: apalis_pool,
+            },
             create_test_event_sender(),
             create_test_inventory(),
             tokio_util::sync::CancellationToken::new(),
@@ -710,10 +715,13 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         ));
         ctx.evm.rpc_url = "http://127.0.0.1:1".parse().unwrap();
-        let pool = create_test_pool().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let error = Box::pin(run_conductor_session(
             ctx,
-            pool,
+            DatabasePools {
+                cqrs: pool,
+                apalis: apalis_pool,
+            },
             create_test_event_sender(),
             create_test_inventory(),
             tokio_util::sync::CancellationToken::new(),

--- a/src/offchain/order/handle_rejection.rs
+++ b/src/offchain/order/handle_rejection.rs
@@ -136,7 +136,6 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
     use crate::offchain::order::noop_order_placer;
     use crate::position::TradeId;
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
@@ -148,7 +147,6 @@ mod tests {
 
     async fn build_test_infra() -> TestInfra {
         let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
             .build(noop_order_placer())

--- a/src/offchain/order/poll_status.rs
+++ b/src/offchain/order/poll_status.rs
@@ -349,7 +349,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use chrono::Utc;
-    use sqlx::SqlitePool;
 
     use st0x_config::ExecutionThreshold;
     use st0x_event_sorcery::StoreBuilder;
@@ -359,16 +358,15 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
     use crate::offchain::order::{OffchainOrderCommand, noop_order_placer};
     use crate::position::{Position, PositionCommand, TradeId};
-    use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
+    use crate::test_utils::{OnchainTradeBuilder, setup_test_pools};
 
     const TEST_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
     struct TestInfra<E: Executor + Clone + Send + Sync + 'static> {
         ctx: PollOrderStatusCtx<E>,
-        pool: SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
         offchain_order: Arc<st0x_event_sorcery::Store<OffchainOrder>>,
         position: Arc<st0x_event_sorcery::Store<Position>>,
     }
@@ -376,8 +374,7 @@ mod tests {
     async fn build_test_infra<E: Executor + Clone + Send + Sync + 'static>(
         executor: E,
     ) -> TestInfra<E> {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = setup_test_pools().await;
 
         let (offchain_order, offchain_order_projection) =
             StoreBuilder::<OffchainOrder>::new(pool.clone())
@@ -393,15 +390,15 @@ mod tests {
         let ctx = PollOrderStatusCtx {
             executor,
             offchain_order_projection,
-            poll_status_queue: PollOrderStatusJobQueue::new(&pool),
-            reconcile_queue: ReconcileOrderFillJobQueue::new(&pool),
-            rejection_queue: HandleOrderRejectionJobQueue::new(&pool),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            reconcile_queue: ReconcileOrderFillJobQueue::new(&apalis_pool),
+            rejection_queue: HandleOrderRejectionJobQueue::new(&apalis_pool),
             poll_interval: TEST_POLL_INTERVAL,
         };
 
         TestInfra {
             ctx,
-            pool,
+            apalis_pool,
             offchain_order,
             position,
         }
@@ -494,10 +491,10 @@ mod tests {
         offchain_order_id
     }
 
-    async fn count_jobs(pool: &SqlitePool, job_type: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+    async fn count_jobs(apalis_pool: &apalis_sqlite::SqlitePool, job_type: &str) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
             .bind(job_type)
-            .fetch_one(pool)
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
@@ -514,12 +511,12 @@ mod tests {
         std::any::type_name::<HandleOrderRejection>()
     }
 
-    async fn min_run_at(pool: &SqlitePool, job_type: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>(
+    async fn min_run_at(apalis_pool: &apalis_sqlite::SqlitePool, job_type: &str) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT MIN(run_at) FROM Jobs WHERE job_type = ? AND status = 'Pending'",
         )
         .bind(job_type)
-        .fetch_one(pool)
+        .fetch_one(apalis_pool)
         .await
         .unwrap()
     }
@@ -540,17 +537,17 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, reconcile_order_fill_job_type()).await,
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
             1,
             "PollOrderStatus must enqueue exactly one ReconcileOrderFill on Filled"
         );
         assert_eq!(
-            count_jobs(&infra.pool, handle_order_rejection_job_type()).await,
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             0,
             "Filled state must not enqueue HandleOrderRejection"
         );
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Filled state must not re-enqueue PollOrderStatus"
         );
@@ -580,20 +577,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             1,
             "Pending broker state must self-reschedule a PollOrderStatus job"
         );
         assert_eq!(
-            count_jobs(&infra.pool, reconcile_order_fill_job_type()).await,
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
             0
         );
         assert_eq!(
-            count_jobs(&infra.pool, handle_order_rejection_job_type()).await,
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             0
         );
 
-        let scheduled_at = min_run_at(&infra.pool, poll_order_status_job_type()).await;
+        let scheduled_at = min_run_at(&infra.apalis_pool, poll_order_status_job_type()).await;
         let poll_interval_secs: i64 = TEST_POLL_INTERVAL.as_secs().try_into().unwrap();
         let expected_min = before_now + poll_interval_secs;
         assert!(
@@ -622,17 +619,17 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, handle_order_rejection_job_type()).await,
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             1,
             "Failed broker state must enqueue exactly one HandleOrderRejection"
         );
         assert_eq!(
-            count_jobs(&infra.pool, reconcile_order_fill_job_type()).await,
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
             0,
             "Failed state must not enqueue ReconcileOrderFill"
         );
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Terminal state must not re-enqueue PollOrderStatus"
         );
@@ -745,7 +742,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, reconcile_order_fill_job_type()).await,
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
             1,
             "Second order's poll must enqueue ReconcileOrderFill despite first order's failure"
         );
@@ -765,7 +762,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Empty projection must not enqueue any poll jobs"
         );
@@ -788,7 +785,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             1,
             "Submitted order must trigger exactly one PollOrderStatus on recovery"
         );
@@ -823,7 +820,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             1,
             "PartiallyFilled order must trigger one PollOrderStatus on recovery"
         );
@@ -857,7 +854,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Filled order must not be re-polled"
         );
@@ -891,7 +888,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Failed order must not be re-polled"
         );
@@ -931,7 +928,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             2,
             "Two Submitted orders + one Filled must enqueue exactly two polls"
         );
@@ -974,7 +971,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             1,
             "Only the order placed by the currently-configured executor must be re-polled"
         );
@@ -1003,17 +1000,17 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            count_jobs(&infra.pool, poll_order_status_job_type()).await,
+            count_jobs(&infra.apalis_pool, poll_order_status_job_type()).await,
             0,
             "Executor mismatch must drop the job without rescheduling"
         );
         assert_eq!(
-            count_jobs(&infra.pool, reconcile_order_fill_job_type()).await,
+            count_jobs(&infra.apalis_pool, reconcile_order_fill_job_type()).await,
             0,
             "Executor mismatch must not enqueue ReconcileOrderFill"
         );
         assert_eq!(
-            count_jobs(&infra.pool, handle_order_rejection_job_type()).await,
+            count_jobs(&infra.apalis_pool, handle_order_rejection_job_type()).await,
             0,
             "Executor mismatch must not enqueue HandleOrderRejection"
         );

--- a/src/offchain/order/reconcile_fill.rs
+++ b/src/offchain/order/reconcile_fill.rs
@@ -146,7 +146,6 @@ mod tests {
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
     use crate::offchain::order::{noop_order_placer, noop_placed_shares};
     use crate::position::TradeId;
     use crate::test_utils::{OnchainTradeBuilder, setup_test_db};
@@ -158,7 +157,6 @@ mod tests {
 
     async fn build_test_infra() -> TestInfra {
         let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
 
         let (offchain_order, _projection) = StoreBuilder::<OffchainOrder>::new(pool.clone())
             .build(noop_order_placer())

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -414,13 +414,11 @@ mod tests {
     use alloy::providers::{ProviderBuilder, mock::Asserter};
     use alloy::rpc::types::Log;
     use rain_math_float::Float;
-    use sqlx::SqlitePool;
     use url::Url;
 
     use super::*;
     use crate::bindings::IRaindexV6;
-    use crate::conductor::setup_apalis_tables;
-    use crate::test_utils::{get_test_order, setup_test_db};
+    use crate::test_utils::{get_test_order, setup_test_db, setup_test_pools};
     use st0x_config::EvmCtx;
 
     fn test_retry_strategy() -> ExponentialBuilder {
@@ -430,14 +428,13 @@ mod tests {
             .with_max_delay(Duration::from_millis(10))
     }
 
-    async fn setup_job_queue(pool: &SqlitePool) -> DexTradeAccountingJobQueue {
-        setup_apalis_tables(pool).await.unwrap();
-        DexTradeAccountingJobQueue::new(pool)
+    fn setup_job_queue(apalis_pool: &apalis_sqlite::SqlitePool) -> DexTradeAccountingJobQueue {
+        DexTradeAccountingJobQueue::new(apalis_pool)
     }
 
-    async fn job_count(pool: &SqlitePool) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs")
-            .fetch_one(pool)
+    async fn job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
@@ -499,8 +496,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_empty_results() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
 
         let asserter = Asserter::new();
         asserter.push_success(&serde_json::json!([])); // clear events
@@ -527,7 +524,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
         assert_eq!(
             load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
             Some(100)
@@ -536,8 +533,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_skips_when_checkpoint_is_caught_up() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -563,7 +560,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
         assert_eq!(
             load_backfill_checkpoint(&pool, &evm_ctx).await.unwrap(),
             Some(100)
@@ -572,8 +569,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_skip_preserves_newer_checkpoint() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -724,8 +721,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_with_clear_v3_events() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -785,13 +782,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 1);
+        assert_eq!(job_count(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn test_backfill_events_with_take_order_v3_events() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -853,13 +850,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 1);
+        assert_eq!(job_count(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn test_backfill_events_enqueues_all_events() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -952,13 +949,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 2);
+        assert_eq!(job_count(&apalis_pool).await, 2);
     }
 
     #[tokio::test]
     async fn test_backfill_events_rpc_failure() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -997,8 +994,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_block_range() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1025,7 +1022,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     fn create_test_take_event(
@@ -1077,8 +1074,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_preserves_chronological_order() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -1125,13 +1122,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 2);
+        assert_eq!(job_count(&apalis_pool).await, 2);
     }
 
     #[tokio::test]
     async fn test_backfill_events_batch_count_verification() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1166,13 +1163,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_backfill_events_batch_boundary_verification() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1207,13 +1204,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_process_batch_with_realistic_data() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -1251,13 +1248,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(enqueued_count, 1);
-        assert_eq!(job_count(&pool).await, 1);
+        assert_eq!(job_count(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn test_backfill_events_large_block_range_batching() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1287,13 +1284,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_backfill_events_mixed_valid_and_invalid_events() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -1346,7 +1343,7 @@ mod tests {
         .unwrap();
 
         // Both events should be enqueued (filtering happens during processing, not backfill)
-        assert_eq!(job_count(&pool).await, 2);
+        assert_eq!(job_count(&apalis_pool).await, 2);
     }
 
     fn create_clear_log(orderbook: Address, order: &IRaindexV6::OrderV4, tx_hash: TxHash) -> Log {
@@ -1383,8 +1380,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_mixed_clear_and_take_events() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -1425,13 +1422,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 2);
+        assert_eq!(job_count(&apalis_pool).await, 2);
     }
 
     #[tokio::test]
     async fn test_process_batch_retry_mechanism() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1466,8 +1463,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_batch_exhausted_retries() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1506,8 +1503,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_partial_batch_failure() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1554,8 +1551,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_corrupted_log_data() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1602,7 +1599,7 @@ mod tests {
         .unwrap();
 
         // Corrupted logs are silently ignored during backfill
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
@@ -1611,8 +1608,8 @@ mod tests {
         // boundary, so a `removed: true` log here implies a deep
         // reorg. We must skip it (logged as error) rather than
         // ingesting a vanished event.
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let order = get_test_order();
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
@@ -1651,7 +1648,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            job_count(&pool).await,
+            job_count(&apalis_pool).await,
             0,
             "logs with removed=true must be skipped, not ingested"
         );
@@ -1659,8 +1656,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_single_block_range() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1687,13 +1684,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_enqueue_batch_events_database_failure() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1722,8 +1719,8 @@ mod tests {
 
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        // Close the database to simulate connection failure
-        pool.close().await;
+        // Close the apalis pool to simulate job-queue connection failure.
+        apalis_pool.close().await;
 
         let result = enqueue_batch_events(
             &provider,
@@ -1744,8 +1741,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_enqueue_batch_events_errors_when_node_tip_behind_requested_range() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1785,13 +1782,13 @@ mod tests {
             ),
             "expected NodeLaggingBehindRequest {{ observed_tip: 50, required_tip: 100 }}, got {error:?}"
         );
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_enqueue_batch_events_filter_creation() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1822,8 +1819,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_enqueue_batch_events_partial_enqueue_failure() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1881,8 +1878,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_concurrent_batch_processing() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1930,13 +1927,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 1);
+        assert_eq!(job_count(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn test_enqueue_batch_events_retry_exponential_backoff() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -1977,8 +1974,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_backfill_events_zero_blocks() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -2001,13 +1998,13 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 
     #[tokio::test]
     async fn test_enqueue_batch_events_mixed_log_types() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -2079,13 +2076,13 @@ mod tests {
 
         let enqueued = result.unwrap();
         assert_eq!(enqueued, 2);
-        assert_eq!(job_count(&pool).await, 2);
+        assert_eq!(job_count(&apalis_pool).await, 2);
     }
 
     #[tokio::test]
     async fn test_backfill_starts_from_deployment_block() {
-        let pool = setup_test_db().await;
-        let job_queue = setup_job_queue(&pool).await;
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
         let evm_ctx = EvmCtx {
             rpc_url: Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
@@ -2113,6 +2110,6 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(job_count(&pool).await, 0);
+        assert_eq!(job_count(&apalis_pool).await, 0);
     }
 }

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -48,6 +48,8 @@ pub(crate) struct CheckPositionsCtx<E: Executor + Clone + Send + Sync + 'static>
 pub(crate) enum CheckPositionsError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
+    #[error("Apalis database error: {0}")]
+    ApalisDatabase(#[from] sqlx_apalis::Error),
     #[error("Position projection query error: {0}")]
     PositionProjection(#[from] st0x_event_sorcery::ProjectionError<Position>),
     #[error("Failed to enqueue follow-up job: {0}")]
@@ -211,17 +213,19 @@ where
 /// restart, multiplying scan load and duplicate hedge enqueues. The fresh
 /// push guarantees the periodic scan starts immediately on this run.
 pub(crate) async fn bootstrap_check_positions(
-    pool: &SqlitePool,
+    apalis_pool: &apalis_sqlite::SqlitePool,
     queue: &CheckPositionsJobQueue,
 ) -> Result<(), CheckPositionsError> {
-    purge_pending_check_positions_jobs(pool).await?;
+    purge_pending_check_positions_jobs(apalis_pool).await?;
     queue.clone().push(CheckPositions).await?;
     Ok(())
 }
 
-async fn purge_pending_check_positions_jobs(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+async fn purge_pending_check_positions_jobs(
+    apalis_pool: &apalis_sqlite::SqlitePool,
+) -> Result<u64, sqlx_apalis::Error> {
     let job_type = std::any::type_name::<CheckPositions>();
-    let deleted = sqlx::query(
+    let deleted = sqlx_apalis::query(
         "DELETE FROM Jobs WHERE job_type = ? AND (status IN (?, ?) \
          OR (status = ? AND attempts < max_attempts))",
     )
@@ -229,7 +233,7 @@ async fn purge_pending_check_positions_jobs(pool: &SqlitePool) -> Result<u64, sq
     .bind(Status::Pending.to_string())
     .bind(Status::Running.to_string())
     .bind(Status::Failed.to_string())
-    .execute(pool)
+    .execute(apalis_pool)
     .await?
     .rows_affected();
 
@@ -256,20 +260,18 @@ mod tests {
     };
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
     use crate::position::{PositionCommand, TradeId};
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::setup_test_pools;
 
     async fn build_ctx(
         pool: SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
         ctx_cfg: Ctx,
         check_interval: Duration,
     ) -> (
         CheckPositionsCtx<MockExecutor>,
         Arc<st0x_event_sorcery::Store<Position>>,
     ) {
-        setup_apalis_tables(&pool).await.unwrap();
-
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
             .await
@@ -280,8 +282,8 @@ mod tests {
         let ctx = CheckPositionsCtx {
             executor,
             position_projection,
-            hedge_queue: HedgeJobQueue::new(&pool),
-            check_positions_queue: CheckPositionsJobQueue::new(&pool),
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
+            check_positions_queue: CheckPositionsJobQueue::new(&apalis_pool),
             ctx: ctx_cfg,
             pool,
             check_interval,
@@ -316,10 +318,10 @@ mod tests {
             .unwrap();
     }
 
-    async fn count_jobs(pool: &SqlitePool, job_type: &str) -> i64 {
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+    async fn count_jobs(apalis_pool: &apalis_sqlite::SqlitePool, job_type: &str) -> i64 {
+        sqlx_apalis::query_scalar::<_, i64>("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
             .bind(job_type)
-            .fetch_one(pool)
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
     }
@@ -367,9 +369,15 @@ mod tests {
 
     #[tokio::test]
     async fn enqueues_one_hedge_per_ready_symbol() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let cfg = dry_run_ctx(&["AAPL", "TSLA"]);
-        let (ctx, position) = build_ctx(pool.clone(), cfg, Duration::from_secs(60)).await;
+        let (ctx, position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            cfg,
+            Duration::from_secs(60),
+        )
+        .await;
 
         let aapl = Symbol::new("AAPL").unwrap();
         let tsla = Symbol::new("TSLA").unwrap();
@@ -391,14 +399,20 @@ mod tests {
 
         CheckPositions.perform(&ctx).await.unwrap();
 
-        assert_eq!(count_jobs(&pool, &hedge_job_type()).await, 2);
+        assert_eq!(count_jobs(&apalis_pool, &hedge_job_type()).await, 2);
     }
 
     #[tokio::test]
     async fn no_positions_above_threshold_enqueues_no_hedge_jobs() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let cfg = dry_run_ctx(&["AAPL"]);
-        let (ctx, position) = build_ctx(pool.clone(), cfg, Duration::from_secs(60)).await;
+        let (ctx, position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            cfg,
+            Duration::from_secs(60),
+        )
+        .await;
 
         let aapl = Symbol::new("AAPL").unwrap();
 
@@ -412,25 +426,29 @@ mod tests {
 
         CheckPositions.perform(&ctx).await.unwrap();
 
-        assert_eq!(count_jobs(&pool, &hedge_job_type()).await, 0);
+        assert_eq!(count_jobs(&apalis_pool, &hedge_job_type()).await, 0);
     }
 
     #[tokio::test]
     async fn reschedules_itself_with_configured_interval() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let cfg = dry_run_ctx(&["AAPL"]);
         let interval = Duration::from_secs(42);
-        let (ctx, _position) = build_ctx(pool.clone(), cfg, interval).await;
+        let (ctx, _position) = build_ctx(pool.clone(), apalis_pool.clone(), cfg, interval).await;
 
         CheckPositions.perform(&ctx).await.unwrap();
 
-        assert_eq!(count_jobs(&pool, &check_positions_job_type()).await, 1);
+        assert_eq!(
+            count_jobs(&apalis_pool, &check_positions_job_type()).await,
+            1
+        );
 
-        let run_at: i64 = sqlx::query_scalar("SELECT run_at FROM Jobs WHERE job_type = ? LIMIT 1")
-            .bind(check_positions_job_type())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
+        let run_at: i64 =
+            sqlx_apalis::query_scalar("SELECT run_at FROM Jobs WHERE job_type = ? LIMIT 1")
+                .bind(check_positions_job_type())
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
 
         let now = chrono::Utc::now().timestamp();
         let expected = now + i64::try_from(interval.as_secs()).unwrap();
@@ -442,11 +460,17 @@ mod tests {
 
     #[tokio::test]
     async fn skips_trading_disabled_symbols_without_blocking_others() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         // RKLB is intentionally absent from the trading config -- the scan
         // must skip it without aborting the rest of the loop.
         let cfg = dry_run_ctx(&["AAPL", "TSLA"]);
-        let (ctx, position) = build_ctx(pool.clone(), cfg, Duration::from_secs(60)).await;
+        let (ctx, position) = build_ctx(
+            pool.clone(),
+            apalis_pool.clone(),
+            cfg,
+            Duration::from_secs(60),
+        )
+        .await;
 
         let aapl = Symbol::new("AAPL").unwrap();
         let rklb = Symbol::new("RKLB").unwrap();
@@ -465,7 +489,7 @@ mod tests {
         CheckPositions.perform(&ctx).await.unwrap();
 
         assert_eq!(
-            count_jobs(&pool, &hedge_job_type()).await,
+            count_jobs(&apalis_pool, &hedge_job_type()).await,
             2,
             "AAPL and TSLA should produce hedges; RKLB (untraded) is skipped"
         );
@@ -473,13 +497,18 @@ mod tests {
 
     #[tokio::test]
     async fn purge_removes_pending_running_and_retryable_failed_but_keeps_terminal() {
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
+        let (_pool, apalis_pool) = setup_test_pools().await;
 
         let job_type = check_positions_job_type();
 
-        async fn insert(pool: &SqlitePool, job_type: &str, id: &str, status: &str, attempts: i64) {
-            sqlx::query(
+        async fn insert(
+            apalis_pool: &apalis_sqlite::SqlitePool,
+            job_type: &str,
+            id: &str,
+            status: &str,
+            attempts: i64,
+        ) {
+            sqlx_apalis::query(
                 "INSERT INTO Jobs (job, id, job_type, status, attempts, max_attempts) \
                  VALUES (?, ?, ?, ?, ?, 25)",
             )
@@ -488,13 +517,13 @@ mod tests {
             .bind(job_type)
             .bind(status)
             .bind(attempts)
-            .execute(pool)
+            .execute(apalis_pool)
             .await
             .unwrap();
         }
 
         insert(
-            &pool,
+            &apalis_pool,
             &job_type,
             "pending-1",
             &Status::Pending.to_string(),
@@ -502,7 +531,7 @@ mod tests {
         )
         .await;
         insert(
-            &pool,
+            &apalis_pool,
             &job_type,
             "running-1",
             &Status::Running.to_string(),
@@ -510,7 +539,7 @@ mod tests {
         )
         .await;
         insert(
-            &pool,
+            &apalis_pool,
             &job_type,
             "failed-retryable",
             &Status::Failed.to_string(),
@@ -518,24 +547,41 @@ mod tests {
         )
         .await;
         insert(
-            &pool,
+            &apalis_pool,
             &job_type,
             "failed-exhausted",
             &Status::Failed.to_string(),
             25,
         )
         .await;
-        insert(&pool, &job_type, "done-1", &Status::Done.to_string(), 1).await;
-        insert(&pool, &job_type, "killed-1", &Status::Killed.to_string(), 1).await;
+        insert(
+            &apalis_pool,
+            &job_type,
+            "done-1",
+            &Status::Done.to_string(),
+            1,
+        )
+        .await;
+        insert(
+            &apalis_pool,
+            &job_type,
+            "killed-1",
+            &Status::Killed.to_string(),
+            1,
+        )
+        .await;
 
-        let deleted = purge_pending_check_positions_jobs(&pool).await.unwrap();
-        assert_eq!(deleted, 3);
-
-        let remaining: Vec<String> = sqlx::query_scalar("SELECT id FROM Jobs WHERE job_type = ?")
-            .bind(&job_type)
-            .fetch_all(&pool)
+        let deleted = purge_pending_check_positions_jobs(&apalis_pool)
             .await
             .unwrap();
+        assert_eq!(deleted, 3);
+
+        let remaining: Vec<String> =
+            sqlx_apalis::query_scalar("SELECT id FROM Jobs WHERE job_type = ?")
+                .bind(&job_type)
+                .fetch_all(&apalis_pool)
+                .await
+                .unwrap();
         assert_eq!(remaining.len(), 3);
         assert!(remaining.contains(&"failed-exhausted".to_string()));
         assert!(remaining.contains(&"done-1".to_string()));

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1659,7 +1659,7 @@ mod tests {
     /// MarketMaking available -- not stay stuck in-flight forever.
     #[tokio::test]
     async fn recover_mint_clears_hedging_inflight() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
         let id = IssuerRequestId::new("mint-recover-inflight");
 
@@ -1722,7 +1722,7 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
 
         // Reactor-wired stores -- the production wiring that dispatches committed
@@ -1797,7 +1797,7 @@ mod tests {
     /// must reconcile it to zero idempotently.
     #[tokio::test]
     async fn recover_mint_does_not_double_count_existing_inflight() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("AAPL").unwrap();
         let id = IssuerRequestId::new("mint-double-count");
 
@@ -1866,7 +1866,7 @@ mod tests {
             inventory.clone(),
             operation_sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
 
         let mint_store = StoreBuilder::<TokenizedEquityMint>::new(pool.clone())

--- a/src/rebalancing/trigger/equity.rs
+++ b/src/rebalancing/trigger/equity.rs
@@ -241,7 +241,7 @@ pub(crate) struct EquityRebalancingCheckScheduler {
 }
 
 impl EquityRebalancingCheckScheduler {
-    pub(crate) fn new(pool: &sqlx::SqlitePool) -> Self {
+    pub(crate) fn new(pool: &apalis_sqlite::SqlitePool) -> Self {
         Self {
             queue: EquityRebalancingCheckJobQueue::new(pool),
         }
@@ -279,7 +279,7 @@ pub(crate) async fn drain_pending_equity_jobs(
     let job_type = std::any::type_name::<EquityRebalancingCheck>();
 
     loop {
-        let row: Option<(String, Vec<u8>)> = sqlx::query_as(
+        let row: Option<(String, Vec<u8>)> = sqlx_apalis::query_as(
             "SELECT id, job FROM Jobs \
              WHERE status = 'Pending' AND job_type = ? \
              ORDER BY run_at LIMIT 1",
@@ -297,7 +297,7 @@ pub(crate) async fn drain_pending_equity_jobs(
             serde_json::from_slice(&payload).expect("deserialize EquityRebalancingCheck payload");
         job.perform(service).await?;
 
-        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
             .bind(&id)
             .execute(&pool)
             .await
@@ -853,41 +853,41 @@ mod tests {
         assert_eq!(job.label().as_str(), "EquityRebalancingCheck(RKLB)");
     }
 
-    async fn count_pending_equity_check_jobs(pool: &sqlx::SqlitePool) -> i64 {
+    async fn count_pending_equity_check_jobs(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
         let job_type = std::any::type_name::<EquityRebalancingCheck>();
-        sqlx::query_scalar::<_, i64>(
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
         )
         .bind(job_type)
-        .fetch_one(pool)
+        .fetch_one(apalis_pool)
         .await
         .expect("count pending equity-check jobs")
     }
 
     #[tokio::test]
     async fn equity_scheduler_enqueue_check_inserts_pending_row() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&apalis_pool);
         let symbol = Symbol::new("AAPL").unwrap();
 
         scheduler.enqueue_check(symbol).await;
 
-        assert_eq!(count_pending_equity_check_jobs(&pool).await, 1);
+        assert_eq!(count_pending_equity_check_jobs(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn equity_scheduler_cancel_pending_marks_pending_rows_done() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&apalis_pool);
 
         scheduler.enqueue_check(Symbol::new("AAPL").unwrap()).await;
         scheduler.enqueue_check(Symbol::new("MSFT").unwrap()).await;
-        assert_eq!(count_pending_equity_check_jobs(&pool).await, 2);
+        assert_eq!(count_pending_equity_check_jobs(&apalis_pool).await, 2);
 
         scheduler.cancel_pending().await;
 
         assert_eq!(
-            count_pending_equity_check_jobs(&pool).await,
+            count_pending_equity_check_jobs(&apalis_pool).await,
             0,
             "cancel_pending must drain all pending rows"
         );
@@ -895,15 +895,15 @@ mod tests {
 
     #[tokio::test]
     async fn equity_scheduler_enqueue_after_cancel_creates_fresh_row() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = EquityRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = EquityRebalancingCheckScheduler::new(&apalis_pool);
         let symbol = Symbol::new("AAPL").unwrap();
 
         scheduler.enqueue_check(symbol.clone()).await;
         scheduler.cancel_pending().await;
         scheduler.enqueue_check(symbol).await;
 
-        assert_eq!(count_pending_equity_check_jobs(&pool).await, 1);
+        assert_eq!(count_pending_equity_check_jobs(&apalis_pool).await, 1);
     }
 
     #[tokio::test]

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -72,7 +72,7 @@ pub(crate) struct RebalancingSchedulers {
 }
 
 impl RebalancingSchedulers {
-    pub(crate) fn new(pool: &SqlitePool) -> Self {
+    pub(crate) fn new(pool: &apalis_sqlite::SqlitePool) -> Self {
         Self {
             equity: EquityRebalancingCheckScheduler::new(pool),
             usdc: UsdcRebalancingCheckScheduler::new(pool),
@@ -124,6 +124,8 @@ pub(crate) enum RebalancingServiceError {
     },
     #[error(transparent)]
     Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    ApalisSqlx(#[from] sqlx_apalis::Error),
     #[error("failed to re-arm a stranded USDC transfer job at startup: {0}")]
     RearmEnqueue(#[from] QueuePushError),
 }
@@ -909,7 +911,7 @@ impl RebalancingService {
             id: UsdcRebalanceId,
         }
 
-        let rows: Result<Vec<(Vec<u8>,)>, _> = sqlx::query_as(
+        let rows: Result<Vec<(Vec<u8>,)>, _> = sqlx_apalis::query_as(
             "SELECT job FROM Jobs \
              WHERE job_type IN (?, ?) \
              AND status IN ('Pending', 'Queued', 'Running')",
@@ -967,21 +969,25 @@ impl RebalancingService {
     /// Unlike the timeout-sweep probe, this PROPAGATES query/decode failures so
     /// startup recovery fails fast rather than silently skipping (or spuriously
     /// firing) a re-arm it could not verify.
-    async fn transfer_has_job_row_for_id(&self, id: &UsdcRebalanceId) -> Result<bool, sqlx::Error> {
+    async fn transfer_has_job_row_for_id(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<bool, sqlx_apalis::Error> {
         #[derive(serde::Deserialize)]
         struct TransferJobId {
             id: UsdcRebalanceId,
         }
 
-        let rows: Vec<(Vec<u8>,)> = sqlx::query_as("SELECT job FROM Jobs WHERE job_type IN (?, ?)")
-            .bind(std::any::type_name::<TransferUsdcToHedging>())
-            .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
-            .fetch_all(self.transfer_usdc_to_hedging_queue.pool())
-            .await?;
+        let rows: Vec<(Vec<u8>,)> =
+            sqlx_apalis::query_as("SELECT job FROM Jobs WHERE job_type IN (?, ?)")
+                .bind(std::any::type_name::<TransferUsdcToHedging>())
+                .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+                .fetch_all(self.transfer_usdc_to_hedging_queue.pool())
+                .await?;
 
         for (payload,) in rows {
             let job: TransferJobId = serde_json::from_slice(&payload)
-                .map_err(|error| sqlx::Error::Decode(Box::new(error)))?;
+                .map_err(|error| sqlx_apalis::Error::Decode(Box::new(error)))?;
             if job.id == *id {
                 return Ok(true);
             }
@@ -1002,13 +1008,16 @@ impl RebalancingService {
     /// same id (which would run two concurrent resumes). Propagates query/decode
     /// failures so startup recovery fails fast rather than silently skipping a
     /// re-arm it could not verify.
-    async fn transfer_live_job_for_id(&self, id: &UsdcRebalanceId) -> Result<bool, sqlx::Error> {
+    async fn transfer_live_job_for_id(
+        &self,
+        id: &UsdcRebalanceId,
+    ) -> Result<bool, sqlx_apalis::Error> {
         #[derive(serde::Deserialize)]
         struct TransferJobId {
             id: UsdcRebalanceId,
         }
 
-        let rows: Vec<(Vec<u8>,)> = sqlx::query_as(
+        let rows: Vec<(Vec<u8>,)> = sqlx_apalis::query_as(
             "SELECT job FROM Jobs \
              WHERE job_type IN (?, ?) \
              AND (status IN ('Pending', 'Queued', 'Running') \
@@ -1021,7 +1030,7 @@ impl RebalancingService {
 
         for (payload,) in rows {
             let job: TransferJobId = serde_json::from_slice(&payload)
-                .map_err(|error| sqlx::Error::Decode(Box::new(error)))?;
+                .map_err(|error| sqlx_apalis::Error::Decode(Box::new(error)))?;
             if job.id == *id {
                 return Ok(true);
             }
@@ -1344,9 +1353,9 @@ impl RebalancingService {
     ) -> Result<(), RebalancingServiceError> {
         use InventorySnapshotEvent::*;
         use RebalancingServiceError::{
-            EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext, Projection,
-            RearmEnqueue, RedemptionUnwrappedExceedsTracked, SettledUsdcExceedsInitiatedAmount,
-            SharesConversion, Sqlx,
+            ApalisSqlx, EquityTrigger, Float, MissingUsdcBridgedAmount, MissingUsdcTrackingContext,
+            Projection, RearmEnqueue, RedemptionUnwrappedExceedsTracked,
+            SettledUsdcExceedsInitiatedAmount, SharesConversion, Sqlx,
         };
 
         self.expire_stuck_operations_with_logging().await;
@@ -1362,6 +1371,7 @@ impl RebalancingService {
             | SettledUsdcExceedsInitiatedAmount { .. }
             | RedemptionUnwrappedExceedsTracked { .. }
             | Sqlx(_)
+            | ApalisSqlx(_)
             | RearmEnqueue(_)) => {
                 return Err(other);
             }
@@ -1505,7 +1515,7 @@ impl RebalancingService {
                     // a LIKE substring) so a queued job for a ticker that contains
                     // this symbol as a substring (e.g. GOOGL vs GOOG) can't suppress
                     // a distinct recovery.
-                    let existing: Result<(i64,), _> = sqlx::query_as(
+                    let existing: Result<(i64,), _> = sqlx_apalis::query_as(
                         "SELECT COUNT(*) FROM Jobs \
                          WHERE job_type = ? \
                          AND status IN ('Pending', 'Queued', 'Running') \
@@ -1582,7 +1592,7 @@ impl RebalancingService {
                     // exactly (json_extract, not a LIKE substring) so a queued
                     // job for a ticker that contains this symbol as a substring
                     // (e.g. GOOGL vs GOOG) can't suppress a distinct recovery.
-                    let existing: Result<(i64,), _> = sqlx::query_as(
+                    let existing: Result<(i64,), _> = sqlx_apalis::query_as(
                         "SELECT COUNT(*) FROM Jobs \
                          WHERE job_type = ? \
                          AND status IN ('Pending', 'Queued', 'Running') \
@@ -2368,9 +2378,9 @@ impl RebalancingService {
     /// an opposite-direction transfer run concurrently against the same funds --
     /// churning capital and paying CCTP/withdrawal fees twice.
     async fn in_flight_usdc_transfer(
-        pool: &sqlx::SqlitePool,
-    ) -> Result<Option<(String, i64)>, sqlx::Error> {
-        sqlx::query_as(
+        pool: &apalis_sqlite::SqlitePool,
+    ) -> Result<Option<(String, i64)>, sqlx_apalis::Error> {
+        sqlx_apalis::query_as(
             "SELECT id, CAST(strftime('%s', 'now') AS INTEGER) - run_at AS age_secs \
              FROM Jobs \
              WHERE job_type IN (?, ?) \
@@ -3706,18 +3716,18 @@ mod tests {
             InventoryView::default(),
             event_sender,
         ));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let wrapper = Arc::new(MockWrapper::new());
 
         let service = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         (service, receiver)
     }
@@ -3750,25 +3760,24 @@ mod tests {
             },
         );
 
-        let pool = crate::test_utils::setup_test_db().await;
-        crate::conductor::setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let (sender, _receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
         let service = RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         );
 
         service.enqueue_recovery_for_current_wallet_balances().await;
 
-        let (jobs,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+        let (jobs,): (i64,) = sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
             .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
             .fetch_one(service.unwrapped_equity_recovery_queue.pool())
             .await
@@ -5185,7 +5194,7 @@ mod tests {
             InventoryView::default(),
             event_sender,
         ));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let wrapper = Arc::new(MockWrapper::new());
 
         let trigger = RebalancingService::new(
@@ -5199,13 +5208,13 @@ mod tests {
                 },
                 disabled_assets: HashSet::new(),
             },
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         );
 
         trigger.check_and_trigger_usdc().await;
@@ -5228,7 +5237,7 @@ mod tests {
             InventoryView::default(),
             event_sender,
         ));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let wrapper = Arc::new(MockWrapper::new());
 
         let trigger = RebalancingService::new(
@@ -5242,13 +5251,13 @@ mod tests {
                 },
                 disabled_assets: HashSet::from([symbol.clone()]),
             },
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         );
 
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
@@ -5418,17 +5427,17 @@ mod tests {
         let (sender, receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let service = Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         (service, receiver)
     }
@@ -5445,7 +5454,7 @@ mod tests {
     /// on the mpsc receiver for Base->Alpaca and now must assert on the queue.
     async fn count_pending_transfer_usdc_to_hedging_jobs(service: &RebalancingService) -> i64 {
         let job_type = std::any::type_name::<TransferUsdcToHedging>();
-        sqlx::query_scalar::<_, i64>(
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
         )
         .bind(job_type)
@@ -5458,7 +5467,7 @@ mod tests {
         service: &RebalancingService,
     ) -> i64 {
         let job_type = std::any::type_name::<TransferUsdcToMarketMaking>();
-        sqlx::query_scalar::<_, i64>(
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
         )
         .bind(job_type)
@@ -5478,7 +5487,7 @@ mod tests {
         let to_hedging_type = std::any::type_name::<TransferUsdcToHedging>();
         let to_mm_type = std::any::type_name::<TransferUsdcToMarketMaking>();
 
-        let rows: Vec<(String, Vec<u8>, String)> = sqlx::query_as(
+        let rows: Vec<(String, Vec<u8>, String)> = sqlx_apalis::query_as(
             "SELECT id, job, job_type FROM Jobs \
              WHERE status = 'Pending' AND (job_type = ? OR job_type = ?) \
              ORDER BY run_at",
@@ -5501,7 +5510,7 @@ mod tests {
                 UsdcRebalanceOperation::AlpacaToBase { amount: job.amount }
             };
 
-            sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+            sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
                 .bind(&row_id)
                 .execute(&pool)
                 .await
@@ -5536,19 +5545,19 @@ mod tests {
         let (sender, receiver) = mpsc::channel(10);
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(inventory, event_sender));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         seed_vault_registry(&pool, symbol).await;
 
         let service = Arc::new(RebalancingService::new(
             config,
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             wrapper,
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = service;
         (reactor, receiver)
@@ -5612,19 +5621,19 @@ mod tests {
             InventoryView::default().with_usdc(usdc(1_000_000), usdc(1_000_000)),
             event_sender,
         ));
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         seed_vault_registry(&pool, &symbol).await;
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -6924,7 +6933,7 @@ mod tests {
             "manual adjustment must not clear the pending-hedge gate"
         );
 
-        let pending_equity_checks = sqlx::query_scalar::<_, i64>(
+        let pending_equity_checks = sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
         )
         .bind(std::any::type_name::<EquityRebalancingCheck>())
@@ -8689,7 +8698,7 @@ mod tests {
         let pool = trigger.usdc_scheduler.queue().pool().clone();
 
         let pending_before: i64 =
-            sqlx::query_scalar(
+            sqlx_apalis::query_scalar(
                 "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
             )
                 .fetch_one(&pool)
@@ -8708,7 +8717,7 @@ mod tests {
         .unwrap();
 
         let pending_after: i64 =
-            sqlx::query_scalar(
+            sqlx_apalis::query_scalar(
                 "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type LIKE '%UsdcRebalancingCheck'",
             )
                 .fetch_one(&pool)
@@ -9602,7 +9611,7 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
             .bind(std::any::type_name::<TransferUsdcToHedging>())
             .execute(queue.pool())
             .await
@@ -10073,12 +10082,13 @@ mod tests {
             "a stranded Base->Alpaca AwaitingAttestation must be re-armed as a hedging job",
         );
 
-        let payload: Vec<u8> =
-            sqlx::query_scalar("SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-                .bind(std::any::type_name::<TransferUsdcToHedging>())
-                .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
-                .await
-                .unwrap();
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .unwrap();
         let job: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
         assert_eq!(
             job.id, id,
@@ -10164,7 +10174,7 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
             .bind(std::any::type_name::<TransferUsdcToHedging>())
             .execute(service.transfer_usdc_to_hedging_queue.pool())
             .await
@@ -10207,12 +10217,13 @@ mod tests {
             "a recoverable post-burn BridgingFailed must be re-armed as a hedging job",
         );
 
-        let payload: Vec<u8> =
-            sqlx::query_scalar("SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-                .bind(std::any::type_name::<TransferUsdcToHedging>())
-                .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
-                .await
-                .unwrap();
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToHedging>())
+        .fetch_one(service.transfer_usdc_to_hedging_queue.pool())
+        .await
+        .unwrap();
         let job: TransferUsdcToHedging = serde_json::from_slice(&payload).unwrap();
         assert_eq!(
             job.id, id,
@@ -10259,7 +10270,7 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query(
+        sqlx_apalis::query(
             "UPDATE Jobs SET status = 'Failed', attempts = max_attempts WHERE job_type = ?",
         )
         .bind(std::any::type_name::<TransferUsdcToHedging>())
@@ -10310,7 +10321,7 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Failed' WHERE job_type = ?")
             .bind(std::any::type_name::<TransferUsdcToHedging>())
             .execute(service.transfer_usdc_to_hedging_queue.pool())
             .await
@@ -10355,7 +10366,7 @@ mod tests {
             })
             .await
             .unwrap();
-        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE job_type = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE job_type = ?")
             .bind(std::any::type_name::<TransferUsdcToHedging>())
             .execute(service.transfer_usdc_to_hedging_queue.pool())
             .await
@@ -10447,12 +10458,13 @@ mod tests {
             "an Alpaca->Base strand must not be routed to the hedging queue",
         );
 
-        let payload: Vec<u8> =
-            sqlx::query_scalar("SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?")
-                .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
-                .fetch_one(service.transfer_usdc_to_market_making_queue.pool())
-                .await
-                .unwrap();
+        let payload: Vec<u8> = sqlx_apalis::query_scalar(
+            "SELECT job FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<TransferUsdcToMarketMaking>())
+        .fetch_one(service.transfer_usdc_to_market_making_queue.pool())
+        .await
+        .unwrap();
         let job: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
         assert_eq!(
             job.id, id,
@@ -10941,10 +10953,10 @@ mod tests {
         // Regression: when usdc is None, startup must not require assets.cash.vault_id.
         // The trigger returns no USDC rebalancing params, so no USDC vault lookup occurs.
         let (sender, _receiver) = mpsc::channel(10);
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let wrapper = Arc::new(MockWrapper::new());
 
-        let schedulers = RebalancingSchedulers::new(&pool);
+        let schedulers = RebalancingSchedulers::new(&apalis_pool);
         let trigger = RebalancingService::new(
             RebalancingServiceConfig {
                 equity: ImbalanceThreshold {
@@ -11333,7 +11345,7 @@ mod tests {
     #[tokio::test]
     async fn trigger_clears_in_progress_flag_when_terminal_event_received() {
         let (sender, _receiver) = mpsc::channel(10);
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
             InventoryView::default().with_usdc(usdc(5000), usdc(5000)),
@@ -11342,13 +11354,13 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             Address::ZERO,
             Address::ZERO,
             inventory,
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
 
         // Set in_progress flag
@@ -11555,20 +11567,20 @@ mod tests {
         ));
 
         let (sender, mut receiver) = mpsc::channel(10);
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         // Seed vault registry so token lookup succeeds
         seed_vault_registry(&pool, &symbol).await;
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -11614,7 +11626,7 @@ mod tests {
     /// Complementary test: verify that trigger DOES fire once both venues have data.
     #[tokio::test]
     async fn trigger_fires_when_both_venues_have_data() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
@@ -11627,13 +11639,13 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -11696,7 +11708,7 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn logs_show_partial_data_skips_imbalance_check() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
@@ -11709,13 +11721,13 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 
@@ -11759,7 +11771,7 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn logs_show_trigger_fires_with_complete_data() {
-        let pool = crate::test_utils::setup_test_db().await;
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
         let symbol = Symbol::new("RKLB").unwrap();
         let (event_sender, _) = broadcast::channel::<Statement>(16);
         let inventory = Arc::new(BroadcastingInventory::new(
@@ -11772,13 +11784,13 @@ mod tests {
 
         let trigger = Arc::new(RebalancingService::new(
             test_config(),
-            Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
             TEST_ORDER_OWNER,
             inventory.clone(),
             sender,
             Arc::new(MockWrapper::new()),
-            RebalancingSchedulers::new(&pool),
+            RebalancingSchedulers::new(&apalis_pool),
         ));
         let reactor = trigger.clone();
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -1099,7 +1099,7 @@ pub(crate) struct UsdcRebalancingCheckScheduler {
 }
 
 impl UsdcRebalancingCheckScheduler {
-    pub(crate) fn new(pool: &sqlx::SqlitePool) -> Self {
+    pub(crate) fn new(pool: &apalis_sqlite::SqlitePool) -> Self {
         Self {
             queue: UsdcRebalancingCheckJobQueue::new(pool),
         }
@@ -1135,7 +1135,7 @@ pub(crate) async fn drain_pending_usdc_jobs(service: &Arc<RebalancingService>) -
     let job_type = std::any::type_name::<UsdcRebalancingCheck>();
 
     loop {
-        let row: Option<(String, Vec<u8>)> = sqlx::query_as(
+        let row: Option<(String, Vec<u8>)> = sqlx_apalis::query_as(
             "SELECT id, job FROM Jobs \
              WHERE status = 'Pending' AND job_type = ? \
              ORDER BY run_at LIMIT 1",
@@ -1156,7 +1156,7 @@ pub(crate) async fn drain_pending_usdc_jobs(service: &Arc<RebalancingService>) -
             Err(never) => match never {},
         }
 
-        sqlx::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE id = ?")
             .bind(&id)
             .execute(&pool)
             .await
@@ -2197,40 +2197,40 @@ mod tests {
         );
     }
 
-    async fn count_pending_usdc_check_jobs(pool: &sqlx::SqlitePool) -> i64 {
+    async fn count_pending_usdc_check_jobs(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
         let job_type = std::any::type_name::<UsdcRebalancingCheck>();
-        sqlx::query_scalar::<_, i64>(
+        sqlx_apalis::query_scalar::<_, i64>(
             "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
         )
         .bind(job_type)
-        .fetch_one(pool)
+        .fetch_one(apalis_pool)
         .await
         .expect("count pending usdc-check jobs")
     }
 
     #[tokio::test]
     async fn usdc_scheduler_enqueue_check_inserts_pending_row() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&apalis_pool);
 
         scheduler.enqueue_check().await;
 
-        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 1);
+        assert_eq!(count_pending_usdc_check_jobs(&apalis_pool).await, 1);
     }
 
     #[tokio::test]
     async fn usdc_scheduler_cancel_pending_marks_pending_rows_done() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&apalis_pool);
 
         scheduler.enqueue_check().await;
         scheduler.enqueue_check().await;
-        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 2);
+        assert_eq!(count_pending_usdc_check_jobs(&apalis_pool).await, 2);
 
         scheduler.cancel_pending().await;
 
         assert_eq!(
-            count_pending_usdc_check_jobs(&pool).await,
+            count_pending_usdc_check_jobs(&apalis_pool).await,
             0,
             "cancel_pending must drain all pending rows"
         );
@@ -2238,14 +2238,14 @@ mod tests {
 
     #[tokio::test]
     async fn usdc_scheduler_enqueue_after_cancel_creates_fresh_row() {
-        let pool = crate::test_utils::setup_test_db().await;
-        let scheduler = UsdcRebalancingCheckScheduler::new(&pool);
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
+        let scheduler = UsdcRebalancingCheckScheduler::new(&apalis_pool);
 
         scheduler.enqueue_check().await;
         scheduler.cancel_pending().await;
         scheduler.enqueue_check().await;
 
-        assert_eq!(count_pending_usdc_check_jobs(&pool).await, 1);
+        assert_eq!(count_pending_usdc_check_jobs(&apalis_pool).await, 1);
     }
 
     #[test]

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -276,13 +276,12 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use sqlx::SqlitePool;
     use uuid::Uuid;
 
     use st0x_float_macro::float;
 
     use super::*;
-    use crate::conductor::setup_apalis_tables;
+    use crate::test_utils::setup_test_apalis_pool;
 
     struct TimeoutBaseToAlpaca;
 
@@ -374,14 +373,12 @@ mod tests {
         }
     }
 
-    async fn setup_queue_pool() -> SqlitePool {
-        let pool = SqlitePool::connect(":memory:").await.unwrap();
-        setup_apalis_tables(&pool).await.unwrap();
-        pool
+    async fn setup_queue_pool() -> apalis_sqlite::SqlitePool {
+        setup_test_apalis_pool().await
     }
 
-    async fn pending_job_count<Task>(pool: &SqlitePool) -> i64 {
-        sqlx::query_scalar(
+    async fn pending_job_count<Task>(pool: &apalis_sqlite::SqlitePool) -> i64 {
+        sqlx_apalis::query_scalar(
             "SELECT COUNT(*) FROM Jobs \
              WHERE job_type = ? AND status = 'Pending'",
         )
@@ -394,8 +391,8 @@ mod tests {
     /// Returns the serialized payload (apalis stores it as a `serde_json` BLOB
     /// via `JsonCodec`) and the `run_at` unix-second timestamp of the single
     /// pending row of the given task type.
-    async fn pending_job_row<Task>(pool: &SqlitePool) -> (Vec<u8>, i64) {
-        sqlx::query_as(
+    async fn pending_job_row<Task>(pool: &apalis_sqlite::SqlitePool) -> (Vec<u8>, i64) {
+        sqlx_apalis::query_as(
             "SELECT job, run_at FROM Jobs \
              WHERE job_type = ? AND status = 'Pending'",
         )

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,7 @@
 //! Shared test fixtures: database setup, stub orders/logs,
 //! and builders for onchain trades and offchain executions.
 
+use alloy::hex;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{Address, B256, LogData, address, bytes, fixed_bytes};
 use alloy::providers::Provider;
@@ -9,6 +10,7 @@ use alloy::rpc::types::{Log, TransactionRequest};
 use chrono::Utc;
 use rain_math_float::Float;
 use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use st0x_execution::{Direction, FractionalShares, Positive};
 
@@ -35,9 +37,11 @@ const TOFU_DECIMALS_CREATION_CODE: &str = "0x6080604052348015600e575f80fd5b50610
 /// the codehash, so the runtime must come from executing the canonical creation
 /// code rather than from a recompiled artifact.
 pub(crate) async fn deploy_tofu_singleton<P: Provider>(provider: &P) {
-    let creation_code = alloy::hex::decode(TOFU_DECIMALS_CREATION_CODE).unwrap();
+    let creation_code = hex::decode(TOFU_DECIMALS_CREATION_CODE).unwrap();
+    let tx = TransactionRequest::default().with_deploy_code(creation_code);
+
     let deployed = provider
-        .send_transaction(TransactionRequest::default().with_deploy_code(creation_code))
+        .send_transaction(tx)
         .await
         .unwrap()
         .get_receipt()
@@ -45,6 +49,7 @@ pub(crate) async fn deploy_tofu_singleton<P: Provider>(provider: &P) {
         .unwrap()
         .contract_address
         .unwrap();
+
     let runtime = provider.get_code_at(deployed).await.unwrap();
     provider
         .anvil_set_code(TOFU_TOKEN_DECIMALS, runtime)
@@ -114,13 +119,45 @@ pub(crate) fn get_test_log() -> Log {
     create_log(293)
 }
 
+static TEST_DATABASE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn test_database_url() -> String {
+    let database_id = TEST_DATABASE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("file:st0x-hedge-test-{database_id}?mode=memory&cache=shared")
+}
+
+/// CQRS pool (sqlx 0.9) and apalis worker pool (sqlx 0.8) over the same DB.
+pub(crate) async fn setup_test_pools() -> (SqlitePool, apalis_sqlite::SqlitePool) {
+    let database_url = test_database_url();
+    let pool = st0x_config::configure_sqlite_pool(&database_url)
+        .await
+        .unwrap();
+
+    sqlx::migrate!()
+        .set_ignore_missing(true)
+        .run(&pool)
+        .await
+        .unwrap();
+    let apalis_pool = crate::conductor::connect_apalis_pool(&database_url)
+        .await
+        .unwrap();
+
+    crate::conductor::setup_apalis_tables(&apalis_pool)
+        .await
+        .unwrap();
+
+    (pool, apalis_pool)
+}
+
+/// apalis worker pool (sqlx 0.8) over the same in-memory DB as [`setup_test_db`].
+pub(crate) async fn setup_test_apalis_pool() -> apalis_sqlite::SqlitePool {
+    setup_test_pools().await.1
+}
+
 /// Centralized test database setup to eliminate duplication across test files.
 /// Creates an in-memory SQLite database with all migrations applied.
 pub(crate) async fn setup_test_db() -> SqlitePool {
-    let pool = SqlitePool::connect(":memory:").await.unwrap();
-    sqlx::migrate!().run(&pool).await.unwrap();
-    crate::conductor::setup_apalis_tables(&pool).await.unwrap();
-    pool
+    setup_test_pools().await.0
 }
 
 /// Shared constructor for positive share quantities in tests.

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -226,7 +226,6 @@ mod tests {
     use crate::conductor::job::Job;
     use crate::offchain::order::{OffchainOrder, OrderPlacementResult, OrderPlacer};
     use crate::position::{Position, PositionCommand, TradeId};
-    use crate::test_utils::setup_test_db;
     use st0x_config::ExecutionThreshold;
 
     fn succeeding_order_placer() -> Arc<dyn OrderPlacer> {
@@ -270,14 +269,13 @@ mod tests {
 
     struct TestInfra {
         ctx: HedgeCtx,
-        pool: sqlx::SqlitePool,
+        apalis_pool: apalis_sqlite::SqlitePool,
         position_projection: Arc<st0x_event_sorcery::Projection<Position>>,
         offchain_order_projection: Arc<st0x_event_sorcery::Projection<OffchainOrder>>,
     }
 
     async fn create_hedge_ctx(order_placer: Arc<dyn OrderPlacer>) -> TestInfra {
-        let pool = setup_test_db().await;
-        crate::conductor::setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
             .build(())
@@ -293,12 +291,12 @@ mod tests {
         let ctx = HedgeCtx {
             position: position.clone(),
             offchain_order,
-            poll_status_queue: PollOrderStatusJobQueue::new(&pool),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
         };
 
         TestInfra {
             ctx,
-            pool,
+            apalis_pool,
             position_projection,
             offchain_order_projection,
         }
@@ -488,7 +486,9 @@ mod tests {
     /// order doesn't sit `Submitted` until the next bot restart.
     #[tokio::test]
     async fn retry_after_failed_poll_enqueue_re_enqueues_poll() {
-        let TestInfra { ctx, pool, .. } = create_hedge_ctx(succeeding_order_placer()).await;
+        let TestInfra {
+            ctx, apalis_pool, ..
+        } = create_hedge_ctx(succeeding_order_placer()).await;
         let symbol = Symbol::new("AAPL").unwrap();
 
         fill_position(
@@ -506,9 +506,9 @@ mod tests {
         job.perform(&ctx).await.unwrap();
 
         let poll_jobs_after_first: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
                 .bind(type_name::<PollOrderStatus>())
-                .fetch_one(&pool)
+                .fetch_one(&apalis_pool)
                 .await
                 .unwrap();
         assert_eq!(
@@ -523,9 +523,9 @@ mod tests {
         job.perform(&ctx).await.unwrap();
 
         let poll_jobs_after_retry: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            sqlx_apalis::query_scalar("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
                 .bind(type_name::<PollOrderStatus>())
-                .fetch_one(&pool)
+                .fetch_one(&apalis_pool)
                 .await
                 .unwrap();
         assert_eq!(

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -253,7 +253,7 @@ mod tests {
     use crate::offchain::order::OffchainOrder;
     use crate::onchain_trade::OnChainTrade;
     use crate::position::Position;
-    use crate::test_utils::{get_test_log, get_test_order, setup_test_db};
+    use crate::test_utils::{get_test_log, get_test_order, setup_test_pools};
     use st0x_config::ExecutionThreshold;
     use st0x_config::create_test_ctx_with_order_owner;
 
@@ -290,7 +290,7 @@ mod tests {
 
     #[tokio::test]
     async fn perform_returns_ok_when_event_filtered_out() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let executor = MockExecutorCtx.try_into_executor().await.unwrap();
@@ -328,10 +328,10 @@ mod tests {
             execution_threshold: ExecutionThreshold::whole_share(),
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&pool),
+            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
         };
 
-        let job_queue = DexTradeAccountingJobQueue::new(&pool);
+        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
 
         let accountant_ctx = AccountantCtx {
             orderbook: ctx.evm.orderbook,
@@ -354,7 +354,7 @@ mod tests {
     /// should be skipped gracefully instead of causing a fatal error.
     #[tokio::test]
     async fn perform_skips_take_order_with_non_hedgeable_pair() {
-        let pool = setup_test_db().await;
+        let (pool, apalis_pool) = setup_test_pools().await;
         let asserter = Asserter::new();
 
         // The order owner matches so the event passes the owner filter.
@@ -455,10 +455,10 @@ mod tests {
             execution_threshold: ExecutionThreshold::whole_share(),
             assets: ctx.assets.clone(),
             counter_trade_submission_lock: Arc::new(tokio::sync::Mutex::new(())),
-            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&pool),
+            poll_status_queue: crate::offchain::order::PollOrderStatusJobQueue::new(&apalis_pool),
         };
 
-        let job_queue = DexTradeAccountingJobQueue::new(&pool);
+        let job_queue = DexTradeAccountingJobQueue::new(&apalis_pool);
 
         let accountant_ctx = AccountantCtx {
             orderbook: ctx.evm.orderbook,

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -677,7 +677,6 @@ mod tests {
     use st0x_raindex::{Raindex, RaindexVaultId};
     use st0x_wrapper::{MockWrapper, Wrapper};
 
-    use crate::conductor::setup_apalis_tables;
     use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand};
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
@@ -712,9 +711,7 @@ mod tests {
         equity_in_progress: HashSet<Symbol>,
         tokenizer: Arc<dyn Tokenizer>,
     ) -> UnwrappedEquityRecoveryCtx {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
@@ -736,7 +733,7 @@ mod tests {
             redemption_store.clone(),
         ));
         let store = Arc::new(test_store(
-            pool.clone(),
+            pool,
             UnwrappedEquityRecoveryServices {
                 raindex,
                 vault_lookup: Arc::new(mock_vault_lookup()),
@@ -754,7 +751,7 @@ mod tests {
             mint_store,
             redemption_store,
             equity_in_progress: Arc::new(RwLock::new(equity_in_progress)),
-            queue: UnwrappedEquityRecoveryJobQueue::new(&pool),
+            queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
             reschedule_interval: Duration::from_secs(1),
         }
     }
@@ -784,9 +781,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let equity_in_progress = Arc::new(RwLock::new(HashSet::from([symbol.clone()])));
 
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
@@ -827,7 +822,7 @@ mod tests {
             mint_store,
             redemption_store,
             equity_in_progress,
-            queue: UnwrappedEquityRecoveryJobQueue::new(&pool),
+            queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
             reschedule_interval: Duration::from_secs(1),
         };
 
@@ -850,11 +845,12 @@ mod tests {
 
         // ...but it MUST have rescheduled itself, or the unchanged orphan balance
         // would be stranded (the snapshot only re-emits on a balance change).
-        let (rescheduled,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
-            .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
-            .fetch_one(ctx.queue.pool())
-            .await
-            .unwrap();
+        let (rescheduled,): (i64,) =
+            sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+                .fetch_one(ctx.queue.pool())
+                .await
+                .unwrap();
         assert_eq!(
             rescheduled, 1,
             "guard contention must reschedule the recovery job (push_with_delay), not silently skip",
@@ -866,8 +862,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let mint_id = IssuerRequestId::new("missing-mint");
 
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
@@ -926,7 +921,7 @@ mod tests {
             mint_store,
             redemption_store,
             equity_in_progress: Arc::new(RwLock::new(HashSet::new())),
-            queue: UnwrappedEquityRecoveryJobQueue::new(&pool),
+            queue: UnwrappedEquityRecoveryJobQueue::new(&apalis_pool),
             reschedule_interval: Duration::from_secs(1),
         };
 
@@ -970,10 +965,9 @@ mod tests {
 
     #[tokio::test]
     async fn enqueue_dedup_matches_symbol_exactly_not_as_substring() {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        crate::conductor::setup_apalis_tables(&pool).await.unwrap();
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
 
-        let mut queue = UnwrappedEquityRecoveryJobQueue::new(&pool);
+        let mut queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
         queue
             .push(UnwrappedEquityRecoveryJob {
                 symbol: Symbol::new("GOOGL").unwrap(),
@@ -989,18 +983,18 @@ mod tests {
              AND json_extract(job, '$.symbol') = ?";
         let job_type = std::any::type_name::<UnwrappedEquityRecoveryJob>();
 
-        let (exact,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+        let (exact,): (i64,) = sqlx_apalis::query_as(DEDUP_QUERY)
             .bind(job_type)
             .bind("GOOGL")
-            .fetch_one(&pool)
+            .fetch_one(&apalis_pool)
             .await
             .unwrap();
         assert_eq!(exact, 1, "exact symbol must match the queued GOOGL job");
 
-        let (substring,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+        let (substring,): (i64,) = sqlx_apalis::query_as(DEDUP_QUERY)
             .bind(job_type)
             .bind("GOOG")
-            .fetch_one(&pool)
+            .fetch_one(&apalis_pool)
             .await
             .unwrap();
         assert_eq!(

--- a/src/vault_registry.rs
+++ b/src/vault_registry.rs
@@ -740,7 +740,7 @@ mod tests {
     use st0x_event_sorcery::{EntityList, Reactor, StoreBuilder, TestHarness, deps, replay};
 
     use super::*;
-    use crate::test_utils::setup_test_db;
+    use crate::test_utils::{setup_test_db, setup_test_pools};
 
     const TEST_ORDERBOOK: Address = address!("0x1234567890123456789012345678901234567890");
     const TEST_OWNER: Address = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
@@ -1722,12 +1722,12 @@ mod tests {
         );
     }
 
-    async fn job_attempts_for_seed(pool: &sqlx::SqlitePool) -> i64 {
-        use sqlx::Row;
+    async fn job_attempts_for_seed(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {
+        use sqlx_apalis::Row;
         let queue_name = std::any::type_name::<SeedVaultRegistry>();
-        sqlx::query("SELECT attempts FROM Jobs WHERE job_type = ?")
+        sqlx_apalis::query("SELECT attempts FROM Jobs WHERE job_type = ?")
             .bind(queue_name)
-            .fetch_one(pool)
+            .fetch_one(apalis_pool)
             .await
             .unwrap()
             .get::<i64, _>("attempts")
@@ -1752,15 +1752,13 @@ mod tests {
         use std::time::Duration;
 
         use crate::conductor::job::{FAIL_STOP_RECOVERY_TIMEOUT, FailureInjector, JobQueue, work};
-        use crate::conductor::setup_apalis_tables;
 
-        let pool = setup_test_db().await;
-        setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = setup_test_pools().await;
 
         let ctx = ctx_with_seeded_assets();
         let seed_ctx = seed_ctx_from(pool.clone(), &ctx).await;
 
-        let mut queue: JobQueue<SeedVaultRegistry> = JobQueue::new(&pool);
+        let mut queue: JobQueue<SeedVaultRegistry> = JobQueue::new(&apalis_pool);
         queue.push(SeedVaultRegistry).await.unwrap();
 
         let injector = FailureInjector::new();
@@ -1802,7 +1800,7 @@ mod tests {
             .expect("Monitor task should not panic")
             .ok();
 
-        let attempts = job_attempts_for_seed(&pool).await;
+        let attempts = job_attempts_for_seed(&apalis_pool).await;
         assert!(
             attempts > 1,
             "Job should have been retried at least once; attempts={attempts}",

--- a/src/wrapped_equity_recovery/job.rs
+++ b/src/wrapped_equity_recovery/job.rs
@@ -457,7 +457,6 @@ mod tests {
 
     use super::super::aggregate::WrappedEquityRecoveryServices;
     use super::*;
-    use crate::conductor::setup_apalis_tables;
     use crate::inventory::BroadcastingInventory;
     use crate::inventory::view::InventoryView;
     use crate::onchain::mock::MockRaindex;
@@ -470,9 +469,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
         let equity_in_progress = Arc::new(RwLock::new(HashSet::from([symbol.clone()])));
 
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        sqlx::migrate!().run(&pool).await.unwrap();
-        setup_apalis_tables(&pool).await.unwrap();
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
 
         let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::new());
         let vault_lookup: Arc<dyn VaultLookup> = Arc::new(MockVaultLookup::new());
@@ -512,7 +509,7 @@ mod tests {
             mint_store,
             redemption_store,
             equity_in_progress,
-            queue: WrappedEquityRecoveryJobQueue::new(&pool),
+            queue: WrappedEquityRecoveryJobQueue::new(&apalis_pool),
             reschedule_interval: Duration::from_secs(1),
         };
         let job = WrappedEquityRecoveryJob {
@@ -528,11 +525,12 @@ mod tests {
             "guard-held perform() must not start recovery; aggregate should be absent, got {state:?}",
         );
 
-        let (rescheduled,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
-            .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
-            .fetch_one(ctx.queue.pool())
-            .await
-            .unwrap();
+        let (rescheduled,): (i64,) =
+            sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+                .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
+                .fetch_one(ctx.queue.pool())
+                .await
+                .unwrap();
         assert_eq!(
             rescheduled, 1,
             "guard contention must reschedule the wrapped recovery job, not mark it done",
@@ -541,10 +539,9 @@ mod tests {
 
     #[tokio::test]
     async fn enqueue_dedup_matches_symbol_exactly_not_as_substring() {
-        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
-        setup_apalis_tables(&pool).await.unwrap();
+        let apalis_pool = crate::test_utils::setup_test_apalis_pool().await;
 
-        let mut queue = WrappedEquityRecoveryJobQueue::new(&pool);
+        let mut queue = WrappedEquityRecoveryJobQueue::new(&apalis_pool);
         queue
             .push(WrappedEquityRecoveryJob {
                 symbol: Symbol::new("GOOGL").unwrap(),
@@ -560,18 +557,18 @@ mod tests {
              AND json_extract(job, '$.symbol') = ?";
         let job_type = std::any::type_name::<WrappedEquityRecoveryJob>();
 
-        let (exact,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+        let (exact,): (i64,) = sqlx_apalis::query_as(DEDUP_QUERY)
             .bind(job_type)
             .bind("GOOGL")
-            .fetch_one(&pool)
+            .fetch_one(&apalis_pool)
             .await
             .unwrap();
         assert_eq!(exact, 1, "exact symbol must match the queued GOOGL job");
 
-        let (substring,): (i64,) = sqlx::query_as(DEDUP_QUERY)
+        let (substring,): (i64,) = sqlx_apalis::query_as(DEDUP_QUERY)
             .bind(job_type)
             .bind("GOOG")
-            .fetch_one(&pool)
+            .fetch_one(&apalis_pool)
             .await
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
## What

Part of RAI-921. Pins `event-sorcery` to tag `0.1.1` and bumps `sqlx` to `0.9.0` for the CQRS/event-store layer.

## Why

The `event-sorcery` `0.1.1` tag includes a `sqlite-es` bug fix that requires `sqlx 0.9.0`. However, `apalis` still depends on `sqlx 0.8.x`, so both versions must coexist in the workspace.

## How

Because `sqlx 0.8` and `sqlx 0.9` cannot share a single connection pool, the workspace now maintains two separate pools:

- **CQRS pool** (`sqlx 0.9`) — used by `event-sorcery` / `sqlite-es` for event store reads and writes.
- **Apalis pool** (`sqlx 0.8`, aliased as `sqlx-apalis`) — used by all apalis job queue operations (`Jobs` table queries, worker storage, the apalis board API).

A `connect_apalis_pool` helper in `conductor.rs` opens the apalis-side pool, and `effective_sqlite_url` in `config/loader.rs` normalises `:memory:` to a named shared-cache URI (`file:st0x-hedge?mode=memory&cache=shared`) so both pools address the same in-memory database during tests and production runs.

All direct `sqlx::query*` calls that touch the `Jobs` table have been migrated to `sqlx_apalis::query*`, and every function that previously accepted a `&SqlitePool` for apalis work now accepts `&apalis_sqlite::SqlitePool` instead.

The `sqlx` workspace dependency is updated to use the new `runtime-tokio` + `tls-rustls` feature flags (replacing the combined `runtime-tokio-rustls` flag removed in 0.9), while the `sqlx 0.8.6` dependency is retained under the `sqlx-apalis` alias for the apalis crate.

## Testing

Test helpers `setup_test_pools()` and `setup_test_apalis_pool()` replace the previous `setup_test_db()` pattern wherever apalis tables are needed, returning both pools initialised against the same shared in-memory database. All existing tests have been updated to use the appropriate pool for each operation, and the `setup_apalis_tables` call has been removed from individual test setup functions in favour of the centralised helpers.

## Anything else

`chrono` was incidentally bumped from `0.4.44` to `0.4.45` and `serde_json` from `1.0.149` to `1.0.150` as transitive dependency updates pulled in by the sqlx upgrade.