### PR TITLE
fix: gate AlpacaToBase CCTP burn on on-chain USDC settlement

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2066,6 +2066,15 @@ Alpaca to Base:
 2. Poll Alpaca until conversion order is filled
 3. Initiate USDC withdrawal from Alpaca (get transfer_id)
 4. Poll Alpaca API until withdrawal status is COMPLETE
+   - **Settlement gate (before proceeding):** verify that the withdrawn USDC is
+     confirmed present in the market-maker Ethereum wallet. Wait for the
+     withdrawal tx to reach the required confirmations on Ethereum (primary
+     gate), then re-check the balance at the entry of the burn step (fallback
+     gate). Alpaca marks a withdrawal "Complete" before the on-chain tx is
+     settled network-wide on load-balanced RPC nodes; burning against an
+     unconfirmed balance causes an ERC20 transfer-exceeds-balance revert. Both
+     gates are retryable: a transient "not yet settled" returns a retriable
+     error without advancing the aggregate.
 5. Query Circle's `/v2/burn/USDC/fees` API for current fast transfer fee
 6. Submit depositForBurn() tx on Ethereum TokenMessenger (domain 0 -> domain 6)
    with minFinalityThreshold=1000 and calculated maxFee for fast transfer

--- a/crates/bridge/src/cctp/evm.rs
+++ b/crates/bridge/src/cctp/evm.rs
@@ -142,7 +142,9 @@ impl<W: Wallet> CctpEndpoint<W> {
             .iter()
             .any(|log| MessageTransmitterV2::MessageSent::decode_log(log.as_ref()).is_ok())
         {
-            return Err(CctpError::MessageSentEventNotFound);
+            return Err(CctpError::MessageSentEventNotFound {
+                tx_hash: receipt.transaction_hash,
+            });
         }
 
         Ok(crate::BurnReceipt {
@@ -289,6 +291,34 @@ impl<W: Wallet> CctpEndpoint<W> {
         receipt
             .block_number
             .ok_or(CctpError::TxReceiptMissingBlock { tx_hash })
+    }
+
+    /// Returns the number of confirmations `tx_hash` has on this endpoint's
+    /// chain, or `None` if the transaction is not yet mined.
+    ///
+    /// Confirmations = (current head block) - (block the tx landed in) + 1.
+    /// A tx in the current head has 1 confirmation (the inclusion block counts),
+    /// matching the `required_confirmations` contract used across the codebase
+    /// (alloy's `with_required_confirmations`, the e2e settlement helper). Used to
+    /// gate operations on on-chain settlement without blocking -- the caller
+    /// decides whether to retry if confirmations are insufficient.
+    pub(super) async fn tx_confirmations(&self, tx_hash: TxHash) -> Result<Option<u64>, CctpError> {
+        let Some(receipt) = self
+            .wallet
+            .provider()
+            .get_transaction_receipt(tx_hash)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(tx_block) = receipt.block_number else {
+            return Ok(None);
+        };
+
+        let head = self.wallet.provider().get_block_number().await?;
+
+        Ok(Some(head.saturating_sub(tx_block).saturating_add(1)))
     }
 
     /// Sends `amount` of this endpoint's USDC from the wallet to `to`, waiting

--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -384,8 +384,8 @@ pub enum CctpError {
     /// bridge failure rather than retried to the deadline.
     #[error("malformed complete attestation: {source}")]
     MalformedAttestation { source: AttestationError },
-    #[error("MessageSent event not found in transaction receipt")]
-    MessageSentEventNotFound,
+    #[error("MessageSent event not found in burn receipt {tx_hash}")]
+    MessageSentEventNotFound { tx_hash: TxHash },
     #[error("MintAndWithdraw event not found in transaction receipt")]
     MintAndWithdrawEventNotFound,
     #[error("transaction {tx_hash} receipt has no block number")]
@@ -831,6 +831,36 @@ impl<EthWallet: Wallet, BaseWallet: Wallet> CctpBridge<EthWallet, BaseWallet> {
             .await
     }
 
+    /// Returns `holder`'s USDC balance on Ethereum, the source chain for
+    /// AlpacaToBase burns.
+    ///
+    /// Used as a fallback settlement gate before executing the CCTP burn:
+    /// verifies that withdrawn USDC is present in the market-maker wallet
+    /// before attempting to burn it. Delegates to the Ethereum endpoint,
+    /// not Base.
+    pub async fn ethereum_usdc_balance(&self, holder: Address) -> Result<U256, CctpError> {
+        self.ethereum
+            .usdc_balance::<OpenChainErrorRegistry>(holder)
+            .await
+    }
+
+    /// Returns the number of confirmations `tx_hash` has on Ethereum, or `None`
+    /// if the transaction is not yet mined.
+    ///
+    /// Used to gate the AlpacaToBase CCTP burn on the Alpaca withdrawal tx
+    /// being settled on Ethereum: Alpaca reports "Complete" before the
+    /// on-chain tx is visible network-wide on load-balanced nodes, so waiting
+    /// for the required confirmations prevents burning against a balance
+    /// that only exists on a lagging node. The returned count follows the
+    /// repo-wide `required_confirmations` contract: the inclusion block counts
+    /// as confirmation 1 (so a mined-in-head tx returns 1, not 0).
+    pub async fn ethereum_tx_confirmations(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<u64>, CctpError> {
+        self.ethereum.tx_confirmations(tx_hash).await
+    }
+
     /// Returns the block in which `tx_hash` was mined on Ethereum, the chain
     /// where BaseToEthereum mints land.
     ///
@@ -995,6 +1025,13 @@ where
             BridgeDirection::BaseToEthereum => self.ethereum.current_block().await,
         }
     }
+
+    async fn source_block(&self, direction: BridgeDirection) -> Result<u64, Self::Error> {
+        match direction {
+            BridgeDirection::EthereumToBase => self.ethereum.current_block().await,
+            BridgeDirection::BaseToEthereum => self.base.current_block().await,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1003,6 +1040,7 @@ mod tests {
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::address;
     use alloy::primitives::{B256, b256, keccak256};
+    use alloy::providers::ext::AnvilApi as _;
     use alloy::providers::{Provider, ProviderBuilder};
     use alloy::signers::Signer;
     use alloy::signers::local::PrivateKeySigner;
@@ -3625,6 +3663,208 @@ mod tests {
                 .unwrap(),
             None,
             "a burn from a different depositor must not be adopted",
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // ethereum_usdc_balance and ethereum_tx_confirmations delegation tests
+    // -------------------------------------------------------------------------
+
+    /// Hypothesis: ethereum_usdc_balance reads from the Ethereum endpoint, not
+    /// Base. Deploy USDC on one chain but not the other; the call must succeed
+    /// on the one that has the contract (Ethereum) and reflect the minted amount.
+    #[tokio::test]
+    async fn ethereum_usdc_balance_reads_from_ethereum_endpoint() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        // Deploy USDC only on the Ethereum endpoint.
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap();
+
+        let holder = PrivateKeySigner::from_bytes(&private_key)
+            .unwrap()
+            .address();
+
+        let balance = bridge.ethereum_usdc_balance(holder).await.unwrap();
+
+        // deploy_mock_usdc mints 1_000_000_000_000 to the deployer.
+        assert_eq!(
+            balance,
+            U256::from(1_000_000_000_000u64),
+            "ethereum_usdc_balance must return the Ethereum USDC balance, not Base"
+        );
+    }
+
+    /// Hypothesis: ethereum_tx_confirmations returns None for a tx hash that
+    /// does not exist on-chain (unmined).
+    #[tokio::test]
+    async fn ethereum_tx_confirmations_returns_none_for_unmined_tx() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            USDC_ETHEREUM,
+        )
+        .await
+        .unwrap();
+
+        let nonexistent_tx =
+            b256!("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+        let result = bridge
+            .ethereum_tx_confirmations(nonexistent_tx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result, None,
+            "ethereum_tx_confirmations must return None for an unmined tx"
+        );
+    }
+
+    /// Hypothesis: ethereum_tx_confirmations returns Some(N) where N >= 1 after
+    /// mining a tx and advancing the chain head.
+    #[tokio::test]
+    async fn ethereum_tx_confirmations_counts_confirmations_correctly() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap();
+
+        let signer = PrivateKeySigner::from_bytes(&private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer.clone()))
+            .connect(&ethereum_endpoint)
+            .await
+            .unwrap();
+        let token = MockMintBurnToken::new(usdc_address, &provider);
+
+        // Mine a tx (mint to self) so we have a real tx hash.
+        let receipt = token
+            .mint(signer.address(), U256::from(1u64))
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        let tx_hash = receipt.transaction_hash;
+
+        // Immediately after mining: 1 confirmation (the inclusion block counts).
+        let confs_immediate = bridge
+            .ethereum_tx_confirmations(tx_hash)
+            .await
+            .unwrap()
+            .expect("tx is mined");
+
+        assert_eq!(
+            confs_immediate, 1,
+            "tx in the current head has 1 confirmation (inclusion block counts)"
+        );
+
+        // After 2 more blocks: 3 confirmations (inclusion block + 2).
+        provider.anvil_mine(Some(2), None).await.unwrap();
+
+        let confs_after_2 = bridge
+            .ethereum_tx_confirmations(tx_hash)
+            .await
+            .unwrap()
+            .expect("tx is still mined");
+
+        assert_eq!(
+            confs_after_2, 3,
+            "tx has 3 confirmations after 2 blocks mined (inclusion block + 2)"
+        );
+    }
+
+    /// Hypothesis: deposit_for_burn (via burn()) returns
+    /// CctpError::MessageSentEventNotFound when the token messenger accepts the
+    /// call and mines a receipt (tx succeeds) but emits no MessageSent log.
+    ///
+    /// This is the post-commit error class: the burn tx IS on-chain. Callers
+    /// must NOT retry the burn on this error -- they must surface it for
+    /// operator reconciliation.
+    #[tokio::test]
+    async fn burn_returns_message_sent_event_not_found_when_receipt_has_no_event() {
+        let (_ethereum_anvil, ethereum_endpoint, private_key) = setup_anvil();
+        let (_base_anvil, base_endpoint, _) = setup_anvil();
+
+        // Deploy real USDC so ensure_usdc_approval succeeds.
+        let usdc_address = deploy_mock_usdc(&ethereum_endpoint, &private_key)
+            .await
+            .unwrap();
+
+        // Place a STOP-only contract at the TokenMessenger address: any call to
+        // it succeeds (receipt status = 1) with empty return data and no events,
+        // triggering MessageSentEventNotFound after the receipt is confirmed.
+        let stop_bytecode = alloy::primitives::Bytes::from(vec![0x00u8]);
+        let no_wallet_provider = ProviderBuilder::new()
+            .connect(&ethereum_endpoint)
+            .await
+            .unwrap();
+        no_wallet_provider
+            .anvil_set_code(TOKEN_MESSENGER_V2, stop_bytecode)
+            .await
+            .unwrap();
+
+        // Mock the Circle fee endpoint so burn() can proceed past query_fast_transfer_fee.
+        let fee_server = MockServer::start();
+        fee_server.mock(|when, then| {
+            when.method(GET).path_includes("/v2/burn/USDC/fees/");
+            then.status(200).json_body(serde_json::json!([
+                {"finalityThreshold": 1000, "minimumFee": 1},
+                {"finalityThreshold": 2000, "minimumFee": 0}
+            ]));
+        });
+
+        let bridge = create_bridge(
+            &ethereum_endpoint,
+            &base_endpoint,
+            &private_key,
+            usdc_address,
+        )
+        .await
+        .unwrap()
+        .with_circle_api_base(fee_server.base_url());
+
+        let signer = PrivateKeySigner::from_bytes(&private_key).unwrap();
+        let recipient = signer.address();
+        let amount = U256::from(1_000u64);
+
+        let error = Bridge::burn(&bridge, BridgeDirection::EthereumToBase, amount, recipient)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, CctpError::MessageSentEventNotFound { .. }),
+            "burn must return MessageSentEventNotFound when the receipt has no \
+             MessageSent event (post-commit error); got: {error:?}"
         );
     }
 }

--- a/crates/bridge/src/cctp/test_contracts.rs
+++ b/crates/bridge/src/cctp/test_contracts.rs
@@ -5,7 +5,7 @@
 //! testing the full USDC bridge pipeline without forking mainnet.
 
 use alloy::network::EthereumWallet;
-use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, TxHash, U256};
 use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
