### PR TITLE
feat: track block_hash on EmittedOnChain and persist it for fork detection

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1069,9 +1069,9 @@ rules and maintain consistency boundaries.
 OnChain trades, offchain orders, and positions are all entities with distinct
 lifecycles, so we model them as separate aggregates:
 
-- **OnChainTrade**: Lifecycle = blockchain fill -> enriched with metadata.
-  Immutable blockchain facts (reorgs not currently handled, see Future
-  Consideration section).
+- **OnChainTrade**: Lifecycle = blockchain fill -> enriched with metadata ->
+  reversed on reorg. Records the `block_hash` of the fill's block for fork
+  detection (see Reorg Handling).
 - **OffchainOrder**: Lifecycle = placed -> submitted -> filled/failed. Broker
   order tracking.
 - **Position**: Lifecycle = accumulates fills -> triggers hedging decisions.
@@ -3715,33 +3715,63 @@ evolves toward lifecycle workflows, the pipeline steps will become discrete
 workflow steps coordinated by apalis-workflow, with each step as a durable
 checkpoint.
 
-#### Future Consideration: Reorg Handling
+#### Reorg Handling
 
-**Note**: Reorg handling is not implemented currently, but the event-sourced
-architecture will make it significantly easier to add in the future.
+Blockchain reorganizations can invalidate a fill the bot already witnessed: a
+confirmed `(tx_hash, log_index)` may be dropped from the canonical chain, or
+reappear on a different fork. Because ingestion is event-sourced, the bot treats
+a reorg as a first-class domain event that reverses the original fill's impact
+rather than mutating or deleting history.
 
-Blockchain reorganizations occur before block finalization. When we eventually
-implement reorg handling, the event-sourced architecture will make it
-significantly easier than the current CRUD approach.
+##### Fork identity
 
-##### Why Event Sourcing Helps
+Every `OnChainTrade` records the `block_hash` of the block its fill was
+confirmed in, alongside `(tx_hash, log_index, block_number)`. The idempotency
+key stays `(tx_hash, log_index)`; `block_hash` is the fork-detection field, not
+part of the key. On backfill or restart the bot distinguishes "same fill, same
+fork" (a duplicate, skipped) from "same `(tx_hash, log_index)`, different
+`block_hash`" (a reorg).
 
-Simply append a reorg event that reverses the position change. The event would
-be: PositionCommand::RecordReorg with tx_hash, log_index, symbol, amount,
-direction, reorg_depth. The resulting PositionEvent::Reorged would reverse the
-original trade's position impact. Views would update automatically. The
-`onchain_trade_view` could mark trades as `reorged: true` without deleting them.
+When either side of the comparison has **no** `block_hash` -- the source log
+carried none, or the fill predates the field -- the backfill/restart path cannot
+classify the re-observation, so it conservatively treats it as a duplicate
+(skipped, never a reversal): a missing hash must never fabricate a reorg against
+a fill that may be perfectly canonical. Fork detection for those fills falls
+back to the live removed-log path (a removed log past the confirmation gate
+still emits `RecordReorg`), which does not depend on the stored hash.
 
-##### Benefits (when implemented)
+_(Design specification -- the detection and reversal paths below describe the
+target behavior, not what runs today. Only `block_hash` storage, the
+fork-identity foundation above, exists so far; detection and reversal are being
+implemented.)_
+
+##### Detection
+
+A reorg is detected on either ingestion path:
+
+- **Live**: a previously confirmed log is removed past the confirmation gate.
+- **Backfill/restart**: a re-observed `(tx_hash, log_index)` carries a
+  `block_hash` that differs from the recorded one.
+
+Either path emits a `RecordReorg` command through the CQRS framework -- never a
+direct SQL write.
+
+##### Reversal
+
+`RecordReorg` produces `OnChainTradeEvent::Reorged` and
+`PositionEvent::Reorged`. The position event reverses the original fill's
+position impact (a buy fill's reorg reverses as a sell of the same size, and
+vice versa). Views update automatically: `onchain_trade_view` and
+`position_view` expose an append-only `reorged` flag -- original rows are
+preserved, never deleted.
+
+##### Why event sourcing fits
 
 - Append-only: no cascading updates across tables
