### PR TITLE
fix: propagate infrastructure errors in trade-accounting DB writes

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1338,6 +1338,34 @@ mod tests {
         file
     }
 
+    /// Pins the first line of defense against database contention: every
+    /// pooled connection runs WAL (writers never block readers) with a
+    /// 10s busy timeout that waits out brief write-lock contention from a
+    /// co-located writer instead of failing instantly. Contention beyond the
+    /// timeout still surfaces as a retryable SQLITE_BUSY error in the trading
+    /// pipeline -- it is not swallowed. If a refactor drops either pragma,
+    /// every lock blip from a co-located process becomes an immediate hard
+    /// error, and this test catches the drift.
+    #[tokio::test]
+    async fn configure_sqlite_pool_pins_wal_and_busy_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let database_url = format!("sqlite://{}/config-pin.sqlite", dir.path().display());
+
+        let pool = configure_sqlite_pool(&database_url).await.unwrap();
+
+        let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+
+        let busy_timeout_ms: i64 = sqlx::query_scalar("PRAGMA busy_timeout")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(busy_timeout_ms, 10_000);
+    }
+
     fn minimal_config_toml() -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -27,7 +27,8 @@ use tracing::{debug, error, info, warn};
 use st0x_config::{AssetsConfig, BrokerCtx, Ctx, CtxError, ExecutionThreshold, RebalancingCtx};
 use st0x_dto::Statement;
 use st0x_event_sorcery::{
-    Projection, Store, StoreBuilder, compact_events, incremental_vacuum, load_all_ids, load_entity,
+    AggregateError, LifecycleError, Projection, SendError, Store, StoreBuilder, compact_events,
+    incremental_vacuum, load_all_ids, load_entity,
 };
 use st0x_evm::Wallet;
 use st0x_execution::{
@@ -59,7 +60,7 @@ use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};
 use crate::onchain::approvals::{build_approval_targets, grant_startup_approvals};
 use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
-use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
+use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{
@@ -1651,11 +1652,21 @@ pub(crate) async fn discover_vaults_for_trade(
 }
 
 /// Returns `true` if the witness was accepted, `false` if rejected.
+/// Executes `OnChainTrade::Witness`, distinguishing domain rejections from
+/// infrastructure failures per the error contract in docs/conductor.md.
+///
+/// Returns `Ok(false)` only for the duplicate-style domain rejections
+/// (already filled/enriched) -- permanent, expected, and safe to skip.
+/// Every other error (database unavailable, aggregate conflict, lifecycle
+/// bug) propagates so the apalis job retries instead of marking the fill
+/// Done: with the backfill checkpoint already advanced, a swallowed
+/// witness failure is a permanently lost fill and silent unhedged
+/// exposure.
 async fn execute_witness_trade(
     onchain_trade: &Store<OnChainTrade>,
     trade: &OnchainTrade,
     block_number: u64,
-) -> bool {
+) -> Result<bool, SendError<OnChainTrade>> {
     let trade_id = OnChainTradeId {
         tx_hash: trade.tx_hash,
         log_index: trade.log_index,
@@ -1671,7 +1682,7 @@ async fn execute_witness_trade(
             symbol = %trade.symbol,
             "Missing block_timestamp for OnChainTrade::Witness"
         );
-        return false;
+        return Ok(false);
     };
 
     let command = OnChainTradeCommand::Witness {
@@ -1691,17 +1702,21 @@ async fn execute_witness_trade(
                 symbol = %trade.symbol,
                 "Successfully executed OnChainTrade::Witness command"
             );
-            true
+            Ok(true)
         }
-        Err(error) => {
+        // A Witness command on an existing aggregate can only be rejected with
+        // AlreadyFilled (AlreadyEnriched is only ever produced by an Enrich
+        // command), so that is the one duplicate-skip case here.
+        Err(AggregateError::UserError(LifecycleError::Apply(OnChainTradeError::AlreadyFilled))) => {
             warn!(
                 tx_hash = ?trade.tx_hash,
                 log_index = trade.log_index,
                 symbol = %trade.symbol,
-                "OnChainTrade::Witness rejected: {error}"
+                "OnChainTrade::Witness rejected as duplicate: already filled"
             );
-            false
+            Ok(false)
         }
+        Err(error) => Err(error),
     }
 }
 
@@ -1815,17 +1830,24 @@ where
         log_index: trade.log_index,
     };
 