@@ -319,7 +319,7 @@ pub async fn mint_usdc(
     usdc: Address,
     to: Address,
     amount: U256,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<TxHash> {
     let signer = PrivateKeySigner::from_bytes(deployer_key)?;
     let wallet = EthereumWallet::from(signer);
     let provider = ProviderBuilder::new()
@@ -328,7 +328,7 @@ pub async fn mint_usdc(
         .await?;
 
     let token = MockMintBurnToken::new(usdc, &provider);
-    token.mint(to, amount).send().await?.get_receipt().await?;
+    let receipt = token.mint(to, amount).send().await?.get_receipt().await?;
 
-    Ok(())
+    Ok(receipt.transaction_hash)
 }

--- a/crates/bridge/src/lib.rs
+++ b/crates/bridge/src/lib.rs
@@ -129,4 +129,10 @@ pub trait Bridge: Send + Sync + 'static {
     /// crash-safe resume scan in [`Bridge::find_recent_mint`] is bounded to
     /// blocks mined strictly after it.
     async fn destination_block(&self, direction: BridgeDirection) -> Result<u64, Self::Error>;
+
+    /// Returns the current head of the burn source chain for `direction`.
+    /// Captured before the burn call so crash-safe resume ([`Bridge::find_recent_burn`])
+    /// has a lower-bound block. For `BaseToEthereum` this is Base chain head;
+    /// for `EthereumToBase` this is Ethereum chain head.
+    async fn source_block(&self, direction: BridgeDirection) -> Result<u64, Self::Error>;
 }

--- a/crates/execution/src/alpaca_broker_api/mock_api.rs
+++ b/crates/execution/src/alpaca_broker_api/mock_api.rs
@@ -465,6 +465,18 @@ impl AlpacaBrokerMock {
             .collect()
     }
 
+    /// Records the on-chain tx hash for an outgoing wallet transfer by
+    /// transfer_id. Used by test infrastructure to inject the real Ethereum
+    /// mint tx hash so the bot's withdrawal-confirmation check can verify it.
+    pub fn set_transfer_tx_hash(&self, transfer_id: &str, tx_hash_hex: String) {
+        lock(&self.state)
+            .wallet_transfers
+            .iter_mut()
+            .find(|transfer| transfer.transfer_id == transfer_id)
+            .unwrap_or_else(|| panic!("set_transfer_tx_hash: no transfer with id {transfer_id}"))
+            .tx_hash = tx_hash_hex;
+    }
+
     /// Returns a snapshot of all current positions.
     pub fn positions(&self) -> Vec<MockPositionSnapshot> {
         let state = lock(&self.state);

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -29,8 +29,7 @@ use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, Equity, EquityTransferServices};
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::transfer::{CrossVenueTransfer, HedgingVenue, MarketMakingVenue};
-use crate::rebalancing::usdc::CrossVenueCashTransfer;
-use crate::rebalancing::usdc::UsdcTransferError;
+use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};
 use crate::tokenization::{
     AlpacaTokenizationService, TokenizationRequest, TokenizationRequestStatus, Tokenizer,
 };
@@ -186,12 +185,18 @@ pub(super) async fn transfer_equity_command<Writer: Write>(
 /// not yet ready. Mirrors the apalis job's redrive cadence.
 const CLI_ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 
-/// Drives a manual USDC transfer to a terminal outcome, redriving on attestation
-/// timeouts so a single CLI invocation cannot strand after the burn.
+/// Drives a manual USDC transfer to a terminal outcome, redriving on the same
+/// retryable waits the apalis worker delayed-redrives -- Circle attestation
+/// timeouts and the AlpacaToBase on-chain settlement gate -- so a single CLI
+/// invocation cannot strand after the burn (or before it, during settlement
+/// lag).
 ///
 /// `resume` is re-invoked with the same `UsdcRebalanceId` on every attempt, so a
-/// timeout resumes the already-burned transfer instead of starting a second
-/// fund-moving one. Any non-timeout error -- including
+/// retry resumes the existing transfer instead of starting a second
+/// fund-moving one. The retryable set mirrors the worker:
+/// `AttestationTimedOut` plus the settlement-wait errors
+/// (`WithdrawalTxUnderconfirmed`, `WalletUsdcInsufficient`,
+/// `SettlementCheckTransient`). Any other error -- including
 /// `AttestationRetryDeadlineElapsed` and a previously-failed aggregate -- is
 /// terminal and returned to the caller.
 async fn redrive_transfer_until_settled<Resume, Fut>(
@@ -211,6 +216,20 @@ where
                     %id,
                     ?redrive_delay,
                     "Circle attestation not ready for manual USDC transfer; retrying after delay"
+                );
+                tokio::time::sleep(redrive_delay).await;
+            }
+            Err(
+                UsdcTransferError::WithdrawalTxUnderconfirmed { id, .. }
+                | UsdcTransferError::WalletUsdcInsufficient { id, .. }
+                | UsdcTransferError::SettlementCheckTransient { id, .. },
+            ) => {
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    ?redrive_delay,
+                    "USDC transfer settlement not yet durable for manual transfer; \
+                     retrying after delay"
                 );
                 tokio::time::sleep(redrive_delay).await;
             }
@@ -417,7 +436,7 @@ async fn run_usdc_transfer<Writer: Write>(
         owner,
     ));
 
-    let attestation_retry_deadline = ctx.rebalancing_ctx()?.attestation_retry_deadline;
+    let rebalancing_ctx = ctx.rebalancing_ctx()?;
 
     let rebalance_manager = CrossVenueCashTransfer::new(
         alpaca_broker,
@@ -427,7 +446,16 @@ async fn run_usdc_transfer<Writer: Write>(
         usdc_store,
         owner,
         RaindexVaultId(usdc_vault_id),
-        attestation_retry_deadline,
+        &UsdcSettlementParams {
+            attestation_retry_deadline: rebalancing_ctx.attestation_retry_deadline,
+            required_confirmations: ctx.evm.required_confirmations,
+            #[cfg(feature = "test-support")]
+            circle_api_base: rebalancing_ctx.circle_api_base.clone(),
+            #[cfg(feature = "test-support")]
+            token_messenger: rebalancing_ctx.token_messenger,
+            #[cfg(feature = "test-support")]
+            message_transmitter: rebalancing_ctx.message_transmitter,
+        },
     );
 
     writeln!(stdout, "   Transfer may take several minutes...")?;
@@ -1016,6 +1044,41 @@ mod tests {
             calls.get(),
             2,
             "the loop must retry exactly once after the timeout, then succeed",
+        );
+    }
+
+    /// The manual redrive loop must also retry the on-chain settlement-wait
+    /// errors the apalis worker delayed-redrives -- otherwise a manual transfer
+    /// would exit on normal settlement lag instead of continuing to completion.
+    #[tokio::test]
+    async fn redrive_loop_retries_settlement_wait_then_succeeds() {
+        let calls = std::cell::Cell::new(0u32);
+
+        let result = redrive_transfer_until_settled(Duration::from_millis(0), || {
+            let attempt = calls.get() + 1;
+            calls.set(attempt);
+            async move {
+                if attempt == 1 {
+                    Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                        id: UsdcRebalanceId(Uuid::from_u128(9)),
+                        tx: b256!(
+                            "0x0000000000000000000000000000000000000000000000000000000000000001"
+                        ),
+                        required: 3,
+                        actual: 1,
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        result.expect("redrive must succeed once the withdrawal tx settles");
+        assert_eq!(
+            calls.get(),
+            2,
+            "the loop must retry exactly once after the settlement wait, then succeed",
         );
     }
 

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -62,7 +62,9 @@ use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeId};
 use crate::position::{Position, PositionCommand, TradeId};
 use crate::position_check::{CheckPositionsJobQueue, bootstrap_check_positions};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
-use crate::rebalancing::usdc::{TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx};
+use crate::rebalancing::usdc::{
+    TransferUsdcToHedgingCtx, TransferUsdcToMarketMakingCtx, UsdcSettlementParams,
+};
 use crate::rebalancing::{
     RebalancerServices, RebalancingCqrsFrameworks, RebalancingSchedulers, RebalancingService,
     RebalancingServiceConfig, to_wrapped_equities,
@@ -1126,7 +1128,6 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         ));
 
         let services = RebalancerServices::new(
-            rebalancing_ctx.clone(),
             alpaca_auth.clone(),
             Arc::clone(&alpaca_wallet),
             deps.ctx.assets.equities.symbols.clone(),
@@ -1134,6 +1135,16 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             base_wallet,
             raindex_service,
             Arc::clone(&tokenizer),
+            UsdcSettlementParams {
+                attestation_retry_deadline: rebalancing_ctx.attestation_retry_deadline,
+                required_confirmations: deps.ctx.evm.required_confirmations,
+                #[cfg(feature = "test-support")]
+                circle_api_base: rebalancing_ctx.circle_api_base.clone(),
+                #[cfg(feature = "test-support")]
+                token_messenger: rebalancing_ctx.token_messenger,
+                #[cfg(feature = "test-support")]
+                message_transmitter: rebalancing_ctx.message_transmitter,
+            },
         )
         .await?;
 

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -3,14 +3,13 @@
 use alloy::primitives::Address;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx, CctpError};
-use st0x_config::{EquityAssetConfig, RebalancingCtx};
+use st0x_config::EquityAssetConfig;
 use st0x_event_sorcery::Store;
 use st0x_evm::Wallet;
 use st0x_execution::{
@@ -20,7 +19,9 @@ use st0x_raindex::{RaindexService, RaindexVaultId};
 use st0x_wrapper::{WrappedEquity, WrapperService};
 
 use super::equity::CrossVenueEquityTransfer;
-use super::usdc::{CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca};
+use super::usdc::{
+    CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca, UsdcSettlementParams,
+};
 use super::{Rebalancer, TriggeredOperation};
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::equity_redemption::EquityRedemption;
@@ -88,7 +89,7 @@ pub(crate) struct RebalancerServices<Chain: Wallet> {
     raindex: Arc<RaindexService<Chain>>,
     tokenizer: Arc<dyn Tokenizer>,
     wrapper: Arc<WrapperService<Chain>>,
-    attestation_retry_deadline: Duration,
+    settlement: UsdcSettlementParams,
 }
 
 impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
@@ -98,7 +99,6 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
     /// needed for CQRS framework initialization in the conductor, which
     /// must happen before this constructor is called.
     pub(crate) async fn new(
-        ctx: RebalancingCtx,
         broker_auth: AlpacaBrokerApiCtx,
         wallet: Arc<AlpacaWalletService>,
         equities: HashMap<Symbol, EquityAssetConfig>,
@@ -106,9 +106,9 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
         base_wallet: Chain,
         raindex: Arc<RaindexService<Chain>>,
         tokenizer: Arc<dyn Tokenizer>,
+        settlement: UsdcSettlementParams,
     ) -> Result<Self, SpawnRebalancerError> {
         let broker = Arc::new(AlpacaBrokerApi::try_from_ctx(broker_auth).await?);
-        let attestation_retry_deadline = ctx.attestation_retry_deadline;
 
         let cctp = Arc::new(
             CctpBridge::try_from_ctx(CctpCtx {
@@ -117,11 +117,11 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
                 ethereum_wallet,
                 base_wallet: base_wallet.clone(),
                 #[cfg(feature = "test-support")]
-                circle_api_base: ctx.circle_api_base.clone(),
+                circle_api_base: settlement.circle_api_base.clone(),
                 #[cfg(feature = "test-support")]
-                token_messenger: ctx.token_messenger,
+                token_messenger: settlement.token_messenger,
                 #[cfg(feature = "test-support")]
-                message_transmitter: ctx.message_transmitter,
+                message_transmitter: settlement.message_transmitter,
             })
             .map_err(|error| SpawnRebalancerError::Cctp(Box::new(error)))?,
         );
@@ -138,7 +138,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             raindex,
             tokenizer,
             wrapper,
-            attestation_retry_deadline,
+            settlement,
         })
     }
 
@@ -174,7 +174,7 @@ impl<Chain: Wallet + Clone> RebalancerServices<Chain> {
             frameworks.usdc,
             market_maker_wallet,
             usdc_vault_id,
-            self.attestation_retry_deadline,
+            &self.settlement,
         ));
 
         let resume_base_to_alpaca: Arc<dyn ResumeBaseToAlpaca> = usdc.clone();
@@ -220,12 +220,15 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use uuid::Uuid;
 
+    use st0x_config::{AssetsConfig, EquitiesConfig, OperationMode, RebalancingCtx};
     use st0x_event_sorcery::test_store;
     use st0x_evm::local::RawPrivateKeyWallet;
     use st0x_execution::{
         AlpacaAccountId, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, FractionalShares, Symbol,
         TimeInForce,
     };
+    use st0x_float_macro::float;
+    use st0x_wrapper::{MockWrapper, WrappedEquity};
 
     use super::*;
     use crate::alpaca_wallet::AlpacaWalletService;
