### PR TITLE
feat: PositionEvent::Reorged reverses position impact and flags position_view

### DIFF
--- a/migrations/20260615194915_position_view_reorged_marker.sql
+++ b/migrations/20260615194915_position_view_reorged_marker.sql
@@ -1,0 +1,18 @@
+-- Surface the reorg marker on position_view.
+--
+-- A reorg appends a `PositionEvent::Reorged`, which sets `last_reorged_at` on
+-- the Position aggregate. The view payload is the serialized Position (wrapped
+-- by Lifecycle<T> as {"Live": <data>}), so a reorged position is one where
+-- `$.Live.last_reorged_at` is non-null -- an append-only marker, since the
+-- original fill events and their reversal both stay in history.
+--
+-- SQLite only allows VIRTUAL (not STORED) generated columns via ALTER TABLE
+-- ADD COLUMN; VIRTUAL is fine here and still indexable.
+
+ALTER TABLE position_view
+    ADD COLUMN last_reorged_at TEXT
+    GENERATED ALWAYS AS (json_extract(payload, '$.Live.last_reorged_at')) VIRTUAL;
+
+CREATE INDEX IF NOT EXISTS idx_position_view_last_reorged_at
+    ON position_view(last_reorged_at)
+    WHERE last_reorged_at IS NOT NULL;

--- a/src/dashboard/event.rs
+++ b/src/dashboard/event.rs
@@ -94,6 +94,7 @@ impl Reactor for Broadcaster {
                     PositionEvent::OnChainOrderFilled { .. }
                         | PositionEvent::OffChainOrderFilled { .. }
                         | PositionEvent::ManualPositionAdjusted { .. }
+                        | PositionEvent::Reorged { .. }
                 ) {
                     return;
                 }
