### PR TITLE
fix: gate dependent on-chain writes on RPC node reaching prerequisite tx block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,6 +6635,7 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "rain-math-float",
+ "serde_json",
  "st0x-evm",
  "st0x-execution",
  "st0x-float-macro",

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -25,8 +25,11 @@ use async_trait::async_trait;
 use rain_error_decoding::AbiDecodedErrorType;
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 use tokio::time::{interval, timeout};
+use tracing::{debug, warn};
 
 pub mod error_decoding;
 pub use error_decoding::{IntoErrorRegistry, NoOpErrorRegistry, OpenChainErrorRegistry};
@@ -142,6 +145,15 @@ impl WalletKind {
     }
 }
 
+/// Poll interval between `eth_blockNumber` calls in [`wait_for_node_sync`].
+pub const NODE_SYNC_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Maximum number of polls before [`wait_for_node_sync`] gives up.
+///
+/// 30 attempts at 1s each gives a 30s budget — generous for even a
+/// temporarily lagging backend node on a fast chain like Base.
+pub const NODE_SYNC_MAX_ATTEMPTS: u32 = 30;
+
 /// Errors that can occur during EVM operations.
 #[derive(Debug, thiserror::Error)]
 pub enum EvmError {
@@ -204,6 +216,18 @@ pub enum EvmError {
     #[cfg(feature = "turnkey")]
     #[error("Turnkey error: {0}")]
     Turnkey(#[from] turnkey::TurnkeyError),
+    /// The RPC node's tip remained below the required block after exhausting
+    /// the poll budget. Raised by [`wait_for_node_sync`] when a load-balanced
+    /// backend never catches up within the retry window.
+    #[error(
+        "RPC node tip {observed_tip} is behind required block {required_block} \
+         after {attempts} polls"
+    )]
+    NodeBehindRequiredBlock {
+        observed_tip: u64,
+        required_block: u64,
+        attempts: u32,
+    },
 }
 
 impl EvmError {
@@ -232,6 +256,7 @@ impl EvmError {
             Self::InvalidPrivateKey(_) => false,
             #[cfg(feature = "turnkey")]
             Self::Turnkey(_) => false,
+            Self::NodeBehindRequiredBlock { .. } => false,
         }
     }
 }
@@ -647,6 +672,99 @@ async fn execute_call<Registry: IntoErrorRegistry, Call: SolCall>(
     }
 }
 
