### PR TITLE
fix: requeue orphaned trading-pipeline jobs at startup

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -319,6 +319,39 @@ async fn requeue_equity_recovery_orphans(
     Ok(())
 }
 
+/// Resets a trading-pipeline queue's orphaned `Running`/`Queued` rows back to
+/// `Pending` at startup, before workers spawn. The trading queues cover the
+/// fill-to-hedge path: trade accounting, hedge placement, status polling,
+/// fill reconciliation, and rejection handling. A row wedged by a dead
+/// process is unrecoverable otherwise (see `JobQueue::requeue_orphaned` for
+/// why apalis never ages it out). Trade accounting is the critical case: its
+/// job row is the only remaining record of an observed fill once the backfill
+/// checkpoint has advanced past the fill's block, so a wedged row there is
+/// permanently unhedged exposure that no rescan will ever surface again.
+async fn requeue_trading_orphans<Task>(
+    queue: &job::JobQueue<Task>,
+    queue_label: &str,
+) -> anyhow::Result<()>
+where
+    Task: serde::Serialize + serde::de::DeserializeOwned + Send + Sync + Unpin + 'static,
+{
+    let count = queue
+        .requeue_orphaned()
+        .await
+        .with_context(|| format!("failed to re-queue orphaned {queue_label} jobs at startup"))?;
+
+    if count > 0 {
+        info!(
+            target: "hedge",
+            count,
+            queue = queue_label,
+            "Re-queued orphaned trading job(s) for crash-safe resume",
+        );
+    }
+
+    Ok(())
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -469,6 +502,18 @@ impl Conductor {
         let mut poll_status_queue = PollOrderStatusJobQueue::new(&apalis_pool);
         let reconcile_queue = ReconcileOrderFillJobQueue::new(&apalis_pool);
         let rejection_queue = HandleOrderRejectionJobQueue::new(&apalis_pool);
+
+        // A previous process may have died mid-job anywhere on the
+        // fill-to-hedge path, leaving apalis `Running` rows no live worker
+        // owns. Reset them before the monitor spawns, exactly like the
+        // transfer/backfill/recovery queues above. Trade accounting is the
+        // one that cannot be recovered any other way: once the backfill
+        // checkpoint advances, its job row is the only record of the fill.
+        requeue_trading_orphans(&job_queue, "trade accounting").await?;
+        requeue_trading_orphans(&hedge_queue, "hedge placement").await?;
+        requeue_trading_orphans(&poll_status_queue, "order status polling").await?;
+        requeue_trading_orphans(&reconcile_queue, "order fill reconciliation").await?;
+        requeue_trading_orphans(&rejection_queue, "order rejection handling").await?;
 
         let wrapped_equity_recovery_queue = WrappedEquityRecoveryJobQueue::new(&apalis_pool);
         let unwrapped_equity_recovery_queue = UnwrappedEquityRecoveryJobQueue::new(&apalis_pool);
@@ -2429,6 +2474,7 @@ mod tests {
         setup_test_db, setup_test_pools,
     };
     use crate::trading::onchain::inclusion::EmittedOnChain;
+    use crate::trading::onchain::trade_accountant::AccountForDexTrade;
     use crate::unwrapped_equity_recovery::UnwrappedEquityRecoveryJob;
     use crate::unwrapped_equity_recovery::aggregate::UnwrappedEquityRecoveryId;
 
@@ -2501,6 +2547,59 @@ mod tests {
                 .unwrap();
         assert_eq!(status, Status::Pending.to_string());
         assert_eq!(lock_by, None);
+    }
+
+    /// A crash mid trade-accounting job leaves a `Running` row that apalis
+    /// never rescues (the deterministic worker name keeps its heartbeat
+    /// fresh), and the backfill checkpoint has already advanced past the
+    /// fill -- the row is the only remaining record of the trade. The
+    /// startup requeue must make it runnable again.
+    #[tokio::test]
+    async fn requeue_trading_orphans_resets_running_accounting_rows() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let queue = DexTradeAccountingJobQueue::new(&apalis_pool);
+        let job_type = std::any::type_name::<AccountForDexTrade>();
+
+        // The lock owner must exist: Jobs.lock_by is a foreign key into Workers.
+        sqlx_apalis::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES (?, 'test', 'test')",
+        )
+        .bind("order-fill-worker-0")
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        // Insert with a real lock owner, exactly as apalis leaves a crashed
+        // Running row, so clearing lock_by/lock_at is actually exercised --
+        // asserting lock_by is None afterwards would pass vacuously otherwise.
+        sqlx_apalis::query(
+            "INSERT INTO Jobs \
+             (job, id, job_type, status, attempts, max_attempts, run_at, priority, lock_by, lock_at) \
+             VALUES (?, ?, ?, ?, 1, 25, 0, 0, ?, ?)",
+        )
+        .bind(vec![0_u8])
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(job_type)
+        .bind(Status::Running.to_string())
+        .bind("order-fill-worker-0")
+        .bind(0_i64)
+        .execute(&apalis_pool)
+        .await
+        .unwrap();
+
+        requeue_trading_orphans(&queue, "trade accounting")
+            .await
+            .unwrap();
+
+        let (status, lock_by, attempts): (String, Option<String>, i64) =
+            sqlx_apalis::query_as("SELECT status, lock_by, attempts FROM Jobs WHERE job_type = ?")
+                .bind(job_type)
+                .fetch_one(&apalis_pool)
+                .await
+                .unwrap();
+        assert_eq!(status, Status::Pending.to_string());
+        assert_eq!(lock_by, None);
+        assert_eq!(attempts, 1, "requeue must preserve the attempt count");
     }
 
     async fn job_count(apalis_pool: &apalis_sqlite::SqlitePool) -> i64 {

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -150,6 +150,20 @@ impl ChaosProxy {
             pending_stale_tips: 0,
         });
     }
