### PR TITLE
feat: emit RecordReorg on removed-past-confirmation log

### DIFF
--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -23,18 +23,40 @@ use std::time::Duration;
 use tracing::{debug, error, info, trace, warn};
 
 use st0x_config::EvmCtx;
+use st0x_event_sorcery::{AggregateError, LifecycleError, Store};
 use st0x_evm::Evm;
-use st0x_execution::Executor;
+use st0x_execution::{Executor, FractionalShares};
+use st0x_registry::get_symbol_lock;
 
 use super::OnChainError;
 use crate::bindings::IRaindexInventory::{OperatorDeposit, OperatorWithdraw};
 use crate::bindings::IRaindexV6::{ClearV3, TakeOrderV3};
 use crate::conductor::job::{Job, Label};
 use crate::onchain::trade::{BotOperator, InventoryTrade, RaindexTradeEvent};
+use crate::onchain_trade::{OnChainTrade, OnChainTradeCommand, OnChainTradeError, OnChainTradeId};
+use crate::position::{Position, PositionCommand, TradeId};
 use crate::trading::onchain::inclusion::EmittedOnChain;
 use crate::trading::onchain::trade_accountant::{
     AccountForDexTrade, AccountantCtx, DexTradeAccountingJobQueue, TradeAccountingError,
 };