@@ -233,12 +236,10 @@ mod tests {
     use crate::onchain::mock::MockRaindex;
     use crate::rebalancing::RebalancingServiceConfig;
     use crate::rebalancing::equity::EquityTransferServices;
+    use crate::rebalancing::usdc::UsdcSettlementParams;
     use crate::tokenization::alpaca::AlpacaTokenizationService;
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
-    use st0x_config::{AssetsConfig, EquitiesConfig, OperationMode};
-    use st0x_float_macro::float;
-    use st0x_wrapper::{MockWrapper, WrappedEquity};
 
     #[test]
     fn to_wrapped_equities_maps_underlying_and_derivative() {
@@ -425,7 +426,16 @@ mod tests {
             raindex,
             tokenizer: tokenization,
             wrapper,
-            attestation_retry_deadline: rebalancing_ctx.attestation_retry_deadline,
+            settlement: UsdcSettlementParams {
+                attestation_retry_deadline: rebalancing_ctx.attestation_retry_deadline,
+                required_confirmations: 0,
+                #[cfg(feature = "test-support")]
+                circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+                #[cfg(feature = "test-support")]
+                token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+                #[cfg(feature = "test-support")]
+                message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+            },
         };
 
         (services, rebalancing_ctx)

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -8424,7 +8424,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -8948,6 +8953,7 @@ mod tests {
     fn make_usdc_withdrawal_confirmed() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::WithdrawalConfirmed {
             confirmed_at: Utc::now(),
+            withdrawal_tx: None,
         }
     }
 
@@ -9892,7 +9898,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -9948,7 +9959,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -9987,7 +10003,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -10024,7 +10045,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -10482,7 +10508,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -11042,7 +11073,12 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -11130,7 +11166,12 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -11257,7 +11298,12 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
 
@@ -11429,7 +11475,12 @@ mod tests {
             .unwrap();
 
         store
-            .send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
 

--- a/src/rebalancing/trigger/usdc.rs
+++ b/src/rebalancing/trigger/usdc.rs
@@ -194,7 +194,7 @@ impl UsdcRebalanceStage {
                 Some(*converted_at)
             }
             (Self::Initiated, Initiated { initiated_at, .. }) => Some(*initiated_at),
-            (Self::WithdrawalConfirmed, WithdrawalConfirmed { confirmed_at }) => {
+            (Self::WithdrawalConfirmed, WithdrawalConfirmed { confirmed_at, .. }) => {
                 Some(*confirmed_at)
             }
             (Self::BridgingInitiated, BridgingInitiated { burned_at, .. }) => Some(*burned_at),
@@ -1747,6 +1747,7 @@ mod tests {
     fn withdrawal_confirmed_event() -> UsdcRebalanceEvent {
         UsdcRebalanceEvent::WithdrawalConfirmed {
             confirmed_at: ts(103),
+            withdrawal_tx: None,
         }
     }
 

--- a/src/rebalancing/usdc/job.rs
+++ b/src/rebalancing/usdc/job.rs
@@ -34,6 +34,13 @@ use crate::usdc_rebalance::UsdcRebalanceId;
 
 const ATTESTATION_REDRIVE_DELAY: Duration = Duration::from_secs(60);
 
+/// Delay before re-enqueueing an Alpaca->Base job when on-chain settlement has
+/// not yet completed. Two to three Ethereum block times (~30 s total) is enough
+/// to give a lagging RPC node time to catch up after Alpaca marks the
+/// withdrawal "Complete", while keeping the redrive cadence tight enough to
+/// avoid materially delaying the transfer.
+const SETTLEMENT_REDRIVE_DELAY: Duration = Duration::from_secs(30);
+
 /// Apalis queue type for [`TransferUsdcToHedging`].
 pub(crate) type TransferUsdcToHedgingJobQueue = JobQueue<TransferUsdcToHedging>;
 
@@ -250,6 +257,48 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
                     .push_with_delay(self.clone(), ATTESTATION_REDRIVE_DELAY)
                     .await?;
             }
+            // Settlement-wait errors: the withdrawal tx has not yet reached the
+            // required on-chain confirmation depth, the Ethereum wallet has not yet
+            // received the withdrawn USDC, or an RPC call in the settlement phase
+            // (confirmation re-check, balance read, or burn scan) failed
+            // transiently. These are all safe to delayed-redrive because the
+            // aggregate is in a durable state (WithdrawalComplete or
+            // BridgingSubmitting) -- they must NOT consume apalis retry budget
+            // (only 3 retries, ~7 s total). Re-enqueue with
+            // SETTLEMENT_REDRIVE_DELAY and return Ok so this attempt completes
+            // cleanly; the delayed job resumes once settlement is likely complete.
+            Err(
+                ref settlement_err @ (UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    ref id, ..
+                }
+                | UsdcTransferError::WalletUsdcInsufficient { ref id, .. }
+                | UsdcTransferError::SettlementCheckTransient { ref id, .. }),
+            ) => {
+                let reason = match settlement_err {
+                    UsdcTransferError::WithdrawalTxUnderconfirmed { .. } => {
+                        "withdrawal tx not yet sufficiently confirmed"
+                    }
+                    UsdcTransferError::WalletUsdcInsufficient { .. } => {
+                        "market-maker wallet has insufficient USDC (withdrawal not yet settled)"
+                    }
+                    UsdcTransferError::SettlementCheckTransient { .. } => {
+                        "settlement-phase RPC check failed transiently"
+                    }
+                    // The outer or-pattern matches only the three variants above.
+                    // This arm is unreachable; it exists only to satisfy exhaustiveness.
+                    _ => unreachable!("outer or-pattern limits to settlement variants"),
+                };
+                warn!(
+                    target: "rebalance",
+                    %id,
+                    delay = ?SETTLEMENT_REDRIVE_DELAY,
+                    "Rescheduling Alpaca->Base USDC transfer: {reason}"
+                );
+                let mut job_queue = ctx.job_queue.clone();
+                job_queue
+                    .push_with_delay(self.clone(), SETTLEMENT_REDRIVE_DELAY)
+                    .await?;
+            }
             Err(UsdcTransferError::AttestationRetryDeadlineElapsed { id }) => {
                 warn!(
                     target: "rebalance",
@@ -275,6 +324,7 @@ impl Job<TransferUsdcToMarketMakingCtx> for TransferUsdcToMarketMaking {
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::{TxHash, U256};
     use chrono::Utc;
     use sqlx::SqlitePool;
     use uuid::Uuid;
@@ -704,6 +754,200 @@ mod tests {
         assert!(
             matches!(error, TransferUsdcToMarketMakingJobError::Transfer(_)),
             "perform must propagate the resume failure as a Transfer error, got {error:?}",
+        );
+    }
+
+    /// Stubs that return settlement-wait errors (retryable, not consumer of
+    /// apalis retry budget).
+    struct UnderconfirmedWithdrawal;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for UnderconfirmedWithdrawal {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                id: id.clone(),
+                tx: TxHash::ZERO,
+                required: 3,
+                actual: 1,
+            })
+        }
+    }
+
+    struct InsufficientUsdcBalance;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for InsufficientUsdcBalance {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            Err(UsdcTransferError::WalletUsdcInsufficient {
+                id: id.clone(),
+                required: U256::from(1_000_000u64),
+                actual: U256::ZERO,
+            })
+        }
+    }
+
+    /// Hypothesis: WithdrawalTxUnderconfirmed re-enqueues with
+    /// SETTLEMENT_REDRIVE_DELAY and returns Ok (job stays alive, no apalis
+    /// retry budget consumed).
+    #[tokio::test]
+    async fn market_making_job_reschedules_underconfirmed_withdrawal() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(UnderconfirmedWithdrawal),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "WithdrawalTxUnderconfirmed must re-enqueue a delayed replacement job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at <= after + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{SETTLEMENT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// Hypothesis: WalletUsdcInsufficient re-enqueues with
+    /// SETTLEMENT_REDRIVE_DELAY and returns Ok (job stays alive, no apalis
+    /// retry budget consumed).
+    #[tokio::test]
+    async fn market_making_job_reschedules_insufficient_usdc_balance() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(InsufficientUsdcBalance),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "WalletUsdcInsufficient must re-enqueue a delayed replacement job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at <= after + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{SETTLEMENT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
+        );
+    }
+
+    /// Stubs for `SettlementCheckTransient` -- models an RPC failure during the
+    /// settlement-phase confirmation re-check or the BridgingSubmitting scan.
+    struct SettlementRpcFailure;
+
+    #[async_trait]
+    impl ResumeAlpacaToBase for SettlementRpcFailure {
+        async fn resume_alpaca_to_base(
+            &self,
+            id: &UsdcRebalanceId,
+            _amount: Usdc,
+        ) -> Result<(), UsdcTransferError> {
+            use st0x_bridge::cctp::CctpError;
+            Err(UsdcTransferError::SettlementCheckTransient {
+                id: id.clone(),
+                source: Box::new(CctpError::ScanInconclusive { from_block: 42 }),
+            })
+        }
+    }
+
+    /// Hypothesis: SettlementCheckTransient (e.g. confirmation-check RPC failure)
+    /// re-enqueues with SETTLEMENT_REDRIVE_DELAY and returns Ok -- the job stays
+    /// alive without consuming the apalis retry budget.
+    #[tokio::test]
+    async fn market_making_job_reschedules_settlement_check_transient() {
+        let pool = setup_queue_pool().await;
+        let job_queue = TransferUsdcToMarketMakingJobQueue::new(&pool);
+        let ctx = TransferUsdcToMarketMakingCtx {
+            transfer: Arc::new(SettlementRpcFailure),
+            job_queue,
+        };
+        let job = TransferUsdcToMarketMaking {
+            id: UsdcRebalanceId(Uuid::new_v4()),
+            amount: Usdc::new(float!(100)),
+        };
+
+        let before = Utc::now().timestamp();
+        job.perform(&ctx).await.unwrap();
+        let after = Utc::now().timestamp();
+
+        assert_eq!(
+            pending_job_count::<TransferUsdcToMarketMaking>(&pool).await,
+            1,
+            "SettlementCheckTransient must re-enqueue a delayed replacement job"
+        );
+
+        let (payload, run_at) = pending_job_row::<TransferUsdcToMarketMaking>(&pool).await;
+        let rescheduled: TransferUsdcToMarketMaking = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(
+            rescheduled.id, job.id,
+            "the rescheduled job must resume the same aggregate id"
+        );
+        assert!(
+            rescheduled.amount.eq(&job.amount).unwrap(),
+            "the rescheduled job must carry the same amount, got {} vs {}",
+            rescheduled.amount,
+            job.amount
+        );
+        assert!(
+            run_at >= before + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() - 5
+                && run_at <= after + i64::try_from(SETTLEMENT_REDRIVE_DELAY.as_secs()).unwrap() + 5,
+            "redrive must be delayed by ~{SETTLEMENT_REDRIVE_DELAY:?} -- \
+             run_at={run_at} before={before} after={after}"
         );
     }
 }

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -30,6 +30,26 @@ use crate::usdc_rebalance::{
     RebalanceDirection, TransferRef, UsdcRebalance, UsdcRebalanceCommand, UsdcRebalanceId,
 };
 
+/// Tuning parameters for the USDC settlement flow.
+///
+/// Bundled together so constructors that require these values stay within
+/// the 8-argument clippy threshold.
+#[derive(Debug)]
+pub(crate) struct UsdcSettlementParams {
+    pub(crate) attestation_retry_deadline: Duration,
+    pub(crate) required_confirmations: u64,
+    /// Circle attestation/fee API base URL (test-only override; production
+    /// builds use the [`st0x_bridge::cctp::CIRCLE_API_BASE`] constant).
+    #[cfg(feature = "test-support")]
+    pub(crate) circle_api_base: String,
+    /// `TokenMessengerV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub(crate) token_messenger: Address,
+    /// `MessageTransmitterV2` contract address (test-only override).
+    #[cfg(feature = "test-support")]
+    pub(crate) message_transmitter: Address,
+}
+
 /// Orchestrates USDC rebalancing between Alpaca (Ethereum) and Rain (Base).
 ///
 /// # Type Parameters
@@ -44,6 +64,7 @@ pub(crate) struct CrossVenueCashTransfer<Chain: Wallet> {
     market_maker_wallet: Address,
     vault_id: RaindexVaultId,
     attestation_retry_deadline: Duration,
+    required_confirmations: u64,
 }
 
 enum AttestationPollOutcome {
@@ -60,7 +81,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         cqrs: Arc<Store<UsdcRebalance>>,
         market_maker_wallet: Address,
         vault_id: RaindexVaultId,
-        attestation_retry_deadline: Duration,
+        settlement: &UsdcSettlementParams,
     ) -> Self {
         Self {
             alpaca_broker,
@@ -70,7 +91,8 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             cqrs,
             market_maker_wallet,
             vault_id,
-            attestation_retry_deadline,
+            attestation_retry_deadline: settlement.attestation_retry_deadline,
+            required_confirmations: settlement.required_confirmations,
         }
     }
 
@@ -596,17 +618,22 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                     return Err(UsdcTransferError::WithdrawalRefMustBeAlpacaId { id: id.clone() });
                 };
 
-                self.poll_and_confirm_withdrawal(id, &transfer_id).await?;
-                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount)
+                let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer_id).await?;
+                // Thread the confirmed withdrawal_tx so the burn-scan lower bound
+                // is derived from the withdrawal tx block (not the raw chain head).
+                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount, withdrawal_tx)
                     .await
             }
 
             Some(WithdrawalComplete {
                 direction: AlpacaToBase,
                 amount,
+                withdrawal_tx,
                 ..
             }) => {
-                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount)
+                // Thread the persisted withdrawal_tx so the durable re-check fires
+                // on apalis redrive (primary gate does not re-run from this arm).
+                self.continue_alpaca_to_base_from_withdrawal_complete(id, amount, withdrawal_tx)
                     .await
             }
 
@@ -806,8 +833,10 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
     ) -> Result<(), UsdcTransferError> {
         let transfer = self.initiate_alpaca_withdrawal(id, filled_amount).await?;
 
-        self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
-        self.continue_alpaca_to_base_from_withdrawal_complete(id, filled_amount)
+        let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
+        // Thread the confirmed withdrawal_tx so the burn-scan lower bound
+        // is derived from the withdrawal tx block (not the raw chain head).
+        self.continue_alpaca_to_base_from_withdrawal_complete(id, filled_amount, withdrawal_tx)
             .await
     }
 
@@ -817,7 +846,59 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         &self,
         id: &UsdcRebalanceId,
         amount: Usdc,
+        withdrawal_tx: Option<TxHash>,
     ) -> Result<(), UsdcTransferError> {
+        // DURABLE confirmation re-check: fires on the redrive path
+        // (`WithdrawalComplete` -> resume) when the primary gate in
+        // `poll_and_confirm_withdrawal` does not re-run. An RPC failure here
+        // is transient (the aggregate is already in the durable
+        // `WithdrawalComplete` state), so we return `SettlementCheckTransient`
+        // so the job delayed-redrives instead of consuming the apalis retry
+        // budget. None means Alpaca returned no tx hash; fall through to the
+        // balance gate.
+        if let Some(tx) = withdrawal_tx {
+            match self
+                .cctp_bridge
+                .ethereum_tx_confirmations(tx)
+                .await
+                .map_err(|error| UsdcTransferError::SettlementCheckTransient {
+                    id: id.clone(),
+                    source: Box::new(error),
+                })? {
+                None => {
+                    warn!(
+                        target: "rebalance",
+                        %id,
+                        %tx,
+                        "Withdrawal tx not yet mined on redrive; retrying"
+                    );
+                    return Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                        id: id.clone(),
+                        tx,
+                        required: self.required_confirmations,
+                        actual: 0,
+                    });
+                }
+                Some(confirmations) if confirmations < self.required_confirmations => {
+                    warn!(
+                        target: "rebalance",
+                        %id,
+                        %tx,
+                        confirmations,
+                        required = self.required_confirmations,
+                        "Withdrawal tx under-confirmed on redrive; retrying"
+                    );
+                    return Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                        id: id.clone(),
+                        tx,
+                        required: self.required_confirmations,
+                        actual: confirmations,
+                    });
+                }
+                Some(_) => {}
+            }
+        }
+
         let burn_amount = match usdc_to_u256(amount) {
             Ok(burn_amount) => burn_amount,
             Err(error) => {
@@ -833,6 +914,13 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
                 return Err(error);
             }
         };
