### PR TITLE
feat: OnChainTradeEvent::Reorged reversal event and onchain_trade_view reorged flag

### DIFF
--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -646,7 +646,7 @@ pub(super) async fn process_found_trade<W: Write>(
     // the originating block hash (OnchainTrade stores only block number and
     // timestamp), so a manually recovered fill is witnessed without a reorg
     // hash. Such a fill is past reorg risk by the time an operator accounts it.
-    let FillAccountingOutcome::Accounted { trade_id } = account_for_onchain_fill(
+    let trade_id = match account_for_onchain_fill(
         pool,
         &onchain_trade_store,
         &position_store,
@@ -656,13 +656,24 @@ pub(super) async fn process_found_trade<W: Write>(
         ctx.execution_threshold,
     )
     .await?
-    else {
-        writeln!(
-            stdout,
-            "Fill {trade_id} is already fully accounted. Nothing to do; \
-             the normal pipeline will hedge any unhedged position exposure."
-        )?;
-        return Ok(());
+    {
+        FillAccountingOutcome::Accounted { trade_id } => trade_id,
+        FillAccountingOutcome::AlreadyAcknowledged => {
+            writeln!(
+                stdout,
+                "Fill {trade_id} is already fully accounted. Nothing to do; \
+                 the normal pipeline will hedge any unhedged position exposure."
+            )?;
+            return Ok(());
+        }
+        FillAccountingOutcome::Reorged => {
+            writeln!(
+                stdout,
+                "Fill {trade_id} was invalidated by a reorg before acknowledgement. \
+                 Nothing to account; the fill no longer exists on the canonical chain."
+            )?;
+            return Ok(());
+        }
     };
 
     let executor_type = ctx.broker.to_supported_executor();

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -2553,22 +2553,50 @@ pub(crate) async fn execute_acknowledge_fill(
     }
 }
 
+/// Outcome of the acknowledge marker write on the `OnChainTrade` aggregate.
+pub(crate) enum FillMarkOutcome {
+    /// The acknowledgement marker is durable -- freshly written, or already
+    /// present from a prior attempt (an idempotent resume). The fill may be
+    /// settled and hedged.
+    Marked,
+    /// A reorg invalidated this fill between the `process_queued_trade`
+    /// reorg-skip guard and the marker write, so `Acknowledge` was rejected with
+    /// `CannotAcknowledgeReorgedFill`. The marker is NOT durable: the fill must
+    /// not be settled (its marker-durable precondition is unmet) or hedged
+    /// (a broker order for a fill that no longer exists on the canonical chain
+    /// is wrong-way exposure). The position impact the acknowledge already
+    /// applied is left for the reorg reversal flow (built across the rest of the
+    /// reorg stack) to reverse.
+    Reorged,
+}
+
 /// Marks the trade acknowledged on the `OnChainTrade` aggregate after the
-/// position write succeeded. A re-driven marker (`AlreadyAcknowledged`) is
-/// idempotent; infrastructure errors propagate so the apalis retry re-drives
-/// the idempotent accounting steps.
+/// position write succeeded, completing the exactly-once pair (ADR 0005).
+/// A re-driven marker (`AlreadyAcknowledged`) is idempotent and reports
+/// [`FillMarkOutcome::Marked`]; a fill reorged mid-pair reports
+/// [`FillMarkOutcome::Reorged`] so the caller skips settle and hedge;
+/// infrastructure errors propagate so the apalis retry re-drives the
+/// idempotent acknowledge pair.
 pub(crate) async fn execute_mark_acknowledged(
     onchain_trade: &Store<OnChainTrade>,
     trade_id: &OnChainTradeId,
-) -> Result<(), SendError<OnChainTrade>> {
+) -> Result<FillMarkOutcome, SendError<OnChainTrade>> {
     match onchain_trade
         .send(trade_id, OnChainTradeCommand::Acknowledge)
         .await
     {
+        // `AlreadyAcknowledged`: a prior attempt already acknowledged (resume).
         Ok(())
         | Err(AggregateError::UserError(LifecycleError::Apply(
             OnChainTradeError::AlreadyAcknowledged,
-        ))) => Ok(()),
+        ))) => Ok(FillMarkOutcome::Marked),
+        // The fill was reorged between the `process_queued_trade` reorg-skip
+        // guard and this send. Surface it so the caller terminates cleanly
+        // without settling or hedging an invalidated fill, instead of swallowing
+        // it as success and letting the pipeline place a broker hedge.
+        Err(AggregateError::UserError(LifecycleError::Apply(
+            OnChainTradeError::CannotAcknowledgeReorgedFill,
+        ))) => Ok(FillMarkOutcome::Reorged),
         Err(error) => Err(error),
     }
 }
