### PR TITLE
fix: stop malformed Raindex order values from crashing the dashboard

### DIFF
--- a/dashboard/src/lib/decimal.test.ts
+++ b/dashboard/src/lib/decimal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decimalAdd,
+  decimalCompare,
+  decimalIsZero,
+  decimalSub,
+  formatDecimal,
+} from './decimal'
+
+describe('formatDecimal', () => {
+  it('formats a normal value with grouping and fixed decimals', () => {
+    expect(formatDecimal('1234567.891', 3)).toBe('1,234,567.891')
+  })
+
+  it('pads to the requested number of decimals', () => {
+    expect(formatDecimal('1.5', 3)).toBe('1.500')
+  })
+
+  it('renders absent values as zero', () => {
+    expect(formatDecimal('', 3)).toBe('0.000')
+    expect(formatDecimal('   ', 3)).toBe('0.000')
+    // The typed `string` contract is enforced only by an unchecked cast of the
+    // upstream JSON, so null/undefined reach this function at runtime.
+    expect(formatDecimal(null as unknown as string, 3)).toBe('0.000')
+    expect(formatDecimal(undefined as unknown as string, 3)).toBe('0.000')
+  })
+
+  it('surfaces a present-but-unparseable value instead of throwing', () => {
+    // Regression: a single bad order value used to throw inside the orders
+    // panel's {#each} render and freeze the entire dashboard until refresh.
+    expect(formatDecimal('1,000', 3)).toBe('1,000')
+    expect(formatDecimal('0x', 3)).toBe('0x')
+    expect(formatDecimal('not-a-number', 3)).toBe('not-a-number')
+  })
+})
+
+describe('decimal arithmetic', () => {
+  it('adds and subtracts decimal strings', () => {
+    expect(decimalAdd('1.5', '2.25')).toBe('3.75')
+    expect(decimalSub('5', '1.5')).toBe('3.5')
+  })
+
+  it('treats absent operands as zero', () => {
+    expect(decimalAdd('', '2')).toBe('2')
+    expect(decimalSub('5', '  ')).toBe('5')
+  })
+
+  it('compares decimal strings', () => {
+    expect(decimalCompare('1', '2')).toBe(-1)
+    expect(decimalCompare('2', '2')).toBe(0)
+    expect(decimalCompare('3', '2')).toBe(1)
+  })
+
+  it('detects zero across absent forms', () => {
+    expect(decimalIsZero('0')).toBe(true)
+    expect(decimalIsZero('')).toBe(true)
+    expect(decimalIsZero('0.5')).toBe(false)
+  })
+
+  it('throws on a present-but-unparseable operand rather than fabricating a number', () => {
+    expect(() => decimalAdd('1,000', '1')).toThrow()
+  })
+})

--- a/dashboard/src/lib/decimal.ts
+++ b/dashboard/src/lib/decimal.ts
@@ -1,7 +1,16 @@
 import Decimal from 'decimal.js'
 
-const toDecimal = (value: string): Decimal =>
-  new Decimal(value !== '' ? value : '0')
+// These values come from external APIs (e.g. the Raindex orders proxy) and are
+// only typed as `string` after an unchecked cast -- at runtime a field can be
+// null, undefined, or whitespace. Treat every genuinely-absent form as "0"
+// (matching the original empty-string guard) so decimal.js never throws on
+// missing data. A value that is present but unparseable (e.g. "1,000", "0x")
+// still throws here; only `formatDecimal` softens that, never the arithmetic
+// helpers, which must not fabricate a number from garbage.
+const toDecimal = (value: string | null | undefined): Decimal => {
+  const trimmed = value?.trim() ?? ''
+  return new Decimal(trimmed === '' ? '0' : trimmed)
+}
 
 export const decimalAdd = (left: string, right: string): string =>
   toDecimal(left).plus(toDecimal(right)).toString()
@@ -15,7 +24,16 @@ export const decimalCompare = (left: string, right: string): number =>
 export const decimalIsZero = (value: string): boolean => toDecimal(value).isZero()
 
 export const formatDecimal = (value: string, decimals: number): string => {
-  const fixed = toDecimal(value).toFixed(decimals)
+  let fixed: string
+  try {
+    fixed = toDecimal(value).toFixed(decimals)
+  } catch {
+    // A present-but-unparseable value would throw, and an unhandled throw
+    // inside a Svelte {#each} render freezes the whole dashboard. Surface the
+    // raw value rather than crashing or fabricating a misleading number.
+    return value
+  }
+
   const [intPart = '0', fracPart] = fixed.split('.')
   const withCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
   return fracPart !== undefined ? `${withCommas}.${fracPart}` : withCommas


### PR DESCRIPTION
## What

- Stop a single malformed Raindex order value from crashing the entire dashboard (`[DecimalError] Invalid argument:` froze the Orders panel until refresh).
- `dashboard/src/lib/decimal.ts`: `toDecimal` now treats every *absent* form (`null`/`undefined`/whitespace/`''`) as `0`; `formatDecimal` surfaces a present-but-unparseable value raw instead of throwing.
- `dashboard/src/lib/decimal.test.ts`: new test file covering the regression and the arithmetic helpers.

## Why

- `orders-panel.svelte` passes `order.outputVaultBalance`/`order.ioRatio` straight into `formatDecimal`. Those fields are typed `string` but only via an unchecked cast of the upstream REST-proxy JSON, so at runtime they can be `null`, `undefined`, or whitespace.
- `new Decimal(...)` throws on all of those (verified against decimal.js 10.6.0). The throw happens inside Svelte's `{#each}` render, which takes down the whole page.
- #653 guarded empty strings only; the other absent forms still crashed.

## How

- `toDecimal` trims and maps any absent value to `'0'` (`value?.trim() ?? ''` then `'' -> '0'`), widening the param to `string | null | undefined` to match runtime reality.
- `formatDecimal` wraps parsing in try/catch: a present-but-unparseable value (e.g. `"1,000"`, `"0x"`) is returned raw — truthful and non-crashing — rather than fabricating a misleading `0`.
- Arithmetic helpers (`decimalAdd`/`Sub`/`Compare`/`IsZero`) stay strict: they still throw on garbage operands so sums are never silently corrupted.

## Testing

- New `decimal.test.ts` (9 tests): normal formatting/grouping, all absent forms render `0`, the present-but-unparseable regression returns raw, and arithmetic still throws on bad operands.
- `bun run check` (0 errors/0 warnings), `bun run lint` clean, full dashboard suite 146 passing.

## Anything else

- Display-layer fix only — no change to the bot's financial math. Surfacing absent values as `0`/raw is consistent with #653's prior intent for these fields.
- Separate open question (not addressed here): why the upstream Raindex REST API emits empty/whitespace `ioRatio`/`outputVaultBalance` for some orders.
