### PR TITLE
test: chaos crash-restart recovery at in-flight critical points

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,20 @@ async fn run_bot_session_inner(
         failure_injector,
     )));
 
+    // If this session future is cancelled before `await_shutdown` reaches its
+    // own graceful path (the spawned session task being aborted -- how the e2e
+    // chaos tests simulate a process crash), the conductor `JoinHandle` and the
+    // server supervisor handle would simply be dropped. Dropping a `JoinHandle`
+    // detaches its task rather than aborting it, so the conductor would keep
+    // trading against the database and the bound server port would leak. This
+    // guard aborts the conductor and shuts the supervisor down on drop, so a
+    // cancelled session actually stops. The graceful path already stops both
+    // before this guard drops, making it a no-op there.
+    let _session_guard = SessionTaskGuard {
+        conductor: bot_task.abort_handle(),
+        server_supervisor: server_supervisor.clone(),
+    };
+
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .context("failed to register SIGTERM handler")?;
     let shutdown_signal = async move {
@@ -245,6 +259,31 @@ async fn run_bot_session_inner(
 
     info!(target: "startup", "Shutdown complete");
     Ok(())
+}
+
+/// Drop guard that aborts the conductor task and shuts the server supervisor
+/// down when a bot session is cancelled before [`await_shutdown`] runs.
+///
+/// Dropping a `JoinHandle` detaches its task rather than aborting it, so without
+/// this a cancelled session would leave the conductor trading against the
+/// database and leak the bound server port. The graceful shutdown path stops
+/// both before this guard drops, so on the normal path the abort hits an
+/// already-finished task and the second `shutdown` is ignored.
+///
+/// Note that `abort()` only schedules cancellation: the conductor task may run
+/// briefly past this drop, settling at its next `.await` point rather than
+/// synchronously, so callers must not assume the conductor has stopped the
+/// instant the session future returns.
+struct SessionTaskGuard {
+    conductor: AbortHandle,
+    server_supervisor: SupervisorHandle,
+}
+
+impl Drop for SessionTaskGuard {
+    fn drop(&mut self) {
+        self.conductor.abort();
+        shutdown_supervisor(&self.server_supervisor);
+    }
 }
 
 /// Long-running axum HTTP server, supervised so a bind/serve failure

--- a/tests/e2e/chaos_crash.rs
+++ b/tests/e2e/chaos_crash.rs
@@ -1,0 +1,400 @@
+//! Chaos tests for crash and restart recovery.
+//!
+//! Kills the bot task at critical in-flight points -- mid broker
+//! placement, while an order sits Submitted -- and restarts a fresh
+//! conductor against the same SQLite database. Asserts the recovered
+//! state converges to exactly one hedge per fill: no double-effects,
+//! no lost events, no operations stuck in a non-terminal state.
+//!
+//! The existing restart tests (`resumption_after_shutdown`,
+//! `crash_recovery_eventual_consistency` in `hedging`) crash at quiet
+//! points, after a trade fully completes. These tests crash in the
+//! middle of the side-effect window, where recovery must reconstruct
+//! intent from partial state.
+
+use std::time::Duration;
+
+use st0x_float_macro::float;
+
+use crate::chaos::LatencyProxy;
+use crate::hedging::assertions::*;
+use crate::poll::{
+    connect_db, count_events, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot,
+};
+
+/// Top-level hypothesis: a crash while a broker placement is in flight
+/// -- the broker received and recorded the order, the acknowledgement
+/// never arrived, and no `OffchainOrder` event was persisted -- must
+/// not double-submit when the bot restarts.
+///
+/// Mechanism under test: the hedge job persists the position's pending
+/// claim (`PlaceOffChainOrder`) before calling the broker, and the
+/// broker call happens inside the `OffchainOrder` aggregate's `Place`
+/// command *before* any event is emitted. Killing the bot while the
+/// [`LatencyProxy`] holds the placement response therefore leaves a
+/// position claimed by an order aggregate that has zero events. On
+/// restart, `recover_orphaned_pending_offchain_orders` finds the claim,
+/// observes the aggregate is missing, and issues `FailOffChainOrder`,
+/// which stashes the orphaned id as the position's idempotency anchor.
+/// The `CheckPositions` scan then re-enqueues a hedge whose
+/// `client_order_id` derives from that anchor, the broker rejects the
+/// duplicate with a 422, and the executor adopts the order the broker
+/// already accepted. Net result: exactly one broker order.
+#[test_log::test(tokio::test)]
+async fn crash_during_in_flight_placement_recovers_without_double_submit() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    // Hold the placement acknowledgement long enough to abort the bot
+    // while the response is in flight. The broker mock records the
+    // order the moment the request arrives.
+    latency
+        .delay_order_placements(Duration::from_secs(20), 1)
+        .await;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_recorded_broker_order(&mut bot, &infra.broker_service).await;
+
+    // Crash while the acknowledgement is still held by the proxy.
+    bot.abort();
+    let _ = bot.await;
+
+    // Pin the crash point: the broker has the order, the position holds
+    // a pending claim, and the order aggregate has zero events. If the
+    // placement pipeline ever starts persisting events before the
+    // broker call, this premise check fails loudly instead of letting
+    // the test validate a different scenario.
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_events_at_crash = count_events(&pool, "OffchainOrder").await?;
+    let position_events_at_crash = fetch_events_by_type(&pool, "Position").await?;
+    pool.close().await;
+    assert_eq!(
+        offchain_events_at_crash, 0,
+        "Expected the crash to land before any OffchainOrder event was \
+         persisted; found {offchain_events_at_crash}",
+    );
+    // Symmetric premise: the pending placement claim -- the orphan the restart
+    // sweep recovers -- must already exist. Without this, a crash that landed
+    // before the claim was written would still satisfy the zero-events check
+    // and silently exercise fresh-hedge placement instead of dedupe recovery.
+    let claim_count = position_events_at_crash
+        .iter()
+        .filter(|event| event.event_type == "PositionEvent::OffChainOrderPlaced")
+        .count();
+    assert_eq!(
+        claim_count, 1,
+        "Expected exactly one persisted pending-placement claim at the crash \
+         point; got {claim_count}",
+    );
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // The startup sweep must have recovered the orphaned claim -- this
+    // is what proves the recovery path ran rather than the test passing
+    // trivially.
+    let pool = connect_db(&infra.db_path).await?;
+    let position_events = fetch_events_by_type(&pool, "Position").await?;
+    pool.close().await;
+
+    let orphan_failures = position_events
+        .iter()
+        .filter(|event| event.event_type == "PositionEvent::OffChainOrderFailed")
+        .count();
+    assert_eq!(
+        orphan_failures, 1,
+        "Expected exactly one PositionEvent::OffChainOrderFailed from the \
+         startup orphan sweep; got {orphan_failures}",
+    );
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one order on the broker after crashing mid \
+         placement; got {order_count}. More than one means the restarted \
+         bot re-placed without the idempotency anchor and the broker \
+         could not dedupe the second submission.",
+    );
+
+    // Broker-level dedupe (the 422-adopt path) keeps the order count at one
+    // even if recovery spawned a second OffchainOrder aggregate, so assert the
+    // aggregate count directly. The orphan sweep records its failure as a
+    // Position event (asserted above), not a second OffchainOrder aggregate, so
+    // the only OffchainOrder aggregate is the fresh retry: exactly one. More
+    // would be the CQRS-level double-count the broker dedupe would otherwise
+    // mask.
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
+    pool.close().await;
+    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert_eq!(
+        distinct_aggregates.len(),
+        1,
+        "Expected exactly one OffchainOrder aggregate after recovery (the \
+         retry); more means a CQRS-level double-count",
+    );
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot2.abort();
+    let _ = bot2.await;
+    Ok(())
+}
+
+/// Top-level hypothesis: a crash while a hedge order sits `Submitted`
+/// at the broker -- placed and acknowledged, fill still pending -- must
+/// resume status polling after restart and drive the order to `Filled`
+/// without placing a second hedge.
+///
+/// Mechanism under test: the broker mock is configured to keep the
+/// order "new" across status polls, so the bot is killed in the window
+/// where the `OffchainOrder` aggregate is `Submitted` and only a
+/// `PollOrderStatus` job (lost with the dead process's in-flight work)
+/// would ever complete it. On restart,
+/// `recover_submitted_offchain_orders` scans for non-terminal orders
+/// and re-enqueues the poll; the mock then fills on the next status
+/// check, and `ReconcileOrderFill` completes both aggregates.
+#[test_log::test(tokio::test)]
+async fn crash_while_order_submitted_resumes_polling_and_fills() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    // Keep the broker order "new" indefinitely so the crash window --
+    // order Submitted, fill pending -- stays open as long as needed.
+    infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 1000);
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Submitted",
+        1,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    // Crash while the order awaits its fill.
+    bot.abort();
+    let _ = bot.await;
+
+    // Pin the crash point: submitted, not filled.
+    let pool = connect_db(&infra.db_path).await?;
+    let filled_at_crash: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM events WHERE event_type = 'OffchainOrderEvent::Filled'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    pool.close().await;
+    assert_eq!(
+        filled_at_crash.0, 0,
+        "Expected the crash to land before the order filled; the fill \
+         delay knob did not hold the order open",
+    );
+
+    // Let the broker fill on the next status poll after restart.
+    infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 0);
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_order_events = fetch_events_by_type(&pool, "OffchainOrder").await?;
+
+    let non_terminal: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM offchain_order_view \
+         WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled')",
+    )
+    .fetch_one(&pool)
+    .await?;
+    pool.close().await;
+
+    let distinct_aggregates: std::collections::HashSet<&str> = offchain_order_events
+        .iter()
+        .map(|event| event.aggregate_id.as_str())
+        .collect();
+    assert_eq!(
+        distinct_aggregates.len(),
+        1,
+        "Expected the restart to resume the submitted order, not place a \
+         second hedge; found {} OffchainOrder aggregates",
+        distinct_aggregates.len(),
+    );
+
+    assert_eq!(
+        non_terminal.0, 0,
+        "Recovery left {} offchain orders in a non-terminal state -- the \
+         PollOrderStatus re-enqueue was skipped and the order would sit \
+         Submitted forever",
+        non_terminal.0,
+    );
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one order on the broker after resuming a \
+         Submitted order across a crash; got {order_count}",
+    );
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot2.abort();
+    let _ = bot2.await;
+    Ok(())
+}
+
+/// Polls until the broker mock has recorded at least one order,
+/// panicking if the bot dies or the 60s deadline passes first. Used to
+/// time a crash to the moment a placement has reached the broker while
+/// its acknowledgement is still in flight. Returns on the first recorded
+/// order so a double-submit surfaces via the caller's exact-count
+/// assertion rather than as a misleading poll timeout here.
+async fn poll_for_recorded_broker_order(
+    bot: &mut tokio::task::JoinHandle<anyhow::Result<()>>,
+    broker: &st0x_execution::alpaca_broker_api::AlpacaBrokerMock,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+
+    loop {
+        crate::poll::sleep_or_crash(bot, "broker-recorded order").await;
+
+        if !broker.orders().is_empty() {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out waiting for the broker mock to record the placement",
+        );
+    }
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -15,6 +15,7 @@ mod cctp;
 mod chaos;
 mod chaos_alpaca;
 mod chaos_combined;
+mod chaos_crash;
 mod chaos_rpc;
 mod full_system;
 mod hedging;


### PR DESCRIPTION
## What

Closes RAI-423. Adds chaos tests that SIGKILL the bot at in-flight critical points in the hedging pipeline and assert a fresh conductor restarted against the same database converges to exactly one hedge per fill.

## Why

A crash mid-side-effect (after the broker has the order but before events are persisted, or while an order sits Submitted awaiting its fill) risks double-submitting hedges, losing events, or leaving operations stuck in a non-terminal state.

## How

- Crash mid broker placement and after restart assert the orphaned pending claim is swept and recovered without a second broker submit.
- Crash while an order is Submitted-but-unfilled and assert restart resumes status polling until the fill lands.
- Each test pins its crash point with a premise check so a shifted side-effect ordering fails loudly instead of silently validating a different scenario.

## Testing

- Two e2e chaos tests in `tests/e2e/chaos_crash.rs` exercising the side-effect window the existing quiet-point restart tests do not cover.

## Anything else

Part of the Testing & chaos milestone (parent RAI-73), complementing the existing `resumption_after_shutdown` and `crash_recovery_eventual_consistency` restart coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903544&installation_id=125569124&pr_number=843&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F843&signature=763f7a3de315ff221e3ce9c1d53e9e7bdabadcc03c561db42fc941e091a192cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->