### PR TITLE
fix: skip unconfigured symbols in the equity rebalancing trigger (whitelist semantics)

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1000,6 +1000,20 @@ impl Ctx {
             .get(symbol)
             .is_some_and(|config| config.rebalancing == OperationMode::Enabled)
     }
+
+    /// Returns whether wrapped/unwrapped wallet equity recovery is enabled
+    /// for the given equity.
+    ///
+    /// Independent of `rebalancing`: a symbol may opt into recovery while
+    /// keeping automatic rebalancing disabled. Assets not present in the
+    /// config are treated as recovery-disabled by default.
+    pub fn is_wrapped_equity_recovery_enabled(&self, symbol: &Symbol) -> bool {
+        self.assets
+            .equities
+            .symbols
+            .get(symbol)
+            .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
+    }
 }
 
 /// Test-only constructor for `Ctx` that internalizes fields e2e tests
@@ -3705,6 +3719,51 @@ mod tests {
         assert!(
             !ctx.is_rebalancing_enabled(&Symbol::new("UNKNOWN").unwrap()),
             "Unknown assets should default to rebalancing disabled"
+        );
+    }
+
+    #[test]
+    fn is_wrapped_equity_recovery_enabled_is_independent_of_rebalancing() {
+        let mut symbols = HashMap::new();
+        symbols.insert(
+            Symbol::new("AAPL").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: Address::ZERO,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        let ctx = Ctx {
+            assets: AssetsConfig {
+                equities: EquitiesConfig {
+                    operational_limit: None,
+                    symbols,
+                },
+                cash: None,
+            },
+            ..create_test_ctx_with_order_owner(address!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ))
+        };
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        assert!(
+            ctx.is_wrapped_equity_recovery_enabled(&aapl),
+            "Recovery should follow wrapped_equity_recovery config"
+        );
+        assert!(
+            !ctx.is_rebalancing_enabled(&aapl),
+            "Recovery-enabled symbol must not imply rebalancing is enabled"
+        );
+        assert!(
+            !ctx.is_wrapped_equity_recovery_enabled(&Symbol::new("UNKNOWN").unwrap()),
+            "Unknown assets should default to recovery disabled"
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -703,12 +703,18 @@ fn build_unwrapped_equity_recovery_ctx(
     }))
 }
 
+fn base_wallet_equity_recovery_enabled(ctx: &Ctx, symbol: &Symbol) -> bool {
+    ctx.is_trading_enabled(symbol)
+        || ctx.is_rebalancing_enabled(symbol)
+        || ctx.is_wrapped_equity_recovery_enabled(symbol)
+}
+
 fn base_wallet_unwrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Address> {
     ctx.assets
         .equities
         .symbols
         .iter()
-        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .filter(|(symbol, _)| base_wallet_equity_recovery_enabled(ctx, symbol))
         .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity))
         .collect()
 }
@@ -718,7 +724,7 @@ fn base_wallet_wrapped_equity_token_addresses(ctx: &Ctx) -> HashMap<Symbol, Addr
         .equities
         .symbols
         .iter()
-        .filter(|(symbol, _)| ctx.is_trading_enabled(symbol) || ctx.is_rebalancing_enabled(symbol))
+        .filter(|(symbol, _)| base_wallet_equity_recovery_enabled(ctx, symbol))
         .map(|(symbol, config)| (symbol.clone(), config.tokenized_equity_derivative))
         .collect()
 }
@@ -1098,16 +1104,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             wrapper: wrapper.clone(),
         };
 
-        let disabled_assets = deps
-            .ctx
-            .assets
-            .equities
-            .symbols
-            .keys()
-            .filter(|symbol| !deps.ctx.is_rebalancing_enabled(symbol))
-            .cloned()
-            .collect();
-
         let transfer_usdc_to_hedging_queue = deps.schedulers.transfer_usdc_to_hedging.clone();
         let transfer_usdc_to_market_making_queue =
             deps.schedulers.transfer_usdc_to_market_making.clone();
@@ -1118,7 +1114,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
                 usdc: rebalancing_ctx.usdc,
                 transfer_timeout: rebalancing_ctx.transfer_timeout,
                 assets: deps.ctx.assets.clone(),