+/// Spin-polls `eth_blockNumber` until the serving node reports >= `required_block`.
+///
+/// Load-balanced RPCs route successive calls to different backend nodes. After
+/// tx N confirms at block B, the very next call may hit a node still at B-1.
+/// This function blocks the caller until one poll observes height >= B, ensuring
+/// dependent writes see the prerequisite tx's effects.
+///
+/// # Errors
+///
+/// Returns [`EvmError::NodeBehindRequiredBlock`] after `max_attempts` polls if
+/// the node never catches up.
+///
+/// Returns [`EvmError::Transport`] if the budget is exhausted while every poll
+/// resulted in a transport error (i.e. no successful `eth_blockNumber` response
+/// was ever received).
+///
+/// Transient transport errors (e.g. a momentary connection failure on a
+/// load-balanced RPC) are treated the same as a behind-tip poll: the attempt
+/// is counted against the budget and the loop continues. This preserves the
+/// full 30-attempt window as tolerance for both sync lag and transient
+/// failures, rather than aborting on the first network hiccup.
+pub async fn wait_for_node_sync(
+    provider: &impl Provider,
+    required_block: u64,
+    poll_interval: Duration,
+    max_attempts: u32,
+) -> Result<(), EvmError> {
+    // The production caller always passes NODE_SYNC_MAX_ATTEMPTS (>= 1).
+    // Passing 0 would cause an empty loop and a misleading NodeBehindRequiredBlock
+    // with observed_tip=0 and attempts=0 — a programming error.
+    debug_assert!(
+        max_attempts >= 1,
+        "wait_for_node_sync: max_attempts must be at least 1"
+    );
+
+    // Tracks the most recent successful block number response.
+    // Only appears in NodeBehindRequiredBlock, which requires at least
+    // one successful poll.
+    let mut observed_tip = 0u64;
+    // True once at least one get_block_number call returned Ok (even if stale).
+    // Used to distinguish "all polls failed with transport error" (return Transport)
+    // from "some polls succeeded but node never caught up" (return NodeBehindRequiredBlock).
+    let mut any_poll_succeeded = false;
+
+    for attempt in 1..=max_attempts {
+        if attempt > 1 {
+            sleep(poll_interval).await;
+        }
+
+        match provider.get_block_number().await {
+            Ok(tip) => {
+                observed_tip = tip;
+                any_poll_succeeded = true;
+                if observed_tip >= required_block {
+                    return Ok(());
+                }
+                debug!(
+                    target: "evm",
+                    observed_tip,
+                    required_block,
+                    attempt,
+                    max_attempts,
+                    "RPC node behind required block; retrying"
+                );
+            }
+            Err(transport_error) => {
+                warn!(
+                    target: "evm",
+                    ?transport_error,
+                    attempt,
+                    max_attempts,
+                    "Transient transport error polling block number; retrying"
+                );
+                // Treat transient transport errors as a behind-tip poll:
+                // count the attempt against the budget and retry, rather
+                // than aborting all remaining retries on the first hiccup.
+                // If attempts are exhausted, return Transport only when no
+                // poll ever succeeded; otherwise fall through to
+                // NodeBehindRequiredBlock with the last observed tip.
+                if attempt == max_attempts && !any_poll_succeeded {
+                    return Err(EvmError::Transport(transport_error));
+                }
+            }
+        }
+    }
+
+    Err(EvmError::NodeBehindRequiredBlock {
+        observed_tip,
+        required_block,
+        attempts: max_attempts,
+    })
+}
+
 /// Poll interval for fallback receipt polling.
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 const RECEIPT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
@@ -844,11 +962,156 @@ mod tests {
     use alloy::node_bindings::{Anvil, AnvilInstance};
     use alloy::primitives::{Address, U256};
     use alloy::providers::ProviderBuilder;
+    use alloy::providers::mock::Asserter;
     use alloy::signers::local::PrivateKeySigner;
     use alloy::sol;
     use std::sync::Arc;
 
     use super::*;
+
+    /// Build a mock provider whose `eth_blockNumber` returns the given sequence
+    /// of block numbers in order, one per call.
+    fn mock_block_number_provider(block_numbers: &[u64]) -> impl Provider + Clone {
+        let asserter = Asserter::new();
+        for block in block_numbers {
+            asserter.push_success(&serde_json::Value::from(*block));
+        }
+        ProviderBuilder::new().connect_mocked_client(asserter)
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_succeeds_when_node_is_already_at_required_block() {
+        let provider = mock_block_number_provider(&[10]);
+
+        wait_for_node_sync(&provider, 10, Duration::ZERO, 5)
+            .await
+            .expect("node is at required block — should succeed immediately");
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_succeeds_when_node_is_ahead_of_required_block() {
+        let provider = mock_block_number_provider(&[15]);
+
+        wait_for_node_sync(&provider, 10, Duration::ZERO, 5)
+            .await
+            .expect("node tip > required block — should succeed immediately");
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_retries_until_node_catches_up() {
+        // Node returns blocks 8, 9 (below required 10), then 10 (at required).
+        let provider = mock_block_number_provider(&[8, 9, 10]);
+
+        wait_for_node_sync(&provider, 10, Duration::ZERO, 5)
+            .await
+            .expect("node catches up on third poll — should succeed");
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_fails_after_budget_exhausted() {
+        // Node always reports block 5, never reaching required block 10.
+        let provider = mock_block_number_provider(&[5, 5, 5]);
+
+        let error = wait_for_node_sync(&provider, 10, Duration::ZERO, 3)
+            .await
+            .expect_err("budget exhausted — should fail");
+
+        assert!(
+            matches!(
+                error,
+                EvmError::NodeBehindRequiredBlock {
+                    observed_tip: 5,
+                    required_block: 10,
+                    attempts: 3,
+                }
+            ),
+            "expected NodeBehindRequiredBlock with correct fields, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_fails_with_transport_error_when_all_attempts_fail() {
+        let asserter = Asserter::new();
+        // Push 3 transport error responses; the exact error returned is an
+        // implementation detail — the contract is that EvmError::Transport is
+        // propagated after the budget is exhausted with all-transport errors.
+        for iteration in 1u32..=3 {
+            asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+                code: -32000,
+                message: format!("connection refused attempt {iteration}").into(),
+                data: None,
+            });
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let result = wait_for_node_sync(&provider, 10, Duration::ZERO, 3).await;
+
+        let error =
+            result.expect_err("all transport errors should propagate as EvmError::Transport");
+        assert!(
+            matches!(error, EvmError::Transport(_)),
+            "expected EvmError::Transport after exhausting budget with all-transport errors, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_node_sync_succeeds_when_second_attempt_succeeds_after_transport_error() {
+        let asserter = Asserter::new();
+        // First attempt: transport error; second attempt: block 10 (at required).
+        let error_payload = alloy::rpc::json_rpc::ErrorPayload {
+            code: -32000,
+            message: "connection refused".into(),
+            data: None,
+        };
+        asserter.push_failure(error_payload);
+        asserter.push_success(&serde_json::Value::from(10u64));
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        wait_for_node_sync(&provider, 10, Duration::ZERO, 5)
+            .await
+            .expect("first transport error then success at block 10 — should succeed");
+    }
+
+    /// Verifies that when early attempts observe a stale tip (poll succeeded)
+    /// and the final attempt returns a transport error, the function returns
+    /// `NodeBehindRequiredBlock` (not `Transport`) using the last observed tip.
+    ///
+    /// This distinguishes the mixed case (some polls succeeded, node stale)
+    /// from the all-transport-error case (every poll failed before seeing any
+    /// block number). Only the all-transport-error case returns `Transport`.
+    #[tokio::test]
+    async fn wait_for_node_sync_returns_node_behind_when_stale_then_transport_error() {
+        let asserter = Asserter::new();
+        let stale_tip = 5u64;
+        let required_block = 10u64;
+        // First two attempts return a stale block number.
+        asserter.push_success(&serde_json::Value::from(stale_tip));
+        asserter.push_success(&serde_json::Value::from(stale_tip));
+        // Third (final) attempt returns a transport error.
+        asserter.push_failure(alloy::rpc::json_rpc::ErrorPayload {
+            code: -32000,
+            message: "connection refused on final attempt".into(),
+            data: None,
+        });
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let error = wait_for_node_sync(&provider, required_block, Duration::ZERO, 3)
+            .await
+            .expect_err("mixed stale-then-transport must fail");
+
+        assert!(
+            matches!(
+                error,
+                EvmError::NodeBehindRequiredBlock {
+                    observed_tip: 5,
+                    required_block: 10,
+                    attempts: 3,
+                }
+            ),
+            "must return NodeBehindRequiredBlock with last observed tip when at \
+             least one poll succeeded, got: {error:?}"
+        );
+    }
 
     sol!(
         #![sol(all_derives = true, rpc)]

--- a/crates/wrapper/Cargo.toml
+++ b/crates/wrapper/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true, optional = true }
 [dev-dependencies]
 alloy-primitives.workspace = true
 rain-math-float.workspace = true
+serde_json.workspace = true
 st0x-float-macro.workspace = true
 tokio = { workspace = true, features = ["full"] }
 

--- a/crates/wrapper/src/lib.rs
+++ b/crates/wrapper/src/lib.rs
@@ -12,7 +12,7 @@ use alloy::contract::Error as ContractError;
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
 
-use st0x_evm::EvmError;
+use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::Symbol;
 
 mod ratio;
@@ -30,6 +30,34 @@ pub use service::WrapperService;
 
 #[cfg(feature = "mock")]
 pub use mock::MockWrapper;
+
+/// Result returned by [`Wrapper::confirm_wrap`]: the shares minted and the block
+/// in which the deposit transaction was included.
+///
+/// The block number is returned so callers can pass it to
+/// [`Wrapper::wait_for_block`] before submitting any dependent on-chain write
+/// that reads the wrapped token balance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WrapConfirmation {
+    /// Actual ERC-4626 shares minted by the deposit.
+    pub shares: U256,
+    /// Block number of the confirmed deposit transaction.
+    pub block: u64,
+}
+
+/// Result returned by [`Wrapper::confirm_unwrap`]: the underlying amount
+/// received and the block in which the redeem transaction was included.
+///
+/// The block number is returned so callers can pass it to
+/// [`Wrapper::wait_for_block`] before submitting any dependent on-chain write
+/// that reads the unwrapped balance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnwrapConfirmation {
+    /// Actual underlying tokens returned by the redeem.
+    pub assets: U256,
+    /// Block number of the confirmed redeem transaction.
+    pub block: u64,
+}
 
 /// The underlying and derivative (ERC-4626 vault) token addresses for a wrappable
 /// equity symbol.
@@ -76,6 +104,43 @@ pub enum WrapperError {
     Contract(#[from] ContractError),
     #[error("Ratio error: {0}")]
     Ratio(#[from] RatioError),
+    #[error("transaction receipt for tx {tx_hash} is missing a block number")]
+    MissingBlockNumber { tx_hash: TxHash },
+}
+
+/// Extracts the number of polling attempts from a `WrapperError` returned by
+/// `Wrapper::wait_for_block`.
+///
+/// Returns the actual attempt count when the error is
+/// `WrapperError::Evm(NodeBehindRequiredBlock { attempts, .. })` — the node
+/// polled that many times and never caught up. Falls back to
+/// [`NODE_SYNC_MAX_ATTEMPTS`] for any other error variant (e.g. a transport
+/// error where every poll failed before any block number was observed, consuming
+/// the full budget without ever recording a successful tip).
+///
+/// Both error paths indicate the full polling budget was consumed; the
+/// difference is only in what diagnostic information is available. Callers use
+/// the extracted attempt count to populate their own `NodeSyncFailed` error
+/// variant.
+pub fn node_sync_attempts(error: &WrapperError) -> u32 {
+    match error {
+        WrapperError::Evm(EvmError::NodeBehindRequiredBlock { attempts, .. }) => *attempts,
+        // All other Evm sub-variants signal full budget consumption with no
+        // recorded attempt count, so fall back to the maximum. The inner
+        // EvmError match uses a wildcard here because EvmError has feature-gated
+        // variants (turnkey, local-signer) that cannot be enumerated from this
+        // crate without mirroring all their cfg gates. The outer WrapperError
+        // match is exhaustive, which is where new variants are most likely to
+        // carry a meaningful attempt count.
+        WrapperError::Evm(_)
+        | WrapperError::SymbolNotConfigured(_)
+        | WrapperError::MissingDepositEvent
+        | WrapperError::MissingWithdrawEvent
+        | WrapperError::RedeemExceedsMax { .. }
+        | WrapperError::Contract(_)
+        | WrapperError::Ratio(_)
+        | WrapperError::MissingBlockNumber { .. } => NODE_SYNC_MAX_ATTEMPTS,
+    }
 }
 
 /// Trait for wrapping and unwrapping tokens via ERC-4626 vaults.
@@ -131,13 +196,18 @@ pub trait Wrapper: Send + Sync {
         receiver: Address,
     ) -> Result<TxHash, WrapperError>;
 
-    /// Wait for a previously submitted wrap transaction to confirm
-    /// and extract the shares minted from the receipt.
+    /// Wait for a previously submitted wrap transaction to confirm,
+    /// extract the shares minted from the receipt, and return the
+    /// confirmation block number alongside the shares.
+    ///
+    /// The block number is returned so callers can pass it to
+    /// [`Wrapper::wait_for_block`] before submitting any dependent
+    /// on-chain write that reads the wrapped token balance.
     async fn confirm_wrap(
         &self,
         wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError>;
+    ) -> Result<WrapConfirmation, WrapperError>;
 
     /// Submit an ERC-4626 redeem without waiting for confirmation.
     ///
@@ -160,13 +230,32 @@ pub trait Wrapper: Send + Sync {
         owner: Address,
     ) -> Result<TxHash, WrapperError>;
 
-    /// Wait for a previously submitted unwrap transaction to confirm
-    /// and extract the underlying amount received from the receipt.
+    /// Wait for a previously submitted unwrap transaction to confirm and
+    /// extract the underlying amount received and the block it confirmed in.
+    ///
+    /// The block number is returned alongside the amount so callers can pass
+    /// it to [`Wrapper::wait_for_block`] before submitting any dependent
+    /// on-chain write that reads the unwrapped balance.
     async fn confirm_unwrap(
         &self,
         wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError>;
+    ) -> Result<UnwrapConfirmation, WrapperError>;
+
+    /// Block until the RPC node's tip is at least `block`.
+    ///
+    /// Load-balanced RPCs may route the next request to a backend that has
+    /// not yet indexed the block produced by a just-confirmed transaction.
+    /// Call this with the block number returned by [`confirm_unwrap`] before
+    /// submitting any dependent on-chain write that reads the unwrapped
+    /// token balance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WrapperError::Evm`] wrapping
+    /// [`st0x_evm::EvmError::NodeBehindRequiredBlock`] if the node never
+    /// catches up within the retry budget.
+    async fn wait_for_block(&self, block: u64) -> Result<(), WrapperError>;
 
     /// Returns the market maker wallet address that owns the wrapped tokens.
     fn owner(&self) -> Address;

--- a/crates/wrapper/src/mock.rs
+++ b/crates/wrapper/src/mock.rs
@@ -6,10 +6,12 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{Mutex, PoisonError};
 
-use st0x_evm::EvmError;
+use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::Symbol;
 
-use crate::{RATIO_ONE, UnderlyingPerWrapped, Wrapper, WrapperError};
+use crate::{
+    RATIO_ONE, UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, Wrapper, WrapperError,
+};
 
 /// Which operation the mock should simulate failing.
 #[derive(Default, PartialEq, Eq)]
@@ -22,6 +24,12 @@ enum MockFailure {
     Unwrap,
     Lookup,
     DerivativeLookup,
+    /// Fails `wait_for_block` with `NodeBehindRequiredBlock` (budget exhausted).
+    WaitForBlock,
+    /// Fails `wait_for_block` with a transport error (all polls failed before
+    /// any block number was observed). Tests the `_ => NODE_SYNC_MAX_ATTEMPTS`
+    /// fallback arm in error-mapping closures.
+    WaitForBlockTransportError,
 }
 
 /// Mock wrapper for testing that returns predictable values.
@@ -34,6 +42,8 @@ pub struct MockWrapper {
     failure: MockFailure,
     /// Maps tx hashes to their submitted amounts for confirm methods.
     submitted_amounts: Mutex<HashMap<TxHash, U256>>,
+    /// Blocks passed to `wait_for_block` calls, in order.
+    wait_for_block_calls: Mutex<Vec<u64>>,
 }
 
 impl MockWrapper {
@@ -46,6 +56,7 @@ impl MockWrapper {
             ratio: RATIO_ONE,
             failure: MockFailure::None,
             submitted_amounts: Mutex::new(HashMap::new()),
+            wait_for_block_calls: Mutex::new(Vec::new()),
         }
     }
 
@@ -59,6 +70,7 @@ impl MockWrapper {
             ratio,
             failure: MockFailure::None,
             submitted_amounts: Mutex::new(HashMap::new()),
+            wait_for_block_calls: Mutex::new(Vec::new()),
         }
     }
 
@@ -123,6 +135,25 @@ impl MockWrapper {
         mock
     }
 
+    /// Creates a mock wrapper that fails `wait_for_block` with a
+    /// `NodeBehindRequiredBlock` error (budget exhausted, at least one poll
+    /// succeeded but always returned a stale tip).
+    pub fn failing_wait_for_block() -> Self {
+        let mut mock = Self::new();
+        mock.failure = MockFailure::WaitForBlock;
+        mock
+    }
+
+    /// Creates a mock wrapper that fails `wait_for_block` with a transport
+    /// error (simulating all polls failing before any block number was observed).
+    /// Used to test the `_ => NODE_SYNC_MAX_ATTEMPTS` fallback arm in
+    /// error-mapping closures.
+    pub fn failing_wait_for_block_transport_error() -> Self {
+        let mut mock = Self::new();
+        mock.failure = MockFailure::WaitForBlockTransportError;
+        mock
+    }
+
     /// Pre-seeds a tx hash into `submitted_amounts` so that `confirm_wrap`
     /// recognises it. Used by tests that manually advance the aggregate to
     /// `WrapSubmitted` without going through `submit_wrap`.
@@ -131,6 +162,14 @@ impl MockWrapper {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(tx_hash, amount);
+    }
+
+    /// Returns a snapshot of the block numbers passed to `wait_for_block`, in call order.
+    pub fn wait_for_block_calls(&self) -> Vec<u64> {
+        self.wait_for_block_calls
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
     }
 }
 
@@ -211,7 +250,7 @@ impl Wrapper for MockWrapper {
         &self,
         _wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError> {
+    ) -> Result<WrapConfirmation, WrapperError> {
         if self.failure == MockFailure::ConfirmWrap {
             return Err(WrapperError::MissingDepositEvent);
         }
@@ -225,12 +264,16 @@ impl Wrapper for MockWrapper {
             ))));
         }
 
-        // 1:1 ratio — return the amount that was submitted for this tx
-        self.submitted_amounts
+        // 1:1 ratio — return the amount that was submitted for this tx.
+        // Block number is 0 in the mock (no real chain).
+        let shares = self
+            .submitted_amounts
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(&tx_hash)
-            .ok_or(WrapperError::MissingDepositEvent)
+            .ok_or(WrapperError::MissingDepositEvent)?;
+
+        Ok(WrapConfirmation { shares, block: 0 })
     }
 
     async fn submit_unwrap(
@@ -254,13 +297,39 @@ impl Wrapper for MockWrapper {
         &self,
         _wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError> {
-        // 1:1 ratio — return the amount that was submitted for this tx
-        self.submitted_amounts
+    ) -> Result<UnwrapConfirmation, WrapperError> {
+        // 1:1 ratio — return the amount that was submitted for this tx.
+        // Block number is 0 in the mock (no real chain).
+        let assets = self
+            .submitted_amounts
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(&tx_hash)
-            .ok_or(WrapperError::MissingWithdrawEvent)
+            .ok_or(WrapperError::MissingWithdrawEvent)?;
+
+        Ok(UnwrapConfirmation { assets, block: 0 })
+    }
+
+    async fn wait_for_block(&self, block: u64) -> Result<(), WrapperError> {
+        self.wait_for_block_calls
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(block);
+        if self.failure == MockFailure::WaitForBlock {
+            return Err(WrapperError::Evm(EvmError::NodeBehindRequiredBlock {
+                observed_tip: 0,
+                required_block: block,
+                attempts: NODE_SYNC_MAX_ATTEMPTS,
+            }));
+        }
+
+        if self.failure == MockFailure::WaitForBlockTransportError {
+            return Err(WrapperError::Evm(EvmError::Transport(
+                alloy::transports::RpcError::NullResp,
+            )));
+        }
+
+        Ok(())
     }
 
     fn owner(&self) -> Address {

--- a/crates/wrapper/src/service.rs
+++ b/crates/wrapper/src/service.rs
@@ -9,12 +9,19 @@ use alloy::sol;
 use alloy::sol_types::SolEvent;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::time::Duration;
 use tracing::info;
 
-use st0x_evm::{IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
+use st0x_evm::{
+    IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL, OpenChainErrorRegistry,
+    Wallet, wait_for_node_sync,
+};
 use st0x_execution::Symbol;
 
-use crate::{UnderlyingPerWrapped, WrappedEquity, Wrapper, WrapperError};
+use crate::{
+    UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, WrappedEquity, Wrapper,
+    WrapperError,
+};
 
 sol!(
     #![sol(all_derives = true, rpc)]
@@ -36,11 +43,36 @@ const RATIO_QUERY_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0,
 pub struct WrapperService<W: Wallet> {
     wallet: W,
     config: HashMap<Symbol, WrappedEquity>,
+    /// Poll interval used by node-sync waits (`wait_for_block` and the
+    /// post-approval deposit gate). Production always uses
+    /// [`NODE_SYNC_POLL_INTERVAL`]; tests override it to avoid sleeping
+    /// through the full production budget.
+    node_sync_poll_interval: Duration,
 }
 
 impl<W: Wallet> WrapperService<W> {
     pub fn new(wallet: W, config: HashMap<Symbol, WrappedEquity>) -> Self {
-        Self { wallet, config }
+        Self {
+            wallet,
+            config,
+            node_sync_poll_interval: NODE_SYNC_POLL_INTERVAL,
+        }
+    }
+
+    /// Constructs a service with a custom node-sync poll interval. Test-only:
+    /// lets node-sync exhaustion paths run without sleeping at the production
+    /// one-second cadence.
+    #[cfg(test)]
+    fn with_node_sync_poll_interval(
+        wallet: W,
+        config: HashMap<Symbol, WrappedEquity>,
+        node_sync_poll_interval: Duration,
+    ) -> Self {
+        Self {
+            wallet,
+            config,
+            node_sync_poll_interval,
+        }
     }
 
     /// Fetches the current conversion ratio for a wrapped token.
@@ -107,9 +139,9 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             .submit_wrap(wrapped_token, underlying_amount, receiver)
             .await?;
 
-        let actual_shares = self.confirm_wrap(wrapped_token, tx_hash).await?;
+        let WrapConfirmation { shares, .. } = self.confirm_wrap(wrapped_token, tx_hash).await?;
 
-        Ok((tx_hash, actual_shares))
+        Ok((tx_hash, shares))
     }
 
     async fn to_underlying(
@@ -123,9 +155,9 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             .submit_unwrap(wrapped_token, wrapped_amount, receiver, owner)
             .await?;
 
-        let actual_assets = self.confirm_unwrap(wrapped_token, tx_hash).await?;
+        let UnwrapConfirmation { assets, .. } = self.confirm_unwrap(wrapped_token, tx_hash).await?;
 
-        Ok((tx_hash, actual_assets))
+        Ok((tx_hash, assets))
     }
 
     async fn submit_wrap(
@@ -161,7 +193,8 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
                 "Approving ERC-4626 vault to spend underlying tokens"
             );
 
-            self.wallet
+            let approval_receipt = self
+                .wallet
                 .submit::<OpenChainErrorRegistry, _>(
                     underlying_token,
                     IERC20::approveCall {
@@ -171,6 +204,25 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
                     "ERC20 approve for ERC4626 deposit",
                 )
                 .await?;
+
+            // The deposit's pre-flight simulation reads the freshly granted
+            // allowance. A load-balanced backend that has not yet indexed the
+            // approval would see a zero allowance and revert the deposit, so
+            // wait for the node to reach the approval block before submitting.
+            let approval_block =
+                approval_receipt
+                    .block_number
+                    .ok_or(WrapperError::MissingBlockNumber {
+                        tx_hash: approval_receipt.transaction_hash,
+                    })?;
+
+            wait_for_node_sync(
+                self.wallet.provider(),
+                approval_block,
+                self.node_sync_poll_interval,
+                NODE_SYNC_MAX_ATTEMPTS,
+            )
+            .await?;
         }
 
         info!(target: "orderbook", %wrapped_token, %underlying_amount, "Sending ERC4626 deposit");
@@ -195,13 +247,17 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         &self,
         wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError> {
+    ) -> Result<WrapConfirmation, WrapperError> {
         let receipt = self
             .wallet
             .confirm::<OpenChainErrorRegistry>(tx_hash)
             .await?;
 
-        let actual_shares = receipt
+        let block = receipt
+            .block_number
+            .ok_or(WrapperError::MissingBlockNumber { tx_hash })?;
+
+        let shares = receipt
             .inner
             .logs()
             .iter()
@@ -213,7 +269,7 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             })
             .ok_or(WrapperError::MissingDepositEvent)?;
 
-        Ok(actual_shares)
+        Ok(WrapConfirmation { shares, block })
     }
 
     async fn submit_unwrap(
@@ -253,13 +309,17 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         &self,
         wrapped_token: Address,
         tx_hash: TxHash,
-    ) -> Result<U256, WrapperError> {
+    ) -> Result<UnwrapConfirmation, WrapperError> {
         let receipt = self
             .wallet
             .confirm::<OpenChainErrorRegistry>(tx_hash)
             .await?;
 
-        let actual_assets = receipt
+        let block = receipt
+            .block_number
+            .ok_or(WrapperError::MissingBlockNumber { tx_hash })?;
+
+        let assets = receipt
             .inner
             .logs()
             .iter()
@@ -271,7 +331,18 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
             })
             .ok_or(WrapperError::MissingWithdrawEvent)?;
 
-        Ok(actual_assets)
+        Ok(UnwrapConfirmation { assets, block })
+    }
+
+    async fn wait_for_block(&self, block: u64) -> Result<(), WrapperError> {
+        wait_for_node_sync(
+            self.wallet.provider(),
+            block,
+            self.node_sync_poll_interval,
+            NODE_SYNC_MAX_ATTEMPTS,
+        )
+        .await
+        .map_err(Into::into)
     }
 
     fn owner(&self) -> Address {
@@ -306,13 +377,17 @@ fn check_redeem_within_max(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::Bytes;
+    use alloy::consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom};
+    use alloy::primitives::{Bloom, Bytes};
+    use alloy::providers::Provider;
+    use alloy::providers::ProviderBuilder;
     use alloy::providers::RootProvider;
+    use alloy::providers::mock::Asserter;
     use alloy::rpc::client::RpcClient;
     use alloy::rpc::types::TransactionReceipt;
-    use std::sync::Arc;
-
+    use alloy::sol_types::SolCall;
     use st0x_evm::{Evm, EvmError};
+    use std::sync::Arc;
 
     use super::*;
 
@@ -529,6 +604,295 @@ mod tests {
                 } if token == wrapped_token && req == requested && max == max_redeem
             ),
             "expected RedeemExceedsMax carrying the requested/max amounts, got: {error:?}"
+        );
+    }
+
+    /// A wallet whose provider is backed by a mock transport (Asserter).
+    /// `wait_for_block` tests only need the provider; `submit_wrap` tests also
+    /// configure canned write results so the approve/deposit flow runs without
+    /// a real chain.
+    struct MockedWallet<P> {
+        address: Address,
+        provider: P,
+        send_receipt: Option<TransactionReceipt>,
+        send_pending_tx_hash: TxHash,
+    }
+
+    impl<P: Provider + Clone + Send + Sync + 'static> MockedWallet<P> {
+        fn new(address: Address, provider: P) -> Self {
+            Self {
+                address,
+                provider,
+                send_receipt: None,
+                send_pending_tx_hash: TxHash::ZERO,
+            }
+        }
+
+        /// Configures the receipt returned by `send` (the approve tx) and the
+        /// hash returned by `send_pending` (the deposit tx) so `submit_wrap`
+        /// can be driven end to end.
+        fn with_write_results(
+            mut self,
+            send_receipt: TransactionReceipt,
+            send_pending_tx_hash: TxHash,
+        ) -> Self {
+            self.send_receipt = Some(send_receipt);
+            self.send_pending_tx_hash = send_pending_tx_hash;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl<P: Provider + Clone + Send + Sync + 'static> Evm for MockedWallet<P> {
+        type Provider = P;
+
+        fn provider(&self) -> &P {
+            &self.provider
+        }
+    }
+
+    #[async_trait]
+    impl<P: Provider + Clone + Send + Sync + 'static> Wallet for MockedWallet<P> {
+        fn address(&self) -> Address {
+            self.address
+        }
+
+        async fn send_pending(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TxHash, EvmError> {
+            Ok(self.send_pending_tx_hash)
+        }
+
+        async fn await_receipt(&self, _tx_hash: TxHash) -> Result<TransactionReceipt, EvmError> {
+            Ok(self
+                .send_receipt
+                .clone()
+                .expect("await_receipt called without a configured send_receipt"))
+        }
+
+        async fn send(
+            &self,
+            _contract: Address,
+            _calldata: Bytes,
+            _note: &str,
+        ) -> Result<TransactionReceipt, EvmError> {
+            Ok(self
+                .send_receipt
+                .clone()
+                .expect("send called without a configured send_receipt"))
+        }
+    }
+
+    /// Verifies that `WrapperService::wait_for_block` delegates to
+    /// `wait_for_node_sync` correctly: when the node is already at the required
+    /// block, the call returns `Ok(())`.
+    #[tokio::test]
+    async fn wait_for_block_succeeds_when_node_is_at_required_block() {
+        let required_block = 42u64;
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::Value::from(required_block));
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = MockedWallet::new(Address::ZERO, provider);
+        let service = WrapperService::new(wallet, HashMap::new());
+
+        service
+            .wait_for_block(required_block)
+            .await
+            .expect("node is at required block -- wait_for_block must succeed");
+    }
+
+    /// Verifies that `WrapperService::wait_for_block` propagates
+    /// `EvmError::NodeBehindRequiredBlock` as `WrapperError::Evm` when the
+    /// node is consistently behind, confirming the `?` propagation inside the
+    /// service is wired correctly. Exercises all NODE_SYNC_MAX_ATTEMPTS (30)
+    /// poll attempts; the zero poll interval keeps the test instant instead of
+    /// sleeping through the production one-second cadence.
+    #[tokio::test]
+    async fn wait_for_block_propagates_node_behind_error_as_wrapper_evm_error() {
+        let required_block = 100u64;
+        let stale_tip = 1u64;
+        let asserter = Asserter::new();
+        // Push NODE_SYNC_MAX_ATTEMPTS stale-block responses so all attempts see
+        // a stale tip and the error is NodeBehindRequiredBlock.
+        for _ in 0..NODE_SYNC_MAX_ATTEMPTS {
+            asserter.push_success(&serde_json::Value::from(stale_tip));
+        }
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = MockedWallet::new(Address::ZERO, provider);
+        let service =
+            WrapperService::with_node_sync_poll_interval(wallet, HashMap::new(), Duration::ZERO);
+
+        let error = service
+            .wait_for_block(required_block)
+            .await
+            .expect_err("stale node must cause wait_for_block to fail");
+
+        assert!(
+            matches!(
+                error,
+                WrapperError::Evm(EvmError::NodeBehindRequiredBlock {
+                    required_block: 100,
+                    observed_tip: 1,
+                    attempts: NODE_SYNC_MAX_ATTEMPTS,
+                })
+            ),
+            "wait_for_block must surface NodeBehindRequiredBlock via WrapperError::Evm, got: {error:?}"
+        );
+    }
+
+    /// Builds a successful receipt carrying the given tx hash and block number.
+    fn receipt_with_block(tx_hash: TxHash, block_number: Option<u64>) -> TransactionReceipt {
+        TransactionReceipt {
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom {
+                receipt: Receipt {
+                    status: true.into(),
+                    cumulative_gas_used: 0,
+                    logs: vec![],
+                },
+                logs_bloom: Bloom::default(),
+            }),
+            transaction_hash: tx_hash,
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number,
+            gas_used: 21000,
+            effective_gas_price: 1,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        }
+    }
+
+    /// Queues the two `eth_call` reads `submit_wrap` performs before the
+    /// approval branch: `asset()` (returns the underlying token) and
+    /// `allowance()` (returned as zero so the on-demand approval path runs).
+    fn push_asset_and_zero_allowance(asserter: &Asserter, underlying_token: Address) {
+        asserter.push_success(&<IERC4626::assetCall as SolCall>::abi_encode_returns(
+            &underlying_token,
+        ));
+        asserter.push_success(&<IERC20::allowanceCall as SolCall>::abi_encode_returns(
+            &U256::ZERO,
+        ));
+    }
+
+    /// On the on-demand approval path, `submit_wrap` must wait for the node to
+    /// reach the approval block before submitting the deposit, then return the
+    /// deposit tx hash once the gate clears.
+    #[tokio::test]
+    async fn submit_wrap_waits_for_node_sync_before_deposit_after_approval() {
+        let underlying = Address::repeat_byte(0x11);
+        let wrapped = Address::repeat_byte(0x22);
+        let receiver = Address::repeat_byte(0x33);
+        let amount = U256::from(1_000u64);
+        let approval_block = 7u64;
+        let approve_tx = TxHash::repeat_byte(0xaa);
+        let deposit_tx = TxHash::repeat_byte(0xbb);
+
+        let asserter = Asserter::new();
+        push_asset_and_zero_allowance(&asserter, underlying);
+        // Node is already at the approval block, so the gate clears on the
+        // first poll and the deposit proceeds.
+        asserter.push_success(&serde_json::Value::from(approval_block));
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = MockedWallet::new(Address::ZERO, provider).with_write_results(
+            receipt_with_block(approve_tx, Some(approval_block)),
+            deposit_tx,
+        );
+        let service =
+            WrapperService::with_node_sync_poll_interval(wallet, HashMap::new(), Duration::ZERO);
+
+        let tx_hash = service
+            .submit_wrap(wrapped, amount, receiver)
+            .await
+            .expect("submit_wrap must succeed once the node-sync gate clears");
+
+        assert_eq!(
+            tx_hash, deposit_tx,
+            "submit_wrap must return the deposit tx hash after the node-sync gate clears"
+        );
+    }
+
+    /// If the node never reaches the approval block, `submit_wrap` must surface
+    /// `NodeBehindRequiredBlock` and never attempt the deposit -- proving the
+    /// deposit is gated on the post-approval node-sync wait.
+    #[tokio::test]
+    async fn submit_wrap_gates_deposit_when_node_stays_behind_approval_block() {
+        let underlying = Address::repeat_byte(0x11);
+        let wrapped = Address::repeat_byte(0x22);
+        let receiver = Address::repeat_byte(0x33);
+        let amount = U256::from(1_000u64);
+        let approval_block = 100u64;
+        let stale_tip = 1u64;
+        let approve_tx = TxHash::repeat_byte(0xaa);
+
+        let asserter = Asserter::new();
+        push_asset_and_zero_allowance(&asserter, underlying);
+        // Every poll sees a stale tip, so the gate never clears.
+        for _ in 0..NODE_SYNC_MAX_ATTEMPTS {
+            asserter.push_success(&serde_json::Value::from(stale_tip));
+        }
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = MockedWallet::new(Address::ZERO, provider).with_write_results(
+            receipt_with_block(approve_tx, Some(approval_block)),
+            TxHash::repeat_byte(0xbb),
+        );
+        let service =
+            WrapperService::with_node_sync_poll_interval(wallet, HashMap::new(), Duration::ZERO);
+
+        let error = service
+            .submit_wrap(wrapped, amount, receiver)
+            .await
+            .expect_err("a node stuck behind the approval block must gate the deposit");
+
+        assert!(
+            matches!(
+                error,
+                WrapperError::Evm(EvmError::NodeBehindRequiredBlock {
+                    required_block: 100,
+                    observed_tip: 1,
+                    attempts: NODE_SYNC_MAX_ATTEMPTS,
+                })
+            ),
+            "submit_wrap must gate the deposit on node sync and surface NodeBehindRequiredBlock, got: {error:?}"
+        );
+    }
+
+    /// A confirmed approval receipt without a block number must fail hard --
+    /// silently skipping the node-sync wait would re-open the stale-RPC race.
+    #[tokio::test]
+    async fn submit_wrap_fails_when_approval_receipt_has_no_block_number() {
+        let underlying = Address::repeat_byte(0x11);
+        let wrapped = Address::repeat_byte(0x22);
+        let receiver = Address::repeat_byte(0x33);
+        let amount = U256::from(1_000u64);
+        let approve_tx = TxHash::repeat_byte(0xaa);
+
+        let asserter = Asserter::new();
+        push_asset_and_zero_allowance(&asserter, underlying);
+
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+        let wallet = MockedWallet::new(Address::ZERO, provider).with_write_results(
+            receipt_with_block(approve_tx, None),
+            TxHash::repeat_byte(0xbb),
+        );
+        let service =
+            WrapperService::with_node_sync_poll_interval(wallet, HashMap::new(), Duration::ZERO);
+
+        let error = service
+            .submit_wrap(wrapped, amount, receiver)
+            .await
+            .expect_err("a blockless approval receipt must fail submit_wrap");
+
+        assert!(
+            matches!(error, WrapperError::MissingBlockNumber { tx_hash } if tx_hash == approve_tx),
+            "submit_wrap must fail with MissingBlockNumber when the approval receipt has no block, got: {error:?}"
         );
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -861,6 +861,7 @@ pub async fn seed_mint_at_tokens_wrapped_for_test(
             wrap_tx_hash,
             wrapped_shares,
             wrapped_at: now,
+            wrap_block: None,
         },
     ];
 