-    if let Ok(Some(_)) = cqrs.onchain_trade.load(&trade_id).await {
-        debug!(
-            ?trade_id,
-            symbol = %trade.symbol,
-            "Trade already processed (duplicate event), skipping"
-        );
-        return Ok(None);
+    match cqrs.onchain_trade.load(&trade_id).await {
+        Ok(Some(_)) => {
+            debug!(
+                ?trade_id,
+                symbol = %trade.symbol,
+                "Trade already processed (duplicate event), skipping"
+            );
+            return Ok(None);
+        }
+        Ok(None) => {}
+        // A failed read must not masquerade as "not a duplicate": the
+        // witness write would also fail on a healthy dedupe path, but
+        // propagating here keeps the retry contract explicit.
+        Err(error) => return Err(error.into()),
     }
 
     let witnessed =
-        execute_witness_trade(&cqrs.onchain_trade, &trade, trade_event.block_number).await;
+        execute_witness_trade(&cqrs.onchain_trade, &trade, trade_event.block_number).await?;
 
     if !witnessed {
         return Ok(None);
@@ -2437,7 +2459,7 @@ mod tests {
     use alloy::primitives::{Address, B256, TxHash, U256, address, bytes, fixed_bytes};
     use apalis::prelude::Status;
     use rain_math_float::Float;
-    use sqlx::SqlitePool;
+    use sqlx::{ConnectOptions, SqlitePool};
     use std::future::pending;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -3391,6 +3413,145 @@ mod tests {
         assert!(
             matches!(offchain_order, OffchainOrder::Submitted { .. }),
             "Offchain order should be Submitted after successful placement, got: {offchain_order:?}"
+        );
+    }
+
+    /// A database write lock during the Witness write must surface as a
+    /// retryable error, not silently drop the fill. Pre-fix,
+    /// `execute_witness_trade` blanket-matched every `SendError` as a
+    /// domain rejection and returned `false`, so the accounting job was
+    /// marked Done with the checkpoint already advanced -- a SQLITE_BUSY
+    /// blip (the documented bot-vs-reporter contention scenario) became
+    /// silent, permanently unhedged exposure. The lock is held by a
+    /// second raw connection via `BEGIN IMMEDIATE`, exactly how another
+    /// process contends for the WAL write lock; the pool's busy timeout
+    /// is scaled down so the test waits milliseconds, not production's
+    /// 10 seconds -- the surfacing code path is identical.
+    #[tokio::test]
+    async fn db_write_lock_during_witness_propagates_error_for_retry() {
+        let (pool, apalis_pool, db_path, _dir) =
+            crate::test_utils::setup_file_backed_test_db(Duration::from_millis(250)).await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let mut locker = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .connect()
+            .await
+            .unwrap();
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut locker)
+            .await
+            .unwrap();
+
+        let result = process_queued_trade(
+            &MockExecutor::new(),
+            &make_trade_event(40),
+            test_trade_with_amount(float!(1.5), 40),
+            &cqrs,
+            true,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(TradeAccountingError::OnChainTradeCommand(_))),
+            "A write-locked database during Witness must propagate a \
+             retryable error so apalis re-runs the job; got: {result:?}",
+        );
+
+        sqlx::query("ROLLBACK").execute(&mut locker).await.unwrap();
+
+        // The apalis retry re-delivers the same job against the healthy
+        // database; the fill must flow through exactly once.
+        process_queued_trade(
+            &MockExecutor::new(),
+            &make_trade_event(40),
+            test_trade_with_amount(float!(1.5), 40),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap()
+        .expect("retry must place the hedge for the recovered fill");
+
+        let (onchain_fills,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Filled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            onchain_fills, 1,
+            "Exactly one witnessed fill after the lock cleared and the \
+             retry ran"
+        );
+
+        // The witness count alone does not prove the fill reached the position.
+        // Assert the full pipeline ran exactly once after recovery: one
+        // position fill, the net updated, and a hedge placed.
+        let (position_fills,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            position_fills, 1,
+            "The recovered fill must reach the position exactly once, not just \
+             the witness layer"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("the position must exist after the recovered fill");
+        assert!(
+            position.net.inner().eq(float!(1.5)).unwrap(),
+            "The position net must reflect the recovered fill"
+        );
+        assert!(
+            position.pending_offchain_order_id.is_some(),
+            "The recovered fill must have placed a pending hedge"
+        );
+    }
+
+    /// A failed dedup read (not just a failed write) must propagate as a
+    /// retryable error rather than being mistaken for "not a duplicate" and
+    /// re-processing the fill.
+    #[tokio::test]
+    async fn dedup_load_failure_propagates_as_retryable_error() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        // Close the pool so the dedup load -- the first DB access in
+        // process_queued_trade -- fails before any write is attempted.
+        pool.close().await;
+
+        let result = process_queued_trade(
+            &MockExecutor::new(),
+            &make_trade_event(41),
+            test_trade_with_amount(float!(1.5), 41),
+            &cqrs,
+            true,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(TradeAccountingError::OnChainTradeCommand(_))),
+            "A failed dedup read must propagate a retryable error, never be \
+             treated as not-a-duplicate; got: {result:?}",
         );
     }
 

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -192,7 +192,7 @@ mod tests {
     use alloy::primitives::address;
     use alloy::providers::ProviderBuilder;
     use alloy::providers::mock::Asserter;
-    use sqlx::SqlitePool;
+    use sqlx::{ConnectOptions, SqlitePool};
 
     use super::*;
     use crate::test_utils::setup_test_pools;
@@ -315,6 +315,78 @@ mod tests {
             0,
             "no safe block to ingest yet -> no enqueue"
         );
+    }
+
+    /// A write-locked database during the backfill enqueue must surface
+    /// as a typed error (the run loop logs it and retries next tick),
+    /// leave nothing enqueued, and enqueue cleanly once the lock clears.
+    /// The lock is a second connection holding `BEGIN IMMEDIATE` against
+    /// a file-backed database -- the documented bot-vs-reporter WAL
+    /// write contention -- with the pool's busy timeout scaled down so
+    /// the test waits milliseconds instead of production's 10 seconds.
+    #[tokio::test]
+    async fn poll_once_surfaces_enqueue_error_under_db_lock_and_resumes() {
+        let (pool, apalis_pool, db_path, _dir) =
+            crate::test_utils::setup_file_backed_test_db(Duration::from_millis(250)).await;
+        let backfill_queue = BackfillJobQueue::new(&apalis_pool);
+        let evm_ctx = EvmCtx {
+            rpc_url: url::Url::parse("http://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+        };
+
+        // One tip response per poll_once call.
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(50));
+        asserter.push_success(&serde_json::Value::from(50));
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let mut monitor = OrderFillMonitor::new(
+            evm_ctx,
+            backfill_queue,
+            pool.clone(),
+            provider,
+            Duration::from_secs(5),
+        );
+
+        let mut locker = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(&db_path)
+            .connect()
+            .await
+            .unwrap();
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut locker)
+            .await
+            .unwrap();
+
+        // The in-flight check is a read and succeeds under the WAL write
+        // lock; the enqueue INSERT blocks, then errors after the busy
+        // timeout.
+        let result = monitor.poll_once().await;
+        assert!(
+            matches!(result, Err(OrderFillMonitorError::Enqueue(_))),
+            "A write-locked database must surface as a typed enqueue \
+             error; got: {result:?}",
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "No backfill range may be enqueued while the lock is held"
+        );
+
+        sqlx::query("ROLLBACK").execute(&mut locker).await.unwrap();
+
+        monitor.poll_once().await.unwrap();
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            1,
+            "The next tick after the lock clears must enqueue the range"
+        );
+
+        let job = loaded_backfill(&apalis_pool).await;
+        assert_eq!(job.from_block, 1, "checkpoint must not have advanced");
+        assert_eq!(job.to_block, 50);
     }
 
     #[tokio::test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -189,6 +189,55 @@ pub(crate) async fn setup_test_db() -> SqlitePool {
     setup_test_pools().await.0
 }
 
