### PR TITLE
feat: monitor finalized blocks for fill ingestion

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -112,10 +112,18 @@ excellent async ecosystem for handling concurrent trading flows.
 
 - Continuous HTTP `eth_getLogs` polling over a single transport -- no WebSocket.
   Every `order_fill_poll_interval` seconds the monitor enqueues a backfill range
-  covering the blocks since the persisted checkpoint, capped at
-  `tip - required_confirmations`; the backfill worker fetches the `Clear` and
-  `TakeOrder` logs for the arbitrageur's owner address and advances the
-  checkpoint only on success.
+  covering the blocks since the persisted checkpoint, capped at the chain's
+  latest **finalized** block (`eth_getBlockByNumber("finalized")`; no finalized
+  block yet means nothing is enqueued); the backfill worker fetches the `Clear`
+  and `TakeOrder` logs for the arbitrageur's owner address and advances the
+  checkpoint only on success. A finalized block cannot reorg, so an ingested
+  fill can never be invalidated -- genuine single-chain reorg protection rather
+  than the earlier `tip - required_confirmations` confirmation-depth heuristic
+  (`required_confirmations` now governs only transaction-submission paths). The
+  tradeoff is hedge latency: on an L2 like Base the `finalized` tag tracks L1
+  finalization and lags the tip by minutes, so a fill is hedged only once its
+  block finalizes. First-class cross-chain reorg handling is tracked separately
+  in the Reorg protection project.
 - WebSocket `.watch()` filter polling and `eth_subscribe`/`subscribe_logs` are
   deliberately rejected: on a load-balanced RPC, filters live on a single
   backend node so most polls are round-robined to nodes returning `-32601`, and

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -426,7 +426,7 @@ pub struct Ctx {
     pub inventory_poll_interval: u64,
     /// Interval (seconds) between continuous `eth_getLogs` polls for orderbook
     /// fills. Each tick enqueues a backfill range over the unprocessed blocks
-    /// (capped at `tip - required_confirmations`).
+    /// (capped at the chain's latest finalized block).
     pub order_fill_poll_interval: u64,
     pub apalis_finished_job_cleanup_interval_secs: u64,
     pub broker: BrokerCtx,

--- a/docs/conductor.md
+++ b/docs/conductor.md
@@ -50,11 +50,15 @@ SupervisorBuilder::default()
 
 Defined in `src/conductor/monitor/order_fills.rs`. Drives continuous HTTP
 `eth_getLogs` ingestion of `ClearV3`/`TakeOrderV3` fills. It is a supervised
-interval task: every `order_fill_poll_interval` seconds it reads the chain tip,
-derives a cutoff at `tip - required_confirmations`, and enqueues a
-`BackfillRange` job for `(checkpoint+1, cutoff)`. The `backfill-worker` fetches
-the logs and pushes an `AccountForDexTrade` job per fill, advancing the
-persisted checkpoint only on success.
+interval task: every `order_fill_poll_interval` seconds it reads the chain's
+latest finalized block via `eth_getBlockByNumber("finalized")`, uses it as the
+cutoff, and enqueues a `BackfillRange` job for `(checkpoint+1, cutoff)` (no
+finalized block yet -> nothing enqueued). The `backfill-worker` fetches the logs
+and pushes an `AccountForDexTrade` job per fill, advancing the persisted
+checkpoint only on success. Capping at the finalized block is genuine
+single-chain reorg protection (a finalized block cannot reorg); it is unrelated
+to `required_confirmations`, which now governs only transaction-submission
+paths.
 
 ```rust
 struct OrderFillMonitor<P> {
@@ -274,13 +278,13 @@ restart, while the old vault remains registered so inventory polling can surface
 any stranded balance.
 
 Ingestion is checkpoint-driven `eth_getLogs` polling, not a live subscription,
-so no events are missed across downtime. Deriving the cutoff
-(`tip - required_confirmations`) is not a startup phase -- the
-`OrderFillMonitor` poll loop reads the chain tip every tick and enqueues a
-`BackfillRange` job for the gap since the persisted checkpoint. The backfill and
-trade-accounting workers start together in Phase 4; catch-up backfill runs
-continuously after spawn while the monitor always resumes from the persisted
-checkpoint and re-scans any gap.
+so no events are missed across downtime. Reading the finalized-block cutoff
+(`eth_getBlockByNumber("finalized")`) is not a startup phase -- the
+`OrderFillMonitor` poll loop reads the latest finalized block every tick and
+enqueues a `BackfillRange` job for the gap since the persisted checkpoint. The
+backfill and trade-accounting workers start together in Phase 4; catch-up
+backfill runs continuously after spawn while the monitor always resumes from the
+persisted checkpoint and re-scans any gap.
 
 Backfill reads the last successful checkpoint from SQLite. The configured
 `deployment_block` seeds only the first run; subsequent runs start at

--- a/example.config.toml
+++ b/example.config.toml
@@ -4,8 +4,9 @@ log_level = "debug"
 database_url = ":memory:"
 apalis_finished_job_cleanup_interval_secs = 3600
 # Interval (seconds) between continuous eth_getLogs polls for orderbook fills.
-# Each tick enqueues a backfill range over the unprocessed blocks, capped at
-# `tip - required_confirmations`. Defaults to 5 when omitted.
+# Each tick enqueues a backfill range over the unprocessed blocks, capped at the
+# chain's latest finalized block (a finalized block cannot reorg). Defaults to 5
+# when omitted.
 order_fill_poll_interval = 5
 hyperdx.service_name = "st0x-hedge"
 
@@ -20,13 +21,12 @@ beneficiary_entity_name = "Acme Corp"
 [raindex]
 orderbook = "0x1111111111111111111111111111111111111111"
 deployment_block = 1
-# Number of block confirmations required before an event is considered
-# safe to ingest. Naive reorg protection (NOT real chain finality):
-# backfill caps `to_block` at `latest - required_confirmations`, and live
-# ingestion defers persistence until events are this many blocks deep.
-# A deep reorg exceeding this depth will still corrupt state; the
-# monitor surfaces that case loudly rather than masking it. Set
-# explicitly per chain based on observed reorg behavior.
+# Block-confirmation depth required before a transaction this bot submits is
+# treated as settled (the primary gate for USDC rebalancing withdrawals). This
+# does NOT govern order-fill ingestion: the fill monitor now caps the backfill
+# range at the chain's latest finalized block (real reorg protection), so tuning
+# this value has no effect on ingestion latency. Set explicitly per chain based
+# on observed confirmation behavior.
 required_confirmations = 3
 
 # Wallet provider — select via `kind`:

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -41,6 +41,7 @@ use st0x_wrapper::WrapperService;
 
 use crate::alpaca_wallet::AlpacaWalletService;
 use crate::conductor::exit::{ConductorExit, MonitorTaskError};
+use crate::conductor::monitor::order_fills::{FinalityProbe, probe_finalized_block_support};
 use crate::dashboard::Broadcaster;
 use crate::equity_redemption::{
     EquityRedemption, interrupted_redemption_ids, symbols_with_stuck_redemptions,
@@ -355,6 +356,30 @@ where
     Ok(())
 }
 
+/// Fails startup fast on an RPC endpoint that cannot serve what order-fill
+/// ingestion depends on: basic reachability and a usable `finalized` block tag.
+/// An endpoint that errors on `finalized`, or aliases it to the chain tip
+/// (disabling reorg protection), is rejected here rather than running silently
+/// degraded; a fresh chain with no finalized block yet is allowed through.
+async fn validate_rpc_endpoint<P: Provider>(provider: &P) -> anyhow::Result<()> {
+    let chain_tip = provider
+        .get_block_number()
+        .await
+        .context("failed to reach RPC endpoint at startup")?;
+
+    match probe_finalized_block_support(provider, chain_tip)
+        .await
+        .context("RPC endpoint cannot serve the `finalized` block tag at startup")?
+    {
+        FinalityProbe::AliasesChainTip => anyhow::bail!(
+            "RPC endpoint reports a finalized block at or beyond the chain tip \
+             ({chain_tip}); it appears to alias the `finalized` tag to `latest`, \
+             which would silently disable reorg protection. Refusing to start"
+        ),
+        FinalityProbe::Supported | FinalityProbe::NotYetAvailable => Ok(()),
+    }
+}
+
 impl Conductor {
     pub(crate) async fn run<E>(
         executor_ctx: impl TryIntoExecutor<Executor = E>,
@@ -383,14 +408,11 @@ impl Conductor {
         // contract calls. No WebSocket -- see `monitor::order_fills`.
         let provider = ProviderBuilder::new().connect_http(ctx.evm.rpc_url.clone());
 
-        // The HTTP transport connects lazily, so probe it once at startup to
-        // fail fast on a misconfigured or unreachable RPC rather than only
-        // surfacing it as repeated poll-loop retries. systemd's bounded
-        // restart loop handles a genuinely-down endpoint from here.
-        provider
-            .get_block_number()
-            .await
-            .context("failed to reach RPC endpoint at startup")?;
+        // The HTTP transport connects lazily, so validate it once at startup to
+        // fail fast on a misconfigured or unreachable RPC rather than surfacing
+        // it as repeated poll-loop retries. systemd's bounded restart loop
+        // handles a genuinely-down endpoint from here.
+        validate_rpc_endpoint(&provider).await?;
         let cache = SymbolCache::default();
 
         setup_apalis_tables(&apalis_pool).await?;

--- a/src/conductor/monitor/order_fills.rs
+++ b/src/conductor/monitor/order_fills.rs
@@ -6,10 +6,10 @@
 //!    checkpoint has not advanced yet, so re-enqueuing would re-scan the
 //!    same blocks (and during a long catch-up would stack unbounded
 //!    overlapping ranges).
-//! 2. Reads the chain tip and derives a cutoff at `tip -
-//!    required_confirmations`. The cutoff never exceeds the confirmation
-//!    boundary, so ingestion never persists logs from blocks that could
-//!    still reorg (under the assumed reorg depth).
+//! 2. Reads the chain's latest finalized block and uses it as the cutoff, so
+//!    ingestion never persists logs from blocks that could still reorg. A
+//!    finalized block cannot reorg, so this is real single-chain reorg
+//!    protection rather than a confirmation-depth heuristic.
 //! 3. Enqueues a `BackfillRange` job covering `(checkpoint+1, cutoff)`.
 //!    The `backfill-worker` fetches the logs via HTTP `eth_getLogs`,
 //!    pushes an accounting job per fill, and advances the checkpoint only
@@ -28,14 +28,18 @@
 //! visible retries (the apalis job) is the deliberate choice here,
 //! aligning liquidity with the issuance bot's ingestion architecture.
 //!
-//! Note: `required_confirmations` is a naive reorg-protection heuristic,
-//! not real chain finality. A deep reorg exceeding the configured depth
-//! will still corrupt state; `backfill_range` surfaces a `removed: true`
-//! log past the confirmation boundary loudly rather than masking it.
+//! Capping at the finalized block is the simplified single-chain reorg
+//! protection: a finalized Base block will not reorg, so an
+//! ingested fill cannot be invalidated. Serious cross-chain reorg handling
+//! (first-class reversal events) is tracked separately in the Reorg
+//! protection project. `backfill_range` still surfaces a `removed: true` log
+//! loudly rather than masking it, as defense in depth.
 
 use std::time::Duration;
 
+use alloy::eips::BlockNumberOrTag;
 use alloy::providers::Provider;
+use alloy::transports::{RpcError, TransportErrorKind};
 use sqlx::SqlitePool;
 use task_supervisor::{SupervisedTask, TaskResult};
 use tokio::time::MissedTickBehavior;
@@ -45,7 +49,9 @@ use st0x_config::EvmCtx;
 
 use crate::conductor::job::QueuePushError;
 use crate::onchain::OnChainError;
-use crate::onchain::backfill::{BackfillJobQueue, BackfillRange, backfill_start_block};
+use crate::onchain::backfill::{
+    BackfillJobQueue, BackfillRange, backfill_start_from_checkpoint, load_backfill_checkpoint,
+};
 
 /// Polls the orderbook chain for `ClearV3` / `TakeOrderV3` fills on a
 /// fixed interval and enqueues durable [`BackfillRange`] jobs that the
@@ -87,7 +93,6 @@ impl<P: Provider + Clone + Send + Sync + 'static> SupervisedTask for OrderFillMo
         info!(
             target: "orderbook",
             interval_secs = self.poll_interval.as_secs(),
-            required_confirmations = self.evm_ctx.required_confirmations,
             "Order fill monitor started (continuous eth_getLogs polling)"
         );
 
@@ -110,8 +115,8 @@ impl<P: Provider + Clone + Send + Sync + 'static> SupervisedTask for OrderFillMo
 
 #[derive(Debug, thiserror::Error)]
 enum OrderFillMonitorError {
-    #[error("RPC error reading chain tip: {0}")]
-    Rpc(#[from] alloy::transports::RpcError<alloy::transports::TransportErrorKind>),
+    #[error("RPC error reading finalized block: {0}")]
+    Rpc(#[from] RpcError<TransportErrorKind>),
     #[error(transparent)]
     OnChain(#[from] OnChainError),
     #[error(transparent)]
@@ -120,11 +125,42 @@ enum OrderFillMonitorError {
     JobStatus(#[from] apalis_sqlite::SqlxError),
 }
 
+/// The branch a single [`OrderFillMonitor::poll_once`] tick took. The supervised
+/// run loop discards it (it reacts only to `Err`); it exists so tests can observe
+/// the cutoff decision -- in particular to tell an expected cold-start skip apart
+/// from a checkpoint-backed skip that signals an RPC finality anomaly. Those two
+/// share identical side effects (no enqueue, checkpoint frozen), so without a
+/// typed outcome an inverted checkpoint check could not be caught from the
+/// outside.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PollOutcome {
+    /// A previous backfill range is still in flight; the tick was skipped.
+    RangeInFlight,
+    /// No finalized block reported and no checkpoint exists yet -- expected
+    /// cold-start lag on a chain shallower than finality.
+    NoFinalityColdStart,
+    /// No finalized block reported while a checkpoint exists -- a finality
+    /// regression (likely a stale or load-balanced RPC); ingestion is paused.
+    NoFinalityWithCheckpoint,
+    /// A backfill range up to the finalized block was enqueued.
+    Enqueued { from_block: u64, to_block: u64 },
+    /// Ingestion has reached the finalized block; nothing to enqueue.
+    CaughtUp,
+    /// The finalized block is behind committed ingestion progress (a checkpoint
+    /// exists) -- a finality regression that pauses ingestion until it advances.
+    FinalityBehindCheckpoint,
+    /// Finality has not yet reached the `deployment_block`: either cold start (no
+    /// checkpoint) or a checkpoint at/below finality with `deployment_block`
+    /// configured ahead of it. Nothing to ingest yet; no committed progress is at
+    /// risk.
+    FinalityBehindDeployment,
+}
+
 impl<P: Provider + Clone> OrderFillMonitor<P> {
     /// One poll iteration: enqueue a backfill range for the unprocessed
-    /// blocks behind the confirmation boundary, unless a previous range
+    /// blocks up to the latest finalized block, unless a previous range
     /// is still in flight or there is nothing new to fetch.
-    async fn poll_once(&mut self) -> Result<(), OrderFillMonitorError> {
+    async fn poll_once(&mut self) -> Result<PollOutcome, OrderFillMonitorError> {
         // Overlap guard: while a previous range is still being processed
         // the checkpoint has not advanced, so a fresh enqueue would
         // re-scan the same blocks. During a long catch-up this would
@@ -134,25 +170,53 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
                 target: "orderbook",
                 "Skipping poll: a backfill range is still in flight"
             );
-            return Ok(());
+            return Ok(PollOutcome::RangeInFlight);
         }
 
-        // Cutoff is the latest block past the confirmation depth. Backfill
-        // is guaranteed not to ingest logs above this boundary, preserving
-        // reorg protection.
-        let cutoff_block =
-            latest_confirmed_block(&self.provider, self.evm_ctx.required_confirmations)
-                .await?
-                .unwrap_or(0);
-        let from_block = backfill_start_block(&self.pool, &self.evm_ctx).await?;
+        // Load the checkpoint once per tick: `from_block` is derived from it, and
+        // both the null-finality guard and the finality-regression branch use
+        // whether it exists to tell an expected cold-start skip from a
+        // checkpoint-backed skip that signals an RPC finality anomaly. One read
+        // keeps those decisions consistent (no intra-tick TOCTOU) and avoids a
+        // redundant round-trip.
+        let checkpoint = load_backfill_checkpoint(&self.pool, &self.evm_ctx).await?;
+
+        // Cutoff is the chain's latest finalized block. Backfill is guaranteed
+        // not to ingest logs above this boundary, and a finalized block cannot
+        // reorg, so an ingested fill can never be invalidated. `None` means the
+        // node reports no finalized block yet (a chain shallower than finality);
+        // there is nothing safe to ingest, so skip the tick.
+        let Some(cutoff_block) = latest_finalized_block(&self.provider).await? else {
+            // No finalized block reported. Once a checkpoint exists the chain
+            // has demonstrably finalized blocks before, so a null response is an
+            // RPC problem (a load-balanced node returning no finality) worth a
+            // warning -- ingestion stalls until it clears. At cold start on a
+            // chain shallower than finality it is expected, so stay quiet.
+            if checkpoint.is_some() {
+                warn!(
+                    target: "orderbook",
+                    "No finalized block reported while a checkpoint exists; the RPC \
+                     node may be returning no finality. Ingestion paused this tick"
+                );
+                return Ok(PollOutcome::NoFinalityWithCheckpoint);
+            }
+
+            debug!(
+                target: "orderbook",
+                "No finalized block reported yet (chain shallower than \
+                 finality); nothing to ingest this tick"
+            );
+            return Ok(PollOutcome::NoFinalityColdStart);
+        };
+
+        let from_block = backfill_start_from_checkpoint(checkpoint, self.evm_ctx.deployment_block);
 
         if from_block <= cutoff_block {
             info!(
                 target: "orderbook",
                 from_block,
                 cutoff_block,
-                required_confirmations = self.evm_ctx.required_confirmations,
-                "Enqueuing order-fill backfill range"
+                "Enqueuing order-fill backfill range up to the finalized block"
             );
 
             self.backfill_queue
@@ -161,30 +225,152 @@ impl<P: Provider + Clone> OrderFillMonitor<P> {
                     to_block: cutoff_block,
                 })
                 .await?;
-        } else {
-            debug!(
-                target: "orderbook",
+
+            return Ok(PollOutcome::Enqueued {
                 from_block,
-                cutoff_block,
-                "Caught up; nothing to enqueue this tick"
-            );
+                to_block: cutoff_block,
+            });
         }
 
-        Ok(())
+        // Nothing to ingest this tick: the next block is past the finalized tip.
+        // Classify why from committed progress (the checkpoint), not from
+        // `from_block` -- the `deployment_block` floor can push `from_block` past
+        // the cutoff even when the checkpoint is well behind it, so branching on
+        // `from_block` would misreport that config case as a finality regression.
+        match checkpoint {
+            // Committed progress is past the finalized block: either finality
+            // regressed (a stale or load-balanced RPC) or, right after upgrading
+            // from the old confirmation-depth cutoff, finality has not yet caught
+            // up to a checkpoint that ran ahead of it. Ingestion pauses either way.
+            Some(checkpoint) if checkpoint > cutoff_block => {
+                warn!(
+                    target: "orderbook",
+                    checkpoint,
+                    cutoff_block,
+                    "Finalized block is behind committed ingestion progress; ingestion \
+                     paused until finality advances. Expected briefly after upgrading \
+                     from the confirmation-depth cutoff; if it persists the RPC node \
+                     may be returning stale finality data"
+                );
+                Ok(PollOutcome::FinalityBehindCheckpoint)
+            }
+            // The checkpoint has reached the finalized block; nothing new yet.
+            Some(_) if from_block == cutoff_block.saturating_add(1) => {
+                debug!(
+                    target: "orderbook",
+                    from_block,
+                    cutoff_block,
+                    "Caught up; nothing to enqueue this tick"
+                );
+                Ok(PollOutcome::CaughtUp)
+            }
+            // Either cold start (no checkpoint) or a checkpoint at/below finality
+            // with `deployment_block` configured ahead of it: both are simply
+            // waiting for finality to reach the deployment block, with no committed
+            // progress at risk. Expected, so stay quiet.
+            _ => {
+                debug!(
+                    target: "orderbook",
+                    from_block,
+                    cutoff_block,
+                    "Finality has not yet reached the deployment block; nothing to \
+                     ingest this tick"
+                );
+                Ok(PollOutcome::FinalityBehindDeployment)
+            }
+        }
     }
 }
 
-/// Latest block past the configured confirmation depth:
-/// `latest_tip - required_confirmations`. Returns `None` when the chain has
-/// fewer blocks than the requested confirmation depth (no block is
-/// safe to ingest yet). This is a naive reorg-protection heuristic,
-/// not real chain finality.
-pub(crate) async fn latest_confirmed_block<P: Provider>(
+/// The chain's latest finalized block number, or `None` when the node reports
+/// no finalized block yet (e.g. a chain shallower than finality). A finalized
+/// block cannot reorg, so capping ingestion at it is real reorg protection for
+/// single-chain operation -- unlike the previous `tip - required_confirmations`
+/// heuristic, which reused the transaction-submission confirmation depth and was
+/// not true finality.
+///
+/// The `None` arm relies on the Ethereum execution-api JSON-RPC convention that
+/// `eth_getBlockByNumber` returns a `null` result (not an error) for a block tag
+/// it cannot resolve yet -- which alloy maps to `Ok(None)`. A node that instead
+/// errors on the `finalized` tag (unsupported method, wrong network behind a
+/// broken proxy) surfaces as the `Err` arm, which
+/// [`probe_finalized_block_support`] rejects at startup and `poll_once` treats
+/// as a transient RPC failure (checkpoint frozen, retried next tick).
+pub(crate) async fn latest_finalized_block<P: Provider>(
     provider: &P,
-    required_confirmations: u64,
-) -> Result<Option<u64>, alloy::transports::RpcError<alloy::transports::TransportErrorKind>> {
-    let tip = provider.get_block_number().await?;
-    Ok(tip.checked_sub(required_confirmations))
+) -> Result<Option<u64>, RpcError<TransportErrorKind>> {
+    Ok(provider
+        .get_block_by_number(BlockNumberOrTag::Finalized)
+        .await?
+        .map(|block| block.header.number))
+}
+
+/// The outcome of [`probe_finalized_block_support`]. Logged inside the probe and
+/// returned so [`crate::conductor`]'s startup decision and tests can observe
+/// which finality state the endpoint is in. [`FinalityProbe::AliasesChainTip`]
+/// and an `Err` are both fatal at the conductor; [`FinalityProbe::NotYetAvailable`]
+/// is the only non-fatal soft signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FinalityProbe {
+    /// The endpoint reports a finalized block strictly behind the chain tip --
+    /// genuine finality, as expected.
+    Supported,
+    /// The endpoint reports no finalized block yet (a chain shallower than
+    /// finality); ingestion is deferred until finality becomes available.
+    NotYetAvailable,
+    /// The endpoint reports a finalized block at or ahead of the chain tip,
+    /// suggesting it aliases the `finalized` tag to `latest` -- which would
+    /// silently disable the reorg protection this monitor depends on.
+    AliasesChainTip,
+}
+
+/// Verifies at startup that the RPC endpoint can serve a usable `finalized` block
+/// tag, so a misconfigured endpoint surfaces at boot instead of letting the bot
+/// run while silently undermining reorg protection. Outcomes:
+///
+/// - An error (unsupported method, wrong-network proxy) is the `Err` arm, which
+///   the caller propagates to fail startup -- mirroring the basic reachability
+///   probe in [`crate::conductor`].
+/// - `None` is the only non-fatal soft signal: a chain shallower than finality (a
+///   fresh test chain) legitimately has no finalized block yet, and failing would
+///   be racy against finality catching up. Logged at `warn` so the deferral is
+///   visible.
+/// - `finalized >= chain_tip` means the endpoint reports a finalized block at or
+///   beyond the tip, which only an endpoint aliasing `finalized` to `latest`
+///   does -- it would restore near-tip ingestion with no reorg protection. The
+///   conductor treats this as fatal. The comparison assumes finality lag dwarfs
+///   any cross-backend skew on a load-balanced RPC, which holds on the deployment
+///   target (Base finalizes ~hundreds of blocks behind the tip, far more than a
+///   few-block skew); detection fundamentally needs a tip read taken no later
+///   than `finalized`, so the caller passes the tip it read just before this
+///   probe rather than this probe re-reading a fresher (and thus always-ahead)
+///   tip.
+pub(crate) async fn probe_finalized_block_support<P: Provider>(
+    provider: &P,
+    chain_tip: u64,
+) -> Result<FinalityProbe, RpcError<TransportErrorKind>> {
+    let Some(finalized) = latest_finalized_block(provider).await? else {
+        warn!(
+            target: "orderbook",
+            "RPC endpoint reports no finalized block at startup; order-fill \
+             ingestion will not begin until the endpoint exposes finality"
+        );
+        return Ok(FinalityProbe::NotYetAvailable);
+    };
+
+    if finalized >= chain_tip {
+        warn!(
+            target: "orderbook",
+            finalized,
+            chain_tip,
+            "RPC endpoint reports a finalized block at or ahead of the chain tip; \
+             it may be aliasing the `finalized` tag to `latest`, which would \
+             silently disable reorg protection"
+        );
+        return Ok(FinalityProbe::AliasesChainTip);
+    }
+
+    Ok(FinalityProbe::Supported)
 }
 
 #[cfg(test)]
@@ -192,16 +378,31 @@ mod tests {
     use alloy::primitives::address;
     use alloy::providers::ProviderBuilder;
     use alloy::providers::mock::Asserter;
+    use alloy::rpc::types::{Block, Transaction};
+    use serde_json::Value;
     use sqlx::{ConnectOptions, SqlitePool};
 
     use super::*;
     use crate::test_utils::setup_test_pools;
 
-    /// Builds a mock provider whose `eth_blockNumber` resolves the tip to
-    /// `block`, so `latest_confirmed_block` returns `block - confs`.
-    fn provider_at_tip(block: u64) -> impl Provider + Clone {
+    /// Builds a mock provider whose `eth_getBlockByNumber("finalized")`
+    /// resolves to a block at `number`, so `latest_finalized_block` returns it.
+    fn finalized_at(number: u64) -> Block {
+        let mut block = Block::<Transaction>::default();
+        block.header.inner.number = number;
+        block
+    }
+
+    fn provider_with_finalized(number: u64) -> impl Provider + Clone {
         let asserter = Asserter::new();
-        asserter.push_success(&serde_json::Value::from(block));
+        asserter.push_success(&finalized_at(number));
+        ProviderBuilder::new().connect_mocked_client(asserter)
+    }
+
+    /// A provider whose node reports no finalized block yet (null response).
+    fn provider_without_finalized() -> impl Provider + Clone {
+        let asserter = Asserter::new();
+        asserter.push_success(&Value::Null);
         ProviderBuilder::new().connect_mocked_client(asserter)
     }
 
@@ -216,7 +417,18 @@ mod tests {
 
     async fn setup<P>(
         provider: P,
-        required_confirmations: u64,
+    ) -> (
+        OrderFillMonitor<P>,
+        SqlitePool,
+        apalis_sqlite::SqlitePool,
+        EvmCtx,
+    ) {
+        setup_with_deployment_block(provider, 1).await
+    }
+
+    async fn setup_with_deployment_block<P>(
+        provider: P,
+        deployment_block: u64,
     ) -> (
         OrderFillMonitor<P>,
         SqlitePool,
@@ -229,8 +441,10 @@ mod tests {
         let evm_ctx = EvmCtx {
             rpc_url: url::Url::parse("http://localhost:8545").unwrap(),
             orderbook: address!("0x1111111111111111111111111111111111111111"),
-            deployment_block: 1,
-            required_confirmations,
+            deployment_block,
+            // No longer used by the monitor cutoff (it caps at the finalized
+            // block); kept on the ctx for transaction-submission paths.
+            required_confirmations: 0,
         };
 
         let monitor = OrderFillMonitor::new(
@@ -255,31 +469,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_once_enqueues_range_capped_at_confirmation_boundary() {
-        // checkpoint=99, tip=105, confs=3 -> cutoff=102, from=100.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
+    async fn poll_once_enqueues_range_up_to_finalized_block() {
+        // checkpoint=99, finalized=102 -> from=100, cutoff=102.
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(102)).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
             .await
             .unwrap();
 
-        monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once().await.unwrap();
 
+        assert_eq!(
+            outcome,
+            PollOutcome::Enqueued {
+                from_block: 100,
+                to_block: 102
+            }
+        );
         assert_eq!(backfill_job_count(&apalis_pool).await, 1);
         let job = loaded_backfill(&apalis_pool).await;
         assert_eq!(job.from_block, 100, "backfill must resume after checkpoint");
-        assert_eq!(
-            job.to_block, 102,
-            "cutoff must equal tip minus required_confirmations"
-        );
+        assert_eq!(job.to_block, 102, "cutoff must equal the finalized block");
     }
 
     #[tokio::test]
     async fn poll_once_uses_deployment_block_without_checkpoint() {
         // No checkpoint: from_block falls back to deployment_block (1).
-        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at_tip(50), 0).await;
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_with_finalized(50)).await;
 
-        monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once().await.unwrap();
 
+        assert_eq!(
+            outcome,
+            PollOutcome::Enqueued {
+                from_block: 1,
+                to_block: 50
+            }
+        );
         let job = loaded_backfill(&apalis_pool).await;
         assert_eq!(job.from_block, 1, "first run resumes from deployment_block");
         assert_eq!(job.to_block, 50);
@@ -287,33 +512,195 @@ mod tests {
 
     #[tokio::test]
     async fn poll_once_skips_when_caught_up() {
-        // checkpoint=105, tip=105, confs=3 -> cutoff=102, from=106 > cutoff.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
-        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 105)
+        // checkpoint=102, finalized=102 -> from=103 > cutoff.
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(102)).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 102)
             .await
             .unwrap();
 
-        monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once().await.unwrap();
 
+        assert_eq!(outcome, PollOutcome::CaughtUp);
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             0,
-            "nothing to enqueue when checkpoint is past the confirmation boundary"
+            "nothing to enqueue when the checkpoint has reached the finalized block"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn poll_once_skips_when_finalized_behind_checkpoint() {
+        // A load-balanced RPC returns a finalized block (150) below the already
+        // persisted checkpoint (200) -> from_block=201 is >1 past the cutoff.
+        // Ingestion must pause (warn path) without enqueuing or moving anything.
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(150)).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 200)
+            .await
+            .unwrap();
+
+        let outcome = monitor.poll_once().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            PollOutcome::FinalityBehindCheckpoint,
+            "a finalized block behind the checkpoint is a finality regression"
+        );
+        assert!(
+            logs_contain("Finalized block is behind committed ingestion progress"),
+            "the finality-regression pause must warn operators"
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "a finalized block behind the checkpoint must not enqueue a range"
+        );
+        assert_eq!(
+            crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+                .await
+                .unwrap(),
+            Some(200),
+            "the checkpoint must not move when finalized regresses behind it"
         );
     }
 
     #[tokio::test]
-    async fn poll_once_does_not_enqueue_when_no_block_is_safe_yet() {
-        // Chain shallower than confs: latest_confirmed_block -> None -> 0.
-        // checkpoint absent so from_block = deployment_block = 1 > 0: skip.
-        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_at_tip(2), 5).await;
+    async fn poll_once_skips_when_finality_behind_deployment_block() {
+        // Cold start (no checkpoint): finality (genesis block 0) sits below the
+        // deployment block (1), so there is nothing to ingest yet. `from_block`
+        // (1) == `cutoff` (0) + 1, but with no committed progress this is NOT
+        // "caught up" -- it is the deployment block one short of finalizing, so
+        // the outcome must be FinalityBehindDeployment, not CaughtUp.
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_with_finalized(0)).await;
 
-        monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once().await.unwrap();
 
+        assert_eq!(
+            outcome,
+            PollOutcome::FinalityBehindDeployment,
+            "cold start with finality below deployment_block must not report CaughtUp"
+        );
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             0,
-            "no safe block to ingest yet -> no enqueue"
+            "nothing to ingest until finality reaches the deployment block"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn poll_once_does_not_warn_when_deployment_block_is_ahead_of_finality() {
+        // Unusual config: a low stale checkpoint (5) but deployment_block (100)
+        // configured ahead of the finalized block (10). `from_block` is driven by
+        // the deployment floor to 100 > cutoff + 1, but committed progress (5) is
+        // NOT past finality -- so this must be the quiet deployment-wait, not the
+        // loud finality-regression warning that blames the RPC.
+        let (mut monitor, pool, apalis_pool, evm_ctx) =
+            setup_with_deployment_block(provider_with_finalized(10), 100).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 5)
+            .await
+            .unwrap();
+
+        let outcome = monitor.poll_once().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            PollOutcome::FinalityBehindDeployment,
+            "a deployment_block ahead of finality is not a finality regression"
+        );
+        assert!(
+            !logs_contain("behind committed ingestion progress"),
+            "must not blame the RPC for a deployment_block/checkpoint config gap"
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "nothing to ingest until finality reaches the deployment block"
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_once_does_not_enqueue_when_no_finalized_block_yet() {
+        // No finalized block and no checkpoint (cold start) -> skip the tick
+        // without enqueuing anything.
+        let (mut monitor, _pool, apalis_pool, _evm_ctx) = setup(provider_without_finalized()).await;
+
+        let outcome = monitor.poll_once().await.unwrap();
+
+        assert_eq!(
+            outcome,
+            PollOutcome::NoFinalityColdStart,
+            "no checkpoint + null finality is an expected cold-start skip"
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "no finalized block to ingest yet -> no enqueue"
+        );
+    }
+
+    /// A null finalized response while a checkpoint already exists must skip the
+    /// tick without moving the checkpoint (the financial invariant: a skip never
+    /// advances ingestion past unverified blocks), and a later tick that sees a
+    /// real finalized block must resume from exactly where it left off.
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn poll_once_skips_intermittent_null_without_moving_checkpoint() {
+        let asserter = Asserter::new();
+        asserter.push_success(&Value::Null);
+        asserter.push_success(&finalized_at(105));
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
+        crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
+            .await
+            .unwrap();
+
+        // First tick: node returns null finality -> skip, checkpoint frozen.
+        // A checkpoint exists, so this is the warn branch, distinct from the
+        // cold-start debug branch despite identical side effects.
+        let first = monitor.poll_once().await.unwrap();
+        assert_eq!(
+            first,
+            PollOutcome::NoFinalityWithCheckpoint,
+            "null finality while a checkpoint exists is the warn (regression) branch"
+        );
+        assert!(
+            logs_contain("No finalized block reported while a checkpoint exists"),
+            "the warn branch must emit an operator-visible warning"
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            0,
+            "a null finalized response must not enqueue a range"
+        );
+        assert_eq!(
+            crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
+                .await
+                .unwrap(),
+            Some(99),
+            "the checkpoint must not move when finality is momentarily null"
+        );
+
+        // Second tick: finality is back -> resume from exactly checkpoint+1.
+        let second = monitor.poll_once().await.unwrap();
+        assert_eq!(
+            second,
+            PollOutcome::Enqueued {
+                from_block: 100,
+                to_block: 105
+            },
+            "a recovered finalized response resumes from checkpoint+1"
+        );
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            1,
+            "a recovered finalized response must resume ingestion"
+        );
+        let job = loaded_backfill(&apalis_pool).await;
+        assert_eq!(job.from_block, 100, "resume from exactly checkpoint+1");
+        assert_eq!(
+            job.to_block, 105,
+            "cutoff equals the recovered finalized block"
         );
     }
 
@@ -326,7 +713,7 @@ mod tests {
         let asserter = Asserter::new();
         asserter.push_failure_msg("connection refused");
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider, 0).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
 
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 99)
             .await
@@ -340,7 +727,7 @@ mod tests {
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             0,
-            "No backfill range may be enqueued off a failed tip read"
+            "No backfill range may be enqueued off a failed finalized-block read"
         );
         assert_eq!(
             crate::onchain::backfill::load_backfill_checkpoint(&pool, &evm_ctx)
@@ -370,10 +757,10 @@ mod tests {
             required_confirmations: 0,
         };
 
-        // One tip response per poll_once call.
+        // One finalized-block response per poll_once call.
         let asserter = Asserter::new();
-        asserter.push_success(&serde_json::Value::from(50));
-        asserter.push_success(&serde_json::Value::from(50));
+        asserter.push_success(&finalized_at(50));
+        asserter.push_success(&finalized_at(50));
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
 
         let mut monitor = OrderFillMonitor::new(
@@ -430,7 +817,7 @@ mod tests {
         // so the empty asserter is never polled).
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter);
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider, 0).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider).await;
 
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
@@ -445,8 +832,13 @@ mod tests {
             .unwrap();
         assert_eq!(backfill_job_count(&apalis_pool).await, 1);
 
-        monitor.poll_once().await.unwrap();
+        let outcome = monitor.poll_once().await.unwrap();
 
+        assert_eq!(
+            outcome,
+            PollOutcome::RangeInFlight,
+            "the overlap guard must return RangeInFlight"
+        );
         assert_eq!(
             backfill_job_count(&apalis_pool).await,
             1,
@@ -461,13 +853,13 @@ mod tests {
         // indefinitely -- the deterministic worker name means apalis never
         // ages the orphan out. `requeue_orphaned`, wired at conductor startup,
         // is what unwedges it.
-        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_at_tip(105), 3).await;
+        let (mut monitor, pool, apalis_pool, evm_ctx) = setup(provider_with_finalized(105)).await;
         crate::onchain::backfill::save_backfill_checkpoint(&pool, &evm_ctx, 10)
             .await
             .unwrap();
 
-        let queue = BackfillJobQueue::new(&apalis_pool);
-        BackfillJobQueue::new(&apalis_pool)
+        let mut queue = BackfillJobQueue::new(&apalis_pool);
+        queue
             .push(BackfillRange {
                 from_block: 11,
                 to_block: 20,
@@ -502,21 +894,95 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(status, "Pending", "requeue makes the orphan re-drivable");
+
+        // A requeued (Pending) job still counts as in flight, so the wedge only
+        // truly lifts once a worker drains it to a terminal state. Simulate that
+        // completion, then confirm the next poll resumes ingestion -- it reaches
+        // the finalized-block RPC (consuming the mock) and enqueues a fresh range.
+        sqlx_apalis::query("UPDATE Jobs SET status = 'Done' WHERE job_type LIKE '%BackfillRange%'")
+            .execute(&apalis_pool)
+            .await
+            .unwrap();
+
+        monitor.poll_once().await.unwrap();
+        assert_eq!(
+            backfill_job_count(&apalis_pool).await,
+            2,
+            "once the orphan reaches a terminal state the poller enqueues a new range"
+        );
     }
 
     #[tokio::test]
-    async fn latest_confirmed_block_subtracts_confirmations() {
-        let confirmed = latest_confirmed_block(&provider_at_tip(105), 3)
+    async fn probe_finalized_block_support_accepts_a_finalized_block() {
+        // Finalized (102) strictly behind the chain tip (110): genuine finality.
+        let outcome = probe_finalized_block_support(&provider_with_finalized(102), 110)
             .await
             .unwrap();
-        assert_eq!(confirmed, Some(102));
+
+        assert_eq!(outcome, FinalityProbe::Supported);
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn probe_finalized_block_support_accepts_missing_finality() {
+        // A chain shallower than finality (null `finalized`) is a legitimate
+        // cold-start state, so the startup probe must not reject it -- failing
+        // here would be racy against finality catching up on a fresh chain.
+        let outcome = probe_finalized_block_support(&provider_without_finalized(), 110)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, FinalityProbe::NotYetAvailable);
+        assert!(
+            logs_contain("RPC endpoint reports no finalized block at startup"),
+            "deferred ingestion at startup must be operator-visible"
+        );
+    }
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn probe_finalized_block_support_flags_finalized_aliasing_the_tip() {
+        // A provider that reports `finalized` at the chain tip (110 == 110) is
+        // likely aliasing `finalized` to `latest`, which would silently disable
+        // reorg protection -- the probe must flag it rather than accept it.
+        let outcome = probe_finalized_block_support(&provider_with_finalized(110), 110)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome, FinalityProbe::AliasesChainTip);
+        assert!(
+            logs_contain("may be aliasing the `finalized` tag to `latest`"),
+            "a tip-aliased finalized tag must be operator-visible"
+        );
     }
 
     #[tokio::test]
-    async fn latest_confirmed_block_returns_none_when_chain_too_shallow() {
-        let confirmed = latest_confirmed_block(&provider_at_tip(2), 3)
+    async fn probe_finalized_block_support_flags_finalized_strictly_ahead_of_tip() {
+        // finalized (111) strictly ahead of the chain tip (110): a finalized read
+        // beyond the tip can only mean the endpoint is not reporting real finality,
+        // so the probe must flag it like the equal case (the `>` half of `>=`).
+        let outcome = probe_finalized_block_support(&provider_with_finalized(111), 110)
             .await
             .unwrap();
-        assert_eq!(confirmed, None);
+
+        assert_eq!(outcome, FinalityProbe::AliasesChainTip);
+    }
+
+    #[tokio::test]
+    async fn probe_finalized_block_support_rejects_an_rpc_error() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("connection refused");
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        // An endpoint that errors on the finalized tag must fail the startup
+        // probe rather than letting the bot start and silently never ingest.
+        let error = probe_finalized_block_support(&provider, 110)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, RpcError::ErrorResp(_)),
+            "a finalized-tag RPC failure must surface as an error response; got: {error:?}"
+        );
     }
 }

--- a/src/onchain/backfill.rs
+++ b/src/onchain/backfill.rs
@@ -196,15 +196,34 @@ where
     }
 }
 