--- a/src/dashboard/transfer_loader.rs
+++ b/src/dashboard/transfer_loader.rs
@@ -537,6 +537,7 @@ mod tests {
                 wrapped_amount: alloy::primitives::U256::from(20),
                 actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::ZERO,
+                raindex_withdraw_block: None,
                 withdrawn_at: two_days_ago,
             })
             .unwrap(),
@@ -572,6 +573,7 @@ mod tests {
                 wrapped_amount: alloy::primitives::U256::from(15),
                 actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::ZERO,
+                raindex_withdraw_block: None,
                 withdrawn_at: now,
             })
             .unwrap(),

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -71,8 +71,10 @@ use uuid::Uuid;
 
 use st0x_dto::{EquityRedemptionOperation, EquityRedemptionStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
+use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, Id};
+use st0x_wrapper::WrapperError;
 
 use crate::bindings::IERC20;
 use crate::rebalancing::equity::EquityTransferServices;
@@ -223,6 +225,21 @@ pub(crate) enum EquityRedemptionError {
     /// Attempted to modify a failed redemption operation
     #[error("Already failed")]
     AlreadyFailed,
+    /// RPC node did not catch up to the required block before the wait budget
+    /// was exhausted. This is a retryable failure; the job should be retried
+    /// once the node has indexed the required block.
+    #[error(
+        "RPC node did not catch up to required block {required_block} \
+         after {attempts} polls"
+    )]
+    NodeSyncFailed { required_block: u64, attempts: u32 },
+    /// The Raindex withdrawal receipt did not include a block number.
+    /// Fresh receipts must carry a block number so the node-sync guard in
+    /// SubmitUnwrap can wait for the correct block before submitting the
+    /// unwrap. A None block number on a freshly confirmed receipt indicates
+    /// an RPC edge case (e.g. pending or uncle-block receipt).
+    #[error("Raindex withdrawal receipt for {tx_hash} is missing block number")]
+    MissingWithdrawBlock { tx_hash: TxHash },
 }
 
 #[derive(Debug, Clone)]
@@ -321,6 +338,13 @@ pub(crate) enum EquityRedemptionEvent {
         #[serde(default)]
         actual_wrapped_amount: Option<U256>,
         raindex_withdraw_tx: TxHash,
+        /// Block number in which the Raindex withdrawal tx confirmed.
+        ///
+        /// `None` for events emitted before this field was added (schema
+        /// backward-compatibility). When `None`, the RPC node-sync wait is
+        /// skipped in `SubmitUnwrap`.
+        #[serde(default)]
+        raindex_withdraw_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
     },
     /// ERC-4626 wrapped tokens have been unwrapped.
@@ -334,6 +358,13 @@ pub(crate) enum EquityRedemptionEvent {
         underlying_token: Address,
         unwrap_tx_hash: TxHash,
         unwrapped_amount: U256,
+        /// Block number in which the unwrap tx confirmed.
+        ///
+        /// `None` for events emitted before this field was added (schema
+        /// backward-compatibility). When `None`, the RPC node-sync wait is
+        /// skipped in `SendTokens`.
+        #[serde(default)]
+        unwrap_block: Option<u64>,
         unwrapped_at: DateTime<Utc>,
     },
     /// Unwrap requested, awaiting submission.
