### PR TITLE
feat: RPC and broker dependency call telemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,7 @@ sqlx-apalis = { version = "0.8.6", package = "sqlx", features = [
 ] }
 st0x-issuance-client = { git = "https://github.com/ST0x-Technology/st0x.issuance.git", tag = "0.2.0", version = "0.1.0" }
 st0x-issuance-dto = { git = "https://github.com/ST0x-Technology/st0x.issuance.git", tag = "0.2.0", version = "0.1.0" }
+tower = { version = "0.5.3", features = ["util"] }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -97,6 +97,9 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     MonitorTelemetry::export_all_to(out_dir)?;
     BlockLagPoint::export_all_to(out_dir)?;
     PollHealth::export_all_to(out_dir)?;
+    DependencyName::export_all_to(out_dir)?;
+    DependencyStats::export_all_to(out_dir)?;
+    DependencyBucket::export_all_to(out_dir)?;
     std::fs::write(out_dir.join("StatementGuard.ts"), Statement::guard_ts())
         .map_err(ts_rs::ExportError::Io)?;
 

--- a/crates/dto/src/performance.rs
+++ b/crates/dto/src/performance.rs
@@ -394,6 +394,46 @@ pub struct FailureEventCount {
 #[serde(rename_all = "camelCase")]
 pub struct InfraReport {
     pub monitor: MonitorTelemetry,
+    /// Latency/error aggregates per external dependency operation, ordered
+    /// by dependency then operation.
+    pub dependencies: Vec<DependencyStats>,
+}
+
+/// External dependency a call sample was recorded against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyName {
+    Rpc,
+    Broker,
+}
+
+/// Latency and error aggregates for one operation against one dependency.
+#[derive(Debug, Clone, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyStats {
+    pub dependency: DependencyName,
+    pub operation: String,
+    #[ts(type = "number")]
+    pub calls: usize,
+    #[ts(type = "number")]
+    pub errors: usize,
+    /// Whole-range latency percentiles.
+    pub latency: Option<LatencyStats>,
+    /// Per-bucket call/error counts and median latency, oldest first.
+    pub buckets: Vec<DependencyBucket>,
+}
+
+/// One time bucket of dependency calls.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyBucket {
+    pub start: DateTime<Utc>,
+    #[ts(type = "number")]
+    pub calls: usize,
+    #[ts(type = "number")]
+    pub errors: usize,
+    #[ts(type = "number | null")]
+    pub p50_ms: Option<i64>,
 }
 
 /// Ingestion-health telemetry sampled by the order-fill monitor.

--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -27,6 +27,7 @@
     type WaterfallSort,
     layoutAttestationTrend,
     layoutBlockLagTrend,
+    layoutDependencySparkline,
     layoutPercentileSeries,
     layoutRebalanceBars,
     layoutWaterfall,
@@ -769,6 +770,68 @@
               {formatDurationMs(poll.duration.maxMs)}
             </span>
           {/if}
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+
+  <Card.Root>
+    <Card.Header class="pb-2">
+      <Card.Title class="text-sm font-medium">Dependency health</Card.Title>
+      <p class="text-xs text-muted-foreground">
+        Per-operation latency and errors for the RPC provider and broker API.
+        Sparkline bars are per-bucket median latency; red bars contain errors.
+      </p>
+    </Card.Header>
+    <Card.Content>
+      {#if (chartInfra.current?.dependencies.length ?? 0) === 0}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          No dependency calls in the selected range.
+        </p>
+      {:else}
+        <div class="flex flex-col gap-1">
+          {#each chartInfra.current?.dependencies ?? [] as row (`${row.dependency}:${row.operation}`)}
+            {@const bars = layoutDependencySparkline(row.buckets, { plotHeight: 12 })}
+            <div class="flex items-center gap-2 text-xs">
+              <span class="w-14 shrink-0 font-semibold uppercase text-muted-foreground">
+                {row.dependency}
+              </span>
+              <span class="w-44 shrink-0 truncate font-mono">{row.operation}</span>
+              <svg
+                viewBox={`0 0 ${String(bars.length * 6)} 14`}
+                class="h-3.5 w-28 shrink-0"
+                preserveAspectRatio="none"
+              >
+                {#each bars as bar, barIndex (barIndex)}
+                  <rect
+                    x={barIndex * 6}
+                    y={14 - bar.height - 1}
+                    width="4"
+                    height={bar.height + 1}
+                    fill={bar.hasErrors ? '#f87171' : '#38bdf8'}
+                    opacity="0.9"
+                  />
+                {/each}
+              </svg>
+              <span class="w-20 shrink-0 text-right tabular-nums text-muted-foreground">
+                {row.calls} calls
+              </span>
+              <span
+                class={`w-16 shrink-0 text-right tabular-nums ${row.errors > 0 ? 'text-red-400' : 'text-muted-foreground'}`}
+              >
+                {row.errors} err
+              </span>
+              <span class="min-w-0 flex-1 truncate text-right tabular-nums text-muted-foreground">
+                {#if row.latency}
+                  p50 {formatDurationMs(row.latency.p50Ms)} · p95
+                  {formatDurationMs(row.latency.p95Ms)} · max
+                  {formatDurationMs(row.latency.maxMs)}
+                {:else}
+                  —
+                {/if}
+              </span>
+            </div>
+          {/each}
         </div>
       {/if}
     </Card.Content>

--- a/dashboard/src/lib/performance/cards.test.ts
+++ b/dashboard/src/lib/performance/cards.test.ts
@@ -198,6 +198,7 @@ const infra = (overrides: Partial<InfraReport['monitor']>): InfraReport => ({
     },
     ...overrides,
   },
+  dependencies: [],
 })
 
 describe('blockLagCard', () => {

--- a/dashboard/src/lib/performance/charts.test.ts
+++ b/dashboard/src/lib/performance/charts.test.ts
@@ -8,6 +8,7 @@ import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming
 import {
   layoutAttestationTrend,
   layoutBlockLagTrend,
+  layoutDependencySparkline,
   layoutPercentileSeries,
   layoutRebalanceBars,
   layoutWaterfall,
@@ -472,6 +473,40 @@ describe('layoutBlockLagTrend', () => {
     expect(layout.points).toEqual([])
     expect(layout.path).toBe('')
     expect(layout.maxLagBlocks).toBe(0)
+  })
+})
+
+describe('layoutDependencySparkline', () => {
+  it('marks error buckets and scales bars to the slowest median', () => {
+    const bars = layoutDependencySparkline(
+      [
+        {
+          start: '2026-06-01T00:00:00Z',
+          calls: 10,
+          errors: 0,
+          p50Ms: 50,
+        },
+        {
+          start: '2026-06-01T01:00:00Z',
+          calls: 8,
+          errors: 2,
+          p50Ms: 200,
+        },
+        {
+          start: '2026-06-01T02:00:00Z',
+          calls: 0,
+          errors: 0,
+          p50Ms: null,
+        },
+      ],
+      { plotHeight: 12 },
+    )
+
+    expect(bars).toEqual([
+      { height: 3, hasErrors: false },
+      { height: 12, hasErrors: true },
+      { height: 0, hasErrors: false },
+    ])
   })
 })
 

--- a/dashboard/src/lib/performance/charts.ts
+++ b/dashboard/src/lib/performance/charts.ts
@@ -2,6 +2,7 @@
 
 import type { AttestationSample } from '$lib/api/AttestationSample'
 import type { BlockLagPoint } from '$lib/api/BlockLagPoint'
+import type { DependencyBucket } from '$lib/api/DependencyBucket'
 import type { HedgeCycleReport } from '$lib/api/HedgeCycleReport'
 import type { LatencyBucket } from '$lib/api/LatencyBucket'
 import type { RebalanceOperationTiming } from '$lib/api/RebalanceOperationTiming'
@@ -310,6 +311,28 @@ export const layoutBlockLagTrend = (
       .join(' '),
     maxLagBlocks,
   }
+}
+
+export type DependencySparkBar = {
+  /** Bar height scaled to the slowest bucket's median, in plot units. */
+  height: number
+  hasErrors: boolean
+}
+
+/**
+ * Lays out per-bucket median latency as sparkline bars; buckets containing
+ * errors are flagged so the template can tint them.
+ */
+export const layoutDependencySparkline = (
+  buckets: DependencyBucket[],
+  options: { plotHeight: number },
+): DependencySparkBar[] => {
+  const maxP50 = Math.max(1, ...buckets.map((bucket) => bucket.p50Ms ?? 0))
+
+  return buckets.map((bucket) => ({
+    height: ((bucket.p50Ms ?? 0) / maxP50) * options.plotHeight,
+    hasErrors: bucket.errors > 0,
+  }))
 }
 
 const PERCENTILE_KEYS: PercentileKey[] = ['p50Ms', 'p90Ms', 'p99Ms']

--- a/migrations/20260612013722_dependency_call_samples.sql
+++ b/migrations/20260612013722_dependency_call_samples.sql
@@ -1,0 +1,18 @@
+-- Latency/error samples for external dependency calls (RPC provider and
+-- broker API), batched in by the telemetry writer task. Same conventions as
+-- the monitor telemetry tables: outside the CQRS event store, pruned after
+-- a retention window, '%Y-%m-%dT%H:%M:%fZ' UTC text timestamps.
+
+CREATE TABLE dependency_call_samples (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recorded_at TEXT NOT NULL,
+    dependency TEXT NOT NULL CHECK (dependency IN ('rpc', 'broker')),
+    operation TEXT NOT NULL,
+    duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+    outcome TEXT NOT NULL CHECK (outcome IN ('ok', 'error')),
+    -- Populated only when outcome = 'error'.
+    error TEXT CHECK ((outcome = 'error') = (error IS NOT NULL))
+);
+
+CREATE INDEX idx_dependency_call_samples_recorded_at
+    ON dependency_call_samples (recorded_at, dependency, operation);

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,7 +22,7 @@ use st0x_execution::FractionalShares;
 use crate::AppState;
 use crate::dashboard::transfer_loader::{InvalidTransferKind, TransferKind};
 use crate::equity_redemption::{EquityRedemptionEvent, RedemptionAggregateId};
-use crate::performance::infra::load_monitor_telemetry;
+use crate::performance::infra::{load_dependency_stats, load_monitor_telemetry};
 use crate::performance::rebalance::load_rebalance_timings;
 use crate::performance::reliability::{
     aggregate_log_entries, load_failure_events, load_job_queue_health,
@@ -1613,16 +1613,28 @@ async fn performance_infra(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let monitor = load_monitor_telemetry(
-        &state.pool,
-        &ReportRange { from, to },
-        state.ctx.evm.orderbook,
-    )
-    .await
-    .inspect_err(|error| error!(%error, "Failed to load monitor telemetry"))
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let range = ReportRange { from, to };
+    // The two loaders hit independent tables, so run them concurrently rather
+    // than paying both round-trips in series.
+    let (monitor, dependencies) = tokio::try_join!(
+        async {
+            load_monitor_telemetry(&state.pool, &range, state.ctx.evm.orderbook)
+                .await
+                .inspect_err(|error| error!(%error, "Failed to load monitor telemetry"))
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        },
+        async {
+            load_dependency_stats(&state.pool, &range)
+                .await
+                .inspect_err(|error| error!(%error, "Failed to load dependency stats"))
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        },
+    )?;
 
-    Ok(Json(InfraReport { monitor }))
+    Ok(Json(InfraReport {
+        monitor,
+        dependencies,
+    }))
 }
 
 pub(crate) fn routes() -> Router<AppState> {
@@ -2236,6 +2248,7 @@ mod tests {
                         "duration": null,
                     },
                 },
+                "dependencies": [],
             })
         );
     }