+
+/// A confirmed fill whose block a reorg dropped past the confirmation depth,
+/// identified for reversal. The `(tx_hash, log_index)` identity is the
+/// [`OnChainTradeId`] of the fill to reverse; `block_number` lets the caller
+/// derive how deep the reorg ran (current tip minus this block).
+#[derive(Debug, Clone)]
+pub(crate) struct RemovedTrade {
+    pub(crate) trade_id: OnChainTradeId,
+    pub(crate) block_number: u64,
+}
+
+/// What an `enqueue_batch_events` pass found: how many fresh fills it enqueued
+/// and which already-accounted fills its logs reported as reorged away.
+#[derive(Debug)]
+struct BatchOutcome {
+    enqueued: usize,
+    removed: Vec<RemovedTrade>,
+}
 
 pub(crate) fn get_backfill_retry_strat() -> ExponentialBuilder {
     const BACKFILL_MAX_RETRIES: usize = 15;
@@ -68,7 +90,7 @@ pub(crate) async fn backfill_events<P: Provider + Clone, B: BackoffBuilder + Clo
     end_block: u64,
     retry_strategy: B,
     job_queue: DexTradeAccountingJobQueue,
-) -> Result<(), OnChainError> {
+) -> Result<Vec<RemovedTrade>, OnChainError> {
     let start_block = backfill_start_block(pool, evm_ctx).await?;
 
     backfill_range(
@@ -109,7 +131,7 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
     to_block: u64,
     retry_strategy: B,
     job_queue: DexTradeAccountingJobQueue,
-) -> Result<(), OnChainError> {
+) -> Result<Vec<RemovedTrade>, OnChainError> {
     if from_block > to_block {
         info!(
             target: "orderbook",
@@ -118,7 +140,7 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
         );
 
         save_backfill_checkpoint(pool, evm_ctx, to_block).await?;
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let total_blocks = to_block - from_block + 1;
@@ -132,8 +154,9 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
     let batch_ranges = generate_batch_ranges(from_block, to_block);
 
     let mut total_enqueued: usize = 0;
+    let mut removed_trades = Vec::new();
     for (batch_start, batch_end) in batch_ranges {
-        let enqueued = enqueue_batch_events(
+        let outcome = enqueue_batch_events(
             provider,
             evm_ctx,
             bot_operator,
@@ -143,14 +166,20 @@ pub(crate) async fn backfill_range<P: Provider + Clone, B: BackoffBuilder + Clon
             job_queue.clone(),
         )
         .await?;
-        total_enqueued += enqueued;
+        total_enqueued += outcome.enqueued;
+        removed_trades.extend(outcome.removed);
     }
 
-    info!(target: "orderbook", total_enqueued, "Backfill completed");
+    info!(
+        target: "orderbook",
+        total_enqueued,
+        total_removed = removed_trades.len(),
+        "Backfill completed"
+    );
 
     save_backfill_checkpoint(pool, evm_ctx, to_block).await?;
 
-    Ok(())
+    Ok(removed_trades)
 }
 
 /// Persistent job queue for backfill jobs.
@@ -198,7 +227,7 @@ where
     }
 
     async fn perform(&self, ctx: &AccountantCtx<Node, Exec>) -> Result<Self::Output, Self::Error> {
-        backfill_range(
+        let removed = backfill_range(
             ctx.evm.provider(),
             &ctx.ctx.evm,
             BotOperator(ctx.ctx.order_owner()),
@@ -208,7 +237,40 @@ where
             get_backfill_retry_strat(),
             ctx.job_queue.clone(),
         )
-        .await
+        .await?;
+
+        if removed.is_empty() {
+            return Ok(());
+        }
+
+        // Depth is measured from the current tip: the dropped block is gone, so
+        // the reorg spans at least `tip - block_number` blocks. Fetched once and
+        // reused for every reversal in this batch.
+        let tip = ctx.evm.provider().get_block_number().await?;
+
+        for removed_trade in removed {
+            // A tip behind the removed block would saturate `reorg_depth` to 0 --
+            // a permanently underreported depth on an audit record. The load-
+            // balanced RPC routed us to a lagging node; fail so apalis retries
+            // against a caught-up one rather than recording a wrong depth.
+            if tip < removed_trade.block_number {
+                return Err(OnChainError::NodeLaggingBehindRequest {
+                    observed_tip: tip,
+                    required_tip: removed_trade.block_number,
+                });
+            }
+            let reorg_depth = tip - removed_trade.block_number;
+
+            record_reorg(
+                &ctx.cqrs.onchain_trade,
+                &ctx.cqrs.position,
+                &removed_trade,
+                reorg_depth,
+            )
+            .await?;
+        }
+
+        Ok(())
     }
 }
 
@@ -230,6 +292,82 @@ pub(crate) fn backfill_start_from_checkpoint(
     checkpoint.map_or(deployment_block, |last_processed_block| {
         (last_processed_block + 1).max(deployment_block)
     })
+}
+
+/// Reverses an already-accounted fill that a reorg dropped at or below the
+/// ingestion cutoff: appends `RecordReorg` to the `OnChainTrade` and `Position`
+/// aggregates through the CQRS framework (never direct SQL). A fill we never
+/// witnessed (e.g. a non-hedgeable pair) has nothing to reverse and is skipped.
+///
+/// The two sends are NOT atomic, so this path is only partially crash-safe. A
+/// crash after the `OnChainTrade` reversal but before the `Position` reversal
+/// leaves the position impact unreversed; on retry the `OnChainTrade`
+/// `AlreadyReorged` guard short-circuits before the `Position` repair can run,
+/// so that window stays open. Closing it is the job of the exactly-once reorg
+/// accounting built later in this stack, which records reversal progress per
+/// trade. A retry that did not crash mid-reversal is safe: if neither send
+/// landed it re-reverses cleanly, and if both landed `AlreadyReorged` makes the
+/// re-run a no-op.
+///
+/// The `Position` reversal runs under the same per-symbol lock that
+/// `AccountForDexTrade` holds while it mutates position state, so a concurrent
+/// live fill for the symbol cannot interleave with the reversal and corrupt the
+/// net.
+async fn record_reorg(
+    onchain_trade: &Store<OnChainTrade>,
+    position: &Store<Position>,
+    removed: &RemovedTrade,
+    reorg_depth: u64,
+) -> Result<(), OnChainError> {
+    let RemovedTrade { trade_id, .. } = removed;
+
+    let Some(trade) = onchain_trade.load(trade_id).await? else {
+        warn!(
+            target: "orderbook",
+            tx_hash = ?trade_id.tx_hash,
+            log_index = trade_id.log_index,
+            "Reorged log has no witnessed OnChainTrade; nothing to reverse"
+        );
+        return Ok(());
+    };
+
+    // Serialize against `AccountForDexTrade`, which holds this same per-symbol
+    // lock while it mutates position state; without it the `Position` reversal
+    // below could interleave with a concurrent live fill and corrupt the net.
+    let symbol_lock = get_symbol_lock(&trade.symbol).await;
+    let _guard = symbol_lock.lock().await;
+
+    match onchain_trade
+        .send(trade_id, OnChainTradeCommand::RecordReorg { reorg_depth })
+        .await
+    {
+        Ok(()) => {}
+        // Already reversed by an earlier delivery. Whether the `Position`
+        // reversal followed it is not knowable here (see the crash window in
+        // this fn's docs), so stop rather than reverse again; repairing a
+        // half-applied reversal is the exactly-once accounting's job.
+        Err(AggregateError::UserError(LifecycleError::Apply(
+            OnChainTradeError::AlreadyReorged,
+        ))) => return Ok(()),
+        Err(error) => return Err(error.into()),
+    }
+
+    position
+        .send(
+            &trade.symbol,
+            PositionCommand::RecordReorg {
+                trade_id: TradeId {
+                    tx_hash: trade_id.tx_hash,
+                    log_index: trade_id.log_index,
+                },
+                amount: FractionalShares::new(trade.amount),
+                direction: trade.direction,
+                reorg_depth,
+            },
+        )
+        .await?;
+
+    Ok(())
 }
 
 /// Loads the checkpoint and derives the backfill resume point in one call.
@@ -599,7 +737,7 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     batch_end: u64,
     retry_strategy: B,
     mut job_queue: DexTradeAccountingJobQueue,
-) -> Result<usize, OnChainError> {
+) -> Result<BatchOutcome, OnChainError> {
     let clear_filter = Filter::new()
         .address(evm_ctx.orderbook)
         .from_block(batch_start)
@@ -680,31 +818,64 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
     let (deposits_by_tx, withdraws_by_tx) = bucket_inventory_logs(inv_logs, bot_operator);
     let inventory_trade_events = pair_inventory_settlements(deposits_by_tx, withdraws_by_tx);
 
-    let trade_events = clear_logs
+    let mut removed_trades = Vec::new();
+    let mut present_logs = Vec::new();
+    for log in clear_logs
         .into_iter()
         .chain(take_logs)
-        .filter(|log| {
-            // Callers cap `to_block` at the ingestion cutoff block.
-            // Under `finalized`, this block cannot reorg, so `removed: true`
-            // implies a deep reorg crossing L1 finality. Under `safe`, a reorg
-            // is plausible (the batch may not yet be L1-finalized). In either
-            // case the fill is skipped to avoid persisting a vanished event. If a
-            // hedge was already placed against this fill, no reversal occurs; full
-            // reorg handling is tracked in the Reorg protection project.
-            if log.removed {
-                warn!(
-                    target: "orderbook",
-                    tx_hash = ?log.transaction_hash,
-                    log_index = ?log.log_index,
-                    block_number = ?log.block_number,
-                    "Backfill returned `removed: true` for a log at or below the \
-                     ingestion cutoff -- reorg detected; skipping. No reversal path \
-                     exists if a hedge was placed against this fill"
-                );
-                return false;
-            }
-            true
-        })
+        .sorted_by_key(|log| (log.block_number, log.log_index))
+    {
+        // The ingestion cutoff (currently the `safe` block) is not final: an L1
+        // reorg of the not-yet-finalized batch can still drop a fill. A
+        // `removed: true` log at or below the cutoff is such a reorg -- record it
+        // for reversal rather than silently dropping a vanished, already-accounted
+        // event.
+        //
+        // NOTE: this `removed: true` path is inert in production today. Both the
+        // monitor and backfill read fills via `eth_getLogs` range queries, which
+        // only ever return the current canonical chain and never flag a log
+        // `removed: true` -- only subscription / `eth_getFilterChanges`
+        // notifications do that, and neither path uses them. The authoritative
+        // reorg detector is a separate block-hash-mismatch re-scan -- comparing
+        // the persisted `block_hash` for a known `(tx_hash, log_index)` against a
+        // freshly observed one -- which is not yet built. This branch is kept as
+        // correct scaffolding for that detector; tests exercise it by
+        // synthesizing `removed: true` logs.
+        if !log.removed {
+            present_logs.push(log);
+            continue;
+        }
+
+        let (Some(tx_hash), Some(log_index), Some(block_number)) =
+            (log.transaction_hash, log.log_index, log.block_number)
+        else {
+            // Fail the batch rather than dropping the reorg: a `continue` here lets
+            // the checkpoint advance past an unreversible removed log, permanently
+            // losing the reversal. Erroring makes apalis retry once the provider
+            // returns complete identity fields.
+            return Err(OnChainError::RemovedLogMissingIdentity {
+                tx_hash: log.transaction_hash,
+                log_index: log.log_index,
+                block_number: log.block_number,
+            });
+        };
+
+        error!(
+            target: "orderbook",
+            ?tx_hash,
+            log_index,
+            block_number,
+            "Backfill returned `removed: true` for a log at or below the ingestion cutoff -- \
+             reorg detected; recording reversal"
+        );
+        removed_trades.push(RemovedTrade {
+            trade_id: OnChainTradeId { tx_hash, log_index },
+            block_number,
+        });
+    }
+
+    let trade_events = present_logs
+        .into_iter()
         .filter_map(|log| {
             if let Ok(clear_event) = log.log_decode::<ClearV3>() {
                 let event = RaindexTradeEvent::ClearV3(Box::new(clear_event.data().clone()));
@@ -742,7 +913,10 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
             .await?;
     }
 
-    Ok(enqueued_count)
+    Ok(BatchOutcome {
+        enqueued: enqueued_count,
+        removed: removed_trades,
+    })
 }
 
 /// Wraps `eth_getLogs` with a read-after-write check on the node's tip.
@@ -789,19 +963,38 @@ fn generate_batch_ranges(start_block: u64, end_block: u64) -> Vec<(u64, u64)> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
 
     use alloy::primitives::{
-        Address, B256, FixedBytes, IntoLogData, TxHash, U256, address, fixed_bytes, uint,
+        Address, B256, Bytes, FixedBytes, IntoLogData, LogData, TxHash, U256, address, fixed_bytes,
+        uint,
     };
     use alloy::providers::{ProviderBuilder, mock::Asserter};
     use alloy::rpc::types::Log;
+    use chrono::Utc;
     use rain_math_float::Float;
-    use st0x_config::{EvmCtx, IngestionCutoff, InventoryMode};
+    use st0x_config::{
+        EvmCtx, ExecutionThreshold, IngestionCutoff, InventoryMode,
+        create_test_ctx_with_order_owner,
+    };
     use url::Url;
+
+    use st0x_event_sorcery::StoreBuilder;
+    use st0x_evm::ReadOnlyEvm;
+    use st0x_execution::{Direction, MockExecutorCtx, Symbol, TryIntoExecutor};
+    use st0x_float_macro::float;
+    use st0x_raindex::RaindexContracts;
+    use st0x_registry::SymbolCache;
 
     use super::*;
     use crate::bindings::IRaindexV6;
+    use crate::conductor::TradeProcessingCqrs;
+    use crate::offchain::order::{OffchainOrder, PollOrderStatusJobQueue, noop_order_placer};
+    use crate::onchain::pyth::PythFeedIds;
     use crate::test_utils::{get_test_order, setup_test_db, setup_test_pools};
+    use crate::trading::offchain::hedge::HedgeJobQueue;
+    use crate::vault_registry::VaultRegistry;
 
     /// A bot-operator address distinct from every event operator seeded in
     /// these tests, so the T13 "skip the bot's own rebalancing events" filter
@@ -1866,7 +2059,8 @@ mod tests {
             job_queue,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .enqueued;
 
         assert_eq!(enqueued_count, 1);
         assert_eq!(job_count(&apalis_pool).await, 1);
@@ -2109,7 +2303,7 @@ mod tests {
         )
         .await;
 
-        let enqueued_count = result.unwrap();
+        let enqueued_count = result.unwrap().enqueued;
         assert_eq!(enqueued_count, 0);
     }
 
@@ -2277,7 +2471,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_backfill_skips_removed_logs() {
+    async fn test_backfill_does_not_enqueue_removed_log_as_fill() {
         // Backfill caller caps `to_block` at the ingestion cutoff
         // block. A `removed: true` log implies a reorg; skip it
         // (logged as warn) rather than ingesting a vanished event.
@@ -2331,7 +2525,7 @@ mod tests {
         assert_eq!(
             job_count(&apalis_pool).await,
             0,
-            "logs with removed=true must be skipped, not ingested"
+            "a removed log must not be enqueued as a fresh fill; it is surfaced for reversal"
         );
     }
 
@@ -2523,7 +2717,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(result.unwrap(), 0);
+        assert_eq!(result.unwrap().enqueued, 0);
     }
 
     #[tokio::test]
@@ -2588,7 +2782,7 @@ mod tests {
         )
         .await;
 
-        let enqueued = result.unwrap();
+        let enqueued = result.unwrap().enqueued;
         assert_eq!(enqueued, 2);
     }
 
@@ -2696,7 +2890,7 @@ mod tests {
         .await;
         let elapsed = start_time.elapsed();
 
-        let enqueued = result.unwrap();
+        let enqueued = result.unwrap().enqueued;
         assert_eq!(enqueued, 0);
 
         // Should have taken at least the test initial delay time due to retries
@@ -2822,7 +3016,7 @@ mod tests {
         )
         .await;
 
-        let enqueued = result.unwrap();
+        let enqueued = result.unwrap().enqueued;
         assert_eq!(enqueued, 2);
         assert_eq!(job_count(&apalis_pool).await, 2);
 
@@ -2998,7 +3192,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3050,7 +3244,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3109,7 +3303,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3174,7 +3368,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3249,7 +3443,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3342,7 +3536,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3431,7 +3625,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3515,7 +3709,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3586,7 +3780,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3676,7 +3870,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3785,7 +3979,7 @@ mod tests {
         push_tip_response(&asserter);
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
-        let enqueued = enqueue_batch_events(
+        let BatchOutcome { enqueued, .. } = enqueue_batch_events(
             &provider,
             &evm_ctx,
             BotOperator(TEST_BOT_OPERATOR),
@@ -3820,5 +4014,424 @@ mod tests {
             }
             other => panic!("expected InventoryTrade event, got {other:?}"),
         }
+    }
+
+    /// A `removed: true` log past the confirmation depth is surfaced as a
+    /// `RemovedTrade` for reversal instead of being silently dropped.
+    #[tokio::test]
+    async fn backfill_surfaces_removed_log_as_reorg() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+
+        let tx_hash = TxHash::repeat_byte(0xcd);
+        let removed_log = Log {
+            inner: alloy::primitives::Log {
+                address: address!("0x1111111111111111111111111111111111111111"),
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            },
+            block_hash: Some(B256::repeat_byte(0x11)),
+            block_number: Some(50),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(3),
+            removed: true,
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([removed_log])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let evm_ctx = EvmCtx {
+            rpc_url: Url::parse("http://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            inventory: InventoryMode::Managed {
+                inventory: address!("0x1111111111111111111111111111111111111111"),
+            },
+            vault_owner: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        };
+
+        let removed = backfill_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            &pool,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            removed.len(),
+            1,
+            "the removed log must be surfaced for reversal"
+        );
+        assert_eq!(removed[0].trade_id.tx_hash, tx_hash);
+        assert_eq!(removed[0].trade_id.log_index, 3);
+        assert_eq!(removed[0].block_number, 50);
+        // The vanished fill must NOT be enqueued as a fresh trade.
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// A `removed: true` log missing its `(tx_hash, log_index)` identity must
+    /// fail the batch with `RemovedLogMissingIdentity` rather than silently
+    /// advancing the checkpoint past a reorg it can never reverse.
+    #[tokio::test]
+    async fn enqueue_batch_events_fails_on_removed_log_without_identity() {
+        let (_pool, apalis_pool) = setup_test_pools().await;
+        let job_queue = setup_job_queue(&apalis_pool);
+        let evm_ctx = EvmCtx {
+            rpc_url: Url::parse("http://localhost:8545").unwrap(),
+            orderbook: address!("0x1111111111111111111111111111111111111111"),
+            inventory: InventoryMode::Managed {
+                inventory: address!("0x1111111111111111111111111111111111111111"),
+            },
+            vault_owner: address!("0x1111111111111111111111111111111111111111"),
+            deployment_block: 1,
+            required_confirmations: 0,
+            ingestion_cutoff: IngestionCutoff::Safe,
+        };
+
+        // A reorged-out log whose `transaction_hash` the provider dropped: the
+        // batch must error, not skip, so apalis retries once identity is intact.
+        let removed_log = Log {
+            inner: alloy::primitives::Log {
+                address: evm_ctx.orderbook,
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            },
+            block_hash: Some(B256::repeat_byte(0x11)),
+            block_number: Some(50),
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: Some(0),
+            log_index: Some(3),
+            removed: true,
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([removed_log])); // clear events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // take events
+        push_tip_response(&asserter);
+        asserter.push_success(&serde_json::json!([])); // inventory events
+        push_tip_response(&asserter);
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let error = enqueue_batch_events(
+            &provider,
+            &evm_ctx,
+            BotOperator(TEST_BOT_OPERATOR),
+            1,
+            100,
+            test_retry_strategy(),
+            job_queue,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                OnChainError::RemovedLogMissingIdentity {
+                    tx_hash: None,
+                    log_index: Some(3),
+                    block_number: Some(50),
+                }
+            ),
+            "a removed log missing its tx_hash must fail with RemovedLogMissingIdentity; got {error:?}"
+        );
+        assert_eq!(job_count(&apalis_pool).await, 0);
+    }
+
+    /// `BackfillRange::perform` measures reorg depth from the current tip. A tip
+    /// behind the removed fill's block would underreport the depth, so the job
+    /// must fail with `NodeLaggingBehindRequest` (apalis then retries against a
+    /// caught-up node) rather than record a wrong depth.
+    #[tokio::test]
+    async fn perform_fails_when_tip_lags_behind_removed_block() {
+        let (pool, apalis_pool) = setup_test_pools().await;
+        let ctx = create_test_ctx_with_order_owner(Address::ZERO);
+
+        // The batch surfaces one removed fill at block 50, then perform reads a
+        // tip of 1 -- behind the removed block, so the depth cannot be computed.
+        let removed_log = Log {
+            inner: alloy::primitives::Log {
+                address: ctx.evm.orderbook,
+                data: LogData::new_unchecked(vec![], Bytes::new()),
+            },
+            block_hash: Some(B256::repeat_byte(0x11)),
+            block_number: Some(50),
+            block_timestamp: None,
+            transaction_hash: Some(TxHash::repeat_byte(0xcd)),
+            transaction_index: Some(0),
+            log_index: Some(3),
+            removed: true,
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!([removed_log])); // clear getLogs
+        push_tip_response(&asserter); // clear tip
+        asserter.push_success(&serde_json::json!([])); // take getLogs
+        push_tip_response(&asserter); // take tip
+        asserter.push_success(&serde_json::json!([])); // inventory getLogs
+        push_tip_response(&asserter); // inventory tip
+        asserter.push_success(&serde_json::json!("0x1")); // perform's tip = 1
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let executor = MockExecutorCtx.try_into_executor().await.unwrap();
+
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, position_projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (offchain_order, _offchain_order_projection) =
+            StoreBuilder::<OffchainOrder>::new(pool.clone())
+                .build(noop_order_placer())
+                .await
+                .unwrap();
+        let (vault_registry, _vault_registry_projection) =
+            StoreBuilder::<VaultRegistry>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        let cqrs = TradeProcessingCqrs {
+            pool: pool.clone(),
+            onchain_trade,
+            position,
+            position_projection,
+            offchain_order,
+            order_placer: noop_order_placer(),
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: ctx.assets.clone(),
+            counter_trade_submission_lock: Arc::new(Mutex::new(())),
+            poll_status_queue: PollOrderStatusJobQueue::new(&apalis_pool),
+            hedge_queue: HedgeJobQueue::new(&apalis_pool),
+        };
+
+        let accountant_ctx = AccountantCtx {
+            contracts: RaindexContracts {
+                orderbook: ctx.evm.orderbook,
+                inventory: ctx.evm.inventory_address(),
+            },
+            ctx,
+            cache: SymbolCache::default(),
+            pyth_feed_ids: PythFeedIds::default(),
+            evm: ReadOnlyEvm::new(provider),
+            cqrs,
+            vault_registry,
+            executor,
+            pool: pool.clone(),
+            job_queue: DexTradeAccountingJobQueue::new(&apalis_pool),
+        };
+
+        let job = BackfillRange {
+            from_block: 1,
+            to_block: 100,
+        };
+        let error = job.perform(&accountant_ctx).await.unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                OnChainError::NodeLaggingBehindRequest {
+                    observed_tip: 1,
+                    required_tip: 50,
+                }
+            ),
+            "a tip behind the removed block must fail with NodeLaggingBehindRequest; got {error:?}"
+        );
+        // The reorg must not be recorded against the lagging tip.
+        assert_eq!(count_events(&pool, "OnChainTradeEvent::Reorged").await, 0);
+        assert_eq!(count_events(&pool, "PositionEvent::Reorged").await, 0);
+    }
+
+    /// `record_reorg` appends `Reorged` to both aggregates through the CQRS
+    /// framework (never direct SQL) and reverses the position to flat.
+    #[tokio::test]
+    async fn record_reorg_emits_reorged_events_through_cqrs() {
+        let pool = setup_test_db().await;
+
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let now = Utc::now();
+
+        seed_witnessed_fill(&onchain_trade, &position, &symbol, tx_hash, log_index, now).await;
+
+        let removed = RemovedTrade {
+            trade_id: OnChainTradeId { tx_hash, log_index },
+            block_number: 100,
+        };
+        let before_reorg = Utc::now();
+        record_reorg(&onchain_trade, &position, &removed, 12)
+            .await
+            .unwrap();
+        let after_reorg = Utc::now();
+
+        assert_eq!(count_events(&pool, "OnChainTradeEvent::Reorged").await, 1);
+        assert_eq!(count_events(&pool, "PositionEvent::Reorged").await, 1);
+
+        let position_state = position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position_state.net,
+            FractionalShares::ZERO,
+            "the reversal must return the position to flat",
+        );
+        let last_reorged_at = position_state
+            .last_reorged_at
+            .expect("the reversal must mark the position reorged");
+        assert!(
+            (before_reorg..=after_reorg).contains(&last_reorged_at),
+            "last_reorged_at {last_reorged_at} must fall within the reversal window \
+             [{before_reorg}, {after_reorg}]"
+        );
+    }
+
+    /// A re-delivered backfill range must not double-reverse: the OnChainTrade
+    /// `AlreadyReorged` guard short-circuits the second emission.
+    #[tokio::test]
+    async fn record_reorg_is_idempotent_across_redelivery() {
+        let pool = setup_test_db().await;
+
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let symbol = Symbol::new("AAPL").unwrap();
+        let tx_hash = TxHash::repeat_byte(0xab);
+        let log_index = 7;
+        let now = Utc::now();
+
+        seed_witnessed_fill(&onchain_trade, &position, &symbol, tx_hash, log_index, now).await;
+
+        let removed = RemovedTrade {
+            trade_id: OnChainTradeId { tx_hash, log_index },
+            block_number: 100,
+        };
+        record_reorg(&onchain_trade, &position, &removed, 12)
+            .await
+            .unwrap();
+        record_reorg(&onchain_trade, &position, &removed, 12)
+            .await
+            .unwrap();
+
+        assert_eq!(count_events(&pool, "OnChainTradeEvent::Reorged").await, 1);
+        assert_eq!(count_events(&pool, "PositionEvent::Reorged").await, 1);
+
+        let position_state = position.load(&symbol).await.unwrap().unwrap();
+        assert_eq!(
+            position_state.net,
+            FractionalShares::ZERO,
+            "a re-delivery must not reverse the fill twice",
+        );
+    }
+
+    /// A reorged log for a fill we never witnessed (e.g. a non-hedgeable pair)
+    /// has no aggregate to reverse and is skipped without error.
+    #[tokio::test]
+    async fn record_reorg_skips_unwitnessed_fill() {
+        let pool = setup_test_db().await;
+
+        let onchain_trade = StoreBuilder::<OnChainTrade>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+        let (position, _projection) = StoreBuilder::<Position>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let removed = RemovedTrade {
+            trade_id: OnChainTradeId {
+                tx_hash: TxHash::repeat_byte(0xee),
+                log_index: 1,
+            },
+            block_number: 100,
+        };
+        record_reorg(&onchain_trade, &position, &removed, 5)
+            .await
+            .unwrap();
+
+        assert_eq!(count_events(&pool, "OnChainTradeEvent::Reorged").await, 0);
+        assert_eq!(count_events(&pool, "PositionEvent::Reorged").await, 0);
+    }
+
+    async fn seed_witnessed_fill(
+        onchain_trade: &Store<OnChainTrade>,
+        position: &Store<Position>,
+        symbol: &Symbol,
+        tx_hash: TxHash,
+        log_index: u64,
+        now: chrono::DateTime<Utc>,
+    ) {
+        onchain_trade
+            .send(
+                &OnChainTradeId { tx_hash, log_index },
+                OnChainTradeCommand::Witness {
+                    symbol: symbol.clone(),
+                    amount: float!(5),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_number: 100,
+                    block_hash: None,
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+
+        position
+            .send(
+                symbol,
+                PositionCommand::AcknowledgeOnChainFill {
+                    symbol: symbol.clone(),
+                    threshold: ExecutionThreshold::whole_share(),
+                    trade_id: TradeId { tx_hash, log_index },
+                    amount: FractionalShares::new(float!(5)),
+                    direction: Direction::Buy,
+                    price_usdc: float!(150),
+                    block_timestamp: now,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn count_events(pool: &SqlitePool, event_type: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM events WHERE event_type = ?")
+            .bind(event_type)
+            .fetch_one(pool)
+            .await
+            .unwrap()
     }
 }

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -1,18 +1,20 @@
 //! Onchain event processing: trade parsing, event backfilling,
 //! position accumulation, and vault management.
 
+use alloy::primitives::TxHash;
 use alloy::primitives::ruint::FromUintError;
 use alloy::transports::{RpcError, TransportErrorKind};
 use rain_math_float::FloatError;
 use std::num::TryFromIntError;
 
-use st0x_event_sorcery::ProjectionError;
+use st0x_event_sorcery::{ProjectionError, SendError};
 use st0x_execution::order::status::ParseOrderStatusError;
 use st0x_execution::{
     EmptySymbolError, ExecutionError, FractionalShares, InvalidDirectionError,
     InvalidExecutorError, InvalidSharesError, NotPositive, PersistenceError, SharesConversionError,
 };
 
+use crate::onchain_trade::OnChainTrade;
 use crate::position::{Position, PositionError};
 
 pub(crate) mod accumulator;
@@ -75,6 +77,10 @@ pub(crate) enum OnChainError {
     InvalidDirection(#[from] InvalidDirectionError),
     #[error("Position error: {0}")]
     Position(#[from] PositionError),
+    #[error("OnChainTrade reorg command failed: {0}")]
+    OnChainTradeReorg(#[source] Box<SendError<OnChainTrade>>),
+    #[error("Position reorg command failed: {0}")]
+    PositionReorg(#[source] Box<SendError<Position>>),
     #[error("Shares conversion error: {0}")]
     SharesConversion(#[from] SharesConversionError),
     #[error(transparent)]
@@ -102,4 +108,29 @@ pub(crate) enum OnChainError {
         observed_tip: u64,
         required_tip: u64,
     },
+    #[error(
+        "Removed log at or below the ingestion cutoff is missing identifying \
+         fields (tx_hash={tx_hash:?}, log_index={log_index:?}, \
+         block_number={block_number:?}); cannot record the reorg reversal"
+    )]
+    RemovedLogMissingIdentity {
+        tx_hash: Option<TxHash>,
+        log_index: Option<u64>,
+        block_number: Option<u64>,
+    },
+}
+
+// `SendError` carries the (large) aggregate state, so box it on the way into
+// `OnChainError` to keep the enum small (avoids `clippy::result_large_err`)
+// while still letting call sites use `?`.
+impl From<SendError<OnChainTrade>> for OnChainError {
+    fn from(error: SendError<OnChainTrade>) -> Self {
+        Self::OnChainTradeReorg(Box::new(error))
+    }
+}
+
+impl From<SendError<Position>> for OnChainError {
+    fn from(error: SendError<Position>) -> Self {
+        Self::PositionReorg(Box::new(error))
+    }
 }


### PR DESCRIPTION
## What

Closes RAI-805. Wires reorg detection into the backfill ingestion path: a
`removed: true` log past the confirmation boundary now emits `RecordReorg` to
the `OnChainTrade` and `Position` aggregates instead of being logged and
dropped. Stacked on RAI-804 (#868).

## Why

`enqueue_batch_events` skipped removed-past-confirmation logs with an error log,
so a confirmed-then-reorged fill's position impact was never reversed. The
reversal events from RAI-803/804 had no producer.

## How

- `enqueue_batch_events` now surfaces removed logs as `RemovedTrade` data rather
  than dropping them; `backfill_range` returns them up to `BackfillRange::perform`.
- `perform` (which holds the CQRS stores) reverses each via `record_reorg`:
  load the `OnChainTrade`, emit `OnChainTrade::RecordReorg` then
  `Position::RecordReorg`, deriving `reorg_depth` from the current tip.
- New `OnChainError` variants for the reorg command sends (boxed via `From` to
  keep the enum small).

## Testing

- Integration tests: a removed log surfaces as a `RemovedTrade` and is not
  re-enqueued as a fresh trade; `record_reorg` emits both `Reorged` events
  through the framework (never direct SQL) and returns the position to flat; a
  fill never witnessed is skipped.
- `cargo nextest run -p st0x-hedge --lib`, workspace clippy.

## Anything else

This slice's two-append reversal has a crash-window gap that #870 (ADR 0007)
hardens into exactly-once accounting -- review found landing this without #870
is unsafe, so they should merge together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Historical backfills now surface removed on-chain events as reorg signals, so reversals are reconciled instead of being ignored.
  * Reorg handling has been extended to record corrective actions for removed trades during backfill processing.

* **Bug Fixes**
  * Batch processing now correctly accounts for removed log entries, preventing silent skipping/rejection and improving reliability around removed events.
  * Reorg processing is now idempotent, avoiding duplicate corrective records on redelivery.
  * Removed events that were never fully witnessed are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->