### PR TITLE
feat: skip frozen assets at the rebalancing trigger

### DIFF
--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -1180,6 +1180,11 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
         let transfer_usdc_to_market_making_queue =
             deps.schedulers.transfer_usdc_to_market_making.clone();
 
+        let issuance_freeze_reader = Arc::new(st0x_issuance_client::IssuanceClient::new(
+            deps.ctx.issuance.base_url.clone(),
+            deps.ctx.issuance.api_key.header_value(),
+        )?);
+
         let rebalancing_service = Arc::new(RebalancingService::new(
             RebalancingServiceConfig {
                 equity: rebalancing_ctx.equity,
@@ -1194,6 +1199,10 @@ fn spawn_rebalancing_infrastructure<Chain: Wallet + Clone>(
             wrapper.clone(),
             deps.schedulers,
         ));
+
+        rebalancing_service
+            .set_freeze_status_reader(issuance_freeze_reader)
+            .await;
 
         let broadcaster = Arc::new(Broadcaster::new(deps.event_sender, deps.pool.clone()));
         let manifest = QueryManifest::new(rebalancing_service.clone(), broadcaster);

--- a/src/rebalancing/trigger/freeze.rs
+++ b/src/rebalancing/trigger/freeze.rs
@@ -1,0 +1,185 @@
+//! Dividend freeze-status gate for the rebalancing trigger.
+//!
+//! The liquidity bot must not initiate a rebalancing flow for an asset that
+//! issuance has frozen for a dividend: the equity redemption saga sends tokens
+//! on-chain before issuance is consulted, so a flow started for a frozen asset
+//! strands funds. The trigger therefore reads the asset's freeze status before
+//! dispatching and skips frozen assets, failing closed when the status cannot
+//! be confirmed.
+
+use async_trait::async_trait;
+
+use st0x_execution::Symbol;
+use st0x_issuance_client::{ClientError, IssuanceClient};
+use st0x_issuance_dto::{TokenizedAssetStatus, UnderlyingSymbol};
+
+/// Reads an asset's dividend freeze status so the rebalancing trigger can skip
+/// frozen assets before starting a flow.
+#[async_trait]
+pub(crate) trait FreezeStatusReader: Send + Sync {
+    /// Returns whether `symbol` is currently frozen for a dividend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FreezeCheckError`] when the status cannot be determined (the
+    /// service is unreachable/errored, or the asset is unknown to issuance);
+    /// callers fail closed on any error rather than risk rebalancing a frozen
+    /// asset.
+    async fn is_frozen(&self, symbol: &Symbol) -> Result<bool, FreezeCheckError>;
+}
+
+/// Why a freeze-status check could not produce a definitive answer. The trigger
+/// fails closed (skips and alerts) on any of these.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FreezeCheckError {
+    /// Issuance returned 404 -- it does not recognise an asset the bot
+    /// rebalances, so the bot cannot confirm the asset is not frozen.
+    #[error("issuance does not recognize asset {symbol}")]
+    AssetUnknown { symbol: Symbol },
+    /// The status request itself failed (transport error, unexpected status).
+    #[error("issuance freeze-status request failed")]
+    Client(#[from] ClientError),
+}
+
+#[async_trait]
+impl FreezeStatusReader for IssuanceClient {
+    async fn is_frozen(&self, symbol: &Symbol) -> Result<bool, FreezeCheckError> {
+        let underlying = UnderlyingSymbol::new(symbol.to_string());
+        match self.tokenized_asset_status(&underlying).await? {
+            Some(response) => Ok(match response.status {
+                TokenizedAssetStatus::Frozen => true,
+                TokenizedAssetStatus::Enabled => false,
+            }),
+            None => Err(FreezeCheckError::AssetUnknown {
+                symbol: symbol.clone(),
+            }),
+        }
+    }
+}
+
+/// Test/`test-support` freeze reader with a fixed outcome, so trigger tests can
+/// exercise the gate without a live issuance service.
+#[cfg(test)]
+#[derive(Clone, Copy)]
+pub(crate) enum StubFreezeReader {
+    /// Asset is not frozen -- rebalancing proceeds.
+    NotFrozen,
+    /// Asset is frozen -- the trigger skips it.
+    Frozen,
+    /// The status cannot be confirmed -- the trigger fails closed.
+    Indeterminate,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl FreezeStatusReader for StubFreezeReader {
+    async fn is_frozen(&self, symbol: &Symbol) -> Result<bool, FreezeCheckError> {
+        match self {
+            Self::NotFrozen => Ok(false),
+            Self::Frozen => Ok(true),
+            Self::Indeterminate => Err(FreezeCheckError::AssetUnknown {
+                symbol: symbol.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::{Method::GET, MockServer};
+    use serde_json::json;
+    use url::Url;
+
+    use super::*;
+
+    fn client_for(server: &MockServer) -> IssuanceClient {
+        IssuanceClient::new(
+            Url::parse(&server.base_url()).expect("valid mock URL"),
+            "test-key",
+        )
+        .expect("client must build")
+    }
+
+    #[tokio::test]
+    async fn is_frozen_maps_a_frozen_asset_to_true() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/AAPL/status");
+            then.status(200).json_body(json!({
+                "underlying": "AAPL",
+                "status": "frozen",
+            }));
+        });
+
+        let frozen = client_for(&server)
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect("a 200 response must resolve");
+
+        mock.assert();
+        assert!(frozen, "issuance reporting frozen must map to Ok(true)");
+    }
+
+    #[tokio::test]
+    async fn is_frozen_maps_an_unfrozen_asset_to_false() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/AAPL/status");
+            then.status(200).json_body(json!({
+                "underlying": "AAPL",
+                "status": "enabled",
+            }));
+        });
+
+        let frozen = client_for(&server)
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect("a 200 response must resolve");
+
+        assert!(
+            !frozen,
+            "issuance reporting not-frozen must map to Ok(false)"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_frozen_fails_closed_when_issuance_does_not_recognize_the_asset() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/AAPL/status");
+            then.status(404);
+        });
+
+        let error = client_for(&server)
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect_err("a 404 must fail closed, never resolve to Ok(false)");
+
+        assert!(
+            matches!(
+                error,
+                FreezeCheckError::AssetUnknown { ref symbol } if *symbol == Symbol::new("AAPL").unwrap()
+            ),
+            "a 404 must map to AssetUnknown so the trigger fails closed, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn is_frozen_fails_closed_on_a_status_error() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/AAPL/status");
+            then.status(500);
+        });
+
+        let error = client_for(&server)
+            .is_frozen(&Symbol::new("AAPL").unwrap())
+            .await
+            .expect_err("a 500 must fail closed, never resolve to Ok(false)");
+
+        assert!(
+            matches!(error, FreezeCheckError::Client(_)),
+            "a server error must map to Client so the trigger fails closed, got: {error:?}"
+        );
+    }
+}

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -1,6 +1,7 @@
 //! Rebalancing trigger that reacts to inventory imbalances.
 
 mod equity;