-- Complete audit trail: preserves both original trade and reorg event
+- Complete audit trail: preserves both the original fill and its reversal
 - Testable: Given-When-Then testing for reorg scenarios
 - Recoverable: fix bugs and replay events to correct state
 - Explicit: reorgs are first-class domain events, not special cases
-
-This demonstrates how the event-sourced architecture provides a cleaner
-foundation for future enhancements.
 
 ### Testing Strategy
 

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -642,12 +642,17 @@ pub(super) async fn process_found_trade<W: Write>(
         anyhow::bail!("Fill {trade_id}: missing block_number, cannot witness fill");
     };
 
+    // process-tx reconstructs the fill from the transaction and does not carry
+    // the originating block hash (OnchainTrade stores only block number and
+    // timestamp), so a manually recovered fill is witnessed without a reorg
+    // hash. Such a fill is past reorg risk by the time an operator accounts it.
     let FillAccountingOutcome::Accounted { trade_id } = account_for_onchain_fill(
         pool,
         &onchain_trade_store,
         &position_store,
         &onchain_trade,
         block_number,
+        None,
         ctx.execution_threshold,
     )
     .await?
@@ -1931,6 +1936,7 @@ mod tests {
                     direction: onchain_trade.direction,
                     price_usdc: onchain_trade.price.value(),
                     block_number: 1,
+                    block_hash: None,
                     block_timestamp,
                 },
             )
@@ -2030,6 +2036,7 @@ mod tests {
                     direction: onchain_trade.direction,
                     price_usdc: onchain_trade.price.value(),
                     block_number: 1,
+                    block_hash: None,
                     block_timestamp,
                 },
             )
@@ -2202,6 +2209,7 @@ mod tests {
             tx_hash: onchain_trade.tx_hash,
             log_index: onchain_trade.log_index,
             block_number: 42,
+            block_hash: None,
             block_timestamp: onchain_trade.block_timestamp,
         };
 
@@ -2726,6 +2734,7 @@ mod tests {
                     direction: onchain_trade.direction,
                     price_usdc: onchain_trade.price.value(),
                     block_number: 42,
+                    block_hash: None,
                     block_timestamp,
                 },
             )
@@ -2822,6 +2831,7 @@ mod tests {
                     direction: onchain_trade.direction,
                     price_usdc: onchain_trade.price.value(),
                     block_number: 42,
+                    block_hash: None,
                     block_timestamp,
                 },
             )
@@ -2945,6 +2955,7 @@ mod tests {
                     direction: fill_a.direction,
                     price_usdc: fill_a.price.value(),
                     block_number: 10,
+                    block_hash: None,
                     block_timestamp: block_timestamp_a,
                 },
             )
@@ -2974,6 +2985,7 @@ mod tests {
                     direction: fill_b.direction,
                     price_usdc: fill_b.price.value(),
                     block_number: 11,
+                    block_hash: None,
                     block_timestamp: block_timestamp_b,
                 },
             )
@@ -3103,6 +3115,7 @@ mod tests {
                     direction: fill_b.direction,
                     price_usdc: fill_b.price.value(),
                     block_number: 11,
+                    block_hash: None,
                     block_timestamp: block_timestamp_b,
                 },
             )

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -8,7 +8,7 @@ mod manifest;
 pub(crate) mod monitor;
 mod trading_queues;
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
 };
