### PR TITLE
test: chaos one-sided outages between RPC, broker, and bot

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -3555,6 +3555,107 @@ mod tests {
         );
     }
 
+    /// A broker outage during trade accounting must record the fill and
+    /// defer the hedge, never lose it: the first attempt errors at the
+    /// broker preflight check (after witness and acknowledge persisted; the
+    /// mock's market-hours check passes, so the failure surfaces one step
+    /// later in `preflight_counter_trade`),
+    /// the apalis retry during the sustained outage dedupe-skips cleanly
+    /// instead of burning the retry budget against the dead broker, and
+    /// the first healthy position rescan places the hedge. One-sided
+    /// availability must produce visible deferred exposure, not silent
+    /// loss.
+    #[tokio::test]
+    async fn broker_outage_records_fill_and_defers_hedge_to_rescan() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let failing_executor = MockExecutor::with_failure("connection refused");
+
+        let result = process_queued_trade(
+            &failing_executor,
+            &make_trade_event(50),
+            test_trade_with_amount(float!(1.5), 50),
+            &cqrs,
+            true,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(TradeAccountingError::Execution(_))),
+            "First attempt must error at the broker preflight check; got: {result:?}",
+        );
+
+        let retry = process_queued_trade(
+            &failing_executor,
+            &make_trade_event(50),
+            test_trade_with_amount(float!(1.5), 50),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            retry, None,
+            "The retry during a sustained outage must dedupe-skip cleanly \
+             rather than re-erroring and exhausting the retry budget"
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("position must exist after the outage attempt");
+        assert!(
+            position.net.inner().eq(float!(1.5)).unwrap(),
+            "The fill must be recorded exactly once despite the outage"
+        );
+        assert_eq!(
+            position.pending_offchain_order_id, None,
+            "No hedge can have been claimed against a dead broker"
+        );
+        assert_eq!(
+            offchain_order_projection.load_all().await.unwrap().len(),
+            0,
+            "No offchain order may exist during the outage"
+        );
+
+        check_and_execute_accumulated_positions(
+            &MockExecutor::new(),
+            AccumulatedPositionExecutionCtx {
+                position: &cqrs.position,
+                position_projection: &cqrs.position_projection,
+                offchain_order: &cqrs.offchain_order,
+                counter_trade_submission_lock: &cqrs.counter_trade_submission_lock,
+                threshold: &cqrs.execution_threshold,
+                assets: &cqrs.assets,
+            },
+            |_| true,
+        )
+        .await
+        .unwrap();
+
+        let recovered = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap()
+            .expect("position must exist after the rescan");
+        let orders = offchain_order_projection.load_all().await.unwrap();
+        assert_eq!(orders.len(), 1, "Exactly one hedge after recovery");
+        assert_eq!(
+            recovered.pending_offchain_order_id,
+            Some(orders[0].0),
+            "The first healthy rescan must place the deferred hedge"
+        );
+    }
+
     /// Re-delivering the identical (tx_hash, log_index) trade through the
     /// accounting pipeline must be single-effect: one OnChainTrade fill
     /// event, one Position fill transition, one offchain order -- the

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -317,6 +317,40 @@ mod tests {
         );
     }
 
+    /// A severed RPC must surface as a typed error -- the run loop's
+    /// warn-and-retry contract depends on it -- and must neither enqueue
+    /// a bogus range nor move the checkpoint, so the post-outage tick
+    /// re-scans exactly the blocks the outage hid.
+    #[tokio::test]
+    async fn poll_once_propagates_rpc_error_without_enqueuing() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("connection refused");
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider, 0).await;
+
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
+            .await
+            .unwrap();
+
+        let result = monitor.poll_once().await;
+        assert!(
+            matches!(result, Err(OrderFillMonitorError::Rpc(_))),
+            "A severed RPC must surface as a typed RPC error; got: {result:?}",
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "No backfill range may be enqueued off a failed tip read"
+        );
+        assert_eq!(
+            crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+                .await
+                .unwrap(),
+            Some(99),
+            "The checkpoint must not move during the outage"
+        );
+    }
+
     /// A write-locked database during the backfill enqueue must surface
     /// as a typed error (the run loop logs it and retries next tick),
     /// leave nothing enqueued, and enqueue cleanly once the lock clears.

