### PR TITLE
refactor: move IERC20/IPyth bindings and USDC constants into st0x-evm

### DIFF
--- a/crates/bridge/src/cctp/mod.rs
+++ b/crates/bridge/src/cctp/mod.rs
@@ -1051,12 +1051,10 @@ mod tests {
     use rand::Rng;
     use st0x_evm::NoOpErrorRegistry;
     use st0x_evm::local::RawPrivateKeyWallet;
+    use st0x_evm::{USDC_BASE, USDC_ETHEREUM};
 
     use super::*;
     use crate::{Attestation, Bridge};
-
-    const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
-    const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 
     fn setup_anvil() -> (AnvilInstance, String, B256) {
         let anvil = Anvil::new().spawn();

--- a/crates/evm/src/bindings.rs
+++ b/crates/evm/src/bindings.rs
@@ -1,0 +1,21 @@
+//! Shared Solidity contract ABI bindings.
+//!
+//! `IERC20` and `IPyth` are pure EVM primitives consumed by every chain-touching
+//! crate in the workspace, so they live here in `st0x-evm` rather than being
+//! redeclared per consumer. Bindings are generated from the `ST0X_*_ABI`
+//! environment variables provided by the Nix dev shell at compile time.
+
+use alloy::sol;
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IERC20, env!("ST0X_IERC20_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IPyth, env!("ST0X_IPYTH_ABI")
+);

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -38,6 +38,12 @@ use error_decoding::{decode_reverted_receipt, decode_rpc_revert};
 pub mod nonce;
 pub use nonce::ResettableNonceManager;
 
+mod bindings;
+pub use bindings::{IERC20, IPyth, PythStructs};
+
+mod tokens;
+pub use tokens::{USDC_BASE, USDC_ETHEREUM, USDC_ETHEREUM_SEPOLIA};
+
 #[cfg(any(feature = "turnkey", feature = "local-signer"))]
 mod submit;
 

--- a/crates/evm/src/test_chain.rs
+++ b/crates/evm/src/test_chain.rs
@@ -6,11 +6,13 @@
 
 use alloy::network::EthereumWallet;
 use alloy::node_bindings::{Anvil, AnvilInstance};
-use alloy::primitives::{Address, B256, U256, address, keccak256, utils::parse_units};
+use alloy::primitives::{Address, B256, U256, keccak256, utils::parse_units};
 use alloy::providers::ext::AnvilApi as _;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
+
+use crate::USDC_BASE;
 
 sol!(
     #![sol(all_derives = true, rpc)]
@@ -23,9 +25,6 @@ sol!(
     IERC20,
     env!("ST0X_IERC20_ABI")
 );
-
-/// Base chain USDC address.
-pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 
 /// OpenZeppelin ERC20 `_balances` mapping storage slot.
 ///

--- a/crates/evm/src/tokens.rs
+++ b/crates/evm/src/tokens.rs
@@ -1,0 +1,12 @@
+//! Canonical USDC token contract addresses across supported chains.
+
+use alloy::primitives::{Address, address};
+
+/// USDC on Ethereum mainnet.
+pub const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+/// USDC on Base mainnet.
+pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+
+/// USDC on Ethereum Sepolia testnet.
+pub const USDC_ETHEREUM_SEPOLIA: Address = address!("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238");

--- a/crates/raindex/src/lib.rs
+++ b/crates/raindex/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! This crate provides the generic [`Raindex`] trait for Rain OrderBook vault
 //! operations (deposit, withdraw, confirm) plus the shared domain types
-//! ([`RaindexVaultId`], [`RaindexError`], [`USDC_BASE`]) used across consumers.
+//! ([`RaindexVaultId`], [`RaindexError`]) used across consumers.
 //!
 //! The concrete Rain implementation lives in the application crate while this
 //! crate owns the shared trait, errors, and identifier types used by consumers.
 
-use alloy::primitives::{Address, B256, TxHash, U256, address};
+use alloy::primitives::{Address, B256, TxHash, U256};
 use alloy::rpc::types::TransactionReceipt;
 use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
@@ -18,9 +18,6 @@ use st0x_evm::EvmError;
 mod service;
 #[cfg(feature = "rain")]
 pub use service::RaindexService;
-
-/// Base USDC token address.
-pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 
 /// Vault identifier for Rain OrderBook vaults.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/raindex/src/service.rs
+++ b/crates/raindex/src/service.rs
@@ -23,11 +23,11 @@ use async_trait::async_trait;
 use rain_math_float::Float;
 use tracing::{debug, info};
 
-use st0x_evm::{Evm, IntoErrorRegistry, OpenChainErrorRegistry, Wallet};
+use st0x_evm::{Evm, IntoErrorRegistry, OpenChainErrorRegistry, USDC_BASE, Wallet};
 use st0x_execution::FractionalShares;
 use st0x_finance::Usdc;
 
-use crate::{Raindex, RaindexError, RaindexVaultId, USDC_BASE};
+use crate::{Raindex, RaindexError, RaindexVaultId};
 
 sol!(
     #![sol(all_derives = true, rpc)]

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,5 +1,6 @@
-//! Solidity contract ABI bindings for raindex orderbook, ERC20,
-//! and Pyth oracle contracts.
+//! Solidity contract ABI bindings for the raindex orderbook and related
+//! rainlang contracts. Shared EVM primitives (`IERC20`, `IPyth`) live in
+//! `st0x-evm`.
 
 use alloy::sol;
 
@@ -7,12 +8,6 @@ sol!(
     #![sol(all_derives = true, rpc)]
     #[derive(serde::Serialize, serde::Deserialize)]
     IRaindexV6, env!("ST0X_IORDERBOOK_V6_ABI")
-);
-
-sol!(
-    #![sol(all_derives = true, rpc)]
-    #[derive(serde::Serialize, serde::Deserialize)]
-    IERC20, env!("ST0X_IERC20_ABI")
 );
 
 sol!(
@@ -73,11 +68,4 @@ sol!(
 sol!(
     #![sol(all_derives = true, rpc)]
     Deployer, env!("ST0X_DEPLOYER_ABI")
-);
-
-sol!(
-    #![sol(all_derives = true, rpc)]
-    #[allow(clippy::too_many_arguments)]
-    #[derive(serde::Serialize, serde::Deserialize)]
-    IPyth, env!("ST0X_IPYTH_ABI")
 );

--- a/src/cli/alpaca_wallet.rs
+++ b/src/cli/alpaca_wallet.rs
@@ -5,7 +5,7 @@ use alloy::primitives::Address;
 use std::io::Write;
 use uuid::Uuid;
 
-use st0x_evm::{Evm, IntoErrorRegistry, Wallet};
+use st0x_evm::{Evm, IERC20, IntoErrorRegistry, USDC_ETHEREUM, USDC_ETHEREUM_SEPOLIA, Wallet};
 use st0x_execution::{
     AlpacaAccountId, AlpacaBrokerApi, ClientOrderId, ConversionDirection, Executor,
     FractionalShares, Positive, Symbol,
@@ -18,8 +18,6 @@ use crate::alpaca_wallet::{
     AlpacaWalletService, Network, TokenSymbol, TransferStatus, TravelRuleInfo, WhitelistEntry,
     WhitelistStatus,
 };
-use crate::bindings::IERC20;
-use crate::onchain::{USDC_ETHEREUM, USDC_ETHEREUM_SEPOLIA};
 use st0x_config::{BrokerCtx, Ctx};
 
 pub(super) async fn alpaca_deposit_command<Registry: IntoErrorRegistry, W: Write>(

--- a/src/cli/cctp.rs
+++ b/src/cli/cctp.rs
@@ -7,13 +7,11 @@ use std::io::Write;
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection};
 use st0x_config::Ctx;
-use st0x_evm::{Evm, IntoErrorRegistry, Wallet};
+use st0x_evm::{Evm, IERC20, IntoErrorRegistry, USDC_BASE, USDC_ETHEREUM, Wallet};
 use st0x_finance::Usdc;
 use st0x_float_serde::format_float_with_fallback;
 
 use super::CctpChain;
-use crate::bindings::IERC20;
-use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 
 impl CctpChain {
     /// Converts to the bridge direction (from this chain to its destination).

--- a/src/cli/rebalancing.rs
+++ b/src/cli/rebalancing.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use st0x_bridge::cctp::{CctpBridge, CctpCtx};
 use st0x_event_sorcery::StoreBuilder;
-use st0x_evm::{Evm, OpenChainErrorRegistry, ReadOnlyEvm};
+use st0x_evm::{Evm, IERC20, OpenChainErrorRegistry, ReadOnlyEvm, USDC_BASE, USDC_ETHEREUM};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiMode, Executor, FractionalShares, Symbol,
     TimeInForce,
@@ -24,9 +24,7 @@ use st0x_wrapper::{Wrapper, WrapperService};
 
 use super::{TransferDirection, TransferType};
 use crate::alpaca_wallet::AlpacaWalletService;
-use crate::bindings::IERC20;
 use crate::equity_redemption::{EquityRedemption, EquityRedemptionCommand, RedemptionAggregateId};
-use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::equity::{CrossVenueEquityTransfer, EquityTransferServices};
 use crate::rebalancing::to_wrapped_equities;
 use crate::rebalancing::usdc::{CrossVenueCashTransfer, UsdcSettlementParams, UsdcTransferError};

--- a/src/cli/vault.rs
+++ b/src/cli/vault.rs
@@ -7,13 +7,10 @@ use std::io::Write;
 use thiserror::Error;
 
 use st0x_config::Ctx;
-use st0x_evm::{Evm, OpenChainErrorRegistry};
+use st0x_evm::{Evm, IERC20, OpenChainErrorRegistry, USDC_BASE};
 use st0x_float_macro::float;
 use st0x_float_serde::format_float_with_fallback;
 use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
-
-use crate::bindings::IERC20;
-use crate::onchain::USDC_BASE;
 
 pub(super) struct Deposit {
     pub(super) amount: Float,
@@ -194,12 +191,12 @@ mod tests {
     use alloy::sol_types::SolCall;
     use url::Url;
 
+    use st0x_evm::IERC20::decimalsCall;
     use st0x_evm::ReadOnlyEvm;
 
     use st0x_finance::Usdc;
 
     use super::*;
-    use crate::bindings::IERC20::decimalsCall;
     use crate::inventory::ImbalanceThreshold;
     use st0x_config::EvmCtx;
     use st0x_config::ExecutionThreshold;
@@ -573,7 +570,7 @@ mod tests {
             "Expected vault ID in output (proving lookup succeeded), got: {output}"
         );
         assert!(
-            output.contains(&crate::onchain::USDC_BASE.to_string()),
+            output.contains(&USDC_BASE.to_string()),
             "Expected USDC token in output, got: {output}"
         );
     }

--- a/src/conductor.rs
+++ b/src/conductor.rs
@@ -31,7 +31,7 @@ use st0x_event_sorcery::{
     AggregateError, LifecycleError, Projection, SendError, Store, StoreBuilder, compact_events,
     incremental_vacuum, load_all_ids, load_entity,
 };
-use st0x_evm::Wallet;
+use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
     ClientOrderId, CounterTradePreflight, CounterTradeReservation, CounterTradeSkipReason,
     ExecutionError, Executor, FractionalShares, MarketOrder, Symbol, TryIntoExecutor,
@@ -54,7 +54,6 @@ use crate::offchain::order::{
     PollOrderStatus, PollOrderStatusJobQueue,
 };
 use crate::onchain::OnchainTrade;
-use crate::onchain::USDC_BASE;
 #[cfg(test)]
 use crate::onchain::accumulator::check_all_positions;
 use crate::onchain::accumulator::{ExecutionCtx, check_execution_readiness};

--- a/src/equity_redemption.rs
+++ b/src/equity_redemption.rs
@@ -71,12 +71,11 @@ use uuid::Uuid;
 
 use st0x_dto::{EquityRedemptionOperation, EquityRedemptionStatus, TransferOperation};
 use st0x_event_sorcery::{DomainEvent, EventSourced, Nil};
-use st0x_evm::{EvmError, NODE_SYNC_MAX_ATTEMPTS};
+use st0x_evm::{EvmError, IERC20, NODE_SYNC_MAX_ATTEMPTS};
 use st0x_execution::Symbol;
 use st0x_finance::{FractionalShares, Id};
 use st0x_wrapper::WrapperError;
 
-use crate::bindings::IERC20;
 use crate::rebalancing::equity::EquityTransferServices;
 use crate::tokenization::Tokenizer;
 use crate::tokenized_equity_mint::TokenizationRequestId;

--- a/src/integration_tests/arbitrage.rs
+++ b/src/integration_tests/arbitrage.rs
@@ -25,7 +25,7 @@ use st0x_config::{
     AssetsConfig, EquitiesConfig, EquityAssetConfig, ExecutionThreshold, OperationMode,
 };
 use st0x_event_sorcery::{Projection, Store, StoreBuilder, test_store};
-use st0x_evm::ReadOnlyEvm;
+use st0x_evm::{ReadOnlyEvm, USDC_BASE};
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, MockExecutor, OrderState, Positive, Symbol,
 };
@@ -46,7 +46,6 @@ use crate::offchain::order::{
     ExecutorOrderPlacer, OffchainOrder, OffchainOrderCommand, OffchainOrderId,
 };
 use crate::onchain::OnchainTrade;
-use crate::onchain::USDC_BASE;
 use crate::onchain::pyth::PythFeedIds;
 use crate::onchain::trade::RaindexTradeEvent;
 use crate::position::{Position, PositionCommand};

--- a/src/integration_tests/rebalancing.rs
+++ b/src/integration_tests/rebalancing.rs
@@ -27,6 +27,7 @@ use st0x_config::{
 };
 use st0x_dto::Statement;
 use st0x_event_sorcery::{Store, StoreBuilder, test_store};
+use st0x_evm::IERC20;
 use st0x_execution::{
     Direction, ExecutorOrderId, FractionalShares, Positive, SupportedExecutor, Symbol,
 };
@@ -36,7 +37,7 @@ use st0x_raindex::{Raindex, RaindexVaultId};
 use st0x_wrapper::{MockWrapper, Wrapper};
 
 use super::{ExpectedEvent, assert_events, fetch_events};
-use crate::bindings::{IERC20, TestERC20};
+use crate::bindings::TestERC20;
 use crate::conductor::job::Job;
 use crate::equity_redemption::{
     EquityRedemption, EquityRedemptionCommand, redemption_aggregate_id,

--- a/src/inventory/polling.rs
+++ b/src/inventory/polling.rs
@@ -17,16 +17,14 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use tracing::{debug, warn};
 
 use st0x_event_sorcery::{SendError, Store};
-use st0x_evm::{Evm, EvmError, OpenChainErrorRegistry, Wallet};
+use st0x_evm::{Evm, EvmError, IERC20, OpenChainErrorRegistry, USDC_BASE, USDC_ETHEREUM, Wallet};
 use st0x_execution::{Executor, FractionalShares, InventoryResult, SharesConversionError, Symbol};
 use st0x_finance::{HasZero, Usd, UsdToCentsError, Usdc};
 use st0x_raindex::{RaindexError, RaindexService, RaindexVaultId};
 
-use crate::bindings::IERC20;
 use crate::inventory::snapshot::{
     InventorySnapshot, InventorySnapshotCommand, InventorySnapshotId,
 };
-use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::rebalancing::usdc::{UsdcTransferError, u256_to_usdc};
 use crate::tokenization::{TokenizationRequestType, Tokenizer, TokenizerError};
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};

--- a/src/onchain/approvals.rs
+++ b/src/onchain/approvals.rs
@@ -19,11 +19,9 @@
 
 use alloy::primitives::{Address, U256};
 
-use st0x_evm::{OpenChainErrorRegistry, Wallet};
+use st0x_evm::{IERC20, OpenChainErrorRegistry, Wallet};
 use st0x_execution::Symbol;
 use st0x_wrapper::{Wrapper, WrapperError};
-
-use crate::bindings::IERC20;
 
 /// High watermark above which an existing allowance is treated as "already
 /// effectively unlimited", so the startup grant skips it. A genuine MAX

--- a/src/onchain/clear.rs
+++ b/src/onchain/clear.rs
@@ -234,11 +234,11 @@ mod tests {
     use serde_json::json;
     use url::Url;
 
+    use st0x_evm::IERC20::{decimalsCall, symbolCall};
     use st0x_evm::ReadOnlyEvm;
     use st0x_execution::FractionalShares;
 
     use super::*;
-    use crate::bindings::IERC20::{decimalsCall, symbolCall};
     use crate::bindings::IRaindexV6;
     use crate::bindings::IRaindexV6::{AfterClearV2, ClearConfigV2, ClearStateChangeV2};
     use crate::onchain::io::WrappedTokenizedShares;

--- a/src/onchain/mock.rs
+++ b/src/onchain/mock.rs
@@ -8,10 +8,8 @@ use alloy::transports::RpcError;
 use async_trait::async_trait;
 use std::sync::Mutex;
 
-use st0x_evm::EvmError;
+use st0x_evm::{EvmError, IERC20};
 use st0x_raindex::{Raindex, RaindexError, RaindexVaultId};
-
-use crate::bindings::IERC20;
 
 /// Whether `submit_deposit` should succeed, fail generically, or fail
 /// with an "execution reverted" RPC error (simulating a revert during

--- a/src/onchain/mod.rs
+++ b/src/onchain/mod.rs
@@ -1,8 +1,6 @@
 //! Onchain event processing: trade parsing, event backfilling,
 //! position accumulation, and vault management.
 
-use alloy::primitives::Address;
-use alloy::primitives::address;
 use alloy::primitives::ruint::FromUintError;
 use alloy::transports::{RpcError, TransportErrorKind};
 use rain_math_float::FloatError;
@@ -95,8 +93,3 @@ pub(crate) enum OnChainError {
         required_tip: u64,
     },
 }
-
-pub(crate) const USDC_ETHEREUM: Address = address!("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
-pub(crate) const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
-pub(crate) const USDC_ETHEREUM_SEPOLIA: Address =
-    address!("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238");

--- a/src/onchain/pyth/mod.rs
+++ b/src/onchain/pyth/mod.rs
@@ -18,10 +18,9 @@ use rain_math_float::{Float, FloatError};
 use st0x_float_macro::float;
 use tracing::debug;
 
+use st0x_evm::IPyth;
+use st0x_evm::PythStructs::Price;
 use st0x_execution::Symbol;
-
-use crate::bindings::IPyth;
-use crate::bindings::PythStructs::Price;
 
 pub const BASE_PYTH_CONTRACT_ADDRESS: Address =
     address!("0x8250f4aF4B972684F7b336503E2D6dFeDeB1487a");
@@ -137,11 +136,12 @@ fn scale_with_exponent(value: &impl ToString, exponent: i32) -> Result<Float, Fl
     }
 }
 
+/// Scales a raw Pyth `Price` to a human-readable Float. Only used in tests for
+/// verifying Pyth price conversions. A free function rather than an inherent
+/// method because `Price` is defined in `st0x-evm`, not this crate.
 #[cfg(test)]
-impl Price {
-    fn to_float(&self) -> Result<Float, FloatError> {
-        scale_with_exponent(&self.price, self.expo)
-    }
+fn price_to_float(price: &Price) -> Result<Float, FloatError> {
+    scale_with_exponent(&price.price, price.expo)
 }
 
 #[cfg(test)]
@@ -154,11 +154,11 @@ mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
 
+    use st0x_evm::IPyth::getPriceUnsafeCall;
     use st0x_float_macro::float;
     use st0x_float_serde::format_float_with_fallback;
 
     use super::*;
-    use crate::bindings::IPyth::getPriceUnsafeCall;
 
     /// Encodes a `Price` as the ABI return data of `getPriceUnsafe`, matching
     /// what an `eth_call` to the Pyth contract would return.
@@ -264,7 +264,7 @@ mod tests {
             publishTime: U256::from(1_700_000_000u64),
         };
 
-        let exact = price.to_float().unwrap();
+        let exact = price_to_float(&price).unwrap();
 
         assert_eq!(format_float_with_fallback(&exact), "1.23456789");
     }
@@ -278,7 +278,7 @@ mod tests {
             publishTime: U256::from(1_700_000_000u64),
         };
 
-        let exact = price.to_float().unwrap();
+        let exact = price_to_float(&price).unwrap();
 
         assert_eq!(format_float_with_fallback(&exact), "42");
     }
@@ -292,7 +292,7 @@ mod tests {
             publishTime: U256::from(1_700_000_000u64),
         };
 
-        let exact = price.to_float().unwrap();
+        let exact = price_to_float(&price).unwrap();
 
         assert_eq!(format_float_with_fallback(&exact), "123000");
     }
@@ -316,7 +316,7 @@ mod tests {
                 publishTime: U256::from(1_700_000_000u64),
             };
 
-            let exact = price.to_float().unwrap();
+            let exact = price_to_float(&price).unwrap();
 
             assert_eq!(
                 format_float_with_fallback(&exact),
@@ -335,7 +335,7 @@ mod tests {
             publishTime: U256::from(1_700_000_000u64),
         };
 
-        let exact = price.to_float().unwrap();
+        let exact = price_to_float(&price).unwrap();
 
         assert_eq!(format_float_with_fallback(&exact), "-50");
     }
@@ -349,7 +349,7 @@ mod tests {
             publishTime: U256::from(1_700_000_000u64),
         };
 
-        let exact = price.to_float().unwrap();
+        let exact = price_to_float(&price).unwrap();
 
         assert_eq!(format_float_with_fallback(&exact), "182.5");
     }

--- a/src/onchain/take_order.rs
+++ b/src/onchain/take_order.rs
@@ -59,14 +59,14 @@ mod tests {
     use chrono::DateTime;
     use rain_math_float::Float;
 
+    use st0x_evm::IERC20::{decimalsCall, symbolCall};
+    use st0x_evm::IPyth::getPriceUnsafeCall;
+    use st0x_evm::PythStructs::Price;
     use st0x_evm::ReadOnlyEvm;
     use st0x_execution::{FractionalShares, Symbol};
 
     use super::*;
-    use crate::bindings::IERC20::{decimalsCall, symbolCall};
-    use crate::bindings::IPyth::getPriceUnsafeCall;
     use crate::bindings::IRaindexV6::{SignedContextV1, TakeOrderConfigV4, TakeOrderV3};
-    use crate::bindings::PythStructs::Price;
     use crate::onchain::io::WrappedTokenizedShares;
     use crate::onchain::pyth::PythFeedIds;
     use crate::symbol::cache::SymbolCache;

--- a/src/onchain/trade.rs
+++ b/src/onchain/trade.rs
@@ -477,12 +477,12 @@ mod tests {
     use alloy::sol_types::SolCall;
     use rain_math_float::Float;
 
+    use st0x_evm::IPyth::getPriceUnsafeCall;
+    use st0x_evm::PythStructs::Price;
     use st0x_evm::ReadOnlyEvm;
 
     use super::*;
-    use crate::bindings::IPyth::getPriceUnsafeCall;
     use crate::bindings::IRaindexV6;
-    use crate::bindings::PythStructs::Price;
     use crate::symbol::cache::SymbolCache;
     use st0x_config::EvmCtx;
     use st0x_float_macro::float;

--- a/src/rebalancing/spawn.rs
+++ b/src/rebalancing/spawn.rs
@@ -8,7 +8,7 @@ use tracing::info;
 use st0x_bridge::cctp::{CctpBridge, CctpCtx, CctpError};
 use st0x_config::EquityAssetConfig;
 use st0x_event_sorcery::Store;
-use st0x_evm::Wallet;
+use st0x_evm::{USDC_BASE, USDC_ETHEREUM, Wallet};
 use st0x_execution::{
     AlpacaBrokerApi, AlpacaBrokerApiCtx, AlpacaBrokerApiError, EmptySymbolError, Executor, Symbol,
 };
@@ -19,7 +19,6 @@ use super::usdc::{
     CrossVenueCashTransfer, ResumeAlpacaToBase, ResumeBaseToAlpaca, UsdcSettlementParams,
 };
 use crate::alpaca_wallet::AlpacaWalletService;
-use crate::onchain::{USDC_BASE, USDC_ETHEREUM};
 use crate::usdc_rebalance::UsdcRebalance;
 
 /// Errors that can occur when spawning the rebalancer.

--- a/src/rebalancing/usdc/manager.rs
+++ b/src/rebalancing/usdc/manager.rs
@@ -15,12 +15,12 @@ use uuid::Uuid;
 use st0x_bridge::cctp::{AttestationResponse, CctpBridge, CctpError};
 use st0x_bridge::{Attestation, Bridge, BridgeDirection, BurnReceipt, MintReceipt};
 use st0x_event_sorcery::Store;
-use st0x_evm::Wallet;
+use st0x_evm::{USDC_BASE, Wallet};
 use st0x_execution::{
     AlpacaBrokerApi, ClientOrderId, ConversionDirection, CryptoOrderOutcome, Positive,
 };
 use st0x_finance::Usdc;
-use st0x_raindex::{Raindex, RaindexService, RaindexVaultId, USDC_BASE};
+use st0x_raindex::{Raindex, RaindexService, RaindexVaultId};
 
 use super::UsdcTransferError;
 use crate::alpaca_wallet::{
@@ -2929,14 +2929,13 @@ mod tests {
     };
     use st0x_event_sorcery::{AggregateError, LifecycleError, test_store};
     use st0x_evm::local::RawPrivateKeyWallet;
-    use st0x_evm::{Evm, NoOpErrorRegistry, Wallet};
+    use st0x_evm::{Evm, IERC20, NoOpErrorRegistry, Wallet};
     use st0x_raindex::RaindexService;
 
     use super::*;
     use crate::alpaca_wallet::{
         AlpacaTransferId, AlpacaWalletClient, AlpacaWalletError, PollingConfig,
     };
-    use crate::bindings::IERC20;
     use crate::usdc_rebalance::{RebalanceDirection, TransferRef, UsdcRebalanceError};
     use st0x_finance::UsdcConversionError;
 

--- a/src/symbol/cache.rs
+++ b/src/symbol/cache.rs
@@ -10,9 +10,9 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use st0x_evm::{Evm, OpenChainErrorRegistry};
+use st0x_evm::{Evm, IERC20, OpenChainErrorRegistry};
 
-use crate::bindings::{IERC20, IRaindexV6::IOV2};
+use crate::bindings::IRaindexV6::IOV2;
 use crate::onchain::OnChainError;
 
 #[derive(Debug, Default, Clone)]

--- a/src/tokenization/alpaca.rs
+++ b/src/tokenization/alpaca.rs
@@ -38,14 +38,13 @@ use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, error, info, trace, warn};
 
 use st0x_evm::{
-    EvmError, IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL,
+    EvmError, IERC20, IntoErrorRegistry, NODE_SYNC_MAX_ATTEMPTS, NODE_SYNC_POLL_INTERVAL,
     OpenChainErrorRegistry, Wallet, wait_for_node_sync,
 };
 use st0x_execution::{AlpacaAccountId, FractionalShares, Symbol};
 
 use super::{MintVerificationError, Tokenizer, TokenizerError};
 use crate::alpaca_wallet::{Network, PollingConfig};
-use crate::bindings::IERC20;
 use crate::tokenized_equity_mint::{IssuerRequestId, TokenizationRequestId};
 
 /// High-level service for Alpaca tokenization operations.

--- a/src/trading/onchain/trade_accountant.rs
+++ b/src/trading/onchain/trade_accountant.rs
@@ -248,10 +248,10 @@ mod tests {
     use rain_math_float::Float;
 
     use st0x_event_sorcery::StoreBuilder;
+    use st0x_evm::IERC20::{decimalsCall, symbolCall};
     use st0x_execution::{MockExecutor, MockExecutorCtx, TryIntoExecutor};
 
     use super::*;
-    use crate::bindings::IERC20::{decimalsCall, symbolCall};
     use crate::bindings::IRaindexV6;
     use crate::bindings::IRaindexV6::{
         ClearConfigV2, SignedContextV1, TakeOrderConfigV4, TakeOrderV3 as TakeOrderV3Event,

--- a/tests/e2e/base_chain.rs
+++ b/tests/e2e/base_chain.rs
@@ -19,8 +19,9 @@ use rain_math_float::Float;
 use std::collections::HashMap;
 
 use st0x_evm::test_chain::{evm_mapping_slot, solidity_short_string};
+pub use st0x_evm::{IERC20, USDC_BASE};
+pub use st0x_hedge::bindings::DeployableERC20;
 use st0x_hedge::bindings::IRaindexV6::{self, TakeOrderV3};
-pub use st0x_hedge::bindings::{DeployableERC20, IERC20};
 use st0x_hedge::bindings::{Deployer, Interpreter, Parser, RaindexV6, Store as RainStore};
 
 /// Rounds a Float to `decimals` decimal places and formats as a string.
@@ -43,10 +44,6 @@ fn format_float(value: Float) -> anyhow::Result<String> {
         .format_with_scientific(false)
         .map_err(|err| anyhow::anyhow!("format_with_scientific failed: {err:?}"))
 }
-
-/// Base chain USDC address, defined locally so e2e tests don't
-/// need `st0x_hedge` to export the constant.
-pub const USDC_BASE: Address = address!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
 
 // Rainlang interpreter components deploy to deterministic "zoltu" addresses; the
 // expression deployer references the parser/store/interpreter by these hardcoded


### PR DESCRIPTION
## What

Consolidates `IERC20`, `IPyth`/`PythStructs`, and the canonical USDC token addresses (`USDC_ETHEREUM`, `USDC_BASE`, `USDC_ETHEREUM_SEPOLIA`) into `st0x-evm`, making them the single source of truth across the workspace.

## Why

These primitives were duplicated across several crates (`src/bindings.rs`, `src/onchain/mod.rs`, `st0x_raindex`, `st0x_evm::test_chain`, and the CCTP bridge tests). Every consumer redeclared the same addresses and ABI bindings independently, creating drift risk and unnecessary coupling to the application crate.

## How

- Added `crates/evm/src/bindings.rs` to house the `IERC20` and `IPyth` ABI bindings, re-exported from `st0x-evm`.
- Added `crates/evm/src/tokens.rs` to hold the three canonical USDC addresses, also re-exported from `st0x-evm`.
- Removed the duplicate `IERC20` and `IPyth` `sol!` macro declarations from `src/bindings.rs`.
- Removed the `USDC_*` address constants from `src/onchain/mod.rs`, `st0x_raindex::lib`, and `st0x_evm::test_chain`.
- Updated all import sites across CLI modules, integration tests, e2e tests, and service crates to pull `IERC20`, `IPyth`, `PythStructs`, and the USDC addresses from `st0x_evm` directly.
- Replaced the `#[cfg(test)] impl Price { fn to_float }` inherent method (which required `Price` to be defined locally) with a free function `price_to_float`, since `Price` now originates in `st0x-evm`.

## Testing

Existing unit and integration tests cover the affected paths. The Pyth price-scaling tests were updated to call the new `price_to_float` free function and continue to assert the same expected float values.

## Screenshots

N/A

## Anything else

`USDC_ETHEREUM_SEPOLIA` is newly exported from `st0x-evm` (it previously only existed in `src/onchain/mod.rs`), making it available to any crate that needs the Sepolia testnet address without depending on the application crate.

---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.liquidity/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784255196&installation_id=125569124&pr_number=881&repository=ST0x-Technology%2Fst0x.liquidity&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.liquidity%2Fpull%2F881&signature=cf89af9a7dd47f2e928c57ed94f3b025d478b22b453b9747d52915c80b902977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.</sup>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized shared EVM contract bindings (IERC20, IPyth) into a new `st0x_evm` module.
  * Consolidated USDC token addresses across supported networks into a dedicated tokens module.
  * Updated all imports throughout the codebase to reference centralized EVM utilities and token definitions instead of local duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->