@@ -2400,6 +2400,7 @@ pub(crate) async fn execute_witness_trade(
     onchain_trade: &Store<OnChainTrade>,
     trade: &OnchainTrade,
     block_number: u64,
+    block_hash: Option<B256>,
     block_timestamp: DateTime<Utc>,
 ) -> Result<bool, SendError<OnChainTrade>> {
     let trade_id = OnChainTradeId {
@@ -2416,6 +2417,7 @@ pub(crate) async fn execute_witness_trade(
         direction: trade.direction,
         price_usdc,
         block_number,
+        block_hash,
         block_timestamp,
     };
 
@@ -2662,6 +2664,7 @@ pub(crate) async fn account_for_onchain_fill(
     position: &Store<Position>,
     trade: &OnchainTrade,
     block_number: u64,
+    block_hash: Option<B256>,
     threshold: ExecutionThreshold,
 ) -> Result<FillAccountingOutcome, TradeAccountingError> {
     let trade_id = OnChainTradeId {
@@ -2706,8 +2709,14 @@ pub(crate) async fn account_for_onchain_fill(
             }
         }
         Ok(None) => {
-            let witnessed =
-                execute_witness_trade(onchain_trade, trade, block_number, block_timestamp).await?;
+            let witnessed = execute_witness_trade(
+                onchain_trade,
+                trade,
+                block_number,
+                block_hash,
+                block_timestamp,
+            )
+            .await?;
 
             if witnessed {
                 execute_enrich_trade(onchain_trade, trade).await;
@@ -2762,6 +2771,7 @@ where
         &cqrs.position,
         &trade,
         trade_event.block_number,
+        trade_event.block_hash,
         cqrs.execution_threshold,
     )
     .await?
@@ -5716,6 +5726,50 @@ mod tests {
         );
     }
 
+    /// The emitted log's block hash must thread end-to-end through ingestion
+    /// into the witnessed fill, where reorg detection later reads it to tell a
+    /// re-observation on a different fork from a duplicate. The aggregate is the
+    /// system of record for the fill, so assert the hash survives there.
+    #[tokio::test]
+    async fn ingestion_threads_block_hash_into_witnessed_fill() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let block_hash = B256::from([0xcd; 32]);
+        let mut trade_event = make_trade_event(70);
+        trade_event.block_hash = Some(block_hash);
+
+        let trade = test_trade_with_amount(float!(1.5), 70);
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+            .await
+            .unwrap()
+            .expect("1.5 shares should witness and hedge the fill");
+
+        let witnessed = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the witnessed trade aggregate must exist after ingestion");
+
+        assert_eq!(
+            witnessed.block_hash,
+            Some(block_hash),
+            "the emitted log's block hash must thread into the witnessed fill"
+        );
+    }
+
     /// A database write lock during the Witness write must surface as a
     /// retryable error, not silently drop the fill. Pre-fix,
     /// `execute_witness_trade` blanket-matched every `SendError` as a
@@ -5889,6 +5943,7 @@ mod tests {
             &cqrs.onchain_trade,
             &witnessing_trade,
             trade_event.block_number,
+            trade_event.block_hash,
             block_timestamp,
         )
         .await
@@ -6068,6 +6123,7 @@ mod tests {
             &cqrs.onchain_trade,
             &trade,
             trade_event.block_number,
+            trade_event.block_hash,
             block_timestamp,
         )
         .await
@@ -6146,6 +6202,7 @@ mod tests {
             &cqrs.onchain_trade,
             &trade,
             trade_event.block_number,
+            trade_event.block_hash,
             block_timestamp,
         )
         .await
@@ -6265,6 +6322,7 @@ mod tests {
             &cqrs.onchain_trade,
             &trade,
             trade_event.block_number,
+            trade_event.block_hash,
             block_timestamp,
         )
         .await
@@ -6407,6 +6465,7 @@ mod tests {
             &cqrs.onchain_trade,
             &trade_a,
             event_a.block_number,
+            event_a.block_hash,
             block_timestamp_a,
         )
         .await

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -225,6 +225,7 @@ mod tests {
                     direction: st0x_execution::Direction::Buy,
                     price_usdc: st0x_float_macro::float!(150),
                     block_number: 12345,
+                    block_hash: None,
                     block_timestamp: now,
                     filled_at: now,
                 },

--- a/src/dashboard/trade_loader.rs
+++ b/src/dashboard/trade_loader.rs
@@ -119,6 +119,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_number: 12345,
+                    block_hash: None,
                     block_timestamp: now,
                 },
             )
@@ -220,6 +221,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150),
                     block_number: 1,
+                    block_hash: None,
                     block_timestamp: now,
                 },
             )
@@ -235,6 +237,7 @@ mod tests {
                     direction: Direction::Sell,
                     price_usdc: float!(200),
                     block_number: 2,
+                    block_hash: None,
                     block_timestamp: now,
                 },
             )
@@ -276,6 +279,7 @@ mod tests {
                         direction: Direction::Buy,
                         price_usdc: float!(100),
                         block_number: log_index,
+                        block_hash: None,
                         block_timestamp: now,
                     },
                 )

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -586,6 +586,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> AnvilOrderBook<P> {
             tx_hash,
             log_index,
             block_number: take_log.block_number.unwrap(),
+            block_hash: take_log.block_hash,
             event: RaindexTradeEvent::TakeOrderV3(Box::new(take_event_for_queue)),
             block_timestamp: trade.block_timestamp,
         };

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -8,7 +8,7 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 
 use alloy::hex::FromHexError;