+
+        // FALLBACK balance gate: verify the withdrawn USDC is present in the
+        // market-maker wallet before attempting the irreversible CCTP burn. When
+        // Alpaca returned no tx hash (withdrawal_tx: None), this is the only
+        // settlement check. When a tx hash is present and confirmed above, this
+        // is a cheap additional sanity check.
+        self.check_ethereum_usdc_balance(id, burn_amount).await?;
 
         let burn_receipt = self.execute_cctp_burn(id, burn_amount).await?;
 
@@ -1023,26 +1111,11 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
 
         let transfer = self.initiate_alpaca_withdrawal(id, usdc_amount).await?;
 
-        self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
+        let withdrawal_tx = self.poll_and_confirm_withdrawal(id, &transfer.id).await?;
 
-        let burn_amount = match usdc_to_u256(usdc_amount) {
-            Ok(amount) => amount,
-            Err(error) => {
-                warn!(target: "rebalance", %error, "USDC to U256 conversion failed after withdrawal");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("USDC conversion failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(error);
-            }
-        };
-        let burn_receipt = self.execute_cctp_burn(id, burn_amount).await?;
-
-        self.continue_alpaca_to_base_from_bridging(id, usdc_amount, burn_receipt.tx)
+        // Thread the confirmed withdrawal_tx so the burn-scan lower bound is
+        // derived from the withdrawal tx block (not the raw chain head).
+        self.continue_alpaca_to_base_from_withdrawal_complete(id, usdc_amount, withdrawal_tx)
             .await?;
 
         info!(target: "rebalance", "Alpaca to Base rebalance completed successfully");
@@ -1090,7 +1163,7 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
         &self,
         id: &UsdcRebalanceId,
         transfer_id: &AlpacaTransferId,
-    ) -> Result<(), UsdcTransferError> {
+    ) -> Result<Option<alloy::primitives::TxHash>, UsdcTransferError> {
         let transfer = match self
             .alpaca_wallet
             .poll_transfer_until_complete(transfer_id)
@@ -1124,55 +1197,156 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             return Err(UsdcTransferError::WithdrawalFailed { status });
         }
 
-        self.cqrs
-            .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await?;
-
-        info!(target: "rebalance", "Alpaca withdrawal confirmed");
-        Ok(())
-    }
-
-    #[instrument(target = "rebalance", skip(self), fields(%id, %amount), level = tracing::Level::DEBUG)]
-    async fn execute_cctp_burn(
-        &self,
-        id: &UsdcRebalanceId,
-        amount: U256,
-    ) -> Result<BurnReceipt, UsdcTransferError> {
-        let burn_receipt = match self
-            .cctp_bridge
-            .burn(
-                BridgeDirection::EthereumToBase,
-                amount,
-                self.market_maker_wallet,
-            )
-            .await
-        {
-            Ok(receipt) => receipt,
-            Err(error) => {
-                warn!(target: "rebalance", "CCTP burn failed: {error}");
-                self.cqrs
-                    .send(
-                        id,
-                        UsdcRebalanceCommand::FailBridging {
-                            reason: format!("Burn failed: {error}"),
-                        },
-                    )
-                    .await?;
-                return Err(UsdcTransferError::Cctp(Box::new(error)));
-            }
-        };
+        // Advance the aggregate to WithdrawalComplete NOW, before the on-chain
+        // confirmation-depth check below. This is intentional: if the confirmation
+        // wait returns early (tx not yet mined or under-confirmed), the aggregate is
+        // already in WithdrawalComplete, so on apalis redrive the resume path enters
+        // continue_alpaca_to_base_from_withdrawal_complete and uses the staleness-safe
+        // fallback balance gate -- it never re-polls Alpaca. Without this ordering, a
+        // transient Alpaca API error on a redrive would hit the poll_transfer error arm
+        // and send FailWithdrawal against a withdrawal that already succeeded.
+        let withdrawal_tx = transfer.tx;
 
         self.cqrs
             .send(
                 id,
-                UsdcRebalanceCommand::InitiateBridging {
-                    burn_tx: burn_receipt.tx,
-                },
+                UsdcRebalanceCommand::ConfirmWithdrawal { withdrawal_tx },
             )
             .await?;
 
-        info!(target: "rebalance", burn_tx = %burn_receipt.tx, "CCTP burn executed");
-        Ok(burn_receipt)
+        info!(target: "rebalance", "Alpaca withdrawal confirmed");
+
+        // PRIMARY settlement gate: wait for the configured required_confirmations
+        // on the on-chain tx that delivered the withdrawn USDC to the market-maker
+        // wallet. Alpaca reports "Complete" before the tx is visible network-wide on
+        // load-balanced RPC nodes, so a balance-read immediately after the status
+        // change can hit a lagging node and return stale data. If the tx is not yet
+        // sufficiently confirmed, return WithdrawalTxUnderconfirmed (retryable) --
+        // the aggregate is already in WithdrawalComplete and withdrawal_tx is
+        // persisted, so on apalis redrive the resume path enters
+        // continue_alpaca_to_base_from_withdrawal_complete and re-runs this same
+        // confirmation check durably before any burn. If the tx hash is absent
+        // (Alpaca did not return one), fall through directly to the balance gate.
+        if let Some(tx) = withdrawal_tx {
+            match self
+                .cctp_bridge
+                .ethereum_tx_confirmations(tx)
+                .await
+                .map_err(|error| UsdcTransferError::SettlementCheckTransient {
+                    id: id.clone(),
+                    source: Box::new(error),
+                })? {
+                None => {
+                    // Tx not yet mined; aggregate is already WithdrawalComplete so
+                    // apalis redrive enters the balance-gate path, not Alpaca re-poll.
+                    warn!(
+                        target: "rebalance",
+                        %id,
+                        %tx,
+                        "Alpaca withdrawal tx not yet mined; retrying"
+                    );
+                    return Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                        id: id.clone(),
+                        tx,
+                        required: self.required_confirmations,
+                        actual: 0,
+                    });
+                }
+                Some(confirmations) if confirmations < self.required_confirmations => {
+                    // Under-confirmed; aggregate is already WithdrawalComplete so
+                    // apalis redrive enters the balance-gate path, not Alpaca re-poll.
+                    warn!(
+                        target: "rebalance",
+                        %id,
+                        %tx,
+                        confirmations,
+                        required = self.required_confirmations,
+                        "Alpaca withdrawal tx under-confirmed; retrying"
+                    );
+                    return Err(UsdcTransferError::WithdrawalTxUnderconfirmed {
+                        id: id.clone(),
+                        tx,
+                        required: self.required_confirmations,
+                        actual: confirmations,
+                    });
+                }
+                Some(confirmations) => {
+                    info!(
+                        target: "rebalance",
+                        %id,
+                        %tx,
+                        confirmations,
+                        "Alpaca withdrawal tx confirmed on-chain"
+                    );
+                }
+            }
+        } else {
+            warn!(
+                target: "rebalance",
+                %id,
+                "Alpaca withdrawal transfer has no tx hash; skipping confirmation check \
+                 (fallback balance gate will verify USDC is present before burn)"
+            );
+        }
+
+        Ok(withdrawal_tx)
+    }
+
+    /// Checks that the market-maker Ethereum wallet holds at least `required`
+    /// USDC before the CCTP burn is attempted.
+    ///
+    /// FALLBACK settlement gate: ensures withdrawn USDC is present in the
+    /// market-maker wallet before burning. This guard fires at the top of
+    /// `continue_alpaca_to_base_from_withdrawal_complete`, which is the single
+    /// code path shared by both the resume-from-WithdrawalComplete path (where
+    /// the PRIMARY confirmation-wait in `poll_and_confirm_withdrawal` does not
+    /// re-run) and the normal flow.
+    ///
+    /// Insufficient balance returns `Err(WalletUsdcInsufficient)` -- a
+    /// retryable error that leaves the aggregate in `WithdrawalComplete` and
+    /// keeps `usdc_in_progress` latched. The job retries at its configured
+    /// apalis interval; no inner polling loop is needed.
+    ///
+    /// NOTE: This gate checks `balance >= required`, not a delta from a
+    /// pre-withdrawal snapshot. The market-maker Ethereum wallet is used
+    /// exclusively as a CCTP burn source and is expected to be empty between
+    /// rebalances. A pre-existing ambient USDC balance would cause the gate
+    /// to pass prematurely. If this invariant is broken (e.g. by a manual
+    /// transfer), operator reconciliation is required.
+    async fn check_ethereum_usdc_balance(
+        &self,
+        id: &UsdcRebalanceId,
+        required: U256,
+    ) -> Result<(), UsdcTransferError> {
+        // RPC failure here is transient: the aggregate is in `WithdrawalComplete`
+        // (a durable state), so return `SettlementCheckTransient` so the job
+        // delayed-redrives instead of consuming the apalis retry budget.
+        let actual = self
+            .cctp_bridge
+            .ethereum_usdc_balance(self.market_maker_wallet)
+            .await
+            .map_err(|error| UsdcTransferError::SettlementCheckTransient {
+                id: id.clone(),
+                source: Box::new(error),
+            })?;
+
+        if actual < required {
+            warn!(
+                target: "rebalance",
+                %id,
+                %required,
+                %actual,
+                "Market-maker Ethereum wallet has insufficient USDC; \
+                 withdrawal may not have settled yet"
+            );
+            return Err(UsdcTransferError::WalletUsdcInsufficient {
+                id: id.clone(),
+                required,
+                actual,
+            });
+        }
+
+        Ok(())
     }
 
     #[instrument(target = "rebalance", skip(self, attestation_response), fields(%id), level = tracing::Level::DEBUG)]
@@ -1370,7 +1544,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             }) => {
                 Self::require_base_to_alpaca(id, &direction)?;
                 self.cqrs
-                    .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::ConfirmWithdrawal {
+                            withdrawal_tx: None,
+                        },
+                    )
                     .await?;
                 self.continue_from_withdrawal_complete(id, amount).await
             }
@@ -2226,7 +2405,12 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             )
             .await?;
         self.cqrs
-            .send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                id,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await?;
 
         info!(target: "rebalance", %withdraw_tx, "Vault withdrawal completed");
@@ -2321,7 +2505,49 @@ impl<Chain: Wallet> CrossVenueCashTransfer<Chain> {
             )
             .await?;
 
-        info!(target: "rebalance", burn_tx = %burn_receipt.tx, "CCTP burn on Base executed");
+        info!(target: "rebalance", burn_tx = %burn_receipt.tx, "CCTP burn executed");
+        Ok(burn_receipt)
+    }
+
+    async fn execute_cctp_burn(
+        &self,
+        id: &UsdcRebalanceId,
+        amount: U256,
+    ) -> Result<BurnReceipt, UsdcTransferError> {
+        let burn_receipt = match self
+            .cctp_bridge
+            .burn(
+                BridgeDirection::EthereumToBase,
+                amount,
+                self.market_maker_wallet,
+            )
+            .await
+        {
+            Ok(receipt) => receipt,
+            Err(error) => {
+                warn!(target: "rebalance", "CCTP burn failed: {error}");
+                self.cqrs
+                    .send(
+                        id,
+                        UsdcRebalanceCommand::FailBridging {
+                            reason: format!("Burn failed: {error}"),
+                        },
+                    )
+                    .await?;
+                return Err(UsdcTransferError::Cctp(Box::new(error)));
+            }
+        };
+
+        self.cqrs
+            .send(
+                id,
+                UsdcRebalanceCommand::InitiateBridging {
+                    burn_tx: burn_receipt.tx,
+                },
+            )
+            .await?;
+
+        info!(target: "rebalance", burn_tx = %burn_receipt.tx, "CCTP burn executed");
         Ok(burn_receipt)
     }
 
@@ -2507,6 +2733,19 @@ mod tests {
     ));
     const TEST_ATTESTATION_RETRY_DEADLINE: Duration = Duration::from_secs(24 * 60 * 60);
 
