### PR TITLE
test: chaos queue backpressure bursts and kill-mid-burst recovery

### DIFF
--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -408,6 +408,8 @@ fn generate_batch_ranges(start_block: u64, end_block: u64) -> Vec<(u64, u64)> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use alloy::primitives::{
         Address, B256, FixedBytes, IntoLogData, TxHash, U256, address, fixed_bytes, uint,
     };
@@ -1070,6 +1072,107 @@ mod tests {
             log_index: Some(1),
             removed: false,
         }
+    }
+
+    /// A burst-sized batch must enqueue exactly one job per
+    /// `(tx_hash, log_index)` in chronological `(block_number, log_index)`
+    /// order regardless of the order the node returned the logs in. The
+    /// sort matters under load: jobs drain through a `concurrency(1)`
+    /// worker, so out-of-order enqueue means out-of-order position
+    /// accumulation against a live hedging threshold.
+    #[tokio::test]
+    async fn burst_batch_enqueues_one_job_per_log_in_chronological_order() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let order = get_test_order();
+        let evm_ctx = EvmCtx {
+            rpc_url: Url::parse("http://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+        };
+
+        // 30 take logs, 3 per block across 10 blocks, served by the
+        // mock node in reverse-chronological order.
+        let logs: Vec<Log> = (0..30u64)
+            .map(|index| {
+                let take_event = create_test_take_event(
+                    &order,
+                    uint!(100_000_000_U256),
+                    uint!(1_000_000_000_000_000_000_U256),
+                );
+                let mut hash_bytes = [0u8; 32];
+                hash_bytes[0] = 0xab;
+                hash_bytes[31] = u8::try_from(index).unwrap();
+
+                let mut log = create_test_log(
+                    evm_ctx.orderbook,
+                    &take_event,
+                    10 + index / 3,
+                    FixedBytes::from(hash_bytes),
+                );
+                log.log_index = Some(index % 3);
+                log
+            })
+            .collect();
+        let reversed: Vec<&Log> = logs.iter().rev().collect();
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([]));
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!(reversed));
+        push_tip_response(&asserter);
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        backfill_events(
+            &provider,
+            &evm_ctx,
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        let payloads: Vec<Vec<u8>> = sqlx::query_scalar("SELECT job FROM Jobs ORDER BY rowid ASC")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert_eq!(payloads.len(), 30, "one job per log, none dropped");
+
+        let jobs: Vec<AccountForDexTrade> = payloads
+            .iter()
+            .map(|payload| serde_json::from_slice(payload).unwrap())
+            .collect();
+
+        let enqueue_order: Vec<(u64, u64)> = jobs
+            .iter()
+            .map(|job| (job.trade.block_number, job.trade.log_index))
+            .collect();
+        let mut chronological = enqueue_order.clone();
+        chronological.sort_unstable();
+        assert_eq!(
+            enqueue_order, chronological,
+            "Jobs must be enqueued in chronological (block, log_index) \
+             order despite the node serving them reversed"
+        );
+
+        // The 30 enqueued jobs map one-to-one onto the 30 distinct input logs:
+        // no two logs collapsed onto a shared (tx_hash, log_index) key and --
+        // together with the count check above -- none was enqueued twice. Note
+        // the inputs are all distinct, so this guards the 1:1 mapping, not an
+        // enqueue-time dedup; per-fill dedup proper lives downstream in
+        // `process_queued_trade`.
+        let distinct: HashSet<(TxHash, u64)> = jobs
+            .iter()
+            .map(|job| (job.trade.tx_hash, job.trade.log_index))
+            .collect();
+        assert_eq!(
+            distinct.len(),
+            30,
+            "the 30 jobs must carry 30 distinct (tx_hash, log_index) keys"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/chaos_load.rs
+++ b/tests/e2e/chaos_load.rs
@@ -1,0 +1,331 @@
+//! Chaos tests for resource exhaustion via queue backpressure.
+//!
+//! Every apalis worker runs with `concurrency(1)`, so the bounded
+//! resource under load is worker throughput: a burst of fills becomes a
+//! backlog of `AccountForDexTrade` jobs draining serially while the
+//! `Position` aggregate accumulates fills behind a pending hedge and
+//! the `CheckPositions` scan re-hedges the remainder. These tests
+//! assert graceful degradation under that backpressure: no silent data
+//! loss, no duplicates, no stuck queues -- convergence regardless of
+//! drain speed.
+//!
+//! OOM, file-descriptor, and CPU exhaustion are not realistically
+//! injectable inside a cargo test (allocator aborts kill the whole
+//! harness; rlimits are process-global and take Anvil and the mock
+//! servers down indiscriminately; CPU burn destabilizes sibling
+//! tests). OOM's observable production consequence -- a SIGKILL with
+//! the queue mid-drain -- is covered here by the crash-mid-burst
+//! scenario.
+
+use st0x_execution::alpaca_broker_api::OrderSide;
+use st0x_float_macro::float;
+use std::time::Duration;
+
+use crate::chaos::ChaosProxy;
+use crate::hedging::assertions::*;
+use crate::poll::{
+    connect_db, count_events_by_type, poll_for_all_jobs_done, poll_for_broker_fills,
+    poll_for_events, spawn_bot,
+};
+
+/// Asserts no offchain order is left in a non-terminal state: `Pending`
+/// means a hedge was never re-driven, `Submitted`/`PartiallyFilled`
+/// mean status polling was dropped -- either way the queue is stuck.
+async fn assert_no_stuck_offchain_orders(db_path: &std::path::Path) -> anyhow::Result<()> {
+    let pool = connect_db(db_path).await?;
+    let non_terminal: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM offchain_order_view \
+         WHERE status IN ('Pending', 'Submitted', 'PartiallyFilled')",
+    )
+    .fetch_one(&pool)
+    .await?;
+    pool.close().await;
+
+    assert_eq!(
+        non_terminal.0, 0,
+        "Backpressure left {} offchain orders stuck in a non-terminal state",
+        non_terminal.0,
+    );
+    Ok(())
+}
+
+/// Counts witnessed onchain trades; under bursts every assertion on
+/// effects must use exact aggregate counts, never broker order counts
+/// (trades legitimately batch into fewer orders).
+async fn assert_witnessed_trades(db_path: &std::path::Path, expected: i64) -> anyhow::Result<()> {
+    let pool = connect_db(db_path).await?;
+    let witnessed = count_events_by_type(&pool, "OnChainTradeEvent::Filled").await?;
+    pool.close().await;
+
+    assert_eq!(
+        witnessed, expected,
+        "Expected exactly {expected} witnessed trades (one per take, no \
+         loss, no duplicates); got {witnessed}",
+    );
+    Ok(())
+}
+
+/// Top-level hypothesis: a burst of fills landing in one backfill range
+/// -- N jobs hitting the single-threaded accounting worker at once,
+/// with the first hedge held pending at the broker -- must drain with
+/// exactly one effect per fill and no stuck queue.
+///
+/// Scenario: all takes fire BEFORE the bot starts, so the initial
+/// checkpoint-driven poll covers every fill in one `BackfillRange` and
+/// enqueues the whole burst at once. The broker mock holds the first
+/// hedge order unfilled across several status polls, forcing later
+/// fills onto the accumulate-while-pending path and the `CheckPositions`
+/// re-hedge. Convergence is asserted via broker fill totals (trades may
+/// legitimately batch into fewer orders), exact witnessed-trade counts,
+/// a fully hedged position, and an empty job queue.
+#[test_log::test(tokio::test)]
+async fn backfill_burst_hedges_every_take_exactly_once() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let take_amount = float!(2.5);
+    let take_count = 8;
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    // Hold each broker order "new" across a few status polls so the
+    // backlog accumulates behind a pending hedge instead of degenerating
+    // into independent quick hedges.
+    infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 4);
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    for _ in 0..take_count {
+        infra
+            .base_chain
+            .take_order()
+            .symbol(equity_symbol)
+            .amount(take_amount)
+            .price(onchain_price)
+            .direction(TakeDirection::SellEquity)
+            .call()
+            .await?;
+    }
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    // Onchain sells hedge as broker buys; 8 takes of 2.5 shares must
+    // fill 20 shares in total, however they batch into orders.
+    poll_for_broker_fills(
+        &mut bot,
+        &infra.broker_service,
+        equity_symbol,
+        OrderSide::Buy,
+        FractionalShares::new(float!(20)),
+        Duration::from_secs(120),
+    )
+    .await;
+
+    poll_for_hedged_position(&mut bot, &infra.db_path, equity_symbol).await;
+    poll_for_all_jobs_done(&mut bot, &infra.db_path, i64::from(take_count)).await;
+
+    assert_witnessed_trades(&infra.db_path, i64::from(take_count)).await?;
+    assert_no_stuck_offchain_orders(&infra.db_path).await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: a live rapid-fire burst spread across two hot
+/// symbols sharing the single accounting worker must not starve either
+/// symbol or lose fills across poll-tick boundaries.
+///
+/// Scenario: orders are prepared upfront (separate owner-account
+/// transactions), then taken back-to-back with no pacing while the bot
+/// is live -- fills land across multiple 1s monitor ticks, exercising
+/// the overlap guard's interplay with the advancing checkpoint under a
+/// sustained backlog. Each symbol must converge to a fully hedged
+/// position with exactly one witnessed trade per take.
+#[test_log::test(tokio::test)]
+async fn live_burst_across_two_symbols_loses_nothing() -> anyhow::Result<()> {
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let aapl_amount = float!(2.0);
+    let tsla_amount = float!(1.5);
+    let takes_per_symbol = 4;
+
+    let infra = TestInfra::start(
+        vec![("AAPL", broker_fill_price), ("TSLA", broker_fill_price)],
+        vec![],
+    )
+    .await?;
+
+    let mut prepared_orders = Vec::new();
+    for symbol_and_amount in [("AAPL", aapl_amount), ("TSLA", tsla_amount)] {
+        for _ in 0..takes_per_symbol {
+            prepared_orders.push(
+                infra
+                    .base_chain
+                    .setup_order()
+                    .symbol(symbol_and_amount.0)
+                    .amount(symbol_and_amount.1)
+                    .price(onchain_price)
+                    .direction(TakeDirection::SellEquity)
+                    .call()
+                    .await?,
+            );
+        }
+    }
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Rapid-fire: no pacing between takes; fills spread across poll
+    // ticks purely by transaction timing.
+    for prepared in &prepared_orders {
+        infra.base_chain.take_prepared_order(prepared).await?;
+    }
+
+    // Both symbols must converge, which is what these polls assert. The checks
+    // are sequential (each poll needs `&mut bot` for crash detection, so they
+    // cannot run concurrently), so they verify *eventual* convergence of both
+    // symbols, not that TSLA is never ordered strictly behind AAPL -- the
+    // interleaved cross-symbol enqueue plus the single-worker queue already
+    // drains the two roughly together, so neither is starved.
+    poll_for_broker_fills(
+        &mut bot,
+        &infra.broker_service,
+        "AAPL",
+        OrderSide::Buy,
+        FractionalShares::new(float!(8)),
+        Duration::from_secs(120),
+    )
+    .await;
+    poll_for_broker_fills(
+        &mut bot,
+        &infra.broker_service,
+        "TSLA",
+        OrderSide::Buy,
+        FractionalShares::new(float!(6)),
+        Duration::from_secs(120),
+    )
+    .await;
+
+    poll_for_hedged_position(&mut bot, &infra.db_path, "AAPL").await;
+    poll_for_hedged_position(&mut bot, &infra.db_path, "TSLA").await;
+    poll_for_all_jobs_done(&mut bot, &infra.db_path, i64::from(takes_per_symbol) * 2).await;
+
+    assert_witnessed_trades(&infra.db_path, i64::from(takes_per_symbol) * 2).await?;
+    assert_no_stuck_offchain_orders(&infra.db_path).await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: an abrupt kill with the job queue mid-drain --
+/// the observable consequence of an OOM kill -- must not lose or
+/// double-process any fill once the bot restarts on the same database.
+///
+/// Scenario: the burst lands in one backfill range, the bot is killed
+/// as soon as the first couple of trades are witnessed (queue still
+/// mid-drain: rows Pending or Running, possibly a hedge in flight), and
+/// a fresh conductor restarts against the same SQLite file. Recovery
+/// must come from the startup orphan requeue plus the
+/// `(tx_hash, log_index)` dedupe and the `client_order_id` idempotency
+/// anchor: exactly one witnessed trade per take, exact broker fill
+/// totals, nothing stuck.
+#[test_log::test(tokio::test)]
+async fn kill_mid_burst_recovers_every_take_exactly_once() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let take_amount = float!(2.5);
+    let take_count = 8;
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+
+    // Route the bot's RPC through a chaos proxy that holds each
+    // `eth_getTransactionReceipt` -- the first RPC call every accounting job
+    // makes -- for 500ms. With the single-threaded worker this drains the burst
+    // at a controlled rate, so the kill below reliably lands while jobs are
+    // still Queued/Running. Without the throttle the in-memory mocks drain all 8
+    // jobs in under one poll interval and the kill degenerates to a clean,
+    // post-drain restart that never exercises the orphan requeue.
+    let chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    for _ in 0..take_count {
+        infra
+            .base_chain
+            .take_order()
+            .symbol(equity_symbol)
+            .amount(take_amount)
+            .price(onchain_price)
+            .direction(TakeDirection::SellEquity)
+            .call()
+            .await?;
+    }
+
+    chaos
+        .delay_transaction_receipts(Duration::from_millis(500), 20)
+        .await;
+
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    // Kill while the queue is still mid-drain: a couple of trades witnessed,
+    // the rest of the burst still Queued/Running behind the throttled receipts.
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 2).await;
+    bot.abort();
+    let _ = bot.await;
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_broker_fills(
+        &mut bot2,
+        &infra.broker_service,
+        equity_symbol,
+        OrderSide::Buy,
+        FractionalShares::new(float!(20)),
+        Duration::from_secs(120),
+    )
+    .await;
+
+    poll_for_hedged_position(&mut bot2, &infra.db_path, equity_symbol).await;
+    poll_for_all_jobs_done(&mut bot2, &infra.db_path, i64::from(take_count)).await;
+
+    assert_witnessed_trades(&infra.db_path, i64::from(take_count)).await?;
+    assert_no_stuck_offchain_orders(&infra.db_path).await?;
+
+    bot2.abort();
+    Ok(())
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -17,6 +17,7 @@ mod chaos_alpaca;
 mod chaos_combined;
 mod chaos_crash;
 mod chaos_db;