@@ -2655,7 +2683,12 @@ pub(crate) async fn position_fill_already_recorded(
 
 pub(crate) enum FillAccountingOutcome {
     AlreadyAcknowledged,
-    Accounted { trade_id: OnChainTradeId },
+    /// A reorg invalidated the fill's block before acknowledgement; nothing
+    /// was accounted and the fill must not be settled or hedged.
+    Reorged,
+    Accounted {
+        trade_id: OnChainTradeId,
+    },
 }
 
 pub(crate) async fn account_for_onchain_fill(
@@ -2696,6 +2729,19 @@ pub(crate) async fn account_for_onchain_fill(
             // no-op when already pruned.
             execute_settle_fill(position, trade).await?;
             return Ok(FillAccountingOutcome::AlreadyAcknowledged);
+        }
+        // A reorg invalidated this fill's block before it was acknowledged.
+        // Skip it as terminal: applying its position impact would account for a
+        // fill that no longer exists, and `Acknowledge` now rejects a reorged
+        // trade -- a retried job would otherwise apply impact then fail the
+        // acknowledge and retry forever.
+        Ok(Some(state)) if state.is_reorged() => {
+            warn!(
+                ?trade_id,
+                symbol = %trade.symbol,
+                "Trade was reorged before acknowledgement; skipping fill accounting"
+            );
+            return Ok(FillAccountingOutcome::Reorged);
         }
         Ok(Some(state)) => {
             info!(
@@ -2779,7 +2825,24 @@ where
         return Ok(None);
     };
 
-    execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await?;
+    // A reorg can land between the load-time skip guard above and this marker
+    // write. When it does, the acknowledge marker is not durable, so the fill
+    // must not be settled or hedged -- placing a broker order for a fill that no
+    // longer exists on the canonical chain is wrong-way exposure. Bail before
+    // settle and hedge; the position impact the acknowledge above applied is left
+    // for the reorg reversal flow (built across the rest of the reorg stack) to
+    // reverse.
+    if matches!(
+        execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await?,
+        FillMarkOutcome::Reorged
+    ) {
+        warn!(
+            ?trade_id,
+            symbol = %trade.symbol,
+            "Fill reorged during the acknowledge pair; skipping settle and hedge"
+        );
+        return Ok(None);
+    }
     // Prune the pending-acknowledgement entry now that the marker is durable
     // (ADR 0010), before any early return below, so the threshold-not-met and
     // placement-skip paths still settle.
@@ -6160,6 +6223,152 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn reorged_trade_skipped_by_resume_path() {
+        // A trade reorged before acknowledgement must be skipped by the resume
+        // path: applying its position impact would account for a fill that no
+        // longer exists, and `Acknowledge` rejects a reorged trade -- a retried
+        // job would otherwise apply impact and then loop on that rejection.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(61);
+        let trade = OnchainTradeBuilder::default()
+            .with_symbol("wtAAPL")
+            .with_equity_token(TEST_EQUITY_TOKEN)
+            .with_amount(float!("1.5"))
+            .with_log_index(61)
+            .build();
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        // Witness the fill, then reorg it before acknowledgement -- the window
+        // where a stale AccountForDexTrade job is still queued.
+        let witnessed = execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            trade_event.block_hash,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        assert!(witnessed, "premise: the witness write must succeed");
+        cqrs.onchain_trade
+            .send(
+                &trade_id,
+                OnChainTradeCommand::RecordReorg { reorg_depth: 3 },
+            )
+            .await
+            .unwrap();
+
+        let result = process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+            .await
+            .expect("a reorged trade must be skipped cleanly, not error and retry");
+
+        assert_eq!(result, None, "a reorged trade must enqueue no hedge");
+        let state = cqrs
+            .onchain_trade
+            .load(&trade_id)
+            .await
+            .unwrap()
+            .expect("the reorged aggregate still exists");
+        assert!(
+            !state.is_acknowledged(),
+            "a reorged trade must not be acknowledged -- its impact is reversed via the reorg path",
+        );
+    }
+
+    /// End-to-end assurance that a reorged fill is never hedged by the
+    /// trade-accounting pipeline. The 1.5-share fill is above the hedging
+    /// threshold, so absent the reorg `process_queued_trade` would place a
+    /// broker hedge (cf. `trade_above_threshold_places_offchain_order`).
+    /// Reorging its block before the queued job runs makes
+    /// `process_queued_trade` hit its load-time reorg-skip guard and
+    /// short-circuit before the acknowledge/settle/hedge path, so no offchain
+    /// order is placed.
+    ///
+    /// This exercises the load-time guard, not the mid-pipeline race (a reorg
+    /// landing between the load and the acknowledge-marker write), which cannot
+    /// be injected deterministically here and is unit-covered by
+    /// `execute_mark_acknowledged_signals_reorged_trade`. `MockExecutor` records
+    /// no placed orders, so "not hedged" is asserted via the absent
+    /// offchain-order id and the absence of any position impact / pending hedge.
+    #[tokio::test]
+    async fn process_queued_trade_does_not_hedge_a_reorged_fill() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(63);
+        let trade = test_trade_with_amount(float!(1.5), 63);
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        // Witness the above-threshold fill, then reorg its block away before the
+        // queued AccountForDexTrade job runs.
+        let witnessed = execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            trade_event.block_hash,
+            block_timestamp,
+        )
+        .await
+        .unwrap();
+        assert!(witnessed, "premise: the witness write must succeed");
+        cqrs.onchain_trade
+            .send(
+                &trade_id,
+                OnChainTradeCommand::RecordReorg { reorg_depth: 3 },
+            )
+            .await
+            .unwrap();
+
+        let result = process_queued_trade(&MockExecutor::new(), &trade_event, trade, &cqrs, true)
+            .await
+            .expect("a reorged fill must be skipped cleanly, not error and retry");
+
+        assert_eq!(
+            result, None,
+            "a reorged fill must not be hedged -- no offchain order id is returned"
+        );
+
+        // The skip short-circuits before the acknowledge/settle/hedge path, so
+        // the position is never created and no offchain hedge is pending.
+        let position = cqrs
+            .position_projection
+            .load(&Symbol::new("AAPL").unwrap())
+            .await
+            .unwrap();
+        assert!(
+            position.is_none(),
+            "a reorged fill must short-circuit before the hedge path, leaving no position or \
+             pending offchain order",
+        );
+    }
+
     /// Composed coverage for the second crash window (ADR 0005): a crash
     /// between the position write (`execute_acknowledge_fill`) and the
     /// `OnChainTrade` acknowledgement marker (`execute_mark_acknowledged`)
@@ -6328,27 +6537,73 @@ mod tests {
         .await
         .unwrap();
 
-        execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id)
-            .await
-            .expect("the first marker write must succeed");
-        execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id)
-            .await
-            .expect("re-driving the marker must be idempotent, not propagate an error");
+        assert!(
+            matches!(
+                execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await,
+                Ok(FillMarkOutcome::Marked)
+            ),
+            "the first marker write must succeed and mark the fill"
+        );
+        assert!(
+            matches!(
+                execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await,
+                Ok(FillMarkOutcome::Marked)
+            ),
+            "re-driving the marker must be idempotent (Marked), not propagate an error"
+        );
+    }
 
