### PR TITLE
fix: show empty-state for single-bucket latency percentile chart

### DIFF
--- a/dashboard/src/lib/components/performance-panel.svelte
+++ b/dashboard/src/lib/components/performance-panel.svelte
@@ -299,6 +299,11 @@
     }),
   )
 
+  // Each percentile line has one point per sampled time bucket, so the first
+  // line's point count is the number of buckets with samples. A trend needs at
+  // least two; a single bucket would otherwise render as a few floating dots.
+  const seriesBucketCount = $derived(seriesLayout.lines[0]?.points.length ?? 0)
+
   const rangeButtonClass = (active: boolean): string =>
     `rounded px-2 py-1 text-xs font-medium transition-colors ${active ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground'}`
 
@@ -515,9 +520,14 @@
       </div>
     </Card.Header>
     <Card.Content>
-      {#if (seriesLayout.lines[0]?.points.length ?? 0) === 0}
+      {#if seriesBucketCount === 0}
         <p class="py-6 text-center text-sm text-muted-foreground">
           No samples for this stage in the selected range.
+        </p>
+      {:else if seriesBucketCount === 1}
+        <p class="py-6 text-center text-sm text-muted-foreground">
+          Only one time bucket has samples in this range, so there's no trend to
+          plot yet. Widen the range or wait for more data to accumulate.
         </p>
       {:else}
         <div class="flex items-start gap-2">

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -193,7 +193,6 @@ export default defineConfig({
           '/logs': backendProxy(),
           '/health': backendProxy(),
           '/orders': backendProxy(),
-          '/performance': backendProxy(),
           '/trades': backendProxy(),
           '/transfers': backendProxy(),
           '/performance': backendProxy(),

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -193,6 +193,7 @@ export default defineConfig({
           '/logs': backendProxy(),
           '/health': backendProxy(),
           '/orders': backendProxy(),
+          '/performance': backendProxy(),
           '/trades': backendProxy(),
           '/transfers': backendProxy(),
           '/performance': backendProxy(),


### PR DESCRIPTION
## What

Guard the latency percentile chart in the Performance tab: when the selected range contains only a single time bucket with samples, render a "no trend yet" empty-state message instead of a few floating dots on an otherwise empty chart.

## Why

The percentile chart needs at least two data points to form a visible trend line. With a single bucket the chart renders isolated floating dots, which look broken rather than informative.

## How

Derive `seriesBucketCount` from `seriesLayout.lines[0]?.points.length` (the number of sampled buckets on the first line). Add an `{:else if seriesBucketCount === 1}` branch before the chart `{:else}` block that renders a centred muted-foreground message prompting the user to widen the range or wait for more data.

## Testing

Covered by the existing `layoutPercentileSeries` unit tests; no new test surface for a conditional rendering guard.

## Screenshots

![CleanShot 2026-06-18 at 15.27.37@2x.png](https://app.graphite.com/user-attachments/assets/9a35d7cf-08ae-45ee-bff0-de4e379b4584.png)

![CleanShot 2026-06-18 at 15.28.08@2x.png](https://app.graphite.com/user-attachments/assets/a18da49c-4d31-4e86-9eca-ab31d219c620.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the latency-percentile chart to provide clearer messaging for edge cases, distinguishing between scenarios with no available samples versus those with insufficient time bucket data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->