@@ -508,6 +539,7 @@ impl PartialEq for EquityRedemptionEvent {
                     wrapped_amount: w1,
                     actual_wrapped_amount: aw1,
                     raindex_withdraw_tx: r1,
+                    raindex_withdraw_block: rb1,
                     withdrawn_at: wa1,
                 },
                 Self::WithdrawnFromRaindex {
@@ -517,6 +549,7 @@ impl PartialEq for EquityRedemptionEvent {
                     wrapped_amount: w2,
                     actual_wrapped_amount: aw2,
                     raindex_withdraw_tx: r2,
+                    raindex_withdraw_block: rb2,
                     withdrawn_at: wa2,
                 },
             ) => {
@@ -526,6 +559,7 @@ impl PartialEq for EquityRedemptionEvent {
                     && w1 == w2
                     && aw1 == aw2
                     && r1 == r2
+                    && rb1 == rb2
                     && wa1 == wa2
             }
             (
@@ -534,6 +568,7 @@ impl PartialEq for EquityRedemptionEvent {
                     underlying_token: u1,
                     unwrap_tx_hash: h1,
                     unwrapped_amount: a1,
+                    unwrap_block: b1,
                     unwrapped_at: t1,
                 },
                 Self::TokensUnwrapped {
@@ -541,6 +576,7 @@ impl PartialEq for EquityRedemptionEvent {
                     underlying_token: u2,
                     unwrap_tx_hash: h2,
                     unwrapped_amount: a2,
+                    unwrap_block: b2,
                     unwrapped_at: t2,
                 },
             ) => {
@@ -550,6 +586,7 @@ impl PartialEq for EquityRedemptionEvent {
                         .is_none_or(|(q1, q2)| q1.eq(q2).unwrap_or(false))
                     && u1 == u2
                     && h1 == h2
+                    && b1 == b2
                     && a1 == a2
                     && t1 == t2
             }
@@ -705,6 +742,9 @@ pub(crate) enum EquityRedemption {
         token: Address,
         wrapped_amount: U256,
         raindex_withdraw_tx: TxHash,
+        /// Block in which the Raindex withdrawal tx confirmed; `None` for pre-fix aggregates.
+        #[serde(default)]
+        raindex_withdraw_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
     },
 
@@ -719,6 +759,9 @@ pub(crate) enum EquityRedemption {
         token: Address,
         wrapped_amount: U256,
         raindex_withdraw_tx: TxHash,
+        /// Block in which the Raindex withdrawal tx confirmed; `None` for pre-fix aggregates.
+        #[serde(default)]
+        raindex_withdraw_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
     },
 
@@ -733,6 +776,9 @@ pub(crate) enum EquityRedemption {
         token: Address,
         wrapped_amount: U256,
         raindex_withdraw_tx: TxHash,
+        /// Block in which the Raindex withdrawal tx confirmed; `None` for pre-fix aggregates.
+        #[serde(default)]
+        raindex_withdraw_block: Option<u64>,
         unwrap_tx_hash: TxHash,
         withdrawn_at: DateTime<Utc>,
     },
@@ -750,6 +796,9 @@ pub(crate) enum EquityRedemption {
         raindex_withdraw_tx: TxHash,
         unwrap_tx_hash: TxHash,
         unwrapped_amount: U256,
+        /// Block in which the unwrap tx confirmed; `None` for pre-fix aggregates.
+        #[serde(default)]
+        unwrap_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
         unwrapped_at: DateTime<Utc>,
     },
@@ -767,6 +816,13 @@ pub(crate) enum EquityRedemption {
         raindex_withdraw_tx: TxHash,
         unwrap_tx_hash: TxHash,
         unwrapped_amount: U256,
+        /// Block in which the unwrap tx confirmed; `None` for pre-fix aggregates.
+        ///
+        /// `None` disables the RPC node-sync wait in `SendTokens` for
+        /// backward-compatibility with in-flight aggregates that were
+        /// persisted before this field was added.
+        #[serde(default)]
+        unwrap_block: Option<u64>,
         withdrawn_at: DateTime<Utc>,
         unwrapped_at: DateTime<Utc>,
     },
@@ -1069,6 +1125,7 @@ impl EventSourced for EquityRedemption {
                 wrapped_amount,
                 actual_wrapped_amount,
                 raindex_withdraw_tx,
+                raindex_withdraw_block,
                 withdrawn_at,
             } => Some(Self::WithdrawnFromRaindex {
                 symbol: symbol.clone(),
@@ -1079,6 +1136,7 @@ impl EventSourced for EquityRedemption {
                     *actual_wrapped_amount,
                 ),
                 raindex_withdraw_tx: *raindex_withdraw_tx,
+                raindex_withdraw_block: *raindex_withdraw_block,
                 withdrawn_at: *withdrawn_at,
             }),
             _ => None,
@@ -1117,6 +1175,7 @@ impl EventSourced for EquityRedemption {
                 wrapped_amount,
                 actual_wrapped_amount,
                 raindex_withdraw_tx,
+                raindex_withdraw_block,
                 withdrawn_at,
             } => match entity {
                 Self::VaultWithdrawPending { .. } | Self::VaultWithdrawSubmitted { .. } => {
@@ -1129,6 +1188,7 @@ impl EventSourced for EquityRedemption {
                             *actual_wrapped_amount,
                         ),
                         raindex_withdraw_tx: *raindex_withdraw_tx,
+                        raindex_withdraw_block: *raindex_withdraw_block,
                         withdrawn_at: *withdrawn_at,
                     })
                 }
@@ -1226,6 +1286,7 @@ impl EventSourced for EquityRedemption {
                     token,
                     wrapped_amount,
                     raindex_withdraw_tx,
+                    raindex_withdraw_block,
                     withdrawn_at,
                 } => Some(Self::UnwrapPending {
                     symbol: symbol.clone(),
@@ -1233,6 +1294,7 @@ impl EventSourced for EquityRedemption {
                     token: *token,
                     wrapped_amount: *wrapped_amount,
                     raindex_withdraw_tx: *raindex_withdraw_tx,
+                    raindex_withdraw_block: *raindex_withdraw_block,
                     withdrawn_at: *withdrawn_at,
                 }),
                 _ => None,
@@ -1248,6 +1310,7 @@ impl EventSourced for EquityRedemption {
                     token,
                     wrapped_amount,
                     raindex_withdraw_tx,
+                    raindex_withdraw_block,
                     withdrawn_at,
                 }
                 | Self::UnwrapPending {
@@ -1256,6 +1319,7 @@ impl EventSourced for EquityRedemption {
                     token,
                     wrapped_amount,
                     raindex_withdraw_tx,
+                    raindex_withdraw_block,
                     withdrawn_at,
                 } => Some(Self::UnwrapSubmitted {
                     symbol: symbol.clone(),
@@ -1263,6 +1327,7 @@ impl EventSourced for EquityRedemption {
                     token: *token,
                     wrapped_amount: *wrapped_amount,
                     raindex_withdraw_tx: *raindex_withdraw_tx,
+                    raindex_withdraw_block: *raindex_withdraw_block,
                     unwrap_tx_hash: *unwrap_tx_hash,
                     withdrawn_at: *withdrawn_at,
                 }),
@@ -1274,6 +1339,7 @@ impl EventSourced for EquityRedemption {
                 underlying_token,
                 unwrap_tx_hash,
                 unwrapped_amount,
+                unwrap_block,
                 unwrapped_at,
             } => match entity {
                 Self::WithdrawnFromRaindex {
@@ -1307,6 +1373,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: *raindex_withdraw_tx,
                     unwrap_tx_hash: *unwrap_tx_hash,
                     unwrapped_amount: *unwrapped_amount,
+                    unwrap_block: *unwrap_block,
                     withdrawn_at: *withdrawn_at,
                     unwrapped_at: *unwrapped_at,
                 }),
@@ -1322,6 +1389,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx,
                     unwrap_tx_hash,
                     unwrapped_amount,
+                    unwrap_block,
                     withdrawn_at,
                     unwrapped_at,
                 } => Some(Self::SendPending {
@@ -1332,6 +1400,7 @@ impl EventSourced for EquityRedemption {
                     raindex_withdraw_tx: *raindex_withdraw_tx,
                     unwrap_tx_hash: *unwrap_tx_hash,
                     unwrapped_amount: *unwrapped_amount,
+                    unwrap_block: *unwrap_block,
                     withdrawn_at: *withdrawn_at,
                     unwrapped_at: *unwrapped_at,
                 }),
@@ -1636,6 +1705,9 @@ impl EventSourced for EquityRedemption {
                             amount: *wrapped_amount,
                             error_message: error.to_string(),
                         })?;
+                    let raindex_withdraw_block = receipt
+                        .block_number
+                        .ok_or(EquityRedemptionError::MissingWithdrawBlock { tx_hash: *tx_hash })?;
                     let recipient = services.wrapper.owner();
                     let actual_wrapped_amount =
                         actual_withdrawn_amount_from_receipt(&receipt, *token, recipient)?;
@@ -1646,6 +1718,7 @@ impl EventSourced for EquityRedemption {
                         wrapped_amount: *wrapped_amount,
                         actual_wrapped_amount: Some(actual_wrapped_amount),
                         raindex_withdraw_tx: *tx_hash,
+                        raindex_withdraw_block: Some(raindex_withdraw_block),
                         withdrawn_at: Utc::now(),
                     }])
                 }
@@ -1667,8 +1740,22 @@ impl EventSourced for EquityRedemption {
                 Self::UnwrapPending {
                     token,
                     wrapped_amount,
+                    raindex_withdraw_block,
                     ..
                 } => {
+                    // Wait for the RPC node to catch up to the block where the
+                    // Raindex withdrawal tx confirmed before submitting the unwrap.
+                    // Without this, a load-balanced backend that hasn't indexed
+                    // the withdrawal may simulate the unwrap against a stale
+                    // wrapped-token balance. `raindex_withdraw_block` is None for
+                    // pre-fix aggregates; skip the wait for backward-compatibility.
+                    if let Some(block) = raindex_withdraw_block {
+                        services
+                            .wrapper
+                            .wait_for_block(*block)
+                            .await
+                            .map_err(|error| node_sync_failed(*block, &error))?;
+                    }
                     let owner = services.wrapper.owner();
                     let unwrap_tx_hash = services
                         .wrapper
@@ -1712,7 +1799,7 @@ impl EventSourced for EquityRedemption {
                             error_message: error.to_string(),
                         })?;
 
-                    let unwrapped_amount = services
+                    let unwrap_confirmation = services
                         .wrapper
                         .confirm_unwrap(*token, *unwrap_tx_hash)
                         .await
@@ -1724,6 +1811,8 @@ impl EventSourced for EquityRedemption {
                             wrapped_amount: *wrapped_amount,
                             error_message: error.to_string(),
                         })?;
+                    let unwrapped_amount = unwrap_confirmation.assets;
+                    let unwrap_block = unwrap_confirmation.block;
                     let quantity =
                         Float::from_fixed_decimal(unwrapped_amount, TOKENIZED_EQUITY_DECIMALS)
                             .map_err(|error| {
@@ -1739,6 +1828,7 @@ impl EventSourced for EquityRedemption {
                         underlying_token,
                         unwrap_tx_hash: *unwrap_tx_hash,
                         unwrapped_amount,
+                        unwrap_block: Some(unwrap_block),
                         unwrapped_at: Utc::now(),
                     }])
                 }
@@ -1761,6 +1851,7 @@ impl EventSourced for EquityRedemption {
                     symbol,
                     underlying_token,
                     unwrapped_amount,
+                    unwrap_block,
                     ..
                 } => {
                     let token = *underlying_token;
@@ -1776,6 +1867,25 @@ impl EventSourced for EquityRedemption {
                             failed_at: Utc::now(),
                         }]);
                     };
+
+                    // Wait for the RPC node to catch up to the block where the
+                    // unwrap tx confirmed before sending the transfer. Without
+                    // this, a load-balanced backend that hasn't indexed the
+                    // unwrap block yet sees the wallet balance as zero and the
+                    // send_for_redemption call reverts with
+                    // ERC20InsufficientBalance. The wait runs on the tokenizer's
+                    // provider -- the same one that performs the transfer -- so
+                    // a caught-up wrapper provider can't mask a lagging
+                    // tokenizer provider. `unwrap_block` is None for aggregates
+                    // persisted before this field was added; in that case the
+                    // wait is skipped for backward-compatibility.
+                    if let Some(block) = unwrap_block {
+                        services
+                            .tokenizer
+                            .wait_for_block(*block)
+                            .await
+                            .map_err(|error| node_sync_failed_from_evm(*block, &error))?;
+                    }
 
                     info!(target: "rebalance", %token, %amount, "Sending unwrapped tokens for redemption");
 
@@ -2234,6 +2344,39 @@ fn parse_requested_stuck_quantity(
     Ok(Some(FractionalShares::new(quantity)))
 }
 
+/// Constructs a [`EquityRedemptionError::NodeSyncFailed`] from a `required_block` and a
+/// [`WrapperError`] returned by `wait_for_block`.
+///
+/// Delegates attempt extraction to [`st0x_wrapper::node_sync_attempts`] so
+/// both the equity-redemption and orphan-recovery paths share the same
+/// extraction logic and stay in sync when new error variants are added.
+fn node_sync_failed(required_block: u64, error: &WrapperError) -> EquityRedemptionError {
+    EquityRedemptionError::NodeSyncFailed {
+        required_block,
+        attempts: st0x_wrapper::node_sync_attempts(error),
+    }
+}
+
+/// Constructs a [`EquityRedemptionError::NodeSyncFailed`] from a node-sync
+/// [`EvmError`] raised by [`Tokenizer::wait_for_block`].
+///
+/// Returns the recorded attempt count for `NodeBehindRequiredBlock`; every
+/// other variant signals the full polling budget was consumed without a
+/// recorded count, so it falls back to [`NODE_SYNC_MAX_ATTEMPTS`]. The match is
+/// non-exhaustive because `EvmError` has feature-gated variants that cannot be
+/// enumerated here.
+fn node_sync_failed_from_evm(required_block: u64, error: &EvmError) -> EquityRedemptionError {
+    let attempts = match error {
+        EvmError::NodeBehindRequiredBlock { attempts, .. } => *attempts,
+        _ => NODE_SYNC_MAX_ATTEMPTS,
+    };
+
+    EquityRedemptionError::NodeSyncFailed {
+        required_block,
+        attempts,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -2243,12 +2386,13 @@ mod tests {
     use alloy::rpc::types::Log;
     use st0x_dto::EquityRedemptionStatus;
     use st0x_event_sorcery::{AggregateError, LifecycleError, TestHarness, TestStore, replay};
+    use st0x_evm::NODE_SYNC_MAX_ATTEMPTS;
     use st0x_float_macro::float;
     use st0x_raindex::RaindexVaultId;
     use st0x_wrapper::MockWrapper;
 
     use super::*;
-    use crate::onchain::mock::MockRaindex;
+    use crate::onchain::mock::{ConfirmTxBehavior, MockRaindex};
     use crate::tokenization::mock::MockTokenizer;
     use crate::vault_lookup::MockVaultLookup;
 
@@ -2337,6 +2481,7 @@ mod tests {
             wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
             actual_wrapped_amount: None,
             raindex_withdraw_tx: TxHash::random(),
+            raindex_withdraw_block: None,
             withdrawn_at: Utc::now(),
         }
     }
@@ -2355,6 +2500,7 @@ mod tests {
             underlying_token: Address::random(),
             unwrap_tx_hash: TxHash::random(),
             unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+            unwrap_block: None,
             unwrapped_at: Utc::now(),
         }
     }
@@ -2730,6 +2876,61 @@ mod tests {
         );
     }
 
