### PR TITLE
test: chaos SQLite lock contention ride-through and fail-fast startup

### DIFF
--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -37,6 +37,7 @@ use axum::extract::State;
 use axum::response::{IntoResponse, Response};
 use reqwest::Client;
 use serde_json::{Value, json};
+use sqlx::ConnectOptions;
 use tokio::sync::Mutex;
 use tracing::warn;
 use url::Url;
@@ -372,6 +373,51 @@ async fn handle_http(
     }
 
     response
+}
+
+/// Holds SQLite's write lock on the bot's database file from a second
+/// connection, modelling a co-located process (e.g. the reporter)
+/// contending for the WAL write lock. Readers are unaffected under WAL;
+/// every bot write blocks until release or the bot pool's busy timeout
+/// expires.
+///
+/// Prefer [`DbLock::release`] for a deterministic, explicit unlock. There is
+/// deliberately no `Drop` impl: dropping the raw `SqliteConnection` -- including
+/// on a test panic between acquire and release -- closes it, which rolls back
+/// the open `BEGIN IMMEDIATE` and releases the WAL lock. A blocking `ROLLBACK`
+/// inside `Drop` would instead risk panicking on the tokio runtime.
+pub(crate) struct DbLock {
+    connection: sqlx::SqliteConnection,
+}
+
+impl DbLock {
+    /// Opens a raw connection to the database file and takes the write
+    /// lock via `BEGIN IMMEDIATE`.
+    pub(crate) async fn acquire(db_path: &std::path::Path) -> anyhow::Result<Self> {
+        // Wait for the bot pool to yield the WAL write lock instead of
+        // failing immediately. SQLite's default busy timeout is 0ms, so
+        // without this `BEGIN IMMEDIATE` races the running pipeline and the
+        // acquire can spuriously return SQLITE_BUSY -- surfacing as a test
+        // failure rather than the contention the test means to exercise.
+        let mut connection = sqlx::sqlite::SqliteConnectOptions::new()
+            .filename(db_path)
+            .busy_timeout(Duration::from_secs(5))
+            .connect()
+            .await?;
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut connection)
+            .await?;
+
+        Ok(Self { connection })
+    }
+
+    /// Releases the write lock.
+    pub(crate) async fn release(mut self) -> anyhow::Result<()> {
+        sqlx::query("ROLLBACK")
+            .execute(&mut self.connection)
+            .await?;
+        Ok(())
+    }
 }
 
 /// Consumes one unit of the armed latency budget if this request matches