-use alloy::primitives::TxHash;
+use alloy::primitives::{B256, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rain_math_float::Float;
@@ -74,6 +74,12 @@ pub(crate) struct OnChainTrade {
     )]
     pub(crate) price_usdc: Float,
     pub(crate) block_number: Option<u64>,
+    /// Hash of the block this fill was confirmed in, persisted so a later
+    /// replay against a different fork is detectable as a reorg rather than a
+    /// duplicate. Absent on aggregates persisted before the field existed and on
+    /// fills whose source log carried no block hash.
+    #[serde(default)]
+    pub(crate) block_hash: Option<B256>,
     pub(crate) block_timestamp: DateTime<Utc>,
     pub(crate) filled_at: DateTime<Utc>,
     pub(crate) enrichment: Option<Enrichment>,
@@ -109,6 +115,7 @@ impl EventSourced for OnChainTrade {
                 direction,
                 price_usdc,
                 block_number,
+                block_hash,
                 block_timestamp,
                 filled_at,
             } => Some(Self {
@@ -117,6 +124,7 @@ impl EventSourced for OnChainTrade {
                 direction: *direction,
                 price_usdc: *price_usdc,
                 block_number: Some(*block_number),
+                block_hash: *block_hash,
                 block_timestamp: *block_timestamp,
                 filled_at: *filled_at,
                 enrichment: None,
@@ -167,6 +175,7 @@ impl EventSourced for OnChainTrade {
                 direction,
                 price_usdc,
                 block_number,
+                block_hash,
                 block_timestamp,
             } => Ok(vec![Filled {
                 symbol,
@@ -174,6 +183,7 @@ impl EventSourced for OnChainTrade {
                 direction,
                 price_usdc,
                 block_number,
+                block_hash,
                 block_timestamp,
                 filled_at: Utc::now(),
             }]),
@@ -185,6 +195,7 @@ impl EventSourced for OnChainTrade {
                 direction,
                 price_usdc,
                 block_number,
+                block_hash,
                 block_timestamp,
                 filled_at,
             } => Ok(vec![Filled {
@@ -193,6 +204,7 @@ impl EventSourced for OnChainTrade {
                 direction,
                 price_usdc,
                 block_number,
+                block_hash,
                 block_timestamp,
                 filled_at,
             }]),
@@ -309,6 +321,7 @@ pub(crate) enum OnChainTradeCommand {
         )]
         price_usdc: Float,
         block_number: u64,
+        block_hash: Option<B256>,
         block_timestamp: DateTime<Utc>,
     },
     /// Test/fixture-only: identical to `Witness` but takes `filled_at`
@@ -329,6 +342,7 @@ pub(crate) enum OnChainTradeCommand {
         )]
         price_usdc: Float,
         block_number: u64,
+        block_hash: Option<B256>,
         block_timestamp: DateTime<Utc>,
         filled_at: DateTime<Utc>,
     },
@@ -359,6 +373,8 @@ pub(crate) enum OnChainTradeEvent {
         )]
         price_usdc: Float,
         block_number: u64,
+        #[serde(default)]
+        block_hash: Option<B256>,
         block_timestamp: DateTime<Utc>,
         filled_at: DateTime<Utc>,
     },
@@ -384,6 +400,7 @@ impl PartialEq for OnChainTradeEvent {
                     direction: dir_a,
                     price_usdc: price_a,
                     block_number: block_num_a,
+                    block_hash: block_hash_a,
                     block_timestamp: block_ts_a,
                     filled_at: fill_a,
                 },
@@ -393,6 +410,7 @@ impl PartialEq for OnChainTradeEvent {
                     direction: dir_b,
                     price_usdc: price_b,
                     block_number: block_num_b,
+                    block_hash: block_hash_b,
                     block_timestamp: block_ts_b,
                     filled_at: fill_b,
                 },