+    fn test_settlement_params() -> UsdcSettlementParams {
+        UsdcSettlementParams {
+            attestation_retry_deadline: TEST_ATTESTATION_RETRY_DEADLINE,
+            required_confirmations: 3,
+            #[cfg(feature = "test-support")]
+            circle_api_base: st0x_bridge::cctp::CIRCLE_API_BASE.to_string(),
+            #[cfg(feature = "test-support")]
+            token_messenger: st0x_bridge::cctp::TOKEN_MESSENGER_V2,
+            #[cfg(feature = "test-support")]
+            message_transmitter: st0x_bridge::cctp::MESSAGE_TRANSMITTER_V2,
+        }
+    }
+
     async fn create_test_store_instance() -> Arc<Store<UsdcRebalance>> {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
@@ -2538,9 +2777,14 @@ mod tests {
         .await
         .unwrap();
 
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
 
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
@@ -2634,7 +2878,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, ConfirmWithdrawal).await.unwrap();
+        cqrs.send(
+            id,
+            ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, InitiateBridging { burn_tx }).await.unwrap();
         cqrs.send(
             id,
@@ -2723,7 +2974,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, ConfirmWithdrawal).await.unwrap();
+        cqrs.send(
+            id,
+            ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, InitiateBridging { burn_tx }).await.unwrap();
         cqrs.send(
             id,
@@ -3076,7 +3334,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -3132,7 +3390,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -3195,7 +3453,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock conversion order (conversion happens before withdrawal)
@@ -3252,7 +3510,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -3292,7 +3550,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -3331,7 +3589,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock the conversion order placement (POST)
@@ -3377,7 +3635,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock the conversion order - will be called but CQRS command will fail
@@ -3431,7 +3689,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Order starts as pending
@@ -3476,7 +3734,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Order starts as pending
@@ -3541,9 +3799,14 @@ mod tests {
         .await
         .unwrap();
 
-        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
 
         cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
@@ -3593,7 +3856,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Order starts as pending then gets rejected
@@ -3645,7 +3908,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock order placement to fail with 500 error
@@ -3713,7 +3976,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock conversion order - MUST be called before withdrawal
@@ -3785,7 +4048,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let conversion_mock = server.mock(|when, then| {
@@ -3853,7 +4116,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Order starts as pending
@@ -3928,7 +4191,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock that should NOT be called - if InitiateConversion fails, no order should be placed
@@ -3993,7 +4256,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Mock order placement to fail with API error
@@ -4057,7 +4320,7 @@ mod tests {
             Arc::clone(&cqrs),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let _order_mock = create_conversion_order_mock(&server, "1000");
@@ -4111,7 +4374,7 @@ mod tests {
             cqrs,
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Request 1000, but only 999.5 fills due to slippage
@@ -4167,7 +4430,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         (manager, cqrs, anvil)
@@ -4203,7 +4466,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         (manager, cqrs, anvil)
@@ -4230,9 +4493,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -4277,9 +4545,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -4330,9 +4603,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -4627,9 +4905,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -4951,9 +5234,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         // Fail BEFORE the burn (no `InitiateBridging`), so the resulting
         // `BridgingFailed` carries `burn_tx_hash: None`. A pre-burn failure has
         // no mint to adopt, so resume must still reject it as terminal -- it is
@@ -5709,7 +5997,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Drive the aggregate to `Attested`, recording the real burn tx and the
@@ -5725,9 +6013,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(
             &id,
             UsdcRebalanceCommand::InitiateBridging {
@@ -5882,7 +6175,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         // Drive to a POST-burn BridgingFailed: InitiateBridging records the burn
@@ -5900,9 +6193,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(
             &id,
             UsdcRebalanceCommand::InitiateBridging {
@@ -6136,7 +6434,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -6191,7 +6489,7 @@ mod tests {
             cqrs.clone(),
             market_maker_wallet,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         );
 
         let id = UsdcRebalanceId(Uuid::new_v4());
@@ -6356,9 +6654,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(&id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(&id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -6471,7 +6774,7 @@ mod tests {
             cqrs,
             chain.bot_address,
             TEST_VAULT_ID,
-            TEST_ATTESTATION_RETRY_DEADLINE,
+            &test_settlement_params(),
         )
     }
 
@@ -6815,9 +7118,14 @@ mod tests {
         )
         .await
         .unwrap();
-        cqrs.send(id, UsdcRebalanceCommand::ConfirmWithdrawal)
-            .await
-            .unwrap();
+        cqrs.send(
+            id,
+            UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
         cqrs.send(id, UsdcRebalanceCommand::InitiateBridging { burn_tx })
             .await
             .unwrap();
@@ -6842,5 +7150,1223 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // Settlement gate tests (on-chain USDC confirmation before CCTP burn)
+    // -------------------------------------------------------------------------
+
+    /// Sets up a single-chain Ethereum anvil with USDC deployed at USDC_ADDRESS
+    /// and optionally mints `usdc_amount` to `recipient`.
+    async fn deploy_ethereum_usdc_chain_with_balance(
+        usdc_amount: U256,
+        recipient: Address,
+    ) -> EthereumUsdcChain {
+        let anvil = Anvil::new().chain_id(1u64).spawn();
+        let endpoint = anvil.endpoint();
+        let bot_key = B256::from_slice(&anvil.keys()[0].to_bytes());
+        let bot_address = PrivateKeySigner::from_bytes(&bot_key).unwrap().address();
+
+        let provider = ProviderBuilder::new().connect(&endpoint).await.unwrap();
+        provider
+            .anvil_set_code(USDC_ADDRESS, TestMintBurnToken::DEPLOYED_BYTECODE.clone())
+            .await
+            .unwrap();
+
+        let signer = PrivateKeySigner::from_bytes(&bot_key).unwrap();
+        let bot_provider = ProviderBuilder::new()
+            .wallet(alloy::network::EthereumWallet::from(signer))
+            .connect(&endpoint)
+            .await
+            .unwrap();
+
+        let token = TestMintBurnToken::new(USDC_ADDRESS, &bot_provider);
+        let mint_receipt = token
+            .mint(recipient, usdc_amount)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        EthereumUsdcChain {
+            endpoint,
+            bot_key,
+            bot_address,
+            mint_tx: mint_receipt.transaction_hash,
+            _anvil: anvil,
+        }
+    }
+
+    /// Builds a manager whose CCTP Ethereum endpoint points at `chain` and whose
+    /// `market_maker_wallet` is the given address. The Base endpoint uses the same
+    /// anvil (tests do not reach Base).
+    async fn build_manager_with_ethereum_chain(
+        chain: &EthereumUsdcChain,
+        server: &MockServer,
+        market_maker_wallet: Address,
+    ) -> (
+        CrossVenueCashTransfer<
+            RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>,
+        >,
+        Arc<Store<UsdcRebalance>>,
+    ) {
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(server));
+        let wallet = create_test_wallet(&chain.endpoint, &chain.bot_key);
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet);
+        let cqrs = create_test_store_instance().await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            market_maker_wallet,
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        (manager, cqrs)
+    }
+
+    /// Stages the aggregate at `WithdrawalComplete` (AlpacaToBase direction).
+    async fn advance_to_withdrawal_complete_alpaca_to_base(
+        cqrs: &Store<UsdcRebalance>,
+        id: &UsdcRebalanceId,
+        amount: Usdc,
+    ) {
+        use UsdcRebalanceCommand::*;
+
+        cqrs.send(
+            id,
+            InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            id,
+            ConfirmWithdrawal {
+                withdrawal_tx: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Hypothesis: check_ethereum_usdc_balance returns WalletUsdcInsufficient
+    /// when the wallet holds zero USDC, without calling FailBridging or
+    /// advancing the aggregate.
+    #[tokio::test]
+    async fn check_ethereum_usdc_balance_insufficient_returns_wallet_usdc_insufficient() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Deploy USDC with NO balance at market_maker_wallet.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let required = U256::from(1_000_000u64); // 1 USDC
+
+        let error = manager
+            .check_ethereum_usdc_balance(&id, required)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WalletUsdcInsufficient { required: r, actual: a, .. }
+                    if r == required && a == U256::ZERO
+            ),
+            "Expected WalletUsdcInsufficient with correct amounts, got: {error:?}"
+        );
+
+        // Aggregate must remain untouched (no FailBridging emitted).
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            state.is_none(),
+            "Aggregate must not be advanced by check_ethereum_usdc_balance; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: check_ethereum_usdc_balance returns Ok when the wallet holds
+    /// at least the required amount, and does not advance the aggregate.
+    #[tokio::test]
+    async fn check_ethereum_usdc_balance_sufficient_returns_ok() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let required = U256::from(1_000_000u64); // 1 USDC
+        let minted = U256::from(5_000_000u64); // 5 USDC (exceeds required)
+
+        let chain = deploy_ethereum_usdc_chain_with_balance(minted, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        // The gate must pass without error when balance >= required.
+        manager
+            .check_ethereum_usdc_balance(&id, required)
+            .await
+            .expect("check_ethereum_usdc_balance must return Ok when balance >= required");
+
+        // The gate must not emit any command -- aggregate stays uninitialized.
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            state.is_none(),
+            "check_ethereum_usdc_balance must not advance the aggregate on success; \
+             got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: check_ethereum_usdc_balance returns Ok at the exact boundary
+    /// where balance == required, confirming the implementation uses strict less-than
+    /// (actual < required) rather than less-than-or-equal.
+    #[tokio::test]
+    async fn check_ethereum_usdc_balance_sufficient_at_exact_boundary_returns_ok() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let required = U256::from(1_000_000u64); // 1 USDC
+
+        // Mint exactly the required amount -- no more, no less.
+        let chain = deploy_ethereum_usdc_chain_with_balance(required, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+
+        manager
+            .check_ethereum_usdc_balance(&id, required)
+            .await
+            .expect("check_ethereum_usdc_balance must return Ok when balance == required");
+
+        let state = cqrs.load(&id).await.unwrap();
+        assert!(
+            state.is_none(),
+            "check_ethereum_usdc_balance must not advance the aggregate at the exact boundary; \
+             got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: continue_alpaca_to_base_from_withdrawal_complete with
+    /// insufficient USDC balance returns WalletUsdcInsufficient (retryable),
+    /// does NOT call FailBridging, and the aggregate stays in WithdrawalComplete.
+    #[tokio::test]
+    async fn continue_from_withdrawal_complete_with_insufficient_balance_returns_retryable_error() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Market-maker wallet has zero USDC on Ethereum.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let error = manager
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::WalletUsdcInsufficient { .. }),
+            "Expected WalletUsdcInsufficient, got: {error:?}"
+        );
+
+        // Aggregate must remain in WithdrawalComplete (no BridgingFailed).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay in WithdrawalComplete, not advance to BridgingFailed; \
+             got: {state:?}"
+        );
+    }
+
+    /// Helper: creates an HTTP mock that serves a single COMPLETE transfer with
+    /// the given `tx_hash` for the transfer polling endpoint.
+    fn mock_complete_withdrawal_with_tx(
+        server: &MockServer,
+        transfer_uuid: Uuid,
+        tx_hash: Option<TxHash>,
+    ) -> httpmock::Mock<'_> {
+        let tx_hash_value = tx_hash.map_or(serde_json::Value::Null, |tx| {
+            serde_json::Value::String(format!("{tx:#x}"))
+        });
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/v1/accounts/904837e3-3b76-47ec-b432-046db621571b/wallets/transfers");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([{
+                    "id": transfer_uuid.to_string(),
+                    "direction": "OUTGOING",
+                    "amount": "100",
+                    "usd_value": "100",
+                    "chain": "ethereum",
+                    "asset": "USDC",
+                    "from_address": "0x0000000000000000000000000000000000000001",
+                    "to_address": "0x2222222222222222222222222222222222222222",
+                    "status": "COMPLETE",
+                    "tx_hash": tx_hash_value,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                }]));
+        })
+    }
+
+    /// Hypothesis: poll_and_confirm_withdrawal returns WithdrawalTxUnderconfirmed
+    /// (retryable) when the withdrawal tx exists but has fewer than the required
+    /// number of confirmations (3). The aggregate MUST advance to WithdrawalComplete
+    /// before the early return so that apalis redrives enter the balance-gate path
+    /// instead of re-polling Alpaca.
+    #[tokio::test]
+    async fn withdrawal_tx_with_fewer_than_required_confirmations_returns_retryable_error() {
+        // Deploy USDC with balance; the endpoint gives us a provider for block checks.
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // The mint_tx in `chain` was mined in block N. The anvil head is at N
+        // (no extra blocks mined), so confirmations = 1 (the inclusion block
+        // counts) < REQUIRED (3).
+        let tx_with_one_confirmation = chain.mint_tx;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let _transfer_mock = mock_complete_withdrawal_with_tx(
+            &server,
+            transfer_uuid,
+            Some(tx_with_one_confirmation),
+        );
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Stage aggregate at Withdrawing.
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    actual: 1,
+                    required: 3,
+                    ..
+                }
+            ),
+            "Expected WithdrawalTxUnderconfirmed with 1 actual confirmation, got: {error:?}"
+        );
+
+        // Aggregate MUST have advanced to WithdrawalComplete before the early return
+        // so that apalis redrives enter the balance-gate path instead of re-polling Alpaca.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete when tx is under-confirmed; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: poll_and_confirm_withdrawal returns WithdrawalTxUnderconfirmed
+    /// when the withdrawal tx hash is not yet mined (not in the chain). The
+    /// unmined path reports actual=0 and a distinct log; the aggregate MUST advance
+    /// to WithdrawalComplete before the early return.
+    #[tokio::test]
+    async fn withdrawal_tx_not_yet_mined_returns_retryable_error() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // A random tx hash that was never submitted to the chain.
+        let unmined_tx = TxHash::ZERO;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let _transfer_mock =
+            mock_complete_withdrawal_with_tx(&server, transfer_uuid, Some(unmined_tx));
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap_err();
+
+        // The not-yet-mined path reports actual=0 (tx block is unknown);
+        // the log message distinguishes it from a mined-but-0-confirmed tx.
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    actual: 0,
+                    required: 3,
+                    ..
+                }
+            ),
+            "Expected WithdrawalTxUnderconfirmed for unmined tx, got: {error:?}"
+        );
+
+        // Aggregate MUST have advanced to WithdrawalComplete before the early return
+        // so that apalis redrives enter the balance-gate path instead of re-polling Alpaca.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete for unmined tx; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: poll_and_confirm_withdrawal returns WithdrawalTxUnderconfirmed
+    /// when the withdrawal tx has exactly 3 - 1
+    /// (the off-by-one boundary: one short is still retryable).
+    #[tokio::test]
+    async fn withdrawal_tx_at_n_minus_1_confirmations_returns_retryable_error() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // Mine REQUIRED - 2 extra blocks so tx confirmations = REQUIRED - 1
+        // (the inclusion block counts as confirmation 1, plus the extras).
+        let provider = ProviderBuilder::new()
+            .connect(&chain.endpoint)
+            .await
+            .unwrap();
+        provider.anvil_mine(Some(3 - 2), None).await.unwrap();
+
+        let tx_hash = chain.mint_tx;
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let _transfer_mock =
+            mock_complete_withdrawal_with_tx(&server, transfer_uuid, Some(tx_hash));
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    actual,
+                    required: 3,
+                    ..
+                } if actual == 3 - 1
+            ),
+            "Expected WithdrawalTxUnderconfirmed with actual=REQUIRED-1, got: {error:?}"
+        );
+
+        // Aggregate MUST have advanced to WithdrawalComplete before the early return
+        // so that apalis redrives enter the balance-gate path instead of re-polling Alpaca.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete at N-1 confirmations; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: poll_and_confirm_withdrawal sends ConfirmWithdrawal and
+    /// advances the aggregate to WithdrawalComplete when the withdrawal tx has
+    /// at least 3.
+    #[tokio::test]
+    async fn withdrawal_tx_with_required_confirmations_sends_confirm_withdrawal() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // Mine REQUIRED - 1 extra blocks so the tx reaches exactly REQUIRED
+        // confirmations (the inclusion block counts as confirmation 1).
+        let provider = ProviderBuilder::new()
+            .connect(&chain.endpoint)
+            .await
+            .unwrap();
+        provider.anvil_mine(Some(3 - 1), None).await.unwrap();
+
+        let tx_hash = chain.mint_tx;
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        let _transfer_mock =
+            mock_complete_withdrawal_with_tx(&server, transfer_uuid, Some(tx_hash));
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap();
+
+        // Aggregate must be in WithdrawalComplete.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete when tx is confirmed; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: when Alpaca returns no tx_hash on the withdrawal transfer,
+    /// poll_and_confirm_withdrawal logs a warning and falls through -- it sends
+    /// ConfirmWithdrawal and advances the aggregate to WithdrawalComplete.
+    /// (The fallback balance gate covers the burn step.)
+    #[tokio::test]
+    async fn withdrawal_tx_absent_falls_through_to_balance_gate() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        // tx_hash is None -- Alpaca did not return one.
+        let _transfer_mock = mock_complete_withdrawal_with_tx(&server, transfer_uuid, None);
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Falls through to ConfirmWithdrawal even without a tx hash.
+        manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap();
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "WithdrawalComplete expected when tx_hash is absent (fall-through); got: {state:?}"
+        );
+    }
+
+    /// Hypothesis (combined path): when Alpaca returns no tx_hash AND the wallet
+    /// balance is insufficient (USDC not yet settled), poll_and_confirm_withdrawal
+    /// still advances the aggregate to WithdrawalComplete (guard latched), and
+    /// the subsequent balance gate returns WalletUsdcInsufficient (retryable) --
+    /// no burn is attempted.
+    #[tokio::test]
+    async fn withdrawal_tx_absent_and_insufficient_balance_returns_wallet_usdc_insufficient() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Deploy USDC chain with ZERO balance -- withdrawal not yet settled.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let transfer_uuid = Uuid::new_v4();
+        // tx_hash is None -- Alpaca did not return one.
+        let _transfer_mock = mock_complete_withdrawal_with_tx(&server, transfer_uuid, None);
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        // poll_and_confirm_withdrawal succeeds (no tx hash to check) and advances
+        // the aggregate to WithdrawalComplete.
+        manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap();
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must be WithdrawalComplete after absent-tx poll; got: {state:?}"
+        );
+
+        // The balance gate (called by continue_alpaca_to_base_from_withdrawal_complete)
+        // returns WalletUsdcInsufficient because the wallet has zero USDC.
+        let required = usdc_to_u256(amount).unwrap();
+        let error = manager
+            .check_ethereum_usdc_balance(&id, required)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WalletUsdcInsufficient { actual: a, .. } if a == U256::ZERO
+            ),
+            "Expected WalletUsdcInsufficient when balance is zero; got: {error:?}"
+        );
+
+        // Aggregate must still be in WithdrawalComplete -- the balance gate is
+        // staleness-safe (no FailBridging emitted on insufficient balance).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must remain WithdrawalComplete after insufficient balance; got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: resuming resume_alpaca_to_base from WithdrawalComplete with
+    /// insufficient USDC balance returns a retryable WalletUsdcInsufficient error,
+    /// the aggregate stays in WithdrawalComplete, and the guard stays latched.
+    #[tokio::test]
+    async fn resume_from_withdrawal_complete_with_insufficient_balance_returns_retryable_error() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Zero USDC on Ethereum -- withdrawal has not settled.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::WalletUsdcInsufficient { .. }),
+            "Expected WalletUsdcInsufficient on resume from WithdrawalComplete with \
+             no settled balance; got: {error:?}"
+        );
+
+        // Guard: aggregate stays in WithdrawalComplete.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must remain in WithdrawalComplete; got: {state:?}"
+        );
+    }
+
+    /// T10: `continue_alpaca_to_base_from_withdrawal_complete` with an
+    /// under-confirmed `withdrawal_tx` returns `WithdrawalTxUnderconfirmed`
+    /// (retryable) and does NOT attempt any burn. The aggregate stays at
+    /// `WithdrawalComplete`.
+    #[tokio::test]
+    async fn continue_from_withdrawal_complete_under_confirmed_tx_returns_retryable() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Zero USDC -- if the burn were attempted the balance gate would fail,
+        // but the confirmation check must fire FIRST, before the balance gate.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // The mint_tx was mined in the most-recent block (0 extra blocks = 1
+        // confirmation, the inclusion block, at the chain head).
+        let under_confirmed_tx = chain.mint_tx;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let error = manager
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(under_confirmed_tx))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    actual: 1,
+                    required: 3,
+                    ..
+                }
+            ),
+            "Expected WithdrawalTxUnderconfirmed (1 confirmation), got: {error:?}"
+        );
+
+        // Aggregate must remain in WithdrawalComplete -- no burn was attempted.
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay at WithdrawalComplete after under-confirmed tx; \
+             got: {state:?}"
+        );
+    }
+
+    /// T11: `continue_alpaca_to_base_from_withdrawal_complete` with
+    /// `withdrawal_tx: None` skips the confirmation gate and proceeds to the
+    /// balance gate (returns WalletUsdcInsufficient if balance is zero).
+    #[tokio::test]
+    async fn continue_from_withdrawal_complete_none_tx_skips_confirmation_gate() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Zero USDC ensures the balance gate fires rather than the burn,
+        // confirming that we got PAST the confirmation gate (which would have
+        // fired first if withdrawal_tx were Some).
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        let error = manager
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, None)
+            .await
+            .unwrap_err();
+
+        // WalletUsdcInsufficient proves we passed the (skipped) confirmation gate.
+        assert!(
+            matches!(error, UsdcTransferError::WalletUsdcInsufficient { .. }),
+            "Expected WalletUsdcInsufficient (balance gate fired after skipped \
+             confirmation gate), got: {error:?}"
+        );
+    }
+
+    /// T14: `resume_alpaca_to_base` from `WithdrawalComplete { withdrawal_tx:
+    /// Some(tx), .. }` with an under-confirmed tx returns
+    /// `WithdrawalTxUnderconfirmed` without attempting any burn. The durable
+    /// re-check fires even on the redrive path (aggregate already at
+    /// `WithdrawalComplete`).
+    #[tokio::test]
+    async fn resume_from_withdrawal_complete_under_confirmed_tx_returns_retryable() {
+        let market_maker_wallet = address!("0x2222222222222222222222222222222222222222");
+
+        // Zero USDC: if the burn were reached the balance gate would fire, but
+        // confirmation check must fire first.
+        let chain = deploy_ethereum_usdc_chain_with_balance(U256::ZERO, market_maker_wallet).await;
+
+        // mint_tx has 0 extra blocks mined = 1 confirmation (inclusion block) at head.
+        let under_confirmed_tx = chain.mint_tx;
+
+        let server = MockServer::start();
+        let (manager, cqrs) =
+            build_manager_with_ethereum_chain(&chain, &server, market_maker_wallet).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // Stage with withdrawal_tx set to the under-confirmed tx, mirroring what
+        // poll_and_confirm_withdrawal would have persisted on the first attempt.
+        use UsdcRebalanceCommand::*;
+        cqrs.send(
+            &id,
+            InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(AlpacaTransferId::from(Uuid::new_v4())),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            ConfirmWithdrawal {
+                withdrawal_tx: Some(under_confirmed_tx),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Redrive: the primary gate does NOT re-run (aggregate is at
+        // WithdrawalComplete, not Withdrawing), but the durable re-check in
+        // continue_alpaca_to_base_from_withdrawal_complete fires.
+        let error = manager
+            .resume_alpaca_to_base(&id, amount)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                UsdcTransferError::WithdrawalTxUnderconfirmed {
+                    actual: 1,
+                    required: 3,
+                    ..
+                }
+            ),
+            "Expected WithdrawalTxUnderconfirmed on redrive from WithdrawalComplete \
+             with under-confirmed tx, got: {error:?}"
+        );
+
+        // Aggregate must stay at WithdrawalComplete (no burn initiated).
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay at WithdrawalComplete on under-confirmed redrive; \
+             got: {state:?}"
+        );
+    }
+
+    /// Builds a manager whose CctpBridge points at an unreachable RPC endpoint,
+    /// so any `ethereum_tx_confirmations` or `ethereum_tx_block` call fails with
+    /// a transport error. Used to exercise the `SettlementCheckTransient` path.
+    async fn build_manager_with_dead_rpc(
+        server: &MockServer,
+    ) -> (
+        CrossVenueCashTransfer<
+            RawPrivateKeyWallet<impl alloy::providers::Provider + Clone + use<>>,
+        >,
+        Arc<Store<UsdcRebalance>>,
+    ) {
+        let dead_endpoint = "http://127.0.0.1:1/";
+        // A throwaway key -- no real txs will be sent against the dead endpoint.
+        let dead_key = B256::from_slice(&[0x01u8; 32]);
+        let wallet = create_test_wallet(dead_endpoint, &dead_key);
+
+        let alpaca_broker = Arc::new(create_test_broker_service(server).await);
+        let alpaca_wallet = Arc::new(create_test_wallet_service(server));
+        let (cctp_bridge, vault_service) = create_test_onchain_services(wallet.clone());
+        let cqrs = create_test_store_instance().await;
+
+        let manager = CrossVenueCashTransfer::new(
+            alpaca_broker,
+            alpaca_wallet,
+            Arc::new(cctp_bridge),
+            Arc::new(vault_service),
+            cqrs.clone(),
+            wallet.address(),
+            TEST_VAULT_ID,
+            &test_settlement_params(),
+        );
+
+        (manager, cqrs)
+    }
+
+    /// Hypothesis: in `continue_alpaca_to_base_from_withdrawal_complete` (durable
+    /// re-check path), an `ethereum_tx_confirmations` RPC failure returns
+    /// `SettlementCheckTransient` -- not `Cctp` -- and the aggregate stays at
+    /// `WithdrawalComplete`. The job delayed-redrives instead of consuming the
+    /// apalis retry budget.
+    #[tokio::test]
+    async fn durable_recheck_rpc_failure_yields_settlement_check_transient() {
+        let server = MockServer::start();
+        let (manager, cqrs) = build_manager_with_dead_rpc(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        advance_to_withdrawal_complete_alpaca_to_base(&cqrs, &id, amount).await;
+
+        // A non-zero tx hash forces the confirmation re-check; the dead RPC will fail.
+        let fake_tx = TxHash::from_slice(&[0xabu8; 32]);
+
+        let error = manager
+            .continue_alpaca_to_base_from_withdrawal_complete(&id, amount, Some(fake_tx))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::SettlementCheckTransient { .. }),
+            "RPC failure in durable confirmation re-check must yield \
+             SettlementCheckTransient, not Cctp; got: {error:?}"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must stay at WithdrawalComplete after transient RPC failure; \
+             got: {state:?}"
+        );
+    }
+
+    /// Hypothesis: in `poll_and_confirm_withdrawal` (primary settlement gate),
+    /// an `ethereum_tx_confirmations` RPC failure after `ConfirmWithdrawal` has
+    /// been persisted returns `SettlementCheckTransient` -- not `Cctp` -- and
+    /// the aggregate stays at `WithdrawalComplete`. The job delayed-redrives
+    /// instead of consuming the apalis retry budget.
+    #[tokio::test]
+    async fn primary_gate_rpc_failure_after_confirm_withdrawal_yields_settlement_check_transient() {
+        let server = MockServer::start();
+        let (manager, cqrs) = build_manager_with_dead_rpc(&server).await;
+
+        let id = UsdcRebalanceId(Uuid::new_v4());
+        let amount = usdc("1");
+
+        // A fake tx hash for Alpaca to return; the dead RPC will fail when
+        // `poll_and_confirm_withdrawal` tries to check its confirmation depth.
+        let fake_tx = TxHash::from_slice(&[0xabu8; 32]);
+
+        let transfer_uuid = Uuid::new_v4();
+        let _transfer_mock =
+            mock_complete_withdrawal_with_tx(&server, transfer_uuid, Some(fake_tx));
+
+        let withdrawal_id = AlpacaTransferId::from(transfer_uuid);
+
+        // Stage aggregate at Withdrawing.
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::InitiateConversion {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                order_id: ClientOrderId::from_uuid(Uuid::new_v4()),
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::ConfirmConversion {
+                filled_amount: amount,
+            },
+        )
+        .await
+        .unwrap();
+        cqrs.send(
+            &id,
+            UsdcRebalanceCommand::Initiate {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount,
+                withdrawal: TransferRef::AlpacaId(withdrawal_id),
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = manager
+            .poll_and_confirm_withdrawal(&id, &withdrawal_id)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, UsdcTransferError::SettlementCheckTransient { .. }),
+            "RPC failure in primary settlement gate must yield SettlementCheckTransient, \
+             not Cctp; got: {error:?}"
+        );
+
+        let state = cqrs.load(&id).await.unwrap().expect("aggregate exists");
+        assert!(
+            matches!(
+                state,
+                UsdcRebalance::WithdrawalComplete {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    ..
+                }
+            ),
+            "Aggregate must advance to WithdrawalComplete before the RPC failure so \
+             apalis redrives enter the durable re-check path; got: {state:?}"
+        );
     }
 }

