### PR TITLE
feat: instrument rebalancer broker USDC-conversion calls in dependency telemetry

### DIFF
--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -60,6 +60,20 @@ pub use order::{
     CryptoOrderResponse, ParseAlpacaLimitPriceError,
 };
 
+impl fmt::Display for CryptoOrderFailureReason {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Canceled => formatter.write_str("Canceled"),
+            Self::Expired => formatter.write_str("Expired"),
+            Self::Rejected => formatter.write_str("Rejected"),
+            Self::DoneForDay => formatter.write_str("DoneForDay"),
+            Self::Replaced => formatter.write_str("Replaced"),
+            Self::Suspended => formatter.write_str("Suspended"),
+            Self::Calculated => formatter.write_str("Calculated"),
+        }
+    }
+}
+
 impl fmt::Display for TimeInForce {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -147,7 +161,7 @@ pub enum AlpacaBrokerApiError {
         status: AccountStatus,
     },
 
-    #[error("Crypto order {order_id} failed: {reason:?}")]
+    #[error("Crypto order {order_id} failed: {reason}")]
     CryptoOrderFailed {
         order_id: Uuid,
         reason: CryptoOrderFailureReason,

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -27,6 +27,8 @@ use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, Redemp
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};
+use crate::telemetry::TelemetrySender;
+use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::tokenization::{
     AlpacaTokenizationService, TokenizationRequest, TokenizationRequestStatus, Tokenizer,
 };
@@ -413,7 +415,13 @@ async fn run_usdc_transfer<Writer: Write>(
         counter_trade_slippage_bps: alpaca_auth.counter_trade_slippage_bps,
     };
 
-    let alpaca_broker = Arc::new(AlpacaBrokerApi::try_from_ctx(broker_auth.clone()).await?);
+    // The CLI has no telemetry writer, so broker dependency samples have nowhere
+    // to go; wrap with a disabled sender purely to satisfy the shared
+    // `CrossVenueCashTransfer` constructor.
+    let alpaca_broker = InstrumentedAlpacaBroker::new(
+        AlpacaBrokerApi::try_from_ctx(broker_auth.clone()).await?,
+        TelemetrySender::disabled(),
+    );
 
     let alpaca_wallet = Arc::new(AlpacaWalletService::new(
         broker_auth.base_url().to_string(),

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -38,9 +38,9 @@ use st0x_event_sorcery::{
 };
 use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
-    AlpacaWalletService, ClientOrderId, CounterTradePreflight, CounterTradeReservation,
-    CounterTradeSkipReason, ExecutionError, Executor, FractionalShares, MarketOrder, Symbol,
-    TryIntoExecutor,
+    AlpacaBrokerApi, AlpacaWalletService, ClientOrderId, CounterTradePreflight,
+    CounterTradeReservation, CounterTradeSkipReason, ExecutionError, Executor, FractionalShares,
+    MarketOrder, Symbol, TryIntoExecutor,
 };
 use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::WrapperService;
@@ -84,6 +84,7 @@ use crate::rebalancing::{
     to_wrapped_equities,
 };
 use crate::symbol::cache::SymbolCache;
+use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::telemetry::executor::InstrumentedExecutor;
 use crate::telemetry::rpc::RpcTelemetryLayer;
 use crate::telemetry::{TelemetrySender, spawn_dependency_call_writer};
@@ -371,15 +372,16 @@ where
 /// Wires the telemetry channel, instrumented executor, and RPC provider together
 /// and spawns the background writer that drains samples into SQLite.
 ///
-/// Returns the instrumented executor, provider (ready for use), and the writer
-/// task handle. Probes the RPC endpoint once to fail fast on misconfiguration
-/// before the rest of startup proceeds: basic reachability plus a usable
-/// `finalized` block tag, which order-fill ingestion depends on for reorg
-/// protection. An endpoint that errors on `finalized`, or aliases it to the
-/// chain tip (disabling reorg protection), is rejected here rather than running
-/// silently degraded; a fresh chain with no finalized block yet is allowed
-/// through. The telemetry sender is held by the executor and RPC layer clones;
-/// when all are dropped the writer exits cleanly.
+/// Returns the instrumented executor, provider (ready for use), the writer task
+/// handle, and the original telemetry sender. Probes the RPC endpoint once to
+/// fail fast on misconfiguration before the rest of startup proceeds: basic
+/// reachability plus a usable `finalized` block tag, which order-fill ingestion
+/// depends on for reorg protection. An endpoint that errors on `finalized`, or
+/// aliases it to the chain tip (disabling reorg protection), is rejected here
+/// rather than running silently degraded; a fresh chain with no finalized block
+/// yet is allowed through. The executor, RPC layer, and the returned sender each
+/// hold a clone of the telemetry channel; the writer exits only when all three
+/// are dropped.
 /// Provider type returned by `ProviderBuilder::new().connect_client(...)` over
 /// an HTTP transport. Named here to make `setup_instrumentation`'s return type
 /// concrete without coupling callers to `alloy` internals.
@@ -395,7 +397,12 @@ async fn setup_instrumentation<E>(
     executor_ctx: impl TryIntoExecutor<Executor = E>,
     rpc_url: &Url,
     pool: SqlitePool,
-) -> anyhow::Result<(InstrumentedExecutor<E>, HttpProvider, JoinHandle<()>)>
+) -> anyhow::Result<(
+    InstrumentedExecutor<E>,
+    HttpProvider,
+    JoinHandle<()>,
+    TelemetrySender,
+)>
 where
     E: Executor,
 {
@@ -443,11 +450,12 @@ where
         FinalityProbe::Supported | FinalityProbe::NotYetAvailable => {}
     }
 
-    // Drop the original sender here; the executor and RPC layer each hold
-    // a clone. When all clones are eventually dropped, the writer exits.
+    // Spawn the writer before returning the sender: the executor, RPC layer,
+    // and the returned sender each hold a clone. When all three are dropped,
+    // the channel closes and the writer task exits cleanly.
     let telemetry_writer = spawn_dependency_call_writer(pool, telemetry_receiver);
 
-    Ok((executor, provider, telemetry_writer))
+    Ok((executor, provider, telemetry_writer, telemetry))
 }
 
 impl Conductor {
@@ -472,7 +480,7 @@ impl Conductor {
             apalis: apalis_pool,
         } = pools;
 
-        let (executor, provider, telemetry_writer) =
+        let (executor, provider, telemetry_writer, telemetry) =
             setup_instrumentation(executor_ctx, &ctx.evm.rpc_url, pool.clone()).await?;
         let cache = SymbolCache::default();
 
@@ -535,16 +543,17 @@ impl Conductor {
             resume_tokenization_queue,
         } = PositionAndRebalancing::setup(
             rebalancing,
-            &ctx,
-            &DatabasePools {
-                cqrs: pool.clone(),
-                apalis: apalis_pool.clone(),
+            RebalancingDeps {
+                pool: pool.clone(),
+                apalis_pool: apalis_pool.clone(),
+                ctx: ctx.clone(),
+                inventory: inventory.clone(),
+                event_sender,
+                vault_registry: vault_registry.clone(),
+                vault_registry_projection,
+                schedulers: schedulers.clone(),
+                telemetry: telemetry.clone(),
             },
-            inventory.clone(),
-            event_sender,
-            vault_registry.clone(),
-            vault_registry_projection,
-            schedulers.clone(),
         )
         .await?;
 
@@ -1076,6 +1085,7 @@ struct RebalancingDeps {
     vault_registry: Arc<Store<VaultRegistry>>,
     vault_registry_projection: Arc<Projection<VaultRegistry>>,
     schedulers: RebalancingSchedulers,
+    telemetry: TelemetrySender,
 }
 
 /// Position + rebalancing-adjacent infrastructure produced during conductor
@@ -1104,45 +1114,35 @@ struct PositionAndRebalancing {
 impl PositionAndRebalancing {
     async fn setup(
         rebalancing: Option<RebalancingCtx>,
-        ctx: &Ctx,
-        pools: &DatabasePools,
-        inventory: Arc<BroadcastingInventory>,
-        event_sender: broadcast::Sender<Statement>,
-        vault_registry: Arc<Store<VaultRegistry>>,
-        vault_registry_projection: Arc<Projection<VaultRegistry>>,
-        schedulers: RebalancingSchedulers,
+        deps: RebalancingDeps,
     ) -> anyhow::Result<Self> {
-        let pool = &pools.cqrs;
-        let apalis_pool = &pools.apalis;
-
         if let Some(rebalancing_ctx) = rebalancing {
-            let wallet_ctx = ctx.wallet()?;
+            let wallet_ctx = deps.ctx.wallet()?;
             let ethereum_wallet = wallet_ctx.ethereum_wallet().clone();
             let base_wallet = wallet_ctx.base_wallet().clone();
+            let redemption_wallet = deps.ctx.redemption_wallet()?;
+
+            // Computed before `deps` is moved into the spawn call, since
+            // `WalletPollingCtx` below also needs the config behind `deps.ctx`.
+            let unwrapped_equity_token_addresses =
+                base_wallet_unwrapped_equity_token_addresses(&deps.ctx);
+            let wrapped_equity_token_addresses =
+                base_wallet_wrapped_equity_token_addresses(&deps.ctx);
 
             let infra = spawn_rebalancing_infrastructure(
                 rebalancing_ctx,
-                ctx.redemption_wallet()?,
+                redemption_wallet,
                 ethereum_wallet.clone(),
                 base_wallet.clone(),
-                RebalancingDeps {
-                    pool: pool.clone(),
-                    apalis_pool: apalis_pool.clone(),
-                    ctx: ctx.clone(),
-                    inventory: inventory.clone(),
-                    event_sender,
-                    vault_registry,
-                    vault_registry_projection,
-                    schedulers,
-                },
+                deps,
             )
             .await?;
 
             let wallet_polling = crate::inventory::WalletPollingCtx {
                 ethereum: Arc::new(ethereum_wallet),
                 base: Arc::new(base_wallet),
-                unwrapped_equity_token_addresses: base_wallet_unwrapped_equity_token_addresses(ctx),
-                wrapped_equity_token_addresses: base_wallet_wrapped_equity_token_addresses(ctx),
+                unwrapped_equity_token_addresses,
+                wrapped_equity_token_addresses,
             };
 
             Ok(Self {
@@ -1166,8 +1166,15 @@ impl PositionAndRebalancing {
                 resume_tokenization_queue: Some(infra.resume_tokenization_queue),
             })
         } else {
+            let RebalancingDeps {
+                pool,
+                inventory,
+                event_sender,
+                ..
+            } = deps;
+
             let broadcaster = Arc::new(Broadcaster::new(event_sender, pool.clone()));
-            let (position, position_projection) = build_position_cqrs(pool, broadcaster).await?;
+            let (position, position_projection) = build_position_cqrs(&pool, broadcaster).await?;
 
             // Without the service, the projection is the only subscriber
             // keeping the dashboard view in sync.
@@ -1355,8 +1362,18 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             alpaca_auth.api_secret.clone(),
         ));
 
+        // Build the broker here (not inside `RebalancerServices::new`) so it can
+        // be wrapped in the telemetry decorator before being threaded down. This
+        // mirrors how the hedge executor is wrapped in `Conductor::run` before
+        // use, so the rebalancer's Alpaca conversion calls emit broker dependency
+        // samples alongside the hedge path.
+        let broker = InstrumentedAlpacaBroker::new(
+            AlpacaBrokerApi::try_from_ctx(alpaca_auth.clone()).await?,
+            deps.telemetry.clone(),
+        );
+
         let services = RebalancerServices::new(
-            alpaca_auth.clone(),
+            broker,
             Arc::clone(&alpaca_wallet),
             ethereum_wallet,
             base_wallet,
@@ -1371,8 +1388,7 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
                 #[cfg(feature = "test-support")]
                 message_transmitter: rebalancing_ctx.message_transmitter,
             },
-        )
-        .await?;
+        )?;
 
         let usdc_vault_id = deps
             .ctx
@@ -6520,16 +6536,17 @@ mod tests {
 
         let position_and_rebalancing = PositionAndRebalancing::setup(
             None,
-            &ctx,
-            &DatabasePools {
-                cqrs: pool.clone(),
-                apalis: apalis_pool.clone(),
+            RebalancingDeps {
+                pool: pool.clone(),
+                apalis_pool: apalis_pool.clone(),
+                ctx: ctx.clone(),
+                inventory,
+                event_sender,
+                vault_registry,
+                vault_registry_projection,
+                schedulers: RebalancingSchedulers::new(&apalis_pool),
+                telemetry: TelemetrySender::disabled(),
             },
-            inventory,
-            event_sender,
-            vault_registry,
-            vault_registry_projection,
-            RebalancingSchedulers::new(&apalis_pool),
         )
         .await
         .unwrap();

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -9,23 +9,19 @@ use st0x_bridge::cctp::{CctpBridge, CctpCtx, CctpError};
 use st0x_config::EquityAssetConfig;
 use st0x_event_sorcery::Store;
 use st0x_evm::{USDC_BASE, USDC_ETHEREUM, Wallet};
-use st0x_execution::{
-    AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, AlpacaWalletService,
-    EmptySymbolError, Executor, Symbol,
-};
+use st0x_execution::{AlpacaWalletService, EmptySymbolError, Symbol};
 use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::WrappedEquity;
 
 use super::usdc::{
     CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca, UsdcSettlementParams,
 };
+use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::usdc_rebalance::UsdcRebalance;
 
 /// Errors that can occur when spawning the rebalancer.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SpawnRebalancerError {
-    #[error("failed to create Alpaca broker API: {0}")]
-    AlpacaBrokerApi(#[from] AlpacaBrokerApiError),
     #[error("failed to create CCTP bridge: {0}")]
     Cctp(#[from] Box<CctpError>),
     #[error("failed to create wrapper service: {0}")]
@@ -64,7 +60,7 @@ pub(crate) struct UsdcTransferResumeHandles {
 /// Holds connections to Alpaca APIs, CCTP bridge, and vault services.
 /// Providers for both chains are obtained from the wallets on `RebalancingCtx`.
 pub(crate) struct RebalancerServices<Chain: Wallet> {
-    broker: Arc<AlpacaBrokerApi>,
+    broker: InstrumentedAlpacaBroker,
     wallet: Arc<AlpacaWalletService>,
     cctp: Arc<CctpBridge<Chain, Chain>>,
     raindex: Arc<RaindexService<Chain>>,
@@ -77,16 +73,14 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
     /// RaindexService is passed in rather than created here because it is
     /// needed for CQRS framework initialization in the conductor, which
     /// must happen before this constructor is called.
-    pub(crate) async fn new(
-        broker_auth: AlpacaBrokerApiCtx,
+    pub(crate) fn new(
+        broker: InstrumentedAlpacaBroker,
         wallet: Arc<AlpacaWalletService>,
         ethereum_wallet: Chain,
         base_wallet: Chain,
         raindex: Arc<RaindexService<Chain>>,
         settlement: UsdcSettlementParams,
     ) -> Result<Self, SpawnRebalancerError> {
-        let broker = Arc::new(AlpacaBrokerApi::try_from_ctx(broker_auth).await?);
-
         let cctp = Arc::new(
             CctpBridge::try_from_ctx(CctpCtx {
                 usdc_ethereum: USDC_ETHEREUM,
@@ -166,8 +160,8 @@ mod tests {
     use st0x_event_sorcery::test_store;
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_execution::{
-        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, AlpacaWalletService, Symbol,
-        TimeInForce,
+        AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode,
+        AlpacaWalletService, Executor, Symbol, TimeInForce,
     };
     use st0x_float_macro::float;
     use st0x_wrapper::WrappedEquity;
@@ -176,6 +170,7 @@ mod tests {
     use crate::inventory::ImbalanceThreshold;
     use crate::rebalancing::RebalancingServiceConfig;
     use crate::rebalancing::usdc::UsdcSettlementParams;
+    use crate::telemetry::TelemetrySender;
 
     #[test]
     fn to_wrapped_equities_maps_underlying_and_derivative() {
@@ -310,10 +305,11 @@ mod tests {
             time_in_force: TimeInForce::default(),
             counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
         };
-        let broker = Arc::new(
+        let broker = InstrumentedAlpacaBroker::new(
             AlpacaBrokerApi::try_from_ctx(broker_auth)
                 .await
                 .expect("Failed to create test broker API"),
+            TelemetrySender::disabled(),
         );
 
         let wallet = Arc::new(AlpacaWalletService::new(
@@ -360,37 +356,6 @@ mod tests {
         };
 
         (services, rebalancing_ctx)
-    }
-
-    #[tokio::test]
-    async fn broker_auth_failure_returns_spawn_error() {
-        let server = MockServer::start();
-
-        let _account_mock = server.mock(|when, then| {
-            when.method(GET).path_includes("/trading/accounts/");
-            then.status(401)
-                .header("content-type", "application/json")
-                .json_body(json!({"message": "Invalid API credentials"}));
-        });
-
-        let broker_auth = AlpacaBrokerApiCtx {
-            api_key: "invalid_key".to_string(),
-            api_secret: "invalid_secret".to_string(),
-            account_id: AlpacaAccountId::new(Uuid::nil()),
-            mode: Some(AlpacaBrokerApiMode::Mock(server.base_url())),
-            asset_cache_ttl: std::time::Duration::from_secs(3600),
-            time_in_force: TimeInForce::default(),
-            counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
-        };
-
-        let spawn_error: SpawnRebalancerError = AlpacaBrokerApi::try_from_ctx(broker_auth)
-            .await
-            .unwrap_err()
-            .into();
-        assert!(
-            matches!(spawn_error, SpawnRebalancerError::AlpacaBrokerApi(_)),
-            "Expected AlpacaBrokerApi error variant, got: {spawn_error:?}"
-        );
     }
 
     #[tokio::test]

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -17,13 +17,14 @@ use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt
 use st0x_event_sorcery::Store;
 use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
-    AlpacaBrokerApi, AlpacaTransferId, AlpacaWalletService, ClientOrderId, ConversionDirection,
-    CryptoOrderOutcome, Network, Positive, TokenSymbol, Transfer, TransferStatus,
+    AlpacaTransferId, AlpacaWalletService, ClientOrderId, ConversionDirection, CryptoOrderOutcome,
+    Network, Positive, TokenSymbol, Transfer, TransferStatus,
 };
 use st0x_finance::Usdc;
 use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
 
 use super::UsdcTransferError;
+use crate::telemetry::broker::InstrumentedAlpacaBroker;
 use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
 };
@@ -54,7 +55,7 @@ pub(crate) struct UsdcSettlementParams {
 ///
 /// * `Chain` - Wallet type used for both Ethereum and Base chains
 pub(crate) struct CrossVenueCashTransfer<Chain: Wallet> {
-    alpaca_broker: Arc<AlpacaBrokerApi>,
+    alpaca_broker: InstrumentedAlpacaBroker,
     alpaca_wallet: Arc<AlpacaWalletService>,
     cctp_bridge: Arc<CctpBridge<Chain, Chain>>,
     raindex: Arc<RaindexService<Chain>>,
@@ -72,7 +73,7 @@ enum AttestationPollOutcome {
 
 impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     pub(crate) fn new(
-        alpaca_broker: Arc<AlpacaBrokerApi>,
+        alpaca_broker: InstrumentedAlpacaBroker,
         alpaca_wallet: Arc<AlpacaWalletService>,
         cctp_bridge: Arc<CctpBridge<Chain, Chain>>,
         raindex: Arc<RaindexService<Chain>>,
@@ -2916,8 +2917,8 @@ mod tests {
 
     use st0x_execution::alpaca_broker_api::CryptoOrderFailureReason;
     use st0x_execution::{
-        AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiError, AlpacaBrokerApiMode, Executor,
-        TimeInForce,
+        AlpacaAccountId, AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError,
+        AlpacaBrokerApiMode, Executor, TimeInForce,
     };
 
     use st0x_bridge::Bridge;
@@ -2932,6 +2933,7 @@ mod tests {
     use st0x_raindex::RaindexService;
 
     use super::*;
+    use crate::telemetry::TelemetrySender;
     use crate::usdc_rebalance::{RebalanceDirection, TransferRef, UsdcRebalanceError};
     use st0x_finance::UsdcConversionError;
 
@@ -3531,7 +3533,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3587,7 +3592,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3650,7 +3658,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3707,7 +3718,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3747,7 +3761,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3786,7 +3803,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3832,7 +3852,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3886,7 +3909,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3931,7 +3957,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -3984,7 +4013,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4105,7 +4137,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4173,7 +4208,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4245,7 +4283,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4313,7 +4354,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4374,7 +4418,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4451,7 +4498,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4515,7 +4565,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4571,7 +4624,10 @@ mod tests {
         let (_anvil, endpoint, private_key) = setup_anvil();
 
         let _account_mock = create_broker_account_mock(&server);
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4628,7 +4684,10 @@ mod tests {
         alloy::node_bindings::AnvilInstance,
     ) {
         let (anvil, endpoint, private_key) = setup_anvil();
-        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -4663,7 +4722,10 @@ mod tests {
         alloy::node_bindings::AnvilInstance,
     ) {
         let (anvil, endpoint, private_key) = setup_anvil();
-        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) =
@@ -6194,7 +6256,10 @@ mod tests {
 
         // Build the manager on the same bridge with Alpaca mocked.
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -6372,7 +6437,10 @@ mod tests {
             .unwrap();
 
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -6632,7 +6700,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -6687,7 +6758,10 @@ mod tests {
         let server = MockServer::start();
         let (_anvil, endpoint, private_key) = setup_anvil();
 
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let wallet = create_test_wallet(&endpoint, &private_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -6975,7 +7049,10 @@ mod tests {
         cqrs: Arc<Store<UsdcRebalance>>,
     ) -> CrossVenueCashTransfer<RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>>
     {
-        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(server).await,
+            TelemetrySender::disabled(),
+        );
         let bridge_wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(bridge_wallet);
 
@@ -7425,7 +7502,10 @@ mod tests {
         >,
         Arc<Store<UsdcRebalance>>,
     ) {
-        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(server));
         let wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
@@ -9167,7 +9247,10 @@ mod tests {
 
         // Build the manager.
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -9307,7 +9390,10 @@ mod tests {
 
         // Build the manager.
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -9439,7 +9525,10 @@ mod tests {
         .unwrap();
 
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -9571,7 +9660,10 @@ mod tests {
 
         // Build the manager.
         let server = MockServer::start();
-        let alpaca_broker = Arc::new(create_test_broker_service(&server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(&server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(&server));
         let vault_service = RaindexService::new(
             create_test_wallet(&chains.base_endpoint, &chains.bot_key),
@@ -9677,7 +9769,10 @@ mod tests {
         let dead_key = B256::from_slice(&[0x01u8; 32]);
         let wallet = create_test_wallet(dead_endpoint, &dead_key);
 
-        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_broker = InstrumentedAlpacaBroker::new(
+            create_test_broker_service(server).await,
+            TelemetrySender::disabled(),
+        );
         let alpaca_wallet = Arc::new(create_test_wallet_service(server));
         let (cctp_bridge, vault_service) = create_test_onchain_services(wallet.clone());
         let cqrs = create_test_store_instance().await;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -28,6 +28,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
+pub(crate) mod broker;
 pub(crate) mod executor;
 pub(crate) mod rpc;
 

--- a/src/telemetry/broker.rs
+++ b/src/telemetry/broker.rs
@@ -1,0 +1,588 @@
+//! Latency/error capture decorator over Alpaca's conversion-only broker methods.
+//!
+//! The rebalancer calls three methods (`convert_usdc_usd`, `find_conversion_order`,
+//! `poll_conversion_to_terminal`) that are specific to Alpaca and not on the generic
+//! `Executor` trait, so `InstrumentedExecutor` does not cover them. This decorator
+//! wraps an `AlpacaBrokerApi` once at rebalancer startup, in
+//! `spawn_rebalancing_infrastructure`, and emits `dependency='broker'` samples for
+//! each call. Lives in the main crate: the execution crate stays telemetry-free.
+//!
+//! # Duration semantics
+//!
+//! The `duration` field in recorded samples has different meanings depending on
+//! the operation:
+//!
+//! - `find_conversion_order` -- a single HTTP request; duration reflects
+//!   point-in-time network latency (milliseconds).
+//! - `convert_usdc_usd` and `poll_conversion_to_terminal` -- these methods
+//!   poll with 500 ms sleeps until the crypto order reaches a terminal state,
+//!   so `duration` captures end-to-end settlement wait time (seconds to
+//!   minutes). Dashboard latency queries must treat these two operations
+//!   separately from `find_conversion_order` to avoid misleading averages.
+
+use std::time::Instant;
+
+use chrono::Utc;
+use rain_math_float::Float;
+use uuid::Uuid;
+
+use st0x_execution::alpaca_broker_api::{CryptoOrderOutcome, CryptoOrderResponse};
+use st0x_execution::{AlpacaBrokerApi, AlpacaBrokerApiError, ClientOrderId, ConversionDirection};
+
+use super::{Dependency, DependencyCallSample, TelemetrySender, scrub_secrets};
+
+/// An [`AlpacaBrokerApi`] whose USDC conversion calls are timed and recorded.
+///
+/// Only the three conversion methods the rebalancer uses are exposed and timed;
+/// they are the calls that produce `dependency='broker'` gaps in the dashboard.
+/// Other `AlpacaBrokerApi` methods are intentionally not surfaced here.
+#[derive(Debug, Clone)]
+pub(crate) struct InstrumentedAlpacaBroker {
+    inner: AlpacaBrokerApi,
+    telemetry: TelemetrySender,
+}
+
+impl InstrumentedAlpacaBroker {
+    pub(crate) fn new(inner: AlpacaBrokerApi, telemetry: TelemetrySender) -> Self {
+        Self { inner, telemetry }
+    }
+
+    fn record<Value>(
+        &self,
+        operation: &'static str,
+        started: Instant,
+        result: &Result<Value, AlpacaBrokerApiError>,
+    ) {
+        self.telemetry.record(DependencyCallSample {
+            recorded_at: Utc::now(),
+            dependency: Dependency::Broker,
+            operation: operation.into(),
+            duration: started.elapsed(),
+            error: result
+                .as_ref()
+                .err()
+                .map(|error| scrub_secrets(&error.to_string())),
+        });
+    }
+
+    pub(crate) async fn convert_usdc_usd(
+        &self,
+        amount: Float,
+        direction: ConversionDirection,
+        client_order_id: &ClientOrderId,
+    ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
+        let started = Instant::now();
+        let result = self
+            .inner
+            .convert_usdc_usd(amount, direction, client_order_id)
+            .await;
+        self.record("convert_usdc_usd", started, &result);
+        result
+    }
+
+    pub(crate) async fn find_conversion_order(
+        &self,
+        client_order_id: &ClientOrderId,
+    ) -> Result<Option<CryptoOrderResponse>, AlpacaBrokerApiError> {
+        let started = Instant::now();
+        let result = self.inner.find_conversion_order(client_order_id).await;
+        self.record("find_conversion_order", started, &result);
+        result
+    }
+
+    pub(crate) async fn poll_conversion_to_terminal(
+        &self,
+        order_id: Uuid,
+    ) -> Result<CryptoOrderResponse, AlpacaBrokerApiError> {
+        let started = Instant::now();
+        let result = self.inner.poll_conversion_to_terminal(order_id).await;
+
+        // The inner method returns `Ok(order)` for BOTH filled and terminally-failed
+        // orders (canceled/expired/rejected); classify to surface failures as errors.
+        // Its poll loop only returns once the order is terminal, so a returned `Ok` is
+        // `Filled` or `Failed` -- `Pending` is not reachable here, but a non-failed
+        // order is not a broker error either way, so it shares the `Filled` arm.
+        let error = match &result {
+            Err(error) => Some(scrub_secrets(&error.to_string())),
+            Ok(order) => match order.classify() {
+                CryptoOrderOutcome::Filled | CryptoOrderOutcome::Pending => None,
+                CryptoOrderOutcome::Failed(reason) => Some(scrub_secrets(&format!(
+                    "conversion order terminally failed: {reason}"
+                ))),
+            },
+        };
+
+        self.telemetry.record(DependencyCallSample {
+            recorded_at: Utc::now(),
+            dependency: Dependency::Broker,
+            operation: "poll_conversion_to_terminal".into(),
+            duration: started.elapsed(),
+            error,
+        });
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::Method::{GET, POST};
+    use httpmock::MockServer;
+    use serde_json::json;
+    use uuid::{Uuid, uuid};
+
+    use st0x_execution::alpaca_broker_api::{AlpacaBrokerApiCtx, AlpacaBrokerApiMode};
+    use st0x_execution::{
+        AlpacaAccountId, AlpacaBrokerApi, ClientOrderId, ConversionDirection, Executor,
+    };
+    use st0x_float_macro::float;
+
+    use super::*;
+    use crate::telemetry::spawn_dependency_call_writer;
+    use crate::test_utils::setup_test_db;
+
+    const TEST_ACCOUNT_ID: AlpacaAccountId =
+        AlpacaAccountId::new(uuid!("904837e3-3b76-47ec-b432-046db621571b"));
+    const TEST_ORDER_ID: Uuid = uuid!("61e7b016-9c91-4a97-b912-615c9d365c9d");
+
+    async fn make_broker(server: &MockServer) -> AlpacaBrokerApi {
+        let _account_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/account"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": TEST_ACCOUNT_ID.to_string(),
+                    "status": "ACTIVE"
+                }));
+        });
+
+        let auth = AlpacaBrokerApiCtx {
+            api_key: "test_key".to_string(),
+            api_secret: "test_secret".to_string(),
+            account_id: TEST_ACCOUNT_ID,
+            mode: Some(AlpacaBrokerApiMode::Mock(server.base_url())),
+            asset_cache_ttl: std::time::Duration::from_secs(3600),
+            time_in_force: st0x_execution::TimeInForce::default(),
+            counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,
+        };
+
+        AlpacaBrokerApi::try_from_ctx(auth)
+            .await
+            .expect("Failed to create test broker API")
+    }
+
+    fn filled_order_json(order_id: &str, amount: &str) -> serde_json::Value {
+        json!({
+            "id": order_id,
+            "symbol": "USDCUSD",
+            "qty": amount,
+            "status": "filled",
+            "filled_avg_price": "1.0001",
+            "filled_qty": amount,
+            "created_at": "2024-01-15T10:30:00Z"
+        })
+    }
+
+    /// Named projection of a `dependency_call_samples` row for readable assertions.
+    #[derive(sqlx::FromRow)]
+    struct SampleRow {
+        dependency: String,
+        operation: String,
+        outcome: String,
+        error: Option<String>,
+    }
+
+    async fn drain_samples(
+        pool: &sqlx::SqlitePool,
+        instrumented: InstrumentedAlpacaBroker,
+        sender: TelemetrySender,
+        receiver: tokio::sync::mpsc::Receiver<DependencyCallSample>,
+    ) -> Vec<SampleRow> {
+        let writer = spawn_dependency_call_writer(pool.clone(), receiver);
+        // Both sender clones must drop for the writer's channel to close: the
+        // decorator holds one internally, the test holds the other.
+        drop(instrumented);
+        drop(sender);
+        writer.await.unwrap();
+
+        sqlx::query_as(
+            "SELECT dependency, operation, outcome, error \
+             FROM dependency_call_samples ORDER BY id",
+        )
+        .fetch_all(pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn records_convert_usdc_usd_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        let _place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(filled_order_json(&TEST_ORDER_ID.to_string(), "100"));
+        });
+
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(filled_order_json(&TEST_ORDER_ID.to_string(), "100"));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        instrumented
+            .convert_usdc_usd(
+                float!(100),
+                ConversionDirection::UsdcToUsd,
+                &client_order_id,
+            )
+            .await
+            .unwrap();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "convert_usdc_usd");
+        assert_eq!(rows[0].outcome, "ok");
+        assert_eq!(rows[0].error, None);
+    }
+
+    #[tokio::test]
+    async fn records_convert_usd_to_usdc_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        let _place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(filled_order_json(&TEST_ORDER_ID.to_string(), "100"));
+        });
+
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(filled_order_json(&TEST_ORDER_ID.to_string(), "100"));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        instrumented
+            .convert_usdc_usd(
+                float!(100),
+                ConversionDirection::UsdToUsdc,
+                &client_order_id,
+            )
+            .await
+            .unwrap();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "convert_usdc_usd");
+        assert_eq!(rows[0].outcome, "ok");
+        assert_eq!(rows[0].error, None);
+    }
+
+    #[tokio::test]
+    async fn records_find_conversion_order_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        // 404 -> find_conversion_order returns Ok(None)
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/orders:by_client_order_id");
+            then.status(404)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "order not found"}));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        let result = instrumented
+            .find_conversion_order(&client_order_id)
+            .await
+            .unwrap();
+        let None = result else {
+            panic!("expected find_conversion_order to return None, got {result:?}")
+        };
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "find_conversion_order");
+        assert_eq!(rows[0].outcome, "ok");
+        assert_eq!(rows[0].error, None);
+    }
+
+    #[tokio::test]
+    async fn records_poll_conversion_to_terminal_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(filled_order_json(&TEST_ORDER_ID.to_string(), "50"));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+
+        instrumented
+            .poll_conversion_to_terminal(TEST_ORDER_ID)
+            .await
+            .unwrap();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "poll_conversion_to_terminal");
+        assert_eq!(rows[0].outcome, "ok");
+        assert_eq!(rows[0].error, None);
+    }
+
+    #[tokio::test]
+    async fn records_convert_usdc_usd_error_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        // POST places the order and returns an id; GET polls for status and
+        // returns "canceled", which poll_crypto_order_until_filled maps to
+        // CryptoOrderFailed immediately without sleeping.
+        let _place_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": TEST_ORDER_ID.to_string(),
+                    "symbol": "USDCUSD",
+                    "qty": "100",
+                    "status": "canceled",
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        });
+
+        let _poll_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": TEST_ORDER_ID.to_string(),
+                    "symbol": "USDCUSD",
+                    "qty": "100",
+                    "status": "canceled",
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        instrumented
+            .convert_usdc_usd(
+                float!(100),
+                ConversionDirection::UsdcToUsd,
+                &client_order_id,
+            )
+            .await
+            .unwrap_err();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "convert_usdc_usd");
+        assert_eq!(rows[0].outcome, "error");
+        assert_eq!(
+            rows[0].error.as_deref(),
+            Some("Crypto order 61e7b016-9c91-4a97-b912-615c9d365c9d failed: Canceled")
+        );
+    }
+
+    #[tokio::test]
+    async fn records_poll_conversion_to_terminal_error_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        // HTTP 500 produces a transport-level error in the poll GET.
+        let _poll_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(500)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "internal server error"}));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+
+        instrumented
+            .poll_conversion_to_terminal(TEST_ORDER_ID)
+            .await
+            .unwrap_err();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "poll_conversion_to_terminal");
+        assert_eq!(rows[0].outcome, "error");
+        assert_eq!(
+            rows[0].error.as_deref(),
+            Some("Alpaca API error (500 Internal Server Error): internal server error")
+        );
+    }
+
+    #[tokio::test]
+    async fn records_broker_api_error_with_scrubbed_message() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        // Return 401 with a message that contains a URL-bearing "secret" -- scrub_secrets
+        // must strip the path component before the error is persisted.
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/orders:by_client_order_id");
+            then.status(401)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "message": "https://broker-api.alpaca.markets/v2/SECRET_KEY: unauthorized"
+                }));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        instrumented
+            .find_conversion_order(&client_order_id)
+            .await
+            .unwrap_err();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "find_conversion_order");
+        assert_eq!(rows[0].outcome, "error");
+        let error_msg = rows[0].error.as_deref().unwrap_or("");
+        // scrub_secrets strips the path after the host, replacing it with /<redacted>.
+        // The colon after SECRET_KEY and the trailing word are preserved as separate tokens.
+        assert_eq!(
+            error_msg,
+            "Alpaca API error (401 Unauthorized): \
+             https://broker-api.alpaca.markets/<redacted> unauthorized",
+            "scrubbed error must redact the URL path and preserve the host"
+        );
+        assert!(
+            !error_msg.contains("SECRET_KEY"),
+            "error message must not contain the secret key; got: {error_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn records_find_conversion_order_error_as_broker_operation() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path_includes("/orders:by_client_order_id");
+            then.status(500)
+                .header("content-type", "application/json")
+                .json_body(json!({"message": "internal server error"}));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+        let client_order_id = ClientOrderId::from_uuid(Uuid::new_v4());
+
+        instrumented
+            .find_conversion_order(&client_order_id)
+            .await
+            .unwrap_err();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "find_conversion_order");
+        assert_eq!(rows[0].outcome, "error");
+        assert_eq!(
+            rows[0].error.as_deref(),
+            Some("Alpaca API error (500 Internal Server Error): internal server error")
+        );
+    }
+
+    #[tokio::test]
+    async fn records_poll_conversion_to_terminal_terminal_failure_records_error() {
+        let pool = setup_test_db().await;
+        let server = MockServer::start();
+        let broker = make_broker(&server).await;
+
+        // Canceled order: inner returns Ok(order) but classify() => Failed(Canceled).
+        let _get_mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/trading/accounts/{TEST_ACCOUNT_ID}/orders/{TEST_ORDER_ID}"
+            ));
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!({
+                    "id": TEST_ORDER_ID.to_string(),
+                    "symbol": "USDCUSD",
+                    "qty": "100",
+                    "status": "canceled",
+                    "created_at": "2024-01-15T10:30:00Z"
+                }));
+        });
+
+        let (sender, receiver) = TelemetrySender::channel();
+        let instrumented = InstrumentedAlpacaBroker::new(broker, sender.clone());
+
+        // Returns Ok even for terminal failures -- the caller classifies.
+        instrumented
+            .poll_conversion_to_terminal(TEST_ORDER_ID)
+            .await
+            .unwrap();
+
+        let rows = drain_samples(&pool, instrumented, sender, receiver).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].dependency, "broker");
+        assert_eq!(rows[0].operation, "poll_conversion_to_terminal");
+        assert_eq!(rows[0].outcome, "error");
+        assert_eq!(
+            rows[0].error.as_deref(),
+            Some("conversion order terminally failed: Canceled")
+        );
+    }
+}