+    /// Verifies that `ConfirmWithdraw` returns `MissingWithdrawBlock` when the
+    /// Raindex receipt does not carry a block number.
+    ///
+    /// A fresh receipt with `block_number: None` (e.g. from a load-balanced RPC
+    /// returning a pending receipt) must fail hard; silently storing `None`
+    /// would bypass the `SubmitUnwrap` node-sync guard, re-introducing the
+    /// stale-RPC regression this PR was created to prevent.
+    #[tokio::test]
+    async fn confirm_withdraw_fails_when_receipt_has_no_block_number() {
+        let services = EquityTransferServices {
+            raindex: Arc::new(
+                MockRaindex::new()
+                    .with_confirm_behavior(ConfirmTxBehavior::SucceedWithoutBlockNumber),
+            ),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+        let store = TestStore::<EquityRedemption>::new(services);
+        let id = redemption_aggregate_id("no-block-number");
+
+        store
+            .send(
+                &id,
+                EquityRedemptionCommand::Redeem {
+                    symbol: Symbol::new("COIN").unwrap(),
+                    quantity: float!(10),
+                    token: Address::random(),
+                    amount: U256::from(10_000_000_000_000_000_000_u128),
+                },
+            )
+            .await
+            .unwrap();
+
+        store
+            .send(&id, EquityRedemptionCommand::SubmitWithdraw)
+            .await
+            .unwrap();
+
+        let error = store
+            .send(&id, EquityRedemptionCommand::ConfirmWithdraw)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                AggregateError::UserError(LifecycleError::Apply(
+                    EquityRedemptionError::MissingWithdrawBlock { .. }
+                ))
+            ),
+            "Expected MissingWithdrawBlock when receipt has no block number, got: {error:?}"
+        );
+    }
+
     #[test]
     fn actual_withdrawn_amount_sums_only_matching_receipt_transfers() {
         let token = Address::repeat_byte(0x11);
@@ -2869,6 +3070,7 @@ mod tests {
                 wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
                 actual_wrapped_amount: None,
                 raindex_withdraw_tx: TxHash::random(),
+                raindex_withdraw_block: None,
                 withdrawn_at: Utc::now(),
             },
             EquityRedemptionEvent::TokensSent {
@@ -3750,6 +3952,7 @@ mod tests {
             token: Address::random(),
             wrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
             raindex_withdraw_tx: TxHash::random(),
+            raindex_withdraw_block: None,
             withdrawn_at: now,
         };
         let TransferOperation::EquityRedemption(op) = withdrawn.to_dto(&id) else {
@@ -3777,6 +3980,7 @@ mod tests {
             raindex_withdraw_tx: TxHash::random(),
             unwrap_tx_hash: TxHash::random(),
             unwrapped_amount: U256::from(50_250_000_000_000_000_000_u128),
+            unwrap_block: None,
             withdrawn_at: now,
             unwrapped_at: later,
         };
@@ -4181,5 +4385,301 @@ mod tests {
             error,
             LifecycleError::Apply(EquityRedemptionError::NotStarted)
         ));
+    }
+
+    /// Verifies that `SendTokens` calls `wait_for_block` with the unwrap
+    /// block number before submitting the transfer, ensuring the RPC node
+    /// has indexed the unwrap tx's effects before the send is attempted.
+    #[tokio::test]
+    async fn send_tokens_waits_for_block_before_sending() {
+        let unwrap_block = 1234u64;
+        let mock_tokenizer = Arc::new(MockTokenizer::new());
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: mock_tokenizer.clone(),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+
+        let events = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                EquityRedemptionEvent::TokensUnwrapped {
+                    quantity: Some(float!(1.0)),
+                    underlying_token: Address::ZERO,
+                    unwrap_tx_hash: TxHash::random(),
+                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    unwrap_block: Some(unwrap_block),
+                    unwrapped_at: Utc::now(),
+                },
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SendTokens)
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one event from SendTokens"
+        );
+        assert!(
+            matches!(events[0], EquityRedemptionEvent::TokensSent { .. }),
+            "expected TokensSent, got {:?}",
+            events[0]
+        );
+
+        let calls = mock_tokenizer.wait_for_block_calls();
+
+        assert_eq!(
+            calls,
+            vec![unwrap_block],
+            "wait_for_block must be called once with the unwrap block number"
+        );
+    }
+
+    /// Verifies the backward-compat path: when `unwrap_block` is `None`
+    /// (aggregates persisted before this field was added), `SendTokens`
+    /// skips `wait_for_block` entirely and proceeds to `send_for_redemption`.
+    #[tokio::test]
+    async fn send_tokens_skips_wait_for_block_when_unwrap_block_is_none() {
+        let mock_tokenizer = Arc::new(MockTokenizer::new());
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: mock_tokenizer.clone(),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+
+        let events = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                EquityRedemptionEvent::TokensUnwrapped {
+                    quantity: Some(float!(1.0)),
+                    underlying_token: Address::ZERO,
+                    unwrap_tx_hash: TxHash::random(),
+                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    unwrap_block: None,
+                    unwrapped_at: Utc::now(),
+                },
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SendTokens)
+            .await
+            .events();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected exactly one event from SendTokens"
+        );
+        assert!(
+            matches!(events[0], EquityRedemptionEvent::TokensSent { .. }),
+            "expected TokensSent to succeed without wait_for_block, got {:?}",
+            events[0]
+        );
+
+        let calls = mock_tokenizer.wait_for_block_calls();
+
+        assert_eq!(
+            calls,
+            Vec::<u64>::new(),
+            "wait_for_block must NOT be called when unwrap_block is None, got calls: {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_tokens_fails_with_node_sync_failed_when_wait_for_block_fails() {
+        let required_block = 42u64;
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: Arc::new(MockTokenizer::new().failing_wait_for_block()),
+            wrapper: Arc::new(MockWrapper::new()),
+        };
+
+        let error = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                withdrawn_from_raindex_event(),
+                EquityRedemptionEvent::TokensUnwrapped {
+                    quantity: Some(float!(1.0)),
+                    underlying_token: Address::ZERO,
+                    unwrap_tx_hash: TxHash::random(),
+                    unwrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    unwrap_block: Some(required_block),
+                    unwrapped_at: Utc::now(),
+                },
+                EquityRedemptionEvent::SendPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SendTokens)
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::NodeSyncFailed {
+                    required_block: 42,
+                    attempts: NODE_SYNC_MAX_ATTEMPTS,
+                })
+            ),
+            "expected NodeSyncFailed {{ required_block: 42, attempts: {NODE_SYNC_MAX_ATTEMPTS} }}, got: {error:?}",
+        );
+    }
+
+    /// Verifies SubmitUnwrap waits for the Raindex withdrawal block before submitting.
+    #[tokio::test]
+    async fn submit_unwrap_waits_for_block_before_submitting() {
+        let withdraw_block = 5555u64;
+        let mock_wrapper = Arc::new(MockWrapper::new());
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: mock_wrapper.clone(),
+        };
+
+        let token = Address::ZERO;
+        let events = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                EquityRedemptionEvent::WithdrawnFromRaindex {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(1.0),
+                    token,
+                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
+                    raindex_withdraw_tx: TxHash::random(),
+                    raindex_withdraw_block: Some(withdraw_block),
+                    withdrawn_at: Utc::now(),
+                },
+                EquityRedemptionEvent::UnwrapPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert!(
+            matches!(events[0], EquityRedemptionEvent::UnwrapSubmitted { .. }),
+            "expected UnwrapSubmitted, got {:?}",
+            events[0]
+        );
+
+        let calls = mock_wrapper.wait_for_block_calls();
+        assert_eq!(
+            calls,
+            vec![withdraw_block],
+            "wait_for_block must be called once with the withdraw block before submitting unwrap"
+        );
+    }
+
+    /// Verifies that when raindex_withdraw_block is None (legacy aggregate),
+    /// SubmitUnwrap skips wait_for_block and proceeds directly.
+    #[tokio::test]
+    async fn submit_unwrap_skips_wait_for_block_when_withdraw_block_is_none() {
+        let mock_wrapper = Arc::new(MockWrapper::new());
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: mock_wrapper.clone(),
+        };
+
+        let token = Address::ZERO;
+        let events = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                EquityRedemptionEvent::WithdrawnFromRaindex {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(1.0),
+                    token,
+                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
+                    raindex_withdraw_tx: TxHash::random(),
+                    raindex_withdraw_block: None,
+                    withdrawn_at: Utc::now(),
+                },
+                EquityRedemptionEvent::UnwrapPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1, "expected exactly one event");
+        assert!(
+            matches!(events[0], EquityRedemptionEvent::UnwrapSubmitted { .. }),
+            "expected UnwrapSubmitted, got {:?}",
+            events[0]
+        );
+
+        assert_eq!(
+            mock_wrapper.wait_for_block_calls(),
+            Vec::<u64>::new(),
+            "wait_for_block must NOT be called when raindex_withdraw_block is None"
+        );
+    }
+
+    /// Verifies that `SubmitUnwrap` propagates a `wait_for_block` failure as
+    /// `NodeSyncFailed` when `raindex_withdraw_block` is `Some`.
+    ///
+    /// Symmetric to `send_tokens_fails_with_node_sync_failed_when_wait_for_block_fails`.
+    /// A copy-paste or refactor error in the `SubmitUnwrap` error-mapping arm
+    /// would mis-classify the error, breaking the retry-logic that depends on
+    /// receiving `NodeSyncFailed`.
+    #[tokio::test]
+    async fn submit_unwrap_fails_with_node_sync_failed_when_wait_for_block_fails() {
+        let required_block = 42u64;
+
+        let services = EquityTransferServices {
+            raindex: Arc::new(MockRaindex::new()),
+            vault_lookup: Arc::new(mock_vault_lookup()),
+            tokenizer: Arc::new(MockTokenizer::new()),
+            wrapper: Arc::new(MockWrapper::failing_wait_for_block()),
+        };
+
+        let error = TestHarness::<EquityRedemption>::with(services)
+            .given(vec![
+                EquityRedemptionEvent::WithdrawnFromRaindex {
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(1.0),
+                    token: Address::ZERO,
+                    wrapped_amount: U256::from(1_000_000_000_000_000_000_u64),
+                    actual_wrapped_amount: Some(U256::from(1_000_000_000_000_000_000_u64)),
+                    raindex_withdraw_tx: TxHash::random(),
+                    raindex_withdraw_block: Some(required_block),
+                    withdrawn_at: Utc::now(),
+                },
+                EquityRedemptionEvent::UnwrapPending {
+                    pending_at: Utc::now(),
+                },
+            ])
+            .when(EquityRedemptionCommand::SubmitUnwrap)
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(EquityRedemptionError::NodeSyncFailed {
+                    required_block: 42,
+                    attempts: NODE_SYNC_MAX_ATTEMPTS,
+                })
+            ),
+            "expected NodeSyncFailed {{ required_block: 42, attempts: {NODE_SYNC_MAX_ATTEMPTS} }}, got: {error:?}",
+        );
     }
 }

--- a/src/onchain/approvals.rs
+++ b/src/onchain/approvals.rs
@@ -288,7 +288,7 @@ mod tests {
 
     use st0x_evm::Evm;
     use st0x_evm::local::RawPrivateKeyWallet;
-    use st0x_wrapper::{UnderlyingPerWrapped, WrappedEquity};
+    use st0x_wrapper::{UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, WrappedEquity};
 
     use super::*;
     use crate::bindings::TestERC20;
@@ -359,7 +359,7 @@ mod tests {
             &self,
             _wrapped_token: Address,
             _tx_hash: TxHash,
-        ) -> Result<U256, WrapperError> {
+        ) -> Result<WrapConfirmation, WrapperError> {
             unimplemented!("confirm_wrap not used by approval target building")
         }
 
@@ -377,8 +377,12 @@ mod tests {
             &self,
             _wrapped_token: Address,
             _tx_hash: TxHash,
-        ) -> Result<U256, WrapperError> {
+        ) -> Result<UnwrapConfirmation, WrapperError> {
             unimplemented!("confirm_unwrap not used by approval target building")
+        }
+
+        async fn wait_for_block(&self, _block: u64) -> Result<(), WrapperError> {
+            unimplemented!("wait_for_block not used by approval target building")
         }
 
         fn owner(&self) -> Address {

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -35,6 +35,11 @@ pub(crate) enum ConfirmTxBehavior {
     Succeed,
     Fail,
     Retryable,
+    /// Returns a successful receipt but with `block_number: None`.
+    /// Simulates the conformant-but-rare RPC edge case where a receipt
+    /// is returned without a block number (e.g. a pending or uncle-block
+    /// receipt from a load-balanced RPC).
+    SucceedWithoutBlockNumber,
 }
 
 /// Arguments captured from the last `submit_deposit` call.
@@ -245,6 +250,21 @@ impl Raindex for MockRaindex {
             }
             ConfirmTxBehavior::Retryable => {
                 return Err(RaindexError::ScanInconclusive { from_block: 0 });
+            }
+            ConfirmTxBehavior::SucceedWithoutBlockNumber => {
+                let logs = self
+                    .withdraw_transfer
+                    .lock()
+                    .unwrap()
+                    .map(|WithdrawCall { token, amount }| {
+                        let amount = self.withdraw_actual_amount.unwrap_or(amount);
+                        vec![transfer_log(token, Address::ZERO, amount)]
+                    })
+                    .unwrap_or_default();
+
+                let mut receipt = successful_receipt(tx_hash, logs);
+                receipt.block_number = None;
+                return Ok(receipt);
             }
             ConfirmTxBehavior::Succeed => {}
         }

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -32,7 +32,9 @@ use st0x_event_sorcery::{SendError, Store};
 use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, SharesConversionError, Symbol};
 use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
-use st0x_wrapper::{UnderlyingPerWrapped, Wrapper, WrapperError};
+use st0x_wrapper::{
+    UnderlyingPerWrapped, UnwrapConfirmation, WrapConfirmation, Wrapper, WrapperError,
+};
 
 use super::RebalancingService;
 use super::trigger::RecoveryClaim;
@@ -283,6 +285,10 @@ impl Tokenizer for PanickingTokenizer {
         unimplemented!("PanickingTokenizer: not available in CLI context")
     }
 
+    async fn wait_for_block(&self, _: u64) -> Result<(), EvmError> {
+        unimplemented!("PanickingTokenizer: not available in CLI context")
+    }
+
     async fn send_for_redemption(&self, _: Address, _: U256) -> Result<TxHash, TokenizerError> {
         unimplemented!("PanickingTokenizer: not available in CLI context")
     }
