### PR TITLE
fix: requeue orphaned trading-pipeline jobs at startup

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -3394,6 +3394,95 @@ mod tests {
         );
     }
 
+    /// Re-delivering the identical (tx_hash, log_index) trade through the
+    /// accounting pipeline must be single-effect: one OnChainTrade fill
+    /// event, one Position fill transition, one offchain order -- the
+    /// duplicate short-circuits at the aggregate-load guard. This is the
+    /// dedup invariant every duplicate-input source (replayed logs,
+    /// duplicate apalis jobs, restart re-backfill) funnels through.
+    #[tokio::test]
+    async fn duplicate_trade_event_is_single_effect() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(30);
+
+        let first = process_queued_trade(
+            &MockExecutor::new(),
+            &trade_event,
+            test_trade_with_amount(float!(1.5), 30),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+        let offchain_order_id =
+            first.expect("1.5 shares should trigger execution with 1-share threshold");
+
+        let second = process_queued_trade(
+            &MockExecutor::new(),
+            &trade_event,
+            test_trade_with_amount(float!(1.5), 30),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            second, None,
+            "Duplicate trade must short-circuit without placing another order"
+        );
+
+        let (onchain_fills,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Filled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(onchain_fills, 1, "Duplicate must not re-witness the trade");
+
+        let (position_fills,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            position_fills, 1,
+            "Duplicate must not double-count the position"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("position should exist");
+        assert!(
+            position.net.inner().eq(float!(1.5)).unwrap(),
+            "Position net must reflect the trade exactly once"
+        );
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(offchain_order_id),
+            "The pending order must still be the first attempt's"
+        );
+
+        let all_orders = offchain_order_projection.load_all().await.unwrap();
+        assert_eq!(
+            all_orders.len(),
+            1,
+            "Exactly one offchain order should exist after the duplicate, got {}",
+            all_orders.len(),
+        );
+    }
+
     #[tokio::test]
     async fn trade_above_threshold_skips_counter_trade_without_offchain_inventory() {
         let (pool, apalis_pool) = setup_test_pools().await;

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -27,6 +27,7 @@
 //! production code paths. Additional behaviours (drop, error, stall)
 //! land alongside the chaos sub-issues that need them.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -52,6 +53,12 @@ pub(crate) enum ChaosBehaviour {
     /// for `duration` before relaying it. Models a slow upstream node:
     /// the request is processed on time, only the answer is late.
     Delay { duration: Duration },
+    /// Merge the last non-empty result previously served for the same
+    /// event signature into the response. Models a load-balanced or
+    /// caching RPC node serving stale results that ignore the requested
+    /// block range -- the same logs are delivered again in a later poll
+    /// round, after the consumer's checkpoint has already advanced.
+    ReplayLogs,
 }
 
 /// Knob describing which method to perturb and for how many calls.
@@ -71,11 +78,17 @@ pub(crate) struct ChaosConfig {
 
 type SharedConfig = Arc<Mutex<Option<ChaosConfig>>>;
 
+/// Last non-empty `eth_getLogs` result served per event signature
+/// (`topics[0]` of the request filter), used by
+/// [`ChaosBehaviour::ReplayLogs`] to re-deliver stale logs.
+type LogsCache = Arc<Mutex<HashMap<String, Vec<Value>>>>;
+
 /// Axum handler state: the mutable chaos config plus what's needed to
 /// forward un-perturbed requests to the real Anvil node.
 #[derive(Clone)]
 struct ProxyState {
     config: SharedConfig,
+    logs_cache: LogsCache,
     upstream: Url,
     client: Client,
 }
@@ -106,6 +119,7 @@ impl ChaosProxy {
         let config: SharedConfig = Arc::new(Mutex::new(None));
         let state = ProxyState {
             config: config.clone(),
+            logs_cache: Arc::new(Mutex::new(HashMap::new())),
             upstream,
             client: Client::new(),
         };
@@ -160,6 +174,19 @@ impl ChaosProxy {
         *self.config.lock().await = Some(ChaosConfig {
             method: "eth_getTransactionReceipt".to_owned(),
             behaviour: ChaosBehaviour::Delay { duration },
+            remaining: count,
+            pending_stale_tips: 0,
+        });
+    }
+
+    /// Convenience: merge the last non-empty `eth_getLogs` result for
+    /// the same event signature into the next `count` `eth_getLogs`
+    /// responses, modelling a stale node re-serving logs the consumer
+    /// already ingested in an earlier poll round.
+    pub(crate) async fn replay_get_logs(&self, count: usize) {
+        *self.config.lock().await = Some(ChaosConfig {
+            method: "eth_getLogs".to_owned(),
+            behaviour: ChaosBehaviour::ReplayLogs,
             remaining: count,
             pending_stale_tips: 0,
         });
@@ -400,17 +427,26 @@ enum Perturbation {
     Synthesize(Value),
     /// Forward upstream, then hold the response for this long.
     DelayResponse(Duration),
+    /// Forward upstream, then merge previously-cached logs for the same
+    /// event signature into the response.
+    ReplayResponse,
 }
 
-/// Decide a single JSON-RPC request: synthesize or delay a perturbed
-/// response when the active chaos config matches, otherwise forward it
-/// upstream untouched.
+/// Decide a single JSON-RPC request: synthesize, delay, or replay a
+/// perturbed response when the active chaos config matches, otherwise
+/// forward it upstream untouched.
+///
+/// Every forwarded `eth_getLogs` response refreshes the per-signature
+/// logs cache so a later [`ChaosBehaviour::ReplayLogs`] arm has stale
+/// logs to re-serve.
 async fn process_one(state: &ProxyState, request: Value) -> Value {
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request
         .get("method")
         .and_then(Value::as_str)
         .map(str::to_owned);
+
+    let is_get_logs = method.as_deref() == Some("eth_getLogs");
 
     let perturbation = match method {
         Some(method) => perturb(state, &method, &id).await,
@@ -424,8 +460,109 @@ async fn process_one(state: &ProxyState, request: Value) -> Value {
             tokio::time::sleep(duration).await;
             response
         }
-        None => forward_or_rpc_error(state, &request, id).await,
+        Some(Perturbation::ReplayResponse) => {
+            let response = forward_or_rpc_error(state, &request, id).await;
+            replay_cached_logs(state, &request, response).await
+        }
+        None => {
+            let response = forward_or_rpc_error(state, &request, id).await;
+            if is_get_logs {
+                cache_get_logs_result(state, &request, &response).await;
+            }
+            response
+        }
     }
+}
+
+/// Extracts the request filter's event signature (`topics[0]`), the key
+/// under which `eth_getLogs` results are cached and replayed.
+fn filter_event_signature(request: &Value) -> Option<String> {
+    request["params"][0]["topics"][0]
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Refreshes the logs cache with this response's result when non-empty,
+/// keyed by the request filter's event signature.
+async fn cache_get_logs_result(state: &ProxyState, request: &Value, response: &Value) {
+    let Some(signature) = filter_event_signature(request) else {
+        return;
+    };
+
+    let Some(logs) = response["result"].as_array() else {
+        return;
+    };
+
+    if logs.is_empty() {
+        return;
+    }
+
+    state
+        .logs_cache
+        .lock()
+        .await
+        .insert(signature, logs.clone());
+}
+
+/// Merges the cached logs for the request's event signature into the
+/// response, skipping logs already present (matched by transaction hash
+/// and log index), then refreshes the cache with the original result.
+/// The merged response models a stale node re-serving logs from outside
+/// the requested block range.
+async fn replay_cached_logs(state: &ProxyState, request: &Value, mut response: Value) -> Value {
+    let Some(signature) = filter_event_signature(request) else {
+        return response;
+    };
+
+    // Read the previously cached logs and refresh the cache with this
+    // response's result under a single lock, so the read-then-refresh is one
+    // atomic critical section rather than two racy acquisitions.
+    let cached_logs = {
+        let mut cache = state.logs_cache.lock().await;
+        let previous = cache.get(&signature).cloned();
+        if let Some(logs) = response["result"]
+            .as_array()
+            .filter(|logs| !logs.is_empty())
+        {
+            cache.insert(signature.clone(), logs.clone());
+        }
+        previous
+    };
+
+    let Some(cached_logs) = cached_logs else {
+        warn!(
+            signature,
+            "ReplayLogs armed but no cached logs for this event signature; \
+             forwarding unmodified"
+        );
+        return response;
+    };
+
+    let Some(result) = response["result"].as_array_mut() else {
+        return response;
+    };
+
+    let log_key = |log: &Value| {
+        (
+            log["transactionHash"].as_str().map(str::to_owned),
+            log["logIndex"].as_str().map(str::to_owned),
+        )
+    };
+    let present: Vec<_> = result.iter().map(log_key).collect();
+
+    let replayed: Vec<Value> = cached_logs
+        .into_iter()
+        .filter(|log| !present.contains(&log_key(log)))
+        .collect();
+
+    warn!(
+        signature,
+        replayed = replayed.len(),
+        "ReplayLogs: re-serving stale logs alongside the live response"
+    );
+    result.extend(replayed);
+
+    response
 }
 
 /// Forwards one request upstream, shaping any transport failure into a
@@ -476,6 +613,10 @@ async fn perturb(state: &ProxyState, method: &str, id: &Value) -> Option<Perturb
                     ChaosBehaviour::Delay { duration } => {
                         cfg.remaining -= 1;
                         Some(Perturbation::DelayResponse(duration))
+                    }
+                    ChaosBehaviour::ReplayLogs => {
+                        cfg.remaining -= 1;
+                        Some(Perturbation::ReplayResponse)
                     }
                 }
             } else {

--- a/tests/e2e/chaos_rpc.rs
+++ b/tests/e2e/chaos_rpc.rs
@@ -13,7 +13,7 @@ use st0x_float_macro::float;
 
 use crate::chaos::ChaosProxy;
 use crate::hedging::assertions::*;
-use crate::poll::{poll_for_events_with_timeout, spawn_bot};
+use crate::poll::{connect_db, poll_for_all_jobs_done, poll_for_events_with_timeout, spawn_bot};
 
 /// Top-level hypothesis: a SellEquity onchain trade observed
 /// only in the bot's initial `eth_getLogs` poll window still produces
@@ -186,6 +186,180 @@ async fn delayed_get_logs_responses_do_not_drop_or_duplicate_events() -> anyhow:
     assert_full_hedging_flow(
         &[expected_position],
         &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: an RPC node re-serving logs the bot already
+/// ingested in an earlier poll round -- after the backfill checkpoint
+/// has advanced past them -- must not double-process the fill. The
+/// duplicate enters the system as a real duplicate `AccountForDexTrade`
+/// job (there is no enqueue-time dedup); the single-effect guard is the
+/// `(tx_hash, log_index)`-keyed OnChainTrade aggregate.
+///
+/// Scenario: the first take is ingested normally through the chaos
+/// proxy, which caches every non-empty `eth_getLogs` result by event
+/// signature. The proxy is then armed to merge those cached logs into
+/// later `eth_getLogs` responses, modelling a load-balanced or caching
+/// node serving stale results that ignore the requested block range. A
+/// second take on another symbol keeps the chain and poller moving. The
+/// premise assertion checks the duplicate job actually entered the
+/// queue -- without that the test could pass trivially -- and the end
+/// state must show exactly one effect per take across broker orders,
+/// onchain vaults, and CQRS state.
+#[test_log::test(tokio::test)]
+async fn replayed_get_logs_across_checkpoint_advances_do_not_double_process() -> anyhow::Result<()>
+{
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price), ("TSLA", broker_fill_price)],
+        vec![],
+    )
+    .await?;
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let take1 = infra
+        .base_chain
+        .take_order()
+        .symbol("AAPL")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // The proxy has now cached take 1's TakeOrderV3 logs. Arm it to
+    // re-serve them in the next poll round's responses -- one armed
+    // count per event-kind query (ClearV3 + TakeOrderV3) in the round.
+    chaos.replay_get_logs(2).await;
+
+    let take2 = infra
+        .base_chain
+        .take_order()
+        .symbol("TSLA")
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        2,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // Premise: the replayed log really entered the queue as a duplicate
+    // accounting job -- two takes plus at least one replayed duplicate.
+    let pool = connect_db(&infra.db_path).await?;
+    let (accounting_jobs,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ?")
+        .bind(std::any::type_name::<st0x_hedge::AccountForDexTrade>())
+        .fetch_one(&pool)
+        .await?;
+    assert!(
+        accounting_jobs >= 3,
+        "Expected the replayed log to enqueue a duplicate accounting job \
+         (2 takes + >=1 replay); found only {accounting_jobs} jobs",
+    );
+
+    // Drain every queue so the replayed duplicate accounting job has
+    // definitively run before the single-effect snapshot below. The duplicate
+    // is a no-op on a correct dedup guard, so it emits no
+    // `OffchainOrderEvent::Filled` and the fill poll above never waited for it.
+    // Without this barrier a broken guard could write the second fill *after*
+    // the snapshot and the assertion would still pass, shipping the bug.
+    poll_for_all_jobs_done(&mut bot, &infra.db_path, accounting_jobs).await;
+
+    // Single effect: exactly one witnessed trade per take despite the
+    // duplicate job.
+    let (onchain_fills,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+            .bind("OnChainTradeEvent::Filled")
+            .fetch_one(&pool)
+            .await?;
+    // The named failure mode is a Position double-count: a duplicate accounting
+    // job that bypasses the witness load-guard but still re-acknowledges the
+    // fill. The witness count alone would not catch that, so assert the
+    // Position fill count directly -- two takes, two fills, never three.
+    let (position_fills,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+            .bind("PositionEvent::OnChainOrderFilled")
+            .fetch_one(&pool)
+            .await?;
+    pool.close().await;
+    assert_eq!(
+        onchain_fills, 2,
+        "Expected exactly one OnChainTrade fill per take; got {onchain_fills}",
+    );
+    assert_eq!(
+        position_fills, 2,
+        "Expected exactly one Position fill per take; a duplicate accounting job \
+         must not double-count the position; got {position_fills}",
+    );
+
+    let expected_positions = [
+        ExpectedPosition::builder()
+            .symbol("AAPL")
+            .amount(sell_amount)
+            .direction(TakeDirection::SellEquity)
+            .onchain_price(onchain_price)
+            .broker_fill_price(broker_fill_price)
+            .expected_accumulated_long(float!(0))
+            .expected_accumulated_short(sell_amount)
+            .expected_net(float!(0))
+            .build(),
+        ExpectedPosition::builder()
+            .symbol("TSLA")
+            .amount(sell_amount)
+            .direction(TakeDirection::SellEquity)
+            .onchain_price(onchain_price)
+            .broker_fill_price(broker_fill_price)
+            .expected_accumulated_long(float!(0))
+            .expected_accumulated_short(sell_amount)
+            .expected_net(float!(0))
+            .build(),
+    ];
+
+    assert_full_hedging_flow(
+        &expected_positions,
+        &[take1, take2],
         &infra.base_chain.provider,
         infra.base_chain.orderbook,
         infra.base_chain.owner,


### PR DESCRIPTION
## What

Closes RAI-424. Adds chaos coverage proving the trading pipeline is idempotent under duplicate inputs: replaying the same onchain event or re-delivering the same accounting job never produces a second effect.

## Why

Load-balanced RPCs and job requeues can deliver the same logical event more than once; without enforced idempotency a single fill could spawn duplicate onchain trades, offchain orders, or aggregate transitions.

## How

- Replays duplicate `(tx_hash, log_index)` onchain logs (a stale / load-balanced RPC node re-serving logs after the checkpoint advanced) and re-delivers a duplicate accounting job, against the real pipeline.
- Asserts the single-effect invariant: one onchain trade and one position fill per logical operation regardless of input duplication.

## Testing

- A dedup unit test drives `process_queued_trade` twice for the same event and asserts a single witnessed trade and a single position fill (the re-delivered-job vector; the accounting worker runs at `concurrency(1)`, so a sequential re-drive is the production execution model).
- An RPC-replay e2e test in `tests/e2e/chaos_rpc.rs` re-serves stale logs across checkpoint advances and asserts exactly-once effects, including the per-event Position fill count.

## Anything else

Part of the Testing & chaos milestone (parent RAI-73). Broker-callback duplication (a duplicate fill acknowledgement through the `OffchainOrder` pipeline) is out of scope here and not exercised by these tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to verify idempotent handling of duplicate trade events in the accounting pipeline without duplicate accounting effects.
  * Added chaos mode testing for log replay scenarios to ensure replayed log events don't result in duplicate trade processing or incorrect accounting records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->