@@ -402,6 +420,7 @@ impl PartialEq for OnChainTradeEvent {
                     && dir_a == dir_b
                     && price_a.eq(*price_b).unwrap_or(false)
                     && block_num_a == block_num_b
+                    && block_hash_a == block_hash_b
                     && block_ts_a == block_ts_b
                     && fill_a == fill_b
             }
@@ -466,6 +485,7 @@ pub(crate) struct PythPrice {
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::b256;
     use st0x_event_sorcery::{LifecycleError, TestHarness, replay};
 
     use super::*;
@@ -484,6 +504,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
             })
             .await
@@ -510,6 +531,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp,
                 filled_at,
             })
@@ -525,6 +547,39 @@ mod tests {
             panic!("Expected Filled, got: {:?}", events[0]);
         };
         assert_eq!(*event_filled_at, filled_at);
+    }
+
+    #[tokio::test]
+    async fn witness_threads_block_hash_into_filled_event() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let block_hash =
+            b256!("0xabababababababababababababababababababababababababababababababab");
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given_no_previous_events()
+            .when(OnChainTradeCommand::Witness {
+                symbol,
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_hash: Some(block_hash),
+                block_timestamp: now,
+            })
+            .await
+            .events();
+
+        let [
+            OnChainTradeEvent::Filled {
+                block_hash: emitted,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("expected a single Filled event, got {events:?}");
+        };
+        assert_eq!(*emitted, Some(block_hash));
     }
 
     #[tokio::test]
@@ -546,6 +601,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             }])
@@ -581,6 +637,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.25),
                     block_number: 12345,
+                    block_hash: None,
                     block_timestamp: now,
                     filled_at: now,
                 },
@@ -651,6 +708,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!("150.25"),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             }])
@@ -680,6 +738,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             }])
@@ -706,6 +765,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.25),
                     block_number: 12345,
+                    block_hash: None,
                     block_timestamp: now,
                     filled_at: now,
                 },
@@ -753,6 +813,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             },
@@ -790,6 +851,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             }])
@@ -799,6 +861,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
             })
             .await
@@ -830,6 +893,7 @@ mod tests {
                     direction: Direction::Buy,
                     price_usdc: float!(150.25),
                     block_number: 12345,
+                    block_hash: None,
                     block_timestamp: now,
                     filled_at: now,
                 },
@@ -846,6 +910,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
             })
             .await
@@ -868,6 +933,7 @@ mod tests {
             direction: Direction::Buy,
             price_usdc: float!(150.25),
             block_number: 12345,
+            block_hash: None,
             block_timestamp: now,
             filled_at: now,
         }])
@@ -878,6 +944,54 @@ mod tests {
         assert!(trade.amount.eq(float!(10.5)).unwrap());
         assert_eq!(trade.direction, Direction::Buy);
         assert!(!trade.is_enriched());
+    }
+
+    #[test]
+    fn filled_carries_block_hash_into_live_state() {
+        let block_hash =
+            b256!("0xabababababababababababababababababababababababababababababababab");
+        let now = Utc::now();
+
+        let trade = replay::<OnChainTrade>(vec![OnChainTradeEvent::Filled {
+            symbol: Symbol::new("AAPL").unwrap(),
+            amount: float!(10.5),
+            direction: Direction::Buy,
+            price_usdc: float!(150.25),
+            block_number: 12345,
+            block_hash: Some(block_hash),
+            block_timestamp: now,
+            filled_at: now,
+        }])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(trade.block_hash, Some(block_hash));
+    }
+
+    /// Fills persisted before `block_hash` existed deserialize with `None`
+    /// rather than failing replay (the `#[serde(default)]` resume guarantee).
+    #[test]
+    fn filled_event_without_block_hash_deserializes_to_none() {
+        let now = Utc::now();
+        let legacy_filled = serde_json::json!({
+            "Filled": {
+                "symbol": "AAPL",
+                "amount": "10.5",
+                "direction": "Buy",
+                "price_usdc": "150.25",
+                "block_number": 12345,
+                "block_timestamp": now,
+                "filled_at": now,
+            }
+        });
+
+        let event: OnChainTradeEvent = serde_json::from_value(legacy_filled).unwrap();
+
+        let OnChainTradeEvent::Filled { block_hash, .. } = event else {
+            panic!("expected Filled, got {event:?}");
+        };
+
+        assert_eq!(block_hash, None);
     }
 
     #[test]