-        let (acknowledged_markers,): (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM events \
-             WHERE aggregate_type = ? AND aggregate_id = ? AND event_type = ?",
+    #[tokio::test]
+    async fn execute_mark_acknowledged_signals_reorged_trade() {
+        // The `process_queued_trade` reorg-skip guard normally prevents a reorged
+        // trade from reaching the acknowledge marker, but a reorg landing between
+        // that guard and this send makes `Acknowledge` return
+        // `CannotAcknowledgeReorgedFill`. The marker write must surface that as
+        // `FillMarkOutcome::Reorged` so `process_queued_trade` skips settle and
+        // hedge instead of swallowing it and placing a broker order for the
+        // invalidated fill.
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let (frameworks, _offchain_order_projection) = create_cqrs_frameworks(&pool).await;
+        let cqrs = trade_processing_cqrs_with_threshold(
+            &frameworks,
+            &pool,
+            ExecutionThreshold::whole_share(),
+            &apalis_pool,
+        );
+
+        let trade_event = make_trade_event(62);
+        let trade = test_trade_with_amount(float!(1.5), 62);
+        let block_timestamp = trade
+            .block_timestamp
+            .expect("test trade carries a block timestamp");
+        let trade_id = OnChainTradeId {
+            tx_hash: trade.tx_hash,
+            log_index: trade.log_index,
+        };
+
+        execute_witness_trade(
+            &cqrs.onchain_trade,
+            &trade,
+            trade_event.block_number,
+            trade_event.block_hash,
+            block_timestamp,
         )
-        .bind(OnChainTrade::AGGREGATE_TYPE)
-        .bind(trade_id.to_string())
-        .bind("OnChainTradeEvent::Acknowledged")
-        .fetch_one(&pool)
         .await
         .unwrap();
+        cqrs.onchain_trade
+            .send(
+                &trade_id,
+                OnChainTradeCommand::RecordReorg { reorg_depth: 3 },
+            )
+            .await
+            .unwrap();
 
-        assert_eq!(
-            acknowledged_markers, 1,
-            "re-driving the marker must not emit a second Acknowledged event"
+        assert!(
+            matches!(
+                execute_mark_acknowledged(&cqrs.onchain_trade, &trade_id).await,
+                Ok(FillMarkOutcome::Reorged)
+            ),
+            "marking a reorged trade must signal Reorged so the caller skips settle and hedge"
         );
     }
 

--- a/src/onchain_trade.rs
+++ b/src/onchain_trade.rs
@@ -91,6 +91,15 @@ pub(crate) struct OnChainTrade {
     /// existed, which is the resume-safe default.
     #[serde(default)]
     pub(crate) acknowledged_at: Option<DateTime<Utc>>,
+    /// Set once a reorg has invalidated this fill's block. Append-only: the
+    /// original fill fields are preserved and the trade is flagged reorged rather
+    /// than deleted, so the reversal stays auditable in the event log.
+    /// `OnChainTrade` has no projection (`PROJECTION: Nil`), so reorg state is
+    /// read from the event log and the `Position` aggregate, not from a view.
+    /// Absent on aggregates persisted before the field existed, which is the
+    /// not-reorged default.
+    #[serde(default)]
+    pub(crate) reorged_at: Option<DateTime<Utc>>,
 }
 
 #[async_trait]
@@ -104,7 +113,7 @@ impl EventSourced for OnChainTrade {
 
     const AGGREGATE_TYPE: &'static str = "OnChainTrade";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         use OnChainTradeEvent::*;
@@ -129,9 +138,10 @@ impl EventSourced for OnChainTrade {
                 filled_at: *filled_at,
                 enrichment: None,
                 acknowledged_at: None,
+                reorged_at: None,
             }),
 
-            Enriched { .. } | Acknowledged { .. } => None,
+            Enriched { .. } | Acknowledged { .. } | Reorged { .. } => None,
         }
     }
 