+/// File-backed variant of [`setup_test_db`] with production-shaped pool
+/// options (WAL journal mode, explicit busy timeout). Needed by tests
+/// that inject SQLite lock contention: an in-memory database cannot be
+/// locked from a second connection, a file can. The `busy_timeout` is
+/// injectable so lock tests wait milliseconds instead of production's
+/// 10 seconds -- the code path under test (`SQLITE_BUSY` surfacing
+/// through the store) is identical, only the wait differs. The apalis
+/// worker pool (sqlx 0.8) is opened over the same file with the same
+/// scaled-down timeout so enqueue contention surfaces just as fast.
+///
+/// Returns the CQRS pool, the apalis worker pool, the database file path
+/// (for opening contending connections), and the tempdir guard keeping
+/// the file alive.
+pub(crate) async fn setup_file_backed_test_db(
+    busy_timeout: std::time::Duration,
+) -> (
+    SqlitePool,
+    apalis_sqlite::SqlitePool,
+    std::path::PathBuf,
+    tempfile::TempDir,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+        .busy_timeout(busy_timeout);
+    let pool = SqlitePool::connect_with(options).await.unwrap();
+
+    sqlx::migrate!().run(&pool).await.unwrap();
+
+    let apalis_options = sqlx_apalis::sqlite::SqliteConnectOptions::new()
+        .filename(&db_path)
+        .create_if_missing(true)
+        .journal_mode(sqlx_apalis::sqlite::SqliteJournalMode::Wal)
+        .busy_timeout(busy_timeout);
+    let apalis_pool = apalis_sqlite::SqlitePool::connect_with(apalis_options)
+        .await
+        .unwrap();
+
+    crate::conductor::setup_apalis_tables(&apalis_pool)
+        .await
+        .unwrap();
+
+    (pool, apalis_pool, db_path, dir)
+}
+
 /// Shared constructor for positive share quantities in tests.
 pub(crate) fn positive_shares(value: &str) -> Positive<FractionalShares> {
     Positive::new(FractionalShares::new(

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -218,6 +218,8 @@ fn reconstruct_log(orderbook: Address, trade: &EmittedOnChain<RaindexTradeEvent>
 pub(crate) enum TradeAccountingError {
     #[error("Onchain trade processing error: {0}")]
     OnChain(#[from] OnChainError),
+    #[error("Onchain trade command failed: {0}")]
+    OnChainTradeCommand(#[from] SendError<crate::onchain_trade::OnChainTrade>),
     #[error("Vault registry command failed: {0}")]
     VaultRegistry(#[from] SendError<VaultRegistry>),
     #[error("Position command failed: {0}")]


### PR DESCRIPTION
## What

Part of RAI-425. Makes the trade-accounting pipeline propagate database-unavailability errors (e.g. SQLITE_BUSY under WAL write contention) as retryable failures instead of mistaking them for permanent domain rejections.

## Why

A SQLITE_BUSY blip during the Witness write was blanket-matched as a duplicate rejection, so the accounting job was marked Done with the backfill checkpoint already advanced — a permanently lost fill and silent, unhedged exposure.

## How

- `execute_witness_trade` now returns a typed result, matching only `AlreadyFilled`/`AlreadyEnriched` as expected domain rejections and propagating every other error so apalis retries.
- The dedupe `load` no longer treats a failed read as "not a duplicate"; infrastructure errors propagate per the docs/conductor.md error contract.
- Adds an `OnChainTradeCommand` variant to `TradeAccountingError` to carry the witness `SendError` through to the retry path.

## Testing

- Chaos test holds a real WAL write lock (`BEGIN IMMEDIATE` on a second connection) during the Witness write and asserts a retryable error surfaces, nothing is left half-written, and the fill flows through exactly once after the lock clears.
- Companion test covers the backfill-enqueue path surfacing a typed error under the same lock and resuming cleanly without advancing the checkpoint.

## Anything else

Part of the Testing & chaos milestone (RAI-425, under RAI-73): database unavailability / lock injection with clean halt and recovery.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903549&installation_id=125569124&pr_number=846&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F846&signature=2c6bc6c69478bb92c8dcfb99985ff32be7f6a39d72894dbb31e8067dd2b97ad8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience to temporary database write-locks; operations now return retryable errors instead of failing silently, enabling automatic recovery on retry.

* **Tests**
  * Added comprehensive test coverage for database lock scenarios during trade processing and order fill monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->