@@ -898,6 +1012,7 @@ mod tests {
                 direction: Direction::Buy,
                 price_usdc: float!(150.25),
                 block_number: 12345,
+                block_hash: None,
                 block_timestamp: now,
                 filled_at: now,
             },

--- a/src/performance.rs
+++ b/src/performance.rs
@@ -243,6 +243,7 @@ pub async fn seed_simulated_hedge_latency_history(
                         direction: Direction::Buy,
                         price_usdc: onchain_price,
                         block_number,
+                        block_hash: None,
                         block_timestamp,
                         filled_at: seen_at,
                     },

--- a/src/trading/onchain/inclusion.rs
+++ b/src/trading/onchain/inclusion.rs
@@ -6,7 +6,7 @@
 //!
 //! [`AccountForDexTrade`]: super::trade_accountant::AccountForDexTrade
 
-use alloy::primitives::TxHash;
+use alloy::primitives::{B256, TxHash};
 use alloy::rpc::types::Log;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -21,6 +21,17 @@ pub(crate) struct EmittedOnChain<Event> {
     pub(crate) tx_hash: TxHash,
     pub(crate) log_index: u64,
     pub(crate) block_number: u64,
+    /// Hash of the block this event was included in. Identifies which fork
+    /// a confirmed `(tx_hash, log_index)` came from, so a later replay against
+    /// a different fork can be detected as a reorg rather than mistaken for a
+    /// duplicate. `None` when the source log carried no block hash (pending
+    /// logs, reconstructed logs).
+    ///
+    /// `#[serde(default)]` so apalis jobs serialized before this field existed
+    /// (in-flight `AccountForDexTrade` payloads during a deploy) still
+    /// deserialize -- they predate fork tracking, so `None` is correct for them.
+    #[serde(default)]
+    pub(crate) block_hash: Option<B256>,
     pub(crate) block_timestamp: Option<DateTime<Utc>>,
 }
 
@@ -52,6 +63,7 @@ impl<Event> EmittedOnChain<Event> {
             tx_hash,
             log_index,
             block_number,
+            block_hash: log.block_hash,
             block_timestamp,
         })
     }
@@ -90,7 +102,7 @@ impl fmt::Display for RequiredField {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, LogData, fixed_bytes};
+    use alloy::primitives::{Address, LogData, b256, fixed_bytes};
     use alloy::rpc::types::Log;
 
     use super::*;
@@ -101,7 +113,9 @@ mod tests {
                 address: Address::ZERO,
                 data: LogData::empty(),
             },
