### PR TITLE
feat: block-lag and poll-cycle ingestion telemetry

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -93,6 +93,10 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     FailureEventType::export_all_to(out_dir)?;
     FailureEventCount::export_all_to(out_dir)?;
     JobQueueHealth::export_all_to(out_dir)?;
+    InfraReport::export_all_to(out_dir)?;
+    MonitorTelemetry::export_all_to(out_dir)?;
+    BlockLagPoint::export_all_to(out_dir)?;
+    PollHealth::export_all_to(out_dir)?;
     std::fs::write(out_dir.join("StatementGuard.ts"), Statement::guard_ts())
         .map_err(ts_rs::ExportError::Io)?;
 

--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -389,6 +389,53 @@ pub struct FailureEventCount {
     pub last_at: DateTime<Utc>,
 }
 
+/// Response of `GET /performance/infra`.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct InfraReport {
+    pub monitor: MonitorTelemetry,
+}
+
+/// Ingestion-health telemetry sampled by the order-fill monitor.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitorTelemetry {
+    /// Latest sampled block lag, regardless of the report range. `None`
+    /// until a sample with a backfill checkpoint exists.
+    #[ts(type = "number | null")]
+    pub current_lag_blocks: Option<i64>,
+    /// When the current lag was sampled, so the dashboard can flag a stale
+    /// monitor (no recent samples) distinctly from a healthy zero lag.
+    pub current_lag_sampled_at: Option<DateTime<Utc>>,
+    /// Worst observed block lag per time bucket, oldest first.
+    pub block_lag: Vec<BlockLagPoint>,
+    pub poll: PollHealth,
+}
+
+/// Worst block lag within one time bucket.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockLagPoint {
+    pub start: DateTime<Utc>,
+    #[ts(type = "number")]
+    pub max_lag_blocks: i64,
+}
+
+/// Poll-cycle health of the order-fill monitor within the report range.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct PollHealth {
+    #[ts(type = "number")]
+    pub cycles: usize,
+    #[ts(type = "number")]
+    pub errors: usize,
+    /// Poll ticks silently dropped because the previous cycle overran.
+    #[ts(type = "number")]
+    pub skipped_ticks: usize,
+    /// Poll duration percentiles; `null` with no cycles in range.
+    pub duration: Option<LatencyStats>,
+}
+
 /// Snapshot of one apalis job queue's health.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 #[serde(rename_all = "camelCase")]

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte'
   import * as Card from '$lib/components/ui/card'
   import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+  import type { InfraReport } from '$lib/api/InfraReport'
   import type { RebalanceStageName } from '$lib/api/RebalanceStageName'
   import type { RebalanceTimings } from '$lib/api/RebalanceTimings'
   import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
@@ -10,10 +11,12 @@
   import { reactive } from '$lib/frp.svelte'
   import {
     fetchHedgeLatencies,
+    fetchInfraReport,
     fetchRebalanceTimings,
     fetchReliabilityReport,
   } from '$lib/performance/api'
   import {
+    blockLagCard,
     detectionCard,
     errorsCard,
     exposureCard,
@@ -23,6 +26,7 @@
     type WaterfallSegmentName,
     type WaterfallSort,
     layoutAttestationTrend,
+    layoutBlockLagTrend,
     layoutPercentileSeries,
     layoutRebalanceBars,
     layoutWaterfall,
@@ -33,9 +37,14 @@
 
   const POLL_INTERVAL_MS = 30_000
   const CARD_WINDOW_HOURS = 24
+  // Mirrors the backend telemetry RETENTION (14d): ingestion-health samples
+  // (block lag, poll cycles) are pruned past this window, so a longer chart
+  // range would just render a truncated view.
+  const INGESTION_RETENTION_MS = 14 * 86_400_000
 
   const latencies = reactive<HedgeLatencies | null>(null)
   const reliability = reactive<ReliabilityReport | null>(null)
+  const infra = reactive<InfraReport | null>(null)
   const error = reactive<string | null>(null)
   const lastRefreshed = reactive<Date | null>(null)
 
@@ -47,6 +56,18 @@
     const seq = ++cardFetchSeq
     const to = new Date()
     const from = new Date(to.getTime() - CARD_WINDOW_HOURS * 3_600_000)
+
+    // Infra (block lag) is supplementary, so fetch it on its own promise: a
+    // transient /performance/infra failure must not block the latency and
+    // reliability refresh. On failure we keep the last infra value, which the
+    // block-lag card already degrades to STALE once its sample ages out.
+    const infraRefresh = fetchInfraReport({ from, to })
+      .then((infraReport) => {
+        if (seq === cardFetchSeq) infra.update(() => infraReport)
+      })
+      .catch(() => {
+        // Isolated: latency/reliability stay fresh even if infra is down.
+      })
 
     try {
       const [latencyReport, reliabilityReport] = await Promise.all([
@@ -68,6 +89,8 @@
         fetchError instanceof Error ? fetchError.message : 'Unknown error',
       )
     }
+
+    await infraRefresh
   }
 
   type RangePreset = '1W' | '1M' | 'YTD' | '1Y' | 'ALL'
@@ -100,6 +123,8 @@
   const chartRange = reactive<RangePreset>('1W')
   const chartLatencies = reactive<HedgeLatencies | null>(null)
   const chartRebalances = reactive<RebalanceTimings | null>(null)
+  const chartInfra = reactive<InfraReport | null>(null)
+  const ingestionTruncated = reactive<boolean>(false)
   const chartError = reactive<string | null>(null)
   // Timestamp captured at the moment the chart fetch was initiated, used as
   // `now` for in-progress cycle and operation elapsed-time calculations.
@@ -113,6 +138,24 @@
       from: rangeStart(chartRange.current, to),
       to,
     }
+
+    // Ingestion-health telemetry is pruned at the retention window, so clamp
+    // the infra query to it and flag when the selected range was truncated --
+    // a 1Y view must not be mistaken for "the system has only run 14 days".
+    const infraFrom = new Date(
+      Math.max(range.from.getTime(), to.getTime() - INGESTION_RETENTION_MS),
+    )
+    ingestionTruncated.update(() => infraFrom.getTime() > range.from.getTime())
+
+    // Infra is supplementary here too: keep its failure from blocking the
+    // latency and rebalance chart refresh (see refresh() for rationale).
+    const infraRefresh = fetchInfraReport({ from: infraFrom, to })
+      .then((infraReport) => {
+        if (seq === chartFetchSeq) chartInfra.update(() => infraReport)
+      })
+      .catch(() => {
+        // Isolated: latency/rebalance charts stay fresh even if infra is down.
+      })
 
     try {
       const [latencyReport, rebalanceReport] = await Promise.all([
@@ -133,6 +176,8 @@
         fetchError instanceof Error ? fetchError.message : 'Unknown error',
       )
     }
+
+    await infraRefresh
   }
 
   const selectRange = (preset: RangePreset) => {
@@ -158,6 +203,7 @@
     exposureCard(latencies.current),
     errorsCard(reliability.current, CARD_WINDOW_HOURS),
     openExposureCard(latencies.current, lastRefreshed.current),
+    blockLagCard(infra.current, lastRefreshed.current),
   ])
 
   const statusClasses = (status: SloStatus): string => {
@@ -284,6 +330,13 @@
     }),
   )
 
