### PR TITLE
refactor: replace boolean knobs with ADTs in executor, tokenizer, and raindex mocks

### DIFF
--- a/crates/execution/src/mock.rs
+++ b/crates/execution/src/mock.rs
@@ -23,12 +23,20 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct MockExecutorCtx;
 
+/// Whether the mock executes operations or fails them. Couples the
+/// failure flag to its message so a message without a failure (or a
+/// failure without a message) is unrepresentable.
+#[derive(Debug, Clone)]
+enum Health {
+    Healthy,
+    Failing { message: String },
+}
+
 /// Unified test executor for dry-run mode and testing that logs operations without executing real trades
 #[derive(Debug, Clone)]
 pub struct MockExecutor {
     order_counter: Arc<AtomicU64>,
-    should_fail: bool,
-    failure_message: String,
+    health: Health,
     inventory_result: InventoryResult,
     order_status_override: Option<OrderState>,
     market_open: bool,
@@ -39,8 +47,7 @@ impl MockExecutor {
     pub fn new() -> Self {
         Self {
             order_counter: Arc::new(AtomicU64::new(1)),
-            should_fail: false,
-            failure_message: String::new(),
+            health: Health::Healthy,
             inventory_result: InventoryResult::Unimplemented,
             order_status_override: None,
             market_open: true,
@@ -50,13 +57,10 @@ impl MockExecutor {
 
     pub fn with_failure(message: impl Into<String>) -> Self {
         Self {
-            order_counter: Arc::new(AtomicU64::new(1)),
-            should_fail: true,
-            failure_message: message.into(),
-            inventory_result: InventoryResult::Unimplemented,
-            order_status_override: None,
-            market_open: true,
-            preflight_price: *MOCK_FILL_PRICE,
+            health: Health::Failing {
+                message: message.into(),
+            },
+            ..Self::new()
         }
     }
 
@@ -74,11 +78,24 @@ impl MockExecutor {
         self
     }
 
-    /// Configures whether the market is considered open.
+    /// Configures the executor to report the market as closed (open is
+    /// the default).
     #[must_use]
-    pub fn with_market_open(mut self, open: bool) -> Self {
-        self.market_open = open;
+    pub fn with_market_closed(mut self) -> Self {
+        self.market_open = false;
         self
+    }
+
+    /// Returns the failure error when the executor is configured to
+    /// fail, shared by every fallible operation.
+    fn fail_if_unhealthy(&self) -> Result<(), ExecutionError> {
+        if let Health::Failing { message } = &self.health {
+            return Err(ExecutionError::MockFailure {
+                message: message.clone(),
+            });
+        }
+
+        Ok(())
     }
 
     #[must_use]
@@ -119,11 +136,7 @@ impl Executor for MockExecutor {
         &self,
         order: MarketOrder,
     ) -> Result<OrderPlacement<Self::OrderId>, Self::Error> {
-        if self.should_fail {
-            return Err(ExecutionError::MockFailure {
-                message: self.failure_message.clone(),
-            });
-        }
+        self.fail_if_unhealthy()?;
 
         let order_id = self.generate_order_id();
 
@@ -143,11 +156,7 @@ impl Executor for MockExecutor {
     }
 
     async fn get_order_status(&self, order_id: &Self::OrderId) -> Result<OrderState, Self::Error> {
-        if self.should_fail {
-            return Err(ExecutionError::OrderNotFound {
-                order_id: order_id.clone(),
-            });
-        }
+        self.fail_if_unhealthy()?;
 
         if let Some(ref override_state) = self.order_status_override {
             debug!(target: "broker", "[TEST] Checking status for order: {}", order_id);
@@ -178,11 +187,7 @@ impl Executor for MockExecutor {
     }
 
     async fn get_inventory(&self) -> Result<InventoryResult, Self::Error> {
-        if self.should_fail {
-            return Err(ExecutionError::MockFailure {
-                message: self.failure_message.clone(),
-            });
-        }
+        self.fail_if_unhealthy()?;
 
         Ok(self.inventory_result.clone())
     }
@@ -191,11 +196,7 @@ impl Executor for MockExecutor {
         &self,
         order: MarketOrder,
     ) -> Result<CounterTradePreflight, Self::Error> {
-        if self.should_fail {
-            return Err(ExecutionError::MockFailure {
-                message: self.failure_message.clone(),
-            });
-        }
+        self.fail_if_unhealthy()?;
 
         let InventoryResult::Fetched(inventory) = &self.inventory_result else {
             return Ok(CounterTradePreflight::Allowed { reservation: None });
@@ -270,8 +271,10 @@ mod tests {
     #[tokio::test]
     async fn test_try_from_ctx_success() {
         let executor = MockExecutor::try_from_ctx(MockExecutorCtx).await.unwrap();
-        assert!(!executor.should_fail);
-        assert_eq!(executor.failure_message, "");
+
+        // A constructed executor is operational: a fallible op succeeds
+        // rather than returning the unhealthy MockFailure.
+        executor.get_inventory().await.unwrap();
     }
 
     #[tokio::test]
@@ -339,7 +342,7 @@ mod tests {
 
         assert!(matches!(
             executor.get_order_status(&"TEST_1".to_string()).await.unwrap_err(),
-            ExecutionError::OrderNotFound { order_id } if order_id == "TEST_1"
+            ExecutionError::MockFailure { message } if message == "Test failure"
         ));
     }
 
@@ -409,7 +412,9 @@ mod tests {
 
         let executor = MockExecutor::new().with_inventory(inventory);
 
-        assert!(!executor.should_fail);
+        // `with_inventory` leaves the executor healthy: a fallible op still
+        // succeeds rather than returning the unhealthy MockFailure.
+        executor.get_inventory().await.unwrap();
         assert_eq!(executor.to_supported_executor(), SupportedExecutor::DryRun);
     }
 

--- a/src/onchain/accumulator.rs
+++ b/src/onchain/accumulator.rs
@@ -376,7 +376,7 @@ mod tests {
         )
         .await;
 
-        let executor = MockExecutor::new().with_market_open(false);
+        let executor = MockExecutor::new().with_market_closed();
 
         let result = check_execution_readiness(
             &executor,
@@ -413,7 +413,7 @@ mod tests {
         )
         .await;
 
-        let executor = MockExecutor::new().with_market_open(true);
+        let executor = MockExecutor::new();
 
         let params = check_execution_readiness(
             &executor,
@@ -444,7 +444,7 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
 
         // Simulate market closed - accumulate multiple trades
-        let closed_executor = MockExecutor::new().with_market_open(false);
+        let closed_executor = MockExecutor::new().with_market_closed();
 
         // First trade while market closed
         initialize_position_with_fill(
@@ -509,7 +509,7 @@ mod tests {
         );
 
         // Market opens - should now execute
-        let open_executor = MockExecutor::new().with_market_open(true);
+        let open_executor = MockExecutor::new();
 
         let params = check_execution_readiness(
             &open_executor,

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -15,23 +15,42 @@ use crate::bindings::IERC20;
 
 /// Whether `submit_deposit` should succeed, fail generically, or fail
 /// with an "execution reverted" RPC error (simulating a revert during
-/// gas estimation).
+/// gas estimation, e.g. `ERC20InsufficientBalance` when tokens are
+/// already in the vault from a previous session).
 #[derive(Default)]
-enum DepositBehavior {
+pub(crate) enum DepositBehavior {
     #[default]
     Succeed,
     FailGeneric,
     FailExecutionReverted,
 }
 
-/// Whether `confirm_tx_receipt` should succeed or fail, simulating a
-/// transaction that was submitted but whose receipt never materializes.
-#[derive(Default, PartialEq, Eq)]
-enum ConfirmTxBehavior {
+/// Whether `confirm_tx_receipt` should succeed, fail terminally
+/// (simulating a submitted transaction whose receipt never
+/// materializes), or fail with a retryable inconclusive scan
+/// (simulating RPC lag rather than a dropped transaction).
+#[derive(Default)]
+pub(crate) enum ConfirmTxBehavior {
     #[default]
     Succeed,
     Fail,
     Retryable,
+}
+
+/// Arguments captured from the last `submit_deposit` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DepositCall {
+    pub(crate) token: Address,
+    pub(crate) vault_id: RaindexVaultId,
+    pub(crate) amount: U256,
+    pub(crate) decimals: u8,
+}
+
+/// Arguments captured from the last `submit_withdraw` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WithdrawCall {
+    token: Address,
+    amount: U256,
 }
 
 pub(crate) struct MockRaindex {
@@ -40,9 +59,9 @@ pub(crate) struct MockRaindex {
     deposit_behavior: DepositBehavior,
     confirm_behavior: ConfirmTxBehavior,
     deposited_token: Mutex<Option<Address>>,
-    deposit_call: Mutex<Option<(Address, RaindexVaultId, U256, u8)>>,
+    deposit_call: Mutex<Option<DepositCall>>,
     confirmed_tx: Mutex<Option<TxHash>>,
-    withdraw_transfer: Mutex<Option<(Address, U256)>>,
+    withdraw_transfer: Mutex<Option<WithdrawCall>>,
     withdraw_actual_amount: Option<U256>,
 }
 
@@ -108,40 +127,19 @@ impl MockRaindex {
         }
     }
 
-    pub(crate) fn failing_deposit() -> Self {
-        Self {
-            deposit_behavior: DepositBehavior::FailGeneric,
-            ..Self::new()
-        }
+    /// Configures how `submit_deposit` behaves; combinable with the
+    /// confirm-behaviour knob, unlike the former one-knob-per-constructor
+    /// design.
+    pub(crate) fn with_deposit_behavior(mut self, behavior: DepositBehavior) -> Self {
+        self.deposit_behavior = behavior;
+        self
     }
 
-    /// Creates a mock that fails `submit_deposit` with an "execution
-    /// reverted" RPC error, simulating a revert during gas estimation
-    /// (e.g., `ERC20InsufficientBalance` when tokens are already in
-    /// the vault from a previous session).
-    pub(crate) fn reverting_deposit() -> Self {
-        Self {
-            deposit_behavior: DepositBehavior::FailExecutionReverted,
-            ..Self::new()
-        }
-    }
-
-    /// Creates a mock whose `confirm_tx_receipt` fails, simulating a
-    /// submitted transaction whose receipt never materializes.
-    pub(crate) fn failing_confirm_tx() -> Self {
-        Self {
-            confirm_behavior: ConfirmTxBehavior::Fail,
-            ..Self::new()
-        }
-    }
-
-    /// Creates a mock whose `confirm_tx_receipt` fails with a retryable
-    /// inconclusive scan, simulating RPC lag rather than a dropped transaction.
-    pub(crate) fn retryable_confirm_tx() -> Self {
-        Self {
-            confirm_behavior: ConfirmTxBehavior::Retryable,
-            ..Self::new()
-        }
+    /// Configures how `confirm_tx_receipt` behaves; combinable with the
+    /// deposit-behaviour knob.
+    pub(crate) fn with_confirm_behavior(mut self, behavior: ConfirmTxBehavior) -> Self {
+        self.confirm_behavior = behavior;
+        self
     }
 
     /// Returns the token address that was passed to the last `deposit()` call.
@@ -149,7 +147,7 @@ impl MockRaindex {
         *self.deposited_token.lock().unwrap()
     }
 
-    pub(crate) fn last_deposit_call(&self) -> Option<(Address, RaindexVaultId, U256, u8)> {
+    pub(crate) fn last_deposit_call(&self) -> Option<DepositCall> {
         *self.deposit_call.lock().unwrap()
     }
 
@@ -185,7 +183,12 @@ impl Raindex for MockRaindex {
         match self.deposit_behavior {
             DepositBehavior::Succeed => {
                 *self.deposited_token.lock().unwrap() = Some(token);
-                *self.deposit_call.lock().unwrap() = Some((token, vault_id, amount, decimals));
+                *self.deposit_call.lock().unwrap() = Some(DepositCall {
+                    token,
+                    vault_id,
+                    amount,
+                    decimals,
+                });
                 Ok(self.deposit_tx)
             }
             DepositBehavior::FailGeneric => Err(RaindexError::ZeroAmount),
@@ -220,7 +223,10 @@ impl Raindex for MockRaindex {
         target_amount: U256,
         _decimals: u8,
     ) -> Result<TxHash, RaindexError> {
-        *self.withdraw_transfer.lock().unwrap() = Some((token, target_amount));
+        *self.withdraw_transfer.lock().unwrap() = Some(WithdrawCall {
+            token,
+            amount: target_amount,
+        });
         Ok(self.withdraw_tx)
     }
 
@@ -230,22 +236,24 @@ impl Raindex for MockRaindex {
     ) -> Result<TransactionReceipt, RaindexError> {
         *self.confirmed_tx.lock().unwrap() = Some(tx_hash);
 
-        if self.confirm_behavior == ConfirmTxBehavior::Fail {
-            return Err(RaindexError::Evm(EvmError::TransactionDropped {
-                tx_hash,
-                elapsed_secs: 0,
-            }));
-        }
-
-        if self.confirm_behavior == ConfirmTxBehavior::Retryable {
-            return Err(RaindexError::ScanInconclusive { from_block: 0 });
+        match self.confirm_behavior {
+            ConfirmTxBehavior::Fail => {
+                return Err(RaindexError::Evm(EvmError::TransactionDropped {
+                    tx_hash,
+                    elapsed_secs: 0,
+                }));
+            }
+            ConfirmTxBehavior::Retryable => {
+                return Err(RaindexError::ScanInconclusive { from_block: 0 });
+            }
+            ConfirmTxBehavior::Succeed => {}
         }
 
         let logs = self
             .withdraw_transfer
             .lock()
             .unwrap()
-            .map(|(token, amount)| {
+            .map(|WithdrawCall { token, amount }| {
                 let amount = self.withdraw_actual_amount.unwrap_or(amount);
                 vec![transfer_log(token, Address::ZERO, amount)]
             })

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -1631,7 +1631,7 @@ mod tests {
     use crate::inventory::{
         BroadcastingInventory, ImbalanceThreshold, Inventory, InventoryView, Venue,
     };
-    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::{RebalancingSchedulers, RebalancingServiceConfig};
     use crate::tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
@@ -2477,7 +2477,7 @@ mod tests {
     async fn mint_transfer_fails_when_raindex_deposit_fails() {
         let transfer = create_equity_transfer(
             Arc::new(MockTokenizer::new()),
-            Arc::new(MockRaindex::failing_deposit()),
+            Arc::new(MockRaindex::new().with_deposit_behavior(DepositBehavior::FailGeneric)),
             Arc::new(MockWrapper::new()),
         )
         .await;
@@ -2729,7 +2729,9 @@ mod tests {
     async fn resume_mint_recovers_when_deposit_reverts() {
         let transfer = create_equity_transfer(
             Arc::new(MockTokenizer::new()),
-            Arc::new(MockRaindex::reverting_deposit()),
+            Arc::new(
+                MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
+            ),
             Arc::new(MockWrapper::new()),
         )
         .await;
@@ -2821,7 +2823,9 @@ mod tests {
 
         let transfer = create_equity_transfer(
             Arc::new(MockTokenizer::new()),
-            Arc::new(MockRaindex::reverting_deposit()),
+            Arc::new(
+                MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
+            ),
             Arc::new(mock_wrapper),
         )
         .await;

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -67,6 +67,20 @@ enum MockTokenSymbolBehavior {
     Override(String),
 }
 
+/// Configurable outcome for `send_for_redemption`.
+#[derive(Clone, Copy)]
+enum MockSendOutcome {
+    Succeed,
+    ApiError,
+}
+
+/// Configurable outcome for `list_pending_requests`.
+#[derive(Clone, Copy)]
+enum MockListPendingOutcome {
+    Succeed,
+    ApiError,
+}
+
 pub(crate) struct MockTokenizer {
     redemption_wallet: Option<Address>,
     redemption_tx: TxHash,
@@ -75,8 +89,8 @@ pub(crate) struct MockTokenizer {
     detection_outcome: Option<MockDetectionOutcome>,
     completion_outcome: Option<MockCompletionOutcome>,
     verification_outcome: MockVerificationOutcome,
-    should_fail_send: bool,
-    should_fail_list_pending: bool,
+    send_outcome: MockSendOutcome,
+    list_pending_outcome: MockListPendingOutcome,
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
     pending_requests: Vec<TokenizationRequest>,
     /// Override the token_symbol in completed mint responses.
@@ -95,8 +109,8 @@ impl MockTokenizer {
             detection_outcome: None,
             completion_outcome: None,
             verification_outcome: MockVerificationOutcome::Success,
-            should_fail_send: false,
-            should_fail_list_pending: false,
+            send_outcome: MockSendOutcome::Succeed,
+            list_pending_outcome: MockListPendingOutcome::Succeed,
             last_issuer_request_id: Mutex::new(None),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
             fees_override: None,
@@ -130,12 +144,12 @@ impl MockTokenizer {
     }
 
     pub(crate) fn with_send_failure(mut self) -> Self {
-        self.should_fail_send = true;
+        self.send_outcome = MockSendOutcome::ApiError;
         self
     }
 
     pub(crate) fn with_list_pending_failure(mut self) -> Self {
-        self.should_fail_list_pending = true;
+        self.list_pending_outcome = MockListPendingOutcome::ApiError;
         self
     }
 
@@ -251,13 +265,15 @@ impl Tokenizer for MockTokenizer {
         _token: Address,
         _amount: U256,
     ) -> Result<TxHash, TokenizerError> {
-        if self.should_fail_send {
-            return Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                message: "mock send_for_redemption failure".to_string(),
-            }));
+        match self.send_outcome {
+            MockSendOutcome::ApiError => {
+                Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "mock send_for_redemption failure".to_string(),
+                }))
+            }
+            MockSendOutcome::Succeed => Ok(self.redemption_tx),
         }
-        Ok(self.redemption_tx)
     }
 
     async fn poll_for_redemption(
@@ -348,11 +364,14 @@ impl Tokenizer for MockTokenizer {
     }
 
     async fn list_pending_requests(&self) -> Result<Vec<TokenizationRequest>, TokenizerError> {
-        if self.should_fail_list_pending {
-            return Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                message: "mock list_pending_requests failure".to_string(),
-            }));
+        match self.list_pending_outcome {
+            MockListPendingOutcome::ApiError => {
+                return Err(TokenizerError::Alpaca(AlpacaTokenizationError::ApiError {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: "mock list_pending_requests failure".to_string(),
+                }));
+            }
+            MockListPendingOutcome::Succeed => {}
         }
 
         Ok(self

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -817,7 +817,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use crate::equity_redemption::redemption_aggregate_id;
-    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::mock::{ConfirmTxBehavior, DepositBehavior, DepositCall, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::tokenized_equity_mint::issuer_request_id;
@@ -1315,12 +1315,12 @@ mod tests {
         );
         assert_eq!(
             raindex.last_deposit_call(),
-            Some((
-                wrapped_token,
-                RaindexVaultId(B256::ZERO),
-                U256::from(123u64),
-                TOKENIZED_EQUITY_DECIMALS,
-            )),
+            Some(DepositCall {
+                token: wrapped_token,
+                vault_id: RaindexVaultId(B256::ZERO),
+                amount: U256::from(123u64),
+                decimals: TOKENIZED_EQUITY_DECIMALS,
+            }),
             "SubmitOrphanDeposit must deposit the confirmed wrapped amount into the \
              wrapped token vault at tokenized-equity precision",
         );
@@ -1329,7 +1329,9 @@ mod tests {
     #[tokio::test]
     async fn submit_orphan_deposit_records_failure_when_raindex_reverts() {
         let services = services_with(
-            Arc::new(MockRaindex::reverting_deposit()),
+            Arc::new(
+                MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
+            ),
             Arc::new(MockWrapper::new()),
         )
         .await;
@@ -1422,7 +1424,7 @@ mod tests {
     #[tokio::test]
     async fn confirm_orphan_deposit_records_failure_when_confirm_tx_fails() {
         let services = services_with(
-            Arc::new(MockRaindex::failing_confirm_tx()),
+            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Fail)),
             Arc::new(MockWrapper::new()),
         )
         .await;
@@ -1455,7 +1457,7 @@ mod tests {
     #[tokio::test]
     async fn confirm_orphan_deposit_retryable_error_keeps_submitted_state_live() {
         let services = services_with(
-            Arc::new(MockRaindex::retryable_confirm_tx()),
+            Arc::new(MockRaindex::new().with_confirm_behavior(ConfirmTxBehavior::Retryable)),
             Arc::new(MockWrapper::new()),
         )
         .await;

--- a/src/wrapped_equity_recovery/aggregate.rs
+++ b/src/wrapped_equity_recovery/aggregate.rs
@@ -584,7 +584,7 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use crate::equity_redemption::redemption_aggregate_id;
-    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::mock::{DepositBehavior, MockRaindex};
     use crate::rebalancing::equity::EquityTransferServices;
     use crate::tokenization::mock::MockTokenizer;
     use crate::tokenized_equity_mint::issuer_request_id;
@@ -813,7 +813,9 @@ mod tests {
     /// `RecoveryFailed` instead of advancing into `OrphanDepositSubmitted`.
     #[tokio::test]
     async fn submit_orphan_deposit_records_failure_when_raindex_reports_revert() {
-        let raindex: Arc<dyn Raindex> = Arc::new(MockRaindex::reverting_deposit());
+        let raindex: Arc<dyn Raindex> = Arc::new(
+            MockRaindex::new().with_deposit_behavior(DepositBehavior::FailExecutionReverted),
+        );
         let wrapper: Arc<dyn Wrapper> = Arc::new(MockWrapper::new());
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();


### PR DESCRIPTION
## What

Closes RAI-103. Replaces the boolean knobs, tuples, and string sentinels that configured the executor, tokenizer, and raindex mocks with proper ADTs, so test setup expresses intent directly.

## Why

Raw booleans and tuple captures in mock setup make invalid combinations representable and obscure what each test is actually configuring, which makes chaos-test scaffolding error-prone.

## How

- `MockExecutor`'s `should_fail`/`failure_message` pair becomes a single `Health` enum, with a named `with_market_closed()` chainer for the market-closed case.
- `MockTokenizer`'s failure booleans become outcome enums consistent with the module's existing `Mock*Outcome` ADTs.
- `MockRaindex`'s tuple captures become named `DepositCall`/`WithdrawCall` structs, and the mutually-exclusive failure constructors collapse into combinable `with_deposit_behavior()`/`with_confirm_behavior()` chainers.

## Testing

- Existing executor, tokenizer, and raindex mock call sites updated to the new ADT APIs and pass under `cargo nextest run`.

## Anything else

Part of the Testing & chaos milestone; this lands the executor/tokenizer/raindex slice of RAI-103, with the Alpaca-broker and snapshot-type mock cleanups deferred to later in the chaos stack to keep conflict-prone work last.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903556&installation_id=125569124&pr_number=851&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F851&signature=4fff41737a744a833952c472419bafceae7808c4c892c04bf799195f926add2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->