### PR TITLE
docs: ADR 0005 exactly-once fill accounting

### DIFF
--- a/adrs/0005-exactly-once-fill-accounting.md
+++ b/adrs/0005-exactly-once-fill-accounting.md
@@ -1,0 +1,100 @@
+# ADR 0005: Exactly-once fill accounting across the Witness/Acknowledge boundary
+
+## Status
+
+Accepted
+
+## Context
+
+`process_queued_trade` (`src/conductor.rs`) drives one observed onchain fill
+through two non-atomic aggregate writes:
+
+1. `execute_witness_trade` -- `OnChainTradeCommand::Witness`, keyed by
+   `(tx_hash, log_index)`.
+2. `execute_acknowledge_fill` -- `PositionCommand::AcknowledgeOnChainFill`,
+   which moves the position and ultimately triggers the hedge.
+
+Duplicate-input protection is pipeline-grained: the function's first step loads
+the `OnChainTrade` aggregate and returns `Ok(None)` if it exists. Two
+consequences:
+
+- **Under-delivery (real bug).** A crash or error between write 1 and write 2
+  leaves the trade witnessed but the position unaware. Any re-delivery of the
+  job (now a real path: orphaned accounting jobs are requeued at startup since
+  the RAI-423 fix) short-circuits at the load guard and returns `Ok(None)`. The
+  fill is permanently unaccounted: `CheckPositions` cannot see a fill the
+  `Position` never learned of, and the only remedy is manual repair via the CLI.
+  RAI-966 holds the reproducing tests.
+- **No defense in depth.** `Position::AcknowledgeOnChainFill` unconditionally
+  emits `OnChainOrderFilled` -- the aggregate itself accepts duplicate
+  `trade_id`s and would double-count if the upstream guard is ever bypassed.
+
+Compounding the first point, `execute_acknowledge_fill` (and
+`execute_enrich_trade`) swallow command errors -- they log and return unit, so
+the apalis job is marked `Done` even when the position write failed, burning the
+one delivery the queue guarantees.
+
+## Decision
+
+Make the dedupe step-grained instead of pipeline-grained, tracking
+acknowledgement on the `OnChainTrade` aggregate (which is already keyed by the
+dedupe identity):
+
+1. Add an acknowledgement marker to `OnChainTrade` (new
+   `OnChainTradeEvent::Acknowledged` event emitted by a new `Acknowledge`
+   command; schema version bump).
+2. `process_queued_trade` becomes a load-and-resume on the `OnChainTrade`
+   aggregate keyed by `(tx_hash, log_index)`:
+   - **acknowledged** -> `Ok(None)` (true duplicate, nothing left to do);
+   - **absent** -> `execute_witness_trade`, then best-effort
+     `execute_enrich_trade`;
+   - **witnessed but not acknowledged** -> skip the witness and resume directly
+     at the acknowledge step.
+
+   All three live cases then converge on the acknowledge pair, issued by the
+   conductor in a fixed order: `execute_acknowledge_fill` (the `Position` write)
+   and, only once it succeeds, `execute_mark_acknowledged` (the
+   `OnChainTradeCommand::Acknowledge` marker). The marker is therefore always
+   the immediate follow-up to a successful position write -- which is exactly
+   the crash window point 4 closes.
+3. `execute_acknowledge_fill` propagates errors so apalis retries the job
+   instead of silently dropping the fill (`execute_enrich_trade` stays
+   best-effort: enrichment is observability data, not financial state).
+4. As defense in depth -- and as the correctness guard for the resume path's
+   crash window between the position write and the marker write -- `Position`
+   rejects a `trade_id` it has already applied. State stays bounded: the
+   position remembers only the most recently applied `trade_id`, which is
+   sufficient because accounting jobs are serialized per symbol
+   (`concurrency(1)` worker plus the per-symbol lock) and re-deliveries are
+   drained in enqueue order, so the only trade that can ever be re-driven
+   against an unmarked acknowledgement is the most recent one. The upstream
+   marker blocks all longer-range duplicates before they reach the position.
+
+## Alternatives considered
+
+- **Position-side trade-id set.** Track every seen `TradeId` in `Position`
+  state. Simple, but the set grows unboundedly for the life of the symbol, and
+  every duplicate still re-runs the witness path first.
+- **Reorder the writes (acknowledge before witness).** Inverts the failure into
+  over-delivery: a crash between acknowledge and witness re-delivers a job whose
+  position update already happened, and the position has no dedupe to stop the
+  double-count. Strictly worse for financial integrity.
+- **Transactional outbox across both aggregates.** Correct but requires
+  cross-aggregate atomic persistence, which the CQRS framework deliberately does
+  not provide (one command, one aggregate, one atomic event batch).
+
+## Consequences
+
+- New `OnChainTrade` event type and schema version bump; existing aggregates
+  remain valid (absence of the marker means "not acknowledged", which is the
+  resume-safe default for old in-flight trades). `Position` also gains a
+  `last_acknowledged_trade_id` field, bumping its schema version.
+- The dedupe contract of `process_queued_trade` changes from "exists == done" to
+  "acknowledged == done". Chaos scenarios for broker-outage retries
+  (RAI-427/RAI-428) were written against this contract: a retry during a broker
+  outage re-drives the acknowledge step idempotently and then returns `Ok(None)`
+  even when hedge placement is still impossible, so a broker blip does not burn
+  the retry budget.
+- RAI-966's reproduction tests (duplicate `AcknowledgeOnChainFill` rejected;
+  witnessed-but-unacknowledged re-delivery recovers the fill) turn green with
+  the RAI-967 fix.


### PR DESCRIPTION
## What

Closes RAI-965. Records the accepted design for closing the Witness/Acknowledge gap in fill accounting as `adrs/0005-exactly-once-fill-accounting.md`.

## Why

A crash or error between the witness write and the acknowledge write leaves an onchain fill witnessed but unaccounted by the position, so a re-delivered job short-circuits at the load guard and permanently drops the fill.

## How

- Make dedupe step-grained: track acknowledgement on the `OnChainTrade` aggregate so re-delivery resumes the acknowledge step instead of skipping it.
- Propagate errors from the acknowledge step so apalis retries instead of marking the job `Done` on a failed position write.
- Add Position-side duplicate-`trade_id` rejection as defense in depth for the resume path's crash window.

## Testing

- Docs-only change; no test coverage. The reproduction and fix land in the linked RAI-966 / RAI-967 issues.

## Anything else

The ADR ships as its own PR so the decision record is reviewable independently of the implementation under parent issue RAI-964.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783903557&installation_id=125569124&pr_number=852&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F852&signature=0288ed3dc00bec8ee9aa2eb76d460b86a537859aef8022198e5b1280457f9443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural documentation for improved fill accounting reliability. Changes enhance the system's ability to properly track and account for fills even after system failures or re-deliveries, preventing fills from being permanently lost during unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->