--- a/src/position_check.rs
+++ b/src/position_check.rs
@@ -367,6 +367,56 @@ mod tests {
         }
     }
 
+    /// A broker outage must not kill the periodic position scan: the
+    /// per-symbol broker preflight errors (the mock's market-hours check
+    /// passes, so the failure surfaces in `preflight_counter_trade`), are
+    /// logged and swallowed, no hedge is enqueued against the dead broker, and
+    /// the scan reschedules itself for the next tick. This invariant is what
+    /// lets a fill recorded during an outage get hedged by the first
+    /// healthy rescan instead of sitting as silent exposure.
+    #[tokio::test]
+    async fn broker_outage_does_not_kill_scan_and_reschedules() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let cfg = dry_run_ctx(&["AAPL"]);
+
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let aapl = Symbol::new("AAPL").unwrap();
+        accumulate_position(
+            &position,
+            &aapl,
+            FractionalShares::new(float!(2.0)),
+            Direction::Buy,
+        )
+        .await;
+
+        let ctx = CheckPositionsCtx {
+            executor: MockExecutor::with_failure("connection refused"),
+            position_projection,
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
+            check_positions_queue: CheckPositionsJobQueue::new(&apalis_pool),
+            ctx: cfg,
+            pool: pool.clone(),
+            check_interval: Duration::from_secs(60),
+        };
+
+        CheckPositions.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            count_jobs(&apalis_pool, &hedge_job_type()).await,
+            0,
+            "No hedge can be enqueued against a dead broker"
+        );
+        assert_eq!(
+            count_jobs(&apalis_pool, &check_positions_job_type()).await,
+            1,
+            "The scan must reschedule itself despite the outage"
+        );
+    }
+
     #[tokio::test]
     async fn enqueues_one_hedge_per_ready_symbol() {
         let (pool, apalis_pool) = setup_test_pools().await;

--- a/tests/e2e/chaos.rs
+++ b/tests/e2e/chaos.rs
@@ -103,9 +103,18 @@ pub(crate) struct ChaosProxy {
     pub endpoint: Url,
     /// Shared mutable config; `None` means transparent forwarding.
     config: SharedConfig,
-    /// Serve loop's handle. Aborted on drop so the proxy dies with its
-    /// parent test.
-    server_task: tokio::task::AbortHandle,
+    /// Shared logs cache, retained so a severed-and-restored proxy keeps
+    /// its replay state.
+    logs_cache: LogsCache,
+    /// Upstream endpoint, retained so [`ChaosProxy::restore`] can respawn
+    /// the serve loop after a severance.
+    upstream: Url,
+    /// Listening port, retained so [`ChaosProxy::restore`] rebinds the
+    /// same address the bot is configured with.
+    port: u16,
+    /// Serve loop's join handle. Aborted on sever/drop; awaited by
+    /// `restore` before rebinding so the listener is fully released first.
+    server_task: tokio::task::JoinHandle<()>,
 }
 
 impl ChaosProxy {
@@ -118,25 +127,62 @@ impl ChaosProxy {
         let endpoint: Url = format!("http://127.0.0.1:{port}").parse()?;
 
         let config: SharedConfig = Arc::new(Mutex::new(None));
+        let logs_cache: LogsCache = Arc::new(Mutex::new(HashMap::new()));
+
         let state = ProxyState {
             config: config.clone(),
-            logs_cache: Arc::new(Mutex::new(HashMap::new())),
-            upstream,
+            logs_cache: logs_cache.clone(),
+            upstream: upstream.clone(),
             client: Client::new(),
         };
-
-        let app = Router::new().fallback(handle_rpc).with_state(state);
-        let handle = tokio::spawn(async move {
-            if let Err(error) = axum::serve(listener, app).await {
-                warn!(?error, "chaos proxy server stopped");
-            }
-        });
+        let server_task = serve_proxy(
+            listener,
+            Router::new().fallback(handle_rpc).with_state(state),
+        );
 
         Ok(Self {
             endpoint,
             config,
-            server_task: handle.abort_handle(),
+            logs_cache,
+            upstream,
+            port,
+            server_task,
         })
+    }
+
+    fn state(&self) -> ProxyState {
+        ProxyState {
+            config: self.config.clone(),
+            logs_cache: self.logs_cache.clone(),
+            upstream: self.upstream.clone(),
+            client: Client::new(),
+        }
+    }
+
+    /// Severs connectivity: the serve loop is aborted and the listener
+    /// dropped, so every connection to the proxy's endpoint is refused --
+    /// the component behind it is down while the rest of the world stays
+    /// up.
+    pub(crate) fn sever(&self) {
+        self.server_task.abort();
+    }
+
+    /// Restores connectivity after [`ChaosProxy::sever`]: rebinds the
+    /// same port and respawns the serve loop with the retained upstream
+    /// and chaos state.
+    pub(crate) async fn restore(&mut self) -> anyhow::Result<()> {
+        // `abort()` only schedules cancellation, so await the severed task's
+        // completion before rebinding -- otherwise the old listener may still
+        // hold the port and race the rebind (SO_REUSEADDR mitigates but does
+        // not eliminate that).
+        self.server_task.abort();
+        let _ = (&mut self.server_task).await;
+        let listener = rebind(self.port)?;
+        self.server_task = serve_proxy(
+            listener,
+            Router::new().fallback(handle_rpc).with_state(self.state()),
+        );
+        Ok(())
     }
 
     /// Convenience: reply to the next `count` `eth_getLogs` calls with
@@ -200,6 +246,27 @@ impl Drop for ChaosProxy {
     }
 }
 
+/// Spawns a proxy serve loop on the given listener, returning its join
+/// handle so callers can both abort it (sever) and await its shutdown
+/// (before rebinding the same port).
+fn serve_proxy(listener: tokio::net::TcpListener, app: Router) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(error) = axum::serve(listener, app).await {
+            warn!(?error, "chaos proxy server stopped");
+        }
+    })
+}
+
+/// Rebinds a previously-used local port for a restored proxy.
+/// `SO_REUSEADDR` is required: the severed proxy's connections linger in
+/// TIME_WAIT and would otherwise fail the rebind.
+fn rebind(port: u16) -> anyhow::Result<tokio::net::TcpListener> {
+    let socket = tokio::net::TcpSocket::new_v4()?;
+    socket.set_reuseaddr(true)?;
+    socket.bind(format!("127.0.0.1:{port}").parse()?)?;
+    Ok(socket.listen(1024)?)
+}
+
 /// Knob describing which plain-HTTP requests to delay and for how many.
 #[derive(Debug, Clone)]
 struct LatencyConfig {
@@ -234,9 +301,15 @@ pub(crate) struct LatencyProxy {
     pub endpoint: Url,
     /// Shared mutable config; `None` means transparent forwarding.
     config: SharedLatencyConfig,
-    /// Serve loop's handle. Aborted on drop so the proxy dies with its
-    /// parent test.
-    server_task: tokio::task::AbortHandle,
+    /// Upstream endpoint, retained so [`LatencyProxy::restore`] can
+    /// respawn the serve loop after a severance.
+    upstream: Url,
+    /// Listening port, retained so [`LatencyProxy::restore`] rebinds the
+    /// same address the bot is configured with.
+    port: u16,
+    /// Serve loop's join handle. Aborted on sever/drop; awaited by
+    /// `restore` before rebinding so the listener is fully released first.
+    server_task: tokio::task::JoinHandle<()>,
 }
 
 impl LatencyProxy {
@@ -251,25 +324,65 @@ impl LatencyProxy {
         let config: SharedLatencyConfig = Arc::new(Mutex::new(None));
         let state = LatencyProxyState {
             config: config.clone(),
-            upstream,
-            // Bound the forward leg so an unresponsive upstream cannot hang the
-            // proxy task indefinitely; the injected latency is a separate sleep,
-            // not this request, so 10s is ample headroom for the real forward.
-            client: Client::builder().timeout(Duration::from_secs(10)).build()?,
+            upstream: upstream.clone(),
+            client: Self::forward_client()?,
         };
-
-        let app = Router::new().fallback(handle_http).with_state(state);
-        let handle = tokio::spawn(async move {
-            if let Err(error) = axum::serve(listener, app).await {
-                warn!(?error, "latency proxy server stopped");
-            }
-        });
+        let server_task = serve_proxy(
+            listener,
+            Router::new().fallback(handle_http).with_state(state),
+        );
 
         Ok(Self {
             endpoint,
             config,
-            server_task: handle.abort_handle(),
+            upstream,
+            port,
+            server_task,
         })
+    }
+
+    /// Forward client for the proxy's upstream leg, bounded by a 10s timeout so
+    /// an unresponsive upstream cannot hang the proxy task indefinitely; the
+    /// injected latency is a separate sleep, not this request.
+    fn forward_client() -> anyhow::Result<Client> {
+        Ok(Client::builder().timeout(Duration::from_secs(10)).build()?)
+    }
+
+    /// Builds a fresh handler state with the timeout-bounded forward client, so
+    /// a restored proxy keeps the same hang-protection as the original.
+    fn state(&self) -> anyhow::Result<LatencyProxyState> {
+        Ok(LatencyProxyState {
+            config: self.config.clone(),
+            upstream: self.upstream.clone(),
+            client: Self::forward_client()?,
+        })
+    }
+
+    /// Severs connectivity: the serve loop is aborted and the listener
+    /// dropped, so every connection to the proxy's endpoint is refused --
+    /// the broker is down while the chain stays up.
+    pub(crate) fn sever(&self) {
+        self.server_task.abort();
+    }
+
+    /// Restores connectivity after [`LatencyProxy::sever`]: rebinds the
+    /// same port and respawns the serve loop with the retained upstream
+    /// and latency state.
+    pub(crate) async fn restore(&mut self) -> anyhow::Result<()> {
+        // `abort()` only schedules cancellation, so await the severed task's
+        // completion before rebinding -- otherwise the old listener may still
+        // hold the port and race the rebind (SO_REUSEADDR mitigates but does
+        // not eliminate that).
+        self.server_task.abort();
+        let _ = (&mut self.server_task).await;
+        let listener = rebind(self.port)?;
+        self.server_task = serve_proxy(
+            listener,
+            Router::new()
+                .fallback(handle_http)
+                .with_state(self.state()?),
+        );
+        Ok(())
     }
 
     /// Convenience: hold the responses of the next `count` broker order

--- a/tests/e2e/chaos_alpaca.rs
+++ b/tests/e2e/chaos_alpaca.rs
@@ -1,11 +1,12 @@
 //! Chaos tests for Alpaca broker fault tolerance.
 //!
-//! Drives the bot through scenarios where the broker processed a
-//! placement but the bot never received a usable acknowledgement: the
-//! Alpaca broker mock returns a 5xx after recording the order, or a
-//! latency proxy holds the response past the client's request timeout.
-//! Asserts the bot does not double-submit hedges when retrying a
-//! placement whose response was lost or late in flight.
+//! Drives the bot through scenarios where the broker misbehaves while
+//! the chain stays healthy: a 5xx returned after recording the order, a
+//! response held past the client's request timeout, and full outages
+//! (connection refused) hitting before a hedge exists or while one sits
+//! Submitted. Asserts the bot never double-submits, never silently
+//! drops a fill, keeps unhedged exposure operator-visible, and recovers
+//! to exactly one broker order once the broker returns.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -294,6 +295,150 @@ async fn placement_response_just_over_client_timeout_does_not_double_submit() ->
     Ok(())
 }
 
+/// Top-level hypothesis: a fill ingested while the broker is completely
+/// down -- connection refused, not slow -- must be recorded and visibly
+/// unhedged, never silently dropped, and the periodic `CheckPositions`
+/// rescan must place exactly one hedge once the broker returns.
+///
+/// Scenario: the [`LatencyProxy`]'s serve loop is severed after startup
+/// (the bot needs the broker reachable to construct its executor), so
+/// every broker call is refused while the chain keeps producing fills.
+/// The accounting job witnesses and acknowledges the fill before its
+/// broker readiness check errors; the retry dedupe-skips; several
+/// `CheckPositions` ticks fire against the dead broker and must swallow
+/// the errors without enqueueing anything. Mid-outage the position view
+/// shows the unhedged exposure (the durable operator-visible signal the
+/// dashboard renders). After restore, the first healthy rescan hedges.
+#[test_log::test(tokio::test)]
+async fn broker_outage_defers_hedge_until_rescan_after_restore() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let mut latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    latency.sever();
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // The fill must be recorded even with the broker dark.
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 1).await;
+
+    // Let several CheckPositions ticks (2s interval) fire against the
+    // dead broker -- the negative assertions below are only meaningful
+    // if the scan actually ran during the outage.
+    wait_for_processing(&mut bot, 6).await;
+
+    let mid_outage_orders = infra.broker_service.orders().len();
+    assert_eq!(
+        mid_outage_orders, 0,
+        "Nothing can have reached the broker during the outage; got \
+         {mid_outage_orders} orders",
+    );
+
+    let pool = connect_db(&infra.db_path).await?;
+    let offchain_events = count_events(&pool, "OffchainOrder").await?;
+    // CheckPositions is a self-rescheduling job: each completed tick is a `Done`
+    // row, so a non-zero count proves the scan actually ran (and swallowed the
+    // broker error) during the outage -- without this the negative assertions
+    // below could pass vacuously if the scan never fired.
+    let (scan_runs,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM Jobs WHERE job_type = ? AND status = 'Done'")
+            .bind(st0x_hedge::check_positions_job_type())
+            .fetch_one(&pool)
+            .await?;
+    let position = Projection::<Position>::sqlite(pool.clone())
+        .load(&Symbol::new(equity_symbol)?)
+        .await?
+        .expect("position must exist mid-outage");
+    pool.close().await;
+
+    assert!(
+        scan_runs >= 1,
+        "At least one CheckPositions scan must have run against the dead broker \
+         for the deferral assertions to be meaningful; got {scan_runs}",
+    );
+    assert_eq!(
+        offchain_events, 0,
+        "No offchain order may exist while the broker is down"
+    );
+    assert_eq!(
+        position.accumulated_short,
+        FractionalShares::new(sell_amount),
+        "The position must visibly carry the unhedged fill"
+    );
+    assert_eq!(
+        position.pending_offchain_order_id, None,
+        "No hedge can be claimed against a dead broker"
+    );
+
+    latency.restore().await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Exactly one hedge after the broker returned; got {order_count}",
+    );
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}
+
 /// Top-level hypothesis: an Alpaca placement whose response is held well
 /// past the client's request timeout must not produce two orders when the
 /// bot recovers.