@@ -155,6 +165,14 @@ impl EventSourced for OnChainTrade {
 
             Acknowledged { acknowledged_at } => Ok(Some(Self {
                 acknowledged_at: Some(*acknowledged_at),
+                ..entity.clone()
+            })),
+
+            // `reorg_depth` is intentionally not stored on aggregate state: it is
+            // audit detail that survives in the event log only. State just needs
+            // the `reorged_at` marker to know the fill was reversed.
+            Reorged { reorged_at, .. } => Ok(Some(Self {
+                reorged_at: Some(*reorged_at),
                 ..entity.clone()
             })),
 
@@ -209,7 +227,7 @@ impl EventSourced for OnChainTrade {
                 filled_at,
             }]),
 
-            Enrich { .. } | Acknowledge => Err(OnChainTradeError::NotFilled),
+            Enrich { .. } | Acknowledge | RecordReorg { .. } => Err(OnChainTradeError::NotFilled),
         }
     }
 
@@ -252,12 +270,34 @@ impl EventSourced for OnChainTrade {
             }
 
             Acknowledge => {
+                // A reorg invalidated this fill's block, so its position impact
+                // must not be applied. Reject before the acknowledged guard: a
+                // retried `AccountForDexTrade` job landing after `RecordReorg`
+                // would otherwise complete the acknowledged marker while the
+                // conductor resume path (keyed on `!is_acknowledged()`) skips
+                // re-applying position impact -- leaving position and dedupe
+                // state inconsistent with a fill invalidated on-chain.
+                if self.is_reorged() {
+                    return Err(OnChainTradeError::CannotAcknowledgeReorgedFill);
+                }
+
                 if self.is_acknowledged() {
                     return Err(OnChainTradeError::AlreadyAcknowledged);
                 }
 
                 Ok(vec![Acknowledged {
                     acknowledged_at: Utc::now(),
+                }])
+            }
+
+            RecordReorg { reorg_depth } => {
+                if self.is_reorged() {
+                    return Err(OnChainTradeError::AlreadyReorged);
+                }
+
+                Ok(vec![Reorged {
+                    reorg_depth,
+                    reorged_at: Utc::now(),
                 }])
             }
         }