+
+    /// Convenience: hold the responses of the next `count`
+    /// `eth_getTransactionReceipt` calls for `duration` each. The receipt
+    /// fetch is the first RPC call the trade-accounting job makes, so a
+    /// held receipt pins that job mid-`perform` -- used by crash tests to
+    /// widen the in-flight window they kill the bot inside.
+    pub(crate) async fn delay_transaction_receipts(&self, duration: Duration, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getTransactionReceipt".to_owned(),
+            behaviour: ChaosBehaviour::Delay { duration },
+            remaining: count,
+            pending_stale_tips: 0,
+        });
+    }
 }
 
 impl Drop for ChaosProxy {

--- a/tests/e2e/chaos_crash.rs
+++ b/tests/e2e/chaos_crash.rs
@@ -16,10 +16,11 @@ use std::time::Duration;
 
 use st0x_float_macro::float;
 
-use crate::chaos::LatencyProxy;
+use crate::chaos::{ChaosProxy, LatencyProxy};
 use crate::hedging::assertions::*;
 use crate::poll::{
-    connect_db, count_events, fetch_events_by_type, poll_for_events_with_timeout, spawn_bot,
+    connect_db, count_events, fetch_events_by_type, poll_for_backfill_checkpoint,
+    poll_for_events_with_timeout, poll_for_running_job, spawn_bot,
 };
 
 /// Top-level hypothesis: a crash while a broker placement is in flight
@@ -370,6 +371,158 @@ async fn crash_while_order_submitted_resumes_polling_and_fills() -> anyhow::Resu
 
     bot2.abort();
     let _ = bot2.await;
+    Ok(())
+}
+
+/// Top-level hypothesis: a crash in the middle of the trade-accounting
+/// job -- fill observed, job enqueued, backfill checkpoint already
+/// advanced past the fill's block, but no CQRS event persisted yet --
+/// must not lose the fill. The job row is the only remaining record of
+/// the trade at that point.
+///
+/// Mechanism under test: the [`ChaosProxy`] holds the
+/// `eth_getTransactionReceipt` response, which is the first RPC call
+/// `AccountForDexTrade::perform` makes, pinning the job in `Running`
+/// with zero events persisted. The bot is killed there. apalis cannot
+/// rescue the orphaned `Running` row on its own: the deterministic
+/// worker name keeps the row's heartbeat fresh after restart, so it
+/// never ages out, and the advanced checkpoint means no rescan will
+/// ever surface the fill again. Startup must reset the orphaned row to
+/// `Pending` (`requeue_trading_orphans`) so the re-spawned worker
+/// re-runs the job and the fill flows through Witness -> Position ->
+/// hedge exactly once.
+#[test_log::test(tokio::test)]
+async fn crash_mid_accounting_job_recovers_the_fill_after_restart() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Pin the accounting job mid-perform: the receipt fetch is its first
+    // RPC call, so holding the response keeps the job Running with zero
+    // CQRS events persisted. The hold must outlast the worst-case time to
+    // reach the abort below -- the Running-job poll and the checkpoint poll
+    // can each take their full 60s timeout (120s combined) -- or a slow run
+    // would deliver the receipt before the crash and let the job complete,
+    // defeating the test. The receipt is never actually awaited (the crash
+    // lands first), so the larger hold does not slow the test.
+    chaos
+        .delay_transaction_receipts(Duration::from_secs(150), 4)
+        .await;
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    let take_block = infra.base_chain.provider.get_block_number().await?;
+
+    poll_for_running_job(
+        &mut bot,
+        &infra.db_path,
+        std::any::type_name::<st0x_hedge::AccountForDexTrade>(),
+        Duration::from_secs(60),
+    )
+    .await;
+
+    // The checkpoint must be past the fill before the crash: that is
+    // what makes the wedged job row the only remaining record of the
+    // trade, so nothing short of rescuing the row can recover the fill.
+    poll_for_backfill_checkpoint(
+        &mut bot,
+        &infra.db_path,
+        take_block,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    bot.abort();
+    let _ = bot.await;
+
+    // Pin the crash point: job observed and enqueued, no event persisted. This
+    // is the pre-witness window, where the existence dedup does not short-circuit
+    // the requeued re-run, so requeue alone recovers the fill. The post-witness
+    // window (witnessed but not acknowledged) is recovered by the exactly-once
+    // acknowledgement marker and is covered by that work, not this test.
+    let pool = connect_db(&infra.db_path).await?;
+    let onchain_events_at_crash = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+    assert_eq!(
+        onchain_events_at_crash, 0,
+        "Expected the crash to land before the trade was witnessed; \
+         found {onchain_events_at_crash} OnChainTrade events",
+    );
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Expected exactly one hedge on the broker for the recovered \
+         fill; got {order_count}",
+    );
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot2.abort();
     Ok(())
 }
 

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -435,6 +435,95 @@ pub async fn connect_db(db_path: &std::path::Path) -> anyhow::Result<SqlitePool>
     Ok(SqlitePool::connect_with(options).await?)
 }
 
