### PR TITLE
perf: cache folded performance read models with a version stamp

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -22,11 +22,11 @@ use st0x_execution::FractionalShares;
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
-use crate::performance::rebalance::load_rebalance_timings;
+use crate::performance::rebalance::rebalance_timing_report;
 use crate::performance::reliability::{
     aggregate_log_entries, load_failure_events, load_job_queue_health,
 };
-use crate::performance::{ReportRange, hedge_latency_report, load_hedge_performance};
+use crate::performance::{ReportRange, hedge_latency_report};
 use crate::rebalancing::RebalancingService;
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, RecheckError, RecheckOutcome};
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizedEquityMintEvent};
@@ -1490,7 +1490,9 @@ async fn performance_latencies(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let performances = load_hedge_performance(&state.pool)
+    let performances = state
+        .performance
+        .hedge_performances(&state.pool)
         .await
         .inspect_err(|error| error!(%error, "Failed to load hedge performance"))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -1511,12 +1513,17 @@ async fn performance_rebalances(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let timings = load_rebalance_timings(&state.pool, &ReportRange { from, to })
+    let operations = state
+        .performance
+        .rebalance_operations(&state.pool)
         .await
         .inspect_err(|error| error!(%error, "Failed to load rebalance timings"))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    Ok(Json(timings))
+    Ok(Json(rebalance_timing_report(
+        &operations,
+        &ReportRange { from, to },
+    )))
 }
 
 async fn performance_reliability(
@@ -1616,6 +1623,7 @@ mod tests {
     use super::*;
     use crate::dashboard;
     use crate::inventory::{self, BroadcastingInventory};
+    use crate::performance::cache::PerformanceCache;
 
     async fn empty_app_state(ctx: Ctx) -> AppState {
         let (sender, _) = broadcast::channel(16);
@@ -1633,6 +1641,7 @@ mod tests {
             )),
             recovery: Arc::new(tokio::sync::OnceCell::new()),
             resume_lock: Arc::new(ResumeLock(Mutex::new(()))),
+            performance: Arc::new(PerformanceCache::default()),
         }
     }
 

--- a/src/dashboard/mod.rs
+++ b/src/dashboard/mod.rs
@@ -365,6 +365,7 @@ mod tests {
             settings: empty_settings(),
             recovery: Arc::new(tokio::sync::OnceCell::new()),
             resume_lock: Arc::new(crate::api::ResumeLock(tokio::sync::Mutex::new(()))),
+            performance: Arc::new(crate::performance::cache::PerformanceCache::default()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub(crate) struct AppState {
     pub(crate) settings: st0x_dto::Settings,
     pub(crate) recovery: Arc<tokio::sync::OnceCell<api::RecoveryHandle>>,
     pub(crate) resume_lock: Arc<api::ResumeLock>,
+    pub(crate) performance: Arc<performance::cache::PerformanceCache>,
 }
 
 #[tracing::instrument(skip_all, target = "startup", level = tracing::Level::INFO)]
@@ -299,6 +300,7 @@ fn spawn_server_supervisor(
         settings: dashboard::settings_from_ctx(ctx),
         recovery,
         resume_lock,
+        performance: Arc::new(performance::cache::PerformanceCache::default()),
     };
 
     let main_router = Router::new()

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -9,6 +9,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use chrono::{DateTime, Duration, Utc};
+use itertools::Itertools;
 use sqlx::SqlitePool;
 use thiserror::Error;
 use tracing::warn;
@@ -22,6 +23,7 @@ use st0x_execution::Symbol;
 use crate::offchain::order::{OffchainOrderEvent, OffchainOrderId};
 use crate::position::PositionEvent;
 
+pub(crate) mod cache;
 pub(crate) mod rebalance;
 pub(crate) mod reliability;
 
@@ -130,20 +132,35 @@ pub(crate) enum PerformanceError {
     Database(#[from] sqlx::Error),
 }
 
-/// Load hedge performance for every symbol with a `Position` aggregate.
+/// Aggregate types the hedge report folds; its cache stamp is scoped to
+/// exactly these (see [`events_version`]).
 ///
-/// Both event streams are read inside one transaction so the report folds a
-/// consistent snapshot: without it, the bot could commit a hedge's events
-/// between the two reads and the report would misclassify it as pending.
+/// MUST stay in lockstep with the streams the fold actually reads (the
+/// `aggregate_type` literals in [`load_hedge_performance`] and
+/// `load_order_timelines`): a stream read here but missing from this list
+/// would never bump the stamp, silently serving stale reports. The cache
+/// tests insert an event of each listed type and assert eviction.
+pub(super) const HEDGE_AGGREGATE_TYPES: &[&str] = &["Position", "OffchainOrder"];
+
+/// Load hedge performance for every symbol with a `Position` aggregate,
+/// together with the events-table version the fold observed (see
+/// [`events_version`]).
+///
+/// Both event streams and the version stamp are read inside one transaction
+/// so the report folds a consistent snapshot: without it, the bot could
+/// commit a hedge's events between the reads and the report would
+/// misclassify it as pending (or the cache would stamp the fold newer than
+/// its contents).
 ///
 /// Undeserializable events and aggregates with malformed ids are skipped with
 /// a warning rather than failing the whole report: one bad historical row
 /// must not take down the dashboard's view of every other symbol.
 pub(crate) async fn load_hedge_performance(
     pool: &SqlitePool,
-) -> Result<Vec<SymbolPerformance>, PerformanceError> {
+) -> Result<(Vec<SymbolPerformance>, EventsVersion), PerformanceError> {
     let mut transaction = pool.begin().await?;
 
+    let events_version = events_version(&mut *transaction, HEDGE_AGGREGATE_TYPES).await?;
     let order_timelines = load_order_timelines(&mut transaction).await?;
 
     let rows: Vec<(String, String)> = sqlx::query_as(
@@ -173,10 +190,49 @@ pub(crate) async fn load_hedge_performance(
         }
     }
 
-    Ok(streams
+    let performances = streams
         .into_iter()
         .map(|(symbol, events)| fold_position_stream(symbol, events, &order_timelines))
-        .collect())
+        .collect();
+    Ok((performances, events_version))
+}
+
+/// Equality-only stamp of a report's event streams. Deliberately derives
+/// neither `PartialOrd` nor `Ord`: rowids are not a monotonic cursor, so
+/// "newer" comparisons would be meaningless -- callers may only ask "did
+/// anything change".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EventsVersion(i64);
+
+/// `MAX(rowid)` over the events rows of the given aggregate types: a cheap
+/// stamp for "has a relevant event been appended since this fold".
+///
+/// The stamp is scoped per report rather than global because other
+/// aggregates' rows ARE deleted at runtime (`InventorySnapshot` compaction)
+/// -- deleting the global max row lets SQLite reuse its rowid, so a global
+/// stamp could read equal across a delete+insert and serve a stale cache.
+/// Rows of the folded aggregate types are never deleted while the process
+/// serves requests, and SQLite assigns fresh rowids above the global max,
+/// so this scoped stamp changes exactly when a relevant event is appended.
+/// Scoping also keeps high-frequency snapshot writes from evicting the
+/// cache.
+pub(super) async fn events_version(
+    executor: impl sqlx::SqliteExecutor<'_>,
+    aggregate_types: &[&str],
+) -> Result<EventsVersion, PerformanceError> {
+    let placeholders = (1..=aggregate_types.len())
+        .map(|position| format!("${position}"))
+        .join(", ");
+    let sql = format!(
+        "SELECT COALESCE(MAX(rowid), 0) FROM events \
+         WHERE aggregate_type IN ({placeholders})"
+    );
+
+    let mut query = sqlx::query_scalar(&sql);
+    for aggregate_type in aggregate_types {
+        query = query.bind(*aggregate_type);
+    }
+    Ok(EventsVersion(query.fetch_one(executor).await?))
 }
 
 /// Broker-side timestamps of one hedge order, folded from its
@@ -1043,6 +1099,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn events_version_tracks_only_scoped_aggregate_types() {
+        let pool = setup_test_db().await;
+
+        let empty = events_version(&pool, HEDGE_AGGREGATE_TYPES).await.unwrap();
+        assert_eq!(empty, EventsVersion(0));
+
+        insert_event(
+            &pool,
+            "Position",
+            "AAPL",
+            1,
+            "PositionEvent::OnChainOrderFilled",
+            "{}",
+        )
+        .await;
+        let after_watched = events_version(&pool, HEDGE_AGGREGATE_TYPES).await.unwrap();
+        assert_ne!(
+            after_watched, empty,
+            "a scoped insert must change the stamp"
+        );
+
+        insert_event(
+            &pool,
+            "InventorySnapshot",
+            "inventory",
+            1,
+            "InventorySnapshotEvent::Recorded",
+            "{}",
+        )
+        .await;
+        let after_unwatched = events_version(&pool, HEDGE_AGGREGATE_TYPES).await.unwrap();
+        assert_eq!(
+            after_unwatched, after_watched,
+            "an unscoped insert must not change the stamp"
+        );
+    }
+
+    #[tokio::test]
     async fn load_hedge_performance_joins_position_and_order_streams() {
         let pool = setup_test_db().await;
         let order_id = OffchainOrderId::new();
@@ -1110,7 +1204,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         assert_eq!(report.len(), 1);
         assert_eq!(report[0].symbol, symbol());
@@ -1162,7 +1256,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         let cycle = &report[0].cycles[0];
         assert_eq!(cycle.outcome, HedgeOutcome::Pending);
@@ -1220,7 +1314,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         assert_eq!(report.len(), 1);
         let cycle = &report[0].cycles[0];
@@ -1253,7 +1347,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         assert_eq!(report.len(), 2);
         assert_eq!(report[0].symbol, Symbol::new("AAPL").unwrap());
@@ -1288,7 +1382,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         assert_eq!(report.len(), 1);
         assert_eq!(report[0].symbol, symbol());
@@ -1346,7 +1440,7 @@ mod tests {
             .await;
         }
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         let cycle = &report[0].cycles[0];
         assert_eq!(cycle.submitted_at, Some(timestamp(2)));
@@ -1414,7 +1508,7 @@ mod tests {
             .await;
         }
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         let cycle = &report[0].cycles[0];
         assert_eq!(cycle.submitted_at, Some(timestamp(12)));
@@ -1664,7 +1758,7 @@ mod tests {
         )
         .await;
 
-        let report = load_hedge_performance(&pool).await.unwrap();
+        let (report, _events_version) = load_hedge_performance(&pool).await.unwrap();
 
         assert_eq!(report.len(), 1);
         assert_eq!(report[0].fills.len(), 1);

--- a/src/performance/cache.rs
+++ b/src/performance/cache.rs
@@ -1,0 +1,364 @@
+//! Version-checked cache for the folded performance read models.
+//!
+//! The hedge and rebalance reports need full event streams for correct
+//! fill-to-hedge attribution, so a fold costs O(total event history).
+//! Folding on every request made each 30-second dashboard poll pay that
+//! cost forever. The cache stamps each folded value with the version of the
+//! event streams its loader observed (see `super::events_version`, scoped
+//! to the report's aggregate types) and refolds only when a fresh probe
+//! disagrees; an idle poll costs one cheap probe.
+//!
+//! Each report sits behind its own mutex held across the refold, so
+//! concurrent requests for the same report wait for one refold instead of
+//! each folding the full history, while the dashboard's simultaneous
+//! latency and rebalance requests still refresh in parallel.
+
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+use tokio::sync::Mutex;
+
+use st0x_dto::RebalanceOperationTiming;
+
+use super::rebalance::{REBALANCE_AGGREGATE_TYPES, load_rebalance_operations};
+use super::{
+    EventsVersion, HEDGE_AGGREGATE_TYPES, PerformanceError, SymbolPerformance,
+    load_hedge_performance,
+};
+
+/// Cached folds of the performance read models, shared via `AppState`.
+#[derive(Debug, Default)]
+pub(crate) struct PerformanceCache {
+    hedge: Mutex<Option<Cached<Vec<SymbolPerformance>>>>,
+    rebalance: Mutex<Option<Cached<Vec<RebalanceOperationTiming>>>>,
+}
+
+#[derive(Debug)]
+struct Cached<Value> {
+    events_version: EventsVersion,
+    value: Arc<Value>,
+}
+
+impl PerformanceCache {
+    /// Folded per-symbol hedge performance, refolded only when the hedge
+    /// event streams changed since the cached fold.
+    // The mutex guard is deliberately held across the refold await: that is
+    // what collapses concurrent requests for this report into a single fold
+    // (the documented thundering-herd guard), so the tightening clippy wants
+    // would defeat the design.
+    #[allow(clippy::significant_drop_tightening)]
+    pub(crate) async fn hedge_performances(
+        &self,
+        pool: &SqlitePool,
+    ) -> Result<Arc<Vec<SymbolPerformance>>, PerformanceError> {
+        let mut slot = self.hedge.lock().await;
+        if let Some(value) = fresh(slot.as_ref(), pool, HEDGE_AGGREGATE_TYPES).await? {
+            return Ok(value);
+        }
+
+        let (performances, events_version) = load_hedge_performance(pool).await?;
+        let value = Arc::new(performances);
+        *slot = Some(Cached {
+            events_version,
+            value: Arc::clone(&value),
+        });
+        Ok(value)
+    }
+
+    /// Folded rebalance operation timings, refolded only when the rebalance
+    /// event stream changed since the cached fold.
+    // See `hedge_performances`: the guard is held across the refold on
+    // purpose to serialize concurrent refolds of this report.
+    #[allow(clippy::significant_drop_tightening)]
+    pub(crate) async fn rebalance_operations(
+        &self,
+        pool: &SqlitePool,
+    ) -> Result<Arc<Vec<RebalanceOperationTiming>>, PerformanceError> {
+        let mut slot = self.rebalance.lock().await;
+        if let Some(value) = fresh(slot.as_ref(), pool, REBALANCE_AGGREGATE_TYPES).await? {
+            return Ok(value);
+        }
+
+        let (operations, events_version) = load_rebalance_operations(pool).await?;
+        let value = Arc::new(operations);
+        *slot = Some(Cached {
+            events_version,
+            value: Arc::clone(&value),
+        });
+        Ok(value)
+    }
+}
+
+/// The cached value, when the report's event streams still match its
+/// version stamp.
+///
+/// The probe deliberately runs outside the fold transaction: under
+/// concurrent writes it may under-report freshness (one extra refold whose
+/// entry is stamped from inside the fold's own transaction), but it can
+/// never over-report freshness and serve stale data. A probe error
+/// propagates to the caller without touching the slot -- the next request
+/// simply probes again.
+async fn fresh<Value: Send + Sync>(
+    cached: Option<&Cached<Value>>,
+    pool: &SqlitePool,
+    aggregate_types: &[&str],
+) -> Result<Option<Arc<Value>>, PerformanceError> {
+    let Some(cached) = cached else {
+        return Ok(None);
+    };
+    let current = super::events_version(pool, aggregate_types).await?;
+    Ok((current == cached.events_version).then(|| Arc::clone(&cached.value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::TxHash;
+    use chrono::{TimeZone, Utc};
+
+    use st0x_execution::{Direction, ExecutorOrderId, FractionalShares};
+    use st0x_finance::Usdc;
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::offchain::order::OffchainOrderEvent;
+    use crate::position::{PositionEvent, TradeId};
+    use crate::test_utils::setup_test_db;
+    use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent};
+
+    async fn insert_event(
+        pool: &SqlitePool,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: String,
+    ) {
+        sqlx::query(
+            "INSERT INTO events \
+             (aggregate_type, aggregate_id, sequence, event_type, event_version, \
+              payload, metadata) \
+             VALUES ($1, $2, $3, $4, '1.0', $5, '{}')",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_fill_event(pool: &SqlitePool, sequence: i64) {
+        let event = PositionEvent::OnChainOrderFilled {
+            trade_id: TradeId {
+                tx_hash: TxHash::random(),
+                log_index: 1,
+            },
+            amount: FractionalShares::new(float!(1)),
+            direction: Direction::Buy,
+            price_usdc: float!(150),
+            block_timestamp: Utc.timestamp_opt(1_750_000_000, 0).unwrap(),
+            seen_at: Utc.timestamp_opt(1_750_000_005, 0).unwrap(),
+        };
+        insert_event(
+            pool,
+            "Position",
+            "AAPL",
+            sequence,
+            "PositionEvent::OnChainOrderFilled",
+            serde_json::to_string(&event).unwrap(),
+        )
+        .await;
+    }
+
+    async fn insert_rebalance_event(pool: &SqlitePool, operation_id: &str) {
+        let event = UsdcRebalanceEvent::WithdrawalSubmitting {
+            direction: RebalanceDirection::BaseToAlpaca,
+            amount: Usdc::new(float!(1000)),
+            from_block: 1,
+            submitting_at: Utc.timestamp_opt(1_750_000_000, 0).unwrap(),
+        };
+        insert_event(
+            pool,
+            "UsdcRebalance",
+            operation_id,
+            1,
+            "UsdcRebalanceEvent::WithdrawalSubmitting",
+            serde_json::to_string(&event).unwrap(),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn serves_cached_fold_while_events_unchanged() {
+        let pool = setup_test_db().await;
+        insert_fill_event(&pool, 1).await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.hedge_performances(&pool).await.unwrap();
+        let second = cache.hedge_performances(&pool).await.unwrap();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "unchanged events table must serve the cached Arc"
+        );
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].fills.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn refolds_when_events_table_grows() {
+        let pool = setup_test_db().await;
+        insert_fill_event(&pool, 1).await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.hedge_performances(&pool).await.unwrap();
+        insert_fill_event(&pool, 2).await;
+        let second = cache.hedge_performances(&pool).await.unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a grown events table must trigger a refold"
+        );
+        assert_eq!(first[0].fills.len(), 1);
+        assert_eq!(second[0].fills.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rebalance_cache_refolds_when_its_stream_grows() {
+        let pool = setup_test_db().await;
+        insert_rebalance_event(&pool, "op-1").await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.rebalance_operations(&pool).await.unwrap();
+        insert_rebalance_event(&pool, "op-2").await;
+        let second = cache.rebalance_operations(&pool).await.unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a grown UsdcRebalance stream must trigger a refold"
+        );
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn caches_empty_fold_on_fresh_database() {
+        let pool = setup_test_db().await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.hedge_performances(&pool).await.unwrap();
+        let second = cache.hedge_performances(&pool).await.unwrap();
+
+        assert!(first.is_empty());
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "an empty events table must still be cached, not refolded per poll"
+        );
+    }
+
+    #[tokio::test]
+    async fn unrelated_aggregate_writes_do_not_evict_the_cache() {
+        let pool = setup_test_db().await;
+        insert_fill_event(&pool, 1).await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.hedge_performances(&pool).await.unwrap();
+        // High-frequency snapshot events (which are also compacted at
+        // runtime) must not invalidate the hedge report's scoped stamp.
+        insert_event(
+            &pool,
+            "InventorySnapshot",
+            "inventory",
+            1,
+            "InventorySnapshotEvent::Recorded",
+            "{}".to_string(),
+        )
+        .await;
+        let second = cache.hedge_performances(&pool).await.unwrap();
+
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "writes to unrelated aggregates must not evict the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn hedge_cache_refolds_when_order_stream_grows() {
+        let pool = setup_test_db().await;
+        insert_fill_event(&pool, 1).await;
+        let cache = PerformanceCache::default();
+
+        let first = cache.hedge_performances(&pool).await.unwrap();
+        // The hedge fold reads the OffchainOrder stream too; an append
+        // there must evict the cache (pins the stamp's scope to every
+        // stream the fold consumes, per HEDGE_AGGREGATE_TYPES).
+        let order = OffchainOrderEvent::Submitted {
+            executor_order_id: ExecutorOrderId::new("broker-1"),
+            submitted_at: Utc.timestamp_opt(1_750_000_010, 0).unwrap(),
+        };
+        insert_event(
+            &pool,
+            "OffchainOrder",
+            "11111111-2222-3333-4444-555555555555",
+            1,
+            "OffchainOrderEvent::Submitted",
+            serde_json::to_string(&order).unwrap(),
+        )
+        .await;
+        let second = cache.hedge_performances(&pool).await.unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "a grown OffchainOrder stream must trigger a hedge refold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_requests_share_one_refold() {
+        let pool = setup_test_db().await;
+        insert_fill_event(&pool, 1).await;
+        let cache = Arc::new(PerformanceCache::default());
+
+        let (first, second) = tokio::join!(
+            {
+                let cache = Arc::clone(&cache);
+                let pool = pool.clone();
+                async move { cache.hedge_performances(&pool).await.unwrap() }
+            },
+            {
+                let cache = Arc::clone(&cache);
+                let pool = pool.clone();
+                async move { cache.hedge_performances(&pool).await.unwrap() }
+            }
+        );
+
+        // The mutex held across the refold serializes the racing requests:
+        // whichever enters second must receive the first one's cached Arc
+        // rather than folding independently.
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "racing requests must share one fold"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebalance_cache_is_independent_of_hedge_cache() {
+        let pool = setup_test_db().await;
+        insert_rebalance_event(&pool, "op-1").await;
+        let cache = PerformanceCache::default();
+
+        let operations = cache.rebalance_operations(&pool).await.unwrap();
+        // A hedge-stream append must not evict the populated rebalance
+        // slot: each slot's stamp is scoped to its own aggregate types.
+        insert_fill_event(&pool, 1).await;
+        let operations_again = cache.rebalance_operations(&pool).await.unwrap();
+
+        assert_eq!(operations.len(), 1);
+        assert!(
+            Arc::ptr_eq(&operations, &operations_again),
+            "hedge writes must not evict the rebalance cache"
+        );
+    }
+}

--- a/src/performance/rebalance.rs
+++ b/src/performance/rebalance.rs
@@ -23,21 +23,32 @@ use crate::usdc_rebalance::{RebalanceDirection, UsdcRebalanceEvent};
 /// still reported via `total_operations`.
 const MAX_OPERATION_REPORTS: usize = 100;
 
-/// Load rebalance stage timings for operations started within `range`.
+/// Aggregate types the rebalance report folds; its cache stamp is scoped to
+/// exactly these (see `super::events_version`).
+pub(super) const REBALANCE_AGGREGATE_TYPES: &[&str] = &["UsdcRebalance"];
+
+/// Fold every `UsdcRebalance` aggregate into an operation timing row,
+/// together with the events-table version the fold observed (see
+/// `super::events_version`). Range filtering happens per request in
+/// [`rebalance_timing_report`] so the fold itself is cacheable.
 ///
 /// Undeserializable events are skipped with a warning rather than failing
 /// the whole report.
-pub(crate) async fn load_rebalance_timings(
+pub(crate) async fn load_rebalance_operations(
     pool: &SqlitePool,
-    range: &ReportRange,
-) -> Result<RebalanceTimings, PerformanceError> {
+) -> Result<(Vec<RebalanceOperationTiming>, super::EventsVersion), PerformanceError> {
+    let mut transaction = pool.begin().await?;
+
+    let events_version =
+        super::events_version(&mut *transaction, REBALANCE_AGGREGATE_TYPES).await?;
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT aggregate_id, payload FROM events \
          WHERE aggregate_type = 'UsdcRebalance' \
          ORDER BY aggregate_id, sequence",
     )
-    .fetch_all(pool)
+    .fetch_all(&mut *transaction)
     .await?;
+    transaction.commit().await?;
 
     let mut streams: BTreeMap<String, Vec<UsdcRebalanceEvent>> = BTreeMap::new();
     for (aggregate_id, payload) in rows {
@@ -54,22 +65,23 @@ pub(crate) async fn load_rebalance_timings(
         .filter_map(|(operation_id, events)| fold_operation(operation_id, &events))
         .collect();
 
-    Ok(rebalance_timing_report(operations, range))
+    Ok((operations, events_version))
 }
 
-/// Assemble the dashboard report from folded operations.
+/// Assemble the dashboard report for `range` from folded operations.
 pub(crate) fn rebalance_timing_report(
-    operations: Vec<RebalanceOperationTiming>,
+    operations: &[RebalanceOperationTiming],
     range: &ReportRange,
 ) -> RebalanceTimings {
-    let mut operations: Vec<RebalanceOperationTiming> = operations
-        .into_iter()
+    let mut in_range: Vec<RebalanceOperationTiming> = operations
+        .iter()
         .filter(|operation| range.contains(operation.started_at))
+        .cloned()
         .collect();
 
-    let stage_summary = stage_summary(&operations);
+    let stage_summary = stage_summary(&in_range);
 
-    let mut attestation_trend: Vec<AttestationSample> = operations
+    let mut attestation_trend: Vec<AttestationSample> = in_range
         .iter()
         .flat_map(|operation| &operation.stages)
         .filter(|stage| stage.stage == RebalanceStageName::Attestation && !stage.failed)
@@ -82,12 +94,12 @@ pub(crate) fn rebalance_timing_report(
         .collect();
     attestation_trend.sort_by_key(|sample| sample.burned_at);
 
-    operations.sort_unstable_by_key(|operation| std::cmp::Reverse(operation.started_at));
-    let total_operations = operations.len();
-    operations.truncate(MAX_OPERATION_REPORTS);
+    in_range.sort_unstable_by_key(|operation| std::cmp::Reverse(operation.started_at));
+    let total_operations = in_range.len();
+    in_range.truncate(MAX_OPERATION_REPORTS);
 
     RebalanceTimings {
-        operations,
+        operations: in_range,
         total_operations,
         stage_summary,
         attestation_trend,
@@ -752,7 +764,7 @@ mod tests {
             })
             .collect();
 
-        let report = rebalance_timing_report(operations, &range());
+        let report = rebalance_timing_report(&operations, &range());
 
         assert_eq!(report.total_operations, MAX_OPERATION_REPORTS + 1);
         assert_eq!(report.operations.len(), MAX_OPERATION_REPORTS);
@@ -762,7 +774,7 @@ mod tests {
     fn report_summarizes_stages_and_attestation_trend() {
         let first = fold_operation("op-1".to_string(), &alpaca_to_base_happy_path()).unwrap();
 
-        let report = rebalance_timing_report(vec![first], &range());
+        let report = rebalance_timing_report(&[first], &range());
 
         assert_eq!(report.total_operations, 1);
         assert_eq!(report.operations.len(), 1);
@@ -787,7 +799,7 @@ mod tests {
             to: timestamp(200_000),
         };
 
-        let report = rebalance_timing_report(vec![operation], &narrow);
+        let report = rebalance_timing_report(&[operation], &narrow);
 
         assert_eq!(report.total_operations, 0);
         assert!(report.operations.is_empty());
@@ -796,7 +808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn load_rebalance_timings_reads_event_store() {
+    async fn load_rebalance_operations_reads_event_store() {
         let pool = setup_test_db().await;
         let operation_id = Uuid::new_v4().to_string();
 
@@ -817,7 +829,8 @@ mod tests {
             .unwrap();
         }
 
-        let report = load_rebalance_timings(&pool, &range()).await.unwrap();
+        let (operations, _events_version) = load_rebalance_operations(&pool).await.unwrap();
+        let report = rebalance_timing_report(&operations, &range());
 
         assert_eq!(report.total_operations, 1);
         let operation = &report.operations[0];


### PR DESCRIPTION
## What

- Add a version-checked cache (`PerformanceCache`) for the folded hedge and rebalance performance read models, shared via `AppState`.
- `/performance/latencies` and `/performance/rebalances` read through the cache; `/performance/reliability` stays uncached (its query is already capped).

## Why

- Both reports fold the full event history (O(total events)), so every 30-second dashboard poll re-folded everything from scratch.
- [RAI-1005](https://linear.app/makeitrain/issue/RAI-1005)

## How

- Each report sits behind its own `tokio::Mutex<Option<Cached<…>>>`. A request locks, probes the events-table version with a cheap `SELECT COALESCE(MAX(rowid), 0) … WHERE aggregate_type IN (…)`, returns the cached `Arc` on a match, else refolds and re-stamps — holding the lock across the refold so concurrent requests for the same report collapse into a single fold.
- The version stamp is scoped per report to the aggregate types it folds (`HEDGE_AGGREGATE_TYPES` = Position + OffchainOrder; rebalance = UsdcRebalance) and read **inside** the loader's transaction. This is correctness-critical: InventorySnapshot events are compacted (deleted) at runtime and SQLite reuses rowids, so a global `MAX(rowid)` could make a stale cache look fresh — a scoped stamp only advances when a folded stream actually grows.
- `load_hedge_performance` / `load_rebalance_operations` now return `(Vec<…>, EventsVersion)`; `rebalance.rs` splits into a cacheable `load_rebalance_operations` fold plus a per-request `rebalance_timing_report(&[…], range)`.
- `EventsVersion` is an equality-only newtype (no `Ord` — versions are compared, never ordered).

## Testing

- New `cache.rs` tests: a cache hit returns the same `Arc`, hedge and rebalance reports refold when their own stream grows, unrelated-aggregate writes do not evict the cache, multi-threaded concurrent requests share one refold, and a direct `events_version` unit test.
- Existing api/dashboard tests updated to thread the cache through `AppState`.

## Anything else

- No schema change. Idle dashboard polls become one O(1) `MAX(rowid)` probe; a refold happens only when the relevant event stream actually grew.
