### PR TITLE
docs: fix workspace crate list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,11 +304,14 @@ Workspace crates:
 
 - **`st0x-hedge`** (root) - Main arbitrage bot: event loop, CQRS/ES aggregates,
   conductor, dashboard backend, and CLI
+- **`st0x-config`** (`crates/config/`) - TOML/secrets loading,
+  `Ctx`/`BrokerCtx`/`Env` assembly, and `setup_tracing`. Restricted: only
+  `st0x-server` and `st0x-cli` may depend on it
 - **`st0x-dto`** (`crates/dto/`) - Dashboard DTOs and TypeScript binding
   generation
-- **`st0x-event-sorcery`** (`crates/event-sorcery/`) - CQRS/event-sourcing
-  helpers, snapshot-backed loading, compactable observational event streams, and
-  testing utilities
+- **`st0x-event-sorcery`** (external git dep) - CQRS/event-sourcing helpers,
+  snapshot-backed loading, compactable observational event streams, and testing
+  utilities
 - **`st0x-execution`** (`crates/execution/`) - Standalone `Executor` trait
   abstraction with Alpaca Broker API and mock implementations
 - **`st0x-bridge`** (`crates/bridge/`) - Cross-chain bridge abstractions and
@@ -320,6 +323,10 @@ Workspace crates:
   and serde helpers for workspace wire formats
 - **`st0x-float-macro`** (`crates/float-macro/`) - Proc-macro for compile-time
   `Float` literals (`float!(1.5)`)
+- **`st0x-raindex`** (`crates/raindex/`) - Raindex orderbook vault
+  deposit/withdraw operations and vault registry seeding
+- **`st0x-wrapper`** (`crates/wrapper/`) - ERC-4626 wrap/unwrap operations and
+  ratio math
 
 ### Infrastructure
 


### PR DESCRIPTION
## What

Fix the "Cargo Workspace" section in README.md:

- Add `st0x-config`, `st0x-raindex`, and `st0x-wrapper` — three crates
  extracted by recent refactors (#739, #743, #744) that were missing from the
  list.
- Fix `st0x-event-sorcery`: the README listed it with the path
  `crates/event-sorcery/`, implying it is a local workspace crate. It is
  actually an external git dependency (`ST0x-Technology/event-sorcery`); no
  such local directory exists.

## Why

The crate list was last updated before the raindex/wrapper/config extractions.
Agents and contributors reading the README would have an incomplete picture of
the workspace structure and might look for a `crates/event-sorcery/` directory
that does not exist.

## How

Minimal textual edits to the "Cargo Workspace" bullet list. No code changes.

## Testing

Verified against `Cargo.toml` workspace members and
`workspace.dependencies.st0x-event-sorcery` (git source).

## Anything else

All other docs reviewed (`SPEC.md`, `docs/*.md`, `crates/execution/AGENTS.md`)
— no factual inaccuracies found.

https://claude.ai/code/session_01Sqf7FhAmXLw7AiZbcF2KTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sqf7FhAmXLw7AiZbcF2KTR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783998538&installation_id=125569124&pr_number=858&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F858&signature=4595f203ca0d462317d68da578d30af1778826ad298132ae555ed940eb9df278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to reflect new workspace crates and revised external dependency listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->