@@ -360,7 +366,7 @@ impl Wrapper for PanickingWrapper {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
-    async fn confirm_wrap(&self, _: Address, _: TxHash) -> Result<U256, WrapperError> {
+    async fn confirm_wrap(&self, _: Address, _: TxHash) -> Result<WrapConfirmation, WrapperError> {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
@@ -374,7 +380,15 @@ impl Wrapper for PanickingWrapper {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
-    async fn confirm_unwrap(&self, _: Address, _: TxHash) -> Result<U256, WrapperError> {
+    async fn confirm_unwrap(
+        &self,
+        _: Address,
+        _: TxHash,
+    ) -> Result<UnwrapConfirmation, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
+    async fn wait_for_block(&self, _: u64) -> Result<(), WrapperError> {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
@@ -514,6 +528,20 @@ pub(crate) enum RedemptionError {
     Rejected,
 }
 
+/// Result of wrapping received mint tokens into ERC-4626 shares.
+///
+/// Returned by [`CrossVenueEquityTransfer::wrap_received_mint`] to give
+/// each element a clear domain name and avoid positional ambiguity in the
+/// `(Address, U256, u64)` tuple it replaces.
+struct WrappedMintResult {
+    /// ERC-4626 derivative token address (the vault).
+    token: Address,
+    /// Number of ERC-4626 shares minted by the wrap.
+    shares: U256,
+    /// Block number in which the wrap transaction was confirmed.
+    block: u64,
+}
+
 /// Orchestrates equity transfers between Raindex and Alpaca.
 ///
 /// Holds CQRS stores for both directions and domain service traits for
@@ -607,17 +635,22 @@ impl CrossVenueEquityTransfer {
     ) -> Result<(), MintError> {
         self.verify_received_mint(&tokens_received).await?;
 
-        let (wrapped_token, wrapped_shares) = self
+        let WrappedMintResult {
+            token,
+            shares,
+            block,
+        } = self
             .wrap_received_mint(issuer_request_id, &tokens_received)
             .await?;
 
-        self.deposit_wrapped_mint(
-            issuer_request_id,
-            &tokens_received.symbol,
-            wrapped_token,
-            wrapped_shares,
-        )
-        .await
+        // Wait for the RPC node to catch up to the block where the wrap tx
+        // confirmed before depositing. Without this, a load-balanced backend
+        // that hasn't indexed the wrap block yet sees the wrapped-token balance
+        // as zero and the vault deposit reverts with ERC20InsufficientBalance.
+        self.wrapper.wait_for_block(block).await?;
+
+        self.deposit_wrapped_mint(issuer_request_id, &tokens_received.symbol, token, shares)
+            .await
     }
 
     async fn deposit_wrapped_mint(
@@ -750,14 +783,14 @@ impl CrossVenueEquityTransfer {
         &self,
         issuer_request_id: &IssuerRequestId,
         tokens_received: &TokensReceivedData,
-    ) -> Result<(Address, U256), MintError> {
+    ) -> Result<WrappedMintResult, MintError> {
         info!(target: "rebalance", "Onchain verification passed, wrapping into ERC-4626 shares");
 
-        let wrapped_token = self.wrapper.lookup_derivative(&tokens_received.symbol)?;
+        let token = self.wrapper.lookup_derivative(&tokens_received.symbol)?;
 
         let wrap_tx_hash = self
             .wrapper
-            .submit_wrap(wrapped_token, tokens_received.shares_minted, self.wallet)
+            .submit_wrap(token, tokens_received.shares_minted, self.wallet)
             .await?;
 
         self.mint_store
@@ -767,23 +800,26 @@ impl CrossVenueEquityTransfer {
             )
             .await?;
 
-        let wrapped_shares = self
-            .wrapper
-            .confirm_wrap(wrapped_token, wrap_tx_hash)
-            .await?;
+        let WrapConfirmation { shares, block } =
+            self.wrapper.confirm_wrap(token, wrap_tx_hash).await?;
 
         self.mint_store
             .send(
                 issuer_request_id,
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash,
-                    wrapped_shares,
+                    wrapped_shares: shares,
+                    wrap_block: block,
                 },
             )
             .await?;
 
-        info!(target: "rebalance", %wrap_tx_hash, %wrapped_shares, "Tokens wrapped, depositing to Raindex vault");
-        Ok((wrapped_token, wrapped_shares))
+        info!(target: "rebalance", %wrap_tx_hash, %shares, "Tokens wrapped, depositing to Raindex vault");
+        Ok(WrappedMintResult {
+            token,
+            shares,
+            block,
+        })
     }
 
     #[allow(clippy::cognitive_complexity)]
@@ -813,7 +849,10 @@ impl CrossVenueEquityTransfer {
                 } => {
                     info!(%issuer_request_id, %wrap_tx_hash, "Resuming submitted wrap");
                     let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
-                    let wrapped_shares = self
+                    let WrapConfirmation {
+                        shares: wrapped_shares,
+                        block: wrap_block,
+                    } = self
                         .wrapper
                         .confirm_wrap(wrapped_token, wrap_tx_hash)
                         .await?;
@@ -824,9 +863,12 @@ impl CrossVenueEquityTransfer {
                             TokenizedEquityMintCommand::WrapTokens {
                                 wrap_tx_hash,
                                 wrapped_shares,
+                                wrap_block,
                             },
                         )
                         .await?;
+
+                    self.wrapper.wait_for_block(wrap_block).await?;
 
                     info!(target: "rebalance", %wrap_tx_hash, %wrapped_shares, "Wrap confirmed on resume, depositing to Raindex vault");
                     return self
@@ -841,10 +883,16 @@ impl CrossVenueEquityTransfer {
                 TokenizedEquityMint::TokensWrapped {
                     symbol,
                     wrapped_shares,
+                    wrap_block,
                     ..
                 } => {
                     info!(%issuer_request_id, "Resuming wrapped mint");
                     let wrapped_token = self.wrapper.lookup_derivative(&symbol)?;
+
+                    // Skip the wait for legacy aggregates persisted before wrap_block was added.
+                    if let Some(block) = wrap_block {
+                        self.wrapper.wait_for_block(block).await?;
+                    }
 
                     return self
                         .try_deposit_or_recover(
@@ -1636,7 +1684,7 @@ mod tests {
     use crate::tokenization::mock::{
         MockCompletionOutcome, MockDetectionOutcome, MockTokenizer, MockVerificationOutcome,
     };
-    use crate::tokenized_equity_mint::issuer_request_id;
+    use crate::tokenized_equity_mint::{TokenizedEquityMintEvent, issuer_request_id};
     use crate::usdc_rebalance::UsdcRebalance;
     use crate::vault_lookup::MockVaultLookup;
     use crate::vault_registry::VaultRegistry;
@@ -2014,15 +2062,27 @@ mod tests {
         raindex: Arc<dyn Raindex>,
         wrapper: Arc<dyn Wrapper>,
     ) -> CrossVenueEquityTransfer {
+        let (transfer, _pool) = create_equity_transfer_with_pool(tokenizer, raindex, wrapper).await;
+        transfer
+    }
+
+    /// Like [`create_equity_transfer`] but also returns the backing pool, so a
+    /// test can seed legacy events directly (e.g. a `TokensWrapped` event
+    /// persisted before the `wrap_block` field existed).
+    async fn create_equity_transfer_with_pool(
+        tokenizer: Arc<dyn Tokenizer>,
+        raindex: Arc<dyn Raindex>,
+        wrapper: Arc<dyn Wrapper>,
+    ) -> (CrossVenueEquityTransfer, SqlitePool) {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
         let services = mock_services();
 
         let mint_store = Arc::new(test_store(pool.clone(), services.clone()));
-        let redemption_store = Arc::new(test_store(pool, services));
+        let redemption_store = Arc::new(test_store(pool.clone(), services));
         let vault_lookup = mock_vault_lookup();
 
-        CrossVenueEquityTransfer::new(
+        let transfer = CrossVenueEquityTransfer::new(
             raindex,
             Arc::new(vault_lookup),
             tokenizer,
@@ -2030,7 +2090,9 @@ mod tests {
             Address::random(),
             mint_store,
             redemption_store,
-        )
+        );
+
+        (transfer, pool)
     }
 
     #[tokio::test]
@@ -2782,6 +2844,7 @@ mod tests {
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash: wrap_tx,
                     wrapped_shares,
+                    wrap_block: 1,
                 },
             )
             .await
@@ -2889,6 +2952,412 @@ mod tests {
             vault_deposit_tx_hash,
             TxHash::ZERO,
             "Recovered deposit must use TxHash::ZERO sentinel"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_mint_from_tokens_wrapped_calls_wait_for_block_with_wrap_block() {
+        // Keep a typed reference so we can inspect both wait_for_block and
+        // deposit call records after resume. Ordering is verified by confirming
+        // both happened: wait_for_block must be called (the guard) and the
+        // deposit must also succeed (proving the guard did not abort the flow).
+        // Strict sequential ordering (wait_for_block strictly before deposit)
+        // cannot be asserted with the current separate-mock seam — the
+        // existing test `mint_transfer_fails_when_wait_for_block_fails` covers
+        // the abort path, proving the guard is on the critical path.
+        let mock_wrapper: Arc<MockWrapper> = Arc::new(MockWrapper::new());
+        let mock_raindex: Arc<MockRaindex> = Arc::new(MockRaindex::new());
+        let wrap_tx = TxHash::random();
+        let wrap_block = 9999u64;
+
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::clone(&mock_raindex) as Arc<dyn Raindex>,
+            Arc::clone(&mock_wrapper) as Arc<dyn Wrapper>,
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-TOKENS-WRAPPED-WAIT");
+
+        // Advance aggregate to TokensWrapped state manually.
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let wrapped_shares = U256::from(10_000_000_000_000_000_000u128);
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: wrap_tx,
+                    wrapped_shares,
+                    wrap_block,
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensWrapped { .. }),
+            "Expected TokensWrapped state before resume, got: {entity:?}"
+        );
+
+        transfer.resume_mint(&id).await.unwrap();
+
+        let calls = mock_wrapper.wait_for_block_calls();
+
+        assert_eq!(
+            calls,
+            vec![wrap_block],
+            "wait_for_block must be called exactly once with wrap_block={wrap_block} on TokensWrapped resume"
+        );
+
+        // Confirm the deposit also ran — proving wait_for_block did not abort
+        // the flow and the guard is on the critical path to deposit.
+        // (strict sequential ordering is covered by the abort test
+        // `resume_mint_from_tokens_wrapped_fails_when_wait_for_block_fails`)
+        assert_eq!(
+            mock_raindex.last_deposited_token(),
+            Some(Address::ZERO),
+            "submit_deposit must have been called with the derivative token after wait_for_block on TokensWrapped resume"
+        );
+    }
+
+    /// Verifies that `resume_mint` from `TokensWrapped` state with `wrap_block:
+    /// None` skips `wait_for_block` entirely (backward-compat path for aggregates
+    /// persisted before the field was added).
+    ///
+    /// If the `if let Some(block) = wrap_block` guard is accidentally removed,
+    /// this test catches it: `wait_for_block` would be called with a sentinel
+    /// value (0 or similar) and the assertion below would fail.
+    #[tokio::test]
+    async fn resume_mint_from_tokens_wrapped_skips_wait_for_block_when_wrap_block_is_none() {
+        let mock_wrapper: Arc<MockWrapper> = Arc::new(MockWrapper::new());
+        let wrap_tx = TxHash::random();
+
+        let (transfer, pool) = create_equity_transfer_with_pool(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::clone(&mock_wrapper) as Arc<dyn Wrapper>,
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-TOKENS-WRAPPED-NO-BLOCK");
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Simulate a legacy aggregate: a `TokensWrapped` event persisted before
+        // the `wrap_block` field existed. The live `WrapTokens` command now
+        // requires `wrap_block`, so the only way to reach a `wrap_block: None`
+        // state is to replay an old event -- seeded here directly with the
+        // field omitted, exercising the `#[serde(default)]` backward-compat path.
+        let wrapped_shares = U256::from(10_000_000_000_000_000_000u128);
+        let legacy_payload = {
+            let mut value = serde_json::to_value(TokenizedEquityMintEvent::TokensWrapped {
+                wrap_tx_hash: wrap_tx,
+                wrapped_shares,
+                wrapped_at: Utc::now(),
+                wrap_block: None,
+            })
+            .unwrap();
+            value["TokensWrapped"]
+                .as_object_mut()
+                .unwrap()
+                .remove("wrap_block");
+            value.to_string()
+        };
+
+        let IssuerRequestId(raw_id) = &id;
+        let next_sequence: i64 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(sequence), -1) + 1 FROM events WHERE aggregate_id = ?",
+        )
+        .bind(raw_id.to_string())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        insert_mint_event(
+            &pool,
+            &id,
+            next_sequence,
+            "TokenizedEquityMintEvent::TokensWrapped",
+            &legacy_payload,
+        )
+        .await;
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensWrapped { .. }),
+            "Expected TokensWrapped state before resume, got: {entity:?}"
+        );
+
+        transfer.resume_mint(&id).await.unwrap();
+
+        assert_eq!(
+            mock_wrapper.wait_for_block_calls(),
+            Vec::<u64>::new(),
+            "wait_for_block must NOT be called when wrap_block is None (legacy aggregate)"
+        );
+    }
+
+    /// Verifies that `resume_mint` from `TokensWrapped` state propagates a
+    /// `wait_for_block` failure as `MintError::Wrapper(WrapperError::Evm(..))`,
+    /// and that the deposit does NOT run when `wait_for_block` fails.
+    ///
+    /// This proves that `wait_for_block` is on the critical path before the
+    /// deposit in the `TokensWrapped` resume branch. A refactor that swaps the
+    /// order (deposit first, wait_for_block second) would make this test fail
+    /// while the happy-path test still passes.
+    #[tokio::test]
+    async fn resume_mint_from_tokens_wrapped_fails_when_wait_for_block_fails() {
+        let mock_raindex: Arc<MockRaindex> = Arc::new(MockRaindex::new());
+        let wrap_tx = TxHash::random();
+
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::clone(&mock_raindex) as Arc<dyn Raindex>,
+            Arc::new(MockWrapper::failing_wait_for_block()),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-TOKENS-WRAPPED-WAIT-FAIL");
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let wrapped_shares = U256::from(10_000_000_000_000_000_000u128);
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::WrapTokens {
+                    wrap_tx_hash: wrap_tx,
+                    wrapped_shares,
+                    wrap_block: 9999u64,
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::TokensWrapped { .. }),
+            "expected TokensWrapped state before resume, got: {entity:?}"
+        );
+
+        let error = transfer
+            .resume_mint(&id)
+            .await
+            .expect_err("wait_for_block failure must propagate from TokensWrapped resume");
+
+        assert!(
+            matches!(
+                error,
+                MintError::Wrapper(WrapperError::Evm(EvmError::NodeBehindRequiredBlock { .. }))
+            ),
+            "expected MintError::Wrapper wrapping NodeBehindRequiredBlock, got: {error:?}"
+        );
+
+        assert!(
+            mock_raindex.last_deposited_token().is_none(),
+            "deposit must NOT run when wait_for_block fails in TokensWrapped resume"
+        );
+    }
+
+    /// Verifies that `resume_mint` from `WrapSubmitted` state propagates a
+    /// `wait_for_block` failure as `MintError::Wrapper(WrapperError::Evm(..))`.
+    ///
+    /// The `WrapSubmitted` branch calls `wait_for_block` unconditionally (block
+    /// comes from a freshly confirmed tx). A missing `?` or wrong error mapping
+    /// would let the flow silently proceed to deposit against a stale node --
+    /// the exact regression this PR was written to prevent.
+    #[tokio::test]
+    async fn resume_mint_from_wrap_submitted_fails_when_wait_for_block_fails() {
+        let mock_wrapper = MockWrapper::failing_wait_for_block();
+        let wrap_tx = TxHash::random();
+
+        // Pre-seed so confirm_wrap recognises the tx hash stored in WrapSubmitted.
+        mock_wrapper.seed_submitted_amount(wrap_tx, U256::from(10_000_000_000_000_000_000u128));
+
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(mock_wrapper),
+        )
+        .await;
+
+        let id = issuer_request_id("ISS-WRAP-SUBMITTED-WAIT-FAIL");
+
+        // Advance to WrapSubmitted: RequestMint -> Poll -> SubmitWrap
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::RequestMint {
+                    issuer_request_id: id.clone(),
+                    symbol: Symbol::new("AAPL").unwrap(),
+                    quantity: float!(10),
+                    wallet: transfer.wallet,
+                },
+            )
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(&id, TokenizedEquityMintCommand::Poll)
+            .await
+            .unwrap();
+
+        transfer
+            .mint_store
+            .send(
+                &id,
+                TokenizedEquityMintCommand::SubmitWrap {
+                    wrap_tx_hash: wrap_tx,
+                },
+            )
+            .await
+            .unwrap();
+
+        let entity = transfer.mint_store.load(&id).await.unwrap().unwrap();
+        assert!(
+            matches!(entity, TokenizedEquityMint::WrapSubmitted { .. }),
+            "expected WrapSubmitted state before resume, got: {entity:?}"
+        );
+
+        let error = transfer
+            .resume_mint(&id)
+            .await
+            .expect_err("wait_for_block failure must propagate from WrapSubmitted resume");
+
+        assert!(
+            matches!(
+                error,
+                MintError::Wrapper(WrapperError::Evm(EvmError::NodeBehindRequiredBlock { .. }))
+            ),
+            "expected MintError::Wrapper wrapping NodeBehindRequiredBlock, got: {error:?}"
+        );
+    }
+
+    /// Verifies that the mint happy-path propagates a `wait_for_block` failure
+    /// as `MintTransferError::PostReceipt(MintError::Wrapper(..))`.
+    ///
+    /// `finalize_received_mint` calls `wait_for_block(wrap_block)` unconditionally
+    /// after wrapping. A missing `?` or wrong error mapping would let the flow
+    /// silently deposit against a stale node.
+    #[tokio::test]
+    async fn mint_transfer_fails_when_wait_for_block_fails() {
+        let transfer = create_equity_transfer(
+            Arc::new(MockTokenizer::new()),
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block()),
+        )
+        .await;
+
+        let error = transfer
+            .resume_equity_to_market_making(
+                &issuer_request_id("ISS-WAIT-BLOCK-FAIL"),
+                &Symbol::new("AAPL").unwrap(),
+                FractionalShares::new(float!(10.0)),
+            )
+            .await
+            .expect_err("wait_for_block failure must propagate in the mint happy path");
+
+        assert!(
+            matches!(
+                error,
+                MintTransferError::PostReceipt(MintError::Wrapper(WrapperError::Evm(
+                    EvmError::NodeBehindRequiredBlock { .. }
+                )))
+            ),
+            "expected PostReceipt(Wrapper(NodeBehindRequiredBlock)), got: {error:?}"
         );
     }
 }

--- a/src/rebalancing/trigger/mod.rs
+++ b/src/rebalancing/trigger/mod.rs
@@ -5620,6 +5620,7 @@ mod tests {
                     token: Address::random(),
                     wrapped_amount: actual_wrapped_amount,
                     raindex_withdraw_tx: TxHash::random(),
+                    raindex_withdraw_block: None,
                     withdrawn_at,
                 },
             )

--- a/src/tokenization.rs
+++ b/src/tokenization.rs
@@ -12,6 +12,7 @@ pub(crate) mod mock;
 
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
+use st0x_evm::EvmError;
 use st0x_execution::{FractionalShares, Symbol};
 
 pub(crate) use alpaca::{
@@ -92,6 +93,13 @@ pub(crate) trait Tokenizer: Send + Sync {
     /// Returns the redemption wallet address where tokens should be sent,
     /// if configured.
     fn redemption_wallet(&self) -> Option<Address>;
+
+    /// Wait for the tokenizer's RPC node to reach `block` before issuing the
+    /// dependent redemption transfer. The wait must run on the same provider
+    /// that performs the transfer (`send_for_redemption`), so it lives on the
+    /// tokenizer rather than the wrapper -- a load-balanced wrapper provider
+    /// catching up gives no guarantee about the tokenizer's provider.
+    async fn wait_for_block(&self, block: u64) -> Result<(), EvmError>;
 
     /// Send tokens to the redemption wallet to initiate redemption.
     async fn send_for_redemption(

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -37,7 +37,10 @@ use thiserror::Error;
 use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, error, info, trace, warn};
 
-use st0x_evm::{EvmError, IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
+use st0x_evm::{
+    EvmError, IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL,
+    OpenChainErrorRegistry, Wallet, wait_for_node_sync,
+};
 use st0x_execution::{AlpacaAccountId, FractionalShares, Symbol};
 
 use super::{MintVerificationError, Tokenizer, TokenizerError};
@@ -128,6 +131,12 @@ impl<W: Wallet> AlpacaTokenizationService<W> {
         self.client
             .send_tokens_for_redemption::<Registry>(token, amount)
             .await
+    }
+
+    /// Wait for the redemption provider's RPC node to reach `block` before the
+    /// redemption transfer, polling the same provider the transfer uses.
+    pub(crate) async fn wait_for_block(&self, block: u64) -> Result<(), EvmError> {
+        self.client.wait_for_block(block).await
     }
 
     /// Poll until Alpaca detects a redemption transfer.
@@ -669,6 +678,19 @@ impl<W: Wallet> AlpacaTokenizationClient<W> {
         Ok(receipt.transaction_hash)
     }
 
+    /// Wait for this client's RPC node to reach `block` before a dependent
+    /// write, polling the wallet's own provider so the gate applies to the
+    /// node that performs the transfer.
+    async fn wait_for_block(&self, block: u64) -> Result<(), EvmError> {
+        wait_for_node_sync(
+            self.wallet.provider(),
+            block,
+            NODE_SYNC_POLL_INTERVAL,
+            NODE_SYNC_MAX_ATTEMPTS,
+        )
+        .await
+    }
+
     /// Find a redemption request by its onchain transaction hash.
     ///
     /// This polls the Alpaca API to check if they have detected a token transfer
@@ -923,6 +945,10 @@ impl<W: Wallet> Tokenizer for AlpacaTokenizationService<W> {
 
     fn redemption_wallet(&self) -> Option<Address> {
         Self::redemption_wallet(self)
+    }
+
+    async fn wait_for_block(&self, block: u64) -> Result<(), EvmError> {
+        Self::wait_for_block(self, block).await
     }
 
     async fn send_for_redemption(
@@ -1520,6 +1546,35 @@ pub(crate) mod tests {
             balance, transfer_amount,
             "redemption wallet should have received tokens"
         );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_block_succeeds_when_node_already_at_block() {
+        let (_anvil, endpoint, key) = setup_anvil();
+        let wallet = RawPrivateKeyWallet::new(
+            &key,
+            ProviderBuilder::new().connect(&endpoint).await.unwrap(),
+            1,
+        )
+        .unwrap();
+
+        // The wait polls the wallet's own provider, so a block it already
+        // reports must clear the gate on the first poll.
+        let current_block = wallet.signing_provider().get_block_number().await.unwrap();
+
+        let client = AlpacaTokenizationClient::new(
+            "http://unused.invalid".to_string(),
+            TEST_ACCOUNT_ID,
+            "test_api_key".to_string(),
+            "test_api_secret".to_string(),
+            wallet,
+            Some(TEST_REDEMPTION_WALLET),
+        );
+
+        client
+            .wait_for_block(current_block)
+            .await
+            .expect("wait_for_block must succeed when the node is already at the block");
     }
 
     #[tokio::test]

--- a/src/tokenization/mock.rs
+++ b/src/tokenization/mock.rs
@@ -6,6 +6,7 @@ use rain_math_float::Float;
 use reqwest::StatusCode;
 use std::sync::Mutex;
 
+use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::{FractionalShares, Symbol};
 
 use super::{
@@ -74,6 +75,14 @@ enum MockSendOutcome {
     ApiError,
 }
 
+/// Configurable outcome for `wait_for_block`.
+#[derive(Clone, Copy)]
+enum MockWaitForBlockOutcome {
+    Succeed,
+    /// Fail with `NodeBehindRequiredBlock` (budget exhausted while behind).
+    NodeBehind,
+}
+
 /// Configurable outcome for `list_pending_requests`.
 #[derive(Clone, Copy)]
 enum MockListPendingOutcome {
@@ -90,6 +99,8 @@ pub(crate) struct MockTokenizer {
     completion_outcome: Option<MockCompletionOutcome>,
     verification_outcome: MockVerificationOutcome,
     send_outcome: MockSendOutcome,
+    wait_for_block_outcome: MockWaitForBlockOutcome,
+    wait_for_block_calls: Mutex<Vec<u64>>,
     list_pending_outcome: MockListPendingOutcome,
     last_issuer_request_id: Mutex<Option<IssuerRequestId>>,
     pending_requests: Vec<TokenizationRequest>,
@@ -110,6 +121,8 @@ impl MockTokenizer {
             completion_outcome: None,
             verification_outcome: MockVerificationOutcome::Success,
             send_outcome: MockSendOutcome::Succeed,
+            wait_for_block_outcome: MockWaitForBlockOutcome::Succeed,
+            wait_for_block_calls: Mutex::new(Vec::new()),
             list_pending_outcome: MockListPendingOutcome::Succeed,
             last_issuer_request_id: Mutex::new(None),
             token_symbol_behavior: MockTokenSymbolBehavior::Default,
@@ -146,6 +159,18 @@ impl MockTokenizer {
     pub(crate) fn with_send_failure(mut self) -> Self {
         self.send_outcome = MockSendOutcome::ApiError;
         self
+    }
+
+    /// Makes `wait_for_block` fail with `NodeBehindRequiredBlock` (budget
+    /// exhausted while the node stayed behind the required block).
+    pub(crate) fn failing_wait_for_block(mut self) -> Self {
+        self.wait_for_block_outcome = MockWaitForBlockOutcome::NodeBehind;
+        self
+    }
+
+    /// Returns the block numbers passed to `wait_for_block`, in call order.
+    pub(crate) fn wait_for_block_calls(&self) -> Vec<u64> {
+        self.wait_for_block_calls.lock().unwrap().clone()
     }
 
     pub(crate) fn with_list_pending_failure(mut self) -> Self {
@@ -258,6 +283,19 @@ impl Tokenizer for MockTokenizer {
 
     fn redemption_wallet(&self) -> Option<Address> {
         self.redemption_wallet
+    }
+
+    async fn wait_for_block(&self, block: u64) -> Result<(), EvmError> {
+        self.wait_for_block_calls.lock().unwrap().push(block);
+
+        match self.wait_for_block_outcome {
+            MockWaitForBlockOutcome::Succeed => Ok(()),
+            MockWaitForBlockOutcome::NodeBehind => Err(EvmError::NodeBehindRequiredBlock {
+                observed_tip: 0,
+                required_block: block,
+                attempts: NODE_SYNC_MAX_ATTEMPTS,
+            }),
+        }
     }
 
     async fn send_for_redemption(

--- a/src/tokenized_equity_mint.rs
+++ b/src/tokenized_equity_mint.rs
@@ -254,6 +254,10 @@ pub(crate) enum TokenizedEquityMintCommand {
     WrapTokens {
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
+        /// Block where the wrap tx confirmed. Mandatory on the live command so
+        /// a new `TokensWrapped` event can never skip the node-sync wait before
+        /// deposit. The persisted event keeps `Option<u64>` for legacy replay.
+        wrap_block: u64,
     },
     DepositToVault {
         vault_deposit_tx_hash: TxHash,
@@ -335,6 +339,10 @@ pub(crate) enum TokenizedEquityMintEvent {
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
         wrapped_at: DateTime<Utc>,
+        /// Block where the wrap tx confirmed; `None` for events emitted before this field was
+        /// added (schema backward-compatibility).
+        #[serde(default)]
+        wrap_block: Option<u64>,
     },
     /// Wrapping failed after tokens were received.
     WrappingFailed {
@@ -477,13 +485,15 @@ impl PartialEq for TokenizedEquityMintEvent {
                     wrap_tx_hash: hash_a,
                     wrapped_shares: shares_a,
                     wrapped_at: time_a,
+                    wrap_block: block_a,
                 },
                 Self::TokensWrapped {
                     wrap_tx_hash: hash_b,
                     wrapped_shares: shares_b,
                     wrapped_at: time_b,
+                    wrap_block: block_b,
                 },
-            ) => hash_a == hash_b && shares_a == shares_b && time_a == time_b,
+            ) => hash_a == hash_b && shares_a == shares_b && time_a == time_b && block_a == block_b,
             (
                 Self::WrappingFailed {
                     symbol: sym_a,
@@ -703,6 +713,9 @@ pub(crate) enum TokenizedEquityMint {
         shares_minted: U256,
         wrap_tx_hash: TxHash,
         wrapped_shares: U256,
+        /// Block where the wrap tx confirmed; `None` for aggregates persisted before this field.
+        #[serde(default)]
+        wrap_block: Option<u64>,
         requested_at: DateTime<Utc>,
         accepted_at: DateTime<Utc>,
         received_at: DateTime<Utc>,
@@ -920,6 +933,7 @@ impl PartialEq for TokenizedEquityMint {
                     shares_minted: mint_a,
                     wrap_tx_hash: wrap_hash_a,
                     wrapped_shares: wrap_shares_a,
+                    wrap_block: wrap_block_a,
                     requested_at: req_a,
                     accepted_at: acc_a,
                     received_at: recv_a,
@@ -935,6 +949,7 @@ impl PartialEq for TokenizedEquityMint {
                     shares_minted: mint_b,
                     wrap_tx_hash: wrap_hash_b,
                     wrapped_shares: wrap_shares_b,
+                    wrap_block: wrap_block_b,
                     requested_at: req_b,
                     accepted_at: acc_b,
                     received_at: recv_b,
@@ -950,6 +965,7 @@ impl PartialEq for TokenizedEquityMint {
                     && mint_a == mint_b
                     && wrap_hash_a == wrap_hash_b
                     && wrap_shares_a == wrap_shares_b
+                    && wrap_block_a == wrap_block_b
                     && req_a == req_b
                     && acc_a == acc_b
                     && recv_a == recv_b
@@ -1485,6 +1501,7 @@ impl EventSourced for TokenizedEquityMint {
                 wrap_tx_hash,
                 wrapped_shares,
                 wrapped_at,
+                wrap_block,
             } => match entity {
                 Self::TokensReceived {
                     symbol,
@@ -1521,6 +1538,7 @@ impl EventSourced for TokenizedEquityMint {
                     shares_minted: *shares_minted,
                     wrap_tx_hash: *wrap_tx_hash,
                     wrapped_shares: *wrapped_shares,
+                    wrap_block: *wrap_block,
                     requested_at: *requested_at,
                     accepted_at: *accepted_at,
                     received_at: *received_at,
@@ -1547,6 +1565,7 @@ impl EventSourced for TokenizedEquityMint {
                     accepted_at,
                     received_at,
                     wrapped_at,
+                    ..
                 } = entity
                 else {
                     return Ok(None);
@@ -1863,12 +1882,14 @@ impl EventSourced for TokenizedEquityMint {
             TokenizedEquityMintCommand::WrapTokens {
                 wrap_tx_hash,
                 wrapped_shares,
+                wrap_block,
             } => match self {
                 Self::TokensReceived { .. } | Self::WrapSubmitted { .. } => {
                     Ok(vec![TokensWrapped {
                         wrap_tx_hash,
                         wrapped_shares,
                         wrapped_at: Utc::now(),
+                        wrap_block: Some(wrap_block),
                     }])
                 }
                 Self::MintRequested { .. } | Self::MintAccepted { .. } => {
@@ -2048,6 +2069,7 @@ mod tests {
             wrap_tx_hash: TxHash::random(),
             wrapped_shares: U256::from(100_000_000_000_000_000_000_u128),
             wrapped_at: Utc::now(),
+            wrap_block: None,
         }
     }
 
@@ -2413,6 +2435,7 @@ mod tests {
             wrap_tx_hash: TxHash::random(),
             wrapped_shares: U256::from(100_000_000_000_000_000_000_u128),
             wrapped_at: Utc::now(),
+            wrap_block: None,
         };
 
         let result = TokenizedEquityMint::evolve(&accepted, &event).unwrap();
@@ -2580,6 +2603,7 @@ mod tests {
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash: TxHash::random(),
                     wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
+                    wrap_block: 1,
                 },
             )
             .await
@@ -2608,6 +2632,7 @@ mod tests {
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash: TxHash::random(),
                     wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
+                    wrap_block: 1,
                 },
             )
             .await
@@ -2784,6 +2809,7 @@ mod tests {
             shares_minted: U256::from(10_000_000_000_000_000_000_u128),
             wrap_tx_hash: TxHash::random(),
             wrapped_shares: U256::from(10_000_000_000_000_000_000_u128),
+            wrap_block: None,
             requested_at: now,
             accepted_at: now,
             received_at: now,
@@ -3045,6 +3071,7 @@ mod tests {
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash: TxHash::random(),
                     wrapped_shares: U256::from(100u64),
+                    wrap_block: 1,
                 },
             )
             .await

--- a/src/unwrapped_equity_recovery/aggregate.rs
+++ b/src/unwrapped_equity_recovery/aggregate.rs
@@ -47,7 +47,7 @@ use uuid::Uuid;
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
 use st0x_execution::{FractionalShares, Symbol};
 use st0x_raindex::Raindex;
-use st0x_wrapper::{Wrapper, WrapperError};
+use st0x_wrapper::{WrapConfirmation, Wrapper, WrapperError, node_sync_attempts};
 
 use crate::equity_redemption::RedemptionAggregateId;
 use crate::rebalancing::equity::CrossVenueEquityTransfer;
@@ -86,9 +86,11 @@ pub(crate) struct UnwrappedEquityRecoveryServices {
 }
 
 /// Domain errors returned from the aggregate's `initialize`/`transition`
-/// handlers. Service failures (raindex/wrapper/transfer) do NOT flow through
-/// this enum -- they are recorded as `RecoveryFailed` events instead, so
-/// failures remain first-class entries in the audit trail.
+/// handlers. Terminal service failures (raindex/wrapper/transfer) are recorded
+/// as `RecoveryFailed` events so failures remain first-class entries in the
+/// audit trail. Retryable service failures that should leave the aggregate
+/// in-place instead surface as errors through this enum (e.g. `NodeSyncFailed`
+/// and the `Retryable*Confirmation` variants).
 #[derive(Debug, Clone, Serialize, Deserialize, Error, PartialEq, Eq)]
 pub(crate) enum UnwrappedEquityRecoveryError {
     #[error("recovery already initialized")]
@@ -108,6 +110,8 @@ pub(crate) enum UnwrappedEquityRecoveryError {
 
     #[error("deposit confirmation for tx {vault_deposit_tx_hash} is retryable")]
     RetryableDepositConfirmation { vault_deposit_tx_hash: TxHash },
+    #[error("RPC node did not catch up to wrap block {required_block} after {attempts} polls")]
+    NodeSyncFailed { required_block: u64, attempts: u32 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -185,6 +189,10 @@ pub(crate) enum UnwrappedEquityRecoveryEvent {
         wrap_tx_hash: TxHash,
         wrapped_amount: U256,
         confirmed_at: DateTime<Utc>,
+        /// Block where the wrap tx confirmed; `None` for events emitted before this field was
+        /// added (schema backward-compatibility).
+        #[serde(default)]
+        wrap_block: Option<u64>,
     },
 
     OrphanDepositSubmitted {
@@ -267,6 +275,9 @@ pub(crate) enum UnwrappedEquityRecovery {
         wrap_submitted_at: DateTime<Utc>,
         wrapped_amount: U256,
         wrap_confirmed_at: DateTime<Utc>,
+        /// Block where the wrap tx confirmed; `None` for aggregates persisted before this field.
+        #[serde(default)]
+        wrap_block: Option<u64>,
     },
 
     OrphanDepositSubmitted {
@@ -410,6 +421,7 @@ impl EventSourced for UnwrappedEquityRecovery {
                     wrap_tx_hash: confirm_wrap_tx_hash,
                     wrapped_amount,
                     confirmed_at,
+                    wrap_block,
                 },
             ) if wrap_tx_hash == confirm_wrap_tx_hash => Some(Self::OrphanWrapped {
                 symbol: symbol.clone(),
@@ -419,6 +431,7 @@ impl EventSourced for UnwrappedEquityRecovery {
                 wrap_submitted_at: *wrap_submitted_at,
                 wrapped_amount: *wrapped_amount,
                 wrap_confirmed_at: *confirmed_at,
+                wrap_block: *wrap_block,
             }),
 
             (
@@ -542,10 +555,27 @@ impl EventSourced for UnwrappedEquityRecovery {
                 Self::OrphanWrapped {
                     symbol,
                     wrapped_amount,
+                    wrap_block,
                     ..
                 },
                 SubmitOrphanDeposit,
-            ) => submit_orphan_deposit_or_fail(services, symbol, *wrapped_amount).await,
+            ) => {
+                // Skip the wait for legacy aggregates persisted before wrap_block was added.
+                if let Some(block) = wrap_block {
+                    services
+                        .wrapper
+                        .wait_for_block(*block)
+                        .await
+                        .inspect_err(|error| {
+                            warn!(target: "rebalance", %symbol, ?error, "Unwrapped equity recovery: wait_for_block failed");
+                        })
+                        .map_err(|error| UnwrappedEquityRecoveryError::NodeSyncFailed {
+                            required_block: *block,
+                            attempts: node_sync_attempts(&error),
+                        })?;
+                }
+                submit_orphan_deposit_or_fail(services, symbol, *wrapped_amount).await
+            }
 
             (
                 Self::OrphanDepositSubmitted {
@@ -687,12 +717,16 @@ async fn confirm_orphan_wrap_or_fail(
         .confirm_wrap(wrapped_token, wrap_tx_hash)
         .await
     {
-        Ok(wrapped_amount) => {
+        Ok(WrapConfirmation {
+            shares: wrapped_amount,
+            block: wrap_block,
+        }) => {
             info!(target: "rebalance", %symbol, %wrap_tx_hash, %wrapped_amount, "Unwrapped equity recovery: confirm_wrap succeeded");
             Ok(vec![UnwrappedEquityRecoveryEvent::OrphanWrapped {
                 wrap_tx_hash,
                 wrapped_amount,
                 confirmed_at: Utc::now(),
+                wrap_block: Some(wrap_block),
             }])
         }
         Err(error) => {
@@ -812,6 +846,7 @@ mod tests {
     use rain_math_float::Float;
 
     use st0x_event_sorcery::EventSourced;
+    use st0x_evm::NODE_SYNC_MAX_ATTEMPTS;
     use st0x_execution::{FractionalShares, Symbol};
     use st0x_raindex::RaindexVaultId;
     use st0x_wrapper::MockWrapper;
@@ -864,6 +899,7 @@ mod tests {
             wrap_submitted_at: Utc::now(),
             wrapped_amount: U256::from(123u64),
             wrap_confirmed_at: Utc::now(),
+            wrap_block: None,
         }
     }
 
@@ -976,6 +1012,7 @@ mod tests {
                 wrap_tx_hash: FAKE_WRAP_TX,
                 wrapped_amount,
                 confirmed_at: wrapped_at,
+                wrap_block: None,
             },
         )
         .unwrap()
@@ -1567,6 +1604,7 @@ mod tests {
             wrap_tx_hash: OTHER_TX,
             wrapped_amount: U256::from(1u64),
             confirmed_at: Utc::now(),
+            wrap_block: None,
         };
         let error = UnwrappedEquityRecovery::evolve(&submitted, &mismatched).unwrap_err();
         assert!(matches!(
@@ -1602,5 +1640,134 @@ mod tests {
         let id = UnwrappedEquityRecoveryId(Uuid::new_v4());
         let parsed = id.to_string().parse::<UnwrappedEquityRecoveryId>().unwrap();
         assert_eq!(id, parsed);
+    }
+
+    #[tokio::test]
+    async fn submit_orphan_deposit_with_wrap_block_calls_wait_for_block() {
+        let raindex = Arc::new(MockRaindex::new());
+        let mock_wrapper = Arc::new(MockWrapper::new().with_wrapped_token(Address::random()));
+        let services = services_with(
+            raindex.clone(),
+            Arc::clone(&mock_wrapper) as Arc<dyn Wrapper>,
+        )
+        .await;
+
+        let state = UnwrappedEquityRecovery::OrphanWrapped {
+            symbol: aapl(),
+            shares: one_share(),
+            detected_at: Utc::now(),
+            wrap_tx_hash: FAKE_WRAP_TX,
+            wrap_submitted_at: Utc::now(),
+            wrapped_amount: U256::from(123u64),
+            wrap_confirmed_at: Utc::now(),
+            wrap_block: Some(9999),
+        };
+
+        let events = state
+            .transition(
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
+                &services,
+            )
+            .await
+            .expect("SubmitOrphanDeposit with wrap_block=Some(9999) should succeed");
+
+        let [UnwrappedEquityRecoveryEvent::OrphanDepositSubmitted { .. }] = events.as_slice()
+        else {
+            panic!("expected OrphanDepositSubmitted, got {events:?}");
+        };
+
+        assert_eq!(
+            mock_wrapper.wait_for_block_calls(),
+            vec![9999u64],
+            "wait_for_block must be called exactly once with wrap_block=9999"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_orphan_deposit_propagates_err_when_wait_for_block_fails() {
+        let services = services_with(
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block()),
+        )
+        .await;
+
+        let state = UnwrappedEquityRecovery::OrphanWrapped {
+            symbol: aapl(),
+            shares: one_share(),
+            detected_at: Utc::now(),
+            wrap_tx_hash: FAKE_WRAP_TX,
+            wrap_submitted_at: Utc::now(),
+            wrapped_amount: U256::from(123u64),
+            wrap_confirmed_at: Utc::now(),
+            wrap_block: Some(9999),
+        };
+
+        let error = state
+            .transition(
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
+                &services,
+            )
+            .await
+            .expect_err("wait_for_block failure must propagate as retryable Err");
+
+        assert!(
+            matches!(
+                error,
+                UnwrappedEquityRecoveryError::NodeSyncFailed {
+                    required_block: 9999,
+                    ..
+                }
+            ),
+            "wait_for_block failure must surface as NodeSyncFailed, got: {error:?}"
+        );
+    }
+
+    /// Verifies that the `_ => NODE_SYNC_MAX_ATTEMPTS` fallback arm in the
+    /// `SubmitOrphanDeposit` error-mapping closure is exercised when
+    /// `wait_for_block` fails with a transport error (as opposed to the
+    /// `NodeBehindRequiredBlock` arm covered by
+    /// `submit_orphan_deposit_propagates_err_when_wait_for_block_fails`).
+    ///
+    /// A transport error means every poll failed before any block number was
+    /// observed, so the budget was fully consumed; the fallback must still
+    /// produce `NodeSyncFailed` with `attempts == NODE_SYNC_MAX_ATTEMPTS`.
+    #[tokio::test]
+    async fn submit_orphan_deposit_propagates_err_when_wait_for_block_fails_with_transport_error() {
+        let services = services_with(
+            Arc::new(MockRaindex::new()),
+            Arc::new(MockWrapper::failing_wait_for_block_transport_error()),
+        )
+        .await;
+
+        let state = UnwrappedEquityRecovery::OrphanWrapped {
+            symbol: aapl(),
+            shares: one_share(),
+            detected_at: Utc::now(),
+            wrap_tx_hash: FAKE_WRAP_TX,
+            wrap_submitted_at: Utc::now(),
+            wrapped_amount: U256::from(123u64),
+            wrap_confirmed_at: Utc::now(),
+            wrap_block: Some(9999),
+        };
+
+        let error = state
+            .transition(
+                UnwrappedEquityRecoveryCommand::SubmitOrphanDeposit,
+                &services,
+            )
+            .await
+            .expect_err("transport error from wait_for_block must propagate as retryable Err");
+
+        assert!(
+            matches!(
+                error,
+                UnwrappedEquityRecoveryError::NodeSyncFailed {
+                    required_block: 9999,
+                    attempts: NODE_SYNC_MAX_ATTEMPTS,
+                }
+            ),
+            "transport error must map to NodeSyncFailed with attempts=NODE_SYNC_MAX_ATTEMPTS, \
+             got: {error:?}"
+        );
     }
 }

--- a/src/unwrapped_equity_recovery/job.rs
+++ b/src/unwrapped_equity_recovery/job.rs
@@ -1524,6 +1524,7 @@ mod tests {
                 TokenizedEquityMintCommand::WrapTokens {
                     wrap_tx_hash: wrap_tx,
                     wrapped_shares: U256::from(5_000_000_000_000_000_000u128),
+                    wrap_block: 1,
                 },
             )
             .await


### PR DESCRIPTION
## Why

[RAI-1069](https://linear.app/makeitrain/issue/RAI-1069/coin-equity-rebalance-dependent-on-chain-writes-fail-on-stale-reads) — COIN equity rebalancing fails at on-chain write steps because the load-balanced RPC routes a dependent transaction to a node that hasn't yet caught up to the block where the prerequisite transaction confirmed. The lagging node simulates against stale state (balance=0) and rejects it with `ERC20InsufficientBalance`. Observed systematically on prod 2026-06-16 across the redemption flow (withdraw→unwrap→transfer) and mint flow (mint→wrap→deposit).

## What

- Adds `wait_for_node_sync` in `crates/evm` — polls `eth_blockNumber` until the serving node reports `>= required_block`, 30 attempts at 1s each.
- Adds `Wrapper::wait_for_block(block)` trait method; `WrapperService` delegates to `wait_for_node_sync`.
- `confirm_wrap` / `confirm_unwrap` return `WrapConfirmation` / `UnwrapConfirmation` structs carrying both the amount and the confirmation block number (replaces bare `U256`).
- Gates dependent writes in the redemption flow: `SubmitUnwrap` waits for the Raindex withdrawal block (wrapper provider); `SendTokens` waits for the unwrap block on the **tokenizer's** provider — the same provider that performs the redemption transfer, so a caught-up wrapper provider can't mask a lagging tokenizer provider.
- Gates the on-demand ERC-20 approval inside `WrapperService::submit_wrap`: after the approval confirms, waits for the node to reach the approval block before submitting the ERC-4626 deposit (the deposit's pre-flight simulation reads the freshly granted allowance).
- Gates deposit in the mint flow: `finalize_received_mint` and both `WrapSubmitted`/`TokensWrapped` resume paths wait for the wrap block before depositing.
- Adds `NodeSyncFailed` retryable error variants to `EquityRedemptionError` and `UnwrappedEquityRecoveryError`; maps `wait_for_block` failures to these variants so callers can distinguish retryable RPC lag from permanent errors.
- `MissingBlockNumber` (`WrapperError`) and `MissingWithdrawBlock` (`EquityRedemptionError`) hard-fail when a freshly confirmed receipt lacks a block number.
- Block numbers flow through events/aggregate state as `Option<u64>` with `#[serde(default)]`; the wait is skipped when `None` for backward-compatibility with in-flight aggregates. The live `WrapTokens` command now takes a mandatory `wrap_block: u64` (only the persisted `TokensWrapped` event keeps `Option<u64>`) so a fresh mint can never emit an event that skips the deposit gate.

## How

- `wait_for_node_sync`: transport errors count against the budget (don't abort early); distinguishes all-transport-error (`EvmError::Transport`) from any-poll-succeeded-but-stale (`EvmError::NodeBehindRequiredBlock`).
- `node_sync_attempts(error)` helper in `crates/wrapper`: extracts attempt count from a `WrapperError`; falls back to `NODE_SYNC_MAX_ATTEMPTS` for the transport-error case. Shared by both the redemption and orphan-recovery call sites.
- `confirm_wrap`/`confirm_unwrap` now extract `receipt.block_number` (fail-hard if absent) and return it in named structs.
- New `WrappedMintResult` private struct in `rebalancing/equity` replaces the `(Address, U256)` tuple returned by `wrap_received_mint`.
- `Tokenizer::wait_for_block(block)` polls the tokenizer's own provider (`wait_for_node_sync` on the Alpaca wallet's provider); the redemption handler calls it instead of the wrapper's so the gate and the transfer share one provider.
- Guards are `if let Some(block) = ...` so aggregates persisted before this fix (`wrap_block: None`, `raindex_withdraw_block: None`, `unwrap_block: None`) skip the wait.

## Testing

- `crates/evm`: 7 unit tests for `wait_for_node_sync` — immediate success, retry-until-catch-up, budget exhausted, all-transport-error, and mixed-stale-then-transport.
- `crates/wrapper/service.rs`: `wait_for_block` success + error-mapping tests via `MockedWallet<AssertedProvider>`; the error-mapping test injects a zero poll interval (runs instantly instead of ~29s). 3 `submit_wrap` tests cover the approval-gate happy path, the node-behind gate (deposit not attempted), and a blockless approval receipt (`MissingBlockNumber`).
- `src/equity_redemption.rs`: `SubmitUnwrap` (wrapper) and `SendTokens` (tokenizer) happy path (block passed), backward-compat (`None` skips), failure (`NodeSyncFailed`); `ConfirmWithdraw` fails with `MissingWithdrawBlock` on a blockless receipt. `SendTokens` tests assert on the tokenizer's `wait_for_block` calls.
- `src/tokenization/alpaca.rs`: `wait_for_block` succeeds against an anvil node already at the required block.
- `src/rebalancing/equity/mod.rs`: `TokensWrapped` resume happy path (wait called, deposit runs), `TokensWrapped` resume abort path (deposit does not run when wait fails), `WrapSubmitted` resume abort path; `finalize_received_mint` abort path (wait failure propagates before deposit).
- `src/unwrapped_equity_recovery/aggregate.rs`: `SubmitOrphanDeposit` wait called, `NodeSyncFailed` on `NodeBehindRequiredBlock`, `NodeSyncFailed` with `attempts=NODE_SYNC_MAX_ATTEMPTS` on transport error (exercises the `_ =>` fallback in `node_sync_attempts`).

## Anything else

- No schema migrations — all new *persisted* event/aggregate fields are additive `Option<u64>` with `#[serde(default)]`. The live `WrapTokens.wrap_block`, `WrapConfirmation.block`, and `UnwrapConfirmation.block` are mandatory (not persisted).
- Breaking (internal API): the `Wrapper` and `Tokenizer` traits gain `wait_for_block`, and `confirm_wrap`/`confirm_unwrap` now return `WrapConfirmation`/`UnwrapConfirmation` structs instead of bare `U256` — all in-tree implementors updated.
- In-flight aggregates at `UnwrapPending`, `SendPending`, `OrphanWrapped`, or `TokensWrapped` with `None` block fields skip the new wait and continue as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Blockchain node synchronization polling to verify nodes reach required block heights before confirming transactions
  * Wrap and unwrap operations now capture the confirmation block number
  * Enhanced error handling for node-sync failures and missing block numbers in wrapping and redemption workflows
  * Mint and redemption processes conditionally wait for blockchain confirmation blocks before proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