@@ -385,4 +530,134 @@ fn alpaca_client_timeout_constants_bracket_placement_delay_boundaries() {
         PLACEMENT_RESPONSE_WELL_OVER_TIMEOUT > PLACEMENT_RESPONSE_JUST_OVER_TIMEOUT,
         "well-over delay must remain above the timeout boundary",
     );
+}
+
+/// Top-level hypothesis: a broker outage while a hedge sits `Submitted`
+/// must end in a loud halt -- never a silently un-polled order -- and a
+/// restart with the broker restored must resume polling to exactly one
+/// filled broker order.
+///
+/// Scenario: the broker mock holds the order "new" indefinitely, the
+/// proxy is severed while the order awaits its fill, and `PollOrderStatus`
+/// exhausts its retry budget against the refused connections. The
+/// fail-stop circuit breaker then halts the bot (the deliberate
+/// fail-stop posture: a one-sided trade must page an operator, not
+/// accumulate silent exposure). On restart with the broker back,
+/// `recover_submitted_offchain_orders` re-enqueues the poll and the
+/// order completes.
+#[test_log::test(tokio::test)]
+async fn broker_outage_with_submitted_order_halts_bot_and_restart_recovers() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let mut latency = LatencyProxy::start(infra.broker_service.base_url().parse()?).await?;
+
+    // Keep the order un-filled so the outage lands while it sits
+    // Submitted, awaiting status polls.
+    infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 10_000);
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_aggregate_events_containing(&mut bot, &infra.db_path, "OffchainOrder", "Submitted", 1)
+        .await;
+
+    latency.sever();
+
+    // PollOrderStatus exhausts its retries against refused connections;
+    // the fail-stop breaker must halt the bot loudly.
+    let join_result = tokio::time::timeout(Duration::from_secs(60), &mut bot)
+        .await
+        .expect("Bot must halt within 60s of the broker going dark with an order in flight");
+    let error = join_result
+        .expect("Bot task must fail, not panic")
+        .expect_err("Bot must fail-stop, not keep running with an un-pollable order");
+    let chain = format!("{error:#}");
+    assert!(
+        chain.contains("Apalis worker failed after retries"),
+        "Bot error chain should contain the terminal job failure, got: {chain}",
+    );
+
+    // Broker comes back; let the order fill on the next poll.
+    infra
+        .broker_service
+        .set_symbol_fill_delay(Symbol::new(equity_symbol)?, 0);
+    latency.restore().await?;
+
+    let ctx2 = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .broker_url_override(latency.endpoint.clone())
+        .call()?;
+    let mut bot2 = spawn_bot(ctx2);
+
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let orders = infra.broker_service.orders();
+    let order_count = orders.len();
+    assert_eq!(
+        order_count, 1,
+        "Exactly one broker order after the restart resumed polling; got \
+         {order_count}",
+    );
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot2.abort();
+    Ok(())
 }