--- a/src/rebalancing/usdc/mod.rs
+++ b/src/rebalancing/usdc/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use job::{
     TransferUsdcToHedgingJobQueue, TransferUsdcToMarketMaking, TransferUsdcToMarketMakingCtx,
     TransferUsdcToMarketMakingJobQueue,
 };
-pub(crate) use manager::{CrossVenueCashTransfer, u256_to_usdc};
+pub(crate) use manager::{CrossVenueCashTransfer, UsdcSettlementParams, u256_to_usdc};
 
 use std::time::Duration;
 
@@ -129,6 +129,40 @@ pub(crate) enum UsdcTransferError {
     )]
     WithdrawalRefMustBeAlpacaId {
         id: crate::usdc_rebalance::UsdcRebalanceId,
+    },
+    #[error(
+        "USDC rebalance {id}: market-maker Ethereum wallet holds {actual} USDC \
+         but {required} is required for the CCTP burn; waiting for withdrawal \
+         to settle on-chain"
+    )]
+    WalletUsdcInsufficient {
+        id: UsdcRebalanceId,
+        required: alloy::primitives::U256,
+        actual: alloy::primitives::U256,
+    },
+    #[error(
+        "USDC rebalance {id}: withdrawal tx {tx} has only {actual} confirmations, \
+         need {required}; waiting for on-chain settlement"
+    )]
+    WithdrawalTxUnderconfirmed {
+        id: UsdcRebalanceId,
+        tx: alloy::primitives::TxHash,
+        required: u64,
+        actual: u64,
+    },
+    /// An RPC call in the settlement phase (confirmation re-check, balance read,
+    /// or burn scan) failed transiently. The aggregate is in
+    /// `WithdrawalComplete` or `BridgingSubmitting` -- a durable, resumable
+    /// state -- so this is safe to delayed-redrive exactly like
+    /// `WithdrawalTxUnderconfirmed`.
+    #[error(
+        "USDC rebalance {id}: settlement-phase RPC check failed transiently; \
+         will retry after delay"
+    )]
+    SettlementCheckTransient {
+        id: UsdcRebalanceId,
+        #[source]
+        source: Box<CctpError>,
     },
 }
 