+mod freeze;
 mod usdc;
 
 #[cfg(test)]
@@ -16,7 +17,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 use rain_math_float::Float;
@@ -28,6 +29,7 @@ use st0x_execution::{FractionalShares, Positive, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, Usdc};
 use st0x_wrapper::{Wrapper, WrapperError};
 
+use self::freeze::FreezeStatusReader;
 use self::usdc::UsdcRebalanceOperation;
 use crate::conductor::job::QueuePushError;
 use crate::equity_redemption::{
@@ -65,6 +67,8 @@ use crate::wrapped_equity_recovery::aggregate::WrappedEquityRecoveryId;
 use crate::wrapped_equity_recovery::{WrappedEquityRecoveryJob, WrappedEquityRecoveryJobQueue};
 
 pub(crate) use equity::{EquityRebalancingCheck, EquityRebalancingCheckScheduler};
+#[cfg(test)]
+pub(crate) use freeze::StubFreezeReader;
 pub(crate) use usdc::{UsdcRebalancingCheck, UsdcRebalancingCheckScheduler};
 
 /// Bundle of the equity + USDC schedulers so constructors and plumbing
@@ -475,6 +479,12 @@ pub(crate) struct RebalancingService {
     orderbook: Address,
     order_owner: Address,
     inventory: Arc<BroadcastingInventory>,
+    /// Reads issuance's per-asset dividend freeze status so the equity trigger
+    /// can skip frozen assets before starting a flow. Set after construction via
+    /// `set_freeze_status_reader` (the conductor builds the issuance client from
+    /// config, mirroring `set_stores`); `None` only in tests that do not
+    /// exercise the gate.
+    freeze_status: RwLock<Option<Arc<dyn FreezeStatusReader>>>,
     pub(crate) equity_in_progress: Arc<std::sync::RwLock<HashMap<Symbol, equity::GuardState>>>,
     pending_offchain_order_symbols: Arc<RwLock<HashSet<Symbol>>>,
     pub(crate) usdc_in_progress: Arc<AtomicBool>,
@@ -583,6 +593,7 @@ impl RebalancingService {
             orderbook,
             order_owner,
             inventory,
+            freeze_status: RwLock::new(None),
             equity_in_progress: Arc::new(std::sync::RwLock::new(HashMap::new())),
             pending_offchain_order_symbols: Arc::new(RwLock::new(HashSet::new())),
             usdc_in_progress: Arc::new(AtomicBool::new(false)),
@@ -626,6 +637,13 @@ impl RebalancingService {
         *self.mint_store.write().await = Some(mint_store);
         *self.redemption_store.write().await = Some(redemption_store);
         *self.usdc_store.write().await = Some(usdc_store);
+    }
+
+    /// Attach the issuance freeze-status reader so the equity trigger can skip
+    /// assets frozen for a dividend. Called by the conductor after construction
+    /// (the reader wraps the issuance client built from config).
+    pub(crate) async fn set_freeze_status_reader(&self, reader: Arc<dyn FreezeStatusReader>) {
+        *self.freeze_status.write().await = Some(reader);
     }
 
     pub(crate) async fn recover_pending_offchain_order_symbols(
@@ -2437,6 +2455,40 @@ impl RebalancingService {
                 "Skipped equity trigger: rebalancing not enabled for symbol"
             );
             return Ok(());
+        }
+
+        // Dividend freeze guard: do not start a rebalancing flow for an asset
+        // issuance has frozen. The check goes before claiming the in-progress
+        // guard or building the operation so a frozen asset is skipped cheaply.
+        // The reader is `None` only in tests that do not exercise the gate; the
+        // conductor always sets it in production.
+        let freeze_status = self.freeze_status.read().await.clone();
+        if let Some(reader) = freeze_status {
+            match reader.is_frozen(symbol).await {
+                Ok(false) => {}
+                Ok(true) => {
+                    info!(
+                        target: "rebalance",
+                        %symbol,
+                        "Skipped equity trigger: asset is frozen for a dividend"
+                    );
+                    return Ok(());
+                }
+                Err(error) => {
+                    // Fail closed: a flow started for a frozen asset strands
+                    // funds, and rebalancing is latency-tolerant, so when
+                    // issuance cannot confirm the asset is unfrozen we skip the
+                    // cycle and alert rather than risk initiating it.
+                    error!(
+                        target: "rebalance",
+                        %symbol,
+                        ?error,
+                        "Skipped equity trigger: could not confirm asset is not \
+                         frozen; failing closed"
+                    );
+                    return Ok(());
+                }
+            }
         }
 
         if self.has_pending_offchain_order(symbol).await {
@@ -6288,6 +6340,65 @@ mod tests {
             jobs.len(),
             1,
             "Whitelisted symbol with an imbalance should dispatch a mint job"
+        );
+        assert_eq!(jobs[0].symbol, symbol);
+    }
+
+    #[tokio::test]
+    async fn frozen_asset_skips_equity_trigger() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger =
+            make_imbalanced_trigger_with_equities(&symbol, rebalancing_enabled_equities(&["AAPL"]))
+                .await;
+        trigger
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Frozen))
+            .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "A frozen asset must not dispatch an equity rebalancing job"
+        );
+    }
+
+    #[tokio::test]
+    async fn indeterminate_freeze_status_fails_closed() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger =
+            make_imbalanced_trigger_with_equities(&symbol, rebalancing_enabled_equities(&["AAPL"]))
+                .await;
+        trigger
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::Indeterminate))
+            .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        assert_eq!(
+            count_pending_equity_mint_jobs(&trigger).await,
+            0,
+            "An indeterminate freeze status must fail closed -- no rebalancing job dispatched"
+        );
+    }
+
+    #[tokio::test]
+    async fn not_frozen_asset_passes_equity_trigger() {
+        let symbol = Symbol::new("AAPL").unwrap();
+        let trigger =
+            make_imbalanced_trigger_with_equities(&symbol, rebalancing_enabled_equities(&["AAPL"]))
+                .await;
+        trigger
+            .set_freeze_status_reader(Arc::new(StubFreezeReader::NotFrozen))
+            .await;
+
+        trigger.check_and_trigger_equity(&symbol).await.unwrap();
+
+        let jobs = take_pending_equity_mint_jobs(&trigger).await;
+        assert_eq!(
+            jobs.len(),
+            1,
+            "A not-frozen asset with an imbalance should still dispatch a mint job"
         );
         assert_eq!(jobs[0].symbol, symbol);
     }