@@ -2292,6 +2305,15 @@ mod tests {
         )
         .await
         .unwrap();
+        sqlx::query(
+            "INSERT INTO dependency_call_samples \
+             (recorded_at, dependency, operation, duration_ms, outcome, error) \
+             VALUES ($1, 'rpc', 'eth_getLogs', 120, 'error', 'timeout')",
+        )
+        .bind(crate::telemetry::sqlite_timestamp(now))
+        .execute(&state.pool)
+        .await
+        .unwrap();
 
         let app = build_app(state);
         let response = app
@@ -2333,6 +2355,24 @@ mod tests {
         assert_eq!(
             report["monitor"]["poll"]["duration"]["p50Ms"],
             serde_json::json!(40)
+        );
+        assert_eq!(
+            report["dependencies"][0]["dependency"],
+            serde_json::json!("rpc")
+        );
+        assert_eq!(
+            report["dependencies"][0]["operation"],
+            serde_json::json!("eth_getLogs")
+        );
+        assert_eq!(report["dependencies"][0]["calls"], serde_json::json!(1));
+        assert_eq!(report["dependencies"][0]["errors"], serde_json::json!(1));
+        assert_eq!(
+            report["dependencies"][0]["latency"]["p50Ms"],
+            serde_json::json!(120)
+        );
+        assert_eq!(
+            report["dependencies"][0]["buckets"][0]["p50Ms"],
+            serde_json::json!(120)
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -9,7 +9,11 @@ pub(crate) mod monitor;
 mod trading_queues;
 
 use alloy::primitives::Address;
-use alloy::providers::{Provider, ProviderBuilder};
+use alloy::providers::fillers::{
+    BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
+};
+use alloy::providers::{Identity, Provider, ProviderBuilder, RootProvider};
+use alloy::rpc::client::ClientBuilder;
 use anyhow::Context;
 use apalis::prelude::Status;
 use chrono::{DateTime, Utc};
@@ -24,6 +28,7 @@ use tokio::task::{JoinError, JoinHandle};
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
+use url::Url;
 
 use st0x_config::{AssetsConfig, BrokerCtx, Ctx, CtxError, ExecutionThreshold, RebalancingCtx};
 use st0x_dto::Statement;
@@ -79,6 +84,9 @@ use crate::rebalancing::{
     to_wrapped_equities,
 };
 use crate::symbol::cache::SymbolCache;
+use crate::telemetry::executor::InstrumentedExecutor;
+use crate::telemetry::rpc::RpcTelemetryLayer;
+use crate::telemetry::{TelemetrySender, spawn_dependency_call_writer};
 use crate::tokenization::Tokenizer;
 use crate::tokenization::alpaca::AlpacaTokenizationService;
 use crate::tokenized_equity_mint::{TokenizedEquityMint, interrupted_mint_ids};
@@ -166,6 +174,8 @@ pub(crate) struct Conductor {
     monitor: JoinHandle<Result<(), MonitorTaskError>>,
     /// Periodically removes terminal rows from the persistent job queue.
     job_cleanup: JoinHandle<()>,
+    /// Drains dependency-call telemetry samples into SQLite in batches.
+    telemetry_writer: JoinHandle<()>,
     /// Cancelled by the outer shutdown handler to trigger graceful drain.
     shutdown_token: CancellationToken,
     /// Independent token for apalis — cancelled explicitly in Phase 2 after
@@ -358,18 +368,70 @@ where
     Ok(())
 }
 
-/// Fails startup fast on an RPC endpoint that cannot serve what order-fill
-/// ingestion depends on: basic reachability and a usable `finalized` block tag.
-/// An endpoint that errors on `finalized`, or aliases it to the chain tip
-/// (disabling reorg protection), is rejected here rather than running silently
-/// degraded; a fresh chain with no finalized block yet is allowed through.
-async fn validate_rpc_endpoint<P: Provider>(provider: &P) -> anyhow::Result<()> {
+/// Wires the telemetry channel, instrumented executor, and RPC provider together
+/// and spawns the background writer that drains samples into SQLite.
+///
+/// Returns the instrumented executor, provider (ready for use), and the writer
+/// task handle. Probes the RPC endpoint once to fail fast on misconfiguration
+/// before the rest of startup proceeds: basic reachability plus a usable
+/// `finalized` block tag, which order-fill ingestion depends on for reorg
+/// protection. An endpoint that errors on `finalized`, or aliases it to the
+/// chain tip (disabling reorg protection), is rejected here rather than running
+/// silently degraded; a fresh chain with no finalized block yet is allowed
+/// through. The telemetry sender is held by the executor and RPC layer clones;
+/// when all are dropped the writer exits cleanly.
+/// Provider type returned by `ProviderBuilder::new().connect_client(...)` over
+/// an HTTP transport. Named here to make `setup_instrumentation`'s return type
+/// concrete without coupling callers to `alloy` internals.
+type HttpProvider = FillProvider<
+    JoinFill<
+        Identity,
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+    >,
+    RootProvider,
+>;
+
+async fn setup_instrumentation<E>(
+    executor_ctx: impl TryIntoExecutor<Executor = E>,
+    rpc_url: &Url,
+    pool: SqlitePool,
+) -> anyhow::Result<(InstrumentedExecutor<E>, HttpProvider, JoinHandle<()>)>
+where
+    E: Executor,
+{
+    // Telemetry channel: the RPC layer and instrumented executor emit
+    // dependency-call samples through it; the writer task batches them
+    // into SQLite in the background.
+    let (telemetry, telemetry_receiver) = TelemetrySender::channel();
+
+    let executor =
+        InstrumentedExecutor::new(executor_ctx.try_into_executor().await?, telemetry.clone());
+
+    // Single HTTP transport: drives continuous eth_getLogs fill polling
+    // (via the OrderFillMonitor + backfill worker) and all read-only
+    // contract calls. No WebSocket -- see `monitor::order_fills`. The
+    // telemetry layer wraps the transport itself, so every JSON-RPC call
+    // from any provider handle is timed.
+    let rpc_client = ClientBuilder::default()
+        .layer(RpcTelemetryLayer::new(telemetry.clone()))
+        .http(rpc_url.clone());
+    let provider = ProviderBuilder::new().connect_client(rpc_client);
+
+    // The HTTP transport connects lazily, so probe it once at startup to
+    // fail fast on a misconfigured or unreachable RPC rather than only
+    // surfacing it as repeated poll-loop retries. systemd's bounded
+    // restart loop handles a genuinely-down endpoint from here.
     let chain_tip = provider
         .get_block_number()
         .await
         .context("failed to reach RPC endpoint at startup")?;
 
-    match probe_finalized_block_support(provider, chain_tip)
+    // Order-fill ingestion caps at the finalized block, so reject an endpoint
+    // that cannot serve a usable `finalized` tag here rather than running
+    // silently degraded. An endpoint reporting a finalized block at or beyond
+    // the tip is aliasing `finalized` to `latest` and would disable reorg
+    // protection; a fresh chain with no finalized block yet is allowed through.
+    match probe_finalized_block_support(&provider, chain_tip)
         .await
         .context("RPC endpoint cannot serve the `finalized` block tag at startup")?
     {
@@ -378,8 +440,14 @@ async fn validate_rpc_endpoint<P: Provider>(provider: &P) -> anyhow::Result<()> 
              ({chain_tip}); it appears to alias the `finalized` tag to `latest`, \
              which would silently disable reorg protection. Refusing to start"
         ),
-        FinalityProbe::Supported | FinalityProbe::NotYetAvailable => Ok(()),
+        FinalityProbe::Supported | FinalityProbe::NotYetAvailable => {}
     }
+
+    // Drop the original sender here; the executor and RPC layer each hold
+    // a clone. When all clones are eventually dropped, the writer exits.
+    let telemetry_writer = spawn_dependency_call_writer(pool, telemetry_receiver);
+
+    Ok((executor, provider, telemetry_writer))
 }
 
 impl Conductor {
@@ -403,18 +471,9 @@ impl Conductor {
             cqrs: pool,
             apalis: apalis_pool,
         } = pools;
-        let executor = executor_ctx.try_into_executor().await?;
 
-        // Single HTTP transport: drives continuous eth_getLogs fill polling
-        // (via the OrderFillMonitor + backfill worker) and all read-only
-        // contract calls. No WebSocket -- see `monitor::order_fills`.
-        let provider = ProviderBuilder::new().connect_http(ctx.evm.rpc_url.clone());
-
-        // The HTTP transport connects lazily, so validate it once at startup to
-        // fail fast on a misconfigured or unreachable RPC rather than surfacing
-        // it as repeated poll-loop retries. systemd's bounded restart loop
-        // handles a genuinely-down endpoint from here.
-        validate_rpc_endpoint(&provider).await?;
+        let (executor, provider, telemetry_writer) =
+            setup_instrumentation(executor_ctx, &ctx.evm.rpc_url, pool.clone()).await?;
         let cache = SymbolCache::default();
 
         setup_apalis_tables(&apalis_pool).await?;
@@ -639,6 +698,7 @@ impl Conductor {
             .resume_tokenization_queue(resume_tokenization_queue)
             .maybe_resume_tokenization_ctx(resume_tokenization_ctx)
             .job_cleanup(job_cleanup)
+            .telemetry_writer(telemetry_writer)
             .call();
 
         // Publish the recovery handle only after all startup work
@@ -694,17 +754,20 @@ impl Conductor {
             warn!(target: "shutdown", %error, "Supervisor exited with error during drain");
         }
 
-        // Abort remaining non-critical background tasks. Equity and USDC
-        // transfers run as apalis jobs, so their in-flight operations drain
-        // with the rest of the queue in Phase 2.
-        self.abort_background_tasks();
+        // Job cleanup is not a drain target, so stop it now. The telemetry
+        // writer stays up through Phase 2 so dependency samples emitted by
+        // draining apalis jobs are still persisted; it is aborted only once
+        // the drain has completed.
+        self.job_cleanup.abort();
 
         // Phase 2: now that producers are stopped, signal apalis to drain
         // in-flight jobs. The apalis token is independent of the outer
         // shutdown token -- we cancel it explicitly after producers stop.
         info!(target: "shutdown", "Phase 2: draining in-flight jobs");
         self.apalis_shutdown_token.cancel();
-        check_monitor_drain_result((&mut self.monitor).await)
+        let monitor_result = check_monitor_drain_result((&mut self.monitor).await);
+        self.telemetry_writer.abort();
+        monitor_result
     }
 
     /// Abort all conductor tasks (force shutdown fallback).
@@ -719,6 +782,7 @@ impl Conductor {
 
     fn abort_background_tasks(&self) {
         self.job_cleanup.abort();
+        self.telemetry_writer.abort();
     }
 }
 
@@ -2709,6 +2773,7 @@ mod tests {
             supervisor,
             monitor,
             job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: CancellationToken::new(),
             apalis_shutdown_token: CancellationToken::new(),
         }
@@ -7348,6 +7413,7 @@ mod tests {
             supervisor,
             monitor,
             job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
         };
@@ -7375,6 +7441,7 @@ mod tests {
             supervisor,
             monitor,
             job_cleanup,
+            telemetry_writer: tokio::spawn(pending::<()>()),
             shutdown_token: shutdown_token.clone(),
             apalis_shutdown_token,
         };

--- a/src/conductor/builder.rs
+++ b/src/conductor/builder.rs
@@ -133,6 +133,7 @@ pub(crate) fn spawn<Prov, Exec>(
     resume_tokenization_queue: ResumeTokenizationJobQueue,
     resume_tokenization_ctx: Option<Arc<ResumeTokenizationCtx>>,
     job_cleanup: JoinHandle<()>,
+    telemetry_writer: JoinHandle<()>,
 ) -> Conductor
 where
     Prov: Provider + Clone + Send + Sync + 'static,
@@ -372,6 +373,7 @@ where
         supervisor,
         monitor,
         job_cleanup,
+        telemetry_writer,
         shutdown_token: context.shutdown_token,
         apalis_shutdown_token: apalis_shutdown_token_for_struct,
     }

--- a/src/performance/infra.rs
+++ b/src/performance/infra.rs
@@ -5,12 +5,16 @@
 //! report: current block lag, worst lag per time bucket, and poll-cycle
 //! duration/error/skipped-tick aggregates. Strictly read-only.
 
+use std::collections::BTreeMap;
+
 use alloy::primitives::Address;
 use chrono::{DateTime, Duration, SubsecRound, Utc};
 use sqlx::SqlitePool;
 use tracing::warn;
 
-use st0x_dto::{BlockLagPoint, MonitorTelemetry, PollHealth};
+use st0x_dto::{
+    BlockLagPoint, DependencyBucket, DependencyName, DependencyStats, MonitorTelemetry, PollHealth,
+};
 
 use super::{PerformanceError, ReportRange, latency_stats};
 use crate::telemetry::{Monitor, PollOutcome, sqlite_timestamp};
@@ -157,6 +161,118 @@ struct AggregateRow {
     cycles: i64,
     errors: Option<i64>,
     skipped_ticks_sum: Option<i64>,
+}
+
+/// One dependency call sample as returned by the SQL query in
+/// `load_dependency_stats`. Named fields prevent the two `i64`s from being
+/// transposed at the construction site.
+struct CallSample {
+    bucket_index: i64,
+    duration_ms: i64,
+    is_error: bool,
+}
+
+/// Per-(dependency, operation) accumulator of [`CallSample`]s, grouped before
+/// aggregation into `DependencyStats`.
+type DependencyGroups = BTreeMap<(DependencyName, String), Vec<CallSample>>;
+
+/// Load per-(dependency, operation) call aggregates for `range`.
+///
+/// The time-bucket index and the error flag are computed in SQL (mirroring
+/// `block_lag_buckets`) so each row arrives as compact scalars rather than
+/// four heap strings plus a parsed timestamp. Raw durations still come back
+/// per row -- SQLite has no percentile function, so the p50/p90/p99 stats are
+/// computed in Rust -- but the per-row footprint is bounded to a single small
+/// `operation` string.
+pub(crate) async fn load_dependency_stats(
+    pool: &SqlitePool,
+    range: &ReportRange,
+) -> Result<Vec<DependencyStats>, PerformanceError> {
+    let width = range.bucket_width();
+    // strftime('%s', ...) truncates to whole seconds, so anchor the bucket
+    // origin the same way (see `block_lag_buckets`).
+    let origin = range.from.trunc_subsecs(0);
+    let rows: Vec<(i64, String, String, i64, bool)> = sqlx::query_as(
+        "SELECT (CAST(strftime('%s', recorded_at) AS INTEGER) - $3) / $4 AS bucket_index, \
+                dependency, operation, duration_ms, outcome = 'error' AS is_error \
+         FROM dependency_call_samples \
+         WHERE recorded_at BETWEEN $1 AND $2 \
+         ORDER BY dependency, operation, bucket_index",
+    )
+    .bind(sqlite_timestamp(range.from))
+    .bind(sqlite_timestamp(range.to))
+    .bind(origin.timestamp())
+    .bind(width.num_seconds())
+    .fetch_all(pool)
+    .await?;
+
+    let mut groups: DependencyGroups = BTreeMap::new();
+    for (bucket_index, raw_dependency, operation, duration_ms, is_error) in rows {
+        let dependency = match raw_dependency.as_str() {
+            "rpc" => DependencyName::Rpc,
+            "broker" => DependencyName::Broker,
+            other => {
+                warn!(
+                    dependency = other,
+                    "Skipping sample with unknown dependency"
+                );
+                continue;
+            }
+        };
+
+        groups
+            .entry((dependency, operation))
+            .or_default()
+            .push(CallSample {
+                bucket_index,
+                duration_ms,
+                is_error,
+            });
+    }
+
+    Ok(groups
+        .into_iter()
+        .map(|((dependency, operation), samples)| {
+            dependency_stats(dependency, operation, &samples, origin, width)
+        })
+        .collect())
+}
+
+fn dependency_stats(
+    dependency: DependencyName,
+    operation: String,
+    samples: &[CallSample],
+    origin: DateTime<Utc>,
+    width: Duration,
+) -> DependencyStats {
+    let mut buckets: BTreeMap<i64, (Vec<i64>, usize)> = BTreeMap::new();
+    for sample in samples {
+        let (durations, errors) = buckets.entry(sample.bucket_index).or_default();
+        durations.push(sample.duration_ms);
+        if sample.is_error {
+            *errors += 1;
+        }
+    }
+
+    let errors = samples.iter().filter(|sample| sample.is_error).count();
+    let mut durations: Vec<i64> = samples.iter().map(|sample| sample.duration_ms).collect();
+
+    DependencyStats {
+        dependency,
+        operation,
+        calls: samples.len(),
+        errors,
+        latency: latency_stats(&mut durations),
+        buckets: buckets
+            .into_iter()
+            .map(|(index, (mut durations, errors))| DependencyBucket {
+                start: origin + Duration::seconds(width.num_seconds() * index),
+                calls: durations.len(),
+                errors,
+                p50_ms: latency_stats(&mut durations).map(|stats| stats.p50_ms),
+            })
+            .collect(),
+    }
 }
 
 /// Stored counts are non-negative by schema CHECK; a negative value means a
@@ -385,6 +501,79 @@ mod tests {
         let duration = telemetry.poll.duration.unwrap();
         assert_eq!(duration.sample_count, 2);
         assert_eq!(duration.max_ms, 300);
+    }
+
+    async fn insert_call(
+        pool: &SqlitePool,
+        seconds: i64,
+        dependency: &str,
+        operation: &str,
+        duration_ms: i64,
+        error: Option<&str>,
+    ) {
+        let outcome = if error.is_some() { "error" } else { "ok" };
+        sqlx::query(
+            "INSERT INTO dependency_call_samples \
+             (recorded_at, dependency, operation, duration_ms, outcome, error) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(sqlite_timestamp(timestamp(seconds)))
+        .bind(dependency)
+        .bind(operation)
+        .bind(duration_ms)
+        .bind(outcome)
+        .bind(error)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn groups_dependency_calls_by_operation_with_buckets() {
+        let pool = setup_test_db().await;
+        insert_call(&pool, 10, "rpc", "eth_blockNumber", 50, None).await;
+        insert_call(&pool, 20, "rpc", "eth_blockNumber", 150, Some("timeout")).await;
+        insert_call(&pool, 4_000, "rpc", "eth_blockNumber", 70, None).await;
+        insert_call(&pool, 30, "broker", "place_market_order", 400, None).await;
+        // Outside the range: must not be counted.
+        insert_call(&pool, -100, "rpc", "eth_blockNumber", 999, None).await;
+
+        let stats = load_dependency_stats(&pool, &range()).await.unwrap();
+
+        assert_eq!(stats.len(), 2);
+        // Look the groups up by their (dependency, operation) key rather than
+        // by index, so the assertions test the grouping invariant instead of
+        // the current sort order.
+        let broker = stats
+            .iter()
+            .find(|row| {
+                row.dependency == DependencyName::Broker && row.operation == "place_market_order"
+            })
+            .expect("missing broker/place_market_order group");
+        assert_eq!(broker.calls, 1);
+        assert_eq!(broker.errors, 0);
+
+        let rpc = stats
+            .iter()
+            .find(|row| row.dependency == DependencyName::Rpc && row.operation == "eth_blockNumber")
+            .expect("missing rpc/eth_blockNumber group");
+        assert_eq!(rpc.calls, 3);
+        assert_eq!(rpc.errors, 1);
+        assert_eq!(rpc.latency.as_ref().unwrap().max_ms, 150);
+        assert_eq!(rpc.latency.as_ref().unwrap().sample_count, 3);
+
+        assert_eq!(rpc.buckets.len(), 2);
+        assert_eq!(rpc.buckets[0].start, timestamp(0));
+        assert_eq!(rpc.buckets[0].calls, 2);
+        assert_eq!(rpc.buckets[0].errors, 1);
+        assert_eq!(rpc.buckets[0].p50_ms, Some(50));
+        assert_eq!(rpc.buckets[1].start, timestamp(3_600));
+        assert_eq!(rpc.buckets[1].calls, 1);
+        assert_eq!(
+            rpc.buckets[1].errors, 0,
+            "errors must not leak across buckets"
+        );
+        assert_eq!(rpc.buckets[1].p50_ms, Some(70));
     }
 
     #[tokio::test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,20 +1,35 @@
 //! Lightweight operational telemetry store.
 //!
-//! Persists high-frequency ingestion-health samples (chain-tip block lag,
-//! poll-cycle duration and skipped ticks) to plain SQLite tables, outside
-//! the CQRS event store: these are operational observations, not domain
-//! events. Writes are best-effort from the caller's perspective -- a failed
-//! sample must never fail the monitored operation -- and rows older than
-//! [`RETENTION`] are pruned opportunistically.
+//! Persists high-frequency operational samples -- chain-tip block lag,
+//! poll-cycle duration and skipped ticks, external dependency call
+//! latency/errors -- to plain SQLite tables, outside the CQRS event store:
+//! these are operational observations, not domain events. Writes are
+//! best-effort from the caller's perspective -- a failed sample must never
+//! fail the monitored operation -- and rows older than [`RETENTION`] are
+//! pruned opportunistically.
+//!
+//! Monitor samples are written inline (one row per poll interval).
+//! Dependency-call samples come from hot paths (every RPC and broker call),
+//! so they flow through a bounded mpsc channel ([`TelemetrySender`]) into a
+//! background writer task that batches inserts and never blocks the caller.
 
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::num::TryFromIntError;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use alloy::primitives::Address;
 use chrono::{DateTime, SecondsFormat, Utc};
 use sqlx::SqlitePool;
 use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+pub(crate) mod executor;
+pub(crate) mod rpc;
 
 /// How long telemetry samples are retained. Telemetry is an operational
 /// debugging aid, not an audit trail; two weeks comfortably covers "what
@@ -173,6 +188,287 @@ pub(crate) async fn prune_expired(
         .await?;
     sqlx::query("DELETE FROM poll_cycle_samples WHERE sampled_at < $1")
         .bind(&cutoff)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
+/// External dependency a call sample belongs to. `Broker` covers whatever
+/// `Executor` implementation is configured, not just Alpaca.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Dependency {
+    Rpc,
+    Broker,
+}
+
+impl Dependency {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Rpc => "rpc",
+            Self::Broker => "broker",
+        }
+    }
+}
+
+/// One observed call to an external dependency.
+#[derive(Debug, Clone)]
+pub(crate) struct DependencyCallSample {
+    pub(crate) recorded_at: DateTime<Utc>,
+    pub(crate) dependency: Dependency,
+    pub(crate) operation: Cow<'static, str>,
+    pub(crate) duration: Duration,
+    /// `Some` when the call failed, rendered for operators.
+    pub(crate) error: Option<String>,
+}
+
+/// Capacity of the sample channel. At one slow batch insert per
+/// `recv_many`, thousands of in-flight samples means the writer is wedged,
+/// not busy -- dropping is the correct behavior on hot paths.
+const DEPENDENCY_CHANNEL_CAPACITY: usize = 4_096;
+
+/// Log every Nth dropped sample so a wedged writer is visible without
+/// turning the hot path into a log storm.
+const DROP_LOG_EVERY: u64 = 1_000;
+
+/// State present only when the sender is connected to a live writer task.
+#[derive(Debug, Clone)]
+struct Connected {
+    channel: mpsc::Sender<DependencyCallSample>,
+    dropped: Arc<AtomicU64>,
+}
+
+/// Non-blocking handle hot paths use to emit [`DependencyCallSample`]s.
+///
+/// `record` never blocks and never fails the caller: when the channel is
+/// full or closed the sample is counted and dropped. A disabled sender
+/// (`connected` is `None`) swallows samples outright -- used where a handle
+/// is structurally required but no writer exists.
+#[derive(Debug, Clone)]
+pub(crate) struct TelemetrySender {
+    connected: Option<Connected>,
+}
+
+impl TelemetrySender {
+    /// A connected sender plus the receiver to hand to
+    /// [`spawn_dependency_call_writer`].
+    pub(crate) fn channel() -> (Self, mpsc::Receiver<DependencyCallSample>) {
+        let (sender, receiver) = mpsc::channel(DEPENDENCY_CHANNEL_CAPACITY);
+        (
+            Self {
+                connected: Some(Connected {
+                    channel: sender,
+                    dropped: Arc::new(AtomicU64::new(0)),
+                }),
+            },
+            receiver,
+        )
+    }
+
+    /// A sender that swallows every sample.
+    pub(crate) fn disabled() -> Self {
+        Self { connected: None }
+    }
+
+    /// Emit one sample, never blocking the caller.
+    pub(crate) fn record(&self, sample: DependencyCallSample) {
+        let Some(connected) = &self.connected else {
+            return;
+        };
+
+        if connected.channel.try_send(sample).is_err() {
+            let count = connected.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+            if count == 1 || count.is_multiple_of(DROP_LOG_EVERY) {
+                warn!(
+                    dropped = count,
+                    "Telemetry channel full or closed; dropping dependency call samples"
+                );
+            }
+        }
+    }
+
+    /// Total samples dropped so far (channel full or closed). Test-only.
+    #[cfg(test)]
+    pub(crate) fn dropped_count(&self) -> u64 {
+        self.connected
+            .as_ref()
+            .map_or(0, |connected| connected.dropped.load(Ordering::Relaxed))
+    }
+}
+
+/// Redact credential-bearing parts of any URL embedded in a dependency error
+/// before it is persisted. Production RPC URLs carry the API key in the path
+/// or query string (e.g. dRPC `?dkey=...`, Alchemy `/v2/<key>`), and a
+/// transport failure surfaces the full URL through the error's `Display`.
+/// Keeping only `scheme://host` preserves the operator-useful "which provider
+/// failed" signal while dropping the secret-bearing remainder.
+///
+/// Trailing non-URL characters (e.g. a closing `)` from a surrounding message)
+/// are detected by trimming URL-legal chars from the right and re-appended
+/// after the redacted output so the surrounding sentence stays readable.
+pub(crate) fn scrub_secrets(message: &str) -> String {
+    message
+        .split(' ')
+        .map(|token| {
+            let Some(scheme_end) = token.find("://") else {
+                return Cow::Borrowed(token);
+            };
+            let rest = &token[scheme_end + 3..];
+            let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+            let authority = &rest[..authority_end];
+            // Drop userinfo (`user:pass@`); keep only the host.
+            let host = authority
+                .rfind('@')
+                .map_or(authority, |at| &authority[at + 1..]);
+            if authority_end == rest.len() && host.len() == authority.len() {
+                return Cow::Borrowed(token);
+            }
+            // Preserve any non-URL trailing characters (e.g. `)`) that were
+            // part of the surrounding message text, not the URL itself.
+            // Find the last char that is a legal URL character; everything
+            // after it is the trailing suffix to re-append.
+            let url_char_end = rest
+                .rfind(|ch: char| {
+                    ch.is_alphanumeric()
+                        || matches!(
+                            ch,
+                            '-' | '.'
+                                | '_'
+                                | '~'
+                                | ':'
+                                | '/'
+                                | '?'
+                                | '#'
+                                | '['
+                                | ']'
+                                | '@'
+                                | '!'
+                                | '$'
+                                | '&'
+                                | '\''
+                                | '('
+                                | '*'
+                                | '+'
+                                | ','
+                                | ';'
+                                | '='
+                                | '%'
+                        )
+                })
+                .map_or(0, |pos| pos + 1);
+            let trailing = &rest[url_char_end..];
+            let suffix = if authority_end == rest.len() {
+                ""
+            } else {
+                "/<redacted>"
+            };
+            Cow::Owned(format!(
+                "{}{host}{suffix}{trailing}",
+                &token[..scheme_end + 3]
+            ))
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Samples drained per write batch.
+const WRITE_BATCH: usize = 256;
+
+/// How often the writer prunes expired dependency-call rows.
+const DEPENDENCY_PRUNE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Spawn the background task that drains the sample channel into
+/// `dependency_call_samples` in batched transactions and prunes expired
+/// rows hourly. Exits when every [`TelemetrySender`] clone is dropped.
+pub(crate) fn spawn_dependency_call_writer(
+    pool: SqlitePool,
+    mut receiver: mpsc::Receiver<DependencyCallSample>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        // `interval_at` (not `interval`) so the first prune fires one full
+        // interval in, not immediately at startup before any rows exist.
+        let mut prune_timer = tokio::time::interval_at(
+            tokio::time::Instant::now() + DEPENDENCY_PRUNE_INTERVAL,
+            DEPENDENCY_PRUNE_INTERVAL,
+        );
+        let mut batch = Vec::with_capacity(WRITE_BATCH);
+
+        loop {
+            tokio::select! {
+                received_count = receiver.recv_many(&mut batch, WRITE_BATCH) => {
+                    if received_count == 0 {
+                        info!("Telemetry channel closed; dependency call writer stopping");
+                        return;
+                    }
+                    if let Err(error) = write_dependency_calls(&pool, &batch).await {
+                        // Telemetry is best-effort, but report the magnitude so
+                        // a persistent write failure (disk full, lock) is not an
+                        // invisible blackhole.
+                        warn!(?error, lost = batch.len(), "Failed to write dependency call samples");
+                    }
+                    batch.clear();
+                }
+                _ = prune_timer.tick() => {
+                    if let Err(error) = prune_expired_dependency_calls(&pool, Utc::now()).await {
+                        warn!(?error, "Failed to prune expired dependency call samples");
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn write_dependency_calls(
+    pool: &SqlitePool,
+    samples: &[DependencyCallSample],
+) -> Result<(), TelemetryError> {
+    let mut transaction = pool.begin().await?;
+
+    for sample in samples {
+        // One unrepresentable duration (>292 million years) must not poison
+        // the whole batch: skip the sample, keep the rest.
+        let duration_ms = match i64::try_from(sample.duration.as_millis()) {
+            Ok(duration_ms) => duration_ms,
+            Err(error) => {
+                warn!(
+                    ?error,
+                    operation = %sample.operation,
+                    "Skipping dependency sample with unrepresentable duration"
+                );
+                continue;
+            }
+        };
+
+        let (outcome, error) = sample
+            .error
+            .as_ref()
+            .map_or(("ok", None), |message| ("error", Some(message.as_str())));
+
+        sqlx::query(
+            "INSERT INTO dependency_call_samples \
+             (recorded_at, dependency, operation, duration_ms, outcome, error) \
+             VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(sqlite_timestamp(sample.recorded_at))
+        .bind(sample.dependency.as_str())
+        .bind(sample.operation.as_ref())
+        .bind(duration_ms)
+        .bind(outcome)
+        .bind(error)
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn prune_expired_dependency_calls(
+    pool: &SqlitePool,
+    now: DateTime<Utc>,
+) -> Result<(), TelemetryError> {
+    sqlx::query("DELETE FROM dependency_call_samples WHERE recorded_at < $1")
+        .bind(sqlite_timestamp(now - RETENTION))
         .execute(pool)
         .await?;
 
@@ -389,5 +685,170 @@ mod tests {
     fn sqlite_timestamp_matches_sqlite_strftime_format() {
         let formatted = sqlite_timestamp(Utc.timestamp_opt(1_750_000_000, 123_000_000).unwrap());
         assert_eq!(formatted, "2025-06-15T15:06:40.123Z");
+    }
+
+    /// Samples are stamped relative to now: the writer task prunes expired
+    /// rows on its first timer tick, so historic timestamps would be
+    /// deleted right after insertion.
+    fn call_sample(
+        seconds: i64,
+        dependency: Dependency,
+        error: Option<&str>,
+    ) -> DependencyCallSample {
+        DependencyCallSample {
+            recorded_at: Utc::now() + chrono::Duration::seconds(seconds),
+            dependency,
+            operation: Cow::Borrowed("eth_blockNumber"),
+            duration: Duration::from_millis(42),
+            error: error.map(str::to_string),
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_persists_batched_samples_and_exits_on_close() {
+        let pool = setup_test_db().await;
+        let (sender, receiver) = TelemetrySender::channel();
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+
+        sender.record(call_sample(0, Dependency::Rpc, None));
+        sender.record(call_sample(1, Dependency::Broker, Some("rejected")));
+        drop(sender);
+        writer.await.unwrap();
+
+        let rows: Vec<(String, String, i64, String, Option<String>)> = sqlx::query_as(
+            "SELECT dependency, operation, duration_ms, outcome, error \
+             FROM dependency_call_samples ORDER BY recorded_at",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, "rpc");
+        assert_eq!(rows[0].1, "eth_blockNumber");
+        assert_eq!(rows[0].2, 42);
+        assert_eq!(rows[0].3, "ok");
+        assert_eq!(rows[0].4, None);
+        assert_eq!(rows[1].0, "broker");
+        assert_eq!(rows[1].3, "error");
+        assert_eq!(rows[1].4, Some("rejected".to_string()));
+    }
+
+    #[test]
+    fn scrub_secrets_redacts_url_credentials() {
+        // dRPC-style key in the query string. The closing `)` is surrounding
+        // message punctuation, not part of the URL, and must be preserved.
+        assert_eq!(
+            scrub_secrets("error sending request for url (https://lb.drpc.org/ogrpc?dkey=SECRET)"),
+            "error sending request for url (https://lb.drpc.org/<redacted>)"
+        );
+        // Alchemy-style key in the path.
+        assert_eq!(
+            scrub_secrets("connect error: https://base-mainnet.g.alchemy.com/v2/SECRET_KEY"),
+            "connect error: https://base-mainnet.g.alchemy.com/<redacted>"
+        );
+        // userinfo credentials.
+        assert_eq!(
+            scrub_secrets("https://user:pass@node.example.com"),
+            "https://node.example.com"
+        );
+        // A plain message with no URL is untouched.
+        assert_eq!(
+            scrub_secrets("broker rejected order: insufficient funds"),
+            "broker rejected order: insufficient funds"
+        );
+    }
+
+    #[test]
+    fn scrub_secrets_bare_host_is_returned_verbatim() {
+        // A bare-host URL with no path or query has no credentials to redact;
+        // it must pass through unchanged.
+        assert_eq!(
+            scrub_secrets("https://eth-mainnet.example.com"),
+            "https://eth-mainnet.example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_never_panics_on_closed_or_disabled_channels() {
+        let (sender, receiver) = TelemetrySender::channel();
+        drop(receiver);
+        sender.record(call_sample(0, Dependency::Rpc, None));
+        assert_eq!(
+            sender.dropped_count(),
+            1,
+            "a record on a closed channel must increment the drop counter"
+        );
+
+        let disabled = TelemetrySender::disabled();
+        disabled.record(call_sample(0, Dependency::Broker, None));
+        assert_eq!(
+            disabled.dropped_count(),
+            0,
+            "a disabled sender has nothing to drop; its count must stay zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_expired_dependency_calls_respects_retention() {
+        let pool = setup_test_db().await;
+        let now = timestamp(0);
+        let expired = call_sample(0, Dependency::Rpc, None);
+        let expired = DependencyCallSample {
+            recorded_at: now - RETENTION - chrono::Duration::hours(1),
+            ..expired
+        };
+        let retained = DependencyCallSample {
+            recorded_at: now - RETENTION + chrono::Duration::hours(1),
+            ..call_sample(0, Dependency::Rpc, None)
+        };
+        write_dependency_calls(&pool, &[expired, retained])
+            .await
+            .unwrap();
+
+        prune_expired_dependency_calls(&pool, now).await.unwrap();
+
+        // Assert the surviving row is the retained one, not merely that one
+        // row remains: a reversed predicate would keep the expired row and
+        // still leave a count of 1.
+        let survivors: Vec<String> =
+            sqlx::query_scalar("SELECT recorded_at FROM dependency_call_samples")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            survivors,
+            vec![sqlite_timestamp(
+                now - RETENTION + chrono::Duration::hours(1)
+            )],
+            "only the in-retention dependency sample survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_drops_and_counts_samples_when_the_channel_is_full() {
+        // No writer drains the channel, so it fills at capacity. record() must
+        // never block: the test completing is itself the non-blocking proof.
+        let (sender, mut receiver) = TelemetrySender::channel();
+        let overflow = 10;
+        for index in 0..DEPENDENCY_CHANNEL_CAPACITY + overflow {
+            sender.record(call_sample(
+                i64::try_from(index).unwrap(),
+                Dependency::Rpc,
+                None,
+            ));
+        }
+
+        assert_eq!(
+            sender.dropped_count(),
+            u64::try_from(overflow).unwrap(),
+            "every sample past capacity is dropped and counted"
+        );
+
+        let mut drained = Vec::new();
+        let drained_count = receiver.recv_many(&mut drained, usize::MAX).await;
+        assert_eq!(
+            drained_count, DEPENDENCY_CHANNEL_CAPACITY,
+            "exactly the channel capacity is buffered; the overflow was dropped"
+        );
     }
 }

--- a/src/telemetry/executor.rs
+++ b/src/telemetry/executor.rs
@@ -1,0 +1,276 @@
+//! Latency/error capture decorator over any [`Executor`].
+//!
+//! Wraps the hedge broker executor once at conductor startup, so every hedge
+//! consumer cloning it (order placement, status polling, inventory polling,
+//! maintenance) emits dependency-call telemetry without knowing about it. The
+//! rebalancer builds its own broker handle and is not covered here. Lives in
+//! the main crate: the execution crate stays independent of the telemetry
+//! store.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use st0x_execution::{
+    CounterTradePreflight, Executor, InventoryResult, MarketOrder, OrderPlacement, OrderState,
+    SupportedExecutor,
+};
+
+use super::{Dependency, DependencyCallSample, TelemetrySender, scrub_secrets};
+
+/// An [`Executor`] whose remote calls are timed and recorded.
+///
+/// Local methods (`to_supported_executor`, `parse_order_id`,
+/// `maintenance_interval`) delegate without recording: they never leave the
+/// process, so timing them would only dilute the dependency signal.
+#[derive(Debug, Clone)]
+pub(crate) struct InstrumentedExecutor<Inner> {
+    inner: Inner,
+    telemetry: TelemetrySender,
+}
+
+impl<Inner> InstrumentedExecutor<Inner> {
+    pub(crate) fn new(inner: Inner, telemetry: TelemetrySender) -> Self {
+        Self { inner, telemetry }
+    }
+}
+
+impl<Inner: Executor> InstrumentedExecutor<Inner> {
+    fn record<Value>(
+        &self,
+        operation: &'static str,
+        started: Instant,
+        result: &Result<Value, Inner::Error>,
+    ) {
+        self.telemetry.record(DependencyCallSample {
+            recorded_at: Utc::now(),
+            dependency: Dependency::Broker,
+            operation: operation.into(),
+            duration: started.elapsed(),
+            // Scrub any URL credentials a broker error might surface before
+            // persisting, matching the RPC path.
+            error: result
+                .as_ref()
+                .err()
+                .map(|error| scrub_secrets(&error.to_string())),
+        });
+    }
+}
+
+#[async_trait]
+impl<Inner: Executor + Clone> Executor for InstrumentedExecutor<Inner> {
+    type Error = Inner::Error;
+    type OrderId = Inner::OrderId;
+    type Ctx = Inner::Ctx;
+
+    /// Builds the inner executor with a disabled telemetry sender. Dead in
+    /// practice: the conductor wraps an already-constructed executor and
+    /// supplies a connected sender; nothing constructs the wrapper through
+    /// its context.
+    async fn try_from_ctx(ctx: Self::Ctx) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: Inner::try_from_ctx(ctx).await?,
+            telemetry: TelemetrySender::disabled(),
+        })
+    }
+
+    async fn is_market_open(&self) -> Result<bool, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.is_market_open().await;
+        self.record("is_market_open", started, &result);
+        result
+    }
+
+    async fn place_market_order(
+        &self,
+        order: MarketOrder,
+    ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.place_market_order(order).await;
+        self.record("place_market_order", started, &result);
+        result
+    }
+
+    async fn get_order_status(&self, order_id: &Self::OrderId) -> Result<OrderState, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.get_order_status(order_id).await;
+        self.record("get_order_status", started, &result);
+        result
+    }
+
+    fn to_supported_executor(&self) -> SupportedExecutor {
+        self.inner.to_supported_executor()
+    }
+
+    fn parse_order_id(&self, order_id_str: &str) -> Result<Self::OrderId, Self::Error> {
+        self.inner.parse_order_id(order_id_str)
+    }
+
+    fn maintenance_interval(&self) -> Option<Duration> {
+        self.inner.maintenance_interval()
+    }
+
+    async fn maintenance_tick(&self) -> Result<(), Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.maintenance_tick().await;
+        self.record("maintenance_tick", started, &result);
+        result
+    }
+
+    async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.get_inventory().await;
+        self.record("get_inventory", started, &result);
+        result
+    }
+
+    async fn preflight_counter_trade(
+        &self,
+        order: MarketOrder,
+    ) -> Result<CounterTradePreflight, Self::Error> {
+        let started = Instant::now();
+        let result = self.inner.preflight_counter_trade(order).await;
+        self.record("preflight_counter_trade", started, &result);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc::error::TryRecvError;
+
+    use st0x_execution::{
+        ClientOrderId, Direction, FractionalShares, MockExecutor, Positive, Symbol,
+    };
+    use st0x_float_macro::float;
+
+    use crate::telemetry::spawn_dependency_call_writer;
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    fn market_order() -> MarketOrder {
+        MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: Positive::new(FractionalShares::new(float!(1))).unwrap(),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::from_uuid(uuid::Uuid::new_v4()),
+        }
+    }
+
+    #[tokio::test]
+    async fn records_broker_calls_with_operation_labels() {
+        let pool = setup_test_db().await;
+        let (sender, receiver) = TelemetrySender::channel();
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+        let executor = InstrumentedExecutor::new(MockExecutor::new(), sender.clone());
+
+        executor.is_market_open().await.unwrap();
+        executor.place_market_order(market_order()).await.unwrap();
+        executor
+            .get_order_status(&executor.parse_order_id("order-1").unwrap())
+            .await
+            .unwrap();
+        executor.maintenance_tick().await.unwrap();
+        executor.get_inventory().await.unwrap();
+        executor
+            .preflight_counter_trade(market_order())
+            .await
+            .unwrap();
+
+        drop(executor);
+        drop(sender);
+        writer.await.unwrap();
+
+        let rows: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT dependency, operation, outcome \
+             FROM dependency_call_samples ORDER BY id",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            rows.len(),
+            6,
+            "all six instrumented methods must emit samples"
+        );
+        let operations: Vec<&str> = rows.iter().map(|(_, op, _)| op.as_str()).collect();
+        assert!(
+            operations.contains(&"is_market_open"),
+            "is_market_open must be recorded"
+        );
+        assert!(
+            operations.contains(&"place_market_order"),
+            "place_market_order must be recorded"
+        );
+        assert!(
+            operations.contains(&"get_order_status"),
+            "get_order_status must be recorded"
+        );
+        assert!(
+            operations.contains(&"maintenance_tick"),
+            "maintenance_tick must be recorded"
+        );
+        assert!(
+            operations.contains(&"get_inventory"),
+            "get_inventory must be recorded"
+        );
+        assert!(
+            operations.contains(&"preflight_counter_trade"),
+            "preflight_counter_trade must be recorded"
+        );
+        for (dep, _, outcome) in &rows {
+            assert_eq!(dep, "broker");
+            assert_eq!(outcome, "ok");
+        }
+    }
+
+    #[tokio::test]
+    async fn records_failed_calls_as_errors() {
+        let pool = setup_test_db().await;
+        let (sender, receiver) = TelemetrySender::channel();
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+        let executor =
+            InstrumentedExecutor::new(MockExecutor::with_failure("broker down"), sender.clone());
+
+        executor
+            .place_market_order(market_order())
+            .await
+            .unwrap_err();
+
+        drop(executor);
+        drop(sender);
+        writer.await.unwrap();
+
+        let (outcome, error): (String, Option<String>) =
+            sqlx::query_as("SELECT outcome, error FROM dependency_call_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(outcome, "error");
+        assert!(
+            error.unwrap().contains("broker down"),
+            "failure message must be recorded"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegates_local_methods_without_recording() {
+        let (sender, mut receiver) = TelemetrySender::channel();
+        let executor = InstrumentedExecutor::new(MockExecutor::new(), sender);
+
+        assert_eq!(
+            executor.to_supported_executor(),
+            MockExecutor::new().to_supported_executor()
+        );
+        executor.parse_order_id("order-1").unwrap();
+        assert_eq!(executor.maintenance_interval(), None);
+
+        drop(executor);
+        assert!(
+            matches!(receiver.try_recv().unwrap_err(), TryRecvError::Disconnected),
+            "local methods must not emit samples"
+        );
+    }
+}

--- a/src/telemetry/rpc.rs
+++ b/src/telemetry/rpc.rs
@@ -1,0 +1,192 @@
+//! Tower layer recording latency/outcome for every RPC transport call.
+//!
+//! Stacked onto the alloy `ClientBuilder`, so it observes every JSON-RPC
+//! request the process makes -- monitor polls, contract reads, transaction
+//! submission -- regardless of which provider handle issued it. Transport
+//! errors (node down, timeout) are recorded; JSON-RPC error payloads inside
+//! a successful HTTP exchange are not, since those are method-level
+//! semantics rather than dependency health.
+
+use std::borrow::Cow;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use alloy::rpc::json_rpc::{RequestPacket, ResponsePacket};
+use alloy::transports::TransportError;
+use chrono::Utc;
+use tower::{Layer, Service};
+
+use super::{Dependency, DependencyCallSample, TelemetrySender, scrub_secrets};
+
+/// Layer wrapping the RPC transport in a [`RpcTelemetryService`].
+#[derive(Debug, Clone)]
+pub(crate) struct RpcTelemetryLayer {
+    telemetry: TelemetrySender,
+}
+
+impl RpcTelemetryLayer {
+    pub(crate) fn new(telemetry: TelemetrySender) -> Self {
+        Self { telemetry }
+    }
+}
+
+impl<Inner> Layer<Inner> for RpcTelemetryLayer {
+    type Service = RpcTelemetryService<Inner>;
+
+    fn layer(&self, inner: Inner) -> Self::Service {
+        RpcTelemetryService {
+            inner,
+            telemetry: self.telemetry.clone(),
+        }
+    }
+}
+
+/// Transport middleware timing each request packet.
+#[derive(Debug, Clone)]
+pub(crate) struct RpcTelemetryService<Inner> {
+    inner: Inner,
+    telemetry: TelemetrySender,
+}
+
+impl<Inner> Service<RequestPacket> for RpcTelemetryService<Inner>
+where
+    Inner: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>,
+    Inner::Future: Send + 'static,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<ResponsePacket, TransportError>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(context)
+    }
+
+    fn call(&mut self, request: RequestPacket) -> Self::Future {
+        let operation = operation_label(&request);
+        let telemetry = self.telemetry.clone();
+        let started = Instant::now();
+        let call = self.inner.call(request);
+
+        Box::pin(async move {
+            let result = call.await;
+            telemetry.record(DependencyCallSample {
+                recorded_at: Utc::now(),
+                dependency: Dependency::Rpc,
+                operation,
+                duration: started.elapsed(),
+                // Transport errors embed the request URL, which carries the
+                // provider API key -- scrub before it reaches the database.
+                error: result
+                    .as_ref()
+                    .err()
+                    .map(|error| scrub_secrets(&error.to_string())),
+            });
+            result
+        })
+    }
+}
+
+/// The JSON-RPC method for single requests; batches are labeled as one
+/// `batch` operation rather than exploded per method.
+fn operation_label(request: &RequestPacket) -> Cow<'static, str> {
+    match request {
+        RequestPacket::Single(single) => single.method_clone(),
+        RequestPacket::Batch(_) => Cow::Borrowed("batch"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::rpc::client::ClientBuilder;
+    use httpmock::MockServer;
+
+    use crate::telemetry::spawn_dependency_call_writer;
+    use crate::test_utils::setup_test_db;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn layered_provider_records_method_latency_and_outcome() {
+        let server = MockServer::start_async().await;
+        let success = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST);
+                then.status(200).json_body(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": "0x10",
+                }));
+            })
+            .await;
+
+        let pool = setup_test_db().await;
+        let (sender, receiver) = TelemetrySender::channel();
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+
+        let client = ClientBuilder::default()
+            .layer(RpcTelemetryLayer::new(sender.clone()))
+            .http(server.url("/").parse().unwrap());
+        let provider = ProviderBuilder::new().connect_client(client);
+
+        let block = provider.get_block_number().await.unwrap();
+        assert_eq!(block, 16);
+        success.assert_async().await;
+
+        drop(provider);
+        drop(sender);
+        writer.await.unwrap();
+
+        let rows: Vec<(String, String, String)> =
+            sqlx::query_as("SELECT dependency, operation, outcome FROM dependency_call_samples")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, "rpc");
+        assert_eq!(rows[0].1, "eth_blockNumber");
+        assert_eq!(rows[0].2, "ok");
+    }
+
+    #[tokio::test]
+    async fn transport_failure_is_recorded_as_error() {
+        let pool = setup_test_db().await;
+        let (sender, receiver) = TelemetrySender::channel();
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+
+        // URL carries a fake API key in the path (Alchemy-style). Nothing
+        // listens on this port so the transport call fails, and the error
+        // message from the HTTP client will contain the full URL. The key
+        // must be scrubbed before the error reaches the database.
+        let client = ClientBuilder::default()
+            .layer(RpcTelemetryLayer::new(sender.clone()))
+            .http("http://127.0.0.1:1/v2/FAKE_KEY_123".parse().unwrap());
+        let provider = ProviderBuilder::new().connect_client(client);
+
+        provider.get_block_number().await.unwrap_err();
+
+        drop(provider);
+        drop(sender);
+        writer.await.unwrap();
+
+        let (operation, outcome, error): (String, String, Option<String>) =
+            sqlx::query_as("SELECT operation, outcome, error FROM dependency_call_samples")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(operation, "eth_blockNumber");
+        assert_eq!(outcome, "error");
+        let error = error.unwrap();
+        assert!(
+            !error.contains("FAKE_KEY_123"),
+            "API key must not appear in persisted error; got: {error:?}"
+        );
+        assert!(
+            error.contains("<redacted>"),
+            "redaction marker must be present in persisted error; got: {error:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What

- [RAI-998](https://linear.app/makeitrain/issue/RAI-998)
- Add a tower `RpcTelemetryLayer` on the alloy HTTP client so every JSON-RPC call is timed and recorded into `dependency_call_samples`.
- Add an `InstrumentedExecutor<Inner>` decorator that times hedge broker calls on the same table.
- Surface per-(dependency, operation) latency percentiles, per-bucket sparkline data, and error counts in `GET /performance/infra` as a `dependencies` field in `InfraReport`.
- New dashboard "Dependency health" card shows per-row sparkline bars (red = errors) + p50/p95/max latencies.

## Why

RAI-997 made ingestion health visible, but the RPC node and broker API the bot depends on were invisible — a slow or flapping provider appeared nowhere in the dashboard.

## How

- **RPC layer:** `RpcTelemetryLayer` (tower middleware) wraps the alloy transport via `ClientBuilder::default().layer(…).http(url)` + `connect_client`, so all JSON-RPC calls from any provider handle are timed. Method name is the operation label; batches labelled `batch`. Transport errors are recorded; JSON-RPC error payloads inside HTTP 200 are not (method semantics, not dependency health). RPC error strings are scrubbed before persistence — transport errors embed the provider URL which carries API keys (`?dkey=`, `/v2/<key>`, userinfo) — redacted to `scheme://host/<redacted>`.
- **Broker decorator:** `InstrumentedExecutor<Inner>` in the main crate times the hedge executor's remote methods. The execution crate stays telemetry-free.
- **Write path:** hot paths emit through a non-blocking `TelemetrySender` (bounded mpsc, `try_send`, drops counted + rate-limit logged) into a background writer that batches inserts via `recv_many` and prunes `dependency_call_samples` hourly.
- **Read path:** `load_dependency_stats` computes bucket index and error flag in SQL, groups by `(dependency, operation)`, and computes percentiles in Rust (SQLite has no percentile function). Mirrors block-lag bucketing convention.
- Migration `20260612013722_dependency_call_samples.sql` (`dependency IN ('rpc','broker')`, `outcome IN ('ok','error')`, time index). New DTOs `DependencyName`, `DependencyStats`, `DependencyBucket`. Adds the `tower` dep.
- Startup wiring extracted to `setup_instrumentation` and `setup_trading_pipeline_queues` helpers to keep `Conductor::run` within line limits. `TelemetrySender` connected-state is a single `Option` — writer holds the receiver; executor and RPC layer each hold a clone; original dropped after spawning.

## Testing

- RPC layer: success via httpmock; transport failure via a closed localhost port.
- Broker decorator: per-operation labels, failure recorded as error, local methods not recorded.
- Writer: batched persist + exit on channel close, full-channel drop counting (proves non-blocking), retention prune asserting the surviving row, secret scrubbing across query/path/userinfo key styles.
- Read path: per-(dependency, operation) bucket aggregation with no cross-bucket error leakage; `/performance/infra` dependency join integration test.
- Dashboard: `layoutDependencySparkline` unit test — bar scaling to slowest bucket median, error bucket flagging, null p50 buckets.

## Anything else

Telemetry is best-effort: a full or wedged channel drops samples (counted, logged) and never blocks a trading hot path. Broker errors are scrubbed of the same URL patterns as RPC before persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dependency health monitoring dashboard card displaying per-dependency/operation call counts, error rates, and latency percentiles with visual indicators
  * Extended the performance API to include external dependency (RPC, Broker) statistics and aggregated telemetry

* **Chores**
  * Added telemetry collection infrastructure for tracking external dependency calls
  * Updated database schema to support dependency call sample storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->