--- a/tests/e2e/chaos_rpc.rs
+++ b/tests/e2e/chaos_rpc.rs
@@ -1,11 +1,11 @@
 //! Chaos tests for RPC fault tolerance.
 //!
 //! These tests wire the bot's onchain provider through a [`ChaosProxy`]
-//! so the test harness can inject transient RPC failures (dropped
-//! responses, 5xx errors, empty `eth_getLogs` results modelling a
-//! load-balancer that routed to a lagging node, delayed responses
-//! modelling a slow node) and assert the bot's recovery logic delivers
-//! the correct end state without losing or duplicating events.
+//! so the test harness can inject RPC faults (empty `eth_getLogs`
+//! results modelling a load-balancer that routed to a lagging node,
+//! delayed responses modelling a slow node, replayed stale logs, and
+//! full connection-refused outages) and assert the bot's recovery logic
+//! delivers the correct end state without losing or duplicating events.
 
 use std::time::Duration;
 
@@ -13,7 +13,10 @@ use st0x_float_macro::float;
 
 use crate::chaos::ChaosProxy;
 use crate::hedging::assertions::*;
-use crate::poll::{connect_db, poll_for_all_jobs_done, poll_for_events_with_timeout, spawn_bot};
+use crate::poll::{
+    connect_db, poll_for_all_jobs_done, poll_for_backfill_checkpoint, poll_for_events_with_timeout,
+    spawn_bot,
+};
 
 /// Top-level hypothesis: a SellEquity onchain trade observed
 /// only in the bot's initial `eth_getLogs` poll window still produces
