### PR TITLE
ci: use Tailscale OAuth client for deploy auth

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -61,7 +61,9 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Resolve deploy host via Tailscale
         run: |

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -48,7 +48,9 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
         with:
-          authkey: ${{ secrets.TS_AUTHKEY }}
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
       - name: Resolve deploy host via Tailscale
         run: |


### PR DESCRIPTION
## What

- [RAI-1016](https://linear.app/makeitrain/issue/RAI-1016/migrate-ci-tailscale-auth-from-static-auth-key-to-oauth-client) — authenticate CI deploys to the tailnet via a Tailscale OAuth client instead of a static auth key.
- `deploy-prod.yaml` and `deploy-staging.yaml`: the `Connect to Tailscale` step now passes `oauth-client-id` + `oauth-secret` + `tags: tag:ci` in place of `authkey`.

## Why

- CI deploy jobs authenticated the ephemeral runner onto the tailnet with a static Tailscale auth key (`secrets.TS_AUTHKEY`). Auth keys expire (max 90 days); when the current one lapsed, the `Connect to Tailscale` step failed with `backend error: invalid key: API key does not exist`, blocking deploys entirely.
- `tailscale/github-action` deprecates `authkey` in favour of an OAuth client, which mints a short-lived auth key per run and does not expire on the 90-day clock — removing this recurring breakage.

## How

- Replace `authkey: ${{ secrets.TS_AUTHKEY }}` with `oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}`, `oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}`, and `tags: tag:ci` in both workflows. Input names verified against `tailscale/github-action@v4`'s `action.yml`.
- `tags` is required under OAuth: the per-run minted key has no user association, so the node must be tagged.

## Testing

No automated tests — this is a GitHub Actions workflow change. `yamlfmt` passes via pre-commit. The path can't be exercised in CI without the live OAuth secrets; verified that `grep -rn TS_AUTHKEY` and `grep -rn 'authkey:' .github/` both return nothing.

## Anything else

**Out-of-band prerequisites — required before deploys succeed (the code change alone leaves deploys red until these are done):**

- Ensure `tag:ci` exists in the Tailscale ACL policy and is granted access to the prod and staging deploy hosts, then create an OAuth client (scope `auth_keys`) tagged `tag:ci`.
- Add `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` to the GitHub `production` and `staging` Environment secrets (the deploy jobs run under `environment: production` / `environment: staging`).
- Delete the stale `TS_AUTHKEY` secret after the first successful deploy.