-            block_hash: None,
+            block_hash: Some(b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            )),
             block_number: Some(42),
             block_timestamp: Some(1_700_000_000),
             transaction_hash: Some(fixed_bytes!(
@@ -122,10 +136,21 @@ mod tests {
         assert_eq!(included.tx_hash, log.transaction_hash.unwrap());
         assert_eq!(included.log_index, 7);
         assert_eq!(included.block_number, 42);
+        assert_eq!(included.block_hash, log.block_hash);
         assert_eq!(
             included.block_timestamp,
             DateTime::from_timestamp(1_700_000_000, 0),
         );
+    }
+
+    #[test]
+    fn from_log_handles_missing_block_hash() {
+        let mut log = valid_log();
+        log.block_hash = None;
+
+        let included = EmittedOnChain::from_log("event", &log).unwrap();
+
+        assert_eq!(included.block_hash, None);
     }
 
     #[test]
@@ -200,5 +225,24 @@ mod tests {
         assert_eq!(RequiredField::TxHash.to_string(), "transaction_hash");
         assert_eq!(RequiredField::LogIndex.to_string(), "log_index");
         assert_eq!(RequiredField::BlockNumber.to_string(), "block_number");
+    }
+
+    /// Apalis jobs serialized before `block_hash` existed (in-flight
+    /// `AccountForDexTrade` payloads during a deploy) must still deserialize,
+    /// with the absent field defaulting to `None` rather than failing the job.
+    #[test]
+    fn emitted_on_chain_without_block_hash_deserializes_to_none() {
+        let json = serde_json::json!({
+            "event": null,
+            "tx_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "log_index": 7,
+            "block_number": 42,
+            "block_timestamp": null,
+            // block_hash intentionally absent
+        });
+
+        let parsed: EmittedOnChain<()> = serde_json::from_value(json).unwrap();
+
+        assert_eq!(parsed.block_hash, None);
     }
 }

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -380,7 +380,7 @@ fn reconstruct_log(contracts: RaindexContracts, trade: &EmittedOnChain<RaindexTr
             address,
             data: log_data,
         },
-        block_hash: None,
+        block_hash: trade.block_hash,
         block_number: Some(trade.block_number),
         block_timestamp,
         transaction_hash: Some(trade.tx_hash),
@@ -578,6 +578,31 @@ mod tests {
 
         let label_str = label.to_string();
         assert_eq!(label_str, "ClearV3:12345:293");
+    }
+
+    #[test]
+    fn reconstruct_log_preserves_block_hash() {
+        // block_hash must survive `EmittedOnChain -> reconstruct_log -> Log` so
+        // fork detection can compare the persisted hash against a re-observed
+        // one; dropping it would make a reorged re-observation of the same
+        // `(tx_hash, log_index)` look like a duplicate rather than a reorg.
+        let block_hash = B256::repeat_byte(0xcd);
+        let mut job = test_job();
+        job.trade.block_hash = Some(block_hash);
+
+        let log = reconstruct_log(
+            RaindexContracts {
+                orderbook: address!("0x2222222222222222222222222222222222222222"),
+                inventory: address!("0x3333333333333333333333333333333333333333"),
+            },
+            &job.trade,
+        );
+
+        assert_eq!(
+            log.block_hash,
+            Some(block_hash),
+            "reconstructed log must carry the original block hash for fork detection"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -25,4 +25,5 @@ mod full_system_chaos;
 mod hedging;
 mod poll;
 mod rebalancing;
+mod reorg;
 mod test_infra;

--- a/tests/e2e/reorg.rs
+++ b/tests/e2e/reorg.rs
@@ -1,0 +1,107 @@
+//! North-star e2e for first-class reorg handling.
+//!
+//! Verifies the end state of reorg handling: a fill the bot has already
+//! witnessed and hedged is dropped by a chain reorg, the bot detects the fork
+//! change, and the event-sourced views reverse the fill's position impact
+//! append-only -- the original fill and its reversal both survive, nothing is
+//! deleted.
+//!
+//! `#[ignore]`d until the chaos-proxy fork simulation that
+//! [`simulate_reorg_dropping_fill`] depends on exists; that simulation drives
+//! the reorg this test asserts against.
+
+use alloy::providers::Provider;
+use std::time::Duration;
+
+use st0x_float_macro::float;
+
+use crate::hedging::assertions::{TakeDirection, TestInfra, build_ctx, spawn_bot};
+use crate::poll::{connect_db, count_events_of_type, poll_for_events};
+
+#[test_log::test(tokio::test)]
+#[ignore = "north-star: needs the chaos-proxy fork simulation (terminal reorg slice)"]
+async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
+    let symbol = "AAPL";
+    let onchain_price = float!(155.00);
+    let broker_fill_price = float!(150.25);
+    let amount = float!(10.0);
+
+    let infra = TestInfra::start(vec![(symbol, broker_fill_price)], vec![]).await?;
+
+    let current_block = infra.base_chain.provider.get_block_number().await?;
+    let ctx = build_ctx()
+        .chain(&infra.base_chain)
+        .broker(&infra.broker_service)
+        .db_path(&infra.db_path)
+        .deployment_block(current_block)
+        .assets(infra.assets_config())
+        .call()?;
+    let mut bot = spawn_bot(ctx);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Ingest a fill and let the bot witness and hedge it.
+    let take_result = infra
+        .base_chain
+        .take_order()
+        .symbol(symbol)
+        .amount(amount)
+        .price(onchain_price)
+        .direction(TakeDirection::SellEquity)
+        .call()
+        .await?;
+
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Filled", 1).await;
+    poll_for_events(&mut bot, &infra.db_path, "OffchainOrderEvent::Filled", 1).await;
+
+    // Simulate a reorg that drops the fill's block from the canonical chain.
+    // The terminal slice implements this via a chaos proxy that forks the chain
+    // and serves a competing history without the take order's block.
+    simulate_reorg_dropping_fill(&infra, &take_result)?;
+
+    // Detection emits RecordReorg, producing the reversal events.
+    poll_for_events(&mut bot, &infra.db_path, "OnChainTradeEvent::Reorged", 1).await;
+    poll_for_events(&mut bot, &infra.db_path, "PositionEvent::Reorged", 1).await;
+
+    let pool = connect_db(&infra.db_path).await?;
+
+    // The reversal is append-only: the original fill survives, the reorg is a
+    // new event, and the views expose a `reorged` flag rather than deleting rows.
+    assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?,
+        1,
+        "the original fill must be preserved, not deleted",
+    );
+    assert_eq!(
+        count_events_of_type(&pool, "PositionEvent::Reorged").await?,
+        1,
+        "the reorg must reverse the fill's position impact exactly once",
+    );
+
+    let reorged_trades: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM onchain_trade_view \
+         WHERE json_extract(payload, '$.Live.reorged') = 1",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(
+        reorged_trades, 1,
+        "the reorged fill must be flagged in onchain_trade_view, not removed",
+    );
+
+    bot.abort();
+    Ok(())
+}
+
+/// Forks the chain so the take order's block is no longer canonical, modelling a
+/// reorg that drops an already-witnessed fill.
+///
+/// Unimplemented until the terminal slice lands the chaos-proxy fork
+/// simulation. The north-star test above is `#[ignore]`d, so this stub never
+/// executes.
+fn simulate_reorg_dropping_fill<Node>(
+    _infra: &TestInfra<Node>,
+    _take_result: &crate::base_chain::TakeOrderResult,
+) -> anyhow::Result<()> {
+    todo!("fork the chain via the chaos proxy to drop the witnessed fill")
+}