@@ -274,6 +314,13 @@ impl OnChainTrade {
     /// trade as fully processed.
     pub(crate) fn is_acknowledged(&self) -> bool {
         self.acknowledged_at.is_some()
+    }
+
+    /// Whether a reorg has invalidated this fill's block. Once set, the trade is
+    /// preserved (not deleted) and flagged reorged in the event log; reorg state
+    /// is read from there and the `Position` aggregate, not from a view.
+    pub(crate) fn is_reorged(&self) -> bool {
+        self.reorged_at.is_some()
     }
 
     pub(crate) fn to_trade(&self, id: &OnChainTradeId) -> Trade {
@@ -298,6 +345,10 @@ pub(crate) enum OnChainTradeError {
     AlreadyFilled,
     #[error("Trade has already been acknowledged by the position")]
     AlreadyAcknowledged,
+    #[error("Trade has already been recorded as reorged")]
+    AlreadyReorged,
+    #[error("Cannot acknowledge a fill whose block was reorged away")]
+    CannotAcknowledgeReorgedFill,
     #[error(
         "Effective gas price {effective_gas_price} exceeds i64::MAX \
          and cannot be stored in SQLite"
@@ -355,6 +406,9 @@ pub(crate) enum OnChainTradeCommand {
     /// Sent only after `AcknowledgeOnChainFill` succeeded, so the
     /// dedupe guard can distinguish "witnessed" from "fully accounted".
     Acknowledge,
+    /// Records that a reorg invalidated this fill's block. `reorg_depth` is
+    /// how many blocks deep the reorg ran, kept for the audit trail.
+    RecordReorg { reorg_depth: u64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -386,6 +440,10 @@ pub(crate) enum OnChainTradeEvent {
     },
     Acknowledged {
         acknowledged_at: DateTime<Utc>,
+    },
+    Reorged {
+        reorg_depth: u64,
+        reorged_at: DateTime<Utc>,
     },
 }
 
@@ -446,6 +504,16 @@ impl PartialEq for OnChainTradeEvent {
                     acknowledged_at: a2,
                 },
             ) => a1 == a2,
+            (
+                Self::Reorged {
+                    reorg_depth: depth_a,
+                    reorged_at: at_a,
+                },
+                Self::Reorged {
+                    reorg_depth: depth_b,
+                    reorged_at: at_b,
+                },
+            ) => depth_a == depth_b && at_a == at_b,
             _ => false,
         }
     }
@@ -459,6 +527,7 @@ impl DomainEvent for OnChainTradeEvent {
             Self::Filled { .. } => "OnChainTradeEvent::Filled".to_string(),
             Self::Enriched { .. } => "OnChainTradeEvent::Enriched".to_string(),
             Self::Acknowledged { .. } => "OnChainTradeEvent::Acknowledged".to_string(),
+            Self::Reorged { .. } => "OnChainTradeEvent::Reorged".to_string(),
         }
     }
 