@@ -360,6 +363,115 @@ async fn replayed_get_logs_across_checkpoint_advances_do_not_double_process() ->
     assert_full_hedging_flow(
         &expected_positions,
         &[take1, take2],
+        &infra.base_chain.provider,
+        infra.base_chain.orderbook,
+        infra.base_chain.owner,
+        &infra.broker_service,
+        &infra.db_path.display().to_string(),
+    )
+    .await?;
+
+    bot.abort();
+    Ok(())
+}
+
+/// Top-level hypothesis: a fully severed RPC -- connection refused on
+/// every call -- must not kill the bot, and a fill that lands onchain
+/// during the outage must be ingested from the persisted checkpoint
+/// once connectivity returns, exactly once.
+///
+/// Scenario: the chaos proxy's serve loop is aborted mid-run, so every
+/// poll tick errors with a refused connection (the run loop's
+/// warn-and-retry contract). The take fires directly against Anvil
+/// while the bot is blind -- the chain stays alive, only the bot's
+/// transport is dead. The mid-outage assertion pins that the fill is
+/// genuinely invisible to the bot; after restore, the checkpoint-driven
+/// backfill must surface it without duplication.
+#[test_log::test(tokio::test)]
+async fn rpc_outage_resumes_from_checkpoint_without_losing_fills() -> anyhow::Result<()> {
+    let equity_symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let sell_amount = float!(10.75);
+
+    let infra = TestInfra::start(vec![(equity_symbol, broker_fill_price)], vec![]).await?;
+    let mut chaos = ChaosProxy::start(infra.base_chain.endpoint().parse()?).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .rpc_url_override(chaos.endpoint.clone())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    // Deterministically wait for the initial backfill to advance the checkpoint
+    // before the outage, so the bot is provably in steady-state polling -- the
+    // failed poll ticks after the sever then reliably exercise the outage
+    // rather than racing the bot's startup on a slow host.
+    poll_for_backfill_checkpoint(
+        &mut bot,
+        &infra.db_path,
+        current_block,
+        Duration::from_secs(30),
+    )
+    .await;
+
+    chaos.sever();
+
+    // The chain keeps moving while the bot is blind.
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    // Several failed 1s poll ticks; sleep_or_crash inside the helper
+    // panics if the bot dies, so this also asserts outage survival.
+    wait_for_processing(&mut bot, 4).await;
+
+    // The outage must actually bite: the fill is invisible to the bot.
+    let pool = connect_db(&infra.db_path).await?;
+    let mid_outage_trades = count_events(&pool, "OnChainTrade").await?;
+    pool.close().await;
+    assert_eq!(
+        mid_outage_trades, 0,
+        "The fill must be invisible while the RPC is severed; found \
+         {mid_outage_trades} OnChainTrade events",
+    );
+
+    chaos.restore().await?;
+
+    poll_for_events_with_timeout(
+        &mut bot,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let expected_position = ExpectedPosition::builder()
+        .symbol(equity_symbol)
+        .amount(sell_amount)
+        .direction(TakeDirection::SellEquity)
+        .onchain_price(onchain_price)
+        .broker_fill_price(broker_fill_price)
+        .expected_accumulated_long(float!(0))
+        .expected_accumulated_short(sell_amount)
+        .expected_net(float!(0))
+        .build();
+
+    assert_full_hedging_flow(
+        &[expected_position],
+        &[take_result],
         &infra.base_chain.provider,
         infra.base_chain.orderbook,
         infra.base_chain.owner,


### PR DESCRIPTION
## What

Closes RAI-428. Adds chaos coverage for one-sided outages between the RPC, the broker, and the bot, asserting that partial failures never leave directional exposure unhedged and that the system surfaces partial-failure state for operators.

## Why

When only one dependency is down (RPC up but broker down, broker up but RPC down, DB reachable but RPC unreachable), a fill can be recorded without its offsetting hedge, silently accumulating directional risk.

## How

- Exercises each one-sided outage by severing/restoring the JSON-RPC and HTTP proxies independently while the pipeline runs.
- Asserts deferred hedges execute on recovery and no order-fill jobs are lost or corrupted across the outage.
- Surfaces partial-failure state through position-check and order-fill monitoring rather than swallowing it.

## Testing

- New e2e chaos cases in `tests/e2e/chaos_alpaca.rs` and `tests/e2e/chaos_rpc.rs` for broker-down and RPC-down outages with in-flight orders and checkpoint-based recovery.
- Verified hedges resume and position accounting stays consistent once connectivity is restored.

## Anything else

Part of the Testing & chaos milestone (RAI-73), extending the existing fault-injection harness to cover partial rather than total outages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903553&installation_id=125569124&pr_number=849&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F849&signature=bc8be81bfe0f524d7ccc90b8ceb96c95cac63e316c40d88fa5d478b4604169f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broker outage fault tolerance tests validating deferred hedging and automatic recovery after connectivity restoration
  * Added RPC error handling tests confirming graceful failure propagation and checkpoint-based recovery
  * Expanded chaos testing suite for broker and RPC disconnection scenarios with recovery validation

* **Chores**
  * Enhanced HTTP chaos proxy infrastructure to support dynamic sever/restore operations while preserving execution state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->