--- a/src/telemetry/executor.rs
+++ b/src/telemetry/executor.rs
@@ -3,9 +3,10 @@
 //! Wraps the hedge broker executor once at conductor startup, so every hedge
 //! consumer cloning it (order placement, status polling, inventory polling,
 //! maintenance) emits dependency-call telemetry without knowing about it. The
-//! rebalancer builds its own broker handle and is not covered here. Lives in
-//! the main crate: the execution crate stays independent of the telemetry
-//! store.
+//! rebalancer's USDC conversion calls are timed by `InstrumentedAlpacaBroker`
+//! in `crate::telemetry::broker`; this decorator covers the generic `Executor`
+//! methods used on the hedge path. Lives in the main crate: the execution crate
+//! stays independent of the telemetry store.
 
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
## What

- [RAI-1013](https://linear.app/makeitrain/issue/RAI-1013)
- Add `InstrumentedAlpacaBroker` (`src/telemetry/broker.rs`) that wraps `AlpacaBrokerApi` with a `TelemetrySender` and records dependency-call samples for the three USDC-conversion methods: `convert_usdc_usd`, `find_conversion_order`, and `poll_conversion_to_terminal`.
- Rebalancer's Alpaca broker calls now appear in the dashboard broker-health panel alongside hedge-path calls.
- `CryptoOrderFailureReason` gets a `Display` impl so persisted error strings are stable human-readable labels rather than debug-format output.

## Why

[RAI-998](https://linear.app/makeitrain/issue/RAI-998) instrumented the hedge executor via `InstrumentedExecutor`, but the rebalancer's broker was built independently inside `RebalancerServices::new` and its three Alpaca-specific USDC-conversion methods are not on the `Executor` trait — so rebalancer broker traffic did not appear in the dependency-health panel.

## How

- `InstrumentedAlpacaBroker` times each conversion method and records a `DependencyCallSample` with `dependency=Broker`, method name as `operation`, and `scrub_secrets`-cleaned error text. Lives in the main crate so the execution crate stays telemetry-free.
- Broker construction moves up into `spawn_rebalancing_infrastructure` in `conductor.rs`, where it is wrapped before being threaded down — mirroring the hedge executor pattern. `RebalancerServices::new` and `CrossVenueCashTransfer::new` now take `InstrumentedAlpacaBroker` directly.
- `TelemetrySender` is plumbed to the rebalancer via a new `telemetry` field on the existing `RebalancingDeps` struct. `PositionAndRebalancing::setup` now takes `RebalancingDeps` as a single struct (was 8 positional args). The CLI wraps with `TelemetrySender::disabled()` since it has no telemetry writer.
- `poll_conversion_to_terminal` records terminally-failed conversions as `outcome='error'`: the inner method returns `Ok(order)` for failed orders, so the decorator inspects the returned order's status to distinguish terminal failure from normal poll completion.
- `RebalancerServices::new` is now sync (broker construction was its only `await`). `SpawnRebalancerError::AlpacaBrokerApi` and its now-redundant test removed — that failure path is covered by the execution crate's `test_try_from_ctx_unauthorized`.

## Testing

8 new unit tests in `src/telemetry/broker.rs`:
- Success outcome for each of the three conversion operations.
- Error outcome for `convert_usdc_usd` (canceled order), `poll_conversion_to_terminal` (HTTP 500 and terminal-failure returned as `Ok`), and `find_conversion_order` (HTTP 500).
- Secret scrubbing: a credentialed error string is redacted before persistence.

All assertions check `dependency='broker'`, operation label, outcome, and exact error text. ~25 `manager.rs` test call sites updated to wrap the broker with `TelemetrySender::disabled()`.

## Anything else

Duration semantics: `convert_usdc_usd` and `poll_conversion_to_terminal` poll with 500ms sleeps until terminal, so their recorded `duration` is end-to-end settlement time (seconds to minutes), not per-call latency. Dashboard latency queries should treat these two operations separately from `find_conversion_order`.