--- a/tests/e2e/rebalancing.rs
+++ b/tests/e2e/rebalancing.rs
@@ -274,6 +274,7 @@ async fn equity_mint_handles_direct_high_precision_sell_price() -> anyhow::Resul
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot = spawn_bot(ctx);
 
@@ -418,6 +419,7 @@ async fn equity_imbalance_triggers_mint() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot = spawn_bot(ctx);
 
@@ -548,6 +550,7 @@ async fn equity_imbalance_triggers_redemption() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -669,6 +672,7 @@ async fn equity_redemption_buy_inv_repeating_reciprocal_regression() -> anyhow::
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot = spawn_bot(ctx);
 
@@ -803,6 +807,7 @@ async fn equity_redemption_buy_literal_reciprocal_regression() -> anyhow::Result
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot = spawn_bot(ctx);
 
@@ -1269,6 +1274,7 @@ async fn redemption_rejected_preserves_inflight_via_sticky() -> anyhow::Result<(
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -1407,6 +1413,7 @@ async fn pending_requests_filtered_by_wallet() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -1559,6 +1566,7 @@ async fn inflight_polling_emits_events_for_pending_requests() -> anyhow::Result<
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -1709,6 +1717,7 @@ async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot1 = spawn_bot(ctx1);
 
@@ -1771,6 +1780,7 @@ async fn interrupted_mint_resumes_after_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot2 = spawn_bot(ctx2);
 
@@ -1916,6 +1926,7 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot1 = spawn_bot(ctx1);
 
@@ -1969,6 +1980,7 @@ async fn interrupted_redemption_resumes_after_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
     let mut bot2 = spawn_bot(ctx2);
 
@@ -2120,6 +2132,7 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot1 = spawn_bot(ctx1);
@@ -2184,6 +2197,7 @@ async fn inflight_state_survives_restart() -> anyhow::Result<()> {
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Disabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let bot2 = spawn_bot(ctx2);
@@ -2302,6 +2316,7 @@ async fn wrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Result<
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Enabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -2469,6 +2484,7 @@ async fn unwrapped_equity_in_bot_wallet_recovers_into_raindex() -> anyhow::Resul
         .equity_imbalance(ImbalanceThreshold::new(float!(0.5), float!(100))?)
         .wrapped_equity_recovery(OperationMode::Enabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);
@@ -2695,6 +2711,7 @@ async fn active_mint_in_tokens_wrapped_recovers_into_raindex_vault() -> anyhow::
         .cash_rebalancing(OperationMode::Disabled)
         .wrapped_equity_recovery(OperationMode::Enabled)
         .redemption_wallet(REDEMPTION_WALLET)
+        .issuance_base_url(infra.issuance_base_url.clone())
         .call()?;
 
     let mut bot = spawn_bot(ctx);

--- a/tests/e2e/rebalancing/assertions.rs
+++ b/tests/e2e/rebalancing/assertions.rs
@@ -215,6 +215,9 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
     // poller still emits the events that dispatch recovery jobs.
     equity_imbalance: Option<ImbalanceThreshold>,
     redemption_wallet: Address,
+    /// Base URL of the mock issuance service (`TestInfra::issuance_base_url`) so
+    /// the rebalancing freeze guard reaches a reachable, not-frozen endpoint.
+    issuance_base_url: url::Url,
 ) -> anyhow::Result<Ctx> {
     let alpaca_auth = AlpacaBrokerApiCtx {
         api_key: TEST_API_KEY.to_owned(),
@@ -275,7 +278,7 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         }),
     };
 