+/// Polls the apalis `Jobs` table until a job of the given type reaches
+/// `Running`, panicking if the bot dies or the timeout passes first.
+/// Used by crash tests to time an abort to the middle of a job's
+/// `perform`.
+pub async fn poll_for_running_job(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    job_type: &str,
+    timeout: Duration,
+) {
+    let connect_opts = SqliteConnectOptions::new().filename(db_path);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("Running {job_type} job");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect_with(connect_opts.clone()).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let running: Result<(i64,), _> =
+            sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status = 'Running'")
+                .bind(job_type)
+                .fetch_one(&pool)
+                .await;
+
+        pool.close().await;
+
+        if matches!(running, Ok((count,)) if count >= 1) {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
+/// Polls until the backfill checkpoint has advanced to at least
+/// `block`, panicking if the bot dies or the timeout passes first. Once
+/// the checkpoint passes a fill's block, the fill's accounting job row
+/// is the only remaining record of it -- crash tests use this to pin
+/// that premise before killing the bot.
+pub async fn poll_for_backfill_checkpoint(
+    bot: &mut JoinHandle<anyhow::Result<()>>,
+    db_path: &std::path::Path,
+    block: u64,
+    timeout: Duration,
+) {
+    let connect_opts = SqliteConnectOptions::new().filename(db_path);
+    let deadline = tokio::time::Instant::now() + timeout;
+    let context = format!("backfill checkpoint >= {block}");
+
+    loop {
+        sleep_or_crash(bot, &context).await;
+
+        let Ok(pool) = SqlitePool::connect_with(connect_opts.clone()).await else {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out after {timeout:?} waiting for {context} (database not ready)",
+            );
+            continue;
+        };
+
+        let checkpoint: Result<(Option<i64>,), _> =
+            sqlx::query_as("SELECT MAX(last_processed_block) FROM backfill_checkpoints")
+                .fetch_one(&pool)
+                .await;
+
+        pool.close().await;
+
+        if matches!(checkpoint, Ok((Some(last),)) if u64::try_from(last).is_ok_and(|last| last >= block))
+        {
+            return;
+        }
+
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "Timed out after {timeout:?} waiting for {context}",
+        );
+    }
+}
+
 /// Counts CQRS events for a specific aggregate type.
 pub async fn count_events(pool: &SqlitePool, aggregate_type: &str) -> anyhow::Result<i64> {
     let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE aggregate_type = ?")


### PR DESCRIPTION
## What

Part of RAI-423. At startup, requeues orphaned `Running`/`Queued` jobs across the entire fill-to-hedge trading pipeline (trade accounting, hedge placement, status polling, fill reconciliation, rejection handling) back to `Pending` before workers spawn.

## Why

A process that dies mid-job leaves apalis rows no live worker owns; the deterministic worker name keeps their heartbeat fresh so apalis never ages them out. A wedged trade-accounting row is unrecoverable any other way once the backfill checkpoint advances past the fill, leaving permanently unhedged exposure no rescan can surface again.

## How

- `requeue_trading_orphans` resets each trading queue's orphaned rows to `Pending` before the monitor spawns, mirroring the transfer/backfill/recovery queues.
- Applied to all five fill-to-hedge queues so a crash anywhere on the path resumes cleanly.

## Testing

- Unit test crashes a trade-accounting job (`Running` row), runs the startup requeue, and asserts the row returns to `Pending` with no lock owner.
- Chaos crash/restart e2e coverage exercises the recovery path end to end.

## Anything else

Part of the Testing & chaos milestone; complements the other crash-recovery queue requeues already in place.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903546&installation_id=125569124&pr_number=844&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F844&signature=e90cb899e2bc5b96904007a474c110e47a484763b4d918fab89d6b8d8201a993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash recovery for trading pipeline jobs that become stuck mid-execution during unexpected shutdowns.

* **Tests**
  * Added chaos test infrastructure for simulating network delays and validating recovery behavior after crashes.
  * Expanded testing utilities for monitoring job states and pipeline checkpoints during recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->