+/// Derives the block to resume backfill from, given the persisted checkpoint
+/// (or its absence). Resumes at `checkpoint + 1` floored at `deployment_block`;
+/// a cold start with no checkpoint begins at `deployment_block`. Pure so a
+/// caller that already holds the checkpoint (the fill monitor's poll loop) can
+/// reuse it without a second read.
+pub(crate) fn backfill_start_from_checkpoint(
+    checkpoint: Option<u64>,
+    deployment_block: u64,
+) -> u64 {
+    checkpoint.map_or(deployment_block, |last_processed_block| {
+        (last_processed_block + 1).max(deployment_block)
+    })
+}
+
+/// Loads the checkpoint and derives the backfill resume point in one call.
+/// Test-only: production resolves the resume point in the fill monitor's poll
+/// loop, which already holds the checkpoint, via
+/// [`backfill_start_from_checkpoint`].
+#[cfg(test)]
 pub(crate) async fn backfill_start_block(
     pool: &SqlitePool,
     evm_ctx: &EvmCtx,
 ) -> Result<u64, OnChainError> {
-    load_backfill_checkpoint(pool, evm_ctx)
-        .await?
-        .map_or(Ok(evm_ctx.deployment_block), |last_processed_block| {
-            Ok((last_processed_block + 1).max(evm_ctx.deployment_block))
-        })
+    let checkpoint = load_backfill_checkpoint(pool, evm_ctx).await?;
+    Ok(backfill_start_from_checkpoint(
+        checkpoint,
+        evm_ctx.deployment_block,
+    ))
 }
 
 pub(crate) async fn load_backfill_checkpoint(
@@ -316,19 +335,19 @@ async fn enqueue_batch_events<P: Provider + Clone, B: BackoffBuilder + Clone>(
         .chain(take_logs)
         .sorted_by_key(|log| (log.block_number, log.log_index))
         .filter(|log| {
-            // Callers cap `to_block` at the confirmation boundary,
-            // so `removed: true` here implies a deep reorg crossing
-            // that depth. Surface it loudly rather than silently
-            // ingesting; skip the log so we don't persist a vanished
-            // event.
+            // Callers cap `to_block` at the chain's finalized block,
+            // which cannot reorg, so `removed: true` here implies a
+            // reorg crossing finality. Surface it loudly rather than
+            // silently ingesting; skip the log so we don't persist a
+            // vanished event.
             if log.removed {
                 error!(
                     target: "orderbook",
                     tx_hash = ?log.transaction_hash,
                     log_index = ?log.log_index,
                     block_number = ?log.block_number,
-                    "Backfill returned `removed: true` for a log past the confirmation depth -- \
-                     deep reorg detected; skipping"
+                    "Backfill returned `removed: true` for a log past the finalized block -- \
+                     reorg crossing finality detected; skipping"
                 );
                 return false;
             }
@@ -494,6 +513,21 @@ mod tests {
         let start_block = backfill_start_block(&pool, &evm_ctx).await.unwrap();
 
         assert_eq!(start_block, 50);
+    }
+
+    #[test]
+    fn backfill_start_from_checkpoint_uses_deployment_block_without_checkpoint() {
+        assert_eq!(backfill_start_from_checkpoint(None, 50), 50);
+    }
+
+    #[test]
+    fn backfill_start_from_checkpoint_resumes_after_checkpoint() {
+        assert_eq!(backfill_start_from_checkpoint(Some(80), 50), 81);
+    }
+
+    #[test]
+    fn backfill_start_from_checkpoint_floors_at_deployment_block() {
+        assert_eq!(backfill_start_from_checkpoint(Some(20), 50), 50);
     }
 
     #[tokio::test]

--- a/tests/e2e/base_chain.rs
+++ b/tests/e2e/base_chain.rs
@@ -208,7 +208,21 @@ impl BaseChain<()> {
         // Auto-mine a block every second so that onchain transactions
         // requiring multiple confirmations (e.g., REQUIRED_CONFIRMATIONS=3
         // in ShareWrapper) complete on Anvil instead of hanging forever.
-        let anvil = Anvil::new().block_time(1).spawn();
+        //
+        // `--slots-in-an-epoch 1` (Foundry anvil flag) shrinks Anvil's finality
+        // lag so the finalized-block fill monitor can ingest within a short
+        // test. Anvil advances the `finalized` block tag a fixed number of
+        // slots/epochs behind the tip; empirically, with the default 32-slot
+        // epoch the lag is large enough that a brief e2e never mines past it --
+        // ingestion is starved and the 120s poll times out. A 1-slot epoch
+        // drops the observed lag to a couple of blocks, which the 1s
+        // auto-mining clears within seconds. (If a future Anvil changes this
+        // relationship the failure is a loud e2e timeout, not a silent pass.)
+        let anvil = Anvil::new()
+            .block_time(1)
+            .arg("--slots-in-an-epoch")
+            .arg("1")
+            .spawn();
 
         let key = B256::from_slice(&anvil.keys()[0].to_bytes());
         let signer = PrivateKeySigner::from_bytes(&key)?;

--- a/tests/e2e/rebalancing.rs
+++ b/tests/e2e/rebalancing.rs
@@ -1820,6 +1820,18 @@ async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
         "Expected a completed mint request after restart"
     );
 
+    // The finalized-block fill monitor ingests fills a few blocks behind the
+    // tip, so the per-fill hedges settle shortly after the mint completes.
+    // Wait for every hedge fill before the one-shot broker-state assertion.
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        i64::try_from(take_results.len())?,
+        Duration::from_secs(120),
+    )
+    .await;
+
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")
         .amount(float!(22.5))
@@ -2006,6 +2018,18 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
         completed_redemptions_after_restart >= 1,
         "Expected a completed redemption request after restart"
     );
+
+    // The finalized-block fill monitor ingests fills a few blocks behind the
+    // tip, so the hedge settles shortly after the redemption completes. Wait
+    // for the hedge fill before the one-shot broker-state assertion.
+    poll_for_events_with_timeout(
+        &mut bot2,
+        &infra.db_path,
+        "OffchainOrderEvent::Filled",
+        1,
+        Duration::from_secs(120),
+    )
+    .await;
 
     let expected_positions = [ExpectedPosition::builder()
         .symbol("AAPL")


### PR DESCRIPTION
## What

Closes RAI-1057. Caps order-fill ingestion at the chain's latest **finalized**
block instead of the `tip - required_confirmations` heuristic.

## Why

`required_confirmations` is a transaction-submission setting; reusing it as the
ingestion cutoff was a confirmation-depth guess, not real finality. A finalized
block cannot reorg, so capping ingestion there is genuine single-chain reorg
protection: an ingested fill can never be invalidated. This is the simplified
interim protection while first-class cross-chain reorg handling is tracked
separately in the Reorg protection project.

## How

- `OrderFillMonitor` reads `eth_getBlockByNumber("finalized")` and uses that
  block as the backfill cutoff; `None` (chain shallower than finality) yields no
  enqueue.
- `finalized` is hardcoded — it is the only safe value; any other tag reopens
  reorg exposure.
- e2e: Anvil finalizes a block only ~2 epochs behind the tip, so the default
  32-slot epoch leaves `finalized` ~64 blocks back — a lag a short test never
  clears. Spawn Anvil with `--slots-in-an-epoch 1` so the lag is ~2 blocks and
  continuous auto-mining finalizes fills within seconds.

## Testing

- Unit: monitor enqueues up to the finalized block, skips when no finalized
  block exists, and surfaces RPC/enqueue errors without moving the checkpoint.
- e2e: `e2e_hedging_via_launch` and `out_of_order_fills` pass; logs show
  `finalized` advancing each tick and fills ingested within the window.
- `cargo clippy -p st0x-hedge --all-targets --all-features` clean.

## Anything else

Stacked on `fix/exactly-once-fill-accounting`. Replaces the descoped first-class
reorg stack (draft PRs preserved under the Reorg protection project).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated order-fill monitoring to cap ingestion using the chain’s latest finalized block, improving reliability around reorg boundaries and checkpoint handling.

* **Tests**
  * Refreshed monitor tests to reflect finalized-block semantics (including “no finalized yet” cases) and updated E2E restart flows to wait for filled events before asserting broker-state positions.

* **Documentation**
  * Updated the Raindex monitor specification, conductor docs, and example config comments to match finalized-block-based backfill behavior.

* **Chores**
  * Adjusted E2E chain startup to use `--slots-in-an-epoch 1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->