--- a/tests/e2e/chaos_db.rs
+++ b/tests/e2e/chaos_db.rs
@@ -1,0 +1,251 @@
+//! Chaos tests for database unavailability.
+//!
+//! Injects SQLite write-lock contention -- a second connection holding
+//! `BEGIN IMMEDIATE` against the bot's database file, exactly how a
+//! co-located process (e.g. the reporter) contends for the WAL write
+//! lock. Asserts the layered posture: transient contention inside the
+//! pool's busy timeout rides through with zero data loss, a sustained
+//! lock at startup fails fast with a clear database error instead of
+//! coming up half-alive, and a restart on the released database resumes
+//! via the checkpoint with exactly-once hedging.
+
+use st0x_float_macro::float;
+use std::time::Duration;
+
+use crate::chaos::DbLock;
+use crate::hedging::assertions::*;
+use crate::poll::{poll_for_events, poll_for_events_with_timeout, spawn_bot};
+
+/// Top-level hypothesis: a write lock held for less than the pool's 10s
+/// busy timeout (the documented bot-vs-reporter contention scenario)
+/// must cause zero data loss and zero duplicates -- every blocked write
+/// waits the lock out and proceeds.
+///
+/// Scenario: the lock is engaged immediately after the take fires, so
+/// the fill pipeline (backfill enqueue, checkpoint save, CQRS writes,
+/// order placement bookkeeping) runs while the write lock is
+/// contended. `configure_sqlite_pool` arms every pooled connection
+/// with WAL + a 10s busy timeout; a 5s hold stays inside that budget,
+/// so SQLite absorbs the contention silently and the end state must be
+/// exactly one hedge.
+#[test_log::test(tokio::test)]
+async fn transient_write_lock_within_busy_timeout_rides_through() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Hold the write lock across the whole fill-processing window: acquire it
+    // before the take so it is already held when the bot's next poll detects
+    // the fill and starts writing (checkpoint advance, CQRS events). Acquiring
+    // after the take would race the sub-second pipeline, which can finish
+    // before the lock engages and exercise no contention at all. 5s < the
+    // pool's 10s busy timeout, so every blocked write must ride it out.
+    let lock = DbLock::acquire(&infra.db_path).await?;
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    lock.release().await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: a database that stays write-locked past the
+/// busy timeout must make startup halt cleanly with an error that names
+/// the database -- not come up half-alive -- and a restart on the
+/// released database must resume from the checkpoint and hedge
+/// exactly once.
+///
+/// Scenario: phase A warms the database (one take fully hedged) and
+/// stops the bot. Phase B fires a second take onchain (touching no
+/// SQLite), engages the lock, and starts a fresh bot: its unconditional
+/// startup writes (orphan requeues, CheckPositions bootstrap) block for
+/// the 10s busy timeout, error with SQLITE_BUSY, and the startup error
+/// propagates out of the bot task. Phase C releases the lock and starts
+/// the bot again: the backfill checkpoint never advanced past take #2,
+/// so it is re-ingested and hedged exactly once.
+#[test_log::test(tokio::test)]
+async fn sustained_lock_at_startup_fails_fast_and_restart_resumes() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    // Phase A: warm run -- one take hedged end-to-end, then stop.
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let take1 = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+    bot.abort();
+    let _ = bot.await;
+
+    // Phase B: take #2 lands onchain while the bot is down, then the
+    // database is locked and a fresh bot starts against it.
+    let take2 = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    let lock = DbLock::acquire(&infra.db_path).await?;
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let bot2 = spawn_bot(ctx2);
+
+    // The first unconditional startup write blocks for the 10s busy
+    // timeout and then errors; the error must propagate out of the bot
+    // task rather than leave it running half-alive.
+    let startup_result = tokio::time::timeout(Duration::from_secs(60), bot2)
+        .await
+        .expect("bot must halt within 60s when the database stays locked")
+        .expect("bot task must not panic");
+
+    let startup_error =
+        startup_result.expect_err("startup against a write-locked database must fail, not come up");
+    // "database is locked" is libsqlite3's canonical SQLITE_BUSY (code 5) text,
+    // which sqlx surfaces verbatim. The bot's startup error is opaque `anyhow`,
+    // so the typed code is not reachable here -- match the canonical phrase.
+    let error_chain = format!("{startup_error:#}");
+    assert!(
+        error_chain.contains("database is locked"),
+        "Startup failure must clearly name the database lock; got: {error_chain}",
+    );
+
+    lock.release().await?;
+
+    // Phase C: restart on the released database; take #2 must be
+    // re-ingested from the checkpoint and hedged exactly once.
+    let ctx3 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot3 = spawn_bot(ctx3);
+
+    poll_for_events_with_timeout(
+        &mut bot3,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        2,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    // Both takes are accounted exactly once, so the cumulative short is two
+    // fills of `sell_amount` -- derived, not a hardcoded literal that would
+    // silently go stale if the fixture amount changed.
+    let cumulative_short = (sell_amount + sell_amount).expect("two fills sum");
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(cumulative_short)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(cumulative_short)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take1, take2],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot3.abort();
+    Ok(())
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -16,6 +16,7 @@ mod chaos;
 mod chaos_alpaca;
 mod chaos_combined;
 mod chaos_crash;
+mod chaos_db;
 mod chaos_rpc;
 mod full_system;
 mod hedging;


### PR DESCRIPTION
## What

Closes RAI-425. Adds chaos coverage for SQLite unavailability: transient write-lock contention rides through with zero data loss, a sustained lock at startup fails fast, and a restart on the released database resumes via the checkpoint with exactly-once hedging.

## Why

A co-located process (e.g. the reporter) holding `BEGIN IMMEDIATE` contends for the WAL write lock; without this coverage we can't prove the bot rides out transient contention, refuses to come up half-alive under a sustained lock, and recovers cleanly once the database is restored.

## How

- Inject lock contention with a second connection holding `BEGIN IMMEDIATE` against the bot's database, mirroring real bot-vs-reporter WAL contention.
- Assert the layered posture: a hold inside the pool's 10s busy timeout is absorbed silently, a sustained lock at startup surfaces a clear database error, and a restart on the freed database resumes via checkpoint with exactly-once hedging.

## Testing

- New `tests/e2e/chaos_db.rs` cases drive the full fill pipeline under contention and verify zero data loss, zero duplicates, and CQRS event-store consistency across each scenario.

## Anything else

Part of the Testing & chaos milestone (parent RAI-73), extending fault-injection coverage to database unavailability.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903550&installation_id=125569124&pr_number=847&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F847&signature=1aa2cef6b32c47d89576114aedd17ea3e754ca3b27706d378b150d184c898068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->