--- a/src/usdc_rebalance.rs
+++ b/src/usdc_rebalance.rs
@@ -241,7 +241,9 @@ pub(crate) enum UsdcRebalanceCommand {
         withdrawal: TransferRef,
     },
     /// Confirm successful withdrawal from source. Valid only from `Withdrawing` state.
-    ConfirmWithdrawal,
+    /// `withdrawal_tx` carries the on-chain tx hash when the source provides one
+    /// (AlpacaToBase), so the confirmation-depth gate can re-run on apalis redrive.
+    ConfirmWithdrawal { withdrawal_tx: Option<TxHash> },
     /// Record the intent to burn for CCTP bridging BEFORE the on-chain call.
     /// Captures the chain head (`from_block`) for crash recovery, mirroring
     /// [`BeginWithdrawal`]. Valid only from `WithdrawalComplete` state.
@@ -350,7 +352,15 @@ pub(crate) enum UsdcRebalanceEvent {
         initiated_at: DateTime<Utc>,
     },
     /// Withdrawal from source completed successfully.
-    WithdrawalConfirmed { confirmed_at: DateTime<Utc> },
+    WithdrawalConfirmed {
+        confirmed_at: DateTime<Utc>,
+        /// On-chain tx hash that delivered USDC to the market-maker wallet.
+        /// `None` if the withdrawal source did not return a tx hash (e.g. onchain
+        /// vault withdrawal in BaseToAlpaca). `#[serde(default)]` ensures
+        /// backward-compatibility with events persisted before this field existed.
+        #[serde(default)]
+        withdrawal_tx: Option<TxHash>,
+    },
     /// Withdrawal from source failed.
     WithdrawalFailed {
         reason: String,
@@ -539,6 +549,11 @@ pub(crate) enum UsdcRebalance {
         amount: Usdc,
         initiated_at: DateTime<Utc>,
         confirmed_at: DateTime<Utc>,
+        /// Persisted so the confirmation-depth gate can re-run on apalis redrive.
+        /// `#[serde(default)]` ensures backward-compat with snapshots persisted
+        /// before this field was added.
+        #[serde(default)]
+        withdrawal_tx: Option<TxHash>,
     },
     /// Withdrawal from source has failed (terminal state)
     WithdrawalFailed {
@@ -934,10 +949,11 @@ impl UsdcRebalance {
                 RebalanceDirection::BaseToAlpaca => false,
             },
             // Post-burn failure (burn already broadcast) keeps the guard so a
-            // re-burn cannot fire against funds CCTP already burned. The
-            // `FailBridging` command only emits `burn_tx_hash: Some` from the
-            // post-burn `Bridging`/`Attested` states; a pre-burn failure (from
-            // `WithdrawalComplete`) carries `None` and reconciles to source.
+            // re-burn cannot fire against funds CCTP already burned. `FailBridging`
+            // from post-burn `Bridging`/`Attested` states emits `burn_tx_hash: Some`
+            // and holds the guard. A plain pre-burn `FailBridging` from
+            // `WithdrawalComplete` carries `burn_tx_hash: None` and reconciles to
+            // source.
             //
             // For a BaseToAlpaca post-burn failure this is not a permanent latch:
             // it is now recoverable and auto-re-armed on startup, and recovery
@@ -1307,7 +1323,10 @@ impl EventSourced for UsdcRebalance {
             },
 
             (
-                WithdrawalConfirmed { confirmed_at },
+                WithdrawalConfirmed {
+                    confirmed_at,
+                    withdrawal_tx,
+                },
                 Self::Withdrawing {
                     direction,
                     amount,
@@ -1319,6 +1338,7 @@ impl EventSourced for UsdcRebalance {
                 amount: *amount,
                 initiated_at: *initiated_at,
                 confirmed_at: *confirmed_at,
+                withdrawal_tx: *withdrawal_tx,
             },
 
             (
@@ -1705,7 +1725,7 @@ impl EventSourced for UsdcRebalance {
 
             InitiatePostDepositConversion { .. } => Err(UsdcRebalanceError::DepositNotConfirmed),
 
-            ConfirmWithdrawal | FailWithdrawal { .. } => {
+            ConfirmWithdrawal { .. } | FailWithdrawal { .. } => {
                 Err(UsdcRebalanceError::WithdrawalNotInitiated)
             }
 
@@ -1713,13 +1733,12 @@ impl EventSourced for UsdcRebalance {
                 Err(UsdcRebalanceError::WithdrawalNotConfirmed)
             }
 
-            ReceiveAttestation { .. } | TimeoutAttestation { .. } | FailBridging { .. } => {
-                Err(UsdcRebalanceError::BridgingNotInitiated)
-            }
+            ReceiveAttestation { .. }
+            | TimeoutAttestation { .. }
+            | FailBridging { .. }
+            | RecoverBridging { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
 
             ConfirmBridging { .. } => Err(UsdcRebalanceError::AttestationNotReceived),
-
-            RecoverBridging { .. } => Err(UsdcRebalanceError::BridgingNotInitiated),
 
             InitiateDeposit { .. } => Err(UsdcRebalanceError::BridgingNotCompleted),
 
@@ -1757,7 +1776,9 @@ impl EventSourced for UsdcRebalance {
                 amount,
                 withdrawal,
             } => self.transition_initiate_withdrawal(direction, amount, withdrawal),
-            ConfirmWithdrawal => self.transition_confirm_withdrawal(),
+            ConfirmWithdrawal { withdrawal_tx } => {
+                self.transition_confirm_withdrawal(withdrawal_tx)
+            }
             FailWithdrawal { reason } => self.transition_fail_withdrawal(reason),
             BeginBridging { from_block } => self.transition_begin_bridging(from_block),
             InitiateBridging { burn_tx } => self.transition_initiate_bridging(burn_tx),
@@ -1956,11 +1977,15 @@ impl UsdcRebalance {
         }])
     }
 
-    fn transition_confirm_withdrawal(&self) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
+    fn transition_confirm_withdrawal(
+        &self,
+        withdrawal_tx: Option<TxHash>,
+    ) -> Result<Vec<UsdcRebalanceEvent>, UsdcRebalanceError> {
         use UsdcRebalanceEvent::*;
         match self {
             Self::Withdrawing { .. } => Ok(vec![WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx,
             }]),
             Self::WithdrawalComplete { .. }
             | Self::BridgingSubmitting { .. }
@@ -2521,6 +2546,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -2678,6 +2704,7 @@ mod tests {
     fn non_init_event_on_uninitialized_produces_failed_state() {
         let error = replay::<UsdcRebalance>(vec![UsdcRebalanceEvent::WithdrawalConfirmed {
             confirmed_at: Utc::now(),
+            withdrawal_tx: None,
         }])
         .unwrap_err();
 
@@ -2819,6 +2846,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
             .when(UsdcRebalanceCommand::BeginBridging { from_block: 99 })
@@ -2849,6 +2877,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingSubmitting {
                     from_block: 99,
@@ -2885,6 +2914,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingSubmitting {
                 from_block: 99,
@@ -2910,7 +2940,9 @@ mod tests {
                 withdrawal_ref: TransferRef::AlpacaId(transfer_id),
                 initiated_at: Utc::now(),
             }])
-            .when(UsdcRebalanceCommand::ConfirmWithdrawal)
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            })
             .await
             .events();
 
@@ -2925,7 +2957,9 @@ mod tests {
     async fn test_cannot_confirm_withdrawal_before_initiating() {
         let error = TestHarness::<UsdcRebalance>::with(())
             .given_no_previous_events()
-            .when(UsdcRebalanceCommand::ConfirmWithdrawal)
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            })
             .await
             .then_expect_error();
 
@@ -2949,9 +2983,12 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
-            .when(UsdcRebalanceCommand::ConfirmWithdrawal)
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            })
             .await
             .then_expect_error();
 
@@ -3015,6 +3052,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
             .when(UsdcRebalanceCommand::FailWithdrawal {
@@ -3074,6 +3112,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
             .when(UsdcRebalanceCommand::InitiateBridging {
@@ -3111,6 +3150,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3149,6 +3189,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: initiated_at,
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: BURN_TX,
@@ -3192,6 +3233,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: initiated_at,
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: BURN_TX,
@@ -3318,6 +3360,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3354,6 +3397,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3686,6 +3730,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
             .when(UsdcRebalanceCommand::ReceiveAttestation {
@@ -3751,6 +3796,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3797,6 +3843,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3848,6 +3895,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3882,6 +3930,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
             ])
             .when(UsdcRebalanceCommand::FailBridging {
@@ -3922,6 +3971,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -3971,6 +4021,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4021,6 +4072,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4072,6 +4124,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4122,6 +4175,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4175,6 +4229,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4222,6 +4277,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4267,6 +4323,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4326,6 +4383,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4380,6 +4438,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4426,6 +4485,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4479,6 +4539,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4529,6 +4590,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4594,6 +4656,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4655,6 +4718,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4709,6 +4773,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash,
@@ -4758,7 +4823,9 @@ mod tests {
                     failed_at: Utc::now(),
                 },
             ])
-            .when(UsdcRebalanceCommand::ConfirmWithdrawal)
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            })
             .await
             .then_expect_error();
 
@@ -4811,6 +4878,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -4855,6 +4923,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -4901,6 +4970,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -4981,6 +5051,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingFailed {
                     burn_tx_hash: None,
@@ -5023,6 +5094,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: fixed_bytes!(
@@ -5062,6 +5134,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -5108,6 +5181,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -5140,6 +5214,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: Utc::now(),
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -5369,6 +5444,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -5417,6 +5493,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -5519,6 +5596,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingFailed {
                     burn_tx_hash: None,
@@ -5586,6 +5664,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -5641,6 +5720,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -5699,6 +5779,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -6018,6 +6099,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -6086,6 +6168,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -6160,6 +6243,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -6223,6 +6307,7 @@ mod tests {
                 },
                 UsdcRebalanceEvent::WithdrawalConfirmed {
                     confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
                 },
                 UsdcRebalanceEvent::BridgingInitiated {
                     burn_tx_hash: burn_tx,
@@ -6292,6 +6377,7 @@ mod tests {
             },
             UsdcRebalanceEvent::WithdrawalConfirmed {
                 confirmed_at: withdrawal_confirmed_at,
+                withdrawal_tx: None,
             },
             UsdcRebalanceEvent::BridgingInitiated {
                 burn_tx_hash: burn_tx,
@@ -6709,6 +6795,7 @@ mod tests {
             amount: Usdc::new(float!(800)),
             initiated_at,
             confirmed_at,
+            withdrawal_tx: None,
         };
 
         let dto = state.to_dto(&id);
@@ -6865,6 +6952,7 @@ mod tests {
                 amount,
                 initiated_at: now,
                 confirmed_at: now,
+                withdrawal_tx: None,
             }
             .holds_rebalance_guard()
         );
@@ -7108,7 +7196,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&bridge_failed, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &bridge_failed,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -7144,7 +7237,9 @@ mod tests {
         store
             .send(
                 &awaiting_attestation,
-                UsdcRebalanceCommand::ConfirmWithdrawal,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
             )
             .await
             .unwrap();
@@ -7181,7 +7276,12 @@ mod tests {
             .await
             .unwrap();
         store
-            .send(&recovered, UsdcRebalanceCommand::ConfirmWithdrawal)
+            .send(
+                &recovered,
+                UsdcRebalanceCommand::ConfirmWithdrawal {
+                    withdrawal_tx: None,
+                },
+            )
             .await
             .unwrap();
         store
@@ -7239,5 +7339,271 @@ mod tests {
             interrupted.unparseable.is_empty(),
             "well-formed UUID aggregate_ids must not be reported as unparseable"
         );
+    }
+
+    // --- T1-T5: crash-safe AlpacaToBase machinery ---
+
+    /// T1: ConfirmWithdrawal with Some(tx) emits WithdrawalConfirmed carrying
+    /// the tx hash, then transitions WithdrawalComplete to carry it too.
+    #[tokio::test]
+    async fn confirm_withdrawal_with_tx_hash_threads_it_through_to_withdrawal_complete() {
+        let tx_hash =
+            fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: Some(tx_hash),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::WithdrawalConfirmed { withdrawal_tx, .. } = &events[0] else {
+            panic!("Expected WithdrawalConfirmed, got {:?}", events[0]);
+        };
+        assert_eq!(*withdrawal_tx, Some(tx_hash));
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            },
+            events[0].clone(),
+        ])
+        .unwrap();
+
+        let Some(UsdcRebalance::WithdrawalComplete { withdrawal_tx, .. }) = state else {
+            panic!("Expected WithdrawalComplete state, got: {state:?}");
+        };
+        assert_eq!(withdrawal_tx, Some(tx_hash));
+    }
+
+    /// T2: ConfirmWithdrawal with None works identically for the None case.
+    #[tokio::test]
+    async fn confirm_withdrawal_with_none_produces_withdrawal_complete_with_none_tx() {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            }])
+            .when(UsdcRebalanceCommand::ConfirmWithdrawal {
+                withdrawal_tx: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::WithdrawalConfirmed { withdrawal_tx, .. } = &events[0] else {
+            panic!("Expected WithdrawalConfirmed, got {:?}", events[0]);
+        };
+        assert_eq!(*withdrawal_tx, None);
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::BaseToAlpaca,
+                amount: Usdc::new(float!(100.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            },
+            events[0].clone(),
+        ])
+        .unwrap();
+
+        let Some(UsdcRebalance::WithdrawalComplete { withdrawal_tx, .. }) = state else {
+            panic!("Expected WithdrawalComplete state, got: {state:?}");
+        };
+        assert_eq!(withdrawal_tx, None);
+    }
+
+    /// T3: Backward compatibility -- replaying a persisted WithdrawalConfirmed
+    /// that lacks the `withdrawal_tx` field (simulated via JSON without the field)
+    /// deserializes via `#[serde(default)]` to `None`, producing WithdrawalComplete
+    /// with `withdrawal_tx: None`.
+    #[test]
+    fn withdrawal_confirmed_without_withdrawal_tx_field_deserializes_to_none() {
+        let old_event = json!({
+            "WithdrawalConfirmed": {
+                "confirmed_at": "2026-01-01T00:00:00Z"
+            }
+        });
+
+        let event: UsdcRebalanceEvent =
+            from_value(old_event).expect("old WithdrawalConfirmed must still deserialize");
+
+        let UsdcRebalanceEvent::WithdrawalConfirmed { withdrawal_tx, .. } = event else {
+            panic!("Expected WithdrawalConfirmed");
+        };
+        assert_eq!(withdrawal_tx, None, "missing field must default to None");
+    }
+
+    /// T3b: State-level mirror of T3 -- a `WithdrawalComplete` snapshot persisted
+    /// before `withdrawal_tx` existed must still load, defaulting the field to
+    /// `None` via `#[serde(default)]`. Guards the restart/resume path: dropping
+    /// the default or adding `deny_unknown_fields` would strand in-flight
+    /// transfers held in a pre-field `WithdrawalComplete` snapshot.
+    #[test]
+    fn withdrawal_complete_snapshot_without_withdrawal_tx_deserializes_to_none() {
+        let tx_hash =
+            fixed_bytes!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let mut snapshot = to_value(UsdcRebalance::WithdrawalComplete {
+            direction: RebalanceDirection::AlpacaToBase,
+            amount: Usdc::new(float!(100.00)),
+            initiated_at: Utc::now(),
+            confirmed_at: Utc::now(),
+            withdrawal_tx: Some(tx_hash),
+        })
+        .expect("WithdrawalComplete state serializes");
+
+        // Simulate a snapshot persisted before the `withdrawal_tx` field existed.
+        snapshot
+            .get_mut("WithdrawalComplete")
+            .and_then(|value| value.as_object_mut())
+            .expect("externally-tagged WithdrawalComplete object")
+            .remove("withdrawal_tx");
+
+        let state = from_value::<UsdcRebalance>(snapshot)
+            .expect("pre-field WithdrawalComplete snapshot must still load");
+
+        let UsdcRebalance::WithdrawalComplete { withdrawal_tx, .. } = state else {
+            panic!("expected WithdrawalComplete, got {state:?}");
+        };
+
+        assert_eq!(withdrawal_tx, None);
+    }
+
+    /// T4: BeginBridging from WithdrawalComplete (AlpacaToBase direction) emits
+    /// BridgingSubmitting and transitions to BridgingSubmitting state carrying
+    /// direction: AlpacaToBase.
+    #[tokio::test]
+    async fn begin_bridging_from_withdrawal_complete_alpaca_to_base_transitions_correctly() {
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(200.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+            ])
+            .when(UsdcRebalanceCommand::BeginBridging { from_block: 42 })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingSubmitting { from_block, .. } = &events[0] else {
+            panic!("Expected BridgingSubmitting event, got {:?}", events[0]);
+        };
+        assert_eq!(*from_block, 42);
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(200.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+                withdrawal_tx: None,
+            },
+            events[0].clone(),
+        ])
+        .unwrap();
+
+        let Some(UsdcRebalance::BridgingSubmitting {
+            direction,
+            from_block,
+            ..
+        }) = state
+        else {
+            panic!("Expected BridgingSubmitting state, got: {state:?}");
+        };
+        assert_eq!(direction, RebalanceDirection::AlpacaToBase);
+        assert_eq!(from_block, 42);
+    }
+
+    /// T5: BridgingSubmitting (AlpacaToBase direction): InitiateBridging transitions
+    /// to Bridging. Verifies InitiateBridging is direction-agnostic.
+    #[tokio::test]
+    async fn initiate_bridging_from_bridging_submitting_alpaca_to_base_transitions_to_bridging() {
+        let burn_tx =
+            fixed_bytes!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let transfer_id = AlpacaTransferId::from(Uuid::new_v4());
+
+        let events = TestHarness::<UsdcRebalance>::with(())
+            .given(vec![
+                UsdcRebalanceEvent::Initiated {
+                    direction: RebalanceDirection::AlpacaToBase,
+                    amount: Usdc::new(float!(200.00)),
+                    withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                    initiated_at: Utc::now(),
+                },
+                UsdcRebalanceEvent::WithdrawalConfirmed {
+                    confirmed_at: Utc::now(),
+                    withdrawal_tx: None,
+                },
+                UsdcRebalanceEvent::BridgingSubmitting {
+                    from_block: 42,
+                    submitting_at: Utc::now(),
+                },
+            ])
+            .when(UsdcRebalanceCommand::InitiateBridging { burn_tx })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let UsdcRebalanceEvent::BridgingInitiated { burn_tx_hash, .. } = &events[0] else {
+            panic!("Expected BridgingInitiated event, got {:?}", events[0]);
+        };
+        assert_eq!(*burn_tx_hash, burn_tx);
+
+        let state = replay::<UsdcRebalance>(vec![
+            UsdcRebalanceEvent::Initiated {
+                direction: RebalanceDirection::AlpacaToBase,
+                amount: Usdc::new(float!(200.00)),
+                withdrawal_ref: TransferRef::AlpacaId(transfer_id),
+                initiated_at: Utc::now(),
+            },
+            UsdcRebalanceEvent::WithdrawalConfirmed {
+                confirmed_at: Utc::now(),
+                withdrawal_tx: None,
+            },
+            UsdcRebalanceEvent::BridgingSubmitting {
+                from_block: 42,
+                submitting_at: Utc::now(),
+            },
+            events[0].clone(),
+        ])
+        .unwrap();
+
+        let Some(UsdcRebalance::Bridging {
+            direction,
+            burn_tx_hash,
+            ..
+        }) = state
+        else {
+            panic!("Expected Bridging state, got: {state:?}");
+        };
+        assert_eq!(direction, RebalanceDirection::AlpacaToBase);
+        assert_eq!(burn_tx_hash, burn_tx);
     }
 }

--- a/tests/e2e/cctp.rs
+++ b/tests/e2e/cctp.rs
@@ -272,7 +272,16 @@ impl AlpacaWithdrawalExecutor {
         )
         .await
         {
-            Ok(()) => MintAttempt::Done,
+            Ok(tx_hash) => {
+                // Record the real on-chain mint tx hash so the bot's
+                // withdrawal-confirmation check can verify it against the
+                // Ethereum chain. Without this, the mock returns the
+                // placeholder 0xcdcd... hash, which isn't on-chain and fails
+                // the confirmation gate.
+                self.broker
+                    .set_transfer_tx_hash(transfer_id, format!("{tx_hash:#x}"));
+                MintAttempt::Done
+            }
             Err(error) => {
                 warn!(
                     %transfer_id,


### PR DESCRIPTION
## What

- Gate the `AlpacaToBase` USDC rebalance CCTP burn on on-chain settlement of the withdrawn USDC, so the burn never fires before the funds are confirmed present.
- Resolves [RAI-1018](https://linear.app/makeitrain/issue/RAI-1018/alpacatobase-rebalance-runs-cctp-burn-before-the-alpaca-withdrawal). Crash-safe-burn hardening follows in stacked PR #859 ([RAI-1020](https://linear.app/makeitrain/issue/RAI-1020/make-the-alpacatobase-cctp-burn-crash-safe-prevent-post-commit-double)).

## Why

- `AlpacaToBase` burned immediately on Alpaca's "Complete" status, before the withdrawn USDC settled on-chain. Under settlement/RPC lag the burn reverted → terminal `BridgingFailed` → the `usdc_in_progress` guard was released → the trigger re-fired and withdrew another ~1000 USDC into the same trap (a runaway draining ~1000/op). Blocker for re-enabling automatic USDC rebalancing.

## How

- **Settlement gate:** `poll_and_confirm_withdrawal` waits for the configured `required_confirmations` on the withdrawal's on-chain tx before the burn. Insufficient confirmations / not-yet-settled return retryable errors (apalis delayed-redrive via `SETTLEMENT_REDRIVE_DELAY`), never a terminal `FailWithdrawal`. Transient RPC failures map to `SettlementCheckTransient` and redrive too, instead of burning the small apalis retry budget.
- **Durable across redrive:** the withdrawal tx hash is persisted through `ConfirmWithdrawal`/`WithdrawalConfirmed`/`WithdrawalComplete` (`#[serde(default)]`, no migration) so the gate re-runs on resume at the same depth as the fresh path.
- **Fallback:** if Alpaca returns no `tx_hash`, the confirmation check is skipped and a wallet-balance gate guards the burn — it checks absolute wallet USDC `>= burn_amount`, so it assumes no ambient USDC in the market-maker Ethereum wallet.
- **Config:** confirmation depth comes from the configured `required_confirmations` (threaded via `UsdcSettlementParams`), not a hardcoded constant. Bridge gains Ethereum-side reads (`ethereum_usdc_balance`, `ethereum_tx_confirmations`, `Bridge::source_block`). The burn itself is unchanged from master here (terminal on error); crash-safe adopt-on-resume is the stacked PR #859.

## Testing

- Aggregate + manager unit tests (tx-hash threading + serde-default compat; under-confirmed → retryable no-burn; `None` tx skips the gate; balance gate insufficient/sufficient/exact-boundary; settlement-transient redrive), job redrive tests, bridge anvil tests, and the `usdc_imbalance_triggers_alpaca_to_base` e2e.

## Anything else

- No SQL migration (`#[serde(default)]` on new fields).
- Deferred to [RAI-1019](https://linear.app/makeitrain/issue/RAI-1019/add-a-settlement-retry-deadline-to-the-alpacatobase-usdc-rebalance): the settlement-wait redrive has no upper deadline — a permanently-absent withdrawal tx loops safely but indefinitely (guard latched until operator intervention), strictly better than the prior fund-draining runaway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced USDC settlement verification with confirmation depth checks and balance validation before executing cross-chain transfers.
  * Automatic retry mechanism for USDC transfers when on-chain settlement confirmations are incomplete.

* **Bug Fixes**
  * Improved error messages for failed transfer events with transaction details.

* **Reliability**
  * Added fallback safety gates to prevent transfers against unconfirmed balances on target chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->