@@ -788,6 +857,255 @@ mod tests {
         let error = TestHarness::<OnChainTrade>::with(())
             .given_no_previous_events()
             .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::NotFilled)
+        ));
+    }
+
+    #[tokio::test]
+    async fn record_reorg_marks_filled_trade_reorged() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![OnChainTradeEvent::Filled {
+                symbol,
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_hash: None,
+                block_timestamp: now,
+                filled_at: now,
+            }])
+            .when(OnChainTradeCommand::RecordReorg { reorg_depth: 3 })
+            .await
+            .events();
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [OnChainTradeEvent::Reorged { reorg_depth: 3, .. }]
+            ),
+            "RecordReorg on a filled trade must emit Reorged carrying the depth; got {events:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn cannot_acknowledge_after_reorg() {
+        // A reorg invalidated the fill, so a retried AccountForDexTrade job that
+        // lands after RecordReorg must not complete the acknowledged marker --
+        // that would desync position/dedupe state from an on-chain-invalid fill.
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![
+                OnChainTradeEvent::Filled {
+                    symbol,
+                    amount: float!(10.5),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150.25),
+                    block_number: 12345,
+                    block_hash: None,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+                OnChainTradeEvent::Reorged {
+                    reorg_depth: 3,
+                    reorged_at: now,
+                },
+            ])
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::CannotAcknowledgeReorgedFill)
+        ));
+    }
+
+    /// The reorg is append-only: marking a trade reorged must leave every
+    /// original fill field intact so the reorged trade stays auditable in the
+    /// event log with its original fill data.
+    #[test]
+    fn reorged_preserves_original_fill_data() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let trade = replay::<OnChainTrade>(vec![
+            OnChainTradeEvent::Filled {
+                symbol: symbol.clone(),
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_hash: None,
+                block_timestamp: now,
+                filled_at: now,
+            },
+            OnChainTradeEvent::Reorged {
+                reorg_depth: 3,
+                reorged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live trade");
+
+        assert!(trade.is_reorged());
+        assert_eq!(trade.symbol, symbol);
+        assert!(trade.amount.eq(float!(10.5)).unwrap());
+        assert_eq!(trade.direction, Direction::Buy);
+        assert_eq!(trade.block_number, Some(12345));
+        assert_eq!(trade.filled_at, now);
+    }
+
+    /// Reorgs strike already-processed fills, so the marker must coexist with
+    /// the acknowledgement rather than replace it.
+    #[test]
+    fn reorg_after_acknowledge_preserves_both_markers() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let trade = replay::<OnChainTrade>(vec![
+            OnChainTradeEvent::Filled {
+                symbol,
+                amount: float!(10.5),
+                direction: Direction::Buy,
+                price_usdc: float!(150.25),
+                block_number: 12345,
+                block_hash: None,
+                block_timestamp: now,
+                filled_at: now,
+            },
+            OnChainTradeEvent::Acknowledged {
+                acknowledged_at: now,
+            },
+            OnChainTradeEvent::Reorged {
+                reorg_depth: 1,
+                reorged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live trade");
+
+        assert!(trade.is_reorged());
+        assert!(trade.is_acknowledged());
+    }
+
+    /// Drives the command path end-to-end: an already-acknowledged fill struck
+    /// by a reorg must emit `Reorged`, keep its acknowledgement, and then reject
+    /// any retried `Acknowledge` with `CannotAcknowledgeReorgedFill` -- so a
+    /// re-delivered `AccountForDexTrade` job can never complete the marker on a
+    /// fill whose block was reorged away. The replay-only sibling is
+    /// `reorg_after_acknowledge_preserves_both_markers`; this one threads the
+    /// real events emitted by each command handler into the next step.
+    #[tokio::test]
+    async fn record_reorg_after_acknowledge_marks_reorged_and_blocks_reacknowledge() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let filled = OnChainTradeEvent::Filled {
+            symbol,
+            amount: float!(10.5),
+            direction: Direction::Buy,
+            price_usdc: float!(150.25),
+            block_number: 12345,
+            block_hash: None,
+            block_timestamp: now,
+            filled_at: now,
+        };
+
+        // Acknowledge the witnessed fill through the command handler.
+        let acknowledge_events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![filled.clone()])
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .events();
+        let [acknowledged] = acknowledge_events.as_slice() else {
+            panic!("Acknowledge must emit a single marker; got {acknowledge_events:?}");
+        };
+        assert!(matches!(
+            acknowledged,
+            OnChainTradeEvent::Acknowledged { .. }
+        ));
+
+        // RecordReorg the now-acknowledged fill through the command handler.
+        let reorg_events = TestHarness::<OnChainTrade>::with(())
+            .given(vec![filled.clone(), acknowledged.clone()])
+            .when(OnChainTradeCommand::RecordReorg { reorg_depth: 4 })
+            .await
+            .events();
+        let [reorged] = reorg_events.as_slice() else {
+            panic!("RecordReorg must emit a single marker; got {reorg_events:?}");
+        };
+        assert!(matches!(
+            reorged,
+            OnChainTradeEvent::Reorged { reorg_depth: 4, .. }
+        ));
+
+        // (a) The live aggregate carries both markers after the command sequence.
+        let trade =
+            replay::<OnChainTrade>(vec![filled.clone(), acknowledged.clone(), reorged.clone()])
+                .unwrap()
+                .expect("replay must produce a live trade");
+        assert!(trade.is_reorged());
+        assert!(trade.is_acknowledged());
+
+        // (b) A retried Acknowledge after the reorg is rejected.
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![filled, acknowledged.clone(), reorged.clone()])
+            .when(OnChainTradeCommand::Acknowledge)
+            .await
+            .then_expect_error();
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::CannotAcknowledgeReorgedFill)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cannot_reorg_twice() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given(vec![
+                OnChainTradeEvent::Filled {
+                    symbol,
+                    amount: float!(10.5),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150.25),
+                    block_number: 12345,
+                    block_hash: None,
+                    block_timestamp: now,
+                    filled_at: now,
+                },
+                OnChainTradeEvent::Reorged {
+                    reorg_depth: 2,
+                    reorged_at: now,
+                },
+            ])
+            .when(OnChainTradeCommand::RecordReorg { reorg_depth: 5 })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(OnChainTradeError::AlreadyReorged)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cannot_reorg_unfilled_trade() {
+        let error = TestHarness::<OnChainTrade>::with(())
+            .given_no_previous_events()
+            .when(OnChainTradeCommand::RecordReorg { reorg_depth: 1 })
             .await
             .then_expect_error();
 

--- a/tests/e2e/reorg.rs
+++ b/tests/e2e/reorg.rs
@@ -65,28 +65,24 @@ async fn reorg_reverts_witnessed_fill() -> anyhow::Result<()> {
 
     let pool = connect_db(&infra.db_path).await?;
 
-    // The reversal is append-only: the original fill survives, the reorg is a
-    // new event, and the views expose a `reorged` flag rather than deleting rows.
+    // The reversal is append-only and asserted against the event stream: the
+    // original fill survives and the reorg is recorded as new events, rather than
+    // any row being deleted. (onchain_trade_view has no writer, so reorg state is
+    // read from the event log / Position aggregate, not from a view.)
     assert_eq!(
         count_events_of_type(&pool, "OnChainTradeEvent::Filled").await?,
         1,
         "the original fill must be preserved, not deleted",
     );
     assert_eq!(
+        count_events_of_type(&pool, "OnChainTradeEvent::Reorged").await?,
+        1,
+        "the reorged fill must be marked via a Reorged event, not removed",
+    );
+    assert_eq!(
         count_events_of_type(&pool, "PositionEvent::Reorged").await?,
         1,
         "the reorg must reverse the fill's position impact exactly once",
-    );
-
-    let reorged_trades: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM onchain_trade_view \
-         WHERE json_extract(payload, '$.Live.reorged') = 1",
-    )
-    .fetch_one(&pool)
-    .await?;
-    assert_eq!(
-        reorged_trades, 1,
-        "the reorged fill must be flagged in onchain_trade_view, not removed",
     );
 
     bot.abort();


### PR DESCRIPTION
## What

Adds `OnChainTradeEvent::Reorged` and an append-only `reorged_at` marker on the
`OnChainTrade` aggregate, surfaced as a `reorged` flag on `onchain_trade_view`.
Second slice of the reorg-handling stack (RAI-294).

Closes RAI-803.

## Why

First-class reorg handling must record that a fill's block was reorged away
**without** destroying the original fill data — the row stays for audit and the
`(tx_hash, log_index)` idempotency key stays valid, so detection and reversal can
build on it. This slice adds the `OnChainTrade` side; the `Position` reversal
(RAI-804 / #868) and the detection producer (RAI-805 / #869) stack on top.

## How

- New `OnChainTradeEvent::Reorged` event recording `reorged_at`, applied to the
  aggregate as an append-only `reorged_at: Option<DateTime<Utc>>` marker — the
  original fill fields are preserved, never deleted.
- Re-recording a reorg on an already-reorged trade returns `AlreadyReorged`, so a
  re-delivered detection cannot double-apply the marker.
- `onchain_trade_view` gains a `reorged` marker (new SQLite migration); the
  idempotency key remains `(tx_hash, log_index)`, with `reorged` as a separate
  flag, so reorged fills can be queried for fork detection and monitoring.

## Testing

- Aggregate tests: recording a reorg sets `reorged_at`; a duplicate reorg is a
  no-op.
- View test: `onchain_trade_view.reorged` is persisted without dropping the row.
- The north-star reorg e2e (`tests/e2e/`) is updated to cover reorg persistence.

## Anything else

- Stacked on #864 (`block_hash` for fork detection). The `Position` reversal
  (#868) and the `RecordReorg` producer (#869 / #870) build on this.
- Per ADR 0009, the RAI-294 stack lands as one coherent unit; #869 must not merge
  without #870 (the permanent-under-reversal finding in ADR 0007).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording chain reorgs on on-chain trades.
  * Reorg status is now tracked alongside existing fill and acknowledgment state.

* **Bug Fixes**
  * Prevents acknowledging trades that have been reorged.
  * Stops reorged trades from being processed again, avoiding retry loops and duplicate accounting.
  * Improves end-to-end reorg visibility by asserting the reorg event in the event stream.

* **Tests**
  * Added coverage for reorg creation, duplicate reorg rejection, and safe handling of reorged trades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->