### PR TITLE
fix: exactly-once fill accounting via OnChainTrade acknowledgement marker

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -11,7 +11,7 @@ use alloy::primitives::Address;
 use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::Context;
 use apalis::prelude::Status;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 use sqlx_apalis::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use std::collections::HashMap;
@@ -61,7 +61,7 @@ use crate::onchain::approvals::{build_approval_targets, grant_startup_approvals}
 use crate::onchain::backfill::BackfillJobQueue;
 use crate::onchain::trade::{RaindexTradeEvent, extract_owned_vaults, extract_vaults_from_clear};
 use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
-use crate::position::{Position, PositionCommand, TradeId};
+use crate::position::{Position, PositionCommand, PositionError, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{
     CrossVenueEquityTransfer, EquityTransferServices, TransferEquityToHedgingCtx,
@@ -1666,6 +1666,7 @@ async fn execute_witness_trade(
     onchain_trade: &Store<OnChainTrade>,
     trade: &OnchainTrade,
     block_number: u64,
+    block_timestamp: DateTime<Utc>,
 ) -> Result<bool, SendError<OnChainTrade>> {
     let trade_id = OnChainTradeId {
         tx_hash: trade.tx_hash,
@@ -1674,16 +1675,6 @@ async fn execute_witness_trade(
 
     let amount = trade.amount.inner();
     let price_usdc = trade.price.value();
-
-    let Some(block_timestamp) = trade.block_timestamp else {
-        warn!(
-            tx_hash = ?trade.tx_hash,
-            log_index = trade.log_index,
-            symbol = %trade.symbol,
-            "Missing block_timestamp for OnChainTrade::Witness"
-        );
-        return Ok(false);
-    };
 
     let command = OnChainTradeCommand::Witness {
         symbol: trade.symbol.base().clone(),
@@ -1765,25 +1756,24 @@ async fn execute_enrich_trade(onchain_trade: &Store<OnChainTrade>, trade: &Oncha
     }
 }
 
+/// Drives `Position::AcknowledgeOnChainFill`, treating the idempotent
+/// re-drive as success rather than an error.
+///
+/// Returns `Ok(())` when the position reflects the fill -- either this call
+/// applied it or a previous attempt already did (`DuplicateTrade`, the
+/// resume path's crash window between the position write and the
+/// acknowledgement marker). Every other error propagates so the apalis job
+/// retries instead of silently dropping the fill.
 async fn execute_acknowledge_fill(
     position: &Store<Position>,
     trade: &OnchainTrade,
     threshold: ExecutionThreshold,
-) {
+    block_timestamp: DateTime<Utc>,
+) -> Result<(), SendError<Position>> {
     let base_symbol = trade.symbol.base();
 
     let amount = trade.amount.inner();
     let price_usdc = trade.price.value();
-
-    let Some(block_timestamp) = trade.block_timestamp else {
-        warn!(
-            tx_hash = ?trade.tx_hash,
-            log_index = trade.log_index,
-            symbol = %trade.symbol,
-            "Missing block_timestamp for Position::AcknowledgeOnChainFill"
-        );
-        return;
-    };
 
     let command = PositionCommand::AcknowledgeOnChainFill {
         symbol: base_symbol.clone(),
@@ -1799,18 +1789,49 @@ async fn execute_acknowledge_fill(
     };
 
     match position.send(base_symbol, command).await {
-        Ok(()) => debug!(
-            tx_hash = ?trade.tx_hash,
-            log_index = trade.log_index,
-            symbol = %trade.symbol,
-            "Successfully executed Position::AcknowledgeOnChainFill command"
-        ),
-        Err(error) => error!(
-            tx_hash = ?trade.tx_hash,
-            log_index = trade.log_index,
-            symbol = %trade.symbol,
-            "Failed to execute Position::AcknowledgeOnChainFill command: {error}"
-        ),
+        Ok(()) => {
+            debug!(
+                tx_hash = ?trade.tx_hash,
+                log_index = trade.log_index,
+                symbol = %trade.symbol,
+                "Successfully executed Position::AcknowledgeOnChainFill command"
+            );
+            Ok(())
+        }
+        Err(AggregateError::UserError(LifecycleError::Apply(PositionError::DuplicateTrade {
+            ref trade_id,
+        }))) => {
+            info!(
+                tx_hash = ?trade.tx_hash,
+                log_index = trade.log_index,
+                symbol = %trade.symbol,
+                %trade_id,
+                "Position already applied this fill; resuming without re-counting"
+            );
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Marks the trade acknowledged on the `OnChainTrade` aggregate after the
+/// position write succeeded, completing the exactly-once pair (ADR 0005).
+/// A re-driven marker (`AlreadyAcknowledged`) is idempotent;
+/// infrastructure errors propagate so the apalis retry re-drives the
+/// idempotent acknowledge pair.
+async fn execute_mark_acknowledged(
+    onchain_trade: &Store<OnChainTrade>,
+    trade_id: &OnChainTradeId,
+) -> Result<(), SendError<OnChainTrade>> {
+    match onchain_trade
+        .send(trade_id, OnChainTradeCommand::Acknowledge)
+        .await
+    {
+        Ok(())
+        | Err(AggregateError::UserError(LifecycleError::Apply(
+            OnChainTradeError::AlreadyAcknowledged,
+        ))) => Ok(()),
+        Err(error) => Err(error),
     }
 }
 
@@ -1830,8 +1851,30 @@ where
         log_index: trade.log_index,
     };
 
+    // A fill we cannot timestamp can be neither witnessed nor acknowledged.
+    // Fail loudly so the apalis retry surfaces it as an operator-visible
+    // failure instead of completing the job and dropping the fill silently.
+    // The timestamp is baked into the job payload, so retries cannot resolve
+    // it -- they burn the (small) retry budget before the terminal-failure
+    // alert fires, which is an acceptable cost for not silently losing a fill.
+    let Some(block_timestamp) = trade.block_timestamp else {
+        error!(
+            ?trade_id,
+            symbol = %trade.symbol,
+            "Missing block_timestamp; cannot account for fill"
+        );
+        return Err(TradeAccountingError::MissingBlockTimestamp {
+            trade_id: trade_id.clone(),
+        });
+    };
+
+    // The dedupe is step-grained (ADR 0005): only a trade the position
+    // has acknowledged is fully processed. A trade that exists but is
+    // not acknowledged means a previous delivery died between the
+    // witness and acknowledge writes -- resume the acknowledge pair
+    // instead of skipping the fill into permanent loss.
     match cqrs.onchain_trade.load(&trade_id).await {
-        Ok(Some(_)) => {
+        Ok(Some(state)) if state.is_acknowledged() => {
             debug!(
                 ?trade_id,
                 symbol = %trade.symbol,
@@ -1839,23 +1882,51 @@ where
             );
             return Ok(None);
         }
-        Ok(None) => {}
+        Ok(Some(state)) => {
+            info!(
+                ?trade_id,
+                symbol = %trade.symbol,
+                "Trade witnessed but not acknowledged; resuming fill accounting"
+            );
+
+            // A crash in the witness->enrich window leaves the trade
+            // witnessed but un-enriched. Enrich now so the acknowledged
+            // trade is not permanently stuck with `enrichment: None` --
+            // mirroring the fresh-trade path. Best-effort: enrichment is
+            // observability data, not financial state.
+            if !state.is_enriched() {
+                execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
+            }
+        }
+        Ok(None) => {
+            let witnessed = execute_witness_trade(
+                &cqrs.onchain_trade,
+                &trade,
+                trade_event.block_number,
+                block_timestamp,
+            )
+            .await?;
+
+            if !witnessed {
+                return Ok(None);
+            }
+
+            execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
+        }
         // A failed read must not masquerade as "not a duplicate": the
         // witness write would also fail on a healthy dedupe path, but
         // propagating here keeps the retry contract explicit.
         Err(error) => return Err(error.into()),
     }
 
-    let witnessed =
-        execute_witness_trade(&cqrs.onchain_trade, &trade, trade_event.block_number).await?;
-
-    if !witnessed {
-        return Ok(None);
-    }
-
-    execute_enrich_trade(&cqrs.onchain_trade, &trade).await;
-
-    execute_acknowledge_fill(&cqrs.position, &trade, cqrs.execution_threshold).await;
+    execute_acknowledge_fill(
+        &cqrs.position,
+        &trade,
+        cqrs.execution_threshold,
+        block_timestamp,
+    )
+    .await?;
+    execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await?;
 
     let base_symbol = trade.symbol.base();
 
@@ -3566,7 +3637,6 @@ mod tests {
     /// persisted prefix is the exact first write `process_queued_trade`
     /// makes, and the retry is `process_queued_trade` itself.
     #[tokio::test]
-    #[ignore = "fails until the exactly-once fill-accounting fix; un-ignored on the fix branch"]
     async fn redelivery_after_crash_between_witness_and_acknowledge_recovers_fill() {
         let (pool, apalis_pool) = setup_test_pools().await;
         let (frameworks, offchain_order_projection) =
@@ -3579,13 +3649,18 @@ mod tests {
         let symbol = Symbol::new("AAPL").unwrap();
 
         let trade_event = make_trade_event(60);
+        let witnessing_trade = test_trade_with_amount(float!(1.5), 60);
+        let block_timestamp = witnessing_trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
 
         // The exact first write process_queued_trade makes -- and then
         // nothing: models the kill between the two aggregate writes.
         let witnessed = execute_witness_trade(
             &cqrs.onchain_trade,
-            &test_trade_with_amount(float!(1.5), 60),
+            &witnessing_trade,
             trade_event.block_number,
+            block_timestamp,
         )
         .await
         .unwrap();
@@ -3653,6 +3728,485 @@ mod tests {
         assert_eq!(
             position_fills, 1,
             "Exactly one position fill event after recovery"
+        );
+
+        // The crash window this fix closes is the gap between the position
+        // write and the acknowledgement marker. Proving the fill reached
+        // the position is not enough: without the marker, every later
+        // re-delivery re-enters the resume path and re-drives the fill,
+        // which the position then rejects as a duplicate. Assert the marker
+        // was actually written -- both as a persisted event and as
+        // acknowledged state on the replayed aggregate.
+        let (acknowledged_markers,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("OnChainTradeEvent::Acknowledged")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            acknowledged_markers, 1,
+            "The resume path must write exactly one Acknowledged marker"
+        );
+
+        let witnessed_trade = test_trade_with_amount(float!(1.5), 60);
+        let trade_id = OnChainTradeId {
+            tx_hash: witnessed_trade.tx_hash,
+            log_index: witnessed_trade.log_index,
+        };
+        let recovered_trade = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the witnessed trade aggregate must exist after recovery");
+        assert!(
+            recovered_trade.is_acknowledged(),
+            "The OnChainTrade must be marked acknowledged so the dedupe \
+             treats the fill as fully processed on subsequent deliveries"
+        );
+
+        // A third delivery after recovery must be a true no-op: the marker
+        // written above makes the dedupe short-circuit to `Ok(None)`
+        // without re-driving the fill. Proving the marker exists is not
+        // enough -- this proves it is read back and honored.
+        let outcome = process_queued_trade(
+            &MockExecutor::new(),
+            &trade_event,
+            test_trade_with_amount(float!(1.5), 60),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outcome, None,
+            "a delivery after the marker is written must dedupe-skip, not re-drive"
+        );
+
+        let (position_fills_after,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            position_fills_after, 1,
+            "the dedupe short-circuit must not write a second fill event"
+        );
+    }
+
+    /// A crash in the witness->enrich window must not leave the fill
+    /// permanently un-enriched. The resume path enriches before
+    /// acknowledging when the trade carries enrichment data, so the
+    /// recovered trade ends up both enriched and acknowledged -- enrichment
+    /// stays best-effort (ADR 0005) but the resume path must not skip it
+    /// when the data is present.
+    #[tokio::test]
+    async fn resume_path_enriches_trade_unenriched_at_crash() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(60);
+        let pyth_price = crate::onchain_trade::PythPrice {
+            value: "150250000".to_string(),
+            expo: -6,
+            conf: "50000".to_string(),
+            publish_time: chrono::Utc::now(),
+        };
+        let trade = OnchainTradeBuilder::default()
+            .with_symbol("wtAAPL")
+            .with_equity_token(TEST_EQUITY_TOKEN)
+            .with_amount(float!("1.5"))
+            .with_log_index(60)
+            .with_enrichment(50000, 1_000_000_000, pyth_price)
+            .build();
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        // Witness only -- model the crash before enrichment ran.
+        let witnessed = execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        assert!(witnessed, "premise: the witness write must succeed");
+        let witnessed_state = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("witnessed aggregate exists");
+        assert!(
+            !witnessed_state.is_enriched(),
+            "premise: the crash left the trade un-enriched"
+        );
+
+        process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap();
+
+        let recovered = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the aggregate exists after recovery");
+        assert!(
+            recovered.is_enriched(),
+            "the resume path must enrich a trade that crashed before enrichment"
+        );
+        assert!(
+            recovered.is_acknowledged(),
+            "the resume path must still acknowledge the recovered fill"
+        );
+    }
+
+    /// Composed coverage for the second crash window (ADR 0005): a crash
+    /// between the position write (`execute_acknowledge_fill`) and the
+    /// `OnChainTrade` acknowledgement marker (`execute_mark_acknowledged`)
+    /// leaves the fill applied to the position but the trade un-acknowledged
+    /// and the hedge unplaced. The re-delivered job, entering through
+    /// `process_queued_trade` itself, must thread the two idempotent steps
+    /// together: re-drive the acknowledge pair (the position rejects the
+    /// duplicate via the single-slot guard, the marker is written) and place
+    /// the hedge exactly once -- never double-count the fill nor place a
+    /// second hedge. The isolated idempotency contracts are covered by
+    /// `execute_acknowledge_fill_redrive_is_idempotent` and
+    /// `execute_mark_acknowledged_is_idempotent`; this test proves the
+    /// composed retry path.
+    #[tokio::test]
+    async fn redelivery_after_crash_between_position_write_and_marker_recovers_fill() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+        let symbol = Symbol::new("AAPL").unwrap();
+
+        let trade_event = make_trade_event(60);
+        let trade = test_trade_with_amount(float!(1.5), 60);
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        // Model the kill in the second crash window: the trade is witnessed
+        // and the position write landed, but the acknowledgement marker and
+        // the hedge never ran.
+        execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        execute_acknowledge_fill(
+            &cqrs.position,
+            &trade,
+            cqrs.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .expect("premise: the position write must land before the crash");
+        let crashed_state = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("premise: the trade is witnessed");
+        assert!(
+            !crashed_state.is_acknowledged(),
+            "premise: the acknowledgement marker must not be written yet"
+        );
+
+        // The re-delivered job after restart, entering through the real
+        // pipeline entrypoint.
+        let recovered_hedge_id = process_queued_trade(
+            &MockExecutor::new(),
+            &trade_event,
+            test_trade_with_amount(float!(1.5), 60),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap()
+        .expect(
+            "the re-delivered job must resume the acknowledge pair and place \
+             the hedge, not skip a witnessed-but-unacknowledged fill",
+        );
+
+        let position = cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("the position must exist after recovery");
+        assert!(
+            position.net.inner().eq(float!(1.5)).unwrap(),
+            "the fill must be accounted exactly once across the crash window"
+        );
+
+        let recovered = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the trade aggregate exists after recovery");
+        assert!(
+            recovered.is_acknowledged(),
+            "the resume path must complete the acknowledgement marker"
+        );
+
+        let orders = offchain_order_projection.load_all().await.unwrap();
+        assert_eq!(
+            orders.len(),
+            1,
+            "the recovered fill must hedge exactly once, not twice"
+        );
+        assert_eq!(
+            orders[0].0, recovered_hedge_id,
+            "process_queued_trade must return the id of the hedge it placed"
+        );
+        assert_eq!(
+            position.pending_offchain_order_id,
+            Some(recovered_hedge_id),
+            "the position must track the recovered hedge"
+        );
+
+        let (position_fills,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            position_fills, 1,
+            "exactly one position fill event after recovery"
+        );
+    }
+
+    /// `execute_mark_acknowledged` absorbs the aggregate's
+    /// `AlreadyAcknowledged` rejection as `Ok(())`, so a re-driven marker
+    /// (the second crash window) is idempotent rather than a propagated
+    /// error that would fail the apalis job on every retry after the first
+    /// marker write.
+    #[tokio::test]
+    async fn execute_mark_acknowledged_is_idempotent() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(60);
+        let trade = test_trade_with_amount(float!(1.5), 60);
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+
+        execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id)
+            .await
+            .expect("the first marker write must succeed");
+        execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id)
+            .await
+            .expect("re-driving the marker must be idempotent, not propagate an error");
+    }
+
+    /// Exactly-once across multiple same-symbol fills: once a fill is
+    /// acknowledged (marker written), re-delivering it -- even after a
+    /// later fill for the same symbol advanced the single-slot
+    /// `last_acknowledged_trade_id` -- is a safe no-op caught by the
+    /// upstream `is_acknowledged()` marker, not a double-count. The single
+    /// slot only holds the most recent fill, so the marker is the backstop
+    /// for these longer-range duplicates (ADR 0005).
+    #[tokio::test]
+    async fn redelivery_of_marked_fill_after_later_fill_is_deduped() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        // Fill A then fill B, both fully processed. B advances the
+        // single-slot guard to B's trade_id, displacing A.
+        let event_a = make_trade_event(60);
+        process_queued_trade(
+            &MockExecutor::new(),
+            &event_a,
+            test_trade_with_amount(float!(1.0), 60),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let event_b = make_trade_event(61);
+        process_queued_trade(
+            &MockExecutor::new(),
+            &event_b,
+            test_trade_with_amount(float!(2.0), 61),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+
+        let (fills_before,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fills_before, 2,
+            "premise: two distinct fills each accounted exactly once"
+        );
+
+        // Re-deliver A after B displaced the slot. The single-slot guard no
+        // longer holds A, so correctness rests entirely on the upstream
+        // marker short-circuiting the dedupe.
+        let outcome = process_queued_trade(
+            &MockExecutor::new(),
+            &event_a,
+            test_trade_with_amount(float!(1.0), 60),
+            &cqrs,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outcome, None,
+            "a marked fill re-delivered after a later fill must dedupe-skip"
+        );
+
+        let (fills_after,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
+                .bind("PositionEvent::OnChainOrderFilled")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            fills_after, 2,
+            "re-delivering the marked fill must not re-apply it (no double-count)"
+        );
+    }
+
+    /// The resume path's idempotency contract in isolation: re-driving a
+    /// fill the position already applied (the crash window between the
+    /// position write and the acknowledgement marker) must succeed without
+    /// counting the fill twice. `execute_acknowledge_fill` maps the
+    /// position's `DuplicateTrade` rejection to `Ok(())`.
+    #[tokio::test]
+    async fn execute_acknowledge_fill_redrive_is_idempotent() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trade = test_trade_with_amount(float!(1.5), 60);
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+
+        execute_acknowledge_fill(
+            &cqrs.position,
+            &trade,
+            cqrs.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .expect("the first acknowledge must apply the fill");
+
+        execute_acknowledge_fill(
+            &cqrs.position,
+            &trade,
+            cqrs.execution_threshold,
+            block_timestamp,
+        )
+        .await
+        .expect("re-driving the same fill must succeed, not propagate an error");
+
+        let position = cqrs
+            .position_projection
+            .load(&symbol)
+            .await
+            .unwrap()
+            .expect("the position must exist after acknowledge");
+        assert!(
+            position.net.inner().eq(float!(1.5)).unwrap(),
+            "the re-drive must not double-count the fill"
+        );
+    }
+
+    /// A fill missing its block timestamp can be neither witnessed nor
+    /// acknowledged, so `process_queued_trade` must fail loudly with a
+    /// retryable error rather than completing the job and dropping the fill
+    /// silently.
+    #[tokio::test]
+    async fn process_queued_trade_rejects_missing_block_timestamp() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) =
+            create_cqrs_frameworks_with_order_placer(&pool, succeeding_order_placer()).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(60);
+        let mut trade = test_trade_with_amount(float!(1.5), 60);
+        trade.block_timestamp = None;
+
+        let error = process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(error, TradeAccountingError::MissingBlockTimestamp { .. }),
+            "a fill without a block timestamp must fail loudly, not drop silently; got {error:?}"
         );
     }
 

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -774,6 +774,11 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
     ];
     assert_events(&pool, &expected).await;
 
@@ -807,6 +812,11 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade2_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -824,15 +834,15 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[4].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade2_filled = &events[4].payload["OnChainOrderFilled"];
+    assert_eq!(events[5].event_type, "PositionEvent::OnChainOrderFilled");
+    let trade2_filled = &events[5].payload["OnChainOrderFilled"];
     assert_eq!(trade2_filled["amount"].as_str().unwrap(), "0.7");
     assert_eq!(trade2_filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(trade2_filled["price_usdc"].as_str().unwrap(), "100");
 
     // Payload spot-checks: OffChainOrderPlaced and Placed shares/direction
-    assert_eq!(events[5].event_type, "PositionEvent::OffChainOrderPlaced");
-    let placed_pos = &events[5].payload["OffChainOrderPlaced"];
+    assert_eq!(events[7].event_type, "PositionEvent::OffChainOrderPlaced");
+    let placed_pos = &events[7].payload["OffChainOrderPlaced"];
     assert_eq!(
         placed_pos["offchain_order_id"].as_str().unwrap(),
         order_id_str
@@ -840,8 +850,8 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
     assert_eq!(placed_pos["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed_pos["shares"].as_str().unwrap(), "1.2");
 
-    assert_eq!(events[6].event_type, "OffchainOrderEvent::Placed");
-    let offchain_placed = &events[6].payload["Placed"];
+    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
+    let offchain_placed = &events[8].payload["Placed"];
     assert_eq!(offchain_placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(offchain_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(offchain_placed["shares"].as_str().unwrap(), "1.2");
@@ -871,9 +881,9 @@ async fn onchain_trades_accumulate_and_trigger_offchain_fill()
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderFilled"),
     ]);
     let events = assert_events(&pool, &expected).await;
-    assert_eq!(events[9].event_type, "PositionEvent::OffChainOrderFilled");
+    assert_eq!(events[11].event_type, "PositionEvent::OffChainOrderFilled");
     assert_eq!(
-        events[9].payload["OffChainOrderFilled"]["offchain_order_id"]
+        events[11].payload["OffChainOrderFilled"]["offchain_order_id"]
             .as_str()
             .unwrap(),
         order_id_str,
@@ -945,8 +955,18 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade2_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -958,8 +978,8 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderFailed"),
     ];
     let events = assert_events(&pool, &expected).await;
-    assert_eq!(events[6].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[6].payload["Placed"];
+    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[8].payload["Placed"];
     assert_eq!(placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
 
@@ -1003,8 +1023,8 @@ async fn position_checker_recovers_failed_execution() -> Result<(), Box<dyn std:
 
     // Extract retry order ID from the new OffchainOrderEvent::Placed event
     let all_events = fetch_events(&pool).await;
-    assert_eq!(all_events[11].event_type, "OffchainOrderEvent::Placed");
-    let retry_id = all_events[11].aggregate_id.clone();
+    assert_eq!(all_events[13].event_type, "OffchainOrderEvent::Placed");
+    let retry_id = all_events[13].aggregate_id.clone();
     assert_ne!(
         retry_id, order_id_str,
         "Retry should create a new offchain order"
@@ -1099,9 +1119,9 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
 
     // Concurrent submissions produce non-deterministic global event ordering:
     // Position and OnChainTrade events for different symbols can fully interleave.
-    // Verify the first 6 events contain the expected set regardless of order.
+    // Verify the first 8 events contain the expected set regardless of order.
     let initial_events = fetch_events(&pool).await;
-    let actual_initial: Vec<ExpectedEvent> = initial_events[..6]
+    let actual_initial: Vec<ExpectedEvent> = initial_events[..8]
         .iter()
         .map(|event| {
             ExpectedEvent::new(
@@ -1116,9 +1136,19 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade2_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
     ];
     for expected_event in &concurrent_set {
         assert!(
@@ -1127,12 +1157,17 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
-    // Build the expected sequence using the actual ordering of the first 6 events
+    // Build the expected sequence using the actual ordering of the first 8 events
     let mut expected: Vec<ExpectedEvent> = actual_initial;
 
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade3_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade3_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new(
             "OffchainOrder",
@@ -1147,8 +1182,8 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     ]);
     let events = assert_events(&pool, &expected).await;
 
-    assert_eq!(events[9].event_type, "OffchainOrderEvent::Placed");
-    let aapl_placed = &events[9].payload["Placed"];
+    assert_eq!(events[12].event_type, "OffchainOrderEvent::Placed");
+    let aapl_placed = &events[12].payload["Placed"];
     assert_eq!(aapl_placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(aapl_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(aapl_placed["shares"].as_str().unwrap(), "1.2");
@@ -1227,6 +1262,11 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     expected.extend([
         ExpectedEvent::new("OnChainTrade", &trade4_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade4_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_MSFT, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new(
             "OffchainOrder",
@@ -1241,8 +1281,8 @@ async fn multi_symbol_isolation() -> Result<(), Box<dyn std::error::Error>> {
     ]);
     let events = assert_events(&pool, &expected).await;
 
-    assert_eq!(events[16].event_type, "OffchainOrderEvent::Placed");
-    let msft_placed = &events[16].payload["Placed"];
+    assert_eq!(events[20].event_type, "OffchainOrderEvent::Placed");
+    let msft_placed = &events[20].payload["Placed"];
     assert_eq!(msft_placed["symbol"].as_str().unwrap(), TEST_MSFT);
     assert_eq!(msft_placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(msft_placed["shares"].as_str().unwrap(), "1");
@@ -1353,8 +1393,18 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade2_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1372,20 +1422,20 @@ async fn buy_direction_accumulates_long() -> Result<(), Box<dyn std::error::Erro
     assert_eq!(trade1_filled["direction"].as_str().unwrap(), "buy");
     assert_eq!(trade1_filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[4].event_type, "PositionEvent::OnChainOrderFilled");
-    let trade2_filled = &events[4].payload["OnChainOrderFilled"];
+    assert_eq!(events[5].event_type, "PositionEvent::OnChainOrderFilled");
+    let trade2_filled = &events[5].payload["OnChainOrderFilled"];
     assert_eq!(trade2_filled["amount"].as_str().unwrap(), "0.7");
     assert_eq!(trade2_filled["direction"].as_str().unwrap(), "buy");
     assert_eq!(trade2_filled["price_usdc"].as_str().unwrap(), "100");
 
     // Hedge direction should be Sell (opposite of onchain Buy), shares = abs(net)
-    assert_eq!(events[6].event_type, "OffchainOrderEvent::Placed");
+    assert_eq!(events[8].event_type, "OffchainOrderEvent::Placed");
     assert_eq!(
-        events[6].payload["Placed"]["direction"].as_str().unwrap(),
+        events[8].payload["Placed"]["direction"].as_str().unwrap(),
         "sell"
     );
     assert_eq!(
-        events[6].payload["Placed"]["shares"].as_str().unwrap(),
+        events[8].payload["Placed"]["shares"].as_str().unwrap(),
         "1.2"
     );
 
@@ -1457,6 +1507,11 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1474,13 +1529,13 @@ async fn exact_threshold_triggers_execution() -> Result<(), Box<dyn std::error::
     assert_eq!(filled["direction"].as_str().unwrap(), "sell");
     assert_eq!(filled["price_usdc"].as_str().unwrap(), "100");
 
-    assert_eq!(events[3].event_type, "PositionEvent::OffChainOrderPlaced");
-    let placed_pos = &events[3].payload["OffChainOrderPlaced"];
+    assert_eq!(events[4].event_type, "PositionEvent::OffChainOrderPlaced");
+    let placed_pos = &events[4].payload["OffChainOrderPlaced"];
     assert_eq!(placed_pos["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed_pos["shares"].as_str().unwrap(), "1");
 
-    assert_eq!(events[4].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[4].payload["Placed"];
+    assert_eq!(events[5].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[5].payload["Placed"];
     assert_eq!(placed["symbol"].as_str().unwrap(), TEST_AAPL);
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed["shares"].as_str().unwrap(), "1");
@@ -1641,6 +1696,11 @@ async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::E
         ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade1_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order1_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1653,6 +1713,11 @@ async fn second_hedge_after_full_lifecycle() -> Result<(), Box<dyn std::error::E
         // Second cycle
         ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+        ExpectedEvent::new(
+            "OnChainTrade",
+            &trade2_agg,
+            "OnChainTradeEvent::Acknowledged",
+        ),
         ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
         ExpectedEvent::new("OffchainOrder", &order2_str, "OffchainOrderEvent::Placed"),
         ExpectedEvent::new(
@@ -1795,6 +1860,11 @@ async fn tiny_fractional_trade_tracks_precisely() -> Result<(), Box<dyn std::err
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade1_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
         ],
     )
     .await;
@@ -1844,6 +1914,11 @@ async fn large_trade_triggers_immediate_execution() -> Result<(), Box<dyn std::e
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade1_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -1972,12 +2047,32 @@ async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::er
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade1_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade2_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("OnChainTrade", &trade3_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade3_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("OnChainTrade", &trade4_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade4_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -1989,8 +2084,8 @@ async fn mixed_direction_trades_partially_cancel() -> Result<(), Box<dyn std::er
     )
     .await;
 
-    assert_eq!(events[10].event_type, "OffchainOrderEvent::Placed");
-    let placed = &events[10].payload["Placed"];
+    assert_eq!(events[14].event_type, "OffchainOrderEvent::Placed");
+    let placed = &events[14].payload["Placed"];
     assert_eq!(placed["direction"].as_str().unwrap(), "buy");
     assert_eq!(placed["shares"].as_str().unwrap(), "1.1");
 
@@ -2089,6 +2184,11 @@ async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade1_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OffChainOrderPlaced"),
             ExpectedEvent::new("OffchainOrder", &order_id_str, "OffchainOrderEvent::Placed"),
             ExpectedEvent::new(
@@ -2099,6 +2199,11 @@ async fn pending_order_blocks_new_execution() -> Result<(), Box<dyn std::error::
             // Trade 2 events: only onchain fill, no offchain order
             ExpectedEvent::new("OnChainTrade", &trade2_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade2_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
         ],
     )
     .await;
@@ -2150,6 +2255,11 @@ async fn duplicate_onchain_event_is_idempotent() -> Result<(), Box<dyn std::erro
             ExpectedEvent::new("OnChainTrade", &trade1_agg, "OnChainTradeEvent::Filled"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::Initialized"),
             ExpectedEvent::new("Position", TEST_AAPL, "PositionEvent::OnChainOrderFilled"),
+            ExpectedEvent::new(
+                "OnChainTrade",
+                &trade1_agg,
+                "OnChainTradeEvent::Acknowledged",
+            ),
         ],
     )
     .await;

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -77,6 +77,14 @@ pub(crate) struct OnChainTrade {
     pub(crate) block_timestamp: DateTime<Utc>,
     pub(crate) filled_at: DateTime<Utc>,
     pub(crate) enrichment: Option<Enrichment>,
+    /// Set once the `Position` aggregate has acknowledged this fill.
+    /// The trade-accounting dedupe treats only acknowledged trades as
+    /// fully processed, so a job re-delivered after a crash between the
+    /// witness and acknowledge writes resumes instead of skipping
+    /// (ADR 0005). Absent on aggregates persisted before the marker
+    /// existed, which is the resume-safe default.
+    #[serde(default)]
+    pub(crate) acknowledged_at: Option<DateTime<Utc>>,
 }
 
 #[async_trait]
@@ -90,7 +98,7 @@ impl EventSourced for OnChainTrade {
 
     const AGGREGATE_TYPE: &'static str = "OnChainTrade";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use OnChainTradeEvent::*;
@@ -112,9 +120,10 @@ impl EventSourced for OnChainTrade {
                 block_timestamp: *block_timestamp,
                 filled_at: *filled_at,
                 enrichment: None,
+                acknowledged_at: None,
             }),
 
-            Enriched { .. } => None,
+            Enriched { .. } | Acknowledged { .. } => None,
         }
     }
 
@@ -133,6 +142,11 @@ impl EventSourced for OnChainTrade {
                     pyth_price: pyth_price.clone(),
                     enriched_at: *enriched_at,
                 }),
+                ..entity.clone()
+            })),
+
+            Acknowledged { acknowledged_at } => Ok(Some(Self {
+                acknowledged_at: Some(*acknowledged_at),
                 ..entity.clone()
             })),
 
@@ -164,7 +178,7 @@ impl EventSourced for OnChainTrade {
                 filled_at: Utc::now(),
             }]),
 
-            Enrich { .. } => Err(OnChainTradeError::NotFilled),
+            Enrich { .. } | Acknowledge => Err(OnChainTradeError::NotFilled),
         }
     }
 
@@ -202,6 +216,16 @@ impl EventSourced for OnChainTrade {
                     enriched_at: Utc::now(),
                 }])
             }
+
+            Acknowledge => {
+                if self.is_acknowledged() {
+                    return Err(OnChainTradeError::AlreadyAcknowledged);
+                }
+
+                Ok(vec![Acknowledged {
+                    acknowledged_at: Utc::now(),
+                }])
+            }
         }
     }
 }
@@ -209,6 +233,13 @@ impl EventSourced for OnChainTrade {
 impl OnChainTrade {
     pub(crate) fn is_enriched(&self) -> bool {
         self.enrichment.is_some()
+    }
+
+    /// Whether the `Position` aggregate has acknowledged this fill --
+    /// the condition under which the trade-accounting dedupe treats the
+    /// trade as fully processed.
+    pub(crate) fn is_acknowledged(&self) -> bool {
+        self.acknowledged_at.is_some()
     }
 
     pub(crate) fn to_trade(&self, id: &OnChainTradeId) -> Trade {
@@ -231,6 +262,8 @@ pub(crate) enum OnChainTradeError {
     AlreadyEnriched,
     #[error("Trade has already been filled")]
     AlreadyFilled,
+    #[error("Trade has already been acknowledged by the position")]
+    AlreadyAcknowledged,
     #[error(
         "Effective gas price {effective_gas_price} exceeds i64::MAX \
          and cannot be stored in SQLite"
@@ -261,6 +294,10 @@ pub(crate) enum OnChainTradeCommand {
         effective_gas_price: u128,
         pyth_price: PythPrice,
     },
+    /// Marks the fill as acknowledged by the `Position` aggregate.
+    /// Sent only after `AcknowledgeOnChainFill` succeeded, so the
+    /// dedupe guard can distinguish "witnessed" from "fully accounted".
+    Acknowledge,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,6 +324,9 @@ pub(crate) enum OnChainTradeEvent {
         effective_gas_price: u128,
         pyth_price: PythPrice,
         enriched_at: DateTime<Utc>,
+    },
+    Acknowledged {
+        acknowledged_at: DateTime<Utc>,
     },
 }
 
@@ -336,6 +376,14 @@ impl PartialEq for OnChainTradeEvent {
                     enriched_at: e2,
                 },
             ) => g1 == g2 && egp1 == egp2 && pp1 == pp2 && e1 == e2,
+            (
+                Self::Acknowledged {
+                    acknowledged_at: a1,
+                },
+                Self::Acknowledged {
+                    acknowledged_at: a2,
+                },
+            ) => a1 == a2,
             _ => false,
         }
     }
@@ -348,6 +396,7 @@ impl DomainEvent for OnChainTradeEvent {
         match self {
             Self::Filled { .. } => "OnChainTradeEvent::Filled".to_string(),
             Self::Enriched { .. } => "OnChainTradeEvent::Enriched".to_string(),
+            Self::Acknowledged { .. } => "OnChainTradeEvent::Acknowledged".to_string(),
         }
     }
 
@@ -540,6 +589,116 @@ mod tests {
             error,
             LifecycleError::Apply(OnChainTradeError::GasPriceOutOfRange { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn acknowledge_marks_witnessed_trade() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![OnChainTradeEvent::Filled {
+                symbol,
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .events();
+
+        assert!(
+            matches!(events.as_slice(), [OnChainTradeEvent::Acknowledged { .. }]),
+            "Acknowledge on a witnessed trade must emit the marker; got {events:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn cannot_acknowledge_twice() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![
+                OnChainTradeEvent::Filled {
+                    symbol,
+                    amount: float!(10.5),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150.25),
+                    block_number: 12345,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+                OnChainTradeEvent::Acknowledged {
+                    acknowledged_at: now,
+                },
+            ])
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::AlreadyAcknowledged)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cannot_acknowledge_unwitnessed_trade() {
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given_no_previous_events()
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::NotFilled)
+        ));
+    }
+
+    /// Production emits `Enriched` before `Acknowledged`: enrichment runs
+    /// in the fresh-trade path, then the position acknowledges the fill.
+    /// The `Acknowledged` evolve handler must preserve the enrichment it
+    /// finds so both markers survive in the live aggregate.
+    #[tokio::test]
+    async fn acknowledge_after_enrich_preserves_both_markers() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let trade = replay::<OnChainTrade>(vec![
+            OnChainTradeEvent::Filled {
+                symbol,
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_timestamp: now,
+                filled_at: now,
+            },
+            OnChainTradeEvent::Enriched {
+                gas_used: 21000,
+                effective_gas_price: 100,
+                pyth_price: PythPrice {
+                    value: "150250000".to_string(),
+                    expo: -6,
+                    conf: "50000".to_string(),
+                    publish_time: now,
+                },
+                enriched_at: now,
+            },
+            OnChainTradeEvent::Acknowledged {
+                acknowledged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live trade");
+
+        assert!(trade.is_acknowledged());
+        assert!(trade.is_enriched());
     }
 
     #[tokio::test]

--- a/src/position.rs
+++ b/src/position.rs
@@ -41,6 +41,15 @@ pub struct Position {
     /// rebalance cycle gets a fresh idempotency key.
     #[serde(default)]
     pub last_failed_offchain_order_id: Option<OffchainOrderId>,
+    /// The most recently applied onchain fill, rejected if re-driven.
+    /// Guards the resume path's crash window between this position
+    /// write and the `OnChainTrade` acknowledgement marker (ADR 0005).
+    /// One slot suffices: accounting jobs are serialized per symbol and
+    /// re-deliveries drain in enqueue order, so only the most recent
+    /// trade can ever be re-driven against an unmarked acknowledgement;
+    /// the upstream marker blocks all longer-range duplicates.
+    #[serde(default)]
+    pub last_acknowledged_trade_id: Option<TradeId>,
     pub threshold: ExecutionThreshold,
     #[serde(
         serialize_with = "st0x_float_serde::serialize_option_float",
@@ -62,6 +71,10 @@ impl std::fmt::Debug for Position {
                 "last_failed_offchain_order_id",
                 &self.last_failed_offchain_order_id,
             )
+            .field(
+                "last_acknowledged_trade_id",
+                &self.last_acknowledged_trade_id,
+            )
             .field("threshold", &self.threshold)
             .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
@@ -80,7 +93,7 @@ impl EventSourced for Position {
 
     const AGGREGATE_TYPE: &'static str = "Position";
     const PROJECTION: Table = Table("position_view");
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use PositionEvent::*;
@@ -96,6 +109,7 @@ impl EventSourced for Position {
                 accumulated_short: FractionalShares::ZERO,
                 pending_offchain_order_id: None,
                 last_failed_offchain_order_id: None,
+                last_acknowledged_trade_id: None,
                 threshold: *threshold,
                 last_price_usdc: None,
                 last_updated: Some(*initialized_at),
@@ -111,6 +125,7 @@ impl EventSourced for Position {
 
         match event {
             OnChainOrderFilled {
+                trade_id,
                 amount,
                 direction: Buy,
                 price_usdc,
@@ -119,12 +134,14 @@ impl EventSourced for Position {
             } => Ok(Some(Self {
                 net: (entity.net + *amount)?,
                 accumulated_long: (entity.accumulated_long + *amount)?,
+                last_acknowledged_trade_id: Some(trade_id.clone()),
                 last_price_usdc: Some(*price_usdc),
                 last_updated: Some(*seen_at),
                 ..entity.clone()
             })),
 
             OnChainOrderFilled {
+                trade_id,
                 direction: Sell,
                 amount,
                 price_usdc,
@@ -133,6 +150,7 @@ impl EventSourced for Position {
             } => Ok(Some(Self {
                 net: (entity.net - *amount)?,
                 accumulated_short: (entity.accumulated_short + *amount)?,
+                last_acknowledged_trade_id: Some(trade_id.clone()),
                 last_price_usdc: Some(*price_usdc),
                 last_updated: Some(*seen_at),
                 ..entity.clone()
@@ -332,14 +350,20 @@ impl EventSourced for Position {
                 price_usdc,
                 block_timestamp,
                 ..
-            } => Ok(vec![PositionEvent::OnChainOrderFilled {
-                trade_id,
-                amount,
-                direction,
-                price_usdc,
-                block_timestamp,
-                seen_at: Utc::now(),
-            }]),
+            } => {
+                if self.last_acknowledged_trade_id.as_ref() == Some(&trade_id) {
+                    return Err(PositionError::DuplicateTrade { trade_id });
+                }
+
+                Ok(vec![PositionEvent::OnChainOrderFilled {
+                    trade_id,
+                    amount,
+                    direction,
+                    price_usdc,
+                    block_timestamp,
+                    seen_at: Utc::now(),
+                }])
+            }
 
             PlaceOffChainOrder {
                 offchain_order_id,
@@ -1362,7 +1386,6 @@ mod tests {
     /// marker; without this rejection the re-drive counts the same fill
     /// twice.
     #[tokio::test]
-    #[ignore = "fails until the exactly-once fill-accounting fix; un-ignored on the fix branch"]
     async fn duplicate_acknowledge_on_chain_fill_is_rejected() {
         let threshold = one_share_threshold();
         let trade_id = TradeId {
@@ -2571,6 +2594,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2598,6 +2622,7 @@ mod tests {
             accumulated_short: FractionalShares::new(float!(2.567)),
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2625,6 +2650,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2655,6 +2681,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2685,6 +2712,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2714,6 +2742,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2744,6 +2773,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
@@ -2774,6 +2804,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: None,
             last_updated: Some(Utc::now()),
@@ -2854,6 +2885,7 @@ mod tests {
             accumulated_short: FractionalShares::ZERO,
             pending_offchain_order_id: None,
             last_failed_offchain_order_id: None,
+            last_acknowledged_trade_id: None,
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -233,6 +233,10 @@ pub(crate) enum TradeAccountingError {
     AlpacaBrokerApi(#[from] AlpacaBrokerApiError),
     #[error("Failed to enqueue PollOrderStatus job: {0}")]
     EnqueuePollJob(#[from] crate::conductor::job::QueuePushError),
+    #[error("Missing block_timestamp for fill {trade_id}; cannot account for it")]
+    MissingBlockTimestamp {
+        trade_id: crate::onchain_trade::OnChainTradeId,
+    },
 }
 
 #[cfg(test)]

--- a/tests/e2e/assert.rs
+++ b/tests/e2e/assert.rs
@@ -239,15 +239,18 @@ fn assert_onchain_trade_events(
     events: &[StoredEvent],
     expected_count: usize,
 ) {
+    // Count witnessed fills, not raw aggregate events: each trade also
+    // carries an `Acknowledged` marker event (ADR 0005), so the fill
+    // event is the one-per-take invariant.
     let all_trades: Vec<&StoredEvent> = events
         .iter()
-        .filter(|event| event.aggregate_type == "OnChainTrade")
+        .filter(|event| event.event_type == "OnChainTradeEvent::Filled")
         .collect();
 
     assert_eq!(
         all_trades.len(),
         expected_count,
-        "Expected exactly {expected_count} OnChainTrade events, got {}",
+        "Expected exactly {expected_count} witnessed OnChainTrade fills, got {}",
         all_trades.len(),
     );
 

--- a/tests/e2e/chaos_load.rs
+++ b/tests/e2e/chaos_load.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use crate::chaos::ChaosProxy;
 use crate::hedging::assertions::*;
 use crate::poll::{
-    connect_db, count_events_by_type, poll_for_all_jobs_done, poll_for_broker_fills,
+    connect_db, count_events_of_type, poll_for_all_jobs_done, poll_for_broker_fills,
     poll_for_events, spawn_bot,
 };
 
@@ -49,12 +49,14 @@ async fn assert_no_stuck_offchain_orders(db_path: &std::path::Path) -> anyhow::R
     Ok(())
 }
 
-/// Counts witnessed onchain trades; under bursts every assertion on
-/// effects must use exact aggregate counts, never broker order counts
-/// (trades legitimately batch into fewer orders).
+/// Counts witnessed onchain fills; under bursts every assertion on
+/// effects must use exact event counts, never broker order counts
+/// (trades legitimately batch into fewer orders). Counts the `Filled`
+/// event specifically -- each trade also carries an `Acknowledged`
+/// marker (ADR 0005).
 async fn assert_witnessed_trades(db_path: &std::path::Path, expected: i64) -> anyhow::Result<()> {
     let pool = connect_db(db_path).await?;
-    let witnessed = count_events_by_type(&pool, "OnChainTradeEvent::Filled").await?;
+    let witnessed = count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?;
     pool.close().await;
 
     assert_eq!(

--- a/tests/e2e/hedging.rs
+++ b/tests/e2e/hedging.rs
@@ -380,6 +380,9 @@ async fn resumption_after_shutdown() -> anyhow::Result<()> {
     bot.abort();
     let _ = bot.await;
 
+    // Each processed trade persists Filled + Acknowledged (ADR 0005).
+    const ONCHAIN_EVENTS_PER_TRADE: i64 = 2;
+
     // Phase 2: Execute 1 more take-order while bot is down
     let take2 = infra
         .base_chain
@@ -409,8 +412,8 @@ async fn resumption_after_shutdown() -> anyhow::Result<()> {
     let post_restart_offchain_events = count_events(&pool, "OffchainOrder").await?;
     assert_eq!(
         post_restart_onchain_events,
-        pre_shutdown_onchain_events + 1,
-        "Restart should persist exactly one new OnChainTrade event",
+        pre_shutdown_onchain_events + ONCHAIN_EVENTS_PER_TRADE,
+        "Restart should persist exactly one new witnessed-and-acknowledged trade",
     );
     assert_eq!(
         post_restart_position_events,
@@ -744,10 +747,11 @@ async fn market_hours_transitions() -> anyhow::Result<()> {
         "No offchain order events should be emitted when market is closed"
     );
 
-    let onchain_events = count_events(&pool, "OnChainTrade").await?;
+    let onchain_fills =
+        crate::poll::count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?;
     assert_eq!(
-        onchain_events, 1,
-        "Exactly one OnChainTrade event should be persisted while market is closed"
+        onchain_fills, 1,
+        "Exactly one witnessed fill should be persisted while market is closed"
     );
     pool.close().await;
 

--- a/tests/e2e/poll.rs
+++ b/tests/e2e/poll.rs
@@ -534,12 +534,11 @@ pub async fn count_events(pool: &SqlitePool, aggregate_type: &str) -> anyhow::Re
     Ok(row.0)
 }
 
-/// Counts CQRS events of a specific event type (e.g. `OnChainTradeEvent::Filled`),
-/// not the whole aggregate. Use this when an aggregate emits more than one event
-/// variant and only one of them should be counted -- `OnChainTrade`, for
-/// instance, emits both `Filled` and `Enriched`, so an aggregate-type count
-/// double-counts once enrichment fires.
-pub async fn count_events_by_type(pool: &SqlitePool, event_type: &str) -> anyhow::Result<i64> {
+/// Counts CQRS events of a specific event type (e.g.
+/// "OnChainTradeEvent::Filled"). Use this instead of [`count_events`]
+/// when the invariant is one-event-per-action and the aggregate also
+/// emits bookkeeping events (enrichment, acknowledgement markers).
+pub async fn count_events_of_type(pool: &SqlitePool, event_type: &str) -> anyhow::Result<i64> {
     let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE event_type = ?")
         .bind(event_type)
         .fetch_one(pool)


### PR DESCRIPTION
## What

Closes RAI-967. Makes fill accounting exactly-once across the witness/acknowledge boundary by adding an acknowledgement marker to the `OnChainTrade` aggregate so the pipeline distinguishes a witnessed fill from a fully accounted one.

## Why

A fill witnessed but not yet acknowledged was permanently lost on job re-delivery: the dedupe treated "witnessed" as "done", so the resume path skipped the unaccounted trade and the hedge never ran.

## How

- Acknowledgement marker on `OnChainTrade` lets dedupe tell "witnessed" apart from "fully accounted".
- `process_queued_trade` re-drives the acknowledge step on resume instead of skipping a witnessed-but-unacknowledged trade.
- Acknowledge-step command errors propagate so apalis retries rather than marking the fill Done; `Position` rejects duplicate trade ids so the resume path cannot double-count.
- A fill missing its `block_timestamp` now fails the accounting job loudly (retryable `MissingBlockTimestamp` error) instead of completing the job and silently dropping the fill.

## Testing

- Integration tests reproduce job re-delivery at the witness/acknowledge boundary and assert the fill is acknowledged exactly once.
- Position-level coverage asserts duplicate trade ids are rejected.
- A unit test asserts `process_queued_trade` rejects a fill with no `block_timestamp` rather than dropping it.

## Anything else

Implements the design accepted in ADR 0005; parent RAI-964.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic acknowledgment tracking for on-chain trades with crash-resumable workflow recovery.

* **Bug Fixes**
  * Enhanced trade processing idempotency to prevent duplicate fills when trades are retried or redelivered.
  * Improved system resilience during unexpected shutdowns and interruptions in the trade settlement workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->