@@ -477,6 +478,111 @@ mod tests {
                 assert!(
                     position.net.eq(st0x_float_macro::float!(-3)).unwrap(),
                     "expected adjusted net -3, got {:?}",
+                    position.net
+                );
+            }
+            other => panic!("expected PositionUpdate message, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reorged_broadcasts_reversed_net() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (broadcaster, mut receiver) = test_broadcaster(pool.clone());
+        let harness = ReactorHarness::new(broadcaster);
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = chrono::Utc::now();
+        let threshold = st0x_config::ExecutionThreshold::Shares(
+            st0x_execution::Positive::new(st0x_execution::FractionalShares::new(
+                st0x_float_macro::float!(1),
+            ))
+            .unwrap(),
+        );
+        let reorged_trade = TradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 0,
+        };
+        let surviving_trade = TradeId {
+            tx_hash: alloy::primitives::TxHash::ZERO,
+            log_index: 1,
+        };
+
+        // Two buys (net 8), then a reorg reverses the first (net 3). The
+        // broadcaster loads the persisted post-reorg position, so the broadcast
+        // net must reflect the reversal, not the pre-reorg total.
+        store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: reorged_trade.clone(),
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(5)),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold,
+                    trade_id: surviving_trade.clone(),
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(3)),
+                    direction: st0x_execution::Direction::Buy,
+                    price_usdc: st0x_float_macro::float!(150),
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &symbol,
+                PositionCommand::RecordReorg {
+                    trade_id: reorged_trade.clone(),
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(5)),
+                    direction: st0x_execution::Direction::Buy,
+                    reorg_depth: 1,
+                },
+            )
+            .await
+            .unwrap();
+
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                PositionEvent::Reorged {
+                    trade_id: reorged_trade,
+                    amount: st0x_execution::FractionalShares::new(st0x_float_macro::float!(5)),
+                    direction: st0x_execution::Direction::Buy,
+                    reorg_depth: 1,
+                    reorged_at: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        let msg = receiver
+            .recv()
+            .await
+            .expect("should receive position update");
+
+        match msg {
+            Statement::PositionUpdate(position) => {
+                assert_eq!(position.symbol, symbol);
+                assert!(
+                    position.net.eq(st0x_float_macro::float!(3)).unwrap(),
+                    "expected reversed net 3, got {:?}",
                     position.net
                 );
             }

--- a/src/performance/projection.rs
+++ b/src/performance/projection.rs
@@ -41,11 +41,17 @@ impl HedgeLatencyProjection {
         event: PositionEvent,
     ) -> Result<(), ProjectionError> {
         match event {
-            // Dedup bookkeeping only (ADR 0010): no performance signal.
+            // No hedge-latency impact: ADR 0010 dedup bookkeeping
+            // (OnChainFillApplied/OnChainFillSettled) and
+            // Initialized/ThresholdUpdated carry no fill timing, and a reorged
+            // fill's latency attribution is left as a follow-up -- the read model
+            // is observability-only, never gates hedging correctness, and reorgs
+            // are rare.
             PositionEvent::Initialized { .. }
             | PositionEvent::ThresholdUpdated { .. }
             | PositionEvent::OnChainFillApplied { .. }
-            | PositionEvent::OnChainFillSettled { .. } => Ok(()),
+            | PositionEvent::OnChainFillSettled { .. }
+            | PositionEvent::Reorged { .. } => Ok(()),
             PositionEvent::OnChainOrderFilled {
                 trade_id,
                 block_timestamp,

--- a/src/position.rs
+++ b/src/position.rs
@@ -76,6 +76,13 @@ pub struct Position {
     )]
     pub last_price_usdc: Option<Float>,
     pub last_updated: Option<DateTime<Utc>>,
+    /// Set when a reorg reversal has been applied to this position. Append-only
+    /// marker -- the reversal is a new event, the original fill events are
+    /// preserved, and `position_view` surfaces that a reorg struck without
+    /// deleting history. Absent on positions persisted before the
+    /// field existed, which is the never-reorged default.
+    #[serde(default)]
+    pub last_reorged_at: Option<DateTime<Utc>>,
 }
 
 impl std::fmt::Debug for Position {
@@ -101,6 +108,7 @@ impl std::fmt::Debug for Position {
             .field("threshold", &self.threshold)
             .field("last_price_usdc", &DebugOptionFloat(&self.last_price_usdc))
             .field("last_updated", &self.last_updated)
+            .field("last_reorged_at", &self.last_reorged_at)
             .finish()
     }
 }
@@ -137,6 +145,10 @@ pub(crate) async fn hydrate_position_gauges(
     Ok(())
 }
 
+// The event-application match in `evolve` (and its async_trait expansion)
+// exceeds the line lint by design: simple-but-long pattern matches stay whole
+// per AGENTS.md rather than splitting into per-arm helpers.
+#[allow(clippy::too_many_lines)]
 #[async_trait]
 impl EventSourced for Position {
     type Id = Symbol;
@@ -169,6 +181,7 @@ impl EventSourced for Position {
                 threshold: *threshold,
                 last_price_usdc: None,
                 last_updated: Some(*initialized_at),
+                last_reorged_at: None,
             }),
 
             _ => None,
@@ -242,6 +255,70 @@ impl EventSourced for Position {
                 pending_acknowledged_trade_ids.remove(trade_id);
                 Ok(Some(Self {
                     pending_acknowledged_trade_ids,
+                    ..entity.clone()
+                }))
+            }
+
+            // A reorg reverses the original fill's impact exactly: undo the net
+            // delta and the accumulator the fill grew. The fill events stay in
+            // history; this reversal is appended on top.
+            //
+            // Clear `last_acknowledged_trade_id` only when it points at the trade
+            // being reorged, and remove the reorged trade_id from
+            // `pending_acknowledged_trade_ids`. The fill-dedupe guard absorbs
+            // crash-window replay of the same event, not a permanent tombstone: if
+            // this exact `(tx_hash, log_index)` re-confirms on the canonical chain
+            // after the reorg resolves, `AcknowledgeOnChainFill` must accept it
+            // instead of rejecting it as a `DuplicateTrade`. That guard ORs both
+            // slots, so the bounded pending set must be pruned too -- clearing only
+            // the anchor would leave the trade_id in the set and keep rejecting the
+            // re-confirmation. Clearing the anchor unconditionally would instead
+            // drop a more recent fill's anchor when an older fill is reorged,
+            // reopening that newer fill's crash-window replay.
+            Reorged {
+                trade_id,
+                direction: Buy,
+                amount,
+                reorged_at,
+                ..
+            } => {
+                let mut pending_acknowledged_trade_ids =
+                    entity.pending_acknowledged_trade_ids.clone();
+                pending_acknowledged_trade_ids.remove(trade_id);
+                Ok(Some(Self {
+                    net: (entity.net - *amount)?,
+                    accumulated_long: (entity.accumulated_long - *amount)?,
+                    last_reorged_at: Some(*reorged_at),
+                    last_acknowledged_trade_id: entity
+                        .last_acknowledged_trade_id
+                        .clone()
+                        .filter(|id| id != trade_id),
+                    pending_acknowledged_trade_ids,
+                    last_updated: Some(*reorged_at),
+                    ..entity.clone()
+                }))
+            }
+
+            Reorged {
+                trade_id,
+                direction: Sell,
+                amount,
+                reorged_at,
+                ..
+            } => {
+                let mut pending_acknowledged_trade_ids =
+                    entity.pending_acknowledged_trade_ids.clone();
+                pending_acknowledged_trade_ids.remove(trade_id);
+                Ok(Some(Self {
+                    net: (entity.net + *amount)?,
+                    accumulated_short: (entity.accumulated_short - *amount)?,
+                    last_reorged_at: Some(*reorged_at),
+                    last_acknowledged_trade_id: entity
+                        .last_acknowledged_trade_id
+                        .clone()
+                        .filter(|id| id != trade_id),
+                    pending_acknowledged_trade_ids,
+                    last_updated: Some(*reorged_at),
                     ..entity.clone()
                 }))
             }
@@ -523,6 +600,37 @@ impl EventSourced for Position {
                 } else {
                     Ok(vec![])
                 }
+            }
+
+            RecordReorg {
+                trade_id,
+                amount,
+                direction,
+                reorg_depth,
+            } => {
+                // A reversal must undo a real (strictly positive) fill amount.
+                // Reject a zero or negative amount rather than appending a
+                // reversal that would corrupt the net position.
+                Positive::new(amount)
+                    .map_err(|_| PositionError::NonPositiveReorgAmount { amount })?;
+
+                warn!(
+                    target: "hedge",
+                    symbol = %self.symbol,
+                    ?trade_id,
+                    ?direction,
+                    %amount,
+                    reorg_depth,
+                    "Reversing position impact of a reorged fill"
+                );
+
+                Ok(vec![PositionEvent::Reorged {
+                    trade_id,
+                    amount,
+                    direction,
+                    reorg_depth,
+                    reorged_at: Utc::now(),
+                }])
             }
 
             PlaceOffChainOrder {
@@ -942,6 +1050,8 @@ impl Position {
 pub enum PositionError {
     #[error("Position has not been initialized")]
     Uninitialized,
+    #[error("Reorg reversal amount must be strictly positive, got {amount:?}")]
+    NonPositiveReorgAmount { amount: FractionalShares },
     #[error(
         "Cannot place offchain order: position \
          {net_position:?} does not meet threshold \
@@ -1046,6 +1156,15 @@ pub enum PositionCommand {
     SettleOnChainFill {
         trade_id: TradeId,
     },
+    /// Reverses an onchain fill that a reorg invalidated. Carries the original
+    /// fill's `amount` and `direction` so the reversal undoes exactly its
+    /// position impact; `reorg_depth` is retained for the audit trail.
+    RecordReorg {
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        reorg_depth: u64,
+    },
     PlaceOffChainOrder {
         offchain_order_id: OffchainOrderId,
         shares: Positive<FractionalShares>,
@@ -1141,6 +1260,13 @@ pub enum PositionEvent {
         trade_id: TradeId,
         settled_at: DateTime<Utc>,
     },
+    Reorged {
+        trade_id: TradeId,
+        amount: FractionalShares,
+        direction: Direction,
+        reorg_depth: u64,
+        reorged_at: DateTime<Utc>,
+    },
     OffChainOrderPlaced {
         offchain_order_id: OffchainOrderId,
         shares: Positive<FractionalShares>,
@@ -1197,6 +1323,7 @@ impl PositionEvent {
             OnChainOrderFilled { seen_at, .. } => *seen_at,
             OnChainFillApplied { applied_at, .. } => *applied_at,
             OnChainFillSettled { settled_at, .. } => *settled_at,
+            Reorged { reorged_at, .. } => *reorged_at,
             OffChainOrderPlaced { placed_at, .. } => *placed_at,
             OffChainOrderFilled {
                 broker_timestamp, ..
@@ -1217,6 +1344,7 @@ impl DomainEvent for PositionEvent {
             OnChainOrderFilled { .. } => Self::ON_CHAIN_ORDER_FILLED_EVENT_TYPE.to_string(),
             OnChainFillApplied { .. } => "PositionEvent::OnChainFillApplied".to_string(),
             OnChainFillSettled { .. } => "PositionEvent::OnChainFillSettled".to_string(),
+            Reorged { .. } => "PositionEvent::Reorged".to_string(),
             OffChainOrderPlaced { .. } => "PositionEvent::OffChainOrderPlaced".to_string(),
             OffChainOrderFilled { .. } => "PositionEvent::OffChainOrderFilled".to_string(),
             OffChainOrderFailed { .. } => "PositionEvent::OffChainOrderFailed".to_string(),
@@ -1307,6 +1435,28 @@ impl PartialEq for PositionEvent {
                     settled_at: c2,
                 },
             ) => t1 == t2 && c1 == c2,
+            (
+                Self::Reorged {
+                    trade_id: left_trade_id,
+                    amount: left_amount,
+                    direction: left_direction,
+                    reorg_depth: left_reorg_depth,
+                    reorged_at: left_reorged_at,
+                },
+                Self::Reorged {
+                    trade_id: right_trade_id,
+                    amount: right_amount,
+                    direction: right_direction,
+                    reorg_depth: right_reorg_depth,
+                    reorged_at: right_reorged_at,
+                },
+            ) => {
+                left_trade_id == right_trade_id
+                    && left_amount == right_amount
+                    && left_direction == right_direction
+                    && left_reorg_depth == right_reorg_depth
+                    && left_reorged_at == right_reorged_at
+            }
             (
                 Self::OffChainOrderPlaced {
                     offchain_order_id: o1,
@@ -1538,6 +1688,18 @@ impl std::fmt::Debug for PositionCommand {
                 .debug_struct("SettleOnChainFill")
                 .field("trade_id", trade_id)
                 .finish(),
+            Self::RecordReorg {
+                trade_id,
+                amount,
+                direction,
+                reorg_depth,
+            } => f
+                .debug_struct("RecordReorg")
+                .field("trade_id", trade_id)
+                .field("amount", amount)
+                .field("direction", direction)
+                .field("reorg_depth", reorg_depth)
+                .finish(),
             Self::PlaceOffChainOrder {
                 offchain_order_id,
                 shares,
@@ -1673,6 +1835,20 @@ impl std::fmt::Debug for PositionEvent {
                 .debug_struct("OnChainFillSettled")
                 .field("trade_id", trade_id)
                 .field("settled_at", settled_at)
+                .finish(),
+            Self::Reorged {
+                trade_id,
+                amount,
+                direction,
+                reorg_depth,
+                reorged_at,
+            } => f
+                .debug_struct("Reorged")
+                .field("trade_id", trade_id)
+                .field("amount", amount)
+                .field("direction", direction)
+                .field("reorg_depth", reorg_depth)
+                .field("reorged_at", reorged_at)
                 .finish(),
             Self::OffChainOrderPlaced {
                 offchain_order_id,
@@ -1908,6 +2084,475 @@ mod tests {
             panic!("Expected OnChainOrderFilled, got: {:?}", events[1]);
         };
         assert_eq!(*event_seen_at, seen_at);
+    }
+
+    #[tokio::test]
+    async fn record_reorg_on_filled_position_emits_reorged_event() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol,
+                    threshold: one_share_threshold(),
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_id.clone(),
+                    amount: FractionalShares::new(float!(5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+            ])
+            .when(PositionCommand::RecordReorg {
+                trade_id: trade_id.clone(),
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                reorg_depth: 2,
+            })
+            .await
+            .events();
+
+        let [
+            PositionEvent::Reorged {
+                trade_id: reorged_trade_id,
+                amount,
+                direction,
+                reorg_depth,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("RecordReorg must emit exactly one Reorged event; got {events:?}");
+        };
+
+        assert_eq!(
+            *reorged_trade_id, trade_id,
+            "the reversal must target the reorged fill"
+        );
+        assert_eq!(
+            *amount,
+            FractionalShares::new(float!(5)),
+            "amount drives the reversal"
+        );
+        assert_eq!(
+            *direction,
+            Direction::Buy,
+            "direction drives the reversal sign"
+        );
+        assert_eq!(*reorg_depth, 2);
+    }
+
+    #[tokio::test]
+    async fn record_reorg_with_non_positive_amount_is_rejected() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+
+        let error = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol,
+                    threshold: one_share_threshold(),
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_id.clone(),
+                    amount: FractionalShares::new(float!(5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+            ])
+            .when(PositionCommand::RecordReorg {
+                trade_id,
+                amount: FractionalShares::ZERO,
+                direction: Direction::Buy,
+                reorg_depth: 2,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(PositionError::NonPositiveReorgAmount { .. })
+            ),
+            "a zero reorg amount must be rejected; got {error:?}",
+        );
+    }
+
+    /// A reorg of a buy fill must return `net` and `accumulated_long` to the
+    /// exact pre-fill state while preserving the original fill events.
+    #[test]
+    fn reorg_reverses_buy_fill_to_pre_fill_state() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol,
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_id.clone(),
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::Reorged {
+                trade_id,
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                reorg_depth: 2,
+                reorged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live position");
+
+        assert_eq!(position.net, FractionalShares::ZERO);
+        assert_eq!(position.accumulated_long, FractionalShares::ZERO);
+        assert_eq!(position.accumulated_short, FractionalShares::ZERO);
+        assert_eq!(position.last_reorged_at, Some(now));
+    }
+
+    /// The sell-side mirror: reversing a sell returns `net` to zero and undoes
+    /// the `accumulated_short` the fill grew.
+    #[test]
+    fn reorg_reverses_sell_fill_to_pre_fill_state() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol,
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_id.clone(),
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Sell,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::Reorged {
+                trade_id,
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Sell,
+                reorg_depth: 1,
+                reorged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live position");
+
+        assert_eq!(position.net, FractionalShares::ZERO);
+        assert_eq!(position.accumulated_short, FractionalShares::ZERO);
+        assert_eq!(position.accumulated_long, FractionalShares::ZERO);
+        assert_eq!(position.last_reorged_at, Some(now));
+    }
+
+    /// `evolve` reverses a `Reorged` by its `amount`/`direction`, NOT by
+    /// `trade_id` (which is audit metadata the aggregate does not match on). A
+    /// 5-share buy reversed out of two buys (5 + 3) leaves the 3-share net --
+    /// the reversal matches the amount, not the named trade.
+    #[test]
+    fn reorg_reverses_by_amount_and_direction_not_trade_id() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let reorged_trade = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let surviving_trade = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 2,
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol,
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: reorged_trade.clone(),
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: surviving_trade,
+                amount: FractionalShares::new(float!(3)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::Reorged {
+                trade_id: reorged_trade,
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                reorg_depth: 1,
+                reorged_at: now,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live position");
+
+        assert_eq!(position.net, FractionalShares::new(float!(3)));
+        assert_eq!(position.accumulated_long, FractionalShares::new(float!(3)));
+    }
+
+    #[tokio::test]
+    async fn reorged_fill_can_be_re_acknowledged_after_canonical_reconfirmation() {
+        // The fill-dedupe guard absorbs crash-window replay but must not
+        // permanently tombstone a fill: if the same (tx, log) re-confirms on the
+        // canonical chain after the reorg resolves, re-acknowledgement must
+        // succeed, not be rejected as a DuplicateTrade.
+        //
+        // The seeded history is the real post-ADR-0010 production state:
+        // `AcknowledgeOnChainFill` always emits `OnChainOrderFilled` +
+        // `OnChainFillApplied` as an atomic pair, so the applied trade_id sits
+        // in `pending_acknowledged_trade_ids`. The `Reorged` evolve must remove
+        // it from that set (mirroring `OnChainFillSettled`); otherwise the dedup
+        // guard's set check would keep rejecting the canonical re-confirmation.
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let amount = FractionalShares::new(float!(5));
+
+        let events = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold: one_share_threshold(),
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: trade_id.clone(),
+                    amount,
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::OnChainFillApplied {
+                    trade_id: trade_id.clone(),
+                    applied_at: now,
+                },
+                PositionEvent::Reorged {
+                    trade_id: trade_id.clone(),
+                    amount,
+                    direction: Direction::Buy,
+                    reorg_depth: 1,
+                    reorged_at: now,
+                },
+            ])
+            .when(PositionCommand::AcknowledgeOnChainFill {
+                symbol,
+                threshold: one_share_threshold(),
+                trade_id,
+                amount,
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+            })
+            .await
+            .events();
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [
+                    PositionEvent::OnChainOrderFilled { .. },
+                    PositionEvent::OnChainFillApplied { .. }
+                ]
+            ),
+            "re-confirmation of a reorged fill must be accepted, not rejected as \
+             DuplicateTrade; got {events:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn reorging_an_older_fill_preserves_a_newer_fills_dedupe_anchor() {
+        // Reversing one fill must not reopen another fill's crash-window guard.
+        // After two fills are acknowledged, reorging the OLDER one must leave the
+        // NEWER fill's dedupe anchor intact, so a re-delivered acknowledge of the
+        // newer fill is still rejected as a duplicate rather than double-counted.
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let threshold = one_share_threshold();
+        let older = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+        let newer = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 2,
+        };
+        let amount = FractionalShares::new(float!(5));
+
+        let error = TestHarness::<Position>::with(())
+            .given(vec![
+                PositionEvent::Initialized {
+                    symbol: symbol.clone(),
+                    threshold,
+                    initialized_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: older.clone(),
+                    amount,
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::OnChainOrderFilled {
+                    trade_id: newer.clone(),
+                    amount,
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                    seen_at: now,
+                },
+                PositionEvent::Reorged {
+                    trade_id: older.clone(),
+                    amount,
+                    direction: Direction::Buy,
+                    reorg_depth: 1,
+                    reorged_at: now,
+                },
+            ])
+            .when(PositionCommand::AcknowledgeOnChainFill {
+                symbol,
+                threshold,
+                trade_id: newer.clone(),
+                amount,
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(PositionError::DuplicateTrade {
+                    trade_id: ref rejected
+                }) if *rejected == newer
+            ),
+            "reorging an older fill must not clear a newer fill's dedupe anchor; \
+             re-acknowledging the newer fill must still be rejected as a \
+             duplicate; got: {error:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn cannot_reorg_uninitialized_position() {
+        let error = TestHarness::<Position>::with(())
+            .given_no_previous_events()
+            .when(PositionCommand::RecordReorg {
+                trade_id: TradeId {
+                    tx_hash: TxHash::random(),
+                    log_index: 1,
+                },
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                reorg_depth: 1,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(PositionError::Uninitialized)
+        ));
+    }
+
+    /// The `position_view.last_reorged_at` column is `json_extract(payload,
+    /// '$.Live.last_reorged_at')`. `Position` serializes flat (the field at the
+    /// top level); the framework's `Lifecycle<Position>` wrapper nests that flat
+    /// object under the externally-tagged `Live` key, so the projection reads
+    /// `$.Live.last_reorged_at`. This pins the exact RFC3339 string the column
+    /// receives for a known `reorged_at`, independent of the serialization under
+    /// test.
+    #[test]
+    fn reorged_marker_serializes_for_view() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let now = Utc::now();
+        let reorged_at = DateTime::parse_from_rfc3339("2026-06-15T19:49:15Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let trade_id = TradeId {
+            tx_hash: TxHash::random(),
+            log_index: 1,
+        };
+
+        let position = replay::<Position>(vec![
+            PositionEvent::Initialized {
+                symbol,
+                threshold: one_share_threshold(),
+                initialized_at: now,
+            },
+            PositionEvent::OnChainOrderFilled {
+                trade_id: trade_id.clone(),
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                price_usdc: float!(150),
+                block_timestamp: now,
+                seen_at: now,
+            },
+            PositionEvent::Reorged {
+                trade_id,
+                amount: FractionalShares::new(float!(5)),
+                direction: Direction::Buy,
+                reorg_depth: 1,
+                reorged_at,
+            },
+        ])
+        .unwrap()
+        .expect("replay must produce a live position");
+
+        let payload = serde_json::to_value(&position).unwrap();
+
+        assert_eq!(
+            payload["last_reorged_at"],
+            serde_json::json!("2026-06-15T19:49:15Z"),
+            "last_reorged_at must serialize to the exact RFC3339 string the \
+             position_view projection extracts via $.Live.last_reorged_at",
+        );
     }
 
     /// Reproduction for the double-count half of the Witness/Acknowledge
@@ -3570,6 +4215,23 @@ mod tests {
     }
 
     #[test]
+    fn timestamp_returns_reorged_at_for_reorged_event() {
+        let reorged_at = Utc::now();
+        let event = PositionEvent::Reorged {
+            trade_id: TradeId {
+                tx_hash: TxHash::random(),
+                log_index: 1,
+            },
+            amount: FractionalShares::new(float!(5)),
+            direction: Direction::Buy,
+            reorg_depth: 1,
+            reorged_at,
+        };
+
+        assert_eq!(event.timestamp(), reorged_at);
+    }
+
+    #[test]
     fn timestamp_returns_placed_at_for_offchain_order_placed_event() {
         let timestamp = Utc::now();
         let event = PositionEvent::OffChainOrderPlaced {
@@ -3656,6 +4318,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let (direction, shares) = position
@@ -3685,6 +4348,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let (direction, shares) = position
@@ -3714,6 +4378,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3746,6 +4411,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3778,6 +4444,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50.7))).unwrap();
@@ -3809,6 +4476,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(7.5))).unwrap();
@@ -3841,6 +4509,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(5))).unwrap();
@@ -3873,6 +4542,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: None,
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let shares_limit = Positive::new(FractionalShares::new(float!(50))).unwrap();
@@ -3955,6 +4625,7 @@ mod tests {
             threshold: ExecutionThreshold::whole_share(),
             last_price_usdc: Some(float!(150)),
             last_updated: Some(Utc::now()),
+            last_reorged_at: None,
         };
 
         let (_, first_shares) = position

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -2337,6 +2337,15 @@ impl Reactor for RebalancingService {
                         self.equity_scheduler.enqueue_check(symbol).await;
                         return Ok(());
                     }
+                    Reorged { .. } => {
+                        // A reorg reversal moves net exposure like a manual
+                        // adjustment, but the event carries no fill price, so the
+                        // usdc leg cannot be reversed precisely here. Nudge an
+                        // equity check and let the polled inventory reconcile the
+                        // new balance.
+                        self.equity_scheduler.enqueue_check(symbol).await;
+                        return Ok(());
+                    }
                 };
 
                 let inventory_result = {
@@ -9511,6 +9520,74 @@ mod tests {
         assert_eq!(
             pending_equity_checks, 1,
             "ManualPositionAdjusted must enqueue exactly one immediate equity recheck"
+        );
+    }
+
+    #[tokio::test]
+    async fn reorged_via_reactor_enqueues_equity_recheck() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let inventory = InventoryView::default()
+            .with_equity(symbol.clone(), shares(5), shares(5))
+            .with_usdc(usdc(10000), usdc(10000));
+
+        let trigger = make_trigger_with_inventory(inventory).await;
+        let harness = ReactorHarness::new(Arc::clone(&trigger));
+
+        // A reorg reversal carries no fill price, so the reactor cannot reverse
+        // the usdc leg precisely; it nudges an immediate equity check and leaves
+        // the polled inventory to reconcile the reversed balance, without
+        // mutating inventory directly here.
+        harness
+            .receive::<Position>(
+                symbol.clone(),
+                PositionEvent::Reorged {
+                    trade_id: TradeId {
+                        tx_hash: TxHash::random(),
+                        log_index: 1,
+                    },
+                    amount: shares(5),
+                    direction: Direction::Buy,
+                    reorg_depth: 1,
+                    reorged_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let inventory = trigger.inventory.read().await;
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::Hedging),
+            Some(shares(5)),
+            "reorg reversal must not directly change hedging equity"
+        );
+        assert_eq!(
+            inventory.equity_available(&symbol, Venue::MarketMaking),
+            Some(shares(5)),
+            "reorg reversal must not directly change market-making equity"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::Hedging),
+            Some(usdc(10000)),
+            "reorg reversal must not directly change hedging USDC"
+        );
+        assert_eq!(
+            inventory.usdc_available(Venue::MarketMaking),
+            Some(usdc(10000)),
+            "reorg reversal must not directly change market-making USDC"
+        );
+        drop(inventory);
+
+        let pending_equity_checks = sqlx_apalis::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE status = 'Pending' AND job_type = ?",
+        )
+        .bind(std::any::type_name::<EquityRebalancingCheck>())
+        .fetch_one(trigger.equity_scheduler.queue().pool())
+        .await
+        .expect("count pending equity-check jobs after Reorged");
+
+        assert_eq!(
+            pending_equity_checks, 1,
+            "Reorged must enqueue exactly one immediate equity recheck"
         );
     }
 


### PR DESCRIPTION
## What

Closes RAI-804. Adds `PositionEvent::Reorged`, which reverses a reorged fill's
impact on the `Position` aggregate, plus an append-only reorged marker on
`position_view`. Stacked on RAI-803 (#867).

## Why

A reorged fill's position impact had no reversal event: `Position::evolve` could
not undo a prior `OnChainOrderFilled`'s effect on `net` and `accumulated_*`. The
event-sourced model forbids deleting the original fill, so the reversal must be
a first-class appended event.

## How

- `PositionCommand::RecordReorg` -> `PositionEvent::Reorged`, carrying the
  original fill's `amount`/`direction` so `evolve` reverses exactly: a buy
  reorg undoes `net += amount` / `accumulated_long += amount`, a sell the
  mirror.
- Append-only `last_reorged_at` marker on `Position`, surfaced via a migration
  adding a generated `last_reorged_at` column + index on `position_view` (the
  original rows are preserved).
- The inventory-trigger reactor handles the new variant.

## Testing

- BDD aggregate tests: buy/sell reorg return `net` and the accumulators to the
  exact pre-fill state; one fill reorged out of two leaves the survivor intact;
  the marker serializes at `$.Live.last_reorged_at`.
- `cargo nextest run -p st0x-hedge --lib`, workspace clippy.

## Anything else

Foundation for the exactly-once reorg accounting (#870, ADR 0007), which adds
the per-trade dedupe and `price_usdc` this slice's reactor handling builds on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persisted reorg audit support for positions, including a new “last reorged” timestamp surfaced in position views.
  * Improved query performance for these reorg timestamps with a view index on non-null values.
  * Rebalancing now triggers an immediate per-symbol equity imbalance check when a reorg occurs.
* **Behavior Changes**
  * Reorg events no longer follow the standard position-update broadcast flow.
* **Tests**
  * Expanded coverage for reorg lifecycle, validation, reversal semantics, serialization into views, and reorg event timestamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->