### PR TITLE
test: chaos latency injection on RPC and broker paths

### DIFF
--- a/crates/execution/proptest-regressions/alpaca_broker_api/order.txt
+++ b/crates/execution/proptest-regressions/alpaca_broker_api/order.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 960fe18102d13168c071de177805a00a87805233773b16f23591e61d0ef77c4a # shrinks to status_code = 1000, message = ""

--- a/crates/execution/src/alpaca_broker_api/client.rs
+++ b/crates/execution/src/alpaca_broker_api/client.rs
@@ -17,6 +17,13 @@ use super::order::{
 };
 use crate::{ClientOrderId, FractionalShares, Positive, Symbol};
 
+/// Request timeout applied to every Alpaca Broker API HTTP call.
+///
+/// Exposed so timing-sensitive tests can derive their boundary delays from
+/// this single source of truth instead of duplicating the literal -- a
+/// change here then cannot silently invalidate those tests.
+pub const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Alpaca Broker API HTTP client with Basic authentication
 pub(crate) struct AlpacaBrokerApiClient {
     http_client: reqwest::Client,
@@ -51,7 +58,7 @@ impl AlpacaBrokerApiClient {
         let http_client = reqwest::Client::builder()
             .default_headers(headers)
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
+            .timeout(HTTP_REQUEST_TIMEOUT)
             .build()?;
         let api_key_header = HeaderName::from_static("apca-api-key-id");
         let api_secret_header = HeaderName::from_static("apca-api-secret-key");
@@ -63,7 +70,7 @@ impl AlpacaBrokerApiClient {
         let market_data_http_client = reqwest::Client::builder()
             .default_headers(market_data_headers)
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(30))
+            .timeout(HTTP_REQUEST_TIMEOUT)
             .build()?;
 
         Ok(Self {

--- a/crates/execution/src/alpaca_broker_api/mod.rs
+++ b/crates/execution/src/alpaca_broker_api/mod.rs
@@ -50,6 +50,9 @@ pub enum AssetStatus {
 }
 
 pub use auth::{AccountStatus, AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode};
+// Exposed as the single source of truth for the broker HTTP request timeout so
+// timing-sensitive integration tests derive their boundaries from it.
+pub use client::HTTP_REQUEST_TIMEOUT;
 pub use executor::AlpacaBrokerApi;
 pub use journal::{JournalResponse, JournalStatus};
 pub use order::{

--- a/crates/execution/src/alpaca_broker_api/order.rs
+++ b/crates/execution/src/alpaca_broker_api/order.rs
@@ -652,6 +652,8 @@ pub(crate) async fn poll_crypto_order_until_filled(
 #[cfg(test)]
 mod tests {
     use httpmock::prelude::*;
+    use proptest::prelude::*;
+    use reqwest::StatusCode;
     use serde_json::json;
     use uuid::uuid;
 
@@ -1629,5 +1631,46 @@ mod tests {
             make_order(BrokerOrderStatus::Canceled).status_display(),
             "canceled"
         );
+    }
+
+    fn api_error(status: StatusCode, message: impl Into<String>) -> AlpacaBrokerApiError {
+        AlpacaBrokerApiError::ApiError {
+            status,
+            alpaca_code: None,
+            message: message.into(),
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn duplicate_client_order_id_detected_for_422_unique_violation(
+            prefix in "\\PC*",
+            suffix in "\\PC*",
+        ) {
+            let message = format!("{prefix}client_order_id must be unique{suffix}");
+            let error = api_error(StatusCode::UNPROCESSABLE_ENTITY, message);
+            prop_assert!(is_duplicate_client_order_id(&error));
+        }
+
+        #[test]
+        fn duplicate_client_order_id_rejects_non_422_status(
+            status_code in 100u16..600u16,
+            message in "\\PC*",
+        ) {
+            prop_assume!(status_code != StatusCode::UNPROCESSABLE_ENTITY.as_u16());
+            let status = StatusCode::from_u16(status_code)
+                .expect("status codes in 100..600 are valid HTTP codes");
+            let error = api_error(status, message);
+            prop_assert!(!is_duplicate_client_order_id(&error));
+        }
+
+        #[test]
+        fn duplicate_client_order_id_rejects_422_without_unique_message(
+            message in prop::string::string_regex("([^\n]|\\n)*").unwrap(),
+        ) {
+            prop_assume!(!message.contains("client_order_id must be unique"));
+            let error = api_error(StatusCode::UNPROCESSABLE_ENTITY, message);
+            prop_assert!(!is_duplicate_client_order_id(&error));
+        }
     }
 }

--- a/crates/execution/src/order/mod.rs
+++ b/crates/execution/src/order/mod.rs
@@ -135,6 +135,7 @@ pub struct MarketOrder {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
     use serde_json::json;
     use uuid::{Uuid, uuid};
 
@@ -194,5 +195,25 @@ mod tests {
 
         let cli: ClientOrderId = serde_json::from_value(json!(PREFIXED)).unwrap();
         assert_eq!(cli, ClientOrderId::Cli(ID));
+    }
+
+    proptest! {
+        #[test]
+        fn display_parse_roundtrip(uuid in prop::array::uniform16(any::<u8>()).prop_map(Uuid::from_bytes)) {
+            for id in [ClientOrderId::from_uuid(uuid), ClientOrderId::cli(uuid)] {
+                let rendered = id.to_string();
+                let parsed: ClientOrderId = rendered.parse().unwrap();
+                prop_assert_eq!(parsed, id);
+            }
+        }
+
+        #[test]
+        fn serde_roundtrip(uuid in prop::array::uniform16(any::<u8>()).prop_map(Uuid::from_bytes)) {
+            for id in [ClientOrderId::from_uuid(uuid), ClientOrderId::cli(uuid)] {
+                let json = serde_json::to_value(&id).unwrap();
+                let parsed: ClientOrderId = serde_json::from_value(json).unwrap();
+                prop_assert_eq!(parsed, id);
+            }
+        }
     }
 }

--- a/src/trading/offchain/hedge.rs
+++ b/src/trading/offchain/hedge.rs
@@ -163,8 +163,7 @@ impl Job<HedgeCtx> for PlaceHedge {
             .load(&self.symbol)
             .await?
             .and_then(|position| position.last_failed_offchain_order_id);
-        let client_order_id_source = anchor.unwrap_or(self.offchain_order_id);
-        let client_order_id = ClientOrderId::from_uuid(client_order_id_source.as_uuid());
+        let client_order_id = client_order_id_for_placement(self.offchain_order_id, anchor);
 
         ctx.offchain_order
             .send(
@@ -210,15 +209,32 @@ impl Job<HedgeCtx> for PlaceHedge {
     }
 }
 
+/// Derives the broker-side [`ClientOrderId`] for a placement attempt.
+///
+/// When a prior attempt failed after the broker accepted the order, the
+/// position aggregate stashes that attempt's [`OffchainOrderId`] as the
+/// idempotency anchor. Retries must reuse its UUID as `client_order_id` so
+/// the broker dedupes rather than double-submitting.
+fn client_order_id_for_placement(
+    offchain_order_id: OffchainOrderId,
+    last_failed_offchain_order_id: Option<OffchainOrderId>,
+) -> ClientOrderId {
+    let idempotency_source = last_failed_offchain_order_id.unwrap_or(offchain_order_id);
+    ClientOrderId::from_uuid(idempotency_source.as_uuid())
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::TxHash;
+    use proptest::prelude::*;
     use std::any::type_name;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     use st0x_event_sorcery::StoreBuilder;
     use st0x_execution::{
-        Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor, Symbol,
+        ClientOrderId, Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor,
+        Symbol,
     };
     use st0x_float_macro::float;
 
@@ -532,5 +548,57 @@ mod tests {
             poll_jobs_after_retry, 2,
             "Retry must re-enqueue PollOrderStatus when the order is still Submitted"
         );
+    }
+
+    fn offchain_order_id_from(uuid: Uuid) -> OffchainOrderId {
+        uuid.to_string().parse().unwrap()
+    }
+
+    fn arb_uuid() -> impl Strategy<Value = Uuid> {
+        prop::array::uniform16(any::<u8>()).prop_map(Uuid::from_bytes)
+    }
+
+    proptest! {
+        #[test]
+        fn client_order_id_for_placement_reuses_anchor_uuid(
+            attempt_uuid in arb_uuid(),
+            anchor_uuid in arb_uuid(),
+        ) {
+            let attempt_id = offchain_order_id_from(attempt_uuid);
+            let anchor_id = offchain_order_id_from(anchor_uuid);
+
+            let derived = client_order_id_for_placement(attempt_id, Some(anchor_id));
+            prop_assert_eq!(derived, ClientOrderId::from_uuid(anchor_uuid));
+        }
+
+        #[test]
+        fn client_order_id_for_placement_falls_back_to_attempt_without_anchor(
+            attempt_uuid in arb_uuid(),
+        ) {
+            let attempt_id = offchain_order_id_from(attempt_uuid);
+
+            let derived = client_order_id_for_placement(attempt_id, None);
+            prop_assert_eq!(derived, ClientOrderId::from_uuid(attempt_uuid));
+        }
+
+        #[test]
+        fn retries_with_same_anchor_share_broker_client_order_id(
+            first_attempt in arb_uuid(),
+            second_attempt in arb_uuid(),
+            anchor in arb_uuid(),
+        ) {
+            prop_assume!(first_attempt != second_attempt);
+
+            let first = client_order_id_for_placement(
+                offchain_order_id_from(first_attempt),
+                Some(offchain_order_id_from(anchor)),
+            );
+            let second = client_order_id_for_placement(
+                offchain_order_id_from(second_attempt),
+                Some(offchain_order_id_from(anchor)),
+            );
+
+            prop_assert_eq!(first, second);
+        }
     }
 }

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -210,7 +210,10 @@ impl LatencyProxy {
         let state = LatencyProxyState {
             config: config.clone(),
             upstream,
-            client: Client::new(),
+            // Bound the forward leg so an unresponsive upstream cannot hang the
+            // proxy task indefinitely; the injected latency is a separate sleep,
+            // not this request, so 10s is ample headroom for the real forward.
+            client: Client::builder().timeout(Duration::from_secs(10)).build()?,
         };
 
         let app = Router::new().fallback(handle_http).with_state(state);
@@ -265,8 +268,6 @@ async fn handle_http(
             .into_response();
     };
 
-    let delay = matched_delay(&state, &parts.method, parts.uri.path()).await;
-
     let mut upstream_url = state.upstream.clone();
     upstream_url.set_path(parts.uri.path());
     upstream_url.set_query(parts.uri.query());
@@ -296,7 +297,19 @@ async fn handle_http(
 
     let status = upstream_response.status();
     let headers = upstream_response.headers().clone();
-    let bytes = upstream_response.bytes().await.unwrap_or_default();
+    let bytes = match upstream_response.bytes().await {
+        Ok(response_bytes) => response_bytes,
+        Err(error) => {
+            warn!(?error, "latency proxy failed to read response body");
+            return (
+                axum::http::StatusCode::BAD_GATEWAY,
+                "latency proxy response body error",
+            )
+                .into_response();
+        }
+    };
+
+    let delay = matched_delay(&state, &parts.method, parts.uri.path()).await;
 
     if let Some(duration) = delay {
         tokio::time::sleep(duration).await;
@@ -304,9 +317,14 @@ async fn handle_http(
 
     let mut response = (status, bytes).into_response();
     for (name, value) in &headers {
-        // reqwest already decoded the body, so framing headers no longer
-        // describe the bytes being relayed; axum sets its own.
-        if name == reqwest::header::TRANSFER_ENCODING || name == reqwest::header::CONTENT_LENGTH {
+        // reqwest already decoded the body, so framing and content-encoding
+        // headers no longer describe the bytes being relayed -- forwarding
+        // Content-Encoding would make the downstream client re-decode plain
+        // bytes. Drop them; axum sets the correct framing for the new body.
+        if name == reqwest::header::TRANSFER_ENCODING
+            || name == reqwest::header::CONTENT_LENGTH
+            || name == reqwest::header::CONTENT_ENCODING
+        {
             continue;
         }
         response.headers_mut().insert(name.clone(), value.clone());
@@ -316,7 +334,8 @@ async fn handle_http(
 }
 
 /// Consumes one unit of the armed latency budget if this request matches
-/// the active [`LatencyConfig`], returning the delay to apply.
+/// the active [`LatencyConfig`], returning the delay to apply. Call only
+/// after the upstream response has been received successfully.
 async fn matched_delay(
     state: &LatencyProxyState,
     method: &reqwest::Method,

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -1,9 +1,10 @@
-//! HTTP-level chaos proxy for the e2e Anvil provider.
+//! HTTP-level chaos proxies for the e2e harness.
 //!
-//! Sits between the bot's `rpc_url` and the real Anvil node. Forwards
-//! JSON-RPC traffic by default; when configured, returns empty
-//! `eth_getLogs` results that model load-balancer inconsistency where
-//! one node in the upstream pool is behind on indexing.
+//! [`ChaosProxy`] sits between the bot's `rpc_url` and the real Anvil
+//! node. Forwards JSON-RPC traffic by default; when configured, perturbs
+//! matched methods: empty `eth_getLogs` results model load-balancer
+//! inconsistency where one node in the upstream pool is behind on
+//! indexing, and delayed responses model upstream latency.
 //!
 //! The bot ingests fills over a single HTTP transport (continuous
 //! `eth_getLogs` polling), so each JSON-RPC request and its response are
@@ -11,12 +12,23 @@
 //! perturbation is decided per request without tracking ids across
 //! frames.
 //!
+//! [`LatencyProxy`] is a plain HTTP pass-through for non-RPC upstreams
+//! (the Alpaca broker mock). It forwards every request immediately --
+//! so the upstream processes it -- and, when armed, holds the response
+//! past the caller's timeout. This models "the broker executed the
+//! request but the acknowledgement was slow", which the caller cannot
+//! distinguish from the request never arriving. The delay lives in a
+//! proxy rather than the broker mock because `httpmock` dynamic
+//! responders are synchronous: sleeping inside one blocks the mock
+//! server's runtime and stalls unrelated endpoints.
+//!
 //! Used by the chaos test suite to validate the bot's recovery paths
-//! against adversarial RPC behaviour without modifying the production
-//! code paths. Additional behaviours (drop, error, stall) land
-//! alongside the chaos sub-issues that need them.
+//! against adversarial external behaviour without modifying the
+//! production code paths. Additional behaviours (drop, error, stall)
+//! land alongside the chaos sub-issues that need them.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::body::Bytes;
@@ -36,6 +48,10 @@ pub(crate) enum ChaosBehaviour {
     /// have returned. Models load-balancer inconsistency where one node
     /// in the pool is behind and answers `eth_getLogs` with no events.
     EmptyResult,
+    /// Forward the request upstream immediately, then hold the response
+    /// for `duration` before relaying it. Models a slow upstream node:
+    /// the request is processed on time, only the answer is late.
+    Delay { duration: Duration },
 }
 
 /// Knob describing which method to perturb and for how many calls.
@@ -121,12 +137,205 @@ impl ChaosProxy {
             pending_stale_tips: 0,
         });
     }
+
+    /// Convenience: hold the responses of the next `count` `eth_getLogs`
+    /// calls for `duration` each, modelling a slow upstream node. The
+    /// requests still reach the real node on time -- only the answers
+    /// are late.
+    pub(crate) async fn delay_get_logs(&self, duration: Duration, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour: ChaosBehaviour::Delay { duration },
+            remaining: count,
+            pending_stale_tips: 0,
+        });
+    }
 }
 
 impl Drop for ChaosProxy {
     fn drop(&mut self) {
         self.server_task.abort();
     }
+}
+
+/// Knob describing which plain-HTTP requests to delay and for how many.
+#[derive(Debug, Clone)]
+struct LatencyConfig {
+    method: reqwest::Method,
+    path_suffix: String,
+    delay: Duration,
+    remaining: usize,
+}
+
+type SharedLatencyConfig = Arc<Mutex<Option<LatencyConfig>>>;
+
+/// Axum handler state for [`LatencyProxy`]: the mutable latency config
+/// plus what's needed to forward requests to the real upstream.
+#[derive(Clone)]
+struct LatencyProxyState {
+    config: SharedLatencyConfig,
+    upstream: Url,
+    client: Client,
+}
+
+/// Plain-HTTP latency-injecting pass-through proxy.
+///
+/// Forwards every request to the upstream immediately -- so the upstream
+/// processes it on time -- and, when armed, holds the matched responses
+/// for the configured duration before relaying them. From the caller's
+/// side a sufficiently delayed response is a timeout on a request the
+/// upstream actually executed.
+#[derive(Debug)]
+pub(crate) struct LatencyProxy {
+    /// `http://127.0.0.1:<port>` the bot should connect to instead of
+    /// the real upstream endpoint.
+    pub endpoint: Url,
+    /// Shared mutable config; `None` means transparent forwarding.
+    config: SharedLatencyConfig,
+    /// Serve loop's handle. Aborted on drop so the proxy dies with its
+    /// parent test.
+    server_task: tokio::task::AbortHandle,
+}
+
+impl LatencyProxy {
+    /// Spawn a latency proxy in front of `upstream` and start listening
+    /// on a free local port. The proxy keeps running until the returned
+    /// handle is dropped.
+    pub(crate) async fn start(upstream: Url) -> anyhow::Result<Self> {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        let endpoint: Url = format!("http://127.0.0.1:{port}").parse()?;
+
+        let config: SharedLatencyConfig = Arc::new(Mutex::new(None));
+        let state = LatencyProxyState {
+            config: config.clone(),
+            upstream,
+            client: Client::new(),
+        };
+
+        let app = Router::new().fallback(handle_http).with_state(state);
+        let handle = tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, app).await {
+                warn!(?error, "latency proxy server stopped");
+            }
+        });
+
+        Ok(Self {
+            endpoint,
+            config,
+            server_task: handle.abort_handle(),
+        })
+    }
+
+    /// Convenience: hold the responses of the next `count` broker order
+    /// placement calls (`POST .../orders`) for `duration` each. The
+    /// placements still reach the broker on time -- only the
+    /// acknowledgements are late.
+    pub(crate) async fn delay_order_placements(&self, duration: Duration, count: usize) {
+        *self.config.lock().await = Some(LatencyConfig {
+            method: reqwest::Method::POST,
+            path_suffix: "/orders".to_owned(),
+            delay: duration,
+            remaining: count,
+        });
+    }
+}
+
+impl Drop for LatencyProxy {
+    fn drop(&mut self) {
+        self.server_task.abort();
+    }
+}
+
+/// Catch-all pass-through handler: forwards the request verbatim to the
+/// upstream, then relays the response -- after the armed delay when the
+/// request matches the active [`LatencyConfig`].
+async fn handle_http(
+    State(state): State<LatencyProxyState>,
+    request: axum::extract::Request,
+) -> Response {
+    let (parts, body) = request.into_parts();
+
+    let Ok(body_bytes) = axum::body::to_bytes(body, usize::MAX).await else {
+        warn!("latency proxy failed to read request body");
+        return (
+            axum::http::StatusCode::BAD_GATEWAY,
+            "latency proxy request body error",
+        )
+            .into_response();
+    };
+
+    let delay = matched_delay(&state, &parts.method, parts.uri.path()).await;
+
+    let mut upstream_url = state.upstream.clone();
+    upstream_url.set_path(parts.uri.path());
+    upstream_url.set_query(parts.uri.query());
+
+    let mut upstream_request = state
+        .client
+        .request(parts.method.clone(), upstream_url)
+        .body(body_bytes);
+    for (name, value) in &parts.headers {
+        if name == reqwest::header::HOST {
+            continue;
+        }
+        upstream_request = upstream_request.header(name, value);
+    }
+
+    let upstream_response = match upstream_request.send().await {
+        Ok(response) => response,
+        Err(error) => {
+            warn!(?error, "latency proxy failed to forward request");
+            return (
+                axum::http::StatusCode::BAD_GATEWAY,
+                "latency proxy upstream error",
+            )
+                .into_response();
+        }
+    };
+
+    let status = upstream_response.status();
+    let headers = upstream_response.headers().clone();
+    let bytes = upstream_response.bytes().await.unwrap_or_default();
+
+    if let Some(duration) = delay {
+        tokio::time::sleep(duration).await;
+    }
+
+    let mut response = (status, bytes).into_response();
+    for (name, value) in &headers {
+        // reqwest already decoded the body, so framing headers no longer
+        // describe the bytes being relayed; axum sets its own.
+        if name == reqwest::header::TRANSFER_ENCODING || name == reqwest::header::CONTENT_LENGTH {
+            continue;
+        }
+        response.headers_mut().insert(name.clone(), value.clone());
+    }
+
+    response
+}
+
+/// Consumes one unit of the armed latency budget if this request matches
+/// the active [`LatencyConfig`], returning the delay to apply.
+async fn matched_delay(
+    state: &LatencyProxyState,
+    method: &reqwest::Method,
+    path: &str,
+) -> Option<Duration> {
+    let mut guard = state.config.lock().await;
+
+    let result = match guard.as_mut() {
+        Some(cfg)
+            if cfg.remaining > 0 && cfg.method == *method && path.ends_with(&cfg.path_suffix) =>
+        {
+            cfg.remaining -= 1;
+            Some(cfg.delay)
+        }
+        Some(_) | None => None,
+    };
+
+    drop(guard);
+    result
 }
 
 /// Single JSON-RPC POST handler. Anvil requests are single objects (one
@@ -152,8 +361,17 @@ async fn handle_rpc(State(state): State<ProxyState>, body: Bytes) -> Response {
     json_response(&response)
 }
 
-/// Decide a single JSON-RPC request: synthesize a perturbed response when
-/// the active chaos config matches, otherwise forward it upstream.
+/// Resolved perturbation for one JSON-RPC request.
+enum Perturbation {
+    /// Reply with this synthesized response instead of forwarding.
+    Synthesize(Value),
+    /// Forward upstream, then hold the response for this long.
+    DelayResponse(Duration),
+}
+
+/// Decide a single JSON-RPC request: synthesize or delay a perturbed
+/// response when the active chaos config matches, otherwise forward it
+/// upstream untouched.
 async fn process_one(state: &ProxyState, request: Value) -> Value {
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request
@@ -161,13 +379,26 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
         .and_then(Value::as_str)
         .map(str::to_owned);
 
-    if let Some(method) = method
-        && let Some(perturbed) = perturb(state, &method, &id).await
-    {
-        return perturbed;
-    }
+    let perturbation = match method {
+        Some(method) => perturb(state, &method, &id).await,
+        None => None,
+    };
 
-    forward_one(state, &request).await.unwrap_or_else(|error| {
+    match perturbation {
+        Some(Perturbation::Synthesize(response)) => response,
+        Some(Perturbation::DelayResponse(duration)) => {
+            let response = forward_or_rpc_error(state, &request, id).await;
+            tokio::time::sleep(duration).await;
+            response
+        }
+        None => forward_or_rpc_error(state, &request, id).await,
+    }
+}
+
+/// Forwards one request upstream, shaping any transport failure into a
+/// JSON-RPC error response carrying the request's `id`.
+async fn forward_or_rpc_error(state: &ProxyState, request: &Value, id: Value) -> Value {
+    forward_one(state, request).await.unwrap_or_else(|error| {
         json!({
             "jsonrpc": "2.0",
             "id": id,
@@ -176,9 +407,9 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
     })
 }
 
-/// Returns a synthesized response if the active chaos config perturbs this
-/// method, or `None` to forward.
-async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Value> {
+/// Returns the perturbation the active chaos config applies to this
+/// method, or `None` to forward untouched.
+async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturbation> {
     let mut guard = state.config.lock().await;
 
     let result = match guard.as_mut() {
@@ -196,14 +427,22 @@ async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Value> 
 
             if is_paired_tip {
                 cfg.pending_stale_tips -= 1;
-                Some(json!({ "jsonrpc": "2.0", "id": id, "result": "0x0" }))
+                Some(Perturbation::Synthesize(
+                    json!({ "jsonrpc": "2.0", "id": id, "result": "0x0" }),
+                ))
             } else if cfg.method == method && cfg.remaining > 0 {
                 match cfg.behaviour {
                     ChaosBehaviour::EmptyResult => {
                         cfg.remaining -= 1;
                         // Queue a stale tip for the next `eth_blockNumber`.
                         cfg.pending_stale_tips += 1;
-                        Some(json!({ "jsonrpc": "2.0", "id": id, "result": [] }))
+                        Some(Perturbation::Synthesize(
+                            json!({ "jsonrpc": "2.0", "id": id, "result": [] }),
+                        ))
+                    }
+                    ChaosBehaviour::Delay { duration } => {
+                        cfg.remaining -= 1;
+                        Some(Perturbation::DelayResponse(duration))
                     }
                 }
             } else {

--- a/tests/e2e/chaos_alpaca.rs
+++ b/tests/e2e/chaos_alpaca.rs
@@ -1,13 +1,16 @@
 //! Chaos tests for Alpaca broker fault tolerance.
 //!
-//! Drives the bot through scenarios where the Alpaca broker mock returns
-//! a 5xx after recording the order in its internal state. Asserts the
-//! bot does not double-submit hedges when retrying a placement whose
-//! response was lost in flight.
+//! Drives the bot through scenarios where the broker processed a
+//! placement but the bot never received a usable acknowledgement: the
+//! Alpaca broker mock returns a 5xx after recording the order, or a
+//! latency proxy holds the response past the client's request timeout.
+//! Asserts the bot does not double-submit hedges when retrying a
+//! placement whose response was lost or late in flight.
 
 use st0x_float_macro::float;
 use std::time::Duration;
 
+use crate::chaos::LatencyProxy;
 use crate::hedging::assertions::*;
 use crate::poll::{connect_db, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot};
 
@@ -110,6 +113,120 @@ async fn transient_alpaca_5xx_after_record_does_not_double_submit() -> anyhow::R
          on the placement response; got {order_count}. More than one \
          means the bot retried without an idempotency key and the \
          broker has no way to dedupe the second submission.",
+    );
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: an Alpaca placement whose response is held past
+/// the client's request timeout must not produce two orders when the bot
+/// recovers -- the broker executed the placement on time, only the
+/// acknowledgement was late.
+///
+/// Mechanism under test: a [`LatencyProxy`] in front of the broker mock
+/// forwards the first placement immediately (the mock records the order)
+/// and holds the response past the Alpaca client's 30s request timeout.
+/// Unlike the 5xx scenario above, the bot never receives an HTTP response
+/// at all -- this exercises the transport-error (`HttpClient`) failure
+/// path rather than the `ApiError` path. The placement's `OffchainOrder`
+/// aggregate goes `Failed`, the position stashes that attempt's id as its
+/// idempotency anchor, and the periodic `CheckPositions` scan re-enqueues
+/// a fresh `PlaceHedge`. The retry derives its broker-side
+/// `client_order_id` from the live anchor, so the broker recognizes the
+/// duplicate, rejects it with a 422, and the executor reconciles by
+/// adopting the order the broker already accepted. Net result: exactly
+/// one broker order despite the timed-out acknowledgement.
+#[test_log::test(tokio::test)]
+async fn delayed_placement_response_past_client_timeout_does_not_double_submit()
+-> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    // Hold the first placement's response for longer than the Alpaca
+    // client's 30s request timeout (hardcoded in the broker HTTP client).
+    // The mock records the order when the request arrives; the bot sees a
+    // timeout. One delayed placement is enough to drive the
+    // dedupe-on-retry recovery path.
+    latency
+        .delay_order_placements(Duration::from_secs(35), 1)
+        .await;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let _take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // Assert the recovery path actually ran, so this can't pass trivially:
+    // the first attempt must have Failed (the timed-out acknowledgement),
+    // and a second OffchainOrder aggregate must exist (the CheckPositions
+    // re-enqueue). The broker dedupe is only exercised when both happened.
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
+    pool.close().await;
+
+    let failed_count = offchain_order_events
+        .iter()
+        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
+        .count();
+    assert_eq!(
+        failed_count, 1,
+        "Expected exactly one OffchainOrder failure (the timed-out \
+         placement) before recovery; got {failed_count}",
+    );
+
+    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert!(
+        distinct_aggregates.len() >= 2,
+        "Expected at least two OffchainOrder aggregates -- the timed-out \
+         first attempt and the re-enqueued retry that reconciled the \
+         broker's existing order; got {}",
+        distinct_aggregates.len(),
+    );
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one order on the broker after a placement whose \
+         response timed out; got {order_count}. More than one means the \
+         bot retried without an idempotency key and the broker has no way \
+         to dedupe the second submission.",
     );
 
     bot.abort();

--- a/tests/e2e/chaos_alpaca.rs
+++ b/tests/e2e/chaos_alpaca.rs
@@ -7,12 +7,159 @@
 //! Asserts the bot does not double-submit hedges when retrying a
 //! placement whose response was lost or late in flight.
 
-use st0x_float_macro::float;
+use std::collections::HashSet;
+use std::path::Path;
 use std::time::Duration;
+
+use alloy::providers::Provider;
+
+use st0x_execution::alpaca_broker_api::{AlpacaBrokerMock, HTTP_REQUEST_TIMEOUT};
+use st0x_float_macro::float;
 
 use crate::chaos::LatencyProxy;
 use crate::hedging::assertions::*;
 use crate::poll::{connect_db, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot};
+
+/// Response arrives before the client times out -- no transport failure.
+/// Held 5s below the timeout (not 1s) so CI scheduling jitter cannot push the
+/// response past the boundary and flip this success case into a spurious
+/// transport-timeout failure.
+const PLACEMENT_RESPONSE_JUST_UNDER_TIMEOUT: Duration =
+    Duration::from_secs(HTTP_REQUEST_TIMEOUT.as_secs() - 5);
+
+/// Minimal delay that exceeds the client timeout and triggers recovery.
+const PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT: Duration =
+    Duration::from_secs(HTTP_REQUEST_TIMEOUT.as_secs() + 1);
+
+/// Comfortable margin above the timeout for slow CI hosts.
+const PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT: Duration =
+    Duration::from_secs(HTTP_REQUEST_TIMEOUT.as_secs() + 5);
+
+struct BrokerDedupeRecoveryExpectation {
+    expected_failures: usize,
+    min_distinct_aggregates: usize,
+}
+
+async fn assert_broker_dedupe_recovery(
+    db_path: &Path,
+    broker: &AlpacaBrokerMock,
+    expectation: BrokerDedupeRecoveryExpectation,
+) {
+    let pool = connect_db(db_path).await.unwrap();
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await.unwrap();
+    pool.close().await;
+
+    let failed_count = offchain_order_events
+        .iter()
+        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
+        .count();
+    assert_eq!(
+        failed_count, expectation.expected_failures,
+        "Expected exactly {} OffchainOrder failure(s) before recovery; got {failed_count}",
+        expectation.expected_failures,
+    );
+
+    let distinct_aggregates: HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert!(
+        distinct_aggregates.len() >= expectation.min_distinct_aggregates,
+        "Expected at least {} OffchainOrder aggregate(s); got {}",
+        expectation.min_distinct_aggregates,
+        distinct_aggregates.len(),
+    );
+
+    let order_count = broker.orders().len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one order on the broker after dedupe recovery; got {order_count}. \
+         More than one means the bot retried without an idempotency key and the broker has no \
+         way to dedupe the second submission.",
+    );
+}
+
+async fn assert_single_successful_hedge_without_recovery(
+    db_path: &Path,
+    broker: &AlpacaBrokerMock,
+) {
+    let pool = connect_db(db_path).await.unwrap();
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await.unwrap();
+    pool.close().await;
+
+    let failed_count = offchain_order_events
+        .iter()
+        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
+        .count();
+    assert_eq!(
+        failed_count, 0,
+        "Expected no OffchainOrder failures when the response arrives before the client \
+         timeout; got {failed_count}",
+    );
+
+    let distinct_aggregates: HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert_eq!(
+        distinct_aggregates.len(),
+        1,
+        "Expected exactly one OffchainOrder aggregate without a recovery retry; got {}",
+        distinct_aggregates.len(),
+    );
+
+    let order_count = broker.orders().len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one broker order after a successful first placement; got {order_count}",
+    );
+}
+
+async fn drive_sell_equity_hedge<P: Provider + Clone>(
+    infra: &TestInfra<P>,
+    latency: &LatencyProxy,
+    poll_timeout: Duration,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let sell_amount = float!(10.75);
+
+    let current_block = infra.base_chain.provider.get_block_number().await.unwrap();
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()
+        .unwrap();
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await
+        .unwrap();
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        poll_timeout,
+    )
+    .await;
+
+    bot
+}
 
 /// Top-level hypothesis: an Alpaca placement that the broker processed but
 /// failed to acknowledge (5xx in flight) must not produce two orders when the
@@ -75,160 +222,167 @@ async fn transient_alpaca_5xx_after_record_does_not_double_submit() -> anyhow::R
     )
     .await;
 
-    // Assert the recovery path actually ran, so this can't pass trivially: the
-    // first attempt must have Failed (the lost-in-flight 503), and a second
-    // OffchainOrder aggregate must exist (the CheckPositions re-enqueue). The
-    // broker dedupe is only exercised when both happened.
-    let pool = connect_db(&infra.db_path).await?;
-    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
-    pool.close().await;
-
-    let failed_count = offchain_order_events
-        .iter()
-        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
-        .count();
-    assert_eq!(
-        failed_count, 1,
-        "Expected exactly one OffchainOrder failure (the transient 503) before \
-         recovery; got {failed_count}",
-    );
-
-    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
-        .iter()
-        .map(|event| event.aggregate_id.as_str())
-        .collect();
-    assert!(
-        distinct_aggregates.len() >= 2,
-        "Expected at least two OffchainOrder aggregates -- the failed first \
-         attempt and the re-enqueued retry that reconciled the broker's \
-         existing order; got {}",
-        distinct_aggregates.len(),
-    );
-
-    let orders = infra.broker_service.orders();
-    let order_count = orders.len();
-    assert_eq!(
-        order_count, 1,
-        "Expected exactly one order on the broker after a transient 5xx \
-         on the placement response; got {order_count}. More than one \
-         means the bot retried without an idempotency key and the \
-         broker has no way to dedupe the second submission.",
-    );
+    assert_broker_dedupe_recovery(
+        &infra.db_path,
+        &infra.broker_service,
+        BrokerDedupeRecoveryExpectation {
+            expected_failures: 1,
+            min_distinct_aggregates: 2,
+        },
+    )
+    .await;
 
     bot.abort();
     Ok(())
 }
 
-/// Top-level hypothesis: an Alpaca placement whose response is held past
-/// the client's request timeout must not produce two orders when the bot
-/// recovers -- the broker executed the placement on time, only the
-/// acknowledgement was late.
-///
-/// Mechanism under test: a [`LatencyProxy`] in front of the broker mock
-/// forwards the first placement immediately (the mock records the order)
-/// and holds the response past the Alpaca client's 30s request timeout.
-/// Unlike the 5xx scenario above, the bot never receives an HTTP response
-/// at all -- this exercises the transport-error (`HttpClient`) failure
-/// path rather than the `ApiError` path. The placement's `OffchainOrder`
-/// aggregate goes `Failed`, the position stashes that attempt's id as its
-/// idempotency anchor, and the periodic `CheckPositions` scan re-enqueues
-/// a fresh `PlaceHedge`. The retry derives its broker-side
-/// `client_order_id` from the live anchor, so the broker recognizes the
-/// duplicate, rejects it with a 422, and the executor reconciles by
-/// adopting the order the broker already accepted. Net result: exactly
-/// one broker order despite the timed-out acknowledgement.
+/// Top-level hypothesis: a placement whose acknowledgement arrives just
+/// before the Alpaca HTTP client's timeout succeeds on the first attempt
+/// without entering the dedupe recovery path.
 #[test_log::test(tokio::test)]
-async fn delayed_placement_response_past_client_timeout_does_not_double_submit()
--> anyhow::Result<()> {
-    let equity_symbol = "AAPL";
-    let onchain_price = float!(155.00);
+async fn placement_response_just_under_client_timeout_succeeds_without_retry() -> anyhow::Result<()>
+{
     let broker_fill_price = float!(150.25);
-    let sell_amount = float!(10.75);
-
-    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
     let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
 
-    // Hold the first placement's response for longer than the Alpaca
-    // client's 30s request timeout (hardcoded in the broker HTTP client).
-    // The mock records the order when the request arrives; the bot sees a
-    // timeout. One delayed placement is enough to drive the
-    // dedupe-on-retry recovery path.
     latency
-        .delay_order_placements(Duration::from_secs(35), 1)
+        .delay_order_placements(PLACEMENT_RESPONSE_JUST_UNDER_TIMEOUT, 1)
         .await;
 
-    let current_block = infra.base_chain.provider.get_block_number().await?;
-    let ctx = build_ctx()
-        .chain(&infra.base_chain)
-        .broker(&infra.broker_service)
-        .db_path(&infra.db_path)
-        .deployment_block(current_block)
-        .assets(infra.assets_config())
-        .broker_url_override(latency.endpoint.clone())
-        .call()?;
-    let mut bot = spawn_bot(ctx);
+    let poll_timeout = PLACEMENT_RESPONSE_JUST_UNDER_TIMEOUT + Duration::from_secs(60);
+    let bot = drive_sell_equity_hedge(&infra, &latency, poll_timeout).await;
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
-
-    let _take_result = infra
-        .base_chain
-        .take_order()
-        .symbol(equity_symbol)
-        .amount(sell_amount)
-        .price(onchain_price)
-        .direction(TakeDirection::SellEquity)
-        .call()
-        .await?;
-
-    poll_for_events_with_timeout(
-        &mut bot,
-        &infra.db_path,
-        "OffchainOrderEvent::Filled",
-        1,
-        Duration::from_secs(120),
-    )
-    .await;
-
-    // Assert the recovery path actually ran, so this can't pass trivially:
-    // the first attempt must have Failed (the timed-out acknowledgement),
-    // and a second OffchainOrder aggregate must exist (the CheckPositions
-    // re-enqueue). The broker dedupe is only exercised when both happened.
-    let pool = connect_db(&infra.db_path).await?;
-    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
-    pool.close().await;
-
-    let failed_count = offchain_order_events
-        .iter()
-        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
-        .count();
-    assert_eq!(
-        failed_count, 1,
-        "Expected exactly one OffchainOrder failure (the timed-out \
-         placement) before recovery; got {failed_count}",
-    );
-
-    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
-        .iter()
-        .map(|event| event.aggregate_id.as_str())
-        .collect();
-    assert!(
-        distinct_aggregates.len() >= 2,
-        "Expected at least two OffchainOrder aggregates -- the timed-out \
-         first attempt and the re-enqueued retry that reconciled the \
-         broker's existing order; got {}",
-        distinct_aggregates.len(),
-    );
-
-    let orders = infra.broker_service.orders();
-    let order_count = orders.len();
-    assert_eq!(
-        order_count, 1,
-        "Expected exactly one order on the broker after a placement whose \
-         response timed out; got {order_count}. More than one means the \
-         bot retried without an idempotency key and the broker has no way \
-         to dedupe the second submission.",
-    );
+    assert_single_successful_hedge_without_recovery(&infra.db_path, &infra.broker_service).await;
 
     bot.abort();
     Ok(())
+}
+
+/// Top-level hypothesis: an Alpaca placement whose response is held just
+/// past the client's request timeout must not produce two orders when the
+/// bot recovers -- the broker executed the placement on time, only the
+/// acknowledgement was late.
+///
+/// Uses the minimal delay (`31s`) above the hardcoded `30s` client timeout
+/// to pin the transport-error boundary rather than a comfortable margin.
+#[test_log::test(tokio::test)]
+async fn placement_response_just_over_client_timeout_does_not_double_submit() -> anyhow::Result<()>
+{
+    let broker_fill_price = float!(150.25);
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    latency
+        .delay_order_placements(PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT, 1)
+        .await;
+
+    let poll_timeout = PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT * 2 + Duration::from_secs(60);
+    let bot = drive_sell_equity_hedge(&infra, &latency, poll_timeout).await;
+
+    assert_broker_dedupe_recovery(
+        &infra.db_path,
+        &infra.broker_service,
+        BrokerDedupeRecoveryExpectation {
+            expected_failures: 1,
+            min_distinct_aggregates: 2,
+        },
+    )
+    .await;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: an Alpaca placement whose response is held well
+/// past the client's request timeout must not produce two orders when the
+/// bot recovers.
+///
+/// Mechanism under test: a [`LatencyProxy`] in front of the broker mock
+/// forwards the first placement immediately (the mock records the order)
+/// and holds the response past the Alpaca client's request timeout.
+/// Unlike the 5xx scenario above, the bot never receives an HTTP response
+/// at all -- this exercises the transport-error (`HttpClient`) failure
+/// path rather than the `ApiError` path.
+#[test_log::test(tokio::test)]
+async fn delayed_placement_response_past_client_timeout_does_not_double_submit()
+-> anyhow::Result<()> {
+    let broker_fill_price = float!(150.25);
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    latency
+        .delay_order_placements(PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT, 1)
+        .await;
+
+    let poll_timeout = PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT * 2 + Duration::from_secs(60);
+    let bot = drive_sell_equity_hedge(&infra, &latency, poll_timeout).await;
+
+    assert_broker_dedupe_recovery(
+        &infra.db_path,
+        &infra.broker_service,
+        BrokerDedupeRecoveryExpectation {
+            expected_failures: 1,
+            min_distinct_aggregates: 2,
+        },
+    )
+    .await;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: when both the initial placement *and* the dedupe
+/// retry receive delayed responses past the client timeout, recovery still
+/// completes with exactly one broker order once the delay budget is
+/// exhausted and the duplicate 422 can be reconciled.
+///
+/// Mechanism under test: the first POST times out after the broker records
+/// the order. The retry reuses the stashed idempotency anchor; the broker
+/// responds with 422 immediately, but the proxy holds that response too, so
+/// the bot sees a second transport timeout. A third attempt hits an
+/// un-delayed 422, the executor reconciles by `client_order_id` lookup,
+/// and hedging completes without a second broker order.
+#[test_log::test(tokio::test)]
+async fn two_delayed_placement_responses_past_client_timeout_do_not_double_submit()
+-> anyhow::Result<()> {
+    let broker_fill_price = float!(150.25);
+    let infra = TestInfra::start(vec![("AAPL", broker_fill_price)], vec![]).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    latency
+        .delay_order_placements(PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT, 2)
+        .await;
+
+    let poll_timeout = PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT * 3 + Duration::from_secs(90);
+    let bot = drive_sell_equity_hedge(&infra, &latency, poll_timeout).await;
+
+    assert_broker_dedupe_recovery(
+        &infra.db_path,
+        &infra.broker_service,
+        BrokerDedupeRecoveryExpectation {
+            expected_failures: 2,
+            min_distinct_aggregates: 3,
+        },
+    )
+    .await;
+
+    bot.abort();
+    Ok(())
+}
+
+#[test]
+fn alpaca_client_timeout_constants_bracket_placement_delay_boundaries() {
+    assert!(
+        PLACEMENT_RESPONSE_JUST_UNDER_TIMEOUT < HTTP_REQUEST_TIMEOUT,
+        "just-under delay must arrive before the client times out",
+    );
+    assert!(
+        PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT > HTTP_REQUEST_TIMEOUT,
+        "just-over delay must exceed the client timeout",
+    );
+    assert!(
+        PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT > PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT,
+        "well-over delay must remain above the timeout boundary",
+    );
 }

--- a/tests/e2e/chaos_combined.rs
+++ b/tests/e2e/chaos_combined.rs
@@ -1,0 +1,115 @@
+//! Cross-cutting chaos tests wiring multiple fault injectors at once.
+//!
+//! Exercises recovery when onchain ingestion and offchain placement both
+//! encounter adversarial upstream behaviour during the same hedge flow.
+
+use std::time::Duration;
+
+use st0x_execution::alpaca_broker_api::HTTP_REQUEST_TIMEOUT;
+use st0x_float_macro::float;
+
+use crate::chaos::{ChaosProxy, LatencyProxy};
+use crate::hedging::assertions::*;
+use crate::poll::{connect_db, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot};
+
+/// One placement response held well past the broker HTTP timeout, forcing the
+/// timeout-recovery path. Derived from the client's `HTTP_REQUEST_TIMEOUT` so it
+/// tracks any change to that single source of truth.
+const PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT: Duration =
+    Duration::from_secs(HTTP_REQUEST_TIMEOUT.as_secs() + 5);
+
+/// Top-level hypothesis: a hedge must complete with exactly one broker
+/// order even when onchain backfill sees transient empty `eth_getLogs`
+/// responses *and* the first placement acknowledgement is held past the
+/// Alpaca client's request timeout.
+///
+/// Mechanism under test: the take fires before the bot starts, so fill
+/// detection depends on the initial `eth_getLogs` backfill. The RPC chaos
+/// proxy returns empty results modelling a lagging load-balancer node; the
+/// tip check retries until the fill is observed. Separately, the broker
+/// latency proxy holds the first placement response past the HTTP client
+/// timeout; dedupe-on-retry must still leave exactly one broker order.
+#[test_log::test(tokio::test)]
+async fn empty_get_logs_and_delayed_placement_together_do_not_drop_or_double_hedge()
+-> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    chaos.empty_get_logs(4).await;
+    latency
+        .delay_order_placements(PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT, 1)
+        .await;
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    let poll_timeout = PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT * 2 + Duration::from_secs(120);
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        poll_timeout,
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
+    pool.close().await;
+
+    let failed_count = offchain_order_events
+        .iter()
+        .filter(|event| event.event_type == "OffchainOrderEvent::Failed")
+        .count();
+    assert_eq!(
+        failed_count, 1,
+        "Expected exactly one timed-out placement before broker dedupe recovery; got {failed_count}",
+    );
+
+    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert!(
+        distinct_aggregates.len() >= 2,
+        "Expected at least two OffchainOrder aggregates -- the CheckPositions re-enqueue that drives \
+         dedupe recovery must produce a second attempt; got {}. Without this the test can pass \
+         vacuously through the plain success path.",
+        distinct_aggregates.len(),
+    );
+
+    let order_count = infra.broker_service.orders().len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one broker order after combined RPC and placement chaos; got {order_count}",
+    );
+
+    bot.abort();
+    Ok(())
+}

--- a/tests/e2e/chaos_rpc.rs
+++ b/tests/e2e/chaos_rpc.rs
@@ -3,9 +3,9 @@
 //! These tests wire the bot's onchain provider through a [`ChaosProxy`]
 //! so the test harness can inject transient RPC failures (dropped
 //! responses, 5xx errors, empty `eth_getLogs` results modelling a
-//! load-balancer that routed to a lagging node) and assert the bot's
-//! recovery logic delivers the correct end state without losing or
-//! duplicating events.
+//! load-balancer that routed to a lagging node, delayed responses
+//! modelling a slow node) and assert the bot's recovery logic delivers
+//! the correct end state without losing or duplicating events.
 
 use std::time::Duration;
 
@@ -74,6 +74,95 @@ async fn transient_empty_get_logs_during_backfill_does_not_drop_events() -> anyh
     // the deployment_block..head range, so 4 empty responses cover the
     // initial sync plus a paranoid retry margin.
     chaos.empty_get_logs(4).await;
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: high latency on `eth_getLogs` responses must not
+/// drop or double-process fills. Each delayed response eventually arrives
+/// with the correct payload; the checkpoint-driven poller must wait for
+/// it rather than re-requesting the same range concurrently (which would
+/// surface the fill twice) or advancing past it (which would lose it).
+///
+/// Scenario: the take fires *before* the bot is up, so the initial
+/// backfill poll is the only thing that can surface it. The chaos proxy
+/// is armed to hold the next batch of `eth_getLogs` responses for
+/// several seconds each -- well within any transport timeout, modelling
+/// a slow-but-correct upstream node. The end state must be exactly one
+/// hedge: `assert_full_hedging_flow` checks broker orders, onchain
+/// vaults, and CQRS state against a single take.
+#[test_log::test(tokio::test)]
+async fn delayed_get_logs_responses_do_not_drop_or_duplicate_events() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    // Take the order BEFORE the bot starts. The bot must catch it via
+    // its checkpoint-driven `eth_getLogs` poll from deployment_block --
+    // exactly the path the delayed responses target.
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // Hold the next batch of `eth_getLogs` responses for 3s each. The
+    // bot's initial backfill issues one call per event kind (ClearV3,
+    // TakeOrderV3) over the deployment_block..head range, so 4 delayed
+    // responses cover the initial sync plus the next poll round.
+    chaos.delay_get_logs(Duration::from_secs(3), 4).await;
 
     let ctx = build_ctx()
         .chain(&infra.base_chain)

--- a/tests/e2e/hedging/assertions.rs
+++ b/tests/e2e/hedging/assertions.rs
@@ -38,12 +38,20 @@ pub(crate) fn build_ctx<P: Provider + Clone>(
     /// `chain.endpoint()`. Used by chaos tests to route the bot
     /// through a fault-injecting proxy.
     rpc_url_override: Option<url::Url>,
+    /// Override the broker base URL the bot connects to. Default is
+    /// `broker.base_url()`. Used by chaos tests to route broker calls
+    /// through a fault-injecting proxy.
+    broker_url_override: Option<url::Url>,
 ) -> anyhow::Result<Ctx> {
+    let broker_url = broker_url_override.map_or_else(
+        || broker.base_url(),
+        |url| url.to_string().trim_end_matches('/').to_owned(),
+    );
     let broker_ctx = BrokerCtx::AlpacaBrokerApi(AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
         api_secret: TEST_API_SECRET.to_owned(),
         account_id: AlpacaAccountId::new(uuid::uuid!("904837e3-3b76-47ec-b432-046db621571b")),
-        mode: Some(AlpacaBrokerApiMode::Mock(broker.base_url())),
+        mode: Some(AlpacaBrokerApiMode::Mock(broker_url)),
         asset_cache_ttl: Duration::from_secs(3600),
         time_in_force: TimeInForce::Day,
         counter_trade_slippage_bps: st0x_execution::DEFAULT_ALPACA_COUNTER_TRADE_SLIPPAGE_BPS,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -14,6 +14,7 @@ mod base_chain;
 mod cctp;
 mod chaos;
 mod chaos_alpaca;
+mod chaos_combined;
 mod chaos_rpc;
 mod full_system;
 mod hedging;


### PR DESCRIPTION
## What

Closes RAI-422. Adds latency-injection chaos coverage that holds RPC and broker responses past their client timeouts, proving the bot neither drops nor double-submits hedges when a slow response eventually arrives.

## Why

Slow-but-correct upstreams are a real failure mode: a delayed `eth_getLogs` result or a broker placement acknowledged past the client timeout must not cause dropped fills or a duplicate order — the placement already executed, only the ack was late.

## How

- Adds a `Delay` perturbation to the chaos proxy that forwards `eth_getLogs` upstream immediately, then holds the response for a configured duration.
- Introduces a plain-HTTP latency proxy for non-RPC upstreams (the Alpaca broker mock), since sleeping inside a synchronous `httpmock` responder would stall unrelated endpoints.
- Threads a broker URL override through test ctx construction so chaos tests can route broker calls through the latency proxy.

## Testing

- Delayed `eth_getLogs` test: holds the next responses several seconds each, asserts exactly one hedge results.
- Delayed-placement test: holds the first broker response past the 30s client timeout, asserts one failed attempt, a re-enqueued retry, and exactly one order on the broker.

## Anything else

Part of the Testing & chaos milestone under RAI-73; reconciliation of the late acknowledgement relies on `(tx_hash, log_index)` idempotency rather than retry suppression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added property-based tests to validate order ID handling and serialization.
  * Expanded fault-tolerance testing with network delay and latency injection scenarios.
  * Added test coverage for order placement resilience under network timeouts and failures.
  * Enhanced validation to verify proper deduplication during broker communication recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->