+  const blockLagTrend = $derived(
+    layoutBlockLagTrend(chartInfra.current?.monitor.blockLag ?? [], {
+      plotWidth: TREND_PLOT_WIDTH,
+      plotHeight: TREND_PLOT_HEIGHT,
+    }),
+  )
+
   const DIRECTION_LABELS: Record<UsdcBridgeDirection, string> = {
     alpaca_to_base: 'Alpaca → Base',
     base_to_alpaca: 'Base → Alpaca',
@@ -304,7 +357,7 @@
   {/if}
 
   <section>
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-5">
       {#each cards as card (card.title)}
         <Card.Root class={`border-l-4 ${statusClasses(card.status)}`}>
           <Card.Header class="pb-1">
@@ -658,6 +711,64 @@
               <circle cx={point.x} cy={point.y} r="2" fill="#fbbf24" />
             {/each}
           </svg>
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <Card.Title class="text-sm font-medium">Ingestion health</Card.Title>
+      {#if ingestionTruncated.current}
+        <p class="text-xs text-muted-foreground">
+          Showing the last 14 days · older samples are pruned by the telemetry
+          retention window.
+        </p>
+      {/if}
+    </Card.Header>
+    <Card.Content>
+      {#if blockLagTrend.points.length === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No block-lag samples in the selected range.
+        </p>
+      {:else}
+        <p class="mb-1 text-xs font-medium text-muted-foreground">
+          Worst block lag per bucket (max {blockLagTrend.maxLagBlocks} blocks)
+        </p>
+        <svg
+          viewBox={`0 0 ${String(TREND_PLOT_WIDTH)} ${String(TREND_PLOT_HEIGHT)}`}
+          class="h-20 w-full"
+          preserveAspectRatio="none"
+        >
+          <polyline
+            points={blockLagTrend.path}
+            fill="none"
+            stroke="#38bdf8"
+            stroke-width="1.5"
+          />
+          {#each blockLagTrend.points as point, pointIndex (pointIndex)}
+            <circle cx={point.x} cy={point.y} r="2" fill="#38bdf8" />
+          {/each}
+        </svg>
+      {/if}
+
+      {#if chartInfra.current}
+        {@const poll = chartInfra.current.monitor.poll}
+        <div class="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t pt-2 text-xs text-muted-foreground">
+          <span>{poll.cycles} poll cycles</span>
+          <span class={poll.errors > 0 ? 'text-red-400' : ''}>
+            {poll.errors} errors
+          </span>
+          <span class={poll.skippedTicks > 0 ? 'text-amber-400' : ''}>
+            {poll.skippedTicks} skipped ticks
+          </span>
+          {#if poll.duration}
+            <span>
+              poll p50 {formatDurationMs(poll.duration.p50Ms)} · p95
+              {formatDurationMs(poll.duration.p95Ms)} · max
+              {formatDurationMs(poll.duration.maxMs)}
+            </span>
+          {/if}
         </div>
       {/if}
     </Card.Content>

--- a/dashboard/src/lib/performance/api.ts
+++ b/dashboard/src/lib/performance/api.ts
@@ -1,4 +1,5 @@
 import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { InfraReport } from '$lib/api/InfraReport'
 import type { RebalanceTimings } from '$lib/api/RebalanceTimings'
 import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
 import { getApiBaseUrl } from '$lib/env'
@@ -58,3 +59,7 @@ export const fetchRebalanceTimings = async (
 export const fetchReliabilityReport = async (
   range: PerformanceRange = {},
 ): Promise<ReliabilityReport> => fetchPerformanceJson('/performance/reliability', range)
+
+export const fetchInfraReport = async (
+  range: PerformanceRange = {},
+): Promise<InfraReport> => fetchPerformanceJson('/performance/infra', range)

--- a/dashboard/src/lib/performance/cards.test.ts
+++ b/dashboard/src/lib/performance/cards.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
 import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { InfraReport } from '$lib/api/InfraReport'
 import type { JobQueueHealth } from '$lib/api/JobQueueHealth'
 import type { LatencyStats } from '$lib/api/LatencyStats'
 import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
 
-import { detectionCard, errorsCard, exposureCard, openExposureCard } from './cards'
+import {
+  blockLagCard,
+  detectionCard,
+  errorsCard,
+  exposureCard,
+  openExposureCard,
+} from './cards'
 
 const makeStats = (overrides: Partial<LatencyStats> = {}): LatencyStats => ({
   p50Ms: 5_000,
@@ -175,6 +182,112 @@ describe('errorsCard', () => {
 
     expect(card.status).toBe('good')
     expect(card.secondary).not.toContain('queue')
+  })
+})
+
+const infra = (overrides: Partial<InfraReport['monitor']>): InfraReport => ({
+  monitor: {
+    currentLagBlocks: 5,
+    currentLagSampledAt: '2026-06-01T00:00:00Z',
+    blockLag: [],
+    poll: {
+      cycles: 100,
+      errors: 0,
+      skippedTicks: 0,
+      duration: null,
+    },
+    ...overrides,
+  },
+})
+
+describe('blockLagCard', () => {
+  // One minute after the helper's currentLagSampledAt: fresh.
+  const freshNow = new Date('2026-06-01T00:01:00Z')
+
+  it('reports unknown while the report has not loaded', () => {
+    const card = blockLagCard(null, freshNow)
+
+    expect(card.status).toBe('unknown')
+    expect(card.primary).toBe('—')
+  })
+
+  it('reports unknown before the first refresh sets a clock', () => {
+    // The guard is `!report || !now`; this exercises the null-`now` branch
+    // independently of the null-report case above.
+    const card = blockLagCard(infra({}), null)
+
+    expect(card.status).toBe('unknown')
+    expect(card.primary).toBe('—')
+  })
+
+  it('reports unknown when no checkpointed sample exists yet', () => {
+    const card = blockLagCard(
+      infra({
+        currentLagBlocks: null,
+        currentLagSampledAt: null,
+      }),
+      freshNow,
+    )
+
+    expect(card.status).toBe('unknown')
+    expect(card.secondary).toBe('no checkpointed samples yet')
+  })
+
+  it('classifies the current lag against the block-lag thresholds', () => {
+    const card = blockLagCard(infra({}), freshNow)
+
+    expect(card.status).toBe('good')
+    expect(card.primary).toBe('5 blocks')
+    expect(card.secondary).toContain('sampled 1m 00s ago')
+  })
+
+  it('degrades to critical on a large lag and surfaces skipped ticks', () => {
+    const card = blockLagCard(
+      infra({
+        currentLagBlocks: 2_000,
+        poll: {
+          cycles: 100,
+          errors: 1,
+          skippedTicks: 7,
+          duration: null,
+        },
+      }),
+      freshNow,
+    )
+
+    expect(card.status).toBe('critical')
+    expect(card.primary).toBe('2000 blocks')
+    expect(card.secondary).toContain('7 skipped ticks')
+  })
+
+  it('classifies a mid-range lag as warning', () => {
+    // Between the good (30) and warning (300) thresholds.
+    const card = blockLagCard(infra({ currentLagBlocks: 100 }), freshNow)
+
+    expect(card.status).toBe('warning')
+    expect(card.primary).toBe('100 blocks')
+  })
+
+  it('degrades a healthy-looking lag to warning when the sample is stale', () => {
+    // A wedged monitor stops sampling: the frozen lag value must not keep
+    // rendering green.
+    const card = blockLagCard(infra({}), new Date('2026-06-01T03:00:00Z'))
+
+    expect(card.status).toBe('warning')
+    expect(card.secondary).toContain('STALE')
+    expect(card.secondary).toContain('3h 00m ago')
+  })
+
+  it('keeps a stale sample critical when the frozen lag was already critical', () => {
+    // Staleness floors the card at warning but must never downgrade a
+    // reading that was already worse.
+    const card = blockLagCard(
+      infra({ currentLagBlocks: 2_000 }),
+      new Date('2026-06-01T03:00:00Z'),
+    )
+
+    expect(card.status).toBe('critical')
+    expect(card.secondary).toContain('STALE')
   })
 })
 

--- a/dashboard/src/lib/performance/cards.ts
+++ b/dashboard/src/lib/performance/cards.ts
@@ -1,8 +1,10 @@
 /** Pure SLO card derivation for the Performance tab. */
 
 import type { HedgeLatencies } from '$lib/api/HedgeLatencies'
+import type { InfraReport } from '$lib/api/InfraReport'
 import type { ReliabilityReport } from '$lib/api/ReliabilityReport'
 import {
+  BLOCK_LAG_THRESHOLDS,
   DETECTION_THRESHOLDS,
   ERROR_COUNT_THRESHOLDS,
   EXPOSURE_WINDOW_THRESHOLDS,
@@ -115,6 +117,57 @@ export const errorsCard = (
             classifySlo(warnings, WARNING_COUNT_THRESHOLDS),
             queueStatus,
           ]),
+  }
+}
+
+/**
+ * A lag sample older than this is stale: the monitor polls every few
+ * seconds, so minutes without a sample means it is wedged or down — the
+ * exact failure the card exists to surface — and the frozen lag value can
+ * no longer be trusted as "current".
+ */
+const BLOCK_LAG_STALE_AFTER_MS = 300_000
+
+export const blockLagCard = (
+  report: InfraReport | null,
+  now: Date | null,
+): SloCard => {
+  if (!report || !now) {
+    return loadingCard('Block lag')
+  }
+
+  const { currentLagBlocks, currentLagSampledAt, poll } = report.monitor
+
+  if (currentLagBlocks === null || currentLagSampledAt === null) {
+    return {
+      title: 'Block lag',
+      primary: '—',
+      secondary: 'no checkpointed samples yet',
+      status: 'unknown',
+    }
+  }
+
+  const sampleAgeMs = now.getTime() - new Date(currentLagSampledAt).getTime()
+
+  if (sampleAgeMs > BLOCK_LAG_STALE_AFTER_MS) {
+    return {
+      title: 'Block lag',
+      primary: `${String(currentLagBlocks)} blocks`,
+      secondary: `STALE · sampled ${formatDurationMs(sampleAgeMs)} ago — monitor silent`,
+      // Staleness floors the card at warning, but a frozen reading that was
+      // already critical stays critical: a wedged monitor is at least as bad
+      // as a fresh one reporting the same lag.
+      status: worstStatus(['warning', classifySlo(currentLagBlocks, BLOCK_LAG_THRESHOLDS)]),
+    }
+  }
+
+  return {
+    title: 'Block lag',
+    primary: `${String(currentLagBlocks)} blocks`,
+    secondary:
+      `sampled ${formatDurationMs(sampleAgeMs)} ago · ` +
+      `${String(poll.skippedTicks)} skipped ticks`,
+    status: classifySlo(currentLagBlocks, BLOCK_LAG_THRESHOLDS),
   }
 }
 

--- a/dashboard/src/lib/performance/charts.test.ts
+++ b/dashboard/src/lib/performance/charts.test.ts
@@ -7,6 +7,7 @@ import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming
 
 import {
   layoutAttestationTrend,
+  layoutBlockLagTrend,
   layoutPercentileSeries,
   layoutRebalanceBars,
   layoutWaterfall,
@@ -370,6 +371,107 @@ describe('layoutAttestationTrend', () => {
     expect(layout.points[0]?.y).toBeCloseTo(25)
     expect(layout.points[1]?.y).toBeCloseTo(0)
     expect(layout.points[1]?.x).toBeCloseTo(100)
+  })
+})
+
+describe('layoutBlockLagTrend', () => {
+  it('centers a single bucket', () => {
+    const layout = layoutBlockLagTrend(
+      [
+        {
+          start: '2026-06-01T00:00:00Z',
+          maxLagBlocks: 12,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    expect(layout.points[0]?.x).toBeCloseTo(50)
+    expect(layout.maxLagBlocks).toBe(12)
+  })
+
+  it('centers a single zero-lag bucket on the baseline', () => {
+    // The common just-started state: one bucket, perfectly caught up. Hits
+    // the single-bucket centering and the divide-by-zero floor together.
+    const layout = layoutBlockLagTrend(
+      [
+        {
+          start: '2026-06-01T00:00:00Z',
+          maxLagBlocks: 0,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    expect(layout.points[0]?.x).toBeCloseTo(50)
+    expect(layout.points[0]?.y).toBe(50)
+    expect(layout.maxLagBlocks).toBe(0)
+  })
+
+  it('scales lag to the worst bucket', () => {
+    const layout = layoutBlockLagTrend(
+      [
+        {
+          start: '2026-06-01T00:00:00Z',
+          maxLagBlocks: 10,
+        },
+        {
+          start: '2026-06-01T01:00:00Z',
+          maxLagBlocks: 40,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    expect(layout.maxLagBlocks).toBe(40)
+    expect(layout.points[0]?.x).toBeCloseTo(0)
+    expect(layout.points[0]?.y).toBeCloseTo(37.5)
+    expect(layout.points[1]?.y).toBeCloseTo(0)
+    expect(layout.points[1]?.x).toBeCloseTo(100)
+  })
+
+  it('keeps a flat zero-lag series on the baseline without dividing by zero', () => {
+    const layout = layoutBlockLagTrend(
+      [
+        {
+          start: '2026-06-01T00:00:00Z',
+          maxLagBlocks: 0,
+        },
+        {
+          start: '2026-06-01T01:00:00Z',
+          maxLagBlocks: 0,
+        },
+      ],
+      {
+        plotWidth: 100,
+        plotHeight: 50,
+      },
+    )
+
+    // The reported maximum is the true series maximum, not the y-scale's
+    // divide-by-zero floor: a healthy panel must read "max 0 blocks".
+    expect(layout.maxLagBlocks).toBe(0)
+    expect(layout.points.every((point) => point.y === 50)).toBe(true)
+  })
+
+  it('returns an empty layout for no buckets', () => {
+    const layout = layoutBlockLagTrend([], {
+      plotWidth: 100,
+      plotHeight: 50,
+    })
+
+    expect(layout.points).toEqual([])
+    expect(layout.path).toBe('')
+    expect(layout.maxLagBlocks).toBe(0)
   })
 })
 

--- a/dashboard/src/lib/performance/charts.ts
+++ b/dashboard/src/lib/performance/charts.ts
@@ -1,6 +1,7 @@
 /** Pure SVG layout math for the Performance tab's latency charts. */
 
 import type { AttestationSample } from '$lib/api/AttestationSample'
+import type { BlockLagPoint } from '$lib/api/BlockLagPoint'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
 import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
@@ -271,6 +272,43 @@ export const layoutAttestationTrend = (
       .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
       .join(' '),
     maxMs,
+  }
+}
+
+export type BlockLagLayout = {
+  points: SeriesPoint[]
+  path: string
+  maxLagBlocks: number
+}
+
+/** Lays out per-bucket worst block lag over time as a single polyline. */
+export const layoutBlockLagTrend = (
+  buckets: BlockLagPoint[],
+  options: {
+    plotWidth: number
+    plotHeight: number
+  },
+): BlockLagLayout => {
+  const maxLagBlocks = Math.max(0, ...buckets.map((bucket) => bucket.maxLagBlocks))
+  // The y-scale denominator is floored at 1 so an all-zero series divides
+  // safely; the reported maximum stays the true value (0 for a healthy
+  // series), never the scale floor.
+  const scaleMax = Math.max(1, maxLagBlocks)
+  const xDenominator = Math.max(1, buckets.length - 1)
+  const points = buckets.map((bucket, index) => ({
+    x:
+      buckets.length <= 1
+        ? options.plotWidth / 2
+        : (index / xDenominator) * options.plotWidth,
+    y: options.plotHeight - (bucket.maxLagBlocks / scaleMax) * options.plotHeight,
+  }))
+
+  return {
+    points,
+    path: points
+      .map((point) => `${point.x.toFixed(1)},${point.y.toFixed(1)}`)
+      .join(' '),
+    maxLagBlocks,
   }
 }
 

--- a/dashboard/src/lib/performance/slo.ts
+++ b/dashboard/src/lib/performance/slo.ts
@@ -39,6 +39,17 @@ export const OPEN_EXPOSURE_AGE_THRESHOLDS: SloThresholds = {
   warning: 1_800_000,
 }
 
+/**
+ * Finalized blocks not yet processed by fill detection. Base produces a
+ * block every ~2s (https://docs.base.org/chain/network-information —
+ * re-derive these if Base ships faster blocks), so 30 blocks ≈ the 60s
+ * detection budget and 300 blocks ≈ 10 minutes of invisible fills.
+ */
+export const BLOCK_LAG_THRESHOLDS: SloThresholds = {
+  good: 30,
+  warning: 300,
+}
+
 const STATUS_RANK: Record<SloStatus, number> = {
   unknown: 0,
   good: 1,

--- a/migrations/20260612011519_monitor_telemetry.sql
+++ b/migrations/20260612011519_monitor_telemetry.sql
@@ -1,0 +1,45 @@
+-- Lightweight ingestion-health telemetry sampled by the order-fill monitor.
+-- High-frequency operational samples, deliberately outside the CQRS event
+-- store. Rows are pruned after a retention window; timestamps are stored as
+-- '%Y-%m-%dT%H:%M:%fZ' UTC text so lexicographic comparison equals time
+-- comparison. Every sample carries the orderbook it was taken against, so a
+-- database reused across configs never mixes telemetry series.
+
+CREATE TABLE block_lag_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sampled_at TEXT NOT NULL,
+    orderbook TEXT NOT NULL,
+    chain_tip INTEGER NOT NULL CHECK (chain_tip >= 0),
+    -- Latest finalized block: the ingestion cutoff lag is measured against.
+    finalized_block INTEGER NOT NULL CHECK (finalized_block >= 0),
+    -- NULL before the first backfill checkpoint exists.
+    last_processed_block INTEGER CHECK (last_processed_block >= 0),
+    -- finalized_block - last_processed_block; NULL while there is no checkpoint.
+    lag_blocks INTEGER CHECK (lag_blocks >= 0)
+);
+
+-- Read path filters by orderbook then ranges over sampled_at.
+CREATE INDEX idx_block_lag_samples_orderbook_sampled_at
+    ON block_lag_samples (orderbook, sampled_at);
+
+-- Retention pruning deletes by sampled_at alone.
+CREATE INDEX idx_block_lag_samples_sampled_at ON block_lag_samples (sampled_at);
+
+CREATE TABLE poll_cycle_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sampled_at TEXT NOT NULL,
+    monitor TEXT NOT NULL,
+    orderbook TEXT NOT NULL,
+    duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+    skipped_ticks INTEGER NOT NULL CHECK (skipped_ticks >= 0),
+    outcome TEXT NOT NULL CHECK (outcome IN ('ok', 'error')),
+    -- Populated only when outcome = 'error'.
+    error TEXT CHECK ((outcome = 'error') = (error IS NOT NULL))
+);
+
+-- Read path filters by monitor and orderbook then ranges over sampled_at.
+CREATE INDEX idx_poll_cycle_samples_monitor_orderbook_sampled_at
+    ON poll_cycle_samples (monitor, orderbook, sampled_at);
+
+-- Retention pruning deletes by sampled_at alone.
+CREATE INDEX idx_poll_cycle_samples_sampled_at ON poll_cycle_samples (sampled_at);

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,12 +16,13 @@ use sqlx::SqlitePool;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
-use st0x_dto::{HedgeLatencies, RebalanceTimings, ReliabilityReport, TradingVenue};
+use st0x_dto::{HedgeLatencies, InfraReport, RebalanceTimings, ReliabilityReport, TradingVenue};
 use st0x_execution::FractionalShares;
 
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
+use crate::performance::infra::load_monitor_telemetry;
 use crate::performance::rebalance::load_rebalance_timings;
 use crate::performance::reliability::{
     aggregate_log_entries, load_failure_events, load_job_queue_health,
@@ -1602,12 +1603,35 @@ async fn performance_reliability(
     }))
 }
 
+async fn performance_infra(
+    State(state): State<AppState>,
+    Query(query): Query<PerformanceRangeQuery>,
+) -> Result<Json<InfraReport>, StatusCode> {
+    let to = query.to.unwrap_or_else(Utc::now);
+    let from = query.from.unwrap_or(to - chrono::Duration::days(7));
+    if from >= to {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let monitor = load_monitor_telemetry(
+        &state.pool,
+        &ReportRange { from, to },
+        state.ctx.evm.orderbook,
+    )
+    .await
+    .inspect_err(|error| error!(%error, "Failed to load monitor telemetry"))
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(InfraReport { monitor }))
+}
+
 pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health))
         .route("/performance/latencies", get(performance_latencies))
         .route("/performance/rebalances", get(performance_rebalances))
         .route("/performance/reliability", get(performance_reliability))
+        .route("/performance/infra", get(performance_infra))
         .route("/logs", get(logs))
         .route("/orders/pending", get(pending_orders))
         .route("/trades", get(trades))
@@ -2175,6 +2199,141 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_infra_returns_empty_report_on_fresh_database() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/infra")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        // The full literal: a missing field or a camelCase typo must fail
+        // loudly, not match a `null` produced by indexing into nothing.
+        assert_eq!(
+            report,
+            serde_json::json!({
+                "monitor": {
+                    "currentLagBlocks": null,
+                    "currentLagSampledAt": null,
+                    "blockLag": [],
+                    "poll": {
+                        "cycles": 0,
+                        "errors": 0,
+                        "skippedTicks": 0,
+                        "duration": null,
+                    },
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn performance_infra_rejects_inverted_range() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let state = empty_app_state(ctx).await;
+        let app = build_app(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/performance/infra\
+                         ?from=2026-01-02T00:00:00Z&to=2026-01-01T00:00:00Z",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn performance_infra_reports_seeded_telemetry() {
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+        let orderbook = ctx.evm.orderbook;
+        let state = empty_app_state(ctx).await;
+        let now = chrono::Utc::now();
+
+        crate::telemetry::record_block_lag(
+            &state.pool,
+            &crate::telemetry::BlockLagSample {
+                sampled_at: now,
+                orderbook,
+                chain_tip: 120,
+                finalized_block: 117,
+                last_processed_block: Some(100),
+            },
+        )
+        .await
+        .unwrap();
+        crate::telemetry::record_poll_cycle(
+            &state.pool,
+            crate::telemetry::Monitor::OrderFill,
+            orderbook,
+            now,
+            std::time::Duration::from_millis(40),
+            1,
+            Ok::<(), &std::convert::Infallible>(()),
+        )
+        .await
+        .unwrap();
+
+        let app = build_app(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/performance/infra")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = body_to_string(response).await;
+        let report: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        // Lag = finalized_block (117) - checkpoint (100).
+        assert_eq!(report["monitor"]["currentLagBlocks"], serde_json::json!(17));
+        assert_eq!(
+            report["monitor"]["blockLag"][0]["maxLagBlocks"],
+            serde_json::json!(17)
+        );
+        // The bucket start anchors the dashboard's x-axis: it must parse as
+        // a timestamp inside the report's default 7-day window.
+        let bucket_start = report["monitor"]["blockLag"][0]["start"]
+            .as_str()
+            .expect("bucket start must be a timestamp string");
+        let bucket_start = chrono::DateTime::parse_from_rfc3339(bucket_start)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert!(
+            bucket_start <= now && now - bucket_start <= chrono::Duration::days(7),
+            "bucket start {bucket_start} must fall inside the default window"
+        );
+        assert_eq!(report["monitor"]["poll"]["cycles"], serde_json::json!(1));
+        assert_eq!(
+            report["monitor"]["poll"]["skippedTicks"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            report["monitor"]["poll"]["duration"]["p50Ms"],
+            serde_json::json!(40)
+        );
     }
 
     #[tokio::test]

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -2,19 +2,28 @@
 //! polling over a persisted checkpoint.
 //!
 //! Every `order_fill_poll_interval` seconds the monitor:
-//! 1. Skips the tick if a `BackfillRange` job is still in flight -- the
+//! 1. Records a block-lag telemetry sample (chain tip, finalized block,
+//!    checkpoint) before any skip, so ingestion lag stays observable even
+//!    during a long catch-up while a `BackfillRange` job is still in flight.
+//!    Lag is measured against the finalized block -- the actual ingestion
+//!    cutoff -- so a caught-up system reads zero.
+//! 2. Skips the tick if a `BackfillRange` job is still in flight -- the
 //!    checkpoint has not advanced yet, so re-enqueuing would re-scan the
 //!    same blocks (and during a long catch-up would stack unbounded
 //!    overlapping ranges).
-//! 2. Reads the chain's latest finalized block and uses it as the cutoff, so
+//! 3. Reads the chain's latest finalized block and uses it as the cutoff, so
 //!    ingestion never persists logs from blocks that could still reorg. A
 //!    finalized block cannot reorg, so this is real single-chain reorg
 //!    protection rather than a confirmation-depth heuristic.
-//! 3. Enqueues a `BackfillRange` job covering `(checkpoint+1, cutoff)`.
+//! 4. Enqueues a `BackfillRange` job covering `(checkpoint+1, cutoff)`.
 //!    The `backfill-worker` fetches the logs via HTTP `eth_getLogs`,
 //!    pushes an accounting job per fill, and advances the checkpoint only
 //!    on success -- so a failed range is retried and never silently
 //!    skipped. Downstream dedupes by `(tx_hash, log_index)`.
+//!
+//! Each tick also records a poll-cycle telemetry sample (poll duration,
+//! ticks skipped by `MissedTickBehavior::Skip`, and success/failure outcome)
+//! and periodically prunes expired telemetry rows.
 //!
 //! This replaces the previous WebSocket `.watch()` filter-polling path.
 //! On a load-balanced RPC, `.watch()` issued `eth_newFilter` once and
@@ -35,11 +44,12 @@
 //! protection project. `backfill_range` still surfaces a `removed: true` log
 //! loudly rather than masking it, as defense in depth.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use alloy::eips::BlockNumberOrTag;
 use alloy::providers::Provider;
 use alloy::transports::{RpcError, TransportErrorKind};
+use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use task_supervisor::{SupervisedTask, TaskResult};
 use tokio::time::MissedTickBehavior;
@@ -51,6 +61,9 @@ use crate::conductor::job::QueuePushError;
 use crate::onchain::OnChainError;
 use crate::onchain::backfill::{
     BackfillJobQueue, BackfillRange, backfill_start_from_checkpoint, load_backfill_checkpoint,
+};
+use crate::telemetry::{
+    BlockLagSample, Monitor, prune_expired, record_block_lag, record_poll_cycle,
 };
 
 /// Polls the orderbook chain for `ClearV3` / `TakeOrderV3` fills on a
@@ -98,11 +111,48 @@ impl<P: Provider + Clone + Send + Sync + 'static> SupervisedTask for OrderFillMo
 
         let mut interval = tokio::time::interval(self.poll_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut previous_tick: Option<Instant> = None;
+        let mut last_prune = Instant::now();
 
         loop {
             interval.tick().await;
+            let tick = Instant::now();
+            let elapsed = previous_tick.map(|previous| tick.duration_since(previous));
+            let skipped = skipped_ticks(elapsed, self.poll_interval);
+            previous_tick = Some(tick);
 
-            if let Err(error) = self.poll_once().await {
+            let sampled_at = Utc::now();
+            let result = self.poll_once(sampled_at).await;
+            // Capture elapsed right after poll_once returns: this measures the
+            // poll cycle's work -- including the in-cycle block-lag write
+            // poll_once performs -- while excluding the poll-cycle telemetry
+            // write below, which would otherwise measure itself.
+            let poll_duration = tick.elapsed();
+
+            // The poll-cycle outcome is a success/failure discriminator, so the
+            // structured PollOutcome on the success path is collapsed to `()`.
+            if let Err(error) = record_poll_cycle(
+                &self.pool,
+                Monitor::OrderFill,
+                self.evm_ctx.orderbook,
+                sampled_at,
+                poll_duration,
+                skipped,
+                result.as_ref().map(|_| ()),
+            )
+            .await
+            {
+                warn!(target: "orderbook", ?error, "Failed to record poll-cycle telemetry");
+            }
+
+            if last_prune.elapsed() >= PRUNE_INTERVAL {
+                last_prune = Instant::now();
+                if let Err(error) = prune_expired(&self.pool, Utc::now()).await {
+                    warn!(target: "orderbook", ?error, "Failed to prune expired telemetry");
+                }
+            }
+
+            if let Err(error) = result {
                 warn!(
                     target: "orderbook",
                     ?error,
@@ -111,6 +161,36 @@ impl<P: Provider + Clone + Send + Sync + 'static> SupervisedTask for OrderFillMo
             }
         }
     }
+}
+
+/// How often expired telemetry rows are pruned.
+const PRUNE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Ticks silently dropped by [`MissedTickBehavior::Skip`] since the previous
+/// tick: under Skip a slow poll fires nothing for the missed slots, so the
+/// only evidence is the wall-clock gap between consecutive ticks.
+///
+/// The accounting deliberately resets on a supervised restart
+/// (`previous_tick` starts `None`): downtime across restarts shows up as a
+/// gap in the `sampled_at` series rather than a skipped-tick count.
+fn skipped_ticks(elapsed_since_previous_tick: Option<Duration>, poll_interval: Duration) -> u64 {
+    let Some(elapsed) = elapsed_since_previous_tick else {
+        return 0;
+    };
+    let interval_ms = poll_interval.as_millis().max(1);
+    // Round to the nearest interval count to absorb timer jitter; intervals
+    // beyond the first are skips.
+    let elapsed_intervals = (elapsed.as_millis() + interval_ms / 2) / interval_ms;
+    // Clamp at i64::MAX (not u64::MAX) so the value always survives the
+    // storage layer's i64 conversion instead of failing the sample write.
+    // The clamp guarantees capped <= i64::MAX, so i64::try_from succeeds;
+    // unsigned_abs() then yields the equivalent u64 without sign extension.
+    let capped = elapsed_intervals
+        .saturating_sub(1)
+        .min(u128::from(i64::MAX.unsigned_abs()));
+    i64::try_from(capped)
+        .map(i64::unsigned_abs)
+        .unwrap_or(i64::MAX.unsigned_abs())
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -160,7 +240,35 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
     /// One poll iteration: enqueue a backfill range for the unprocessed
     /// blocks up to the latest finalized block, unless a previous range
     /// is still in flight or there is nothing new to fetch.
-    async fn poll_once(&mut self) -> Result<PollOutcome, OrderFillMonitorError> {
+    async fn poll_once(
+        &mut self,
+        sampled_at: DateTime<Utc>,
+    ) -> Result<PollOutcome, OrderFillMonitorError> {
+        // Read the chain tip and latest finalized block up front, before the
+        // overlap guard, so the block-lag sample is recorded even while a
+        // backfill is still in flight -- a long catch-up (or a stuck backfill)
+        // is exactly when growing lag must stay observable. The finalized block
+        // read here is also the ingestion cutoff used below.
+        let chain_tip = self.provider.get_block_number().await?;
+        let finalized = latest_finalized_block(&self.provider).await?;
+
+        // Block-lag telemetry is best-effort: a failed sample must never fail
+        // the poll. Lag is measured against the finalized block -- the real
+        // ingestion cutoff -- so a caught-up system reads zero rather than a
+        // permanent floor. A null finalized block records as 0, which saturates
+        // lag to 0.
+        let sampled_checkpoint = load_backfill_checkpoint(&self.pool, &self.evm_ctx).await?;
+        let sample = BlockLagSample {
+            sampled_at,
+            orderbook: self.evm_ctx.orderbook,
+            chain_tip,
+            finalized_block: finalized.unwrap_or(0),
+            last_processed_block: sampled_checkpoint,
+        };
+        if let Err(error) = record_block_lag(&self.pool, &sample).await {
+            warn!(target: "orderbook", ?error, "Failed to record block-lag telemetry");
+        }
+
         // Overlap guard: while a previous range is still being processed
         // the checkpoint has not advanced, so a fresh enqueue would
         // re-scan the same blocks. During a long catch-up this would
@@ -173,12 +281,12 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
             return Ok(PollOutcome::RangeInFlight);
         }
 
-        // Load the checkpoint once per tick: `from_block` is derived from it, and
-        // both the null-finality guard and the finality-regression branch use
-        // whether it exists to tell an expected cold-start skip from a
-        // checkpoint-backed skip that signals an RPC finality anomaly. One read
-        // keeps those decisions consistent (no intra-tick TOCTOU) and avoids a
-        // redundant round-trip.
+        // Re-read the checkpoint now that the guard has passed: an in-flight job
+        // may have completed (advancing the checkpoint) between the telemetry
+        // read above and the guard, and deriving the range from the stale value
+        // would re-scan blocks that job just processed. This single post-guard
+        // read is the source for both the null-finality branch and the range
+        // derivation, keeping those decisions consistent (no intra-tick TOCTOU).
         let checkpoint = load_backfill_checkpoint(&self.pool, &self.evm_ctx).await?;
 
         // Cutoff is the chain's latest finalized block. Backfill is guaranteed
@@ -186,7 +294,7 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
         // reorg, so an ingested fill can never be invalidated. `None` means the
         // node reports no finalized block yet (a chain shallower than finality);
         // there is nothing safe to ingest, so skip the tick.
-        let Some(cutoff_block) = latest_finalized_block(&self.provider).await? else {
+        let Some(cutoff_block) = finalized else {
             // No finalized block reported. Once a checkpoint exists the chain
             // has demonstrably finalized blocks before, so a null response is an
             // RPC problem (a load-balanced node returning no finality) worth a
@@ -393,16 +501,39 @@ mod tests {
         block
     }
 
+    /// Single finalized-block read, for [`probe_finalized_block_support`] tests
+    /// (the probe reads only the finalized block; the tip is passed in).
     fn provider_with_finalized(number: u64) -> impl Provider + Clone {
         let asserter = Asserter::new();
         asserter.push_success(&finalized_at(number));
         ProviderBuilder::new().connect_mocked_client(asserter)
     }
 
-    /// A provider whose node reports no finalized block yet (null response).
+    /// A provider whose node reports no finalized block yet (null response),
+    /// for [`probe_finalized_block_support`] tests (single finalized read).
     fn provider_without_finalized() -> impl Provider + Clone {
         let asserter = Asserter::new();
         asserter.push_success(&Value::Null);
+        ProviderBuilder::new().connect_mocked_client(asserter)
+    }
+
+    /// Queues the two RPC responses a single `poll_once` tick reads, in order:
+    /// `eth_blockNumber` (the chain tip) then `eth_getBlockByNumber("finalized")`.
+    /// `finalized: None` queues a JSON null -- a node reporting no finalized
+    /// block yet.
+    fn push_tick(asserter: &Asserter, chain_tip: u64, finalized: Option<u64>) {
+        asserter.push_success(&Value::from(chain_tip));
+        match finalized {
+            Some(number) => asserter.push_success(&finalized_at(number)),
+            None => asserter.push_success(&Value::Null),
+        }
+    }
+
+    /// Mock provider answering a single `poll_once` tick: chain tip `chain_tip`
+    /// then finalized block `finalized`.
+    fn provider_at(chain_tip: u64, finalized: u64) -> impl Provider + Clone {
+        let asserter = Asserter::new();
+        push_tick(&asserter, chain_tip, Some(finalized));
         ProviderBuilder::new().connect_mocked_client(asserter)
     }
 
@@ -471,12 +602,12 @@ mod tests {
     #[tokio::test]
     async fn poll_once_enqueues_range_up_to_finalized_block() {
         // checkpoint=99, finalized=102 -> from=100, cutoff=102.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(102)).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at(110, 102)).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
             .await
             .unwrap();
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -494,9 +625,9 @@ mod tests {
     #[tokio::test]
     async fn poll_once_uses_deployment_block_without_checkpoint() {
         // No checkpoint: from_block falls back to deployment_block (1).
-        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_with_finalized(50)).await;
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at(55, 50)).await;
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -513,12 +644,12 @@ mod tests {
     #[tokio::test]
     async fn poll_once_skips_when_caught_up() {
         // checkpoint=102, finalized=102 -> from=103 > cutoff.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(102)).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at(110, 102)).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 102)
             .await
             .unwrap();
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(outcome, PollOutcome::CaughtUp);
         assert_eq!(
@@ -534,12 +665,12 @@ mod tests {
         // A load-balanced RPC returns a finalized block (150) below the already
         // persisted checkpoint (200) -> from_block=201 is >1 past the cutoff.
         // Ingestion must pause (warn path) without enqueuing or moving anything.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(150)).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at(205, 150)).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 200)
             .await
             .unwrap();
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -571,9 +702,9 @@ mod tests {
         // (1) == `cutoff` (0) + 1, but with no committed progress this is NOT
         // "caught up" -- it is the deployment block one short of finalizing, so
         // the outcome must be FinalityBehindDeployment, not CaughtUp.
-        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_with_finalized(0)).await;
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at(5, 0)).await;
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -596,12 +727,12 @@ mod tests {
         // NOT past finality -- so this must be the quiet deployment-wait, not the
         // loud finality-regression warning that blames the RPC.
         let (mut monitor, pool, apalis_pool, evm_ctx) =
-            setup_with_deployment_block(provider_with_finalized(10), 100).await;
+            setup_with_deployment_block(provider_at(15, 10), 100).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 5)
             .await
             .unwrap();
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -623,9 +754,12 @@ mod tests {
     async fn poll_once_does_not_enqueue_when_no_finalized_block_yet() {
         // No finalized block and no checkpoint (cold start) -> skip the tick
         // without enqueuing anything.
-        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_without_finalized()).await;
+        let asserter = Asserter::new();
+        push_tick(&asserter, 50, None);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider).await;
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -646,9 +780,12 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn poll_once_skips_intermittent_null_without_moving_checkpoint() {
+        // Two ticks: the first reports null finality, the second a real
+        // finalized block. Each tick reads the chain tip then the finalized
+        // block.
         let asserter = Asserter::new();
-        asserter.push_success(&Value::Null);
-        asserter.push_success(&finalized_at(105));
+        push_tick(&asserter, 104, None);
+        push_tick(&asserter, 110, Some(105));
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
         let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
@@ -658,7 +795,7 @@ mod tests {
         // First tick: node returns null finality -> skip, checkpoint frozen.
         // A checkpoint exists, so this is the warn branch, distinct from the
         // cold-start debug branch despite identical side effects.
-        let first = monitor.poll_once().await.unwrap();
+        let first = monitor.poll_once(Utc::now()).await.unwrap();
         assert_eq!(
             first,
             PollOutcome::NoFinalityWithCheckpoint,
@@ -682,7 +819,7 @@ mod tests {
         );
 
         // Second tick: finality is back -> resume from exactly checkpoint+1.
-        let second = monitor.poll_once().await.unwrap();
+        let second = monitor.poll_once(Utc::now()).await.unwrap();
         assert_eq!(
             second,
             PollOutcome::Enqueued {
@@ -719,7 +856,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = monitor.poll_once().await;
+        let result = monitor.poll_once(Utc::now()).await;
         assert!(
             matches!(result, Err(OrderFillMonitorError::Rpc(_))),
             "A severed RPC must surface as a typed RPC error; got: {result:?}",
@@ -727,7 +864,7 @@ mod tests {
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             0,
-            "No backfill range may be enqueued off a failed finalized-block read"
+            "No backfill range may be enqueued off a failed chain-state read"
         );
         assert_eq!(
             crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
@@ -757,10 +894,10 @@ mod tests {
             required_confirmations: 0,
         };
 
-        // One finalized-block response per poll_once call.
+        // One chain-tip + finalized-block response pair per poll_once call.
         let asserter = Asserter::new();
-        asserter.push_success(&finalized_at(50));
-        asserter.push_success(&finalized_at(50));
+        push_tick(&asserter, 55, Some(50));
+        push_tick(&asserter, 55, Some(50));
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let mut monitor = OrderFillMonitor::new(
@@ -781,10 +918,11 @@ mod tests {
             .await
             .unwrap();
 
-        // The in-flight check is a read and succeeds under the WAL write
-        // lock; the enqueue INSERT blocks, then errors after the busy
-        // timeout.
-        let result = monitor.poll_once().await;
+        // The block-lag telemetry write blocks then fails under the lock, but
+        // it is best-effort (swallowed). The in-flight check is a read and
+        // succeeds under the WAL write lock; the enqueue INSERT then blocks and
+        // errors after the busy timeout -- that is the error poll_once returns.
+        let result = monitor.poll_once(Utc::now()).await;
         assert!(
             matches!(result, Err(OrderFillMonitorError::Enqueue(_))),
             "A write-locked database must surface as a typed enqueue \
@@ -798,7 +936,7 @@ mod tests {
 
         sqlx::query("ROLLBACK").execute(&mut locker).await.unwrap();
 
-        monitor.poll_once().await.unwrap();
+        monitor.poll_once(Utc::now()).await.unwrap();
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             1,
@@ -813,11 +951,10 @@ mod tests {
     #[tokio::test]
     async fn poll_once_skips_while_backfill_in_flight() {
         // A pending BackfillRange already exists: the overlap guard must
-        // short-circuit before enqueuing (and before touching the provider,
-        // so the empty asserter is never polled).
-        let asserter = Asserter::new();
-        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
+        // short-circuit before enqueuing. The block-lag sample IS still
+        // recorded first -- a long catch-up (a backfill in flight) is exactly
+        // when lag must stay observable.
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at(140, 100)).await;
 
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
@@ -832,7 +969,7 @@ mod tests {
             .unwrap();
         assert_eq!(backfill_job_count(&apalis_pool).await, 1);
 
-        let outcome = monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once(Utc::now()).await.unwrap();
 
         assert_eq!(
             outcome,
@@ -844,6 +981,16 @@ mod tests {
             1,
             "overlap guard must prevent a second enqueue while one is in flight"
         );
+        let lag_blocks: Option<i64> =
+            sqlx::query_scalar("SELECT lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            lag_blocks,
+            Some(90),
+            "lag (finalized 100 - checkpoint 10) must be sampled even while a backfill is in flight"
+        );
     }
 
     #[tokio::test]
@@ -853,7 +1000,15 @@ mod tests {
         // indefinitely -- the deterministic worker name means apalis never
         // ages the orphan out. `requeue_orphaned`, wired at conductor startup,
         // is what unwedges it.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(105)).await;
+        //
+        // Both ticks read the provider (the lag sample is recorded before the
+        // overlap guard): the first while wedged, the second after the orphan
+        // reaches a terminal state.
+        let asserter = Asserter::new();
+        push_tick(&asserter, 110, Some(105));
+        push_tick(&asserter, 110, Some(105));
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
             .unwrap();
@@ -876,7 +1031,8 @@ mod tests {
         .unwrap();
 
         // The wedge: the poller skips while the orphan counts as in flight.
-        monitor.poll_once().await.unwrap();
+        // The lag sample is still recorded (reads happen before the guard).
+        monitor.poll_once(Utc::now()).await.unwrap();
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             1,
@@ -904,11 +1060,116 @@ mod tests {
             .await
             .unwrap();
 
-        monitor.poll_once().await.unwrap();
+        monitor.poll_once(Utc::now()).await.unwrap();
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             2,
             "once the orphan reaches a terminal state the poller enqueues a new range"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_once_records_block_lag_sample() {
+        // tip=105, finalized=102, checkpoint=99 -> lag = finalized - checkpoint = 3.
+        let (mut monitor, pool, _apalis_pool, evm_ctx) = setup(provider_at(105, 102)).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
+            .await
+            .unwrap();
+
+        monitor.poll_once(Utc::now()).await.unwrap();
+
+        let (chain_tip, finalized_block, last_processed_block, lag_blocks): (
+            i64,
+            i64,
+            Option<i64>,
+            Option<i64>,
+        ) = sqlx::query_as(
+            "SELECT chain_tip, finalized_block, last_processed_block, lag_blocks \
+             FROM block_lag_samples",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(chain_tip, 105);
+        assert_eq!(finalized_block, 102);
+        assert_eq!(last_processed_block, Some(99));
+        assert_eq!(lag_blocks, Some(3));
+    }
+
+    #[tokio::test]
+    async fn poll_once_reads_zero_lag_when_caught_up() {
+        // checkpoint == finalized: a healthy caught-up system must read 0, not a
+        // permanent floor.
+        let (mut monitor, pool, _apalis_pool, evm_ctx) = setup(provider_at(105, 102)).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 102)
+            .await
+            .unwrap();
+
+        monitor.poll_once(Utc::now()).await.unwrap();
+
+        let lag_blocks: Option<i64> =
+            sqlx::query_scalar("SELECT lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(lag_blocks, Some(0));
+    }
+
+    #[tokio::test]
+    async fn poll_once_records_null_lag_without_checkpoint() {
+        let (mut monitor, pool, _apalis_pool, _evm_ctx) = setup(provider_at(55, 50)).await;
+
+        monitor.poll_once(Utc::now()).await.unwrap();
+
+        let lag_blocks: Option<i64> =
+            sqlx::query_scalar("SELECT lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(lag_blocks, None);
+    }
+
+    #[test]
+    fn skipped_ticks_is_zero_for_first_and_on_time_ticks() {
+        let interval = Duration::from_secs(5);
+
+        assert_eq!(skipped_ticks(None, interval), 0);
+        assert_eq!(skipped_ticks(Some(Duration::from_secs(5)), interval), 0);
+        // Jitter well under half an interval still counts as on time.
+        assert_eq!(
+            skipped_ticks(Some(Duration::from_millis(5_400)), interval),
+            0
+        );
+    }
+
+    #[test]
+    fn skipped_ticks_counts_missed_intervals() {
+        let interval = Duration::from_secs(5);
+
+        assert_eq!(skipped_ticks(Some(Duration::from_secs(10)), interval), 1);
+        assert_eq!(skipped_ticks(Some(Duration::from_secs(31)), interval), 5);
+        // The rounding boundary: half an interval past the first tick tips
+        // the count from "on time" to one skip.
+        assert_eq!(
+            skipped_ticks(Some(Duration::from_millis(7_499)), interval),
+            0
+        );
+        assert_eq!(
+            skipped_ticks(Some(Duration::from_millis(7_500)), interval),
+            1
+        );
+    }
+
+    #[test]
+    fn skipped_ticks_clamps_at_i64_max_for_storage() {
+        // A pathological gap must clamp at i64::MAX (the storage layer's
+        // integer width), not fail the eventual sample write.
+        assert_eq!(
+            skipped_ticks(
+                Some(Duration::from_millis(u64::MAX)),
+                Duration::from_millis(1)
+            ),
+            i64::MAX.unsigned_abs()
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod position;
 mod position_check;
 mod rebalancing;
 mod symbol;
+mod telemetry;
 mod tokenization;
 mod trading;
 #[cfg(feature = "mock")]

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -43,6 +43,7 @@ use st0x_execution::Symbol;
 use crate::offchain::order::{OffchainOrder, OffchainOrderEvent, OffchainOrderId};
 use crate::position::{Position, PositionEvent, TradeId};
 
+pub(crate) mod infra;
 pub(crate) mod rebalance;
 pub(crate) mod reliability;
 

--- a/src/performance/infra.rs
+++ b/src/performance/infra.rs
@@ -1,0 +1,410 @@
+//! Ingestion-infrastructure read model over the telemetry store.
+//!
+//! Surfaces the order-fill monitor's block-lag and poll-cycle samples
+//! (recorded by `crate::telemetry`) as the dashboard's ingestion-health
+//! report: current block lag, worst lag per time bucket, and poll-cycle
+//! duration/error/skipped-tick aggregates. Strictly read-only.
+
+use alloy::primitives::Address;
+use chrono::{DateTime, Duration, SubsecRound, Utc};
+use sqlx::SqlitePool;
+use tracing::warn;
+
+use st0x_dto::{BlockLagPoint, MonitorTelemetry, PollHealth};
+
+use super::{PerformanceError, ReportRange, latency_stats};
+use crate::telemetry::{Monitor, PollOutcome, sqlite_timestamp};
+
+/// Load the monitor's ingestion-health telemetry for `range`, scoped to
+/// the configured `orderbook` (samples carry the orderbook they were taken
+/// against, so a database reused across configs never mixes lag series).
+///
+/// The current block lag reflects the latest sample regardless of the
+/// range: it answers "how far behind is detection right now", while the
+/// bucketed series answers "how did lag trend over the window".
+pub(crate) async fn load_monitor_telemetry(
+    pool: &SqlitePool,
+    range: &ReportRange,
+    orderbook: Address,
+) -> Result<MonitorTelemetry, PerformanceError> {
+    let (current_lag_blocks, current_lag_sampled_at) = current_lag(pool, orderbook).await?;
+    let block_lag = block_lag_buckets(pool, range, orderbook).await?;
+    let poll_summary = poll_health(pool, range, orderbook).await?;
+
+    Ok(MonitorTelemetry {
+        current_lag_blocks,
+        current_lag_sampled_at,
+        block_lag,
+        poll: poll_summary,
+    })
+}
+
+async fn current_lag(
+    pool: &SqlitePool,
+    orderbook: Address,
+) -> Result<(Option<i64>, Option<DateTime<Utc>>), PerformanceError> {
+    let latest: Option<(String, i64)> = sqlx::query_as(
+        "SELECT sampled_at, lag_blocks FROM block_lag_samples \
+         WHERE lag_blocks IS NOT NULL AND orderbook = $1 \
+         ORDER BY sampled_at DESC, id DESC LIMIT 1",
+    )
+    .bind(orderbook.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(match latest {
+        Some((raw_sampled_at, lag_blocks)) => {
+            // A corrupt timestamp makes the lag value unanchorable in time.
+            // Return both fields as null so the TS client treats it as "no
+            // sample" rather than showing lag without a timestamp.
+            let ts = parse_timestamp(&raw_sampled_at);
+            (ts.map(|_| lag_blocks), ts)
+        }
+        None => (None, None),
+    })
+}
+
+/// Worst lag per time bucket, aggregated in SQL so a multi-day range never
+/// materializes its raw sample rows (one per poll tick) into the heap.
+/// Samples without a checkpoint carry a NULL lag; they prove the monitor
+/// polled but contribute nothing to the lag trend.
+async fn block_lag_buckets(
+    pool: &SqlitePool,
+    range: &ReportRange,
+    orderbook: Address,
+) -> Result<Vec<BlockLagPoint>, PerformanceError> {
+    let width = range.bucket_width();
+    // strftime('%s', ...) truncates sample timestamps to whole seconds, so
+    // the bucket origin is truncated the same way; otherwise a fractional
+    // origin could push the last bucket's computed start past the newest
+    // sample it contains.
+    let origin = range.from.trunc_subsecs(0);
+    let rows: Vec<(i64, i64)> = sqlx::query_as(
+        "SELECT (CAST(strftime('%s', sampled_at) AS INTEGER) - $4) / $5 AS bucket_index, \
+                MAX(lag_blocks) AS max_lag_blocks \
+         FROM block_lag_samples \
+         WHERE sampled_at BETWEEN $1 AND $2 AND orderbook = $3 \
+           AND lag_blocks IS NOT NULL \
+         GROUP BY bucket_index \
+         ORDER BY bucket_index",
+    )
+    .bind(sqlite_timestamp(range.from))
+    .bind(sqlite_timestamp(range.to))
+    .bind(orderbook.to_string())
+    .bind(origin.timestamp())
+    .bind(width.num_seconds())
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(index, max_lag_blocks)| BlockLagPoint {
+            start: origin + Duration::seconds(width.num_seconds() * index),
+            max_lag_blocks,
+        })
+        .collect())
+}
+
+async fn poll_health(
+    pool: &SqlitePool,
+    range: &ReportRange,
+    orderbook: Address,
+) -> Result<PollHealth, PerformanceError> {
+    // Aggregate cycles, errors, and skipped_ticks in SQL to avoid
+    // materializing potentially large row sets into the heap. The error count
+    // uses the canonical PollOutcome discriminator so writer and reader cannot
+    // drift. Duration percentiles still require the individual values, so only
+    // that column is fetched as a separate query.
+    let aggregate: AggregateRow = sqlx::query_as(
+        "SELECT COUNT(*) AS cycles, \
+                SUM(CASE WHEN outcome = $5 THEN 1 ELSE 0 END) AS errors, \
+                SUM(skipped_ticks) AS skipped_ticks_sum \
+         FROM poll_cycle_samples \
+         WHERE sampled_at BETWEEN $1 AND $2 AND monitor = $3 AND orderbook = $4",
+    )
+    .bind(sqlite_timestamp(range.from))
+    .bind(sqlite_timestamp(range.to))
+    .bind(Monitor::OrderFill.as_str())
+    .bind(orderbook.to_string())
+    .bind(PollOutcome::Error.as_str())
+    .fetch_one(pool)
+    .await?;
+
+    let mut durations: Vec<i64> = sqlx::query_scalar(
+        "SELECT duration_ms FROM poll_cycle_samples \
+         WHERE sampled_at BETWEEN $1 AND $2 AND monitor = $3 AND orderbook = $4",
+    )
+    .bind(sqlite_timestamp(range.from))
+    .bind(sqlite_timestamp(range.to))
+    .bind(Monitor::OrderFill.as_str())
+    .bind(orderbook.to_string())
+    .fetch_all(pool)
+    .await?;
+
+    Ok(PollHealth {
+        cycles: count(aggregate.cycles),
+        errors: count(aggregate.errors.unwrap_or(0)),
+        skipped_ticks: count(aggregate.skipped_ticks_sum.unwrap_or(0)),
+        duration: latency_stats(&mut durations),
+    })
+}
+
+/// SQL-aggregated counts for one poll-health query. `cycles` is never null
+/// (`COUNT(*)` always returns a value); the `SUM` columns are `NULL` when
+/// there are no matching rows, mapped to zero by the caller.
+#[derive(sqlx::FromRow)]
+struct AggregateRow {
+    cycles: i64,
+    errors: Option<i64>,
+    skipped_ticks_sum: Option<i64>,
+}
+
+/// Stored counts are non-negative by schema CHECK; a negative value means a
+/// corrupted row, logged loudly before falling back to zero.
+fn count(value: i64) -> usize {
+    usize::try_from(value).unwrap_or_else(|_| {
+        warn!(value, "Negative count in telemetry row; reporting zero");
+        0
+    })
+}
+
+fn parse_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|parsed| parsed.with_timezone(&Utc))
+        .inspect_err(|error| warn!(%raw, %error, "Skipping telemetry row with malformed timestamp"))
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::time::Duration as StdDuration;
+
+    use alloy::primitives::address;
+    use chrono::TimeZone;
+
+    use crate::telemetry::{BlockLagSample, record_block_lag, record_poll_cycle};
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
+    }
+
+    /// Orderbook all test samples are recorded against.
+    const ORDERBOOK: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn range() -> ReportRange {
+        ReportRange {
+            from: timestamp(0),
+            to: timestamp(86_400),
+        }
+    }
+
+    async fn insert_lag_for(
+        pool: &SqlitePool,
+        orderbook: Address,
+        seconds: i64,
+        chain_tip: u64,
+        checkpoint: Option<u64>,
+    ) {
+        record_block_lag(
+            pool,
+            &BlockLagSample {
+                sampled_at: timestamp(seconds),
+                orderbook,
+                chain_tip,
+                finalized_block: chain_tip.saturating_sub(3),
+                last_processed_block: checkpoint,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn insert_lag(pool: &SqlitePool, seconds: i64, chain_tip: u64, checkpoint: Option<u64>) {
+        insert_lag_for(pool, ORDERBOOK, seconds, chain_tip, checkpoint).await;
+    }
+
+    #[tokio::test]
+    async fn reports_latest_lag_and_bucketed_maxima() {
+        let pool = setup_test_db().await;
+        insert_lag(&pool, 10, 110, Some(100)).await; // finalized 107, lag 7
+        insert_lag(&pool, 20, 125, Some(100)).await; // finalized 122, lag 22
+        insert_lag(&pool, 4_000, 210, Some(205)).await; // finalized 207, lag 2
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.current_lag_blocks, Some(2));
+        assert_eq!(telemetry.current_lag_sampled_at, Some(timestamp(4_000)));
+        assert_eq!(
+            telemetry.block_lag,
+            vec![
+                BlockLagPoint {
+                    start: timestamp(0),
+                    max_lag_blocks: 22,
+                },
+                BlockLagPoint {
+                    start: timestamp(3_600),
+                    max_lag_blocks: 2,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn current_lag_ignores_range_but_buckets_respect_it() {
+        let pool = setup_test_db().await;
+        // Outside (after) the report range, with a DISTINCT lag value so
+        // the assertion can tell which sample won: finalized 497, lag 2.
+        insert_lag(&pool, 100_000, 500, Some(495)).await;
+        // In range: finalized 107, lag 7.
+        insert_lag(&pool, 10, 110, Some(100)).await;
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            telemetry.current_lag_blocks,
+            Some(2),
+            "current lag must come from the freshest sample, even out of range"
+        );
+        assert_eq!(telemetry.block_lag.len(), 1);
+        assert_eq!(telemetry.block_lag[0].max_lag_blocks, 7);
+    }
+
+    #[tokio::test]
+    async fn other_orderbooks_samples_are_excluded() {
+        let pool = setup_test_db().await;
+        insert_lag(&pool, 10, 110, Some(100)).await; // lag 7
+        insert_lag_for(
+            &pool,
+            address!("0x2222222222222222222222222222222222222222"),
+            20,
+            500,
+            Some(400),
+        )
+        .await;
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.current_lag_blocks, Some(7));
+        assert_eq!(telemetry.block_lag.len(), 1);
+        assert_eq!(telemetry.block_lag[0].max_lag_blocks, 7);
+    }
+
+    #[tokio::test]
+    async fn checkpointless_samples_do_not_produce_lag_points() {
+        let pool = setup_test_db().await;
+        insert_lag(&pool, 10, 110, None).await;
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.current_lag_blocks, None);
+        assert_eq!(telemetry.current_lag_sampled_at, None);
+        assert!(telemetry.block_lag.is_empty());
+    }
+
+    #[tokio::test]
+    async fn aggregates_poll_cycle_health() {
+        let pool = setup_test_db().await;
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            ORDERBOOK,
+            timestamp(10),
+            StdDuration::from_millis(100),
+            0,
+            Ok::<(), &Infallible>(()),
+        )
+        .await
+        .unwrap();
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            ORDERBOOK,
+            timestamp(20),
+            StdDuration::from_millis(300),
+            2,
+            Err(&"rpc unreachable"),
+        )
+        .await
+        .unwrap();
+        // Outside the range: must not be counted.
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            ORDERBOOK,
+            timestamp(-100),
+            StdDuration::from_millis(900),
+            5,
+            Ok::<(), &Infallible>(()),
+        )
+        .await
+        .unwrap();
+        // A different monitor's samples must not pollute the aggregates.
+        sqlx::query(
+            "INSERT INTO poll_cycle_samples \
+             (sampled_at, monitor, orderbook, duration_ms, skipped_ticks, outcome, error) \
+             VALUES ($1, 'other_monitor', $2, 9000, 9, 'ok', NULL)",
+        )
+        .bind(sqlite_timestamp(timestamp(30)))
+        .bind(ORDERBOOK.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+        // Another orderbook's poll cycles must not pollute the aggregates
+        // either: a database reused across configs keeps series separate.
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            address!("0x2222222222222222222222222222222222222222"),
+            timestamp(40),
+            StdDuration::from_millis(7_000),
+            8,
+            Err(&"other orderbook outage"),
+        )
+        .await
+        .unwrap();
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.poll.cycles, 2);
+        assert_eq!(telemetry.poll.errors, 1);
+        assert_eq!(telemetry.poll.skipped_ticks, 2);
+        let duration = telemetry.poll.duration.unwrap();
+        assert_eq!(duration.sample_count, 2);
+        assert_eq!(duration.max_ms, 300);
+    }
+
+    #[tokio::test]
+    async fn empty_store_yields_empty_report() {
+        let pool = setup_test_db().await;
+
+        let telemetry = load_monitor_telemetry(&pool, &range(), ORDERBOOK)
+            .await
+            .unwrap();
+
+        assert_eq!(telemetry.current_lag_blocks, None);
+        assert!(telemetry.block_lag.is_empty());
+        assert_eq!(
+            telemetry.poll,
+            PollHealth {
+                cycles: 0,
+                errors: 0,
+                skipped_ticks: 0,
+                duration: None,
+            }
+        );
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,393 @@
+//! Lightweight operational telemetry store.
+//!
+//! Persists high-frequency ingestion-health samples (chain-tip block lag,
+//! poll-cycle duration and skipped ticks) to plain SQLite tables, outside
+//! the CQRS event store: these are operational observations, not domain
+//! events. Writes are best-effort from the caller's perspective -- a failed
+//! sample must never fail the monitored operation -- and rows older than
+//! [`RETENTION`] are pruned opportunistically.
+
+use std::fmt::Display;
+use std::num::TryFromIntError;
+use std::time::Duration;
+
+use alloy::primitives::Address;
+use chrono::{DateTime, SecondsFormat, Utc};
+use sqlx::SqlitePool;
+use thiserror::Error;
+
+/// How long telemetry samples are retained. Telemetry is an operational
+/// debugging aid, not an audit trail; two weeks comfortably covers "what
+/// changed since last week" investigations.
+const RETENTION: chrono::Duration = chrono::Duration::days(14);
+
+/// One observation of how far fill detection trails the chain.
+#[derive(Debug, Clone)]
+pub(crate) struct BlockLagSample {
+    pub(crate) sampled_at: DateTime<Utc>,
+    pub(crate) orderbook: Address,
+    pub(crate) chain_tip: u64,
+    pub(crate) finalized_block: u64,
+    /// `None` before the first backfill checkpoint exists.
+    pub(crate) last_processed_block: Option<u64>,
+}
+
+impl BlockLagSample {
+    /// Finalized blocks not yet processed: `finalized_block -
+    /// last_processed_block`. Measured against the finalized block (the
+    /// ingestion cutoff) rather than the raw tip because the checkpoint can
+    /// only ever advance to the finalized block -- against the raw tip a fully
+    /// caught-up system would read a permanent floor of the finality lag
+    /// instead of zero. Saturates at zero: a load-balanced RPC can briefly
+    /// report a finalized block behind the checkpoint, which is staleness
+    /// noise, not negative lag.
+    fn lag_blocks(&self) -> Option<u64> {
+        self.last_processed_block
+            .map(|checkpoint| self.finalized_block.saturating_sub(checkpoint))
+    }
+}
+
+/// Monitor a poll-cycle sample belongs to. An enum (not a free string) so
+/// writers and the read path cannot drift on the label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Monitor {
+    OrderFill,
+}
+
+impl Monitor {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::OrderFill => "order_fill",
+        }
+    }
+}
+
+/// Whether a poll cycle succeeded or produced an error. An enum (not a raw
+/// string) so the writer and reader share a single source of truth for the
+/// discriminator stored in the `outcome` column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PollOutcome {
+    Ok,
+    Error,
+}
+
+impl PollOutcome {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Error => "error",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum TelemetryError {
+    #[error("failed to write telemetry sample")]
+    Database(#[from] sqlx::Error),
+    #[error("telemetry value out of range for storage")]
+    IntConversion(#[from] TryFromIntError),
+}
+
+/// Format a timestamp exactly like SQLite's
+/// `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` so stored text timestamps
+/// compare lexicographically as times.
+pub(crate) fn sqlite_timestamp(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+/// Persist one block-lag sample.
+pub(crate) async fn record_block_lag(
+    pool: &SqlitePool,
+    sample: &BlockLagSample,
+) -> Result<(), TelemetryError> {
+    let lag_blocks = sample.lag_blocks().map(i64::try_from).transpose()?;
+    let last_processed_block = sample.last_processed_block.map(i64::try_from).transpose()?;
+
+    sqlx::query(
+        "INSERT INTO block_lag_samples \
+         (sampled_at, orderbook, chain_tip, finalized_block, last_processed_block, \
+          lag_blocks) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(sqlite_timestamp(sample.sampled_at))
+    .bind(sample.orderbook.to_string())
+    .bind(i64::try_from(sample.chain_tip)?)
+    .bind(i64::try_from(sample.finalized_block)?)
+    .bind(last_processed_block)
+    .bind(lag_blocks)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Persist one poll-cycle sample. The outcome keeps the caller's structured
+/// error until this storage boundary, where it is rendered once into the
+/// operator-facing `error` text column.
+pub(crate) async fn record_poll_cycle(
+    pool: &SqlitePool,
+    monitor: Monitor,
+    orderbook: Address,
+    sampled_at: DateTime<Utc>,
+    duration: Duration,
+    skipped_ticks: u64,
+    // `Sync` so `&error` is `Send` and the returned future stays `Send` for
+    // the supervised monitor task.
+    outcome: Result<(), &(impl Display + Sync)>,
+) -> Result<(), TelemetryError> {
+    let (outcome_label, error) = match outcome {
+        Ok(()) => (PollOutcome::Ok, None),
+        Err(error) => (PollOutcome::Error, Some(error.to_string())),
+    };
+
+    sqlx::query(
+        "INSERT INTO poll_cycle_samples \
+         (sampled_at, monitor, orderbook, duration_ms, skipped_ticks, outcome, error) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(sqlite_timestamp(sampled_at))
+    .bind(monitor.as_str())
+    .bind(orderbook.to_string())
+    .bind(i64::try_from(duration.as_millis())?)
+    .bind(i64::try_from(skipped_ticks)?)
+    .bind(outcome_label.as_str())
+    .bind(error)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Delete telemetry samples older than the retention window. Cheap when
+/// there is nothing to delete (indexed seek), so callers run it on their
+/// own cadence without coordination.
+pub(crate) async fn prune_expired(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+) -> Result<(), TelemetryError> {
+    let cutoff = sqlite_timestamp(now - RETENTION);
+
+    sqlx::query("DELETE FROM block_lag_samples WHERE sampled_at < $1")
+        .bind(&cutoff)
+        .execute(pool)
+        .await?;
+    sqlx::query("DELETE FROM poll_cycle_samples WHERE sampled_at < $1")
+        .bind(&cutoff)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use alloy::primitives::address;
+    use chrono::TimeZone;
+
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    fn timestamp(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_750_000_000 + seconds, 0).unwrap()
+    }
+
+    fn sample(seconds: i64, chain_tip: u64, checkpoint: Option<u64>) -> BlockLagSample {
+        BlockLagSample {
+            sampled_at: timestamp(seconds),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            chain_tip,
+            // Finality trails the tip by a few blocks in this mock.
+            finalized_block: chain_tip.saturating_sub(3),
+            last_processed_block: checkpoint,
+        }
+    }
+
+    #[tokio::test]
+    async fn record_block_lag_computes_lag_from_checkpoint() {
+        let pool = setup_test_db().await;
+
+        record_block_lag(&pool, &sample(0, 105, Some(100)))
+            .await
+            .unwrap();
+
+        let (chain_tip, lag_blocks): (i64, Option<i64>) =
+            sqlx::query_as("SELECT chain_tip, lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(chain_tip, 105);
+        // Lag measures finalized_block (105 - 3 = 102) minus the checkpoint
+        // (100): a caught-up system reads zero, not the finality lag.
+        assert_eq!(lag_blocks, Some(2));
+    }
+
+    #[tokio::test]
+    async fn record_block_lag_stores_null_lag_without_checkpoint() {
+        let pool = setup_test_db().await;
+
+        record_block_lag(&pool, &sample(0, 105, None))
+            .await
+            .unwrap();
+
+        let (last_processed_block, lag_blocks): (Option<i64>, Option<i64>) =
+            sqlx::query_as("SELECT last_processed_block, lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(last_processed_block, None);
+        assert_eq!(lag_blocks, None);
+    }
+
+    #[tokio::test]
+    async fn record_block_lag_saturates_stale_finalized_to_zero() {
+        let pool = setup_test_db().await;
+
+        // A load-balanced RPC reported a finalized block behind the checkpoint.
+        record_block_lag(&pool, &sample(0, 99, Some(100)))
+            .await
+            .unwrap();
+
+        let lag_blocks: Option<i64> =
+            sqlx::query_scalar("SELECT lag_blocks FROM block_lag_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(lag_blocks, Some(0));
+    }
+
+    /// Orderbook all test samples are recorded against.
+    const ORDERBOOK: Address = address!("0x1111111111111111111111111111111111111111");
+
+    #[tokio::test]
+    async fn record_poll_cycle_stores_outcome_and_error() {
+        let pool = setup_test_db().await;
+
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            ORDERBOOK,
+            timestamp(0),
+            Duration::from_millis(250),
+            2,
+            Err(&"rpc unreachable"),
+        )
+        .await
+        .unwrap();
+
+        let row: (String, String, i64, i64, String, Option<String>) = sqlx::query_as(
+            "SELECT monitor, orderbook, duration_ms, skipped_ticks, outcome, error \
+             FROM poll_cycle_samples",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, "order_fill");
+        assert_eq!(row.1, ORDERBOOK.to_string());
+        assert_eq!(row.2, 250);
+        assert_eq!(row.3, 2);
+        assert_eq!(row.4, PollOutcome::Error.as_str());
+        assert_eq!(row.5, Some("rpc unreachable".to_string()));
+    }
+
+    #[tokio::test]
+    async fn record_poll_cycle_stores_ok_outcome_with_null_error() {
+        let pool = setup_test_db().await;
+        use std::convert::Infallible;
+
+        record_poll_cycle(
+            &pool,
+            Monitor::OrderFill,
+            ORDERBOOK,
+            timestamp(0),
+            Duration::from_millis(100),
+            0,
+            Ok::<(), &Infallible>(()),
+        )
+        .await
+        .unwrap();
+
+        let (outcome, error): (String, Option<String>) =
+            sqlx::query_as("SELECT outcome, error FROM poll_cycle_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            outcome,
+            PollOutcome::Ok.as_str(),
+            "a successful cycle must be stored with the ok discriminator"
+        );
+        assert_eq!(
+            error, None,
+            "a successful cycle must have a null error column"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_expired_keeps_samples_inside_retention() {
+        let pool = setup_test_db().await;
+        let now = timestamp(0);
+        let expired = now - RETENTION - chrono::Duration::hours(1);
+        // Exactly at the cutoff: the predicate is strictly `<`, so a sample
+        // precisely RETENTION old must survive.
+        let at_cutoff = now - RETENTION;
+        let retained = now - RETENTION + chrono::Duration::hours(1);
+
+        for sampled_at in [expired, at_cutoff, retained] {
+            record_block_lag(
+                &pool,
+                &BlockLagSample {
+                    sampled_at,
+                    ..sample(0, 105, Some(100))
+                },
+            )
+            .await
+            .unwrap();
+            record_poll_cycle(
+                &pool,
+                Monitor::OrderFill,
+                ORDERBOOK,
+                sampled_at,
+                Duration::ZERO,
+                0,
+                Ok::<(), &Infallible>(()),
+            )
+            .await
+            .unwrap();
+        }
+
+        prune_expired(&pool, now).await.unwrap();
+
+        // Both tables share the cutoff computation; assert each strictly-`<`
+        // predicate keeps the at-cutoff row by listing the survivors exactly.
+        let lag_rows: Vec<String> =
+            sqlx::query_scalar("SELECT sampled_at FROM block_lag_samples ORDER BY sampled_at")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        let cycle_rows: Vec<String> =
+            sqlx::query_scalar("SELECT sampled_at FROM poll_cycle_samples ORDER BY sampled_at")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        let survivors = vec![sqlite_timestamp(at_cutoff), sqlite_timestamp(retained)];
+        assert_eq!(
+            lag_rows, survivors,
+            "the at-cutoff and in-retention lag samples survive; only the \
+             expired one is pruned"
+        );
+        assert_eq!(
+            cycle_rows, survivors,
+            "the at-cutoff and in-retention poll cycles survive; only the \
+             expired one is pruned"
+        );
+    }
+
+    #[test]
+    fn sqlite_timestamp_matches_sqlite_strftime_format() {
+        let formatted = sqlite_timestamp(Utc.timestamp_opt(1_750_000_000, 123_000_000).unwrap());
+        assert_eq!(formatted, "2025-06-15T15:06:40.123Z");
+    }
+}


### PR DESCRIPTION
## What

- Per-poll telemetry store: two new SQLite tables (`block_lag_samples`, `poll_cycle_samples`) sampled by the order-fill monitor each tick; rows carry the orderbook they were sampled against and are pruned after 14 days.
- `GET /performance/infra` endpoint surfacing current lag, worst-lag-per-bucket trend, and poll-cycle health (duration percentiles, error count, skipped ticks).
- Dashboard: a block-lag SLO card (5th in the card row) and a block-lag trend sparkline on the Performance tab.

## Why

- [RAI-997](https://linear.app/makeitrain/issue/RAI-997)
- The monitor's ingestion lag and poll health were invisible — nothing showed whether fill detection was keeping up with the chain or silently stuck.

## How

- Migration `monitor_telemetry`: `block_lag_samples` and `poll_cycle_samples` with composite `(orderbook, sampled_at)` / `(monitor, orderbook, sampled_at)` read indexes and `sampled_at` prune indexes; timestamps as RFC3339-millis text for lexicographic time ordering.
- `OrderFillMonitor::poll_once` records the block-lag sample **before** the in-flight overlap guard so lag stays observable during long catch-ups and stuck backfills. Lag is measured against the **confirmed** tip (not the raw tip), so a caught-up system reads 0 blocks (not a permanent floor of `required_confirmations`). After the guard passes the checkpoint is re-read so a job completing in between doesn't cause the monitor to re-scan already-processed blocks.
- Skipped ticks under `MissedTickBehavior::Skip` are inferred from wall-clock gap between consecutive ticks, rounded to the nearest interval, and clamped at `i64::MAX` for safe storage.
- Read model `src/performance/infra.rs`: aggregates computed in SQL via `GROUP BY` (not heap-materialized), scoped to the configured orderbook.
- `Monitor` enum (not a free string) keeps writers and the read path from drifting on the label. `PollOutcome` enum (`ok`/`error`) stored as a SQL `CHECK` constraint.
- Dashboard block-lag card degrades to warning when the latest sample is stale (no recent samples) and stays critical if the frozen lag was already critical; SLO thresholds anchored to Base's ~2s block time (30 blocks = 60s warning, 300 blocks = 10 min critical).

## Testing

- Backend: telemetry record/prune (including exact at-cutoff retention boundary), `poll_once` lag sampling (caught-up reads 0, in-flight still samples, null without a checkpoint), skipped-tick jitter boundary and `i64::MAX` clamp, infra read aggregation + cross-orderbook exclusion, `/performance/infra` endpoint (seeded, empty, inverted-range rejection).
- Dashboard: card classification across good/warning/critical/stale, `layoutBlockLagTrend` (centering, scaling, all-zero divide-by-zero, empty).

## Anything else

- Adds one migration. Telemetry is best-effort — a failed sample never fails the monitored poll. These tables are intentionally outside CQRS (operational observations, not domain events).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard displays new "Ingestion health" card showing block lag trends and poll cycle diagnostics.
  * New API endpoint `/performance/infra` exposes infrastructure and monitor telemetry.
  * System now tracks and records block lag samples and poll cycle metrics for observability.

* **Database**
  * New telemetry schema added to persist block-lag and poll-cycle samples with time-based indexes and pruning support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->