-    Ctx::for_test()
+    let mut ctx = Ctx::for_test()
         .database_url(db_path.display().to_string())
         .rpc_url(chain.endpoint().parse()?)
         .orderbook(chain.orderbook)
@@ -286,8 +289,9 @@ pub(crate) fn build_rebalancing_ctx<P: Provider + Clone>(
         .wallet(wallet_ctx)
         .assets(assets)
         .redemption_wallet(redemption_wallet)
-        .call()
-        .map_err(Into::into)
+        .call()?;
+    ctx.issuance.base_url = issuance_base_url;
+    Ok(ctx)
 }
 
 /// Builds a `Ctx` with USDC rebalancing enabled and both chain endpoints.

--- a/tests/e2e/test_infra.rs
+++ b/tests/e2e/test_infra.rs
@@ -100,6 +100,11 @@ pub struct TestInfra<P> {
     pub broker_service: Arc<AlpacaBrokerMock>,
     pub tokenization_service: AlpacaTokenizationMock,
     pub attestation_service: CctpAttestationMock,
+    /// Mock issuance freeze-status endpoint (always reports not-frozen) so the
+    /// rebalancing freeze guard lets e2e flows through. Kept alive for the test.
+    _issuance_service: httpmock::MockServer,
+    /// Base URL of `_issuance_service`, for wiring into the bot's issuance ctx.
+    pub issuance_base_url: url::Url,
     /// `(symbol, vault_address, underlying_address)` per deployed equity vault.
     pub equity_addresses: Vec<(String, Address, Address)>,
 }