-                disabled_assets,
             },
             deps.vault_registry,
             deps.ctx.evm.orderbook,
@@ -2398,7 +2393,6 @@ mod tests {
     use apalis::prelude::Status;
     use rain_math_float::Float;
     use sqlx::SqlitePool;
-    use std::collections::HashSet;
     use std::future::pending;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2431,7 +2425,8 @@ mod tests {
     use crate::rebalancing::equity::{TransferEquityToHedging, TransferEquityToMarketMaking};
     use crate::rebalancing::{RebalancingSchedulers, RebalancingService};
     use crate::test_utils::{
-        OnchainTradeBuilder, get_test_log, get_test_order, setup_test_db, setup_test_pools,
+        OnchainTradeBuilder, get_test_log, get_test_order, rebalancing_enabled_equities,
+        setup_test_db, setup_test_pools,
     };
     use crate::trading::onchain::inclusion::EmittedOnChain;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
@@ -2599,9 +2594,11 @@ mod tests {
         let aapl = Symbol::new("AAPL").unwrap();
         let tsla = Symbol::new("TSLA").unwrap();
         let spym = Symbol::new("SPYM").unwrap();
+        let coin = Symbol::new("COIN").unwrap();
         let aapl_token = Address::random();
         let tsla_token = Address::random();
         let spym_token = Address::random();
+        let coin_token = Address::random();
 
         let mut symbols = HashMap::new();
         symbols.insert(
@@ -2643,6 +2640,19 @@ mod tests {
                 operational_limit: None,
             },
         );
+        symbols.insert(
+            coin.clone(),
+            EquityAssetConfig {
+                tokenized_equity: coin_token,
+                tokenized_equity_derivative: Address::random(),
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
 
         let ctx = Ctx {
             assets: AssetsConfig {
@@ -2661,11 +2671,12 @@ mod tests {
 
         assert_eq!(
             actual.len(),
-            2,
-            "Only trading-enabled or rebalancing-enabled assets should be polled"
+            3,
+            "Trading-enabled, rebalancing-enabled, and recovery-enabled assets should be polled"
         );
         assert_eq!(actual.get(&aapl), Some(&aapl_token));
         assert_eq!(actual.get(&tsla), Some(&tsla_token));
+        assert_eq!(actual.get(&coin), Some(&coin_token));
         assert!(
             !actual.contains_key(&spym),
             "Disabled assets should be excluded from Base-wallet unwrapped equity polling"
@@ -2677,9 +2688,11 @@ mod tests {
         let aapl = Symbol::new("AAPL").unwrap();
         let tsla = Symbol::new("TSLA").unwrap();
         let spym = Symbol::new("SPYM").unwrap();
+        let coin = Symbol::new("COIN").unwrap();
         let aapl_wrapped_token = Address::random();
         let tsla_wrapped_token = Address::random();
         let spym_wrapped_token = Address::random();
+        let coin_wrapped_token = Address::random();
 
         let mut symbols = HashMap::new();
         symbols.insert(
@@ -2721,6 +2734,19 @@ mod tests {
                 operational_limit: None,
             },
         );
+        symbols.insert(
+            coin.clone(),
+            EquityAssetConfig {
+                tokenized_equity: Address::random(),
+                tokenized_equity_derivative: coin_wrapped_token,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
 
         let ctx = Ctx {
             assets: AssetsConfig {
@@ -2739,11 +2765,12 @@ mod tests {
 
         assert_eq!(
             actual.len(),
-            2,
-            "Only trading-enabled or rebalancing-enabled assets should be polled"
+            3,
+            "Trading-enabled, rebalancing-enabled, and recovery-enabled assets should be polled"
         );
         assert_eq!(actual.get(&aapl), Some(&aapl_wrapped_token));
         assert_eq!(actual.get(&tsla), Some(&tsla_wrapped_token));
+        assert_eq!(actual.get(&coin), Some(&coin_wrapped_token));
         assert!(
             !actual.contains_key(&spym),
             "Disabled assets should be excluded from Base-wallet wrapped equity polling"
@@ -3988,10 +4015,9 @@ mod tests {
                 }),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
-                    equities: EquitiesConfig::default(),
+                    equities: rebalancing_enabled_equities(&["AAPL"]),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             vault_registry,
             orderbook,
@@ -4097,10 +4123,9 @@ mod tests {
                 usdc: Some(threshold),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
-                    equities: EquitiesConfig::default(),
+                    equities: rebalancing_enabled_equities(&["AAPL"]),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             vault_registry,
             orderbook,
@@ -4216,10 +4241,9 @@ mod tests {
                 }),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
-                    equities: EquitiesConfig::default(),
+                    equities: rebalancing_enabled_equities(&["AAPL"]),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             vault_registry,
             orderbook,
@@ -4353,10 +4377,9 @@ mod tests {
                 }),
                 transfer_timeout: Duration::from_secs(30 * 60),
                 assets: AssetsConfig {
-                    equities: EquitiesConfig::default(),
+                    equities: rebalancing_enabled_equities(&["AAPL"]),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             vault_registry,
             orderbook,

--- a/src/conductor/manifest.rs
+++ b/src/conductor/manifest.rs
@@ -121,7 +121,7 @@ impl QueryManifest {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, TxHash, fixed_bytes};
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
     use std::time::Duration;
     use tokio::sync::broadcast;
 
@@ -143,11 +143,11 @@ mod tests {
     use crate::rebalancing::{
         RebalancingSchedulers, RebalancingService, RebalancingServiceConfig, drain_pending_jobs,
     };
-    use crate::test_utils::setup_test_pools;
+    use crate::test_utils::{rebalancing_enabled_equities, setup_test_pools};
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::{VaultRegistryCommand, VaultRegistryId};
-    use st0x_config::{AssetsConfig, EquitiesConfig, ExecutionThreshold};
+    use st0x_config::{AssetsConfig, ExecutionThreshold};
 
     fn test_trigger_config() -> RebalancingServiceConfig {
         RebalancingServiceConfig {
@@ -161,11 +161,9 @@ mod tests {
             }),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
-                equities: EquitiesConfig::default(),
+                equities: rebalancing_enabled_equities(&["AAPL"]),
                 cash: None,
             },
-
-            disabled_assets: HashSet::new(),
         }
     }
 

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -14,7 +14,7 @@ use httpmock::Mock;
 use httpmock::prelude::*;
 use serde_json::json;
 use sqlx::SqlitePool;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -208,7 +208,6 @@ fn test_trigger_config() -> RebalancingServiceConfig {
                 reserved: None,
             }),
         },
-        disabled_assets: HashSet::new(),
     }
 }
 
@@ -1748,7 +1747,6 @@ async fn usdc_operational_limits_cap_across_trigger_cycles() {
         }),
         transfer_timeout: Duration::from_secs(30 * 60),
         assets,
-        disabled_assets: HashSet::new(),
     };
 
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
@@ -1876,7 +1874,6 @@ async fn usdc_in_progress_blocks_concurrent_triggers() {
         }),
         transfer_timeout: Duration::from_secs(30 * 60),
         assets,
-        disabled_assets: HashSet::new(),
     };
 
     let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
@@ -1975,7 +1972,6 @@ async fn threshold_config_controls_trigger_sensitivity() {
                     reserved: None,
                 }),
             },
-            disabled_assets: HashSet::new(),
         };
         let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
         let wrapper = Arc::new(MockWrapper::new());
@@ -2034,7 +2030,6 @@ async fn threshold_config_controls_trigger_sensitivity() {
                     reserved: None,
                 }),
             },
-            disabled_assets: HashSet::new(),
         };
         let vault_registry = Arc::new(test_store::<VaultRegistry>(pool.clone(), ()));
         let wrapper = Arc::new(MockWrapper::new());

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1614,7 +1614,6 @@ mod tests {
     use alloy::primitives::{Address, B256, address};
     use chrono::Utc;
     use sqlx::SqlitePool;
-    use std::collections::HashSet;
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::broadcast;
@@ -1797,7 +1796,6 @@ mod tests {
                     equities: EquitiesConfig::default(),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             address!("0x0000000000000000000000000000000000000001"),
@@ -1943,7 +1941,6 @@ mod tests {
                     equities: EquitiesConfig::default(),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             Arc::new(test_store::<VaultRegistry>(pool.clone(), ())),
             address!("0x0000000000000000000000000000000000000001"),

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -160,7 +160,7 @@ mod tests {
     use httpmock::Method::GET;
     use httpmock::MockServer;
     use serde_json::json;
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use uuid::Uuid;
 
     use st0x_config::{AssetsConfig, EquitiesConfig, OperationMode, RebalancingCtx};
@@ -246,7 +246,6 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
-            disabled_assets: HashSet::new(),
         };
 
         assert!(trigger_config.equity.target.eq(float!(0.5)).unwrap());
@@ -265,7 +264,6 @@ mod tests {
                 equities: EquitiesConfig::default(),
                 cash: None,
             },
-            disabled_assets: HashSet::new(),
         };
 
         let usdc_threshold = trigger_config.usdc.expect("USDC threshold should be Some");

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -154,7 +154,21 @@ pub(crate) struct RebalancingServiceConfig {
     pub(crate) usdc: Option<ImbalanceThreshold>,
     pub(crate) transfer_timeout: Duration,
     pub(crate) assets: AssetsConfig,
-    pub(crate) disabled_assets: HashSet<Symbol>,
+}
+
+impl RebalancingServiceConfig {
+    /// Whitelist gate for the equity rebalancing trigger: only symbols
+    /// explicitly configured with `rebalancing = "enabled"` are eligible.
+    /// Symbols observed in inventory but absent from the config are skipped
+    /// cleanly instead of falling through to the `WrapperService`
+    /// `SymbolNotConfigured` error backstop.
+    fn is_equity_rebalancing_enabled(&self, symbol: &Symbol) -> bool {
+        self.assets
+            .equities
+            .symbols
+            .get(symbol)
+            .is_some_and(|config| config.rebalancing == OperationMode::Enabled)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2341,10 +2355,6 @@ impl RebalancingService {
     }
 
     fn is_wrapped_equity_recovery_enabled(&self, symbol: &Symbol) -> bool {
-        if self.config.disabled_assets.contains(symbol) {
-            return false;
-        }
-
         self.config
             .assets
             .equities
@@ -2360,7 +2370,12 @@ impl RebalancingService {
     ) -> Result<(), equity::EquityTriggerError> {
         self.expire_stuck_operations_with_logging().await;
 
-        if self.config.disabled_assets.contains(symbol) {
+        if !self.config.is_equity_rebalancing_enabled(symbol) {
+            debug!(
+                target: "rebalance",
+                %symbol,
+                "Skipped equity trigger: rebalancing not enabled for symbol"
+            );
             return Ok(());
         }
 
@@ -4043,7 +4058,7 @@ mod tests {
     use chrono::{Duration as ChronoDuration, Utc};
     use rain_math_float::Float;
     use sqlx::SqlitePool;
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
@@ -4075,6 +4090,7 @@ mod tests {
     use crate::inventory::{InventoryError, InventoryView, TransferOp, Venue};
     use crate::offchain::order::OffchainOrderId;
     use crate::position::{Position, PositionCommand, PositionEvent, TradeId, TriggerReason};
+    use crate::test_utils::rebalancing_enabled_equities;
     use crate::tokenized_equity_mint::{TokenizationRequestId, issuer_request_id};
     use crate::usdc_rebalance::{
         TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
@@ -4093,7 +4109,7 @@ mod tests {
             }),
             transfer_timeout: Duration::from_secs(30 * 60),
             assets: AssetsConfig {
-                equities: EquitiesConfig::default(),
+                equities: rebalancing_enabled_equities(&["AAPL", "TSLA", "GOOG", "RKLB"]),
                 cash: Some(CashAssetConfig {
                     vault_ids: Vec::new(),
                     rebalancing: OperationMode::Enabled,
@@ -4101,7 +4117,6 @@ mod tests {
                     reserved: None,
                 }),
             },
-            disabled_assets: HashSet::new(),
         }
     }
 
@@ -4183,6 +4198,114 @@ mod tests {
         assert_eq!(
             jobs, 1,
             "startup recovery scan must enqueue persisted positive unwrapped wallet balances",
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_equity_recovery_enqueues_when_rebalancing_disabled() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol.clone(), FractionalShares::new(float!(5)));
+        let now = Utc::now();
+        let inventory_view = InventoryView::default().set_inflight_equity_at_location(
+            InFlightEquityLocation::BaseWalletUnwrapped,
+            &balances,
+            now,
+            now,
+        );
+
+        let mut config = test_config();
+        config.assets.equities.symbols.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: Address::random(),
+                tokenized_equity_derivative: Address::random(),
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Enabled,
+                operational_limit: None,
+            },
+        );
+
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
+        let service = RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool),
+        );
+
+        service.enqueue_recovery_for_current_wallet_balances().await;
+
+        let (jobs,): (i64,) = sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<UnwrappedEquityRecoveryJob>())
+            .fetch_one(service.unwrapped_equity_recovery_queue.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            jobs, 1,
+            "wrapped equity recovery must not depend on rebalancing being enabled",
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_equity_recovery_skips_when_recovery_disabled() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let mut balances = BTreeMap::new();
+        balances.insert(symbol.clone(), FractionalShares::new(float!(5)));
+        let now = Utc::now();
+        let inventory_view = InventoryView::default().set_inflight_equity_at_location(
+            InFlightEquityLocation::BaseWalletWrapped,
+            &balances,
+            now,
+            now,
+        );
+
+        let mut config = test_config();
+        config.assets.equities.symbols.insert(
+            symbol.clone(),
+            EquityAssetConfig {
+                tokenized_equity: Address::random(),
+                tokenized_equity_derivative: Address::random(),
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Disabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
+        let (event_sender, _) = broadcast::channel::<Statement>(16);
+        let inventory = Arc::new(BroadcastingInventory::new(inventory_view, event_sender));
+        let service = RebalancingService::new(
+            config,
+            Arc::new(test_store::<VaultRegistry>(pool, ())),
+            TEST_ORDERBOOK,
+            TEST_ORDER_OWNER,
+            inventory,
+            Arc::new(MockWrapper::new()),
+            RebalancingSchedulers::new(&apalis_pool),
+        );
+
+        service.enqueue_recovery_for_current_wallet_balances().await;
+
+        let (jobs,): (i64,) = sqlx_apalis::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+            .bind(std::any::type_name::<WrappedEquityRecoveryJob>())
+            .fetch_one(service.wrapped_equity_recovery_queue.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            jobs, 0,
+            "recovery-disabled symbols must not enqueue wallet recovery jobs",
         );
     }
 
@@ -5611,7 +5734,6 @@ mod tests {
                     equities: EquitiesConfig::default(),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,
@@ -5635,35 +5757,55 @@ mod tests {
         );
     }
 
+    /// Builds an imbalanced (too much offchain -> Mint) trigger whose equity
+    /// assets config is overridden, with the symbol seeded in the vault
+    /// registry and a permissive `MockWrapper` so the only thing standing
+    /// between the imbalance and a dispatched mint job is the config
+    /// whitelist itself.
+    async fn make_imbalanced_trigger_with_equities(
+        symbol: &Symbol,
+        equities: EquitiesConfig,
+    ) -> Arc<RebalancingService> {
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(0), shares(0))
+            .update_equity(
+                symbol,
+                Inventory::available(Venue::MarketMaking, Operator::Add, shares(20)),
+                Utc::now(),
+            )
+            .unwrap()
+            .update_equity(
+                symbol,
+                Inventory::available(Venue::Hedging, Operator::Add, shares(80)),
+                Utc::now(),
+            )
+            .unwrap();
+
+        let config = RebalancingServiceConfig {
+            assets: AssetsConfig {
+                equities,
+                cash: None,
+            },
+            ..test_config()
+        };
+
+        make_trigger_with_inventory_and_registry_config(inventory, symbol, config).await
+    }
+
+    /// A symbol configured with `rebalancing = "disabled"` must be skipped by
+    /// the whitelist even when its inventory is imbalanced.
     #[tokio::test]
     async fn disabled_asset_skips_equity_trigger() {
         let symbol = Symbol::new("AAPL").unwrap();
-        let (event_sender, _) = broadcast::channel::<Statement>(16);
-        let inventory = Arc::new(BroadcastingInventory::new(
-            InventoryView::default(),
-            event_sender,
-        ));
-        let (pool, apalis_pool) = crate::test_utils::setup_test_pools().await;
-        let wrapper = Arc::new(MockWrapper::new());
 
-        let trigger = RebalancingService::new(
-            RebalancingServiceConfig {
-                equity: test_config().equity,
-                usdc: test_config().usdc,
-                transfer_timeout: test_config().transfer_timeout,
-                assets: AssetsConfig {
-                    equities: EquitiesConfig::default(),
-                    cash: None,
-                },
-                disabled_assets: HashSet::from([symbol.clone()]),
-            },
-            Arc::new(test_store::<VaultRegistry>(pool, ())),
-            TEST_ORDERBOOK,
-            TEST_ORDER_OWNER,
-            inventory,
-            wrapper,
-            RebalancingSchedulers::new(&apalis_pool),
-        );
+        let mut equities = rebalancing_enabled_equities(&["AAPL"]);
+        equities
+            .symbols
+            .get_mut(&symbol)
+            .expect("AAPL is configured")
+            .rebalancing = OperationMode::Disabled;
+
+        let trigger = make_imbalanced_trigger_with_equities(&symbol, equities).await;
 
         trigger.check_and_trigger_equity(&symbol).await.unwrap();
 
@@ -5677,6 +5819,52 @@ mod tests {
             0,
             "Disabled asset should not trigger equity rebalancing"
         );
+    }
+
+    /// A symbol observed in inventory but absent from the equity assets
+    /// config must be skipped by the whitelist before any vault or wrapper
+    /// work -- not dispatched and only caught by the `WrapperService`
+    /// `SymbolNotConfigured` error backstop.
+    #[tokio::test]
+    async fn unconfigured_symbol_skips_equity_trigger() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let trigger =
+            make_imbalanced_trigger_with_equities(&symbol, EquitiesConfig::default()).await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "Unconfigured symbol should be skipped by the whitelist, not dispatched"
+        );
+        assert_eq!(
+            count_pending_equity_redemption_jobs(&trigger).await,
+            0,
+            "Unconfigured symbol should be skipped by the whitelist, not dispatched"
+        );
+    }
+
+    /// Positive control for the whitelist: the same imbalance with the symbol
+    /// configured `rebalancing = "enabled"` dispatches the mint job.
+    #[tokio::test]
+    async fn whitelisted_symbol_passes_equity_trigger() {
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let trigger =
+            make_imbalanced_trigger_with_equities(&symbol, rebalancing_enabled_equities(&["AAPL"]))
+                .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        let jobs = take_pending_equity_mint_jobs(&trigger).await;
+        assert_eq!(
+            jobs.len(),
+            1,
+            "Whitelisted symbol with an imbalance should dispatch a mint job"
+        );
+        assert_eq!(jobs[0].symbol, symbol);
     }
 
     #[tokio::test]
@@ -12920,7 +13108,6 @@ mod tests {
                     equities: EquitiesConfig::default(),
                     cash: None,
                 },
-                disabled_assets: HashSet::new(),
             },
             Arc::new(test_store::<VaultRegistry>(pool, ())),
             TEST_ORDERBOOK,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,11 +12,40 @@ use rain_math_float::Float;
 use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use st0x_execution::{Direction, FractionalShares, Positive};
+use st0x_config::{EquitiesConfig, EquityAssetConfig, OperationMode};
+use st0x_execution::{Direction, FractionalShares, Positive, Symbol};
 
 use crate::bindings::IRaindexV6::{EvaluableV4, IOV2, OrderV4};
 use crate::onchain::OnchainTrade;
 use crate::onchain::io::{TokenizedSymbol, Usdc, WrappedTokenizedShares};
+
+/// Builds an equity assets config with the given symbols whitelisted for
+/// rebalancing. The trigger only dispatches transfers for symbols configured
+/// with `rebalancing = "enabled"`, so trigger tests must whitelist the
+/// symbols they exercise.
+pub(crate) fn rebalancing_enabled_equities(symbols: &[&str]) -> EquitiesConfig {
+    EquitiesConfig {
+        operational_limit: None,
+        symbols: symbols
+            .iter()
+            .map(|symbol| {
+                (
+                    Symbol::new(*symbol).unwrap(),
+                    EquityAssetConfig {
+                        tokenized_equity: Address::ZERO,
+                        tokenized_equity_derivative: Address::ZERO,
+                        pyth_feed_id: None,
+                        vault_ids: Vec::new(),
+                        trading: OperationMode::Disabled,
+                        rebalancing: OperationMode::Enabled,
+                        wrapped_equity_recovery: OperationMode::Disabled,
+                        operational_limit: None,
+                    },
+                )
+            })
+            .collect(),
+    }
+}
 
 /// Deterministic singleton address of the TOFUTokenDecimals contract. The
 /// orderbook's `LibTOFUTokenDecimals.ensureDeployed` hardcodes this address and


### PR DESCRIPTION
## What

Introduces a dedicated `wrapped_equity_recovery` operation mode flag on `EquityAssetConfig`, decoupling wallet equity recovery from the `rebalancing` flag. Removes the `disabled_assets: HashSet<Symbol>` field from `RebalancingServiceConfig`, replacing it with a config-driven whitelist check (`is_equity_rebalancing_enabled`) directly on the config struct.

## Why

Previously, enabling wallet equity recovery for a symbol required also enabling rebalancing, and the `disabled_assets` set was a runtime override that duplicated what the config already expressed. This made it impossible to recover stranded wrapped/unwrapped equity for symbols that should not participate in automatic rebalancing. The `disabled_assets` field was also error-prone — symbols observed in inventory but absent from the config could fall through to the `WrapperService` `SymbolNotConfigured` error backstop rather than being skipped cleanly at the trigger boundary.

## How

- Added `is_wrapped_equity_recovery_enabled` to `Ctx`, reading the new `wrapped_equity_recovery` field on `EquityAssetConfig`.
- Introduced `base_wallet_equity_recovery_enabled` in `conductor.rs` that ORs trading, rebalancing, and wrapped equity recovery flags, so the base-wallet token address maps include recovery-only symbols.
- Replaced the `disabled_assets` set with `RebalancingServiceConfig::is_equity_rebalancing_enabled`, which gates the equity trigger on the symbol being explicitly configured with `rebalancing = "enabled"`. Symbols absent from the config are skipped cleanly with a debug log rather than propagating to downstream error handling.
- `is_wrapped_equity_recovery_enabled` on `RebalancingService` no longer consults `disabled_assets` and reads directly from the assets config.
- Added a `rebalancing_enabled_equities` test helper that builds an `EquitiesConfig` with the given symbols whitelisted for rebalancing, used across trigger tests that previously relied on an empty config with an empty `disabled_assets` set.

## Testing

- `is_wrapped_equity_recovery_enabled_is_independent_of_rebalancing`: verifies that a symbol with `wrapped_equity_recovery = "enabled"` and `rebalancing = "disabled"` returns the correct values from both config accessors, and that an unknown symbol defaults to recovery disabled.
- `wrapped_equity_recovery_enqueues_when_rebalancing_disabled`: confirms that `enqueue_recovery_for_current_wallet_balances` enqueues an `UnwrappedEquityRecoveryJob` for a symbol with recovery enabled but rebalancing disabled.
- `wrapped_equity_recovery_skips_when_recovery_disabled`: confirms no `WrappedEquityRecoveryJob` is enqueued when `wrapped_equity_recovery = "disabled"`.
- `disabled_asset_skips_equity_trigger`: updated to use the new config-driven whitelist — sets `rebalancing = "disabled"` on an otherwise-configured symbol and asserts no mint or redemption jobs are dispatched.
- `unconfigured_symbol_skips_equity_trigger`: asserts that a symbol present in inventory but absent from the equity config is skipped at the whitelist boundary.
- `whitelisted_symbol_passes_equity_trigger`: positive control confirming that the same imbalance with `rebalancing = "enabled"` dispatches a mint job.
- Base-wallet token address map tests extended with a `COIN` symbol (`rebalancing = "disabled"`, `wrapped_equity_recovery = "enabled"`) to verify it is included in polling.