### PR DESCRIPTION
## What

Closes RAI-802. Foundation slice of the reorg-protection epic (RAI-294): records
the `block_hash` of each onchain fill and persists it, so a later replay against
a different fork is distinguishable from a duplicate. Promotes the SPEC reorg
section from "Future Consideration" to specified behavior and scaffolds the
ignored north-star e2e.

## Why

`EmittedOnChain` carried `(tx_hash, log_index, block_number)` but not
`block_hash`, so on backfill/restart the bot could not tell "same fill, same
fork" from "same `(tx_hash, log_index)`, different fork." Fork detection -- and
every downstream reorg slice -- needs the block hash recorded against each fill.

## How

- `EmittedOnChain` gains `block_hash: Option<B256>`, populated from the alloy
  `Log` in `from_log` and round-tripped through `reconstruct_log`.
- Threaded through `OnChainTradeCommand::Witness` -> `OnChainTradeEvent::Filled`
  -> the `OnChainTrade` aggregate, so it lands in the `onchain_trade_view`
  payload. `#[serde(default)]` keeps pre-existing events and aggregates
  replay-safe.
- New migration indexes `$.Live.block_hash`. Idempotency key stays
  `(tx_hash, log_index)`; `block_hash` is the fork-detection field, not part of
  the key.
- SPEC: reorg handling promoted to specified behavior -- first-class `Reorged`
  events, append-only `reorged` view flags, detection on removed logs and
  block-hash mismatch.
- `tests/e2e/reorg.rs`: `#[ignore]`d north-star asserting ingest -> fork drops
  fill -> views revert. Stays ignored until RAI-807 lands the chaos-proxy fork
  simulation.

## Testing

- New unit tests: `from_log` carries / handles-missing `block_hash`; aggregate
  replay carries it into live state; serializes at `$.Live.block_hash` for the
  view index; legacy `Filled` events without the field deserialize to `None`.
- `cargo nextest run -p st0x-hedge --lib` (1668 passed), workspace clippy clean,
  e2e target compiles with the ignored north-star test registered.

## Anything else

Foundation slice -- the `Reorged` events (RAI-803/804), detection paths
(RAI-805/806), and the e2e chaos proxy (RAI-807) land in follow-up PRs stacked
above. Stacked on the exactly-once-fill-accounting branch (#854).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for blockchain reorg handling in on-chain trade processing.
  * Trades now retain block-hash information so reorged fills can be identified and reversed safely.
  * Reorgs now surface as append-only reversal events, preserving history while updating positions and views.

* **Tests**
  * Added end-to-end coverage for a reorg scenario where a previously witnessed fill is later rolled back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->