### PR TITLE
feat: dividend-bump CLI command for the wtStock NAV bump

### DIFF
--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1124,6 +1124,18 @@ impl Ctx {
             .get(symbol)
             .is_some_and(|config| config.wrapped_equity_recovery == OperationMode::Enabled)
     }
+
+    /// Returns the configured tokenized-equity (minted onchain token) address
+    /// for `symbol`, or `None` when the symbol is absent from
+    /// `[assets.equities]`. Lets operator commands resolve the token from the
+    /// ticker instead of taking an error-prone address argument.
+    pub fn tokenized_equity(&self, symbol: &Symbol) -> Option<Address> {
+        self.assets
+            .equities
+            .symbols
+            .get(symbol)
+            .map(|config| config.tokenized_equity)
+    }
 }
 
 /// Test-only constructor for `Ctx` that internalizes fields e2e tests

--- a/crates/wrapper/src/lib.rs
+++ b/crates/wrapper/src/lib.rs
@@ -184,6 +184,26 @@ pub trait Wrapper: Send + Sync {
         owner: Address,
     ) -> Result<(TxHash, U256), WrapperError>;
 
+    /// Donates underlying tokens directly into the wrapper to bump its NAV.
+    ///
+    /// A bare ERC-20 transfer of the underlying into the ERC-4626 vault raises
+    /// `totalAssets()` without minting any shares, so `convertToAssets` rises
+    /// for every existing holder. This is the dividend / corporate-action
+    /// NAV-bump path -- distinct from [`to_wrapped`](Wrapper::to_wrapped), which
+    /// mints shares to a receiver.
+    ///
+    /// # Arguments
+    /// * `wrapped_token` - The ERC-4626 vault (wrapper) address to donate into
+    /// * `underlying_amount` - Amount of underlying tokens to transfer in
+    ///
+    /// # Returns
+    /// The transfer transaction hash, once confirmed.
+    async fn donate(
+        &self,
+        wrapped_token: Address,
+        underlying_amount: U256,
+    ) -> Result<TxHash, WrapperError>;
+
     /// Submit an ERC-4626 deposit without waiting for confirmation.
     ///
     /// Handles approval if needed, submits the deposit transaction, and

--- a/crates/wrapper/src/mock.rs
+++ b/crates/wrapper/src/mock.rs
@@ -22,6 +22,7 @@ enum MockFailure {
     ConfirmWrap,
     RetryableConfirmWrap,
     Unwrap,
+    Donate,
     Lookup,
     DerivativeLookup,
     /// Fails `wait_for_block` with `NodeBehindRequiredBlock` (budget exhausted).
@@ -100,6 +101,13 @@ impl MockWrapper {
     pub fn failing_unwrap() -> Self {
         let mut mock = Self::new();
         mock.failure = MockFailure::Unwrap;
+        mock
+    }
+
+    /// Creates a mock wrapper that fails on donate (NAV-bump transfer) operations.
+    pub fn failing_donate() -> Self {
+        let mut mock = Self::new();
+        mock.failure = MockFailure::Donate;
         mock
     }
 
@@ -227,6 +235,23 @@ impl Wrapper for MockWrapper {
         }
         // 1:1 ratio for mock - underlying amount equals wrapped amount
         Ok((self.unwrap_tx, wrapped_amount))
+    }
+
+    async fn donate(
+        &self,
+        _wrapped_token: Address,
+        _underlying_amount: U256,
+    ) -> Result<TxHash, WrapperError> {
+        if self.failure == MockFailure::Donate {
+            return Err(WrapperError::Evm(EvmError::Transport(RpcError::ErrorResp(
+                alloy::rpc::json_rpc::ErrorPayload {
+                    code: -32000,
+                    message: "wrapper donation transfer failed".into(),
+                    data: None,
+                },
+            ))));
+        }
+        Ok(TxHash::random())
     }
 
     async fn submit_wrap(

--- a/crates/wrapper/src/service.rs
+++ b/crates/wrapper/src/service.rs
@@ -160,6 +160,43 @@ impl<W: Wallet> Wrapper for WrapperService<W> {
         Ok((tx_hash, assets))
     }
 
+    async fn donate(
+        &self,
+        wrapped_token: Address,
+        underlying_amount: U256,
+    ) -> Result<TxHash, WrapperError> {
+        let underlying_token: Address = self
+            .wallet
+            .call::<OpenChainErrorRegistry, _>(wrapped_token, IERC4626::assetCall {})
+            .await?;
+
+        info!(
+            target: "orderbook",
+            %underlying_token,
+            %wrapped_token,
+            %underlying_amount,
+            "Donating underlying into ERC-4626 wrapper to bump NAV"
+        );
+
+        let receipt = self
+            .wallet
+            .submit::<OpenChainErrorRegistry, _>(
+                underlying_token,
+                IERC20::transferCall {
+                    to: wrapped_token,
+                    amount: underlying_amount,
+                },
+                "ERC20 transfer donating into ERC4626 wrapper",
+            )
+            .await?;
+
+        let tx_hash = receipt.transaction_hash;
+
+        info!(target: "orderbook", %tx_hash, "Wrapper NAV donation confirmed");
+
+        Ok(tx_hash)
+    }
+
     async fn submit_wrap(
         &self,
         wrapped_token: Address,

--- a/docs/cli-ops.md
+++ b/docs/cli-ops.md
@@ -13,8 +13,10 @@ on any specific command.
 
 ## Token Address Reference
 
-The `-t` flag on tokenization/redemption commands expects the **unwrapped**
-token contract address for that equity. Current addresses:
+The **unwrapped** tokenized-equity contract address per symbol. The tokenization
+and redemption commands resolve this from `-s` via `[assets.equities]`, so it no
+longer has to be passed by hand; the table is kept for reference and
+cross-checking. Current addresses:
 
 | Symbol | Unwrapped Token Address                      |
 | ------ | -------------------------------------------- |
@@ -36,8 +38,11 @@ token contract address for that equity. Current addresses:
 
 ### Buying and Minting (Acquiring Tokenized Shares)
 
-To get tokenized shares into a wallet, buy offchain shares via the broker and
-then tokenize them onchain.
+To get tokenized shares into the **market-making** wallet, buy offchain shares
+via the broker and then tokenize them onchain. These run as the market-making
+bot (`stox`). For a dividend bump, use `s01 dividend-bump` instead (it runs as
+the issuer -- see below); do not follow the steps here with the liquidity
+wallet.
 
 **Step 1: Buy shares offchain**
 
@@ -52,14 +57,47 @@ Alpaca dashboard to confirm the order filled before proceeding.
 
 ```
 stox alpaca-tokenize -s COIN -q 10 \
-  -t 0x626757e6f50675d17fcad312e82f989ae7a23d38 \
   -r 0xbd41F40D91eE4E816Ada1Aa842e94aEb6B6385a6
 ```
 
-- `-t` is the unwrapped token contract address (see table above)
+- The tokenized-equity address is resolved from `-s` via `[assets.equities]`, so
+  it never has to be entered by hand
 - `-r` is the wallet that receives the minted tokens -- **always specify this**.
   Use the Fireblocks liquidity address
   (`0xbd41F40D91eE4E816Ada1Aa842e94aEb6B6385a6`)
+
+### Applying a Dividend NAV Bump (Donating into the Wrapper)
+
+When a dividend or corporate action revalues an equity, bump the wtStock
+wrapper's NAV with a single `dividend-bump` command: it buys the equivalent
+shares with the dividend cash, tokenizes them onchain, and **donates** the
+tokenized shares into the wrapper, waiting for each step to settle before the
+next. A bare ERC-20 transfer into the ERC-4626 vault raises its
+`convertToAssets` ratio without minting any wrapped shares -- see
+[wrapper-nav-bump.md](wrapper-nav-bump.md) for why.
+
+Run it as the **issuer** with `s01` -- the issuer-config counterpart of `stox`
+(same binary, but defaulting to the issuer's `[wallet]` turnkey signer, Alpaca
+account, and database) -- so the buy, tokenize, and donate are funded and signed
+by the issuer rather than the market-making wallet:
+
+```
+s01 dividend-bump -s COIN -q 10
+```
+
+`s01` defaults to `/run/st0x/s01-issuer.config` and
+`/run/agenix/s01-issuer.toml`; override with `S01_CONFIG`/`S01_SECRETS`.
+**Always run a dividend bump as the issuer:** a plain `stox dividend-bump` would
+buy, tokenize, and donate from the **market-making** wallet, not the issuer. To
+use `stox` you must pass the issuer `--config`/`--secrets` explicitly.
+
+The command buys 10 COIN offchain and waits for the fill, tokenizes the shares
+to the configured wallet and waits for them to arrive onchain, then transfers
+them into the wrapper and waits for confirmation. No wrapped shares are minted
+-- every existing wtCOIN holder's shares are simply worth more. The standalone
+`buy`, `alpaca-tokenize`, and `donate-equity` subcommands remain for running a
+single step in isolation; use `wrap-equity` only when you want to _receive_
+wrapped shares (a deposit), never for a dividend bump.
 
 ### Selling and Redeeming (Liquidating Tokenized Shares)
 
@@ -68,8 +106,7 @@ Reverse of buying and minting: redeem tokens offchain, then sell the shares.
 **Step 1: Redeem tokens**
 
 ```
-stox alpaca-redeem -s COIN -q 10 \
-  -t 0x626757e6f50675d17fcad312e82f989ae7a23d38
+stox alpaca-redeem -s COIN -q 10
 ```
 
 **Step 2: Sell shares offchain**

--- a/os.nix
+++ b/os.nix
@@ -15,6 +15,8 @@ let
 
   certDir = "/var/lib/tailscale-cert";
 
+  # `stox` runs the CLI as the market-making bot: it defaults to the deployed
+  # liquidity config/secrets so operators don't pass --config/--secrets.
   cli = pkgs.writeShellApplication {
     name = "stox";
     runtimeInputs = [ st0x-cli ];
@@ -22,6 +24,22 @@ let
       exec st0x-cli \
         --config "''${STOX_CONFIG:-/run/st0x/st0x-hedge.config}" \
         --secrets "''${STOX_SECRETS:-/run/agenix/st0x-hedge.toml}" \
+        "$@"
+    '';
+  };
+
+  # `s01` runs the same CLI as the issuer: it defaults to the issuer
+  # config/secrets (separate turnkey wallet + Alpaca account + DB) so the
+  # dividend bump (buy -> tokenize -> donate) is funded and signed by the
+  # issuer rather than the market-making wallet. Override with
+  # S01_CONFIG/S01_SECRETS to point at an ad-hoc issuer config.
+  s01 = pkgs.writeShellApplication {
+    name = "s01";
+    runtimeInputs = [ st0x-cli ];
+    text = ''
+      exec st0x-cli \
+        --config "''${S01_CONFIG:-/run/st0x/s01-issuer.config}" \
+        --secrets "''${S01_SECRETS:-/run/agenix/s01-issuer.toml}" \
         "$@"
     '';
   };
@@ -219,6 +237,7 @@ in
     vim
     zellij
     cli
+    s01
   ];
 
   system.stateVersion = "24.11";

--- a/src/cli/dividend.rs
+++ b/src/cli/dividend.rs
@@ -1,0 +1,150 @@
+//! Composite dividend NAV-bump command.
+//!
+//! Runs the three issuer steps of a dividend bump -- buy the equity offchain,
+//! tokenize it onchain, donate the tokenized shares into the ERC-4626 wrapper --
+//! in a single invocation. Each step waits for the previous one to settle (the
+//! buy for its fill, the tokenize for tokens to land onchain, the donate for its
+//! receipt), so the flow is reliable instead of a babysat three-command runbook.
+//! Shares are tokenized to, and donated from, the configured `[wallet]`, so the
+//! issuer config funds and signs the whole bump.
+
+use std::io::Write;
+
+use alloy::providers::Provider;
+
+use st0x_config::Ctx;
+use st0x_execution::{FractionalShares, Positive, Symbol};
+
+use super::{rebalancing, trading, wrapper};
+
+pub(super) async fn dividend_bump_command<Writer: Write, Prov: Provider + Clone + 'static>(
+    stdout: &mut Writer,
+    symbol: Symbol,
+    quantity: Positive<FractionalShares>,
+    ctx: &Ctx,
+    provider: Prov,
+) -> anyhow::Result<()> {
+    writeln!(stdout, "Dividend NAV bump: {quantity} {symbol}")?;
+
+    writeln!(
+        stdout,
+        "Step 1/3: buying {quantity} {symbol} and waiting for fill"
+    )?;
+    trading::execute_market_buy_until_filled(ctx, symbol.clone(), quantity, stdout).await?;
+
+    writeln!(stdout, "Step 2/3: tokenizing {quantity} {symbol} onchain")?;
+    rebalancing::alpaca_tokenize_command(
+        stdout,
+        symbol.clone(),
+        quantity.inner(),
+        None,
+        ctx,
+        provider,
+    )
+    .await?;
+
+    writeln!(
+        stdout,
+        "Step 3/3: donating {quantity} {symbol} into the wrapper"
+    )?;
+    wrapper::donate_equity_command(stdout, symbol, quantity, ctx).await?;
+
+    writeln!(stdout, "✅ Dividend NAV bump completed")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, address};
+    use alloy::providers::ProviderBuilder;
+    use url::Url;
+
+    use st0x_config::create_test_issuance_ctx;
+    use st0x_config::{
+        AssetsConfig, BrokerCtx, EquitiesConfig, EvmCtx, ExecutionThreshold, LogLevel, TradingMode,
+    };
+
+    use super::*;
+    use crate::test_utils::positive_shares;
+
+    fn dry_run_ctx() -> Ctx {
+        Ctx {
+            database_url: ":memory:".to_string(),
+            log_level: LogLevel::Debug,
+            log_dir: None,
+            server_port: 8080,
+            board_port: 8081,
+            evm: EvmCtx {
+                rpc_url: Url::parse("http://localhost:8545").unwrap(),
+                orderbook: address!("0x1234567890123456789012345678901234567890"),
+                deployment_block: 1,
+                required_confirmations: 0,
+            },
+            order_polling_interval: 15,
+            order_polling_max_jitter: 5,
+            position_check_interval: 60,
+            inventory_poll_interval: 60,
+            order_fill_poll_interval: 5,
+            apalis_finished_job_cleanup_interval_secs: 3600,
+            broker: BrokerCtx::DryRun,
+            telemetry: None,
+            alerts: None,
+            trading_mode: TradingMode::Standalone,
+            order_owner: Address::ZERO,
+            wallet: None,
+            wallet_meta: None,
+            execution_threshold: ExecutionThreshold::whole_share(),
+            assets: AssetsConfig {
+                equities: EquitiesConfig::default(),
+                cash: None,
+            },
+            travel_rule: None,
+            rest_api: None,
+            issuance: create_test_issuance_ctx(),
+            redemption_wallet: None,
+        }
+    }
+
+    /// The bump must run buy -> tokenize -> donate in order and stop at the first
+    /// failing step. With a DryRun broker the mock buy fills, but tokenization
+    /// fails because the symbol is not configured, so the donate step must never
+    /// run and the error must propagate to the caller.
+    #[tokio::test]
+    async fn dividend_bump_stops_after_buy_when_tokenize_fails() {
+        let ctx = dry_run_ctx();
+        let provider =
+            ProviderBuilder::new().connect_http(Url::parse("http://localhost:8545").unwrap());
+        let mut stdout = Vec::new();
+
+        let error = dividend_bump_command(
+            &mut stdout,
+            Symbol::new("COIN").unwrap(),
+            positive_shares("10"),
+            &ctx,
+            provider,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("equity COIN is not configured in [assets.equities]"),
+            "tokenize must fail on the unconfigured symbol, got: {error}"
+        );
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Buy filled"),
+            "the buy must complete before tokenize runs; output: {output}"
+        );
+        assert!(
+            output.contains("Step 2/3"),
+            "tokenize must be attempted after the buy; output: {output}"
+        );
+        assert!(
+            !output.contains("Step 3/3"),
+            "donate must not run after tokenize fails; output: {output}"
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 mod alpaca_wallet;
 mod cctp;
+mod dividend;
 mod rebalancing;
 mod repair;
 mod submit;
@@ -263,6 +264,37 @@ pub enum Commands {
         quantity: Positive<FractionalShares>,
     },
 
+    /// Donate tokenized equity into its ERC-4626 wrapper to bump the wrapper NAV
+    ///
+    /// A bare transfer of the underlying into the vault raises its share price
+    /// (`convertToAssets`) without minting new wrapped shares -- the dividend /
+    /// corporate-action NAV bump. Point `--config`/`--secrets` at the dividend
+    /// turnkey wallet to fund it from issuance.
+    DonateEquity {
+        /// Stock symbol (e.g., AAPL, TSLA)
+        #[arg(short = 's', long = "symbol")]
+        symbol: Symbol,
+        /// Number of tokenized shares to donate into the wrapper (must be positive)
+        #[arg(short = 'q', long = "quantity", value_parser = parse_positive_shares)]
+        quantity: Positive<FractionalShares>,
+    },
+
+    /// Apply a dividend NAV bump in one step: buy the equity, tokenize it, and
+    /// donate it into the wrapper
+    ///
+    /// Runs buy -> tokenize -> donate in sequence, waiting for each step to
+    /// settle (buy fill, tokens onchain, donate receipt). Shares are tokenized
+    /// to and donated from the configured `[wallet]`; point `--config` /
+    /// `--secrets` at the issuer turnkey wallet.
+    DividendBump {
+        /// Stock symbol (e.g., AAPL, TSLA)
+        #[arg(short = 's', long = "symbol")]
+        symbol: Symbol,
+        /// Number of shares to buy, tokenize, and donate (must be positive)
+        #[arg(short = 'q', long = "quantity", value_parser = parse_positive_shares)]
+        quantity: Positive<FractionalShares>,
+    },
+
     /// Transfer USDC between trading venues (Raindex <-> Alpaca)
     ///
     /// Requires Alpaca broker and rebalancing environment variables.
@@ -504,15 +536,13 @@ pub enum Commands {
     /// This is an isolated test command that only interacts with Alpaca's API,
     /// without any Raindex/vault operations.
     AlpacaTokenize {
-        /// Stock symbol (e.g., AAPL, TSLA)
+        /// Stock symbol (e.g., AAPL, TSLA) -- resolves the tokenized-equity
+        /// address from `[assets.equities]`
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
         /// Number of shares to tokenize (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
-        /// Token contract address (to verify balance after tokenization)
-        #[arg(short = 't', long = "token")]
-        token: Address,
         /// Recipient wallet address (defaults to configured wallet address)
         #[arg(short = 'r', long = "recipient")]
         recipient: Option<Address>,
@@ -524,15 +554,13 @@ pub enum Commands {
     /// This is an isolated test command that only interacts with Alpaca's API,
     /// without any Raindex/vault operations.
     AlpacaRedeem {
-        /// Stock symbol (e.g., AAPL, TSLA)
+        /// Stock symbol (e.g., AAPL, TSLA) -- resolves the tokenized-equity
+        /// address from `[assets.equities]`
         #[arg(short = 's', long = "symbol")]
         symbol: Symbol,
         /// Number of shares to redeem (supports fractional shares)
         #[arg(short = 'q', long = "quantity")]
         quantity: FractionalShares,
-        /// Token contract address
-        #[arg(short = 't', long = "token")]
-        token: Address,
         /// Alpaca redemption wallet (overrides [tokenization] config)
         #[arg(long = "redemption-wallet")]
         redemption_wallet: Option<Address>,
@@ -738,6 +766,10 @@ enum SimpleCommand {
         quantity: Positive<FractionalShares>,
     },
     UnwrapEquity {
+        symbol: Symbol,
+        quantity: Positive<FractionalShares>,
+    },
+    DonateEquity {
         symbol: Symbol,
         quantity: Positive<FractionalShares>,
     },
@@ -950,14 +982,16 @@ enum ProviderCommand {
     AlpacaTokenize {
         symbol: Symbol,
         quantity: FractionalShares,
-        token: Address,
         recipient: Option<Address>,
     },
     AlpacaRedeem {
         symbol: Symbol,
         quantity: FractionalShares,
-        token: Address,
         redemption_wallet: Option<Address>,
+    },
+    DividendBump {
+        symbol: Symbol,
+        quantity: Positive<FractionalShares>,
     },
     AlpacaTokenizationRequests,
 }
@@ -1026,6 +1060,9 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         }
         Commands::UnwrapEquity { symbol, quantity } => {
             Ok(SimpleCommand::UnwrapEquity { symbol, quantity })
+        }
+        Commands::DonateEquity { symbol, quantity } => {
+            Ok(SimpleCommand::DonateEquity { symbol, quantity })
         }
         Commands::AlpacaDeposit { amount } => Ok(SimpleCommand::AlpacaDeposit { amount }),
         Commands::AlpacaWithdraw { amount, to_address } => {
@@ -1097,25 +1134,24 @@ fn classify_command(command: Commands) -> Result<SimpleCommand, ProviderCommand>
         Commands::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         } => Err(ProviderCommand::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         }),
         Commands::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         } => Err(ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         }),
+        Commands::DividendBump { symbol, quantity } => {
+            Err(ProviderCommand::DividendBump { symbol, quantity })
+        }
         Commands::OrderStatus { order_id } => Ok(SimpleCommand::OrderStatus { order_id }),
         Commands::Submit { to, data, yes } => Ok(SimpleCommand::Submit { to, data, yes }),
         Commands::RebuildView { aggregate, id, all } => {
@@ -1216,6 +1252,9 @@ async fn run_simple_command<W: Write>(
         }
         SimpleCommand::UnwrapEquity { symbol, quantity } => {
             wrapper::unwrap_equity_command(stdout, symbol, quantity, ctx).await
+        }
+        SimpleCommand::DonateEquity { symbol, quantity } => {
+            wrapper::donate_equity_command(stdout, symbol, quantity, ctx).await
         }
         SimpleCommand::AlpacaDeposit { amount } => {
             alpaca_wallet::alpaca_deposit_command::<OpenChainErrorRegistry, _>(stdout, amount, ctx)
@@ -1482,29 +1521,21 @@ async fn run_provider_command<W: Write>(
         ProviderCommand::AlpacaTokenize {
             symbol,
             quantity,
-            token,
             recipient,
         } => {
-            rebalancing::alpaca_tokenize_command(
-                stdout, symbol, quantity, token, recipient, ctx, provider,
-            )
-            .await
+            rebalancing::alpaca_tokenize_command(stdout, symbol, quantity, recipient, ctx, provider)
+                .await
         }
         ProviderCommand::AlpacaRedeem {
             symbol,
             quantity,
-            token,
             redemption_wallet,
         } => {
-            rebalancing::alpaca_redeem_command(
-                stdout,
-                symbol,
-                quantity,
-                token,
-                redemption_wallet,
-                ctx,
-            )
-            .await
+            rebalancing::alpaca_redeem_command(stdout, symbol, quantity, redemption_wallet, ctx)
+                .await
+        }
+        ProviderCommand::DividendBump { symbol, quantity } => {
+            dividend::dividend_bump_command(stdout, symbol, quantity, ctx, provider).await
         }
         ProviderCommand::AlpacaTokenizationRequests => {
             rebalancing::alpaca_tokenization_requests_command(stdout, ctx).await
@@ -1582,6 +1613,28 @@ mod tests {
             }
             other => panic!("expected buy command, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn dividend_bump_command_parses_symbol_and_quantity() {
+        let cli =
+            Cli::try_parse_from(["st0x-cli", "dividend-bump", "-s", "COIN", "-q", "10.5"]).unwrap();
+
+        match cli.command {
+            Commands::DividendBump { symbol, quantity } => {
+                assert_eq!(symbol, Symbol::new("COIN").unwrap());
+                assert_eq!(quantity, positive_shares("10.5"));
+            }
+            other => panic!("expected dividend-bump command, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dividend_bump_command_rejects_zero_quantity() {
+        let error = Cli::try_parse_from(["st0x-cli", "dividend-bump", "-s", "COIN", "-q", "0"])
+            .unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains('0'), "unexpected clap error: {rendered}");
     }
 
     #[test]
@@ -1671,6 +1724,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification"),
         }
@@ -1692,6 +1746,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected process-tx provider command"),
             Ok(_) => panic!("expected provider command classification"),
@@ -1818,6 +1873,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification, got provider command"),
         }
@@ -1847,6 +1903,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification, got provider command"),
         }
@@ -1873,6 +1930,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification, got provider command"),
         }
@@ -2140,6 +2198,7 @@ mod tests {
                 | ProviderCommand::ResetAllowance { .. }
                 | ProviderCommand::AlpacaTokenize { .. }
                 | ProviderCommand::AlpacaRedeem { .. }
+                | ProviderCommand::DividendBump { .. }
                 | ProviderCommand::AlpacaTokenizationRequests,
             ) => panic!("expected simple command classification"),
         }

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -817,7 +817,6 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: FractionalShares,
-    token: Address,
     recipient: Option<Address>,
     ctx: &Ctx,
     provider: Prov,
@@ -825,6 +824,10 @@ pub(super) async fn alpaca_tokenize_command<Writer: Write, Prov: Provider + Clon
     writeln!(stdout, "🔄 Requesting tokenization via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+
+    let token = ctx
+        .tokenized_equity(&symbol)
+        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -949,13 +952,16 @@ pub(super) async fn alpaca_redeem_command<Writer: Write>(
     stdout: &mut Writer,
     symbol: Symbol,
     quantity: FractionalShares,
-    token: Address,
     redemption_wallet_flag: Option<Address>,
     ctx: &Ctx,
 ) -> anyhow::Result<()> {
     writeln!(stdout, "🔄 Requesting redemption via Alpaca API")?;
     writeln!(stdout, "   Symbol: {symbol}")?;
     writeln!(stdout, "   Quantity: {quantity}")?;
+
+    let token = ctx
+        .tokenized_equity(&symbol)
+        .ok_or_else(|| anyhow::anyhow!("equity {symbol} is not configured in [assets.equities]"))?;
     writeln!(stdout, "   Token: {token}")?;
 
     let BrokerCtx::AlpacaBrokerApi(alpaca_auth) = &ctx.broker else {
@@ -1250,6 +1256,7 @@ pub(crate) async fn recheck_transfer_command<W: Write>(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address, b256};
+    use alloy::providers::ProviderBuilder;
     use rain_math_float::Float;
     use url::Url;
     use uuid::uuid;
@@ -1269,7 +1276,8 @@ mod tests {
     use st0x_config::RebalancingCtx;
     use st0x_config::create_test_issuance_ctx;
     use st0x_config::{
-        AssetsConfig, CashAssetConfig, EquitiesConfig, LogLevel, OperationMode, TradingMode,
+        AssetsConfig, CashAssetConfig, EquitiesConfig, EquityAssetConfig, LogLevel, OperationMode,
+        TradingMode,
     };
 
     /// RAI-835: the manual redrive loop must re-invoke `resume` on the same id
@@ -2816,6 +2824,85 @@ mod tests {
         assert!(
             err_msg.contains("only valid from BridgingSubmitting or WithdrawalComplete"),
             "WithdrawalFailed state must be rejected as not in bridging phase; got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn tokenized_equity_resolves_from_config() {
+        let mut ctx = create_ctx_without_rebalancing();
+        let token = address!("0x626757e6f50675d17fcad312e82f989ae7a23d38");
+        ctx.assets.equities.symbols.insert(
+            Symbol::new("COIN").unwrap(),
+            EquityAssetConfig {
+                tokenized_equity: token,
+                tokenized_equity_derivative: Address::ZERO,
+                pyth_feed_id: None,
+                vault_ids: Vec::new(),
+                trading: OperationMode::Enabled,
+                rebalancing: OperationMode::Disabled,
+                wrapped_equity_recovery: OperationMode::Disabled,
+                operational_limit: None,
+            },
+        );
+
+        assert_eq!(
+            ctx.tokenized_equity(&Symbol::new("COIN").unwrap()),
+            Some(token),
+            "a configured symbol must resolve to its tokenized_equity address",
+        );
+        assert_eq!(
+            ctx.tokenized_equity(&Symbol::new("AAPL").unwrap()),
+            None,
+            "an unconfigured symbol must resolve to None, never a default address",
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_tokenize_fails_when_symbol_not_configured() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let provider =
+            ProviderBuilder::new().connect_http(Url::parse("http://localhost:8545").unwrap());
+        let mut stdout = Vec::new();
+
+        let error = alpaca_tokenize_command(
+            &mut stdout,
+            Symbol::new("COIN").unwrap(),
+            FractionalShares::new(float!(10)),
+            None,
+            &ctx,
+            provider,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("equity COIN is not configured in [assets.equities]"),
+            "an unconfigured symbol must fail before any network call, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn alpaca_redeem_fails_when_symbol_not_configured() {
+        let ctx = create_alpaca_ctx_without_rebalancing();
+        let mut stdout = Vec::new();
+
+        let error = alpaca_redeem_command(
+            &mut stdout,
+            Symbol::new("COIN").unwrap(),
+            FractionalShares::new(float!(10)),
+            None,
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("equity COIN is not configured in [assets.equities]"),
+            "an unconfigured symbol must fail before any network call, got: {error}"
         );
     }
 }

--- a/src/cli/trading.rs
+++ b/src/cli/trading.rs
@@ -449,6 +449,72 @@ pub(super) async fn execute_broker_order<W: Write>(
     }
 }
 
+/// Poll cadence for the dividend-bump buy-fill wait. Mirrors the tokenization
+/// poll loop in `alpaca_tokenize_command`: a market buy normally fills quickly,
+/// but the composite flow must not tokenize against an unfilled order.
+const BUY_FILL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+const BUY_FILL_MAX_ATTEMPTS: u32 = 150;
+
+/// Places a market buy and blocks until the broker reports it filled, so the
+/// dividend NAV bump can act on the acquired shares instead of racing an
+/// unfilled order into the tokenization step.
+pub(super) async fn execute_market_buy_until_filled<W: Write>(
+    ctx: &Ctx,
+    symbol: Symbol,
+    shares: Positive<FractionalShares>,
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    let market_order = MarketOrder {
+        symbol,
+        shares,
+        direction: Direction::Buy,
+        client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+    };
+
+    match &ctx.broker {
+        BrokerCtx::AlpacaBrokerApi(alpaca_auth) => {
+            let broker = alpaca_auth.clone().try_into_executor().await?;
+            place_market_order_until_filled(&broker, market_order, stdout).await
+        }
+        BrokerCtx::DryRun => {
+            let broker = MockExecutorCtx.try_into_executor().await?;
+            place_market_order_until_filled(&broker, market_order, stdout).await
+        }
+    }
+}
+
+async fn place_market_order_until_filled<Exec: Executor, W: Write>(
+    broker: &Exec,
+    market_order: MarketOrder,
+    stdout: &mut W,
+) -> anyhow::Result<()> {
+    let placement = broker.place_market_order(market_order).await?;
+    writeln!(stdout, "   Buy order placed: {}", placement.order_id)?;
+
+    for attempt in 1..=BUY_FILL_MAX_ATTEMPTS {
+        match broker.get_order_status(&placement.order_id).await? {
+            OrderState::Filled { order_id, .. } => {
+                writeln!(stdout, "   Buy filled (order {order_id})")?;
+                return Ok(());
+            }
+            OrderState::Failed { error_reason, .. } => {
+                anyhow::bail!("buy order failed: {error_reason:?}");
+            }
+            OrderState::Pending | OrderState::Submitted { .. } => {
+                if attempt % 10 == 0 {
+                    writeln!(
+                        stdout,
+                        "   Waiting for buy fill... (attempt {attempt}/{BUY_FILL_MAX_ATTEMPTS})"
+                    )?;
+                }
+                tokio::time::sleep(BUY_FILL_POLL_INTERVAL).await;
+            }
+        }
+    }
+
+    anyhow::bail!("timed out waiting for the buy order to fill")
+}
+
 pub(super) async fn process_found_trade<W: Write>(
     onchain_trade: OnchainTrade,
     ctx: &Ctx,
@@ -1164,6 +1230,54 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "--time-in-force is not supported with --limit-price"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_returns_once_the_broker_reports_filled() {
+        // MockExecutor reports Filled by default, so the poll resolves on the
+        // first status check.
+        let broker = MockExecutor::new();
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .expect("a filled order must resolve the buy-fill wait");
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(
+            output.contains("Buy filled"),
+            "the buy-fill wait must report the fill, got: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn market_buy_fails_when_the_broker_rejects_the_order() {
+        let broker = MockExecutor::new().with_order_status(OrderState::Failed {
+            failed_at: Utc::now(),
+            error_reason: Some("rejected".to_string()),
+        });
+        let order = MarketOrder {
+            symbol: Symbol::new("AAPL").unwrap(),
+            shares: positive_shares("10"),
+            direction: Direction::Buy,
+            client_order_id: ClientOrderId::cli(Uuid::new_v4()),
+        };
+        let mut stdout = Vec::new();
+
+        let error = place_market_order_until_filled(&broker, order, &mut stdout)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("buy order failed"),
+            "a rejected order must fail the buy-fill wait, got: {error}"
         );
     }
 }

--- a/src/cli/wrapper.rs
+++ b/src/cli/wrapper.rs
@@ -26,9 +26,9 @@ pub(super) async fn wrap_equity_command<Writer: Write>(
     wrap_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
 }
 
-async fn wrap_equity_with_wrapper<Writer: Write, W: Wrapper + ?Sized>(
+async fn wrap_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized>(
     stdout: &mut Writer,
-    wrapper: &W,
+    wrapper: &WrapperImpl,
     owner: Address,
     symbol: Symbol,
     quantity: Positive<FractionalShares>,
@@ -90,9 +90,9 @@ pub(super) async fn unwrap_equity_command<Writer: Write>(
     unwrap_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
 }
 
-async fn unwrap_equity_with_wrapper<Writer: Write, W: Wrapper + ?Sized>(
+async fn unwrap_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized>(
     stdout: &mut Writer,
-    wrapper: &W,
+    wrapper: &WrapperImpl,
     owner: Address,
     symbol: Symbol,
     quantity: Positive<FractionalShares>,
@@ -131,6 +131,62 @@ async fn unwrap_equity_with_wrapper<Writer: Write, W: Wrapper + ?Sized>(
     Ok(())
 }
 
+pub(super) async fn donate_equity_command<Writer: Write>(
+    stdout: &mut Writer,
+    symbol: Symbol,
+    quantity: Positive<FractionalShares>,
+    ctx: &Ctx,
+) -> anyhow::Result<()> {
+    let wallet_ctx = ctx.wallet()?;
+    let base_wallet = wallet_ctx.base_wallet().clone();
+    let owner = base_wallet.address();
+    let wrapper = WrapperService::new(
+        base_wallet,
+        to_wrapped_equities(&ctx.assets.equities.symbols),
+    );
+
+    donate_equity_with_wrapper(stdout, &wrapper, owner, symbol, quantity).await
+}
+
+async fn donate_equity_with_wrapper<Writer: Write, WrapperImpl: Wrapper + ?Sized>(
+    stdout: &mut Writer,
+    wrapper: &WrapperImpl,
+    owner: Address,
+    symbol: Symbol,
+    quantity: Positive<FractionalShares>,
+) -> anyhow::Result<()> {
+    writeln!(
+        stdout,
+        "Donating tokenized equity into the wrapper to bump its NAV"
+    )?;
+    writeln!(stdout, "   Symbol: {symbol}")?;
+    writeln!(stdout, "   Donation quantity: {quantity}")?;
+    writeln!(stdout, "   Source wallet: {owner}")?;
+
+    let wrapped_token = wrapper.lookup_derivative(&symbol)?;
+    let underlying_token = wrapper.lookup_underlying(&symbol)?;
+
+    writeln!(stdout, "   Wrapped token (NAV recipient): {wrapped_token}")?;
+    writeln!(stdout, "   Underlying token: {underlying_token}")?;
+
+    let underlying_amount = quantity.inner().to_u256_18_decimals()?;
+    writeln!(
+        stdout,
+        "   Underlying amount (smallest unit): {underlying_amount}"
+    )?;
+    writeln!(
+        stdout,
+        "   Transferring underlying into the wrapper (no shares minted)..."
+    )?;
+
+    let donate_tx_hash = wrapper.donate(wrapped_token, underlying_amount).await?;
+
+    writeln!(stdout, "   Transaction hash: {donate_tx_hash}")?;
+    writeln!(stdout, "Donation completed successfully!")?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::Address;
@@ -140,8 +196,8 @@ mod tests {
     use st0x_wrapper::MockWrapper;
 
     use super::{
-        unwrap_equity_command, unwrap_equity_with_wrapper, wrap_equity_command,
-        wrap_equity_with_wrapper,
+        donate_equity_command, donate_equity_with_wrapper, unwrap_equity_command,
+        unwrap_equity_with_wrapper, wrap_equity_command, wrap_equity_with_wrapper,
     };
     use crate::test_utils::positive_shares;
     use st0x_config::EvmCtx;
@@ -368,6 +424,100 @@ mod tests {
         assert!(
             error.to_string().contains("Missing Withdraw event"),
             "expected unwrap error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn donate_equity_requires_wallet_config() {
+        let ctx = create_ctx_without_rebalancing();
+        let mut stdout = Vec::new();
+
+        let error = donate_equity_command(
+            &mut stdout,
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+            &ctx,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("configured [wallet] section"),
+            "expected wallet config error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn donate_equity_success_prints_transaction_details() {
+        let wrapped_token = Address::repeat_byte(0x22);
+        let underlying_token = Address::repeat_byte(0x11);
+        let wrapper = MockWrapper::new()
+            .with_wrapped_token(wrapped_token)
+            .with_tokenized_shares(underlying_token);
+        let mut stdout = Vec::new();
+
+        donate_equity_with_wrapper(
+            &mut stdout,
+            &wrapper,
+            Address::repeat_byte(0xaa),
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+        )
+        .await
+        .unwrap();
+
+        let output = String::from_utf8(stdout).unwrap();
+        assert!(output.contains("Donating tokenized equity into the wrapper to bump its NAV"));
+        assert!(output.contains("Symbol: AAPL"));
+        assert!(output.contains("Donation quantity: 10.5"));
+        assert!(output.contains(&format!("Wrapped token (NAV recipient): {wrapped_token}")));
+        assert!(output.contains(&format!("Underlying token: {underlying_token}")));
+        assert!(output.contains("no shares minted"));
+        assert!(output.contains("Transaction hash:"));
+        assert!(output.contains("Donation completed successfully"));
+    }
+
+    #[tokio::test]
+    async fn donate_equity_propagates_symbol_lookup_failure() {
+        let wrapper = MockWrapper::failing_derivative_lookup();
+        let mut stdout = Vec::new();
+
+        let error = donate_equity_with_wrapper(
+            &mut stdout,
+            &wrapper,
+            Address::repeat_byte(0xaa),
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("Symbol not configured: AAPL"),
+            "expected symbol lookup error, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn donate_equity_propagates_transfer_failure() {
+        let wrapper = MockWrapper::failing_donate();
+        let mut stdout = Vec::new();
+
+        let error = donate_equity_with_wrapper(
+            &mut stdout,
+            &wrapper,
+            Address::repeat_byte(0xaa),
+            Symbol::new("AAPL").unwrap(),
+            positive_shares("10.5"),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("wrapper donation transfer failed"),
+            "expected donate transfer error, got: {error}"
         );
     }
 }

--- a/src/onchain/approvals.rs
+++ b/src/onchain/approvals.rs
@@ -346,6 +346,14 @@ mod tests {
             unimplemented!("unwrap not used by approval target building")
         }
 
+        async fn donate(
+            &self,
+            _wrapped_token: Address,
+            _underlying_amount: U256,
+        ) -> Result<TxHash, WrapperError> {
+            unimplemented!("donate not used by approval target building")
+        }
+
         async fn submit_wrap(
             &self,
             _wrapped_token: Address,

--- a/src/rebalancing/equity/mod.rs
+++ b/src/rebalancing/equity/mod.rs
@@ -367,6 +367,10 @@ impl Wrapper for PanickingWrapper {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }
 
+    async fn donate(&self, _: Address, _: U256) -> Result<TxHash, WrapperError> {
+        unimplemented!("PanickingWrapper: not available in CLI context")
+    }
+
     async fn submit_wrap(&self, _: Address, _: U256, _: Address) -> Result<TxHash, WrapperError> {
         unimplemented!("PanickingWrapper: not available in CLI context")
     }


### PR DESCRIPTION
## What

RAI-1040. Makes the dividend NAV bump a **one-command** issuer operation, run via
a new **`s01`** issuer CLI. Adds a `dividend-bump` subcommand that buys the
equity, tokenizes it, and donates the tokenized shares into the wtStock ERC-4626
wrapper in a single invocation, waiting for each step to settle. Includes the
`donate-equity` primitive it builds on, resolves the tokenized-equity address from
the ticker on `alpaca-tokenize`/`alpaca-redeem`, and adds the `s01` wrapper that
runs the CLI as the issuer.

Liquidity-CLI track of the dividend flow (the issuer-CLI track RAI-394/395/896
becomes the V1 port, RAI-1046 -- not both).

## Why

RAI-1039 confirmed the bump is a bare ERC-20 transfer of the underlying into the
vault (no shares minted). A donate-only command is just an ERC-20 transfer tool;
the real operation is buy -> tokenize -> donate, so it should be one reliable
command run as the issuer, not a babysat three-step runbook with hand-set env
vars. Passing token addresses by hand (the old `alpaca-tokenize -t`) was an
error-prone footgun the ticker already disambiguates.

## How

- `crates/wrapper`: `donate(wrapped_token, amount)` on `Wrapper`/`WrapperService`
  + `MockWrapper`.
- `src/cli/dividend.rs`: a `dividend-bump -s -q` command running buy -> tokenize
  -> donate via the existing command functions; tokenizes to and donates from the
  configured `[wallet]`.
- `src/cli/trading.rs`: a market-buy-and-wait-for-fill helper (the buy was
  fire-and-forget; the composite must not tokenize against an unfilled order).
- `src/cli`: `alpaca-tokenize`/`alpaca-redeem` resolve the tokenized-equity
  address from `-s` via `[assets.equities]` (`Ctx::tokenized_equity`); dropped
  `-t`.
- `os.nix`: an `s01` CLI wrapper -- the issuer counterpart of `stox` -- defaulting
  to the issuer config/secrets (`/run/st0x/s01-issuer.config`,
  `/run/agenix/s01-issuer.toml`), overridable via `S01_CONFIG`/`S01_SECRETS`.
- `docs/cli-ops.md`: the dividend NAV bump is now `s01 dividend-bump`, not a
  three-step runbook.

## Testing

`cargo check`, `clippy --all-targets --all-features` (clean), `fmt`; new tests:
buy-fill wait resolves on fill / fails on rejection (MockExecutor), `dividend-bump`
parsing, tokenize/redeem ticker resolution + fail-fast, MockWrapper donate tests.
Full cli suite (157) green. Nixos config evaluates with the `s01` package.

## Anything else

- `dividend-bump` is sequential with per-step settlement waits, **not** a
  resumable saga; the standalone `buy`/`alpaca-tokenize`/`donate-equity` remain.
- The issuer **config + encrypted secret** are operator-provided (issuer turnkey
  wallet + Alpaca account + a separate DB): create `config/<env>/s01-issuer.toml`
  and `secret/s01-issuer.toml.age`, or run `s01` today with `S01_CONFIG`/
  `S01_SECRETS` pointed at an existing issuer config. The agenix-install
  deploy step is a follow-up once those exist.
- Stacked on `docs/wrapper-nav-bump` (#878, RAI-1039).