@@ -167,6 +172,9 @@ impl TestInfra<()> {
 
         let attestation_service = CctpAttestationMock::start().await;
         debug!("CCTP attestation mock started");
+
+        let issuance_service = start_issuance_mock().await;
+        let issuance_base_url = issuance_service.base_url().parse()?;
         info!("Test infrastructure ready");
 
         Ok(TestInfra {
@@ -176,6 +184,8 @@ impl TestInfra<()> {
             broker_service,
             tokenization_service,
             attestation_service,
+            _issuance_service: issuance_service,
+            issuance_base_url,
             equity_addresses,
         })
     }
@@ -251,6 +261,21 @@ async fn start_broker_mock(
     debug!(broker_url = %broker_service.base_url(), "Broker mock started");
 
     Ok(broker_service)
+}
+
+/// Starts a mock issuance HTTP server whose freeze-status endpoint always
+/// reports the asset enabled and not frozen, so the rebalancing freeze guard
+/// lets e2e rebalancing flows proceed (production points this at real issuance).
+async fn start_issuance_mock() -> httpmock::MockServer {
+    let server = httpmock::MockServer::start_async().await;
+    server.mock(|when, then| {
+        when.method(httpmock::Method::GET);
+        then.status(200).json_body(serde_json::json!({
+            "underlying": "TEST",
+            "status": "enabled",
+        }));
+    });
+    server
 }
 
 type MockBrokerState = (Vec<(Symbol, Float)>, Vec<MockPosition>);


### PR DESCRIPTION
## What

Closes RAI-1062 (sub-issue of RAI-1038). The equity rebalancing trigger now skips
assets issuance has frozen for a dividend, and fails closed when it can't
confirm an asset is unfrozen.

## Why

A rebalancing flow started for a frozen asset strands funds: the equity
redemption saga withdraws, unwraps, and sends tokens on-chain before issuance is
consulted, and there is no issuance-side rejection once `TokensSent` fires. The
guard must prevent *initiating* a flow, so it lives at the trigger, before
enqueue.

## How

- New `FreezeStatusReader` trait (`src/rebalancing/trigger/freeze.rs`),
  implemented for the issuance `IssuanceClient`: `is_frozen(symbol)` maps the
  status endpoint (404 -> `AssetUnknown`, transport/status errors -> `Client`).
- `check_and_trigger_equity` queries it right after the rebalancing-enabled
  check: frozen -> skip + log; **error/unknown -> fail closed** (skip + alert),
  since rebalancing is latency-tolerant and failing open recreates the
  stranded-funds risk.
- The reader is injected via `set_freeze_status_reader` after construction
  (mirroring the existing `set_stores` pattern), so the `RebalancingService::new`
  test call sites are untouched; the conductor builds the issuance client from
  config and sets it.
- USDC rebalancing is **not** gated: `check_and_trigger_usdc` has no per-asset
  target (cash isn't a tokenized equity and can't be dividend-frozen).

## Testing

- New trigger tests: frozen -> no job, indeterminate -> fails closed (no job),
  not-frozen -> dispatches. Full `st0x-hedge --lib` (1667) green; clippy + fmt
  clean.
- The e2e harness now serves a mock issuance freeze-status endpoint (always
  not-frozen) wired into the rebalancing ctx, so e2e flows pass through the gate;
  `interrupted_mint_resumes_after_restart` passes.

## Anything else

Builds on #875 (the issuance client + config). Draft until #875 / RAI-1059/1060
land.