+mod chaos_load;
 mod chaos_rpc;
 mod full_system;
 mod hedging;

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -534,6 +534,20 @@ pub async fn count_events(pool: &SqlitePool, aggregate_type: &str) -> anyhow::Re
     Ok(row.0)
 }
 
+/// Counts CQRS events of a specific event type (e.g. `OnChainTradeEvent::Filled`),
+/// not the whole aggregate. Use this when an aggregate emits more than one event
+/// variant and only one of them should be counted -- `OnChainTrade`, for
+/// instance, emits both `Filled` and `Enriched`, so an aggregate-type count
+/// double-counts once enrichment fires.
+pub async fn count_events_by_type(pool: &SqlitePool, event_type: &str) -> anyhow::Result<i64> {
+    let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+        .bind(event_type)
+        .fetch_one(pool)
+        .await?;
+
+    Ok(row.0)
+}
+
 /// Fetches all domain events ordered by insertion.
 pub async fn fetch_all_domain_events(
     pool: &SqlitePool,


### PR DESCRIPTION
## What

Closes RAI-426. Adds chaos coverage for resource exhaustion under worker queue backpressure: bursts of fills overwhelming the single-threaded accounting worker, including a kill-mid-drain restart that stands in for an OOM SIGKILL.

## Why

Under load a burst of fills becomes a backlog of `AccountForDexTrade` jobs draining serially while the `Position` aggregate accumulates behind a pending hedge. Without coverage, backpressure could silently drop fills, double-process them, or leave the queue stuck.

## How

- Exercises the `concurrency(1)` accounting worker with backfill bursts, live cross-symbol rapid-fire, and a crash-mid-burst restart on the same database.
- Asserts graceful degradation in domain terms: exactly one effect per fill, no stuck offchain orders, a fully hedged position, and an empty queue regardless of drain speed.
- OOM/file-descriptor/CPU exhaustion are not injectable inside a cargo test; the observable production consequence of an OOM (SIGKILL mid-drain) is covered by the crash-mid-burst scenario.

## Testing

- Adds `tests/e2e/chaos_load.rs` covering burst hedging, live two-symbol bursts, and kill-mid-burst recovery.
- Adds a backfill unit test asserting a burst batch enqueues exactly one job per `(tx_hash, log_index)` in chronological order despite the node serving logs reversed.

## Anything else

Part of the Testing & chaos milestone (parent RAI-73).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903552&installation_id=125569124&pr_number=848&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F848&signature=9e8080726932a8094860e12cf09ca0ecaf0ab63874e